### PR TITLE
Use jar-no-fork as the goal instead of jar for maven-source-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1038,11 +1038,12 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
+          <version>3.0.1</version>
           <executions>
             <execution>
               <id>attach-sources</id>
               <goals>
-                <goal>jar</goal>
+                <goal>jar-no-fork</goal>
               </goals>
             </execution>
           </executions>


### PR DESCRIPTION
The current plugin has a few issues:
(1) it does not list the version as recommend by Maven (minor issue though).
(2) Using jar as the goal instead of the default jar-no-fork which causes our internal release failure in Uber.

As explained in the following links:
https://maven.apache.org/plugins/maven-source-plugin/jar-no-fork-mojo.html
https://stackoverflow.com/questions/10567551/difference-between-maven-source-plugin-jar-and-jar-no-fork-goal

jar-no-fork is more suitable to attach to Maven build cycle and using jar as a goal will cause re-run all of the goals bound to generate-sources and its predecessors. I assume more use cases of this plugin is to build and release. Thus jar-no-fork is more suitable. 

More important, using jar as the goal results in two almost identical goals for the attach-sources plugin during the Maven release (in our case to an internal artifactory). The maven effective-pom is attached below. That means the source jars will be uploaded twice to our artifactory in Uber -- which results in release failure due to file overwrite issues. How does LinkedIn solve this issue? But still I think jar-no-fork is overall a better option.

>  mvn -Prelease-profile help:effective-pom

          <artifactId>maven-source-plugin</artifactId>
          <version>3.0.1</version>
          <executions>
            <execution>
              <id>attach-sources</id>
              <goals>
                <goal>jar-no-fork</goal>
                <goal>jar</goal>
              </goals>
            </execution>
          </executions>
          <inherited>true</inherited>
        </plugin>


