### PR TITLE
Enable FULL-AUTO rebalance mode for leadControllerResource after the first live instance shows up

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2041,7 +2041,7 @@ public class PinotHelixResourceManager {
    */
   public PinotResourceManagerResponse dropInstance(String instanceName) {
     // Check if the instance is live
-    if (_helixDataAccessor.getProperty(_keyBuilder.liveInstance(instanceName)) != null) {
+    if (getLiveInstance(instanceName) != null) {
       return PinotResourceManagerResponse.failure("Instance " + instanceName + " is still live");
     }
 
@@ -2095,8 +2095,7 @@ public class PinotHelixResourceManager {
     String offlineState = SegmentOnlineOfflineStateModel.OFFLINE;
 
     while (System.currentTimeMillis() < deadline) {
-      PropertyKey liveInstanceKey = _keyBuilder.liveInstance(instanceName);
-      LiveInstance liveInstance = _helixDataAccessor.getProperty(liveInstanceKey);
+      LiveInstance liveInstance = getLiveInstance(instanceName);
       if (liveInstance == null) {
         if (!enableInstance) {
           // If we disable the instance, we actually don't care whether live instance being null. Thus, returning success should be good.
@@ -2145,6 +2144,10 @@ public class PinotHelixResourceManager {
     }
     return PinotResourceManagerResponse
         .failure("Instance " + (enableInstance ? "enable" : "disable") + " failed, timeout");
+  }
+
+  public LiveInstance getLiveInstance(String instanceName) {
+    return _helixDataAccessor.getProperty(_keyBuilder.liveInstance(instanceName));
   }
 
   public RebalanceResult rebalanceTable(String tableNameWithType, Configuration rebalanceConfig)

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/HelixSetupUtils.java
@@ -40,7 +40,6 @@ import org.apache.helix.model.MasterSlaveSMD;
 import org.apache.helix.model.ResourceConfig;
 import org.apache.helix.model.StateModelDefinition;
 import org.apache.helix.model.builder.CustomModeISBuilder;
-import org.apache.helix.model.builder.FullAutoModeISBuilder;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
 import org.apache.pinot.common.utils.helix.LeadControllerUtils;
 import org.apache.pinot.controller.helix.core.PinotHelixBrokerResourceOnlineOfflineStateModelGenerator;
@@ -154,7 +153,7 @@ public class HelixSetupUtils {
       LOGGER.info("Adding resource: {}", LEAD_CONTROLLER_RESOURCE_NAME);
 
       // FULL-AUTO Master-Slave state model with a rebalance strategy, auto-rebalance by default
-      FullAutoModeISBuilder idealStateBuilder = new FullAutoModeISBuilder(LEAD_CONTROLLER_RESOURCE_NAME);
+      CustomModeISBuilder idealStateBuilder = new CustomModeISBuilder(LEAD_CONTROLLER_RESOURCE_NAME);
       idealStateBuilder.setStateModel(MasterSlaveSMD.name)
           .setRebalanceStrategy(leadControllerResourceRebalanceStrategy);
       // Initialize partitions and replicas
@@ -175,10 +174,10 @@ public class HelixSetupUtils {
       idealState.setInstanceGroupTag(CONTROLLER_INSTANCE);
       // Set batch message mode
       idealState.setBatchMessageMode(enableBatchMessageMode);
+
       // Explicitly disable this resource when creating this new resource.
       // When all the controllers are running the code with the logic to handle this resource, it can be enabled for backward compatibility.
       // In the next major release, we can enable this resource by default, so that all the controller logic can be separated.
-
       helixAdmin.addResource(helixClusterName, LEAD_CONTROLLER_RESOURCE_NAME, idealState);
     } else if (!idealState.isEnabled()) {
       // Enable lead controller resource and let resource config be the only switch for enabling logic of lead controller resource.


### PR DESCRIPTION
This RB enables FULL-AUTO rebalance mode for leadControllerResource after the first live instance shows up.

By doing so, the first controller can start calculating the partition assignment after all the materials are fully prepared.

No algorithm related exception thrown any more when starting the 1st controller.