### PR TITLE
add callback interface for upsert component

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -32,6 +32,7 @@ import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.data.manager.config.TableDataManagerConfig;
 import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
+import org.apache.pinot.core.data.manager.callback.DataManagerCallback;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
 import org.apache.pinot.core.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -108,14 +109,14 @@ public abstract class BaseTableDataManager implements TableDataManager {
    * @param immutableSegment Immutable segment to add
    */
   @Override
-  public void addSegment(ImmutableSegment immutableSegment) {
+  public void addSegment(ImmutableSegment immutableSegment, DataManagerCallback dataManagerCallback) {
     String segmentName = immutableSegment.getSegmentName();
     _logger.info("Adding immutable segment: {} to table: {}", segmentName, _tableNameWithType);
     _serverMetrics.addValueToTableGauge(_tableNameWithType, ServerGauge.DOCUMENT_COUNT,
         immutableSegment.getSegmentMetadata().getTotalDocs());
     _serverMetrics.addValueToTableGauge(_tableNameWithType, ServerGauge.SEGMENT_COUNT, 1L);
 
-    ImmutableSegmentDataManager newSegmentManager = new ImmutableSegmentDataManager(immutableSegment);
+    ImmutableSegmentDataManager newSegmentManager = new ImmutableSegmentDataManager(immutableSegment, dataManagerCallback);
     SegmentDataManager oldSegmentManager = _segmentDataManagerMap.put(segmentName, newSegmentManager);
     if (oldSegmentManager == null) {
       _logger.info("Added new immutable segment: {} to table: {}", segmentName, _tableNameWithType);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/TableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/TableDataManager.java
@@ -26,6 +26,8 @@ import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.data.manager.config.TableDataManagerConfig;
+import org.apache.pinot.core.data.manager.callback.DataManagerCallback;
+import org.apache.pinot.core.data.manager.callback.TableDataManagerCallback;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
 import org.apache.pinot.core.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -58,7 +60,7 @@ public interface TableDataManager {
   /**
    * Adds a loaded immutable segment into the table.
    */
-  void addSegment(ImmutableSegment immutableSegment);
+  void addSegment(ImmutableSegment immutableSegment, DataManagerCallback dataManagerCallback);
 
   /**
    * Adds a segment from local disk into the OFFLINE table.
@@ -122,4 +124,10 @@ public interface TableDataManager {
    * @return
    */
   File getTableDataDir();
+
+  /**
+   * get the callback object for this table, either no-op object for the regular table or upsert callback for
+   * upsert-enabled table
+   */
+  TableDataManagerCallback getTableDataManagerCallback();
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/DataManagerCallback.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/DataManagerCallback.java
@@ -27,8 +27,8 @@ import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import java.io.IOException;
 
 /**
- * create component inject to {@link org.apache.pinot.core.data.manager.SegmentDataManager} for handling extra logic for
- * other workflows other than regular append-mode ingestion.
+ * Component inject to {@link org.apache.pinot.core.data.manager.SegmentDataManager} for handling extra logic for
+ * upsert-enabled pinot ingestion mode.
  */
 @InterfaceStability.Evolving
 public interface DataManagerCallback {
@@ -36,7 +36,8 @@ public interface DataManagerCallback {
   void init() throws IOException;
 
   /**
-   * create a {@link IndexSegmentCallback} object to allow SegmentDataManager to create proper IndexSegment.
+   * create a {@link IndexSegmentCallback} object to allow SegmentDataManager to create proper IndexSegment that supports
+   * either append/upsert mode
    *
    * In append-tables callback, this method will create a DefaultIndexSegmentCallback
    * In upsert-tables callback, this method will create a UpsertDataManagerCallbackImpl

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/DataManagerCallback.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/DataManagerCallback.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager.callback;
+
+import org.apache.pinot.core.data.manager.SegmentDataManager;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+
+import java.io.IOException;
+
+/**
+ * component inject to {@link org.apache.pinot.core.data.manager.SegmentDataManager} for handling extra logic for
+ * other workflows other than regular append-mode ingestion.
+ */
+public interface DataManagerCallback {
+
+  void init() throws IOException;
+
+  /**
+   * component inject to {@link org.apache.pinot.core.indexsegment.IndexSegment} for handling extra logic for
+   * other workflows other than regular append-mode ingestion.
+   */
+  IndexSegmentCallback getIndexSegmentCallback();
+
+  /**
+   * process the row after transformation in the ingestion process
+   * this mostly exists such that we can attach offset info to generic rows object.
+   * happens after the row has been ingested into pinot but before the row is indexed
+   * @param row the row of newly ingested and transformed data from upstream
+   * @param offset the offset of this particular pinot record
+   */
+  void processTransformedRow(GenericRow row, StreamPartitionMsgOffset offset);
+
+  /**
+   * process the row after we have finished the index the current row
+   * ensure that we can emit the metadata for a primary key entry to the coordinator service
+   * @param row the row we just index to the current segment
+   * @param offset the offset associated with the current row
+   */
+  void postIndexProcessing(GenericRow row, StreamPartitionMsgOffset offset);
+
+  /**
+   * callback for when a realtime segment data manager done with the current consumption loop
+   * for the data associated with a segment
+   */
+  void postConsumeLoop();
+
+  /**
+   * callback when the associated data manager is destroyed by pinot server in call {@link SegmentDataManager#destroy()}
+   * ensure we can remove any data initialized by this callback object
+   */
+  void destroy();
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/IndexSegmentCallback.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/IndexSegmentCallback.java
@@ -18,29 +18,47 @@
  */
 package org.apache.pinot.core.data.manager.callback;
 
+import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.segment.index.column.ColumnIndexContainer;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
+import org.apache.pinot.spi.annotations.InterfaceStability;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 
 import java.util.Map;
 
 /**
- * component inject to {@link org.apache.pinot.core.indexsegment.IndexSegment} for handling extra logic for
+ * component inject to {@link IndexSegment} for handling extra logic for
  * other workflows other than regular append-mode ingestion.
  */
+@InterfaceStability.Evolving
 public interface IndexSegmentCallback {
 
   /**
-   * initialize the callback from {@link org.apache.pinot.core.indexsegment.IndexSegment}
+   * initialize the callback from {@link IndexSegment}. This happens in constructor of {@link IndexSegment} class and
+   * happens after all other component in those constructor has been created
+   *
+   * In append-tables callback, this method will do nothing
+   * In upsert-tables callback, this method will initialize the necessary virtual columns for upsert table
+   * (offset mapping, $validFrom, $validUntil columns)
+   *
+   * this method ensure that virtual columns index (forward/reverted index) can be created properly as they requires
+   * insight into docId and other IndexSegment information
+   *
    * @param segmentMetadata the metadata associated with the current segment
    * @param columnIndexContainerMap mapping of necessary column name and the associate columnIndexContainer
    */
   void init(SegmentMetadata segmentMetadata, Map<String, ColumnIndexContainer> columnIndexContainerMap);
 
   /**
-   * perform any operation from the callback for the given row after it has been processed and index
-   * right now this method is a bit duplicate of
-   * {@link org.apache.pinot.core.data.manager.callback.IndexSegmentCallback#postProcessRecords(GenericRow, int)}
+   * perform any operation from the callback for the given row after it has been processed and index.
+   * This method happens after indexing finished in MutableSegmentImpl.index(GenericRow, RowMetadata) method
+   *
+   * In append-tables callback, this method will do nothing
+   * In upsert-tables callback, this method will build offset mapping and update virtual columns for the column if necessary
+   *
+   * This method is similar to
+   * {@link org.apache.pinot.core.data.manager.callback.DataManagerCallback#postIndexProcessing(GenericRow, StreamPartitionMsgOffset)}
    * However, the other method don't have information to docID and it is necessary for upsert virtual columns
    * to have these information to build the forward index and offset columns to build mapping between offset -> docId
    *
@@ -51,8 +69,9 @@ public interface IndexSegmentCallback {
 
   /**
    * retrieve a information related to an upsert-enable segment virtual column for debug purpose
+   *
    * @param offset the offset of the record we are trying to get the virtual columnn data for
    * @return string representation of the virtual column data information
    */
-  String getVirtualColumnInfo(long offset);
+  String getVirtualColumnInfo(StreamPartitionMsgOffset offset);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/IndexSegmentCallback.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/IndexSegmentCallback.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager.callback;
+
+import org.apache.pinot.core.segment.index.column.ColumnIndexContainer;
+import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
+import org.apache.pinot.spi.data.readers.GenericRow;
+
+import java.util.Map;
+
+/**
+ * component inject to {@link org.apache.pinot.core.indexsegment.IndexSegment} for handling extra logic for
+ * other workflows other than regular append-mode ingestion.
+ */
+public interface IndexSegmentCallback {
+
+  /**
+   * initialize the callback from {@link org.apache.pinot.core.indexsegment.IndexSegment}
+   * @param segmentMetadata the metadata associated with the current segment
+   * @param columnIndexContainerMap mapping of necessary column name and the associate columnIndexContainer
+   */
+  void init(SegmentMetadata segmentMetadata, Map<String, ColumnIndexContainer> columnIndexContainerMap);
+
+  /**
+   * perform any operation from the callback for the given row after it has been processed and index
+   * right now this method is a bit duplicate of
+   * {@link org.apache.pinot.core.data.manager.callback.IndexSegmentCallback#postProcessRecords(GenericRow, int)}
+   * However, the other method don't have information to docID and it is necessary for upsert virtual columns
+   * to have these information to build the forward index and offset columns to build mapping between offset -> docId
+   *
+   * @param row the current pinot row we just indexed into the current IndexSegment
+   * @param docId the docId of this record
+   */
+  void postProcessRecords(GenericRow row, int docId);
+
+  /**
+   * retrieve a information related to an upsert-enable segment virtual column for debug purpose
+   * @param offset the offset of the record we are trying to get the virtual columnn data for
+   * @return string representation of the virtual column data information
+   */
+  String getVirtualColumnInfo(long offset);
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/IndexSegmentCallback.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/IndexSegmentCallback.java
@@ -66,11 +66,4 @@ public interface IndexSegmentCallback {
    */
   void onRowIndexed(GenericRow row, int docId);
 
-  /**
-   * Retrieve information related to an upsert-enable segment virtual column for debug purpose
-   *
-   * @param offset the offset of the record we are trying to get the virtual columnn data for
-   * @return string representation of the virtual column data information
-   */
-  String getVirtualColumnInfo(StreamPartitionMsgOffset offset);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/TableDataManagerCallback.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/TableDataManagerCallback.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.data.manager.callback;
 
 import org.apache.pinot.common.metrics.ServerMetrics;
-import org.apache.pinot.core.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.spi.annotations.InterfaceStability;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
@@ -35,23 +34,22 @@ public interface TableDataManagerCallback {
 
   /**
    * Initialize callback from {@link org.apache.pinot.core.data.manager.TableDataManager}, injected into
-   * {@link org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager} constructor to make sure this class is
-   * initialized during the creation process.
+   * {@link org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager} init() method to make sure this class
+   * is initialized during the creation process.
    */
   void init();
 
   /**
    * Handle any internal logic for upsert table to add segment to its internal update log storage. this method is injected into
-   * {@link org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager#addSegment(File, IndexLoadingConfig)}
+   * RealtimeTableDataManager#addSegment(File, IndexLoadingConfig)
    *
-   * In append-tables callback, this method will do nothing
-   * In upsert-tables callback, this method will notify the local update log storage to create proper storage provider
+   * In upsert-enabled tables callback, this method will notify the local update log storage to create proper storage provider
    * for this new segment
    *
    * @param tableName the name of the table we are trying to add the segment to
    * @param segmentName the name of the segment we are trying to add
    */
-  void addSegment(String tableName, String segmentName);
+  void onSegmentAdd(String tableName, String segmentName);
 
   /**
    * Return a callback object for a mutable segment data manager callback component when a table create a new

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/TableDataManagerCallback.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/TableDataManagerCallback.java
@@ -27,7 +27,7 @@ import org.apache.pinot.spi.data.Schema;
 import java.io.File;
 
 /**
- * component inject to {@link org.apache.pinot.core.data.manager.TableDataManager} for handling extra logic for
+ * Component inject to {@link org.apache.pinot.core.data.manager.TableDataManager} for handling extra logic for
  * other workflows other than regular append-mode ingestion.
  */
 @InterfaceStability.Evolving
@@ -41,7 +41,7 @@ public interface TableDataManagerCallback {
   void init();
 
   /**
-   * handle any internal logic for upsert table to add segment to its internal table storage. this method is injected into
+   * Handle any internal logic for upsert table to add segment to its internal update log storage. this method is injected into
    * {@link org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager#addSegment(File, IndexLoadingConfig)}
    *
    * In append-tables callback, this method will do nothing
@@ -54,8 +54,9 @@ public interface TableDataManagerCallback {
   void addSegment(String tableName, String segmentName);
 
   /**
-   * return a callback object for a mutable segment data manager callback component when a table create a new
-   * immutable {@link org.apache.pinot.core.data.manager.SegmentDataManager}
+   * Return a callback object for a mutable segment data manager callback component when a table create a new
+   * mutable {@link org.apache.pinot.core.data.manager.SegmentDataManager}. We will create a proper callback based on
+   * whether the current pinot server config and whether the table is upsert-enabled
    *
    * @param tableName the name of the table
    * @param segmentName the name of the segment
@@ -69,8 +70,9 @@ public interface TableDataManagerCallback {
       TableConfig tableConfig, ServerMetrics serverMetrics);
 
   /**
-   * return a callback object for an Immutable segment data manager callback component when a table create a new
-   * immutable {@link org.apache.pinot.core.data.manager.SegmentDataManager}
+   * Return a callback object for an Immutable segment data manager callback component when a table create a new
+   * immutable {@link org.apache.pinot.core.data.manager.SegmentDataManager}, we will create a proper callback based on
+   * whether the current pinot server config and whether the table is upsert-enabled
    *
    * @param tableName the name of the table
    * @param segmentName the name of the segment
@@ -84,15 +86,8 @@ public interface TableDataManagerCallback {
       TableConfig tableConfig, ServerMetrics serverMetrics);
 
   /**
-   * create a no-op default callback for segmentDataManager that don't support upsert
+   * Create a no-op default callback for segmentDataManager that don't support upsert
    * (eg, offline table, HLL consumers etc)
-   *
-   * @param tableName the name of the table
-   * @param segmentName the name of the segment
-   * @param schema the table schema
-   * @param tableConfig the config of the table
-   * @param serverMetrics the server metrics object
-   * @return a no-op default callback for data manager
    */
   DataManagerCallback getDefaultDataManagerCallback();
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/TableDataManagerCallback.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/TableDataManagerCallback.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager.callback;
+
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.core.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+
+import java.io.File;
+
+/**
+ * component inject to {@link org.apache.pinot.core.data.manager.TableDataManager} for handling extra logic for
+ * other workflows other than regular append-mode ingestion.
+ */
+public interface TableDataManagerCallback {
+
+  void init();
+
+  /**
+   * Callback to ensure other components related to the callback are added when
+   * {@link org.apache.pinot.core.data.manager.TableDataManager#addSegment(File, IndexLoadingConfig)} is called
+   */
+  void addSegment(String tableName, String segmentName);
+
+  /**
+   * return a callback object for a mutable segment data manager callback component when a table create a new
+   * immutable {@link org.apache.pinot.core.data.manager.SegmentDataManager}
+   */
+  DataManagerCallback getMutableDataManagerCallback(String tableName, String segmentName, Schema schema,
+      TableConfig tableConfig, ServerMetrics serverMetrics);
+
+  /**
+   * return a callback object for an Immutable segment data manager callback component when a table create a new
+   * immutable {@link org.apache.pinot.core.data.manager.SegmentDataManager}
+   */
+  DataManagerCallback getImmutableDataManagerCallback(String tableName, String segmentName, Schema schema,
+      TableConfig tableConfig, ServerMetrics serverMetrics);
+
+  /**
+   * create a no-op default callback for segmentDataManager that don't support upsert
+   * (eg, offline table, HLL consumers etc)
+   * @return a no-op default callback for data manager
+   */
+  DataManagerCallback getDefaultDataManagerCallback();
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/DefaultDataManagerCallbackImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/DefaultDataManagerCallbackImpl.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager.callback.impl;
+
+import org.apache.pinot.core.data.manager.callback.DataManagerCallback;
+import org.apache.pinot.core.data.manager.callback.IndexSegmentCallback;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+
+
+/**
+ * class that used for regular append-only ingestion mode or data processing that don't support upsert
+ * all method are no-op to ensure that regular append-only ingestion mode has the same performance as before
+ */
+public class DefaultDataManagerCallbackImpl implements DataManagerCallback {
+
+  public static final DefaultDataManagerCallbackImpl INSTANCE = new DefaultDataManagerCallbackImpl();
+
+  private final IndexSegmentCallback _indexSegmentCallback;
+
+  private DefaultDataManagerCallbackImpl() {
+    _indexSegmentCallback = DefaultIndexSegmentCallback.INSTANCE;
+  }
+
+  @Override
+  public void init() {
+  }
+
+  /**
+   * return cached default index segment callback to ensure better performance
+   * @return a default cached object of {@link org.apache.pinot.core.data.manager.callback.IndexSegmentCallback}
+   */
+  public IndexSegmentCallback getIndexSegmentCallback() {
+    return _indexSegmentCallback;
+  }
+
+  @Override
+  public void processTransformedRow(GenericRow row, StreamPartitionMsgOffset offset) {
+  }
+
+  @Override
+  public void postIndexProcessing(GenericRow row, StreamPartitionMsgOffset offset) {
+  }
+
+  @Override
+  public void postConsumeLoop() {
+  }
+
+  @Override
+  public void destroy() {
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/DefaultDataManagerCallbackImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/DefaultDataManagerCallbackImpl.java
@@ -23,7 +23,6 @@ import org.apache.pinot.core.data.manager.callback.IndexSegmentCallback;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 
-
 /**
  * class that used for regular append-only ingestion mode or data processing that don't support upsert
  * all method are no-op to ensure that regular append-only ingestion mode has the same performance as before

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/DefaultDataManagerCallbackImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/DefaultDataManagerCallbackImpl.java
@@ -42,7 +42,7 @@ public class DefaultDataManagerCallbackImpl implements DataManagerCallback {
   }
 
   /**
-   * return cached default index segment callback to ensure better performance
+   * return cached default index segment callback for better performance
    * @return a default cached object of {@link org.apache.pinot.core.data.manager.callback.IndexSegmentCallback}
    */
   public IndexSegmentCallback getIndexSegmentCallback() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/DefaultDataManagerCallbackImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/DefaultDataManagerCallbackImpl.java
@@ -38,7 +38,7 @@ public class DefaultDataManagerCallbackImpl implements DataManagerCallback {
   }
 
   @Override
-  public void init() {
+  public void onDataManagerCreation() {
   }
 
   /**
@@ -50,18 +50,18 @@ public class DefaultDataManagerCallbackImpl implements DataManagerCallback {
   }
 
   @Override
-  public void processTransformedRow(GenericRow row, StreamPartitionMsgOffset offset) {
+  public void onRowTransformed(GenericRow row, StreamPartitionMsgOffset offset) {
   }
 
   @Override
-  public void postIndexProcessing(GenericRow row, StreamPartitionMsgOffset offset) {
+  public void onRowIndexed(GenericRow row, StreamPartitionMsgOffset offset) {
   }
 
   @Override
-  public void postConsumeLoop() {
+  public void onConsumptionStoppedOrEndReached() {
   }
 
   @Override
-  public void destroy() {
+  public void onDataManagerDestroyed() {
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/DefaultIndexSegmentCallback.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/DefaultIndexSegmentCallback.java
@@ -45,9 +45,4 @@ public class DefaultIndexSegmentCallback implements IndexSegmentCallback {
   @Override
   public void onRowIndexed(GenericRow row, int docId) {
   }
-
-  @Override
-  public String getVirtualColumnInfo(StreamPartitionMsgOffset offset) {
-    return Strings.EMPTY;
-  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/DefaultIndexSegmentCallback.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/DefaultIndexSegmentCallback.java
@@ -39,11 +39,11 @@ public class DefaultIndexSegmentCallback implements IndexSegmentCallback {
   }
 
   @Override
-  public void init(SegmentMetadata segmentMetadata, Map<String, ColumnIndexContainer> columnIndexContainerMap) {
+  public void onIndexSegmentCreation(SegmentMetadata segmentMetadata, Map<String, ColumnIndexContainer> columnIndexContainerMap) {
   }
 
   @Override
-  public void postProcessRecords(GenericRow row, int docId) {
+  public void onRowIndexed(GenericRow row, int docId) {
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/DefaultIndexSegmentCallback.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/DefaultIndexSegmentCallback.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager.callback.impl;
+
+import joptsimple.internal.Strings;
+import org.apache.pinot.core.data.manager.callback.IndexSegmentCallback;
+import org.apache.pinot.core.segment.index.column.ColumnIndexContainer;
+import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
+import org.apache.pinot.spi.data.readers.GenericRow;
+
+import java.util.Map;
+
+/**
+ * class that used for regular append-only ingestion mode or data processing that don't support upsert
+ * all method are no-op to ensure that regular append-only ingestion mode has the same performance as before
+ */
+public class DefaultIndexSegmentCallback implements IndexSegmentCallback {
+
+  public static final DefaultIndexSegmentCallback INSTANCE = new DefaultIndexSegmentCallback();
+
+  private DefaultIndexSegmentCallback() {
+  }
+
+  @Override
+  public void init(SegmentMetadata segmentMetadata, Map<String, ColumnIndexContainer> columnIndexContainerMap) {
+  }
+
+  @Override
+  public void postProcessRecords(GenericRow row, int docId) {
+  }
+
+  @Override
+  public String getVirtualColumnInfo(long offset) {
+    return Strings.EMPTY;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/DefaultIndexSegmentCallback.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/DefaultIndexSegmentCallback.java
@@ -23,6 +23,7 @@ import org.apache.pinot.core.data.manager.callback.IndexSegmentCallback;
 import org.apache.pinot.core.segment.index.column.ColumnIndexContainer;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 
 import java.util.Map;
 
@@ -46,7 +47,7 @@ public class DefaultIndexSegmentCallback implements IndexSegmentCallback {
   }
 
   @Override
-  public String getVirtualColumnInfo(long offset) {
+  public String getVirtualColumnInfo(StreamPartitionMsgOffset offset) {
     return Strings.EMPTY;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/DefaultTableDataManagerCallbackImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/DefaultTableDataManagerCallbackImpl.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager.callback.impl;
+
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.core.data.manager.callback.DataManagerCallback;
+import org.apache.pinot.core.data.manager.callback.TableDataManagerCallback;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+
+/**
+ * class that used for regular append-only ingestion mode or data processing that don't support upsert
+ * all method are no-op to ensure that regular append-only ingestion mode has the same performance as before
+ */
+public class DefaultTableDataManagerCallbackImpl implements TableDataManagerCallback {
+
+  private static final DefaultDataManagerCallbackImpl DEFAULT_DM_CALLBACK = DefaultDataManagerCallbackImpl.INSTANCE;
+
+  @Override
+  public void init() {
+  }
+
+  @Override
+  public void addSegment(String tableName, String segmentName) {
+  }
+
+  /**
+   * return the default cached instance of data manager callback to ensure better performance
+   */
+  @Override
+  public DataManagerCallback getMutableDataManagerCallback(String tableName, String segmentName,
+      Schema schema, TableConfig tableConfig, ServerMetrics serverMetrics) {
+    return DEFAULT_DM_CALLBACK;
+  }
+
+  @Override
+  public DataManagerCallback getImmutableDataManagerCallback(String tableName, String segmentName,
+      Schema schema, TableConfig tableConfig, ServerMetrics serverMetrics) {
+    return DEFAULT_DM_CALLBACK;
+  }
+  @Override
+  public DataManagerCallback getDefaultDataManagerCallback() {
+    return DEFAULT_DM_CALLBACK;
+  }
+
+
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/DefaultTableDataManagerCallbackImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/DefaultTableDataManagerCallbackImpl.java
@@ -37,7 +37,7 @@ public class DefaultTableDataManagerCallbackImpl implements TableDataManagerCall
   }
 
   @Override
-  public void addSegment(String tableName, String segmentName) {
+  public void onSegmentAdd(String tableName, String segmentName) {
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/TableDataManagerCallbackProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/TableDataManagerCallbackProvider.java
@@ -64,8 +64,6 @@ public class TableDataManagerCallbackProvider {
         LOGGER.error("failed to load table data manager class {}", upsertClassName);
         ExceptionUtils.rethrow(e);
       }
-      Preconditions.checkState(upsertTableDataManagerCallBackClass.isAssignableFrom(TableDataManagerCallback.class),
-          "configured class not assignable from Callback class");
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/TableDataManagerCallbackProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/TableDataManagerCallbackProvider.java
@@ -22,7 +22,6 @@ import com.google.common.base.Preconditions;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
-import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.core.data.manager.callback.TableDataManagerCallback;
 import org.apache.pinot.core.data.manager.config.TableDataManagerConfig;
 import org.slf4j.Logger;
@@ -58,8 +57,6 @@ public class TableDataManagerCallbackProvider {
       LOGGER.error("failed to load table data manager class {}", appendClassName, e);
       ExceptionUtils.rethrow(e);
     }
-    Preconditions.checkState(defaultTableDataManagerCallBackClass.isAssignableFrom(TableDataManagerCallback.class),
-        "configured class not assignable from Callback class", defaultTableDataManagerCallBackClass);
     if (StringUtils.isNotEmpty(upsertClassName)) {
       try {
         upsertTableDataManagerCallBackClass = (Class<TableDataManagerCallback>) Class.forName(upsertClassName);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/TableDataManagerCallbackProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/callback/impl/TableDataManagerCallbackProvider.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager.callback.impl;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.pinot.common.utils.CommonConstants;
+import org.apache.pinot.core.data.manager.callback.TableDataManagerCallback;
+import org.apache.pinot.core.data.manager.config.TableDataManagerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * class for creating appropriate {@link TableDataManagerCallback} depends on the config
+ * allow upsert-enabled pinot server to inject proper logic while keeping append-only pinot server keep the same
+ */
+public class TableDataManagerCallbackProvider {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(TableDataManagerCallbackProvider.class);
+
+  private Class<TableDataManagerCallback> defaultTableDataManagerCallBackClass;
+  private Class<TableDataManagerCallback> upsertTableDataManagerCallBackClass;
+
+  public static final String UPSERT_CALLBACK_CLASS_CONFIG_KEY = "upsert.tableDataManager.callback";
+  public static final String DEFAULT_CALLBACK_CLASS_CONFIG_KEY = "append.tableDataManager.callback";
+  public static final String CALLBACK_CLASS_CONFIG_DEFAULT = DefaultTableDataManagerCallbackImpl.class.getName();
+
+  /**
+   * Class to initialize table data manager callback provider
+   * Pinot will extract callback runtime configuration from config key {@value UPSERT_CALLBACK_CLASS_CONFIG_KEY}
+   * to create proper callback class for upsert-enabled pinot server environment
+   * @param configuration the configuration for the pinot upsert components
+   */
+  public TableDataManagerCallbackProvider(Configuration configuration) {
+    String appendClassName = configuration.getString(DEFAULT_CALLBACK_CLASS_CONFIG_KEY, CALLBACK_CLASS_CONFIG_DEFAULT);
+    String upsertClassName = configuration.getString(UPSERT_CALLBACK_CLASS_CONFIG_KEY);
+    try {
+      defaultTableDataManagerCallBackClass = (Class<TableDataManagerCallback>) Class.forName(appendClassName);
+    } catch (ClassNotFoundException e) {
+      LOGGER.error("failed to load table data manager class {}", appendClassName, e);
+      ExceptionUtils.rethrow(e);
+    }
+    Preconditions.checkState(defaultTableDataManagerCallBackClass.isAssignableFrom(TableDataManagerCallback.class),
+        "configured class not assignable from Callback class", defaultTableDataManagerCallBackClass);
+    if (StringUtils.isNotEmpty(upsertClassName)) {
+      try {
+        upsertTableDataManagerCallBackClass = (Class<TableDataManagerCallback>) Class.forName(upsertClassName);
+      } catch (ClassNotFoundException e) {
+        LOGGER.error("failed to load table data manager class {}", upsertClassName);
+        ExceptionUtils.rethrow(e);
+      }
+      Preconditions.checkState(upsertTableDataManagerCallBackClass.isAssignableFrom(TableDataManagerCallback.class),
+          "configured class not assignable from Callback class");
+    }
+  }
+
+  /**
+   * create a proper callback for the table, depends on whether the table is configured for upsert or not
+   * @param tableDataManagerConfig the config for the table
+   */
+  public TableDataManagerCallback getTableDataManagerCallback(TableDataManagerConfig tableDataManagerConfig) {
+    if (tableDataManagerConfig.isTableForUpsert()) {
+      return getUpsertTableDataManagerCallback();
+    } else {
+      return getDefaultTableDataManagerCallback();
+    }
+  }
+
+  private TableDataManagerCallback getUpsertTableDataManagerCallback() {
+    try {
+      return upsertTableDataManagerCallBackClass.newInstance();
+    } catch (Exception ex) {
+      LOGGER.error("failed to initialize new table data manager callback {}", upsertTableDataManagerCallBackClass.getName());
+      ExceptionUtils.rethrow(ex);
+    }
+    return null;
+  }
+
+  public TableDataManagerCallback getDefaultTableDataManagerCallback() {
+    try {
+      return defaultTableDataManagerCallBackClass.newInstance();
+    } catch (Exception ex) {
+      LOGGER.error("failed to initialize new table data manager callback {}", upsertTableDataManagerCallBackClass.getName());
+      ExceptionUtils.rethrow(ex);
+    }
+    return null;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/config/TableDataManagerConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/config/TableDataManagerConfig.java
@@ -35,6 +35,7 @@ public class TableDataManagerConfig {
   private static final String TABLE_DATA_MANAGER_DATA_DIRECTORY = "directory";
   private static final String TABLE_DATA_MANAGER_CONSUMER_DIRECTORY = "consumerDirectory";
   private static final String TABLE_DATA_MANAGER_NAME = "name";
+  private static final String IS_TABLE_FOR_UPSERT = "isTableForUpsert";
 
   private final Configuration _tableDataManagerConfig;
 
@@ -62,6 +63,10 @@ public class TableDataManagerConfig {
     return _tableDataManagerConfig.getString(TABLE_DATA_MANAGER_NAME);
   }
 
+  public boolean isTableForUpsert() {
+    return _tableDataManagerConfig.getBoolean(IS_TABLE_FOR_UPSERT);
+  }
+
   public static TableDataManagerConfig getDefaultHelixTableDataManagerConfig(
       @Nonnull InstanceDataManagerConfig instanceDataManagerConfig, @Nonnull String tableNameWithType) {
     Configuration defaultConfig = new PropertiesConfiguration();
@@ -83,5 +88,9 @@ public class TableDataManagerConfig {
     // If we wish to override some table level configs using table config, override them here
     // Note: the configs in TableDataManagerConfig is immutable once the table is created, which mean it will not pick
     // up the latest table config
+
+    // provide information on whether this particular table support upsert or not
+    // set isTableForUpsert to true if the table config indicate this table is an upsert table
+    _tableDataManagerConfig.setProperty(IS_TABLE_FOR_UPSERT, tableConfig.getUpsertConfig() != null);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/ImmutableSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/ImmutableSegmentDataManager.java
@@ -18,8 +18,13 @@
  */
 package org.apache.pinot.core.data.manager.offline;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.pinot.core.data.manager.SegmentDataManager;
+import org.apache.pinot.core.data.manager.callback.DataManagerCallback;
+import org.apache.pinot.core.data.manager.callback.impl.DefaultDataManagerCallbackImpl;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
+
+import java.io.IOException;
 
 
 /**
@@ -28,9 +33,20 @@ import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
 public class ImmutableSegmentDataManager extends SegmentDataManager {
 
   private final ImmutableSegment _immutableSegment;
+  private final DataManagerCallback _dataManagerCallback;
 
   public ImmutableSegmentDataManager(ImmutableSegment immutableSegment) {
+    this(immutableSegment, DefaultDataManagerCallbackImpl.INSTANCE);
+  }
+
+  public ImmutableSegmentDataManager(ImmutableSegment immutableSegment, DataManagerCallback dataManagerCallback) {
     _immutableSegment = immutableSegment;
+    _dataManagerCallback = dataManagerCallback;
+    try {
+      _dataManagerCallback.init();
+    } catch (IOException ex) {
+      ExceptionUtils.rethrow(ex);
+    }
   }
 
   @Override
@@ -45,6 +61,7 @@ public class ImmutableSegmentDataManager extends SegmentDataManager {
 
   @Override
   public void destroy() {
+    _dataManagerCallback.destroy();
     _immutableSegment.destroy();
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/ImmutableSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/ImmutableSegmentDataManager.java
@@ -42,11 +42,7 @@ public class ImmutableSegmentDataManager extends SegmentDataManager {
   public ImmutableSegmentDataManager(ImmutableSegment immutableSegment, DataManagerCallback dataManagerCallback) {
     _immutableSegment = immutableSegment;
     _dataManagerCallback = dataManagerCallback;
-    try {
-      _dataManagerCallback.init();
-    } catch (IOException ex) {
-      ExceptionUtils.rethrow(ex);
-    }
+    _dataManagerCallback.onDataManagerCreation();
   }
 
   @Override
@@ -61,7 +57,7 @@ public class ImmutableSegmentDataManager extends SegmentDataManager {
 
   @Override
   public void destroy() {
-    _dataManagerCallback.destroy();
+    _dataManagerCallback.onDataManagerDestroyed();
     _immutableSegment.destroy();
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/OfflineTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/OfflineTableDataManager.java
@@ -20,6 +20,9 @@ package org.apache.pinot.core.data.manager.offline;
 
 import java.io.File;
 import javax.annotation.concurrent.ThreadSafe;
+
+import org.apache.pinot.core.data.manager.callback.DataManagerCallback;
+import org.apache.pinot.core.data.manager.callback.TableDataManagerCallback;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.core.data.manager.BaseTableDataManager;
@@ -32,6 +35,12 @@ import org.apache.pinot.core.segment.index.loader.IndexLoadingConfig;
  */
 @ThreadSafe
 public class OfflineTableDataManager extends BaseTableDataManager {
+
+  private TableDataManagerCallback _tableDataManagerCallback;
+
+  public OfflineTableDataManager(TableDataManagerCallback tableDataManagerCallback) {
+    _tableDataManagerCallback = tableDataManagerCallback;
+  }
 
   @Override
   protected void doInit() {
@@ -49,6 +58,13 @@ public class OfflineTableDataManager extends BaseTableDataManager {
   public void addSegment(File indexDir, IndexLoadingConfig indexLoadingConfig)
       throws Exception {
     Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
-    addSegment(ImmutableSegmentLoader.load(indexDir, indexLoadingConfig, schema));
+    DataManagerCallback callback = _tableDataManagerCallback.getDefaultDataManagerCallback();
+    addSegment(ImmutableSegmentLoader.load(indexDir, indexLoadingConfig,
+        callback, schema), callback);
+  }
+
+  @Override
+  public TableDataManagerCallback getTableDataManagerCallback() {
+    return _tableDataManagerCallback;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/TableDataManagerProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/TableDataManagerProvider.java
@@ -20,6 +20,9 @@ package org.apache.pinot.core.data.manager.offline;
 
 import java.util.concurrent.Semaphore;
 import javax.annotation.Nonnull;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metrics.ServerMetrics;
@@ -28,6 +31,7 @@ import org.apache.pinot.core.data.manager.config.InstanceDataManagerConfig;
 import org.apache.pinot.core.data.manager.config.TableDataManagerConfig;
 import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.core.data.manager.callback.impl.TableDataManagerCallbackProvider;
 
 
 /**
@@ -35,11 +39,18 @@ import org.apache.pinot.spi.config.table.TableType;
  */
 public class TableDataManagerProvider {
   private static Semaphore _segmentBuildSemaphore;
+  private static TableDataManagerCallbackProvider _tableDataManagerCallbackProvider;
 
   private TableDataManagerProvider() {
   }
 
   public static void init(InstanceDataManagerConfig instanceDataManagerConfig) {
+    init(instanceDataManagerConfig, new TableDataManagerCallbackProvider(new PropertiesConfiguration()));
+  }
+
+  public static void init(InstanceDataManagerConfig instanceDataManagerConfig,
+                          TableDataManagerCallbackProvider callbackProvider) {
+    _tableDataManagerCallbackProvider = callbackProvider;
     int maxParallelBuilds = instanceDataManagerConfig.getMaxParallelSegmentBuilds();
     if (maxParallelBuilds > 0) {
       _segmentBuildSemaphore = new Semaphore(maxParallelBuilds, true);
@@ -49,13 +60,16 @@ public class TableDataManagerProvider {
   public static TableDataManager getTableDataManager(@Nonnull TableDataManagerConfig tableDataManagerConfig,
       @Nonnull String instanceId, @Nonnull ZkHelixPropertyStore<ZNRecord> propertyStore,
       @Nonnull ServerMetrics serverMetrics) {
+    Preconditions.checkNotNull(_tableDataManagerCallbackProvider, "callback provider is not init");
     TableDataManager tableDataManager;
     switch (TableType.valueOf(tableDataManagerConfig.getTableDataManagerType())) {
       case OFFLINE:
-        tableDataManager = new OfflineTableDataManager();
+        tableDataManager = new OfflineTableDataManager(
+            _tableDataManagerCallbackProvider.getDefaultTableDataManagerCallback());
         break;
       case REALTIME:
-        tableDataManager = new RealtimeTableDataManager(_segmentBuildSemaphore);
+        tableDataManager = new RealtimeTableDataManager(_segmentBuildSemaphore,
+            _tableDataManagerCallbackProvider.getTableDataManagerCallback(tableDataManagerConfig));
         break;
       default:
         throw new IllegalStateException();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -451,6 +451,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   @Override
   public void destroy() {
     LOGGER.info("Trying to shutdown RealtimeSegmentDataManager : {}!", _segmentName);
+
     _isShuttingDown = true;
     try {
       _streamLevelConsumer.shutdown();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -29,6 +29,8 @@ import java.util.TimerTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.core.data.manager.callback.impl.DefaultIndexSegmentCallback;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.common.metadata.instance.InstanceZKMetadata;
 import org.apache.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
 import org.apache.pinot.common.metrics.ServerGauge;
@@ -50,6 +52,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConsumerFactory;
@@ -196,7 +199,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
                 indexLoadingConfig.isDirectRealtimeOffheapAllocation(), serverMetrics))
             .setStatsHistory(realtimeTableDataManager.getStatsHistory())
             .setNullHandlingEnabled(indexingConfig.isNullHandlingEnabled()).build();
-    _realtimeSegment = new MutableSegmentImpl(realtimeSegmentConfig);
+    _realtimeSegment = new MutableSegmentImpl(realtimeSegmentConfig, DefaultIndexSegmentCallback.INSTANCE);
 
     _notifier = realtimeTableDataManager;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -477,6 +477,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
             for (Object singleRow : (Collection) decodedRow.getValue(GenericRow.MULTIPLE_RECORDS_KEY)) {
               GenericRow transformedRow = _recordTransformer.transform((GenericRow) singleRow);
               if (transformedRow != null) {
+                _dataManagerCallback.processTransformedRow(transformedRow, _currentOffset);
                 realtimeRowsConsumedMeter = _serverMetrics
                     .addMeteredTableValue(_metricKeyName, ServerMeter.REALTIME_ROWS_CONSUMED, 1, realtimeRowsConsumedMeter);
                 indexedMessageCount++;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -230,7 +230,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     LoaderUtils.reloadFailureRecovery(indexDir);
 
     // tell callback to add segment
-    _tableDataManagerCallback.addSegment(_tableNameWithType, segmentName);
+    _tableDataManagerCallback.onSegmentAdd(_tableNameWithType, segmentName);
 
     if (indexDir.exists() && (realtimeSegmentZKMetadata.getStatus() == Status.DONE)) {
       // Segment already exists on disk, and metadata has been committed. Treat it like an offline segment

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -229,6 +229,9 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     // of the index directory and loading segment from it
     LoaderUtils.reloadFailureRecovery(indexDir);
 
+    // tell callback to add segment
+    _tableDataManagerCallback.addSegment(_tableNameWithType, segmentName);
+
     if (indexDir.exists() && (realtimeSegmentZKMetadata.getStatus() == Status.DONE)) {
       // Segment already exists on disk, and metadata has been committed. Treat it like an offline segment
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -24,6 +24,11 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.common.DataSource;
+
+import org.apache.pinot.core.data.manager.callback.IndexSegmentCallback;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.core.indexsegment.IndexSegmentUtils;
 import org.apache.pinot.core.io.reader.DataFileReader;
 import org.apache.pinot.core.segment.index.column.ColumnIndexContainer;
@@ -34,9 +39,6 @@ import org.apache.pinot.core.segment.index.readers.InvertedIndexReader;
 import org.apache.pinot.core.segment.store.SegmentDirectory;
 import org.apache.pinot.core.startree.v2.StarTreeV2;
 import org.apache.pinot.core.startree.v2.store.StarTreeIndexContainer;
-import org.apache.pinot.spi.data.FieldSpec;
-import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.data.readers.GenericRow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,14 +50,19 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
   private final SegmentMetadataImpl _segmentMetadata;
   private final Map<String, ColumnIndexContainer> _indexContainerMap;
   private final StarTreeIndexContainer _starTreeIndexContainer;
+  private final IndexSegmentCallback _segmentCallback;
+
 
   public ImmutableSegmentImpl(SegmentDirectory segmentDirectory, SegmentMetadataImpl segmentMetadata,
       Map<String, ColumnIndexContainer> columnIndexContainerMap,
-      @Nullable StarTreeIndexContainer starTreeIndexContainer) {
+      @Nullable StarTreeIndexContainer starTreeIndexContainer, IndexSegmentCallback segmentCallback) {
     _segmentDirectory = segmentDirectory;
     _segmentMetadata = segmentMetadata;
     _indexContainerMap = columnIndexContainerMap;
     _starTreeIndexContainer = starTreeIndexContainer;
+    _segmentCallback = segmentCallback;
+
+    _segmentCallback.init(segmentMetadata, columnIndexContainerMap);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -62,7 +62,7 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
     _starTreeIndexContainer = starTreeIndexContainer;
     _segmentCallback = segmentCallback;
 
-    _segmentCallback.init(segmentMetadata, columnIndexContainerMap);
+    _segmentCallback.onIndexSegmentCreation(segmentMetadata, columnIndexContainerMap);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImpl.java
@@ -331,7 +331,7 @@ public class MutableSegmentImpl implements MutableSegment {
       }
       virtualColumnIndexContainer.put(column, provider.buildColumnIndexContainer(virtualColumnContext));
     }
-    _indexSegmentCallback.init(_segmentMetadata, virtualColumnIndexContainer);
+    _indexSegmentCallback.onIndexSegmentCreation(_segmentMetadata, virtualColumnIndexContainer);
 
     if (_realtimeLuceneReaders != null) {
       // add the realtime lucene index readers to the global queue for refresh task to pick up
@@ -433,7 +433,7 @@ public class MutableSegmentImpl implements MutableSegment {
 
       // Update number of document indexed at last to make the latest record queryable
       canTakeMore = _numDocsIndexed++ < _capacity;
-      _indexSegmentCallback.postProcessRecords(row, docId);
+      _indexSegmentCallback.onRowIndexed(row, docId);
     } else {
       Preconditions
           .checkState(_aggregateMetrics, "Invalid document-id during indexing: " + docId + " expected: " + numDocs);

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/updater/SegmentDeletionListener.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/updater/SegmentDeletionListener.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.segment.updater;
+
+/**
+ * Listener for any further clean up action when the physical data for a given segment is removed from a pinot server
+ */
+public interface SegmentDeletionListener {
+
+  /**
+   * called when a segment data is deleted from physical storage of this pinot server
+   * @param tableNameWithType the name of the table with the type
+   * @param segmentName name of the segment
+   */
+  void onSegmentDeletion(String tableNameWithType, String segmentName);
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/updater/WatermarkManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/updater/WatermarkManager.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.segment.updater;
+
+import org.apache.commons.configuration.Configuration;
+import org.apache.pinot.common.metrics.AbstractMetrics;
+
+import java.util.Map;
+
+public interface WatermarkManager {
+
+  void init(Configuration config, AbstractMetrics metrics);
+
+  Map<String, Map<Integer, Long>> getHighWaterMarkTablePartitionMap();
+
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/virtualcolumn/VirtualColumnContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/virtualcolumn/VirtualColumnContext.java
@@ -28,10 +28,22 @@ import org.apache.pinot.spi.data.FieldSpec;
 public class VirtualColumnContext {
   private FieldSpec _fieldSpec;
   private int _totalDocCount;
+  private boolean _isMutableSegment;
 
   public VirtualColumnContext(FieldSpec fieldSpec, int totalDocCount) {
+    this(fieldSpec, totalDocCount, false);
+  }
+
+  /**
+   * create context for a virtual column
+   * @param fieldSpec spec for the current virtual column
+   * @param totalDocCount total doc count for the current segment, maybe estimation for mutable segment
+   * @param isMutableSegment indicate whether the current segment is a mutable segment or not
+   */
+  public VirtualColumnContext(FieldSpec fieldSpec, int totalDocCount, boolean isMutableSegment) {
     _fieldSpec = fieldSpec;
     _totalDocCount = totalDocCount;
+    _isMutableSegment = isMutableSegment;
   }
 
   public FieldSpec getFieldSpec() {
@@ -40,5 +52,9 @@ public class VirtualColumnContext {
 
   public int getTotalDocCount() {
     return _totalDocCount;
+  }
+
+  public boolean isMutableSegment() {
+    return _isMutableSegment;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -35,6 +35,8 @@ import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.data.manager.config.TableDataManagerConfig;
 import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
 import org.apache.pinot.core.data.manager.offline.OfflineTableDataManager;
+import org.apache.pinot.core.data.manager.callback.impl.DefaultDataManagerCallbackImpl;
+import org.apache.pinot.core.data.manager.callback.impl.DefaultTableDataManagerCallbackImpl;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
 import org.testng.Assert;
@@ -100,7 +102,7 @@ public class BaseTableDataManagerTest {
 
   private TableDataManager makeTestableManager()
       throws Exception {
-    TableDataManager tableDataManager = new OfflineTableDataManager();
+    TableDataManager tableDataManager = new OfflineTableDataManager(new DefaultTableDataManagerCallbackImpl());
     TableDataManagerConfig config;
     {
       config = mock(TableDataManagerConfig.class);
@@ -139,7 +141,7 @@ public class BaseTableDataManagerTest {
     // Add the segment, get it for use, remove the segment, and then return it.
     // Make sure that the segment is not destroyed before return.
     ImmutableSegment immutableSegment = makeImmutableSegment(segmentName, totalDocs);
-    tableDataManager.addSegment(immutableSegment);
+    tableDataManager.addSegment(immutableSegment, DefaultDataManagerCallbackImpl.INSTANCE);
     SegmentDataManager segmentDataManager = tableDataManager.acquireSegment(segmentName);
     Assert.assertEquals(segmentDataManager.getReferenceCount(), 2);
     tableDataManager.removeSegment(segmentName);
@@ -161,7 +163,7 @@ public class BaseTableDataManagerTest {
     // Add a new segment and remove it in order this time.
     final String anotherSeg = "AnotherSegment";
     ImmutableSegment ix1 = makeImmutableSegment(anotherSeg, totalDocs);
-    tableDataManager.addSegment(ix1);
+    tableDataManager.addSegment(ix1, DefaultDataManagerCallbackImpl.INSTANCE);
     SegmentDataManager sdm1 = tableDataManager.acquireSegment(anotherSeg);
     Assert.assertNotNull(sdm1);
     Assert.assertEquals(sdm1.getReferenceCount(), 2);
@@ -178,7 +180,7 @@ public class BaseTableDataManagerTest {
     Assert.assertEquals(sdm1.getReferenceCount(), 1);
     // Now replace the segment with another one.
     ImmutableSegment ix2 = makeImmutableSegment(anotherSeg, totalDocs + 1);
-    tableDataManager.addSegment(ix2);
+    tableDataManager.addSegment(ix2, DefaultDataManagerCallbackImpl.INSTANCE);
     // Now the previous one should have been destroyed, and
     Assert.assertEquals(sdm1.getReferenceCount(), 0);
     verify(ix1, times(1)).destroy();
@@ -222,7 +224,8 @@ public class BaseTableDataManagerTest {
 
     for (int i = _lo; i <= _hi; i++) {
       final String segName = SEGMENT_PREFIX + i;
-      tableDataManager.addSegment(makeImmutableSegment(segName, random.nextInt()));
+      tableDataManager.addSegment(makeImmutableSegment(segName, random.nextInt()),
+          DefaultDataManagerCallbackImpl.INSTANCE);
       _allSegManagers.add(_internalSegMap.get(segName));
     }
 
@@ -409,7 +412,8 @@ public class BaseTableDataManagerTest {
     private void addSegment() {
       final int segmentToAdd = _hi + 1;
       final String segName = SEGMENT_PREFIX + segmentToAdd;
-      _tableDataManager.addSegment(makeImmutableSegment(segName, _random.nextInt()));
+      _tableDataManager.addSegment(makeImmutableSegment(segName, _random.nextInt()),
+          DefaultDataManagerCallbackImpl.INSTANCE);
       _allSegManagers.add(_internalSegMap.get(segName));
       _hi = segmentToAdd;
     }
@@ -418,7 +422,8 @@ public class BaseTableDataManagerTest {
     private void replaceSegment() {
       int segToReplace = _random.nextInt(_hi - _lo + 1) + _lo;
       final String segName = SEGMENT_PREFIX + segToReplace;
-      _tableDataManager.addSegment(makeImmutableSegment(segName, _random.nextInt()));
+      _tableDataManager.addSegment(makeImmutableSegment(segName, _random.nextInt()),
+          DefaultDataManagerCallbackImpl.INSTANCE);
       _allSegManagers.add(_internalSegMap.get(segName));
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -30,6 +30,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.core.data.manager.callback.impl.DefaultDataManagerCallbackImpl;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.common.metadata.instance.InstanceZKMetadata;
 import org.apache.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import org.apache.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
@@ -43,7 +45,6 @@ import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConsumerFactory;
 import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamMessageDecoder;
 import org.apache.pinot.core.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.LongMsgOffsetFactory;
 import org.apache.pinot.spi.stream.PermanentConsumerException;
@@ -789,7 +790,7 @@ public class LLRealtimeSegmentDataManagerTest {
         throws Exception {
       super(segmentZKMetadata, tableConfig, realtimeTableDataManager, resourceDataDir,
           new IndexLoadingConfig(makeInstanceDataManagerConfig(), tableConfig), schema, llcSegmentName,
-          semaphoreMap.get(llcSegmentName.getPartitionId()), serverMetrics);
+          semaphoreMap.get(llcSegmentName.getPartitionId()), serverMetrics, DefaultDataManagerCallbackImpl.INSTANCE);
       _state = LLRealtimeSegmentDataManager.class.getDeclaredField("_state");
       _state.setAccessible(true);
       _shouldStop = LLRealtimeSegmentDataManager.class.getDeclaredField("_shouldStop");

--- a/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImplAggregateMetricsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImplAggregateMetricsTest.java
@@ -26,6 +26,13 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang.RandomStringUtils;
+import org.apache.pinot.core.io.reader.DataFileReader;
+import org.apache.pinot.core.segment.index.column.ColumnIndexContainer;
+import org.apache.pinot.core.segment.index.metadata.ColumnMetadata;
+import org.apache.pinot.core.segment.index.readers.Dictionary;
+import org.apache.pinot.core.segment.index.readers.InvertedIndexReader;
+import org.apache.pinot.core.segment.virtualcolumn.VirtualColumnContext;
+import org.apache.pinot.core.segment.virtualcolumn.VirtualColumnProvider;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.MetricFieldSpec;
@@ -64,7 +71,7 @@ public class MutableSegmentImplAggregateMetricsTest {
         new DimensionFieldSpec("$virtualDimension", FieldSpec.DataType.INT, true, Object.class);
     schema.addField(virtualDimensionFieldSpec);
     MetricFieldSpec virtualMetricFieldSpec = new MetricFieldSpec("$virtualMetric", FieldSpec.DataType.INT);
-    virtualMetricFieldSpec.setVirtualColumnProvider("provider.class");
+    virtualMetricFieldSpec.setVirtualColumnProvider(mockVCProvider.class.getName());
     schema.addField(virtualMetricFieldSpec);
     MutableSegmentImpl mutableSegmentImpl = MutableSegmentImplTestUtils
         .createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(METRIC, METRIC_2)),
@@ -144,5 +151,36 @@ public class MutableSegmentImplAggregateMetricsTest {
   private String buildKey(GenericRow row) {
     return row.getValue(DIMENSION_1) + KEY_SEPARATOR + row.getValue(DIMENSION_2) + KEY_SEPARATOR + row
         .getValue(TIME_COLUMN1) + KEY_SEPARATOR + row.getValue(TIME_COLUMN2);
+  }
+
+  public static class mockVCProvider implements VirtualColumnProvider {
+
+    public mockVCProvider() {}
+
+    @Override
+    public DataFileReader buildReader(VirtualColumnContext context) {
+      return null;
+    }
+
+    @Override
+    public Dictionary buildDictionary(VirtualColumnContext context) {
+      return null;
+    }
+
+    @Override
+    public ColumnMetadata buildMetadata(VirtualColumnContext context) {
+      return null;
+    }
+
+    @Override
+    public InvertedIndexReader buildInvertedIndex(VirtualColumnContext context) {
+      return null;
+    }
+
+    @Override
+    public ColumnIndexContainer buildColumnIndexContainer(VirtualColumnContext context) {
+      return null;
+    }
+
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImplAggregateMetricsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImplAggregateMetricsTest.java
@@ -68,10 +68,10 @@ public class MutableSegmentImplAggregateMetricsTest {
         .build();
     // Add virtual columns, which should not be aggregated
     DimensionFieldSpec virtualDimensionFieldSpec =
-        new DimensionFieldSpec("$virtualDimension", FieldSpec.DataType.INT, true, Object.class);
+        new DimensionFieldSpec("$virtualDimension", FieldSpec.DataType.INT, true, MockVCProvider.class);
     schema.addField(virtualDimensionFieldSpec);
     MetricFieldSpec virtualMetricFieldSpec = new MetricFieldSpec("$virtualMetric", FieldSpec.DataType.INT);
-    virtualMetricFieldSpec.setVirtualColumnProvider(mockVCProvider.class.getName());
+    virtualMetricFieldSpec.setVirtualColumnProvider(MockVCProvider.class.getName());
     schema.addField(virtualMetricFieldSpec);
     MutableSegmentImpl mutableSegmentImpl = MutableSegmentImplTestUtils
         .createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(METRIC, METRIC_2)),
@@ -153,9 +153,9 @@ public class MutableSegmentImplAggregateMetricsTest {
         .getValue(TIME_COLUMN1) + KEY_SEPARATOR + row.getValue(TIME_COLUMN2);
   }
 
-  public static class mockVCProvider implements VirtualColumnProvider {
+  public static class MockVCProvider implements VirtualColumnProvider {
 
-    public mockVCProvider() {}
+    public MockVCProvider() {}
 
     @Override
     public DataFileReader buildReader(VirtualColumnContext context) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImplTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/indexsegment/mutable/MutableSegmentImplTestUtils.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.indexsegment.mutable;
 import java.util.Set;
 import javax.annotation.Nonnull;
 import org.apache.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
+import org.apache.pinot.core.data.manager.callback.impl.DefaultIndexSegmentCallback;
 import org.apache.pinot.core.io.writer.impl.DirectMemoryManager;
 import org.apache.pinot.core.realtime.impl.RealtimeSegmentConfig;
 import org.apache.pinot.core.realtime.impl.RealtimeSegmentStatsHistory;
@@ -59,6 +60,6 @@ public class MutableSegmentImplTestUtils {
             .setRealtimeSegmentZKMetadata(new RealtimeSegmentZKMetadata())
             .setMemoryManager(new DirectMemoryManager(SEGMENT_NAME)).setStatsHistory(statsHistory)
             .setAggregateMetrics(aggregateMetrics).setNullHandlingEnabled(nullHandlingEnabled).build();
-    return new MutableSegmentImpl(realtimeSegmentConfig);
+    return new MutableSegmentImpl(realtimeSegmentConfig, DefaultIndexSegmentCallback.INSTANCE);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithNullValueVectorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithNullValueVectorTest.java
@@ -42,6 +42,7 @@ import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.TableDataManager;
 import org.apache.pinot.core.data.manager.config.TableDataManagerConfig;
 import org.apache.pinot.core.data.manager.offline.TableDataManagerProvider;
+import org.apache.pinot.core.data.manager.callback.impl.DefaultDataManagerCallbackImpl;
 import org.apache.pinot.core.query.executor.QueryExecutor;
 import org.apache.pinot.core.query.executor.ServerQueryExecutorV1Impl;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
@@ -145,7 +146,7 @@ public class SegmentGenerationWithNullValueVectorTest {
         .getTableDataManager(tableDataManagerConfig, "testInstance", mock(ZkHelixPropertyStore.class),
             mock(ServerMetrics.class));
     tableDataManager.start();
-    tableDataManager.addSegment(_segment);
+    tableDataManager.addSegment(_segment, DefaultDataManagerCallbackImpl.INSTANCE);
     _instanceDataManager = mock(InstanceDataManager.class);
     when(_instanceDataManager.getTableDataManager(TABLE_NAME)).thenReturn(tableDataManager);
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithNullValueVectorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/creator/SegmentGenerationWithNullValueVectorTest.java
@@ -40,6 +40,7 @@ import org.apache.pinot.common.request.InstanceRequest;
 import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.TableDataManager;
+import org.apache.pinot.core.data.manager.config.InstanceDataManagerConfig;
 import org.apache.pinot.core.data.manager.config.TableDataManagerConfig;
 import org.apache.pinot.core.data.manager.offline.TableDataManagerProvider;
 import org.apache.pinot.core.data.manager.callback.impl.DefaultDataManagerCallbackImpl;
@@ -141,6 +142,7 @@ public class SegmentGenerationWithNullValueVectorTest {
     when(tableDataManagerConfig.getTableDataManagerType()).thenReturn("OFFLINE");
     when(tableDataManagerConfig.getTableName()).thenReturn(TABLE_NAME);
     when(tableDataManagerConfig.getDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
+    TableDataManagerProvider.init(mock(InstanceDataManagerConfig.class));
     @SuppressWarnings("unchecked")
     TableDataManager tableDataManager = TableDataManagerProvider
         .getTableDataManager(tableDataManagerConfig, "testInstance", mock(ZkHelixPropertyStore.class),

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/index/loader/LoaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/index/loader/LoaderTest.java
@@ -23,8 +23,14 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
+
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.core.data.manager.callback.impl.DefaultDataManagerCallbackImpl;
+import org.apache.pinot.core.segment.creator.impl.inv.text.LuceneTextIndexCreator;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.MetricFieldSpec;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.core.indexsegment.IndexSegment;
@@ -34,7 +40,6 @@ import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.core.segment.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.core.segment.creator.impl.SegmentCreationDriverFactory;
 import org.apache.pinot.core.segment.creator.impl.V1Constants;
-import org.apache.pinot.core.segment.creator.impl.inv.text.LuceneTextIndexCreator;
 import org.apache.pinot.core.segment.index.converter.SegmentV1V2ToV3FormatConverter;
 import org.apache.pinot.core.segment.index.metadata.ColumnMetadata;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
@@ -45,10 +50,6 @@ import org.apache.pinot.core.segment.store.ColumnIndexType;
 import org.apache.pinot.core.segment.store.SegmentDirectory;
 import org.apache.pinot.core.segment.store.SegmentDirectoryPaths;
 import org.apache.pinot.segments.v1.creator.SegmentTestUtils;
-import org.apache.pinot.spi.data.DimensionFieldSpec;
-import org.apache.pinot.spi.data.FieldSpec;
-import org.apache.pinot.spi.data.MetricFieldSpec;
-import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
@@ -226,12 +227,14 @@ public class LoaderTest {
     schema.addField(new DimensionFieldSpec("SVString", FieldSpec.DataType.STRING, true, ""));
     schema.addField(new DimensionFieldSpec("MVString", FieldSpec.DataType.STRING, false, ""));
 
-    IndexSegment indexSegment = ImmutableSegmentLoader.load(_indexDir, _v1IndexLoadingConfig, schema);
+    IndexSegment indexSegment = ImmutableSegmentLoader
+        .load(_indexDir, _v1IndexLoadingConfig, DefaultDataManagerCallbackImpl.INSTANCE, schema);
     Assert.assertEquals(indexSegment.getDataSource("SVString").getDictionary().get(0), "");
     Assert.assertEquals(indexSegment.getDataSource("MVString").getDictionary().get(0), "");
     indexSegment.destroy();
 
-    indexSegment = ImmutableSegmentLoader.load(_indexDir, _v3IndexLoadingConfig, schema);
+    indexSegment = ImmutableSegmentLoader
+        .load(_indexDir, _v3IndexLoadingConfig, DefaultDataManagerCallbackImpl.INSTANCE, schema);
     Assert.assertEquals(indexSegment.getDataSource("SVString").getDictionary().get(0), "");
     Assert.assertEquals(indexSegment.getDataSource("MVString").getDictionary().get(0), "");
     indexSegment.destroy();
@@ -246,7 +249,8 @@ public class LoaderTest {
 
     FieldSpec byteMetric = new MetricFieldSpec(newColumnName, FieldSpec.DataType.BYTES, defaultValue);
     schema.addField(byteMetric);
-    IndexSegment indexSegment = ImmutableSegmentLoader.load(_indexDir, _v3IndexLoadingConfig, schema);
+    IndexSegment indexSegment = ImmutableSegmentLoader
+        .load(_indexDir, _v3IndexLoadingConfig, DefaultDataManagerCallbackImpl.INSTANCE, schema);
     Assert
         .assertEquals(BytesUtils.toHexString((byte[]) indexSegment.getDataSource(newColumnName).getDictionary().get(0)),
             defaultValue);

--- a/pinot-core/src/test/java/org/apache/pinot/query/executor/QueryExecutorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/executor/QueryExecutorTest.java
@@ -36,6 +36,7 @@ import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.TableDataManager;
 import org.apache.pinot.core.data.manager.config.TableDataManagerConfig;
 import org.apache.pinot.core.data.manager.offline.TableDataManagerProvider;
+import org.apache.pinot.core.data.manager.callback.impl.DefaultDataManagerCallbackImpl;
 import org.apache.pinot.core.indexsegment.IndexSegment;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
@@ -103,7 +104,7 @@ public class QueryExecutorTest {
             mock(ServerMetrics.class));
     tableDataManager.start();
     for (ImmutableSegment indexSegment : _indexSegments) {
-      tableDataManager.addSegment(indexSegment);
+      tableDataManager.addSegment(indexSegment, DefaultDataManagerCallbackImpl.INSTANCE);
     }
     InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
     when(instanceDataManager.getTableDataManager(TABLE_NAME)).thenReturn(tableDataManager);

--- a/pinot-core/src/test/java/org/apache/pinot/query/executor/QueryExecutorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/query/executor/QueryExecutorTest.java
@@ -34,6 +34,7 @@ import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.TableDataManager;
+import org.apache.pinot.core.data.manager.config.InstanceDataManagerConfig;
 import org.apache.pinot.core.data.manager.config.TableDataManagerConfig;
 import org.apache.pinot.core.data.manager.offline.TableDataManagerProvider;
 import org.apache.pinot.core.data.manager.callback.impl.DefaultDataManagerCallbackImpl;
@@ -98,6 +99,7 @@ public class QueryExecutorTest {
     when(tableDataManagerConfig.getTableDataManagerType()).thenReturn("OFFLINE");
     when(tableDataManagerConfig.getTableName()).thenReturn(TABLE_NAME);
     when(tableDataManagerConfig.getDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
+    TableDataManagerProvider.init(mock(InstanceDataManagerConfig.class));
     @SuppressWarnings("unchecked")
     TableDataManager tableDataManager = TableDataManagerProvider
         .getTableDataManager(tableDataManagerConfig, "testInstance", mock(ZkHelixPropertyStore.class),

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
@@ -39,6 +39,7 @@ import org.apache.pinot.core.data.manager.TableDataManager;
 import org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.server.upsert.SegmentDeletionHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,12 +54,19 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
   private final String _instanceId;
   private final InstanceDataManager _instanceDataManager;
   private final SegmentFetcherAndLoader _fetcherAndLoader;
+  private final SegmentDeletionHandler _segmentDeletionHandler;
 
   public SegmentOnlineOfflineStateModelFactory(String instanceId, InstanceDataManager instanceDataManager,
       SegmentFetcherAndLoader fetcherAndLoader) {
+    this(instanceId, instanceDataManager, fetcherAndLoader, new SegmentDeletionHandler());
+  }
+
+  public SegmentOnlineOfflineStateModelFactory(String instanceId, InstanceDataManager instanceDataManager,
+      SegmentFetcherAndLoader fetcherAndLoader, SegmentDeletionHandler segmentDeletionHandler) {
     _instanceId = instanceId;
     _instanceDataManager = instanceDataManager;
     _fetcherAndLoader = fetcherAndLoader;
+    _segmentDeletionHandler = segmentDeletionHandler;
   }
 
   public static String getStateModelName() {
@@ -203,6 +211,7 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
           FileUtils.deleteQuietly(segmentDir);
           _logger.info("Deleted segment directory {}", segmentDir);
         }
+        _segmentDeletionHandler.deleteSegmentFromLocalStorage(tableNameWithType, segmentName);
       } catch (final Exception e) {
         _logger.error("Cannot delete the segment : " + segmentName + " from local directory!\n" + e.getMessage(), e);
         Utils.rethrowException(e);

--- a/pinot-server/src/main/java/org/apache/pinot/server/upsert/DefaultUpsertComponentContainer.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/upsert/DefaultUpsertComponentContainer.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.upsert;
+
+import com.codahale.metrics.MetricRegistry;
+import org.apache.commons.configuration.Configuration;
+
+public class DefaultUpsertComponentContainer implements UpsertComponentContainer {
+
+  private final SegmentDeletionHandler deletionHandler = new SegmentDeletionHandler();
+
+  @Override
+  public void registerMetrics(MetricRegistry registry) {
+
+  }
+
+  @Override
+  public void init(Configuration config) {
+  }
+
+  @Override
+  public SegmentDeletionHandler getSegmentDeletionHandler() {
+    return deletionHandler;
+  }
+
+  @Override
+  public void start() {
+  }
+
+  @Override
+  public void stop() {
+  }
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/upsert/SegmentDeletionHandler.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/upsert/SegmentDeletionHandler.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.upsert;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.pinot.core.segment.updater.SegmentDeletionListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public class SegmentDeletionHandler {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentDeletionHandler.class);
+
+  private List<SegmentDeletionListener> _deleteListeners;
+
+
+  public SegmentDeletionHandler() {
+    this(ImmutableList.of());
+  }
+
+  public SegmentDeletionHandler(List<SegmentDeletionListener> listeners) {
+    _deleteListeners = listeners;
+  }
+
+  public void deleteSegmentFromLocalStorage(String tableNameWithType, String segmentName) {
+    //TODO move the deletion from file system logic to here
+    LOGGER.info("trying to perform deletion for {}:{} on {} deletion handler", tableNameWithType, segmentName,
+        _deleteListeners.size());
+    for (SegmentDeletionListener deletionListener : _deleteListeners) {
+      try {
+        deletionListener.onSegmentDeletion(tableNameWithType, segmentName);
+      } catch (Exception ex) {
+        LOGGER.error("failed to delete table {} segment {} with exception", tableNameWithType, segmentName, ex);
+      }
+    }
+  }
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/upsert/UpsertComponentContainer.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/upsert/UpsertComponentContainer.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.upsert;
+
+import com.codahale.metrics.MetricRegistry;
+import org.apache.commons.configuration.Configuration;
+
+public interface UpsertComponentContainer {
+
+  void registerMetrics(MetricRegistry registry);
+
+  void init(Configuration config);
+
+  SegmentDeletionHandler getSegmentDeletionHandler();
+
+  void start();
+
+  void stop();
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/upsert/UpsertComponentContainerProvider.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/upsert/UpsertComponentContainerProvider.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.upsert;
+
+import com.google.common.base.Preconditions;
+import org.apache.commons.configuration.Configuration;
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.apache.pinot.common.metrics.AbstractMetrics;
+import org.apache.pinot.core.segment.updater.WatermarkManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class UpsertComponentContainerProvider {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(UpsertComponentContainerProvider.class);
+
+  public static final String UPSERT_COMPONENT_CONFIG_KEY = "watermarkManager.class";
+  public static final String UPSERT_COMPONENT_CONFIG_DEFAULT = DefaultUpsertComponentContainer.class.getName();
+
+  private final Configuration _conf;
+  private UpsertComponentContainer _instance;
+
+  public UpsertComponentContainerProvider(Configuration conf, AbstractMetrics metrics) {
+    _conf = conf;
+    String className = _conf.getString(UPSERT_COMPONENT_CONFIG_KEY, UPSERT_COMPONENT_CONFIG_DEFAULT);
+    LOGGER.info("creating watermark manager with class {}", className);
+    try {
+      Class<UpsertComponentContainer> comonentContainerClass = (Class<UpsertComponentContainer>) Class.forName(className);
+      Preconditions.checkState(comonentContainerClass.isAssignableFrom(WatermarkManager.class),
+          "configured class not assignable from Callback class");
+      _instance = comonentContainerClass.newInstance();
+      _instance.init(_conf);
+    } catch (Exception e) {
+      LOGGER.error("failed to load watermark manager class", className, e);
+      ExceptionUtils.rethrow(e);
+    }
+  }
+
+  public UpsertComponentContainer getInstance() {
+    return _instance;
+  }
+}

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
@@ -33,6 +33,7 @@ import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.TableDataManager;
+import org.apache.pinot.core.data.manager.config.InstanceDataManagerConfig;
 import org.apache.pinot.core.data.manager.config.TableDataManagerConfig;
 import org.apache.pinot.core.data.manager.offline.TableDataManagerProvider;
 import org.apache.pinot.core.data.manager.callback.impl.DefaultDataManagerCallbackImpl;
@@ -79,6 +80,7 @@ public abstract class BaseResourceTest {
 
     // Mock the instance data manager
     InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
+
     when(instanceDataManager.getTableDataManager(anyString()))
         .thenAnswer(invocation -> _tableDataManagerMap.get(invocation.getArguments()[0]));
     when(instanceDataManager.getAllTables()).thenReturn(_tableDataManagerMap.keySet());
@@ -144,6 +146,7 @@ public abstract class BaseResourceTest {
         .thenReturn(TableNameBuilder.getTableTypeFromTableName(tableNameWithType).name());
     when(tableDataManagerConfig.getTableName()).thenReturn(tableNameWithType);
     when(tableDataManagerConfig.getDataDir()).thenReturn(INDEX_DIR.getAbsolutePath());
+    TableDataManagerProvider.init(mock(InstanceDataManagerConfig.class));
     TableDataManager tableDataManager = TableDataManagerProvider
         .getTableDataManager(tableDataManagerConfig, "testInstance", mock(ZkHelixPropertyStore.class),
             mock(ServerMetrics.class));

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
@@ -35,6 +35,7 @@ import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.TableDataManager;
 import org.apache.pinot.core.data.manager.config.TableDataManagerConfig;
 import org.apache.pinot.core.data.manager.offline.TableDataManagerProvider;
+import org.apache.pinot.core.data.manager.callback.impl.DefaultDataManagerCallbackImpl;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
@@ -132,7 +133,7 @@ public abstract class BaseResourceTest {
     ImmutableSegment immutableSegment =
         ImmutableSegmentLoader.load(new File(INDEX_DIR, driver.getSegmentName()), ReadMode.mmap);
     segments.add(immutableSegment);
-    _tableDataManagerMap.get(tableNameWithType).addSegment(immutableSegment);
+    _tableDataManagerMap.get(tableNameWithType).addSegment(immutableSegment, DefaultDataManagerCallbackImpl.INSTANCE);
     return immutableSegment;
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/realtime/provisioning/MemoryEstimator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/realtime/provisioning/MemoryEstimator.java
@@ -25,6 +25,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.core.data.manager.callback.impl.DefaultIndexSegmentCallback;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
 import org.apache.pinot.core.data.readers.PinotSegmentRecordReader;
 import org.apache.pinot.core.indexsegment.mutable.MutableSegmentImpl;
@@ -34,7 +36,6 @@ import org.apache.pinot.core.realtime.impl.RealtimeSegmentConfig;
 import org.apache.pinot.core.realtime.impl.RealtimeSegmentStatsHistory;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.DataSizeUtils;
 
@@ -133,7 +134,8 @@ public class MemoryEstimator {
             .setStatsHistory(sampleStatsHistory);
 
     // create mutable segment impl
-    MutableSegmentImpl mutableSegmentImpl = new MutableSegmentImpl(realtimeSegmentConfigBuilder.build());
+    MutableSegmentImpl mutableSegmentImpl = new MutableSegmentImpl(realtimeSegmentConfigBuilder.build(),
+        DefaultIndexSegmentCallback.INSTANCE);
 
     // read all rows and index them
     try (PinotSegmentRecordReader segmentRecordReader = new PinotSegmentRecordReader(_sampleCompletedSegment)) {
@@ -231,7 +233,8 @@ public class MemoryEstimator {
               .setStatsHistory(statsHistory);
 
       // create mutable segment impl
-      MutableSegmentImpl mutableSegmentImpl = new MutableSegmentImpl(realtimeSegmentConfigBuilder.build());
+      MutableSegmentImpl mutableSegmentImpl = new MutableSegmentImpl(realtimeSegmentConfigBuilder.build(),
+          DefaultIndexSegmentCallback.INSTANCE);
       long memoryForConsumingSegmentPerPartition = memoryManager.getTotalAllocatedBytes();
       mutableSegmentImpl.destroy();
       FileUtils.deleteQuietly(statsFileCopy);


### PR DESCRIPTION
added list of critical interface that we need to inject to pinot core/server to ensure we can add proper logic for upsert-enabled pinotserver and tables and making sure existing pinot tables perform the same as before. Pinot upsert related logics will be implemented in separate package and injected to runtime environment via config. This diff also provided a no-op implementation to ensure that existing pinot ingestion workflow stay the same

design doc for pinot upsert feature: [google doc](https://docs.google.com/document/d/1SFFir7ByxCff-aVYxQeTHpNhPXeP5q7P4g_6O2iNGgU/edit?usp=sharing) (our corp privacy policy disallow blanket sharing so please send a view/comment request to me and I usually accept it as soon as I see it)

this change focus on the changes in pinot core/server

List of interfaces added:
**TableDataManagerCallback/DataManagerCallback/IndexSegmentCallback**
for use in the associated table/datamanger/indexsegment.

list of default interface added:
**DefaultDataManagerCallbackImpl/DefaultIndexSegmentCallback/DefaultTableDataManagerCallbackImpl**
for use in offline/non-upsert tables