### PR TITLE
Implement optimized version of PinotByteBuffer.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/memory/PinotNonNativeUnsafeByteBuffer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/memory/PinotNonNativeUnsafeByteBuffer.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.segment.memory;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.MappedByteBuffer;
@@ -29,198 +30,214 @@ import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.core.util.CleanerUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import sun.misc.Unsafe;
+import sun.nio.ch.DirectBuffer;
 
 
 @ThreadSafe
-public class PinotByteBuffer extends PinotDataBuffer {
-  private static final Logger LOGGER = LoggerFactory.getLogger(PinotByteBuffer.class);
-  private final ByteBuffer _buffer;
+public class PinotNonNativeUnsafeByteBuffer extends PinotDataBuffer {
+  private final DirectBuffer _buffer;
+  private final long _address;
   private final boolean _flushable;
+  private static final Unsafe UNSAFE = getUnsafe();
 
-  public static PinotByteBuffer allocateDirect(int size, ByteOrder byteOrder) {
-    return new PinotByteBuffer(ByteBuffer.allocateDirect(size).order(byteOrder), true, false);
+  private static Unsafe getUnsafe() {
+    try {
+      Field var0 = Unsafe.class.getDeclaredField("theUnsafe");
+      var0.setAccessible(true);
+      return (Unsafe)(var0.get((Object)null));
+    } catch (NoSuchFieldException e) {
+      throw new IllegalStateException("sun.misc.Unsafe is not available in this JVM", e);
+    } catch (IllegalAccessException e) {
+      throw new IllegalStateException(e);
+    }
   }
 
-  static PinotByteBuffer loadFile(File file, long offset, int size, ByteOrder byteOrder)
+  public static PinotNonNativeUnsafeByteBuffer allocateDirect(int size) {
+    return new PinotNonNativeUnsafeByteBuffer(ByteBuffer.allocateDirect(size), true, false);
+  }
+
+  static PinotNonNativeUnsafeByteBuffer loadFile(File file, long offset, int size)
       throws IOException {
-    PinotByteBuffer buffer = allocateDirect(size, byteOrder);
+    PinotNonNativeUnsafeByteBuffer buffer = allocateDirect(size);
     buffer.readFrom(0, file, offset, size);
     return buffer;
   }
 
-  static PinotByteBuffer mapFile(File file, boolean readOnly, long offset, int size, ByteOrder byteOrder)
+  static PinotNonNativeUnsafeByteBuffer mapFile(File file, boolean readOnly, long offset, int size)
       throws IOException {
     if (readOnly) {
       try (FileChannel fileChannel = new RandomAccessFile(file, "r").getChannel()) {
-        ByteBuffer buffer = fileChannel.map(FileChannel.MapMode.READ_ONLY, offset, size).order(byteOrder);
-        return new PinotByteBuffer(buffer, true, false);
+        ByteBuffer buffer = fileChannel.map(FileChannel.MapMode.READ_ONLY, offset, size);
+        return new PinotNonNativeUnsafeByteBuffer(buffer, true, false);
       }
     } else {
       try (FileChannel fileChannel = new RandomAccessFile(file, "rw").getChannel()) {
-        ByteBuffer buffer = fileChannel.map(FileChannel.MapMode.READ_WRITE, offset, size).order(byteOrder);
-        return new PinotByteBuffer(buffer, true, true);
+        ByteBuffer buffer = fileChannel.map(FileChannel.MapMode.READ_WRITE, offset, size);
+        return new PinotNonNativeUnsafeByteBuffer(buffer, true, true);
       }
     }
   }
 
-  private PinotByteBuffer(ByteBuffer buffer, boolean closeable, boolean flushable) {
+  private PinotNonNativeUnsafeByteBuffer(ByteBuffer buffer, boolean closeable, boolean flushable) {
     super(closeable);
-    _buffer = buffer;
+    _buffer = (DirectBuffer)buffer;
+    _address = _buffer.address();
     _flushable = flushable;
   }
 
   @Override
   public byte getByte(int offset) {
-    return _buffer.get(offset);
+    return UNSAFE.getByte(_address + offset);
   }
 
   @Override
   public byte getByte(long offset) {
     assert offset <= Integer.MAX_VALUE;
-    return _buffer.get((int) offset);
+    return UNSAFE.getByte(_address + (int) offset);
   }
 
   @Override
   public void putByte(int offset, byte value) {
-    _buffer.put(offset, value);
+    UNSAFE.putByte(_address + offset, value);
   }
 
   @Override
   public void putByte(long offset, byte value) {
     assert offset <= Integer.MAX_VALUE;
-    _buffer.put((int) offset, value);
+    UNSAFE.putByte(_address + (int) offset, value);
   }
 
   @Override
   public char getChar(int offset) {
-    return _buffer.getChar(offset);
+    return Character.reverseBytes(UNSAFE.getChar(_address + offset));
   }
 
   @Override
   public char getChar(long offset) {
     assert offset <= Integer.MAX_VALUE;
-    return _buffer.getChar((int) offset);
+    return Character.reverseBytes(UNSAFE.getChar(_address + (int) offset));
   }
 
   @Override
   public void putChar(int offset, char value) {
-    _buffer.putChar(offset, value);
+    UNSAFE.putChar(_address + offset, Character.reverseBytes(value));
   }
 
   @Override
   public void putChar(long offset, char value) {
     assert offset <= Integer.MAX_VALUE;
-    _buffer.putChar((int) offset, value);
+    UNSAFE.putChar(_address + (int) offset, Character.reverseBytes(value));
   }
 
   @Override
   public short getShort(int offset) {
-    return _buffer.getShort(offset);
+    return Short.reverseBytes(UNSAFE.getShort(_address + offset));
   }
 
   @Override
   public short getShort(long offset) {
     assert offset <= Integer.MAX_VALUE;
-    return _buffer.getShort((int) offset);
+    return Short.reverseBytes(UNSAFE.getShort(_address + (int) offset));
   }
 
   @Override
   public void putShort(int offset, short value) {
-    _buffer.putShort(offset, value);
+    UNSAFE.putShort(_address + offset, Short.reverseBytes(value));
   }
 
   @Override
   public void putShort(long offset, short value) {
     assert offset <= Integer.MAX_VALUE;
-    _buffer.putShort((int) offset, value);
+    UNSAFE.putShort(_address + (int) offset, Short.reverseBytes(value));
   }
 
   @Override
   public int getInt(int offset) {
-    return _buffer.getInt(offset);
+    return Integer.reverseBytes(UNSAFE.getInt(_address + offset));
   }
 
   @Override
   public int getInt(long offset) {
     assert offset <= Integer.MAX_VALUE;
-    return _buffer.getInt((int) offset);
+    return Integer.reverseBytes(UNSAFE.getInt(_address + (int) offset));
   }
 
   @Override
   public void putInt(int offset, int value) {
-    _buffer.putInt(offset, value);
+    UNSAFE.putInt(_address + offset, Integer.reverseBytes(value));
   }
 
   @Override
   public void putInt(long offset, int value) {
     assert offset <= Integer.MAX_VALUE;
-    _buffer.putInt((int) offset, value);
+    UNSAFE.putInt(_address + (int) offset, Integer.reverseBytes(value));
   }
 
   @Override
   public long getLong(int offset) {
-    return _buffer.getLong(offset);
+    return Long.reverseBytes(UNSAFE.getLong(_address + offset));
   }
 
   @Override
   public long getLong(long offset) {
     assert offset <= Integer.MAX_VALUE;
-    return _buffer.getLong((int) offset);
+    return Long.reverseBytes(UNSAFE.getLong(_address + (int) offset));
   }
 
   @Override
   public void putLong(int offset, long value) {
-    _buffer.putLong(offset, value);
+    UNSAFE.putLong(_address + offset, Long.reverseBytes(value));
   }
 
   @Override
   public void putLong(long offset, long value) {
     assert offset <= Integer.MAX_VALUE;
-    _buffer.putLong((int) offset, value);
+    UNSAFE.putLong(_address + (int) offset, Long.reverseBytes(value));
   }
 
   @Override
   public float getFloat(int offset) {
-    return _buffer.getFloat(offset);
+    return Float.intBitsToFloat(Integer.reverseBytes(UNSAFE.getInt(_address + offset)));
   }
 
   @Override
   public float getFloat(long offset) {
     assert offset <= Integer.MAX_VALUE;
-    return _buffer.getFloat((int) offset);
+    return Float.intBitsToFloat(Integer.reverseBytes(UNSAFE.getInt(_address + (int) offset)));
   }
 
   @Override
   public void putFloat(int offset, float value) {
-    _buffer.putFloat(offset, value);
+    UNSAFE.putInt(_address + offset, Integer.reverseBytes(Float.floatToRawIntBits(value)));
   }
 
   @Override
   public void putFloat(long offset, float value) {
     assert offset <= Integer.MAX_VALUE;
-    _buffer.putFloat((int) offset, value);
+    UNSAFE.putInt(_address + (int) offset, Integer.reverseBytes(Float.floatToRawIntBits(value)));
   }
 
   @Override
   public double getDouble(int offset) {
-    return _buffer.getDouble(offset);
+    return Double.longBitsToDouble(Long.reverseBytes(UNSAFE.getLong(_address + offset)));
   }
 
   @Override
   public double getDouble(long offset) {
     assert offset <= Integer.MAX_VALUE;
-    return _buffer.getDouble((int) offset);
+    return Double.longBitsToDouble(Long.reverseBytes(UNSAFE.getLong(_address + (int) offset)));
   }
 
   @Override
   public void putDouble(int offset, double value) {
-    _buffer.putDouble(offset, value);
+    UNSAFE.putLong(_address + offset, Long.reverseBytes(Double.doubleToRawLongBits(value)));
   }
 
   @Override
   public void putDouble(long offset, double value) {
     assert offset <= Integer.MAX_VALUE;
-    _buffer.putDouble((int) offset, value);
+    UNSAFE.putLong(_address + (int) offset, Long.reverseBytes(Double.doubleToRawLongBits(value)));
   }
 
   @Override
@@ -233,7 +250,7 @@ public class PinotByteBuffer extends PinotDataBuffer {
         buffer[i] = getByte(intOffset++);
       }
     } else {
-      ByteBuffer duplicate = _buffer.duplicate();
+      ByteBuffer duplicate = ((ByteBuffer)_buffer).duplicate();
       duplicate.position(intOffset);
       duplicate.get(buffer, destOffset, size);
     }
@@ -245,7 +262,7 @@ public class PinotByteBuffer extends PinotDataBuffer {
     assert size <= Integer.MAX_VALUE;
     int start = (int) offset;
     int end = start + (int) size;
-    ByteBuffer duplicate = _buffer.duplicate();
+    ByteBuffer duplicate = ((ByteBuffer)_buffer).duplicate();
     duplicate.position(start).limit(end);
     buffer.readFrom(destOffset, duplicate);
   }
@@ -260,7 +277,7 @@ public class PinotByteBuffer extends PinotDataBuffer {
         putByte(intOffset++, buffer[i]);
       }
     } else {
-      ByteBuffer duplicate = _buffer.duplicate();
+      ByteBuffer duplicate = ((ByteBuffer)_buffer).duplicate();
       duplicate.position(intOffset);
       duplicate.put(buffer, srcOffset, size);
     }
@@ -269,7 +286,7 @@ public class PinotByteBuffer extends PinotDataBuffer {
   @Override
   public void readFrom(long offset, ByteBuffer buffer) {
     assert offset <= Integer.MAX_VALUE;
-    ByteBuffer duplicate = _buffer.duplicate();
+    ByteBuffer duplicate = ((ByteBuffer)_buffer).duplicate();
     duplicate.position((int) offset);
     duplicate.put(buffer);
   }
@@ -280,7 +297,7 @@ public class PinotByteBuffer extends PinotDataBuffer {
     assert offset <= Integer.MAX_VALUE;
     assert size <= Integer.MAX_VALUE;
     try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r")) {
-      ByteBuffer duplicate = _buffer.duplicate();
+      ByteBuffer duplicate = ((ByteBuffer)_buffer).duplicate();
       int start = (int) offset;
       int end = start + (int) size;
       duplicate.position(start).limit(end);
@@ -290,23 +307,23 @@ public class PinotByteBuffer extends PinotDataBuffer {
 
   @Override
   public long size() {
-    return _buffer.limit();
+    return ((ByteBuffer)_buffer).limit();
   }
 
   @Override
   public ByteOrder order() {
-    return _buffer.order();
+    return ((ByteBuffer)_buffer).order();
   }
 
   @Override
   public PinotDataBuffer view(long start, long end, ByteOrder byteOrder) {
     assert start <= end;
     assert end <= Integer.MAX_VALUE;
-    ByteBuffer duplicate = _buffer.duplicate();
+    ByteBuffer duplicate = ((ByteBuffer)_buffer).duplicate();
     duplicate.position((int) start).limit((int) end);
     ByteBuffer buffer = duplicate.slice();
     buffer.order(byteOrder);
-    return new PinotByteBuffer(buffer, false, false);
+    return new PinotNonNativeUnsafeByteBuffer(buffer, false, false);
   }
 
   @Override
@@ -314,7 +331,7 @@ public class PinotByteBuffer extends PinotDataBuffer {
     assert offset <= Integer.MAX_VALUE;
     int start = (int) offset;
     int end = start + size;
-    ByteBuffer duplicate = _buffer.duplicate();
+    ByteBuffer duplicate = ((ByteBuffer)_buffer).duplicate();
     duplicate.position(start).limit(end);
     ByteBuffer buffer = duplicate.slice();
     buffer.order(byteOrder);
@@ -332,7 +349,7 @@ public class PinotByteBuffer extends PinotDataBuffer {
   protected void release()
       throws IOException {
     if (CleanerUtil.UNMAP_SUPPORTED) {
-      CleanerUtil.getCleaner().freeBuffer(_buffer);
+      CleanerUtil.getCleaner().freeBuffer((ByteBuffer)_buffer);
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/memory/PinotDataBufferTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/memory/PinotDataBufferTest.java
@@ -116,6 +116,62 @@ public class PinotDataBufferTest {
   }
 
   @Test
+  public void testPinotNativeUnsafeByteBuffer()
+      throws Exception {
+    try (PinotDataBuffer buffer = PinotNativeUnsafeByteBuffer.allocateDirect(BUFFER_SIZE)) {
+      testPinotDataBuffer(buffer);
+    }
+    try (PinotDataBuffer buffer = PinotNativeUnsafeByteBuffer.allocateDirect(BUFFER_SIZE)) {
+      testPinotDataBuffer(buffer);
+    }
+    try (RandomAccessFile randomAccessFile = new RandomAccessFile(TEMP_FILE, "rw")) {
+      randomAccessFile.setLength(FILE_OFFSET + BUFFER_SIZE);
+      try (PinotDataBuffer buffer = PinotNativeUnsafeByteBuffer.loadFile(TEMP_FILE, FILE_OFFSET, BUFFER_SIZE)) {
+        testPinotDataBuffer(buffer);
+      }
+      try (PinotDataBuffer buffer = PinotNativeUnsafeByteBuffer.loadFile(TEMP_FILE, FILE_OFFSET, BUFFER_SIZE)) {
+        testPinotDataBuffer(buffer);
+      }
+      try (PinotDataBuffer buffer = PinotNativeUnsafeByteBuffer.mapFile(TEMP_FILE, false, FILE_OFFSET, BUFFER_SIZE)) {
+        testPinotDataBuffer(buffer);
+      }
+      try (PinotDataBuffer buffer = PinotNativeUnsafeByteBuffer.mapFile(TEMP_FILE, false, FILE_OFFSET, BUFFER_SIZE)) {
+        testPinotDataBuffer(buffer);
+      }
+    } finally {
+      FileUtils.forceDelete(TEMP_FILE);
+    }
+  }
+
+  @Test
+  public void testPinotNonNativeUnsafeByteBuffer()
+      throws Exception {
+    try (PinotDataBuffer buffer = PinotNonNativeUnsafeByteBuffer.allocateDirect(BUFFER_SIZE)) {
+      testPinotDataBuffer(buffer);
+    }
+    try (PinotDataBuffer buffer = PinotNonNativeUnsafeByteBuffer.allocateDirect(BUFFER_SIZE)) {
+      testPinotDataBuffer(buffer);
+    }
+    try (RandomAccessFile randomAccessFile = new RandomAccessFile(TEMP_FILE, "rw")) {
+      randomAccessFile.setLength(FILE_OFFSET + BUFFER_SIZE);
+      try (PinotDataBuffer buffer = PinotNonNativeUnsafeByteBuffer.loadFile(TEMP_FILE, FILE_OFFSET, BUFFER_SIZE)) {
+        testPinotDataBuffer(buffer);
+      }
+      try (PinotDataBuffer buffer = PinotNonNativeUnsafeByteBuffer.loadFile(TEMP_FILE, FILE_OFFSET, BUFFER_SIZE)) {
+        testPinotDataBuffer(buffer);
+      }
+      try (PinotDataBuffer buffer = PinotNonNativeUnsafeByteBuffer.mapFile(TEMP_FILE, false, FILE_OFFSET, BUFFER_SIZE)) {
+        testPinotDataBuffer(buffer);
+      }
+      try (PinotDataBuffer buffer = PinotNonNativeUnsafeByteBuffer.mapFile(TEMP_FILE, false, FILE_OFFSET, BUFFER_SIZE)) {
+        testPinotDataBuffer(buffer);
+      }
+    } finally {
+      FileUtils.forceDelete(TEMP_FILE);
+    }
+  }
+
+  @Test
   public void testPinotNativeOrderLBuffer()
       throws Exception {
     try (PinotDataBuffer buffer = PinotNativeOrderLBuffer.allocateDirect(BUFFER_SIZE)) {
@@ -366,6 +422,44 @@ public class PinotDataBufferTest {
       }
       try (PinotDataBuffer readBuffer = PinotByteBuffer
           .mapFile(TEMP_FILE, true, FILE_OFFSET, BUFFER_SIZE, PinotDataBuffer.NATIVE_ORDER)) {
+        getInts(readBuffer);
+      }
+    } finally {
+      FileUtils.forceDelete(TEMP_FILE);
+    }
+  }
+
+  @Test
+  public void testPinotNativeUnsafeByteBufferReadWriteFile()
+      throws Exception {
+    try (PinotDataBuffer writeBuffer = PinotNativeUnsafeByteBuffer
+        .mapFile(TEMP_FILE, false, FILE_OFFSET, BUFFER_SIZE)) {
+      putInts(writeBuffer);
+      try (PinotDataBuffer readBuffer = PinotNativeUnsafeByteBuffer
+          .loadFile(TEMP_FILE, FILE_OFFSET, BUFFER_SIZE)) {
+        getInts(readBuffer);
+      }
+      try (PinotDataBuffer readBuffer = PinotNativeUnsafeByteBuffer
+          .mapFile(TEMP_FILE, true, FILE_OFFSET, BUFFER_SIZE)) {
+        getInts(readBuffer);
+      }
+    } finally {
+      FileUtils.forceDelete(TEMP_FILE);
+    }
+  }
+
+  @Test
+  public void testPinotNonNativeUnsafeByteBufferReadWriteFile()
+      throws Exception {
+    try (PinotDataBuffer writeBuffer = PinotNonNativeUnsafeByteBuffer
+        .mapFile(TEMP_FILE, false, FILE_OFFSET, BUFFER_SIZE)) {
+      putInts(writeBuffer);
+      try (PinotDataBuffer readBuffer = PinotNonNativeUnsafeByteBuffer
+          .loadFile(TEMP_FILE, FILE_OFFSET, BUFFER_SIZE)) {
+        getInts(readBuffer);
+      }
+      try (PinotDataBuffer readBuffer = PinotNonNativeUnsafeByteBuffer
+          .mapFile(TEMP_FILE, true, FILE_OFFSET, BUFFER_SIZE)) {
         getInts(readBuffer);
       }
     } finally {

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkPinotByteBuffer.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkPinotByteBuffer.java
@@ -1,0 +1,151 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import java.io.IOException;
+import java.nio.ByteOrder;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.core.data.table.Table;
+import org.apache.pinot.core.segment.memory.PinotByteBuffer;
+import org.apache.pinot.core.segment.memory.PinotNativeUnsafeByteBuffer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@Warmup(iterations = 3)
+@Measurement(iterations = 5)
+@Fork(1)
+@State(Scope.Benchmark)
+public class BenchmarkPinotByteBuffer {
+  private static final int SIZE = 100_000_000; // 100MB
+  private static final int TYPE_WIDTH = Integer.BYTES;
+  private static final int INT_ARRAY_LENGTH = SIZE/Integer.BYTES;
+  private PinotByteBuffer _pinotByteBuffer;
+  private PinotNativeUnsafeByteBuffer _pinotNativeUnsafeByteBuffer;
+  private Random _random;
+  private int[] indexes = new int[INT_ARRAY_LENGTH];
+
+  @Setup
+  public void setUp() {
+    _pinotByteBuffer = PinotByteBuffer.allocateDirect(SIZE, ByteOrder.nativeOrder());
+    _pinotNativeUnsafeByteBuffer = PinotNativeUnsafeByteBuffer.allocateDirect(SIZE);
+    _random = new Random();
+    for (int i = 0; i < INT_ARRAY_LENGTH; i++) {
+      indexes[i] = _random.nextInt(INT_ARRAY_LENGTH);
+    }
+    for (int i = 0; i < INT_ARRAY_LENGTH; i++) {
+      _pinotByteBuffer.putInt(i * TYPE_WIDTH, 100 + i);
+    }
+    for (int i = 0; i < INT_ARRAY_LENGTH; i++) {
+      _pinotNativeUnsafeByteBuffer.putInt(i * TYPE_WIDTH, 200 + i);
+    }
+  }
+
+  @TearDown
+  public void tearDown()
+      throws IOException {
+    _pinotByteBuffer.close();
+    _pinotNativeUnsafeByteBuffer.close();
+  }
+
+  @Benchmark
+  public void pinotByteBufferReadSequential() {
+    for (int i = 0; i < INT_ARRAY_LENGTH; i++) {
+      _pinotByteBuffer.getInt(i * TYPE_WIDTH);
+    }
+  }
+
+  @Benchmark
+  public void pinotNativeUnsafeByteBufferReadSequential() {
+    for (int i = 0; i < INT_ARRAY_LENGTH; i++) {
+      _pinotNativeUnsafeByteBuffer.getInt(i * TYPE_WIDTH);
+    }
+  }
+
+  @Benchmark
+  public void pinotByteBufferReadRandom() {
+    for (int i = 0; i < INT_ARRAY_LENGTH; i++) {
+      _pinotByteBuffer.getInt(indexes[i] * TYPE_WIDTH);
+    }
+  }
+
+  @Benchmark
+  public void pinotNativeUnsafeByteBufferReadRandom() {
+    for (int i = 0; i < INT_ARRAY_LENGTH; i++) {
+      _pinotNativeUnsafeByteBuffer.getInt(indexes[i] * TYPE_WIDTH);
+    }
+  }
+
+  @Benchmark
+  public void pinotByteBufferWriteRandom() throws Exception {
+    try (PinotByteBuffer buffer = PinotByteBuffer.allocateDirect(SIZE, ByteOrder.nativeOrder())){
+      for (int i = 0; i < INT_ARRAY_LENGTH; i++) {
+        buffer.putInt(indexes[i] * TYPE_WIDTH,  100 + i);
+      }
+    }
+  }
+
+  @Benchmark
+  public void pinotNativeUnsafeByteBufferWriteRandom() throws Exception {
+    try (PinotNativeUnsafeByteBuffer buffer = PinotNativeUnsafeByteBuffer.allocateDirect(SIZE)){
+      for (int i = 0; i < INT_ARRAY_LENGTH; i++) {
+        buffer.putInt(indexes[i] * TYPE_WIDTH,  100 + i);
+      }
+    }
+  }
+
+  @Benchmark
+  public void pinotByteBufferWriteSequential() throws Exception {
+    try (PinotByteBuffer buffer = PinotByteBuffer.allocateDirect(SIZE, ByteOrder.nativeOrder())){
+      for (int i = 0; i < INT_ARRAY_LENGTH; i++) {
+        buffer.putInt(i * TYPE_WIDTH, 100 + i);
+      }
+    }
+  }
+
+  @Benchmark
+  public void pinotByteBufferOptimizedWriteSequential() throws Exception {
+    try (PinotNativeUnsafeByteBuffer buffer = PinotNativeUnsafeByteBuffer.allocateDirect(SIZE)){
+      for (int i = 0; i < INT_ARRAY_LENGTH; i++) {
+        buffer.putInt(i * TYPE_WIDTH, 100 + i);
+      }
+    }
+  }
+
+  public static void main(String[] args)
+      throws Exception {
+    ChainedOptionsBuilder opt = new OptionsBuilder().include(BenchmarkPinotByteBuffer.class.getSimpleName());
+    new Runner(opt.build()).run();
+  }
+}


### PR DESCRIPTION
We can directly work on the address of the underlying memory chunk by-passing all the chain of function calls and do get/set at the absolute address computed as starting virtual address of underlying memory + offset.

Two implementations are provided:

- PinotNativeUnsafeByteBuffer
- PinotNonNativeUnsafeByteBuffer