### PR TITLE
Use current time millis in task name for easier debugging

### DIFF
--- a/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
+++ b/pinot-controller/src/main/java/com/linkedin/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
@@ -189,7 +189,7 @@ public class PinotHelixTaskResourceManager {
     Preconditions.checkState(numConcurrentTasksPerInstance > 0);
 
     String taskType = pinotTaskConfigs.get(0).getTaskType();
-    String parentTaskName = TASK_PREFIX + taskType + TASK_NAME_SEPARATOR + System.nanoTime();
+    String parentTaskName = TASK_PREFIX + taskType + TASK_NAME_SEPARATOR + System.currentTimeMillis();
     LOGGER.info(
         "Submitting parent task: {} of type: {} with {} child task configs: {} to Minion instances with tag: {}",
         parentTaskName, taskType, numChildTasks, pinotTaskConfigs, minionInstanceTag);


### PR DESCRIPTION
Use current time millis instead of nano time so that we know when the task get scheduled for easier debugging