### PR TITLE
Add an integration test for LLC with PinotFS on non-local FS.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/filesystem/PinotFS.java
+++ b/pinot-common/src/main/java/org/apache/pinot/filesystem/PinotFS.java
@@ -22,7 +22,6 @@ import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.nio.file.Paths;
 import org.apache.commons.configuration.Configuration;
 import org.apache.pinot.annotations.InterfaceAudience;
 import org.apache.pinot.annotations.InterfaceStability;
@@ -101,7 +100,7 @@ public abstract class PinotFS implements Closeable {
       }
     } else {
       // ensures the parent path of dst exists.
-      URI parentUri = Paths.get(dstUri).getParent().toUri();
+      URI parentUri = dstUri.getPath().endsWith("/") ? dstUri.resolve("..") : dstUri.resolve(".");
       mkdir(parentUri);
     }
     return doMove(srcUri, dstUri);

--- a/pinot-hadoop-filesystem/src/main/java/org/apache/pinot/filesystem/HadoopPinotFS.java
+++ b/pinot-hadoop-filesystem/src/main/java/org/apache/pinot/filesystem/HadoopPinotFS.java
@@ -51,7 +51,7 @@ import static org.apache.pinot.common.utils.CommonConstants.SegmentOperations.RE
  */
 public class HadoopPinotFS extends PinotFS {
   private static final Logger LOGGER = LoggerFactory.getLogger(HadoopPinotFS.class);
-  private org.apache.hadoop.fs.FileSystem _hadoopFS = null;
+  protected org.apache.hadoop.fs.FileSystem _hadoopFS = null;
   private int _retryCount = RETRY_DEFAULT;
   private int _retryWaitMs = RETRY_WAITIME_MS_DEFAULT;
   private org.apache.hadoop.conf.Configuration _hadoopConf;

--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -197,6 +197,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-hadoop-filesystem</artifactId>
+      <version>${project.version}</version>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-minion</artifactId>
       <version>${project.version}</version>
       <type>test-jar</type>

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCPinotFSRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCPinotFSRealtimeClusterIntegrationTest.java
@@ -1,0 +1,63 @@
+package org.apache.pinot.integration.tests;
+
+import java.io.File;
+import java.nio.file.Files;
+import org.apache.commons.configuration.BaseConfiguration;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.pinot.common.utils.ZkStarter;
+import org.apache.pinot.controller.ControllerConf;
+import org.testng.annotations.BeforeClass;
+
+
+public class LLCPinotFSRealtimeClusterIntegrationTest extends LLCRealtimeClusterIntegrationTest {
+  public static final String CONSUMER_DIRECTORY = "/tmp/consumer-test";
+  public static final long RANDOM_SEED = System.currentTimeMillis();
+  private static MiniDFSCluster hdfsCluster;
+
+  @BeforeClass
+  @Override
+  public void setUp()
+      throws Exception {
+    // Build a local HDFS cluster.
+    File baseDir = Files.createTempDirectory("test_hdfs").toFile().getAbsoluteFile();
+    org.apache.hadoop.conf.Configuration conf = new org.apache.hadoop.conf.Configuration();
+    conf.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, baseDir.getAbsolutePath());
+    MiniDFSCluster.Builder builder = new MiniDFSCluster.Builder(conf);
+    hdfsCluster = builder.build();
+    // Remove the consumer directory
+    File consumerDirectory = new File(CONSUMER_DIRECTORY);
+    if (consumerDirectory.exists()) {
+      FileUtils.deleteDirectory(consumerDirectory);
+    }
+
+    super.setUp();
+  }
+
+  @Override
+  public void startController() {
+    this.startController(getControllerWithDeepStorageConfiguration());
+  }
+
+  public ControllerConf getControllerWithDeepStorageConfiguration() {
+    ControllerConf config = new ControllerConf();
+    config.setControllerHost(LOCAL_HOST);
+    config.setControllerPort(Integer.toString(DEFAULT_CONTROLLER_PORT));
+    // Config to use remote HDFS storage and local tmp directory.
+    config.setDataDir("hdfs://localhost:" + hdfsCluster.getNameNodePort() + "/");
+    config.setLocalTempDir("/tmp");
+    // Config the Pinot FS class.
+    Configuration pinotFSConfig = new BaseConfiguration();
+    pinotFSConfig
+        .setProperty("pinot.controller.storage.factory.class.hdfs", "org.apache.pinot.integration.tests.MockHadoopPinotFS");
+    config.setPinotFSFactoryClasses(pinotFSConfig);
+    // Config the HDFS client default FS.
+    config.setProperty("pinot.controller.storage.factory.hdfs.fs.defaultFS",
+        "hdfs://localhost:" + hdfsCluster.getNameNodePort() + "/");
+    config.setProperty("pinot.controller.storage.factory.hdfs.secure", "false");
+    config.setZkStr(ZkStarter.DEFAULT_ZK_STR);
+    config.setHelixClusterName(getClass().getSimpleName());
+    return config;
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCPinotFSRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCPinotFSRealtimeClusterIntegrationTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.integration.tests;
 
 import java.io.File;
@@ -49,8 +67,8 @@ public class LLCPinotFSRealtimeClusterIntegrationTest extends LLCRealtimeCluster
     config.setLocalTempDir("/tmp");
     // Config the Pinot FS class.
     Configuration pinotFSConfig = new BaseConfiguration();
-    pinotFSConfig
-        .setProperty("pinot.controller.storage.factory.class.hdfs", "org.apache.pinot.integration.tests.MockHadoopPinotFS");
+    pinotFSConfig.setProperty("pinot.controller.storage.factory.class.hdfs",
+        "org.apache.pinot.integration.tests.MockHadoopPinotFS");
     config.setPinotFSFactoryClasses(pinotFSConfig);
     // Config the HDFS client default FS.
     config.setProperty("pinot.controller.storage.factory.hdfs.fs.defaultFS",

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MockHadoopPinotFS.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MockHadoopPinotFS.java
@@ -1,0 +1,29 @@
+package org.apache.pinot.integration.tests;
+
+import java.io.IOException;
+import java.util.Iterator;
+import org.apache.commons.configuration.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.pinot.filesystem.HadoopPinotFS;
+
+
+public class MockHadoopPinotFS extends HadoopPinotFS {
+  public MockHadoopPinotFS() {
+
+  }
+  @Override
+  public void init(Configuration config) {
+    org.apache.hadoop.conf.Configuration hdfsClientCfg = new org.apache.hadoop.conf.Configuration();
+    Iterator keyItr = config.getKeys();
+    while(keyItr.hasNext()) {
+      Object key = keyItr.next();
+      hdfsClientCfg.set(key.toString(), config.getString(key.toString()));
+    }
+    try {
+      _hadoopFS = FileSystem.get(hdfsClientCfg);
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    return;
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MockHadoopPinotFS.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MockHadoopPinotFS.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.integration.tests;
 
 import java.io.IOException;
@@ -11,11 +29,12 @@ public class MockHadoopPinotFS extends HadoopPinotFS {
   public MockHadoopPinotFS() {
 
   }
+
   @Override
   public void init(Configuration config) {
     org.apache.hadoop.conf.Configuration hdfsClientCfg = new org.apache.hadoop.conf.Configuration();
     Iterator keyItr = config.getKeys();
-    while(keyItr.hasNext()) {
+    while (keyItr.hasNext()) {
       Object key = keyItr.next();
       hdfsClientCfg.set(key.toString(), config.getString(key.toString()));
     }


### PR DESCRIPTION
1. Add a new integration test on Low Level Consumer on non-local Pinot FS. A mini hdfs cluster is used in test instead.

2. Fix a bug in move() of PinotFS.java: it does not work with a non-local FS (i.e., uri starting with hdfs://)because  Paths.get() needs an external configured FilesystemProvider. A simpler and more reliable solution is to use URI.resolve(): it does not need any external dependency.   