### PR TITLE
Generate a single routing table if replication is 1

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/BalancedRandomRoutingTableBuilder.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/builder/BalancedRandomRoutingTableBuilder.java
@@ -43,7 +43,8 @@ public class BalancedRandomRoutingTableBuilder extends BaseRoutingTableBuilder {
   public void init(Configuration configuration, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore,
       BrokerMetrics brokerMetrics) {
     super.init(configuration, tableConfig, propertyStore, brokerMetrics);
-    _numRoutingTables = configuration.getInt(NUM_ROUTING_TABLES_KEY, DEFAULT_NUM_ROUTING_TABLES);
+    int numReplicas = tableConfig.getValidationConfig().getReplicationNumber();
+    _numRoutingTables = numReplicas == 1 ? 1 : configuration.getInt(NUM_ROUTING_TABLES_KEY, DEFAULT_NUM_ROUTING_TABLES);
   }
 
   @Override


### PR DESCRIPTION
If the replication is 1, we don't have to generate different versions of routing tables as all of them will be same