### PR TITLE
Use normal Logger rather than AsyncLogger for pinot-admin's console log

### DIFF
--- a/pinot-tools/src/main/resources/conf/pinot-admin-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/pinot-admin-log4j2.xml
@@ -45,8 +45,8 @@
     <AsyncLogger name="org.apache.pinot.controller.ControllerStarter" level="info" additivity="false">
       <AppenderRef ref="console"/>
     </AsyncLogger>
-    <AsyncLogger name="org.apache.pinot.tools.admin" level="info" additivity="false">
+    <Logger name="org.apache.pinot.tools.admin" level="info" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncLogger>
+    </Logger>
   </Loggers>
 </Configuration>


### PR DESCRIPTION
I tried some pinot-admin subcommands and noticed that it sometimes exited before the error messages were displayed.
I think it misleads users and makes difficult for them to understand what's happened.

```
# With AsyncLogger
~/repos/incubator-pinot/pinot-distribution/target/apache-pinot-incubating-0.2.0-SNAPSHOT-bin/apache-pinot-incubating-0.2.0-SNAPSHOT-bin$ JAVA_OPTS="-Dpinot.admin.system.exit=true" bin/pinot-admin.sh GenerateData
~/repos/incubator-pinot/pinot-distribution/target/apache-pinot-incubating-0.2.0-SNAPSHOT-bin/apache-pinot-incubating-0.2.0-SNAPSHOT-bin$ echo $?
1

# With Logger
~/repos/incubator-pinot/pinot-distribution/target/apache-pinot-incubating-0.2.0-SNAPSHOT-bin/apache-pinot-incubating-0.2.0-SNAPSHOT-bin$ JAVA_OPTS="-Dpinot.admin.system.exit=true" bin/pinot-admin.sh GenerateData
08:01:52.904 PinotAdministrator - Error: Option "-numFiles" is required
~/repos/incubator-pinot/pinot-distribution/target/apache-pinot-incubating-0.2.0-SNAPSHOT-bin/apache-pinot-incubating-0.2.0-SNAPSHOT-bin$ echo $?
1
```