### PR TITLE
Fix ByteBuffer incompatible issue

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
@@ -29,6 +29,7 @@ import it.unimi.dsi.fastutil.ints.IntSet;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -401,8 +402,8 @@ public class ObjectSerDeUtils {
 
     private ByteBuffer sliceByteBuffer(ByteBuffer byteBuffer, int size) {
       ByteBuffer slice = byteBuffer.slice();
-      slice.limit(size);
-      byteBuffer.position(byteBuffer.position() + size);
+      ((Buffer) slice).limit(size);
+      ((Buffer) byteBuffer).position(byteBuffer.position() + size);
       return slice;
     }
   };

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableBuilder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableBuilder.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.common.datatable;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
@@ -102,7 +103,7 @@ public class DataTableBuilder {
   }
 
   public void setColumn(int colId, boolean value) {
-    _currentRowDataByteBuffer.position(_columnOffsets[colId]);
+    ((Buffer) _currentRowDataByteBuffer).position(_columnOffsets[colId]);
     if (value) {
       _currentRowDataByteBuffer.put((byte) 1);
     } else {
@@ -111,37 +112,37 @@ public class DataTableBuilder {
   }
 
   public void setColumn(int colId, byte value) {
-    _currentRowDataByteBuffer.position(_columnOffsets[colId]);
+    ((Buffer) _currentRowDataByteBuffer).position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.put(value);
   }
 
   public void setColumn(int colId, char value) {
-    _currentRowDataByteBuffer.position(_columnOffsets[colId]);
+    ((Buffer) _currentRowDataByteBuffer).position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putChar(value);
   }
 
   public void setColumn(int colId, short value) {
-    _currentRowDataByteBuffer.position(_columnOffsets[colId]);
+    ((Buffer) _currentRowDataByteBuffer).position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putShort(value);
   }
 
   public void setColumn(int colId, int value) {
-    _currentRowDataByteBuffer.position(_columnOffsets[colId]);
+    ((Buffer) _currentRowDataByteBuffer).position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putInt(value);
   }
 
   public void setColumn(int colId, long value) {
-    _currentRowDataByteBuffer.position(_columnOffsets[colId]);
+    ((Buffer) _currentRowDataByteBuffer).position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putLong(value);
   }
 
   public void setColumn(int colId, float value) {
-    _currentRowDataByteBuffer.position(_columnOffsets[colId]);
+    ((Buffer) _currentRowDataByteBuffer).position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putFloat(value);
   }
 
   public void setColumn(int colId, double value) {
-    _currentRowDataByteBuffer.position(_columnOffsets[colId]);
+    ((Buffer) _currentRowDataByteBuffer).position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putDouble(value);
   }
 
@@ -154,7 +155,7 @@ public class DataTableBuilder {
       _reverseDictionaryMap.put(columnName, new HashMap<>());
     }
 
-    _currentRowDataByteBuffer.position(_columnOffsets[colId]);
+    ((Buffer) _currentRowDataByteBuffer).position(_columnOffsets[colId]);
     Integer dictId = dictionary.get(value);
     if (dictId == null) {
       dictId = dictionary.size();
@@ -173,7 +174,7 @@ public class DataTableBuilder {
     TODO: Store bytes as variable size data instead of String. Make the change for the next version data table for
           backward-compatibility
 
-    _currentRowDataByteBuffer.position(_columnOffsets[colId]);
+    ((Buffer) _currentRowDataByteBuffer).position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putInt(_variableSizeDataByteArrayOutputStream.size());
     byte[] bytes = value.getBytes();
     _currentRowDataByteBuffer.putInt(bytes.length);
@@ -183,7 +184,7 @@ public class DataTableBuilder {
 
   public void setColumn(int colId, Object value)
       throws IOException {
-    _currentRowDataByteBuffer.position(_columnOffsets[colId]);
+    ((Buffer) _currentRowDataByteBuffer).position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putInt(_variableSizeDataByteArrayOutputStream.size());
     int objectTypeValue = ObjectSerDeUtils.ObjectType.getObjectType(value).getValue();
     byte[] bytes = ObjectSerDeUtils.serialize(value, objectTypeValue);
@@ -194,7 +195,7 @@ public class DataTableBuilder {
 
   public void setColumn(int colId, int[] values)
       throws IOException {
-    _currentRowDataByteBuffer.position(_columnOffsets[colId]);
+    ((Buffer) _currentRowDataByteBuffer).position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putInt(_variableSizeDataByteArrayOutputStream.size());
     _currentRowDataByteBuffer.putInt(values.length);
     for (int value : values) {
@@ -204,7 +205,7 @@ public class DataTableBuilder {
 
   public void setColumn(int colId, long[] values)
       throws IOException {
-    _currentRowDataByteBuffer.position(_columnOffsets[colId]);
+    ((Buffer) _currentRowDataByteBuffer).position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putInt(_variableSizeDataByteArrayOutputStream.size());
     _currentRowDataByteBuffer.putInt(values.length);
     for (long value : values) {
@@ -214,7 +215,7 @@ public class DataTableBuilder {
 
   public void setColumn(int colId, float[] values)
       throws IOException {
-    _currentRowDataByteBuffer.position(_columnOffsets[colId]);
+    ((Buffer) _currentRowDataByteBuffer).position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putInt(_variableSizeDataByteArrayOutputStream.size());
     _currentRowDataByteBuffer.putInt(values.length);
     for (float value : values) {
@@ -224,7 +225,7 @@ public class DataTableBuilder {
 
   public void setColumn(int colId, double[] values)
       throws IOException {
-    _currentRowDataByteBuffer.position(_columnOffsets[colId]);
+    ((Buffer) _currentRowDataByteBuffer).position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putInt(_variableSizeDataByteArrayOutputStream.size());
     _currentRowDataByteBuffer.putInt(values.length);
     for (double value : values) {
@@ -234,7 +235,7 @@ public class DataTableBuilder {
 
   public void setColumn(int colId, String[] values)
       throws IOException {
-    _currentRowDataByteBuffer.position(_columnOffsets[colId]);
+    ((Buffer) _currentRowDataByteBuffer).position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putInt(_variableSizeDataByteArrayOutputStream.size());
     _currentRowDataByteBuffer.putInt(values.length);
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/compression/PassThroughCompressor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/compression/PassThroughCompressor.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.io.compression;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 
@@ -35,7 +36,7 @@ public class PassThroughCompressor implements ChunkCompressor {
     outCompressed.put(inUncompressed);
 
     // Make the output ByteBuffer read for read.
-    outCompressed.flip();
+    ((Buffer) outCompressed).flip();
     return outCompressed.limit();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/compression/PassThroughDecompressor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/compression/PassThroughDecompressor.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.io.compression;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 
 
@@ -32,7 +33,7 @@ public class PassThroughDecompressor implements ChunkDecompressor {
     decompressedOutput.put(compressedInput);
 
     // Flip the output ByteBuffer for reading.
-    decompressedOutput.flip();
+    ((Buffer) decompressedOutput).flip();
     return decompressedOutput.limit();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/reader/impl/v1/BaseChunkSingleValueReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/reader/impl/v1/BaseChunkSingleValueReader.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.io.reader.impl.v1;
 
 import com.google.common.base.Preconditions;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import org.apache.pinot.core.io.compression.ChunkCompressorFactory;
 import org.apache.pinot.core.io.compression.ChunkDecompressor;
@@ -137,7 +138,7 @@ public abstract class BaseChunkSingleValueReader extends BaseSingleColumnSingleV
     }
 
     ByteBuffer decompressedBuffer = context.getChunkBuffer();
-    decompressedBuffer.clear();
+    ((Buffer) decompressedBuffer).clear();
 
     try {
       _chunkDecompressor.decompress(_dataBuffer.toDirectByteBuffer(chunkPosition, chunkSize), decompressedBuffer);

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/reader/impl/v1/FixedByteChunkSingleValueReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/reader/impl/v1/FixedByteChunkSingleValueReader.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.io.reader.impl.v1;
 
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import org.apache.pinot.core.io.reader.impl.ChunkReaderContext;
 import org.apache.pinot.core.io.writer.impl.v1.FixedByteChunkSingleValueWriter;
@@ -130,7 +131,7 @@ public class FixedByteChunkSingleValueReader extends BaseChunkSingleValueReader 
     ByteBuffer chunkBuffer = getChunkForRow(row, context);
 
     byte[] bytes = _reusableBytes.get();
-    chunkBuffer.position(chunkRowId * _lengthOfLongestEntry);
+    ((Buffer) chunkBuffer).position(chunkRowId * _lengthOfLongestEntry);
     chunkBuffer.get(bytes);
     return bytes;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/reader/impl/v1/VarByteChunkSingleValueReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/reader/impl/v1/VarByteChunkSingleValueReader.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.io.reader.impl.v1;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.core.io.reader.impl.ChunkReaderContext;
@@ -61,7 +62,7 @@ public class VarByteChunkSingleValueReader extends BaseChunkSingleValueReader {
     int length = nextRowOffset - rowOffset;
     byte[] bytes = _reusableBytes.get();
 
-    chunkBuffer.position(rowOffset);
+    ((Buffer) chunkBuffer).position(rowOffset);
     chunkBuffer.get(bytes, 0, length);
 
     return StringUtil.decodeUtf8(bytes, 0, length);
@@ -83,7 +84,7 @@ public class VarByteChunkSingleValueReader extends BaseChunkSingleValueReader {
     int length = nextRowOffset - rowOffset;
     byte[] bytes = new byte[length];
 
-    chunkBuffer.position(rowOffset);
+    ((Buffer) chunkBuffer).position(rowOffset);
     chunkBuffer.get(bytes, 0, length);
     return bytes;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/v1/BaseChunkSingleValueWriter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/v1/BaseChunkSingleValueWriter.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import org.apache.pinot.core.io.compression.ChunkCompressor;
@@ -138,7 +139,7 @@ public abstract class BaseChunkSingleValueWriter implements SingleColumnSingleVa
     }
 
     // Write the header and close the file.
-    _header.flip();
+    ((Buffer) _header).flip();
     _dataFile.write(_header, 0);
     _dataFile.close();
   }
@@ -202,12 +203,12 @@ public abstract class BaseChunkSingleValueWriter implements SingleColumnSingleVa
    */
   protected void writeChunk() {
     int sizeToWrite;
-    _chunkBuffer.flip();
+    ((Buffer) _chunkBuffer).flip();
 
     try {
       sizeToWrite = _chunkCompressor.compress(_chunkBuffer, _compressedBuffer);
       _dataFile.write(_compressedBuffer, _dataOffset);
-      _compressedBuffer.clear();
+      ((Buffer) _compressedBuffer).clear();
     } catch (IOException e) {
       LOGGER.error("Exception caught while compressing/writing data chunk", e);
       throw new RuntimeException(e);
@@ -221,6 +222,6 @@ public abstract class BaseChunkSingleValueWriter implements SingleColumnSingleVa
 
     _dataOffset += sizeToWrite;
 
-    _chunkBuffer.clear();
+    ((Buffer) _chunkBuffer).clear();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/v1/VarByteChunkSingleValueWriter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/v1/VarByteChunkSingleValueWriter.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.io.writer.impl.v1;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.Buffer;
 import javax.annotation.concurrent.NotThreadSafe;
 import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.core.io.compression.ChunkCompressorFactory;
@@ -94,7 +95,7 @@ public class VarByteChunkSingleValueWriter extends BaseChunkSingleValueWriter {
     _chunkBuffer.putInt(_chunkHeaderOffset, _chunkDataOffSet);
     _chunkHeaderOffset += CHUNK_HEADER_ENTRY_ROW_OFFSET_SIZE;
 
-    _chunkBuffer.position(_chunkDataOffSet);
+    ((Buffer) _chunkBuffer).position(_chunkDataOffSet);
     _chunkBuffer.put(bytes);
     _chunkDataOffSet += bytes.length;
 
@@ -114,7 +115,7 @@ public class VarByteChunkSingleValueWriter extends BaseChunkSingleValueWriter {
     }
 
     // Write the header and close the file.
-    _header.flip();
+    ((Buffer) _header).flip();
     _dataFile.write(_header, 0);
     _dataFile.close();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/memory/PinotByteBuffer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/memory/PinotByteBuffer.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.segment.memory;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.MappedByteBuffer;
@@ -234,7 +235,7 @@ public class PinotByteBuffer extends PinotDataBuffer {
       }
     } else {
       ByteBuffer duplicate = _buffer.duplicate();
-      duplicate.position(intOffset);
+      ((Buffer) duplicate).position(intOffset);
       duplicate.get(buffer, destOffset, size);
     }
   }
@@ -246,7 +247,7 @@ public class PinotByteBuffer extends PinotDataBuffer {
     int start = (int) offset;
     int end = start + (int) size;
     ByteBuffer duplicate = _buffer.duplicate();
-    duplicate.position(start).limit(end);
+    ((Buffer) duplicate).position(start).limit(end);
     buffer.readFrom(destOffset, duplicate);
   }
 
@@ -261,7 +262,7 @@ public class PinotByteBuffer extends PinotDataBuffer {
       }
     } else {
       ByteBuffer duplicate = _buffer.duplicate();
-      duplicate.position(intOffset);
+      ((Buffer) duplicate).position(intOffset);
       duplicate.put(buffer, srcOffset, size);
     }
   }
@@ -270,7 +271,7 @@ public class PinotByteBuffer extends PinotDataBuffer {
   public void readFrom(long offset, ByteBuffer buffer) {
     assert offset <= Integer.MAX_VALUE;
     ByteBuffer duplicate = _buffer.duplicate();
-    duplicate.position((int) offset);
+    ((Buffer) duplicate).position((int) offset);
     duplicate.put(buffer);
   }
 
@@ -283,7 +284,7 @@ public class PinotByteBuffer extends PinotDataBuffer {
       ByteBuffer duplicate = _buffer.duplicate();
       int start = (int) offset;
       int end = start + (int) size;
-      duplicate.position(start).limit(end);
+      ((Buffer) duplicate).position(start).limit(end);
       randomAccessFile.getChannel().read(duplicate, srcOffset);
     }
   }
@@ -303,7 +304,7 @@ public class PinotByteBuffer extends PinotDataBuffer {
     assert start <= end;
     assert end <= Integer.MAX_VALUE;
     ByteBuffer duplicate = _buffer.duplicate();
-    duplicate.position((int) start).limit((int) end);
+    ((Buffer) duplicate).position((int) start).limit((int) end);
     ByteBuffer buffer = duplicate.slice();
     buffer.order(byteOrder);
     return new PinotByteBuffer(buffer, false, false);
@@ -315,7 +316,7 @@ public class PinotByteBuffer extends PinotDataBuffer {
     int start = (int) offset;
     int end = start + size;
     ByteBuffer duplicate = _buffer.duplicate();
-    duplicate.position(start).limit(end);
+    ((Buffer) duplicate).position(start).limit(end);
     ByteBuffer buffer = duplicate.slice();
     buffer.order(byteOrder);
     return buffer;

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/docidsets/BitmapDocIdSetTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/docidsets/BitmapDocIdSetTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.common.docidsets;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
@@ -58,7 +59,7 @@ public class BitmapDocIdSetTest {
       // there were runs to compress
       final ByteBuffer buffer = ByteBuffer.allocate(mutableRoaringBitmap.serializedSizeInBytes());
       mutableRoaringBitmap.serialize(buffer);
-      buffer.flip();
+      ((Buffer) buffer).flip();
       ImmutableRoaringBitmap immutableRoaringBitmap = new ImmutableRoaringBitmap(buffer);
       list.add(immutableRoaringBitmap);
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithBytesTypeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithBytesTypeTest.java
@@ -22,6 +22,7 @@ import com.google.common.primitives.Ints;
 import com.tdunning.math.stats.TDigest;
 import java.io.File;
 import java.io.IOException;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -294,7 +295,7 @@ public class SegmentGenerationWithBytesTypeTest {
         tDigest.asBytes(buffer);
         _fixedExpected.add(buffer.array());
 
-        buffer.flip();
+        ((Buffer) buffer).flip();
         record.put(FIXED_BYTES_UNSORTED_COLUMN, buffer);
 
         if (i % 2 == 0) {
@@ -305,7 +306,7 @@ public class SegmentGenerationWithBytesTypeTest {
         tDigest.asBytes(buffer);
         _varExpected.add(buffer.array());
 
-        buffer.flip();
+        ((Buffer) buffer).flip();
         record.put(VARIABLE_BYTES_COLUMN, buffer);
 
         recordWriter.append(record);

--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
@@ -28,6 +28,7 @@ import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageException;
 import com.google.cloud.storage.StorageOptions;
 import com.google.common.collect.ImmutableList;
+import java.nio.Buffer;
 import org.apache.commons.configuration.Configuration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.slf4j.Logger;
@@ -339,9 +340,9 @@ public class GcsPinotFS  extends PinotFS {
     ByteBuffer buffer = ByteBuffer.allocate(BUFFER_SIZE);
     SeekableByteChannel channel = Files.newByteChannel(srcFile.toPath());
     for (int bytesRead = channel.read(buffer); bytesRead != -1; bytesRead = channel.read(buffer)) {
-      buffer.flip();
+      ((Buffer) buffer).flip();
       writeChannel.write(buffer);
-      buffer.clear();
+      ((Buffer) buffer).clear();
     }
     writeChannel.close();
   }


### PR DESCRIPTION
It seems that compiling the code with SDK 9+ in a JDK 8 JVM will produce a `NoSuchMethodError`.
This can be reproduced by running any integration tests locally.
Casting ByteBuffer to Buffer for the following methods fixes the issue (verified after running integration test again):
```
position(int)
limit(int)
mark​()
reset​()
clear()
flip()
rewind​()
```

Similar issue from other repo: https://github.com/eclipse/jetty.project/issues/3244