### PR TITLE
Integrate vectorized bit-unpacking

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/io/reader/impl/v1/FixedBitSingleValueReader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/reader/impl/v1/FixedBitSingleValueReader.java
@@ -20,15 +20,15 @@ package org.apache.pinot.core.io.reader.impl.v1;
 
 import org.apache.pinot.core.io.reader.BaseSingleColumnSingleValueReader;
 import org.apache.pinot.core.io.reader.ReaderContext;
-import org.apache.pinot.core.io.util.FixedBitIntReaderWriter;
+import org.apache.pinot.core.io.util.FixedBitIntReaderWriterV2;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
 
 
 public final class FixedBitSingleValueReader extends BaseSingleColumnSingleValueReader {
-  private final FixedBitIntReaderWriter _reader;
+  private final FixedBitIntReaderWriterV2 _reader;
 
   public FixedBitSingleValueReader(PinotDataBuffer dataBuffer, int numRows, int numBitsPerValue) {
-    _reader = new FixedBitIntReaderWriter(dataBuffer, numRows, numBitsPerValue);
+    _reader = new FixedBitIntReaderWriterV2(dataBuffer, numRows, numBitsPerValue);
   }
 
   @Override
@@ -42,11 +42,8 @@ public final class FixedBitSingleValueReader extends BaseSingleColumnSingleValue
   }
 
   @Override
-  public void readValues(int[] rows, int rowsStartIndex, int rowSize, int[] values, int valuesStartIndex) {
-    int rowsEndIndex = rowsStartIndex + rowSize;
-    for (int i = rowsStartIndex; i < rowsEndIndex; i++) {
-      values[valuesStartIndex++] = getInt(rows[i]);
-    }
+  public void readValues(int[] docIds, int docIdStartIndex, int docIdLength, int[] out, int outPos) {
+    _reader.readValues(docIds, docIdStartIndex, docIdLength, out, outPos);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/util/BasePinotBitSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/util/BasePinotBitSet.java
@@ -1,0 +1,164 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.io.util;
+
+import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+
+
+public abstract class BasePinotBitSet implements PinotBitSet {
+  private static final int[] NUM_BITS_SET = new int[1 << Byte.SIZE];
+  private static final int[][] NTH_BIT_SET = new int[Byte.SIZE][1 << Byte.SIZE];
+  private static final int[] FIRST_BIT_SET = NTH_BIT_SET[0];
+  private static final int BYTE_MASK = 0xFF;
+
+  protected PinotDataBuffer _dataBuffer;
+  protected int _numBitsPerValue;
+
+  public BasePinotBitSet(PinotDataBuffer dataBuffer, int numBitsPerValue) {
+    _dataBuffer = dataBuffer;
+    _numBitsPerValue = numBitsPerValue;
+  }
+
+  static {
+    for (int i = 0; i < (1 << Byte.SIZE); i++) {
+      int numBitsSet = 0;
+      for (int j = 0; j < Byte.SIZE; j++) {
+        if ((i & (0x80 >>> j)) != 0) {
+          NUM_BITS_SET[i]++;
+          NTH_BIT_SET[numBitsSet][i] = j;
+          numBitsSet++;
+        }
+      }
+    }
+  }
+
+  @Override
+  public void writeInt(int index, int value) {
+    long bitOffset = (long) index * _numBitsPerValue;
+    int byteOffset = (int) (bitOffset / Byte.SIZE);
+    int bitOffsetInFirstByte = (int) (bitOffset % Byte.SIZE);
+
+    int firstByte = _dataBuffer.getByte(byteOffset);
+
+    int firstByteMask = BYTE_MASK >>> bitOffsetInFirstByte;
+    int numBitsLeft = _numBitsPerValue - (Byte.SIZE - bitOffsetInFirstByte);
+    if (numBitsLeft <= 0) {
+      // The value is inside the first byte
+      firstByteMask &= BYTE_MASK << -numBitsLeft;
+      _dataBuffer.putByte(byteOffset, (byte) ((firstByte & ~firstByteMask) | (value << -numBitsLeft)));
+    } else {
+      // The value is in multiple bytes
+      _dataBuffer
+          .putByte(byteOffset, (byte) ((firstByte & ~firstByteMask) | ((value >>> numBitsLeft) & firstByteMask)));
+      while (numBitsLeft > Byte.SIZE) {
+        numBitsLeft -= Byte.SIZE;
+        _dataBuffer.putByte(++byteOffset, (byte) (value >> numBitsLeft));
+      }
+      int lastByte = _dataBuffer.getByte(++byteOffset);
+      _dataBuffer.putByte(byteOffset,
+          (byte) ((lastByte & (BYTE_MASK >>> numBitsLeft)) | (value << (Byte.SIZE - numBitsLeft))));
+    }
+  }
+
+  @Override
+  public void writeInt(int startIndex, int length, int[] values) {
+    long startBitOffset = (long) startIndex * _numBitsPerValue;
+    int byteOffset = (int) (startBitOffset / Byte.SIZE);
+    int bitOffsetInFirstByte = (int) (startBitOffset % Byte.SIZE);
+
+    int firstByte = _dataBuffer.getByte(byteOffset);
+
+    for (int i = 0; i < length; i++) {
+      int value = values[i];
+      if (bitOffsetInFirstByte == Byte.SIZE) {
+        bitOffsetInFirstByte = 0;
+        firstByte = _dataBuffer.getByte(++byteOffset);
+      }
+      int firstByteMask = BYTE_MASK >>> bitOffsetInFirstByte;
+      int numBitsLeft = _numBitsPerValue - (Byte.SIZE - bitOffsetInFirstByte);
+      if (numBitsLeft <= 0) {
+        // The value is inside the first byte
+        firstByteMask &= BYTE_MASK << -numBitsLeft;
+        firstByte = ((firstByte & ~firstByteMask) | (value << -numBitsLeft));
+        _dataBuffer.putByte(byteOffset, (byte) firstByte);
+        bitOffsetInFirstByte = Byte.SIZE + numBitsLeft;
+      } else {
+        // The value is in multiple bytes
+        _dataBuffer
+            .putByte(byteOffset, (byte) ((firstByte & ~firstByteMask) | ((value >>> numBitsLeft) & firstByteMask)));
+        while (numBitsLeft > Byte.SIZE) {
+          numBitsLeft -= Byte.SIZE;
+          _dataBuffer.putByte(++byteOffset, (byte) (value >> numBitsLeft));
+        }
+        int lastByte = _dataBuffer.getByte(++byteOffset);
+        firstByte = (lastByte & (0xFF >>> numBitsLeft)) | (value << (Byte.SIZE - numBitsLeft));
+        _dataBuffer.putByte(byteOffset, (byte) firstByte);
+        bitOffsetInFirstByte = numBitsLeft;
+      }
+    }
+  }
+
+  // Helper functions used by multi-value reader and writer
+  // for it's header bitmap structure
+
+  public static void setBit(PinotDataBuffer dataBuffer, int bitOffset) {
+    int byteOffset = bitOffset / Byte.SIZE;
+    int bitOffsetInByte = bitOffset % Byte.SIZE;
+    dataBuffer.putByte(byteOffset, (byte) (dataBuffer.getByte(byteOffset) | (0x80 >>> bitOffsetInByte)));
+  }
+
+  public static void unsetBit(PinotDataBuffer dataBuffer, int bitOffset) {
+    int byteOffset = bitOffset / Byte.SIZE;
+    int bitOffsetInByte = bitOffset % Byte.SIZE;
+    dataBuffer.putByte(byteOffset, (byte) (dataBuffer.getByte(byteOffset) & (0xFF7F >>> bitOffsetInByte)));
+  }
+
+  public static int getNextSetBitOffset(PinotDataBuffer dataBuffer, int bitOffset) {
+    int byteOffset = bitOffset / Byte.SIZE;
+    int bitOffsetInFirstByte = bitOffset % Byte.SIZE;
+    int firstByte = (dataBuffer.getByte(byteOffset) << bitOffsetInFirstByte) & BYTE_MASK;
+    if (firstByte != 0) {
+      return bitOffset + FIRST_BIT_SET[firstByte];
+    }
+    while (true) {
+      int currentByte = dataBuffer.getByte(++byteOffset) & BYTE_MASK;
+      if (currentByte != 0) {
+        return (byteOffset * Byte.SIZE) | FIRST_BIT_SET[currentByte];
+      }
+    }
+  }
+
+  public static int getNextNthSetBitOffset(PinotDataBuffer dataBuffer, int bitOffset, int n) {
+    int byteOffset = bitOffset / Byte.SIZE;
+    int bitOffsetInFirstByte = bitOffset % Byte.SIZE;
+    int firstByte = (dataBuffer.getByte(byteOffset) << bitOffsetInFirstByte) & BYTE_MASK;
+    int numBitsSet = NUM_BITS_SET[firstByte];
+    if (numBitsSet >= n) {
+      return bitOffset + NTH_BIT_SET[n - 1][firstByte];
+    }
+    while (true) {
+      n -= numBitsSet;
+      int currentByte = dataBuffer.getByte(++byteOffset) & BYTE_MASK;
+      numBitsSet = NUM_BITS_SET[currentByte];
+      if (numBitsSet >= n) {
+        return (byteOffset * Byte.SIZE) | NTH_BIT_SET[n - 1][currentByte];
+      }
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/util/FixedBitIntReaderWriter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/util/FixedBitIntReaderWriter.java
@@ -25,29 +25,34 @@ import org.apache.pinot.core.segment.memory.PinotDataBuffer;
 
 public final class FixedBitIntReaderWriter implements Closeable {
   private final PinotDataBitSet _dataBitSet;
-  private final int _numBitsPerValue;
 
   public FixedBitIntReaderWriter(PinotDataBuffer dataBuffer, int numValues, int numBitsPerValue) {
     Preconditions
         .checkState(dataBuffer.size() == (int) (((long) numValues * numBitsPerValue + Byte.SIZE - 1) / Byte.SIZE));
-    _dataBitSet = new PinotDataBitSet(dataBuffer);
-    _numBitsPerValue = numBitsPerValue;
+    _dataBitSet = new PinotDataBitSet(dataBuffer, numBitsPerValue);
   }
 
   public int readInt(int index) {
-    return _dataBitSet.readInt(index, _numBitsPerValue);
+    return _dataBitSet.readInt(index);
   }
 
   public void readInt(int startIndex, int length, int[] buffer) {
-    _dataBitSet.readInt(startIndex, _numBitsPerValue, length, buffer);
+    _dataBitSet.readInt(startIndex, length, buffer);
+  }
+
+  public void readValues(int[] docIds, int docIdStartIndex, int docIdLength, int[] values, int valuesStartIndex) {
+    int docIdEndIndex = docIdStartIndex + docIdLength;
+    for (int i = docIdStartIndex; i < docIdEndIndex; i++) {
+      values[valuesStartIndex++] = readInt(docIds[i]);
+    }
   }
 
   public void writeInt(int index, int value) {
-    _dataBitSet.writeInt(index, _numBitsPerValue, value);
+    _dataBitSet.writeInt(index, value);
   }
 
   public void writeInt(int startIndex, int length, int[] values) {
-    _dataBitSet.writeInt(startIndex, _numBitsPerValue, length, values);
+    _dataBitSet.writeInt(startIndex, length, values);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/util/PinotBitSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/util/PinotBitSet.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.io.util;
+
+import java.io.Closeable;
+
+
+public interface PinotBitSet extends Closeable {
+
+  /**
+   * Decode integers starting at a given index.
+   * @param index index
+   * @return unpacked integer
+   */
+  int readInt(long index);
+
+  /**
+   * Decode integers for a contiguous range of indexes represented by startIndex
+   * and length
+   * @param startIndex start docId
+   * @param length length
+   * @param out out array to store the unpacked integers
+   */
+  void readInt(long startIndex, int length, int[] out);
+
+  /**
+   * Encode integer starting at a given index.
+   * @param index index
+   * @param value integer to encode
+   */
+  void writeInt(int index, int value);
+
+  /**
+   * Encode integers for a contiguous range of indexes represented by startIndex
+   * and length
+   * @param startIndex start docId
+   * @param length length
+   * @param buffer array of integers to encode
+   */
+  void writeInt(int startIndex, int length, int[] buffer);
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/util/PinotDataBitSetFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/util/PinotDataBitSetFactory.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.io.util;
+
+import org.apache.pinot.core.segment.memory.PinotDataBuffer;
+
+public class PinotDataBitSetFactory {
+
+  public static PinotBitSet createBitSet(PinotDataBuffer pinotDataBuffer, int numBitsPerValue) {
+    switch (numBitsPerValue) {
+      // for power of 2 encodings, use the faster vectorized reader
+      case 1:
+        return new PinotDataBitSetV2.Bit1Encoded(pinotDataBuffer, numBitsPerValue);
+      case 2:
+        return new PinotDataBitSetV2.Bit2Encoded(pinotDataBuffer, numBitsPerValue);
+      case 4:
+        return new PinotDataBitSetV2.Bit4Encoded(pinotDataBuffer, numBitsPerValue);
+      case 8:
+        return new PinotDataBitSetV2.Bit8Encoded(pinotDataBuffer, numBitsPerValue);
+      case 16:
+        return new PinotDataBitSetV2.Bit16Encoded(pinotDataBuffer, numBitsPerValue);
+      case 32:
+        return new PinotDataBitSetV2.RawInt(pinotDataBuffer, numBitsPerValue);
+      // for non-power of 2 encodings, fallback to the older reader
+      default:
+        return new PinotDataBitSet(pinotDataBuffer, numBitsPerValue);
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/v1/FixedBitSingleValueWriter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/io/writer/impl/v1/FixedBitSingleValueWriter.java
@@ -22,12 +22,13 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteOrder;
 import org.apache.pinot.core.io.util.FixedBitIntReaderWriter;
+import org.apache.pinot.core.io.util.FixedBitIntReaderWriterV2;
 import org.apache.pinot.core.io.writer.SingleColumnSingleValueWriter;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
 
 
 public class FixedBitSingleValueWriter implements SingleColumnSingleValueWriter {
-  private FixedBitIntReaderWriter dataFileWriter;
+  private FixedBitIntReaderWriterV2 dataFileWriter;
 
   public FixedBitSingleValueWriter(File file, int rows, int columnSizeInBits)
       throws Exception {
@@ -36,7 +37,7 @@ public class FixedBitSingleValueWriter implements SingleColumnSingleValueWriter 
     // Backward-compatible: index file is always big-endian
     PinotDataBuffer dataBuffer =
         PinotDataBuffer.mapFile(file, false, 0, length, ByteOrder.BIG_ENDIAN, getClass().getSimpleName());
-    dataFileWriter = new FixedBitIntReaderWriter(dataBuffer, rows, columnSizeInBits);
+    dataFileWriter = new FixedBitIntReaderWriterV2(dataBuffer, rows, columnSizeInBits);
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/io/util/PinotDataBitSetV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/io/util/PinotDataBitSetV2Test.java
@@ -25,6 +25,11 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
+/**
+ * Test for new implementation of {@link PinotBitSet}
+ * that supports vectorized operations for power of 2
+ * encodings.
+ */
 public class PinotDataBitSetV2Test {
 
   private void batchRead(PinotDataBitSetV2 bitset, int startDocId, int batchLength, int[] unpacked,
@@ -38,7 +43,7 @@ public class PinotDataBitSetV2Test {
   @Test
   public void testBit2Encoded() throws Exception {
     int cardinality = 3;
-    int rows = 10000;
+    int rows = 100000;
     int[] forwardIndex = new int[rows];
     Random random = new Random();
 
@@ -48,134 +53,135 @@ public class PinotDataBitSetV2Test {
 
     int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(cardinality - 1);
     int bitPackedBufferSize = (rows * numBitsPerValue + Byte.SIZE - 1) / Byte.SIZE;
-    PinotDataBitSetV2 bitSet = getEmptyBitSet(bitPackedBufferSize, numBitsPerValue);
+    try (PinotDataBuffer dataBuffer = getBuffer(bitPackedBufferSize);
+        PinotDataBitSetV2 bitSet = getEmptyBitSet(dataBuffer, bitPackedBufferSize, numBitsPerValue)) {
+      Assert.assertEquals(2, numBitsPerValue);
+      Assert.assertTrue(bitSet instanceof PinotDataBitSetV2.Bit2Encoded);
 
-    Assert.assertEquals(2, numBitsPerValue);
-    Assert.assertTrue(bitSet instanceof PinotDataBitSetV2.Bit2Encoded);
+      for (int i = 0; i < rows; i++) {
+        bitSet.writeInt(i, forwardIndex[i]);
+      }
 
-    for (int i = 0; i < rows; i++) {
-      bitSet.writeInt(i, forwardIndex[i]);
-    }
+      // test single read API for sequential consecutive
+      for (int i = 0; i < rows; i++) {
+        int unpacked = bitSet.readInt(i);
+        Assert.assertEquals(forwardIndex[i], unpacked);
+      }
 
-    // test single read API for sequential consecutive
-    for (int i = 0; i < rows; i++) {
-      int unpacked = bitSet.readInt(i);
-      Assert.assertEquals(forwardIndex[i], unpacked);
-    }
+      // for each batch:
+      // 3 aligned reads at 4-byte boundary to unpack 16 integers after each read -- 48 integers unpacked
+      // followed by reading the next byte to unpack 2 integers from first 4 bits
+      int batchLength = 50;
+      int[] unpacked = new int[batchLength];
+      int startDocId;
+      for (startDocId = 0; startDocId < rows; startDocId += 50) {
+        bitSet.readInt(startDocId, batchLength, unpacked);
+        for (int i = 0; i < batchLength; i++) {
+          Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
+        }
+      }
 
-    // for each batch:
-    // 3 aligned reads at 4-byte boundary to unpack 16 integers after each read -- 48 integers unpacked
-    // followed by reading the next byte to unpack 2 integers from first 4 bits
-    int batchLength = 50;
-    int[] unpacked = new int[batchLength];
-    int startDocId;
-    for (startDocId = 0; startDocId < rows; startDocId += 50) {
+      // 3 aligned reads at 4-byte boundary to unpack 16 integers after each read -- 48 integers unpacked
+      // followed by reading the next 2 bytes to unpack 8 integers
+      batchLength = 56;
+      unpacked = new int[batchLength];
+      startDocId = 1;
+      batchRead(bitSet, startDocId, batchLength, unpacked, forwardIndex);
+
+      // 3 aligned reads at 4-byte boundary to unpack 16 integers after each read -- 48 integers unpacked
+      // followed by reading the next 2 bytes to unpack 8 integers
+      // followed by reading the next byte to unpack 4 integers
+      batchLength = 60;
+      unpacked = new int[batchLength];
+      startDocId = 20;
+      batchRead(bitSet, startDocId, batchLength, unpacked, forwardIndex);
+
+      // 3 aligned reads at 4-byte boundary to unpack 16 integers after each read -- 48 integers unpacked
+      // followed by reading the next 2 bytes to unpack 8 integers
+      // followed by reading the next byte to unpack 4 integers
+      // followed by reading the next byte to unpack 1 integer from first 2 bits
+      batchLength = 61;
+      unpacked = new int[batchLength];
+      startDocId = 20;
+      batchRead(bitSet, startDocId, batchLength, unpacked, forwardIndex);
+
+      // 3 aligned reads at 4-byte boundary to unpack 16 integers after each read -- 48 integers unpacked
+      // followed by reading the next 2 bytes to unpack 8 integers
+      // followed by reading the next byte to unpack 4 integers
+      // followed by reading the next byte to unpack 2 integers from first 4 bits
+      batchLength = 62;
+      unpacked = new int[batchLength];
+      startDocId = 20;
+      batchRead(bitSet, startDocId, batchLength, unpacked, forwardIndex);
+
+      // 3 aligned reads at 4-byte boundary to unpack 16 integers after each read -- 48 integers unpacked
+      // followed by reading the next 2 bytes to unpack 8 integers
+      // followed by reading the next byte to unpack 4 integers
+      // followed by reading the next byte to unpack 6 integers from first 6 bits
+      batchLength = 63;
+      unpacked = new int[batchLength];
+      startDocId = 20;
+      batchRead(bitSet, startDocId, batchLength, unpacked, forwardIndex);
+
+      // unaligned read on the first byte to unpack 3 integers
+      // followed by 3 aligned reads at byte boundary to unpack 4 integers after each read -- 12 integers unpacked
+      // followed by reading the next byte to unpack 2 integer from first 4 bits
+      // 3 + 12 + 2  = 17 unpacked integers
+      batchLength = 17;
+      unpacked = new int[batchLength];
+      startDocId = 1;
       bitSet.readInt(startDocId, batchLength, unpacked);
       for (int i = 0; i < batchLength; i++) {
         Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
       }
+
+      // unaligned read on the first byte to unpack 3 integers (bits 2 to 7)
+      // followed by 3 aligned reads at 4-byte boundary to unpack 16 integers after each read -- 48 integers unpacked
+      // followed by 1 aligned read at byte boundary to unpack 4 integers -- 4 integers unpacked
+      // followed by reading the next byte to unpack 3 integers from first 6 bits
+      // 3 + 48 + 4 + 3 = 58 unpacked integers
+      batchLength = 58;
+      unpacked = new int[batchLength];
+      startDocId = 1;
+      bitSet.readInt(startDocId, batchLength, unpacked);
+      for (int i = 0; i < batchLength; i++) {
+        Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
+      }
+
+      // for each batch:
+      // unaligned read on the first byte to unpack 2 integers (bits 4 to 7)
+      // followed by 3 aligned reads at 4-byte boundary to unpack 16 integers after each read -- 48 integers unpacked
+      // followed by 2 aligned reads at byte boundary to unpack 4 integers after each read -- 8 integers unpacked
+      // 3 + 48 + 8 = 58 unpacked integers
+      startDocId = 2;
+      unpacked = new int[batchLength];
+      bitSet.readInt(startDocId, batchLength, unpacked);
+      for (int i = 0; i < batchLength; i++) {
+        Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
+      }
+
+      // for each batch:
+      // unaligned read on the first byte to unpack 1 integers (bits 6 to 7)
+      // followed by 3 aligned reads at 4-byte boundary to unpack 16 integers after each read -- 48 integers unpacked
+      // followed by 2 aligned reads at byte boundary to unpack 4 integers after each read -- 8 integers unpacked
+      // followed by reading the next byte to unpack 1 integer from first 2 bits
+      // 1 + 48 + 8 + 1 = 58 unpacked integers
+      startDocId = 3;
+      unpacked = new int[batchLength];
+      bitSet.readInt(startDocId, batchLength, unpacked);
+      for (int i = 0; i < batchLength; i++) {
+        Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
+      }
+
+      // test bulk API for sequential but not necessarily consecutive
+      testBulkSequentialWithGaps(dataBuffer, forwardIndex, rows, 2);
     }
-
-    // 3 aligned reads at 4-byte boundary to unpack 16 integers after each read -- 48 integers unpacked
-    // followed by reading the next 2 bytes to unpack 8 integers
-    batchLength = 56;
-    unpacked = new int[batchLength];
-    startDocId = 1;
-    batchRead(bitSet, startDocId, batchLength, unpacked, forwardIndex);
-
-    // 3 aligned reads at 4-byte boundary to unpack 16 integers after each read -- 48 integers unpacked
-    // followed by reading the next 2 bytes to unpack 8 integers
-    // followed by reading the next byte to unpack 4 integers
-    batchLength = 60;
-    unpacked = new int[batchLength];
-    startDocId = 20;
-    batchRead(bitSet, startDocId, batchLength, unpacked, forwardIndex);
-
-    // 3 aligned reads at 4-byte boundary to unpack 16 integers after each read -- 48 integers unpacked
-    // followed by reading the next 2 bytes to unpack 8 integers
-    // followed by reading the next byte to unpack 4 integers
-    // followed by reading the next byte to unpack 1 integer from first 2 bits
-    batchLength = 61;
-    unpacked = new int[batchLength];
-    startDocId = 20;
-    batchRead(bitSet, startDocId, batchLength, unpacked, forwardIndex);
-
-    // 3 aligned reads at 4-byte boundary to unpack 16 integers after each read -- 48 integers unpacked
-    // followed by reading the next 2 bytes to unpack 8 integers
-    // followed by reading the next byte to unpack 4 integers
-    // followed by reading the next byte to unpack 2 integers from first 4 bits
-    batchLength = 62;
-    unpacked = new int[batchLength];
-    startDocId = 20;
-    batchRead(bitSet, startDocId, batchLength, unpacked, forwardIndex);
-
-    // 3 aligned reads at 4-byte boundary to unpack 16 integers after each read -- 48 integers unpacked
-    // followed by reading the next 2 bytes to unpack 8 integers
-    // followed by reading the next byte to unpack 4 integers
-    // followed by reading the next byte to unpack 6 integers from first 6 bits
-    batchLength = 63;
-    unpacked = new int[batchLength];
-    startDocId = 20;
-    batchRead(bitSet, startDocId, batchLength, unpacked, forwardIndex);
-
-    // for each batch:
-    // unaligned read on the first byte to unpack 3 integers
-    // followed by 3 aligned reads at byte boundary to unpack 4 integers after each read -- 12 integers unpacked
-    // followed by reading the next byte to unpack 2 integer from first 4 bits
-    // 3 + 12 + 2  = 17 unpacked integers
-    batchLength = 17;
-    unpacked = new int[batchLength];
-    startDocId = 1;
-    bitSet.readInt(startDocId, batchLength, unpacked);
-    for (int i = 0; i < batchLength; i++) {
-      Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
-    }
-
-    // unaligned read on the first byte to unpack 3 integers (bits 2 to 7)
-    // followed by 3 aligned reads at 4-byte boundary to unpack 16 integers after each read -- 48 integers unpacked
-    // followed by 1 aligned read at byte boundary to unpack 4 integers -- 4 integers unpacked
-    // followed by reading the next byte to unpack 3 integers from first 6 bits
-    // 3 + 48 + 4 + 3 = 58 unpacked integers
-    batchLength = 58;
-    unpacked = new int[batchLength];
-    startDocId = 1;
-    bitSet.readInt(startDocId, batchLength, unpacked);
-    for (int i = 0; i < batchLength; i++) {
-      Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
-    }
-
-    // for each batch:
-    // unaligned read on the first byte to unpack 2 integers (bits 4 to 7)
-    // followed by 3 aligned reads at 4-byte boundary to unpack 16 integers after each read -- 48 integers unpacked
-    // followed by 2 aligned reads at byte boundary to unpack 4 integers after each read -- 8 integers unpacked
-    // 3 + 48 + 8 = 58 unpacked integers
-    startDocId = 2;
-    unpacked = new int[batchLength];
-    bitSet.readInt(startDocId, batchLength, unpacked);
-    for (int i = 0; i < batchLength; i++) {
-      Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
-    }
-
-    // for each batch:
-    // unaligned read on the first byte to unpack 1 integers (bits 6 to 7)
-    // followed by 3 aligned reads at 4-byte boundary to unpack 16 integers after each read -- 48 integers unpacked
-    // followed by 2 aligned reads at byte boundary to unpack 4 integers after each read -- 8 integers unpacked
-    // followed by reading the next byte to unpack 1 integer from first 2 bits
-    // 1 + 48 + 8 + 1 = 58 unpacked integers
-    startDocId = 3;
-    unpacked = new int[batchLength];
-    bitSet.readInt(startDocId, batchLength, unpacked);
-    for (int i = 0; i < batchLength; i++) {
-      Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
-    }
-
-    bitSet.close();
   }
 
   @Test
   public void testBit4Encoded() throws Exception {
     int cardinality = 11;
-    int rows = 10000;
+    int rows = 100000;
     int[] forwardIndex = new int[rows];
     Random random = new Random();
 
@@ -185,103 +191,99 @@ public class PinotDataBitSetV2Test {
 
     int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(cardinality - 1);
     int bitPackedBufferSize = (rows * numBitsPerValue + Byte.SIZE - 1) / Byte.SIZE;
-    PinotDataBitSetV2 bitSet = getEmptyBitSet(bitPackedBufferSize, numBitsPerValue);
+    try (PinotDataBuffer dataBuffer = getBuffer(bitPackedBufferSize);
+        PinotDataBitSetV2 bitSet = getEmptyBitSet(dataBuffer, bitPackedBufferSize, numBitsPerValue)) {
+      Assert.assertEquals(4, numBitsPerValue);
+      Assert.assertTrue(bitSet instanceof PinotDataBitSetV2.Bit4Encoded);
 
-    Assert.assertEquals(4, numBitsPerValue);
-    Assert.assertTrue(bitSet instanceof PinotDataBitSetV2.Bit4Encoded);
+      for (int i = 0; i < rows; i++) {
+        bitSet.writeInt(i, forwardIndex[i]);
+      }
 
-    for (int i = 0; i < rows; i++) {
-      bitSet.writeInt(i, forwardIndex[i]);
-    }
+      // test single read API for sequential consecutive
+      for (int i = 0; i < rows; i++) {
+        int unpacked = bitSet.readInt(i);
+        Assert.assertEquals(forwardIndex[i], unpacked);
+      }
 
-    // test single read API for sequential consecutive
-    for (int i = 0; i < rows; i++) {
-      int unpacked = bitSet.readInt(i);
-      Assert.assertEquals(forwardIndex[i], unpacked);
-    }
+      // test array API for sequential consecutive
 
-    // test array API for sequential consecutive
+      // for each batch: do a combination of aligned and unaligned reads
+      // 6 aligned reads at 4-byte boundary to unpack 8 integers after each read -- 48 integers unpacked
+      // followed by reading the next byte to unpack 2 integers
+      int batchLength = 50;
+      int[] unpacked = new int[batchLength];
+      int startDocId;
+      for (startDocId = 0; startDocId < rows; startDocId += batchLength) {
+        bitSet.readInt(startDocId, batchLength, unpacked);
+        for (int i = 0; i < batchLength; i++) {
+          Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
+        }
+      }
 
-    // for each batch: do a combination of aligned and unaligned reads
-    // 6 aligned reads at 4-byte boundary to unpack 8 integers after each read -- 48 integers unpacked
-    // followed by reading the next byte to unpack 2 integers
-    int batchLength = 50;
-    int[] unpacked = new int[batchLength];
-    int startDocId;
-    for (startDocId = 0; startDocId < rows; startDocId += batchLength) {
+      // 12 aligned reads at 4-byte boundary to unpack 8 integers after each read -- 96 integers unpacked
+      batchLength = 96;
+      unpacked = new int[batchLength];
+      startDocId = 19;
       bitSet.readInt(startDocId, batchLength, unpacked);
       for (int i = 0; i < batchLength; i++) {
         Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
       }
+
+      // only a single unaligned read from the middle of a byte (44th bit)
+      batchLength = 1;
+      startDocId = 21;
+      bitSet.readInt(startDocId, batchLength, unpacked);
+      Assert.assertEquals(forwardIndex[startDocId], unpacked[0]);
+
+      // unaligned read within a byte to unpack an integer from bits 4 to 7
+      // followed by 2 aligned reads at 4-byte boundary to unpack 8 integers after each read -- unpacked 16 integers
+      // followed by 1 aligned read at 2-byte boundary to unpack 4 integers
+      // followed by 1 aligned read at byte boundary to unpack 2 integers
+      // followed by reading the next byte to unpack integer from first 4 bits
+      // 1 + 16 + 4 + 2 + 1 = 24 unpacked integers
+      startDocId = 1;
+      batchLength = 24;
+      unpacked = new int[batchLength];
+      bitSet.readInt(startDocId, batchLength, unpacked);
+      for (int i = 0; i < batchLength; i++) {
+        Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
+      }
+
+      // unaligned read within a byte to unpack an integer from bits 4 to 7
+      // 1 aligned read at 2-byte boundary to unpack 4 integers
+      // followed by 1 aligned read at byte boundary to unpack 2 integers
+      // followed by reading the next byte to unpack integer from first 4 bits
+      // 1 + 4 + 2 + 1 = 8 unpacked integers
+      startDocId = 1;
+      batchLength = 8;
+      unpacked = new int[batchLength];
+      bitSet.readInt(startDocId, batchLength, unpacked);
+      for (int i = 0; i < batchLength; i++) {
+        Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
+      }
+
+      // 1 aligned read at 2-byte boundary to unpack 4 integers
+      // followed by 1 aligned read at byte boundary to unpack 2 integers
+      // followed by reading the next byte to unpack integer from first 4 bits
+      // 4 + 2 + 1 = 7 unpacked integers
+      startDocId = 4;
+      batchLength = 7;
+      unpacked = new int[batchLength];
+      bitSet.readInt(startDocId, batchLength, unpacked);
+      for (int i = 0; i < batchLength; i++) {
+        Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
+      }
+
+      // test bulk API for sequential but not necessarily consecutive
+      testBulkSequentialWithGaps(dataBuffer, forwardIndex, rows, 4);
     }
-
-    // 12 aligned reads at 4-byte boundary to unpack 8 integers after each read -- 96 integers unpacked
-    batchLength = 96;
-    unpacked = new int[batchLength];
-    startDocId = 19;
-    bitSet.readInt(startDocId, batchLength, unpacked);
-    for (int i = 0; i < batchLength; i++) {
-      Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
-    }
-
-    // only a single unaligned read from the middle of a byte (44th bit)
-    batchLength = 1;
-    startDocId = 21;
-    bitSet.readInt(startDocId, batchLength, unpacked);
-    Assert.assertEquals(forwardIndex[startDocId], unpacked[0]);
-
-    // unaligned read within a byte to unpack an integer from bits 4 to 7
-    // followed by 2 aligned reads at 4-byte boundary to unpack 8 integers after each read -- unpacked 16 integers
-    // followed by 1 aligned read at 2-byte boundary to unpack 4 integers
-    // followed by 1 aligned read at byte boundary to unpack 2 integers
-    // followed by reading the next byte to unpack integer from first 4 bits
-    // 1 + 16 + 4 + 2 + 1 = 24 unpacked integers
-    startDocId = 1;
-    batchLength = 24;
-    unpacked = new int[batchLength];
-    bitSet.readInt(startDocId, batchLength, unpacked);
-    for (int i = 0; i < batchLength; i++) {
-      Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
-    }
-
-    // unaligned read within a byte to unpack an integer from bits 4 to 7
-    // 1 aligned read at 2-byte boundary to unpack 4 integers
-    // followed by 1 aligned read at byte boundary to unpack 2 integers
-    // followed by reading the next byte to unpack integer from first 4 bits
-    // 1 + 4 + 2 + 1 = 8 unpacked integers
-    startDocId = 1;
-    batchLength = 8;
-    unpacked = new int[batchLength];
-    bitSet.readInt(startDocId, batchLength, unpacked);
-    for (int i = 0; i < batchLength; i++) {
-      Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
-    }
-
-    // 1 aligned read at 2-byte boundary to unpack 4 integers
-    // followed by 1 aligned read at byte boundary to unpack 2 integers
-    // followed by reading the next byte to unpack integer from first 4 bits
-    // 4 + 2 + 1 = 7 unpacked integers
-    startDocId = 4;
-    batchLength = 7;
-    unpacked = new int[batchLength];
-    bitSet.readInt(startDocId, batchLength, unpacked);
-    for (int i = 0; i < batchLength; i++) {
-      Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
-    }
-
-    // test bulk API for sequential but not necessarily consecutive
-    testBulkSequentialWithGaps(bitSet, 1, 50, -1, forwardIndex);
-    testBulkSequentialWithGaps(bitSet, 5, 57, 4, forwardIndex);
-    testBulkSequentialWithGaps(bitSet, 17, 109, 19, forwardIndex);
-    testBulkSequentialWithGaps(bitSet, 17, 1, 19, forwardIndex);
-
-    bitSet.close();
   }
 
   @Test
   public void testBit8Encoded() throws Exception {
     int cardinality = 190;
-    int rows = 10000;
+    int rows = 100000;
     int[] forwardIndex = new int[rows];
     Random random = new Random();
 
@@ -291,59 +293,55 @@ public class PinotDataBitSetV2Test {
 
     int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(cardinality - 1);
     int bitPackedBufferSize = (rows * numBitsPerValue + Byte.SIZE - 1) / Byte.SIZE;
-    PinotDataBitSetV2 bitSet = getEmptyBitSet(bitPackedBufferSize, numBitsPerValue);
+    try (PinotDataBuffer dataBuffer = getBuffer(bitPackedBufferSize);
+        PinotDataBitSetV2 bitSet = getEmptyBitSet(dataBuffer, bitPackedBufferSize, numBitsPerValue)) {
+      Assert.assertEquals(8, numBitsPerValue);
+      Assert.assertTrue(bitSet instanceof PinotDataBitSetV2.Bit8Encoded);
 
-    Assert.assertEquals(8, numBitsPerValue);
-    Assert.assertTrue(bitSet instanceof PinotDataBitSetV2.Bit8Encoded);
+      for (int i = 0; i < rows; i++) {
+        bitSet.writeInt(i, forwardIndex[i]);
+      }
 
-    for (int i = 0; i < rows; i++) {
-      bitSet.writeInt(i, forwardIndex[i]);
-    }
+      // test single read API for sequential consecutive
+      for (int i = 0; i < rows; i++) {
+        int unpacked = bitSet.readInt(i);
+        Assert.assertEquals(forwardIndex[i], unpacked);
+      }
 
-    // test single read API for sequential consecutive
-    for (int i = 0; i < rows; i++) {
-      int unpacked = bitSet.readInt(i);
-      Assert.assertEquals(forwardIndex[i], unpacked);
-    }
+      // test array API for sequential consecutive
 
-    // test array API for sequential consecutive
+      // for each batch:
+      // 12 aligned reads at 4-byte boundary to unpack 4 integers after each read -- 48 integers unpacked
+      // followed by reading the next 2 bytes to unpack 2 integers
+      int batchLength = 50;
+      int[] unpacked = new int[batchLength];
+      int startDocId;
+      for (startDocId = 0; startDocId < rows; startDocId += batchLength) {
+        bitSet.readInt(startDocId, batchLength, unpacked);
+        for (int i = 0; i < batchLength; i++) {
+          Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
+        }
+      }
 
-    // for each batch:
-    // 12 aligned reads at 4-byte boundary to unpack 4 integers after each read -- 48 integers unpacked
-    // followed by reading the next 2 bytes to unpack 2 integers
-    int batchLength = 50;
-    int[] unpacked = new int[batchLength];
-    int startDocId;
-    for (startDocId = 0; startDocId < rows; startDocId += batchLength) {
+      // for each batch:
+      // 24 aligned reads at 4-byte boundary to unpack 4 integers after each read -- 96 integers unpacked
+      batchLength = 96;
+      unpacked = new int[batchLength];
+      startDocId = 7;
       bitSet.readInt(startDocId, batchLength, unpacked);
       for (int i = 0; i < batchLength; i++) {
         Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
       }
+
+      // unaligned spill over
+      startDocId = 19;
+      batchLength = 3;
+      bitSet.readInt(startDocId, batchLength, unpacked);
+      Assert.assertEquals(forwardIndex[startDocId], unpacked[0]);
+
+      // test bulk API for sequential but not necessarily consecutive
+      testBulkSequentialWithGaps(dataBuffer, forwardIndex, rows, 8);
     }
-
-    // for each batch:
-    // 24 aligned reads at 4-byte boundary to unpack 4 integers after each read -- 96 integers unpacked
-    batchLength = 96;
-    unpacked = new int[batchLength];
-    startDocId = 7;
-    bitSet.readInt(startDocId, batchLength, unpacked);
-    for (int i = 0; i < batchLength; i++) {
-      Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
-    }
-
-    // unaligned spill over
-    startDocId = 19;
-    batchLength = 3;
-    bitSet.readInt(startDocId, batchLength, unpacked);
-    Assert.assertEquals(forwardIndex[startDocId], unpacked[0]);
-
-    // test bulk API for sequential but not necessarily consecutive
-    testBulkSequentialWithGaps(bitSet, 1, 50, -1, forwardIndex);
-    testBulkSequentialWithGaps(bitSet, 5, 57, 4, forwardIndex);
-    testBulkSequentialWithGaps(bitSet, 17, 109, 19, forwardIndex);
-    testBulkSequentialWithGaps(bitSet, 17, 1, 19, forwardIndex);
-
-    bitSet.close();
   }
 
   @Test
@@ -359,61 +357,110 @@ public class PinotDataBitSetV2Test {
 
     int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(cardinality - 1);
     int bitPackedBufferSize = (rows * numBitsPerValue + Byte.SIZE - 1) / Byte.SIZE;
-    PinotDataBitSetV2 bitSet = getEmptyBitSet(bitPackedBufferSize, numBitsPerValue);
+    try (PinotDataBuffer dataBuffer = getBuffer(bitPackedBufferSize);
+        PinotDataBitSetV2 bitSet = getEmptyBitSet(dataBuffer, bitPackedBufferSize, numBitsPerValue)) {
+      Assert.assertEquals(16, numBitsPerValue);
+      Assert.assertTrue(bitSet instanceof PinotDataBitSetV2.Bit16Encoded);
 
-    Assert.assertEquals(16, numBitsPerValue);
-    Assert.assertTrue(bitSet instanceof PinotDataBitSetV2.Bit16Encoded);
+      for (int i = 0; i < rows; i++) {
+        bitSet.writeInt(i, forwardIndex[i]);
+      }
 
-    for (int i = 0; i < rows; i++) {
-      bitSet.writeInt(i, forwardIndex[i]);
-    }
+      // test single read API for sequential consecutive
+      for (int i = 0; i < rows; i++) {
+        int unpacked = bitSet.readInt(i);
+        Assert.assertEquals(forwardIndex[i], unpacked);
+      }
 
-    // test single read API for sequential consecutive
-    for (int i = 0; i < rows; i++) {
-      int unpacked = bitSet.readInt(i);
-      Assert.assertEquals(forwardIndex[i], unpacked);
-    }
+      // test array API for sequential consecutive
 
-    // test array API for sequential consecutive
+      // for each batch:
+      // 25 aligned reads at 4-byte boundary to unpack 2 integers after each read -- 50 integers unpacked
+      int batchLength = 50;
+      int[] unpacked = new int[batchLength];
+      int startDocId;
+      for (startDocId = 0; startDocId < rows; startDocId += batchLength) {
+        bitSet.readInt(startDocId, batchLength, unpacked);
+        for (int i = 0; i < batchLength; i++) {
+          Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
+        }
+      }
 
-    // for each batch:
-    // 25 aligned reads at 4-byte boundary to unpack 2 integers after each read -- 50 integers unpacked
-    int batchLength = 50;
-    int[] unpacked = new int[batchLength];
-    int startDocId;
-    for (startDocId = 0; startDocId < rows; startDocId += batchLength) {
+      // 25 aligned reads at 4-byte boundary to unpack 2 integers after each read -- 50 integers unpacked
+      // followed by unpacking 1 integer from the next 2 bytes
+      batchLength = 51;
+      startDocId = 3;
+      unpacked = new int[batchLength];
       bitSet.readInt(startDocId, batchLength, unpacked);
       for (int i = 0; i < batchLength; i++) {
         Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
       }
+
+      // unaligned spill over
+      startDocId = 7;
+      batchLength = 1;
+      bitSet.readInt(startDocId, batchLength, unpacked);
+      Assert.assertEquals(forwardIndex[startDocId], unpacked[0]);
+
+      // test array API for sequential but not necessarily consecutive
+      testBulkSequentialWithGaps(dataBuffer, forwardIndex, rows, 16);
     }
-
-    // 25 aligned reads at 4-byte boundary to unpack 2 integers after each read -- 50 integers unpacked
-    // followed by unpacking 1 integer from the next 2 bytes
-    batchLength = 51;
-    startDocId = 3;
-    unpacked = new int[batchLength];
-    bitSet.readInt(startDocId, batchLength, unpacked);
-    for (int i = 0; i < batchLength; i++) {
-      Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
-    }
-
-    // unaligned spill over
-    startDocId = 7;
-    batchLength = 1;
-    bitSet.readInt(startDocId, batchLength, unpacked);
-    Assert.assertEquals(forwardIndex[startDocId], unpacked[0]);
-
-    // test array API for sequential but not necessarily consecutive
-    testBulkSequentialWithGaps(bitSet, 1, 50, -1, forwardIndex);
-    testBulkSequentialWithGaps(bitSet, 5, 57, 4, forwardIndex);
-    testBulkSequentialWithGaps(bitSet, 17, 109, 19, forwardIndex);
-    testBulkSequentialWithGaps(bitSet, 17, 1, 19, forwardIndex);
-
-    bitSet.close();
   }
 
-  private void testBulkSequentialWithGaps(PinotDataBitSetV2 bitset, int gaps, int batchLength, int startDocId, int[] forwardIndex) {
+  @Test
+  public void testBit32Encoded() throws Exception {
+    int cardinality = 100000;
+    int rows = 100000;
+    int[] forwardIndex = new int[rows];
+    Random random = new Random();
+
+    for (int i = 0; i < rows; i++) {
+      forwardIndex[i] = random.nextInt(cardinality);
+    }
+
+    int numBitsPerValue = 32;
+    int bitPackedBufferSize = (rows * numBitsPerValue + Byte.SIZE - 1) / Byte.SIZE;
+    try (PinotDataBuffer dataBuffer = getBuffer(bitPackedBufferSize);
+        PinotDataBitSetV2 bitSet = getEmptyBitSet(dataBuffer, bitPackedBufferSize, numBitsPerValue)) {
+      Assert.assertTrue(bitSet instanceof PinotDataBitSetV2.RawInt);
+
+      for (int i = 0; i < rows; i++) {
+        bitSet.writeInt(i, forwardIndex[i]);
+      }
+
+      // test single read API for sequential consecutive
+      for (int i = 0; i < rows; i++) {
+        int unpacked = bitSet.readInt(i);
+        Assert.assertEquals(forwardIndex[i], unpacked);
+      }
+
+      // test array API for sequential consecutive
+      int batchLength = 50;
+      int[] unpacked = new int[batchLength];
+      int startDocId;
+      for (startDocId = 0; startDocId < rows; startDocId += batchLength) {
+        bitSet.readInt(startDocId, batchLength, unpacked);
+        for (int i = 0; i < batchLength; i++) {
+          Assert.assertEquals(forwardIndex[startDocId + i], unpacked[i]);
+        }
+      }
+
+      // test array API for sequential but not necessarily consecutive
+      testBulkSequentialWithGaps(dataBuffer, forwardIndex, rows, 32);
+    }
+  }
+
+  private void testBulkSequentialWithGaps(PinotDataBuffer dataBuffer, int[] forwardIndex, int rows, int numBits) {
+    testBulkSequentialWithGaps(dataBuffer, 1, 50, -1, forwardIndex, rows, numBits);
+    testBulkSequentialWithGaps(dataBuffer, 3, 57, 4, forwardIndex, rows, numBits);
+    testBulkSequentialWithGaps(dataBuffer, 5, 109, 9, forwardIndex, rows, numBits);
+    testBulkSequentialWithGaps(dataBuffer, 7, 1000, 4, forwardIndex, rows, numBits);
+    testBulkSequentialWithGaps(dataBuffer, 17, 233, 19, forwardIndex, rows, numBits);
+    testBulkSequentialWithGaps(dataBuffer, 1, 1, 19, forwardIndex, rows, numBits);
+  }
+
+  private void testBulkSequentialWithGaps(PinotDataBuffer dataBuffer, int gaps,
+      int batchLength, int startDocId, int[] forwardIndex, int rows, int numBits) {
     int docId = startDocId;
     int[] docIds = new int[batchLength];
     Random random = new Random();
@@ -422,17 +469,21 @@ public class PinotDataBitSetV2Test {
       docIds[i] = docId;
     }
     int[] unpacked = new int[batchLength];
-    bitset.readInt(docIds, 0, batchLength, unpacked, 0);
+    FixedBitIntReaderWriterV2 bitReader = new FixedBitIntReaderWriterV2(dataBuffer, rows, numBits);
+    bitReader.readValues(docIds, 0, batchLength, unpacked, 0);
     for (int i = 0; i < batchLength; i++) {
       Assert.assertEquals(forwardIndex[docIds[i]], unpacked[i]);
     }
   }
 
-  private PinotDataBitSetV2 getEmptyBitSet(int size, int numBitsPerValue) {
-    PinotDataBuffer bitPackedBuffer = PinotDataBuffer.allocateDirect(size, ByteOrder.BIG_ENDIAN, null);
+  private PinotDataBuffer getBuffer(int size) {
+    return PinotDataBuffer.allocateDirect(size, ByteOrder.BIG_ENDIAN, null);
+  }
+
+  private PinotDataBitSetV2 getEmptyBitSet(PinotDataBuffer bitPackedBuffer, int size, int numBitsPerValue) {
     for (int i = 0; i < size; i++) {
       bitPackedBuffer.readFrom(0, new byte[size]);
     }
-    return PinotDataBitSetV2.createBitSet(bitPackedBuffer, numBitsPerValue);
+    return (PinotDataBitSetV2)PinotDataBitSetFactory.createBitSet(bitPackedBuffer, numBitsPerValue);
   }
 }

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkPinotDataBitSet.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkPinotDataBitSet.java
@@ -30,6 +30,7 @@ import org.apache.pinot.core.io.reader.impl.v1.FixedBitSingleValueReader;
 import org.apache.pinot.core.io.util.FixedBitIntReaderWriter;
 import org.apache.pinot.core.io.util.FixedBitIntReaderWriterV2;
 import org.apache.pinot.core.io.util.PinotDataBitSet;
+import org.apache.pinot.core.io.util.PinotDataBitSetFactory;
 import org.apache.pinot.core.io.util.PinotDataBitSetV2;
 import org.apache.pinot.core.io.writer.impl.v1.FixedBitSingleValueWriter;
 import org.apache.pinot.core.segment.memory.PinotDataBuffer;
@@ -55,16 +56,19 @@ public class BenchmarkPinotDataBitSet {
   private static final int CARDINALITY_4_BITS = 12;
   private static final int CARDINALITY_8_BITS = 190;
   private static final int CARDINALITY_16_BITS = 40000;
+  private static final int CARDINALITY_32_BITS = 100000;
 
-  private File twoBitEncodedFile = new File("/Users/steotia/two-bit-encoded");
-  private File fourBitEncodedFile = new File("/Users/steotia/four-bit-encoded");
-  private File eightBitEncodedFile = new File("/Users/steotia/eight-bit-encoded");
-  private File sixteenBitEncodedFile = new File("/Users/steotia/sixteen-bit-encoded");
+  private File twoBitEncodedFile = new File("/Users/steotia/2-bit-encoded");
+  private File fourBitEncodedFile = new File("/Users/steotia/4-bit-encoded");
+  private File eightBitEncodedFile = new File("/Users/steotia/8-bit-encoded");
+  private File sixteenBitEncodedFile = new File("/Users/steotia/16-bit-encoded");
+  private File thirtyTwoBitEncodedFile = new File("/Users/steotia/32-bit-encoded");
 
   private File rawFile2 = new File("/Users/steotia/raw2");
   private File rawFile4 = new File("/Users/steotia/raw4");
   private File rawFile8 = new File("/Users/steotia/raw8");
   private File rawFile16 = new File("/Users/steotia/raw16");
+  private File rawFile32 = new File("/Users/steotia/raw32");
 
   static int ROWS = 20_000_000;
   static int NUM_DOCIDS_WITH_GAPS = 9000;
@@ -73,30 +77,27 @@ public class BenchmarkPinotDataBitSet {
   private int[] rawValues4 = new int[ROWS];
   private int[] rawValues8 = new int[ROWS];
   private int[] rawValues16 = new int[ROWS];
+  private int[] rawValues32 = new int[ROWS];
 
   PinotDataBuffer _pinotDataBuffer2;
-  private PinotDataBitSet _bitSet2;
-  private PinotDataBitSetV2 _bitSet2Fast;
-  private FixedBitSingleValueReader _bit2Reader;
+  private FixedBitIntReaderWriter _bit2Reader;
   private FixedBitIntReaderWriterV2 _bit2ReaderFast;
 
   PinotDataBuffer _pinotDataBuffer4;
-  private PinotDataBitSet _bitSet4;
-  private PinotDataBitSetV2 _bitSet4Fast;
-  private FixedBitSingleValueReader _bit4Reader;
+  private FixedBitIntReaderWriter _bit4Reader;
   private FixedBitIntReaderWriterV2 _bit4ReaderFast;
 
   PinotDataBuffer _pinotDataBuffer8;
-  private PinotDataBitSet _bitSet8;
-  private PinotDataBitSetV2 _bitSet8Fast;
-  private FixedBitSingleValueReader _bit8Reader;
+  private FixedBitIntReaderWriter _bit8Reader;
   private FixedBitIntReaderWriterV2 _bit8ReaderFast;
 
   PinotDataBuffer _pinotDataBuffer16;
-  private PinotDataBitSet _bitSet16;
-  private PinotDataBitSetV2 _bitSet16Fast;
-  private FixedBitSingleValueReader _bit16Reader;
+  private FixedBitIntReaderWriter _bit16Reader;
   private FixedBitIntReaderWriterV2 _bit16ReaderFast;
+
+  PinotDataBuffer _pinotDataBuffer32;
+  private FixedBitIntReaderWriter _bit32Reader;
+  private FixedBitIntReaderWriterV2 _bit32ReaderFast;
 
   int[] unpacked = new int[32];
   int[] unalignedUnpacked2Bit = new int[50];
@@ -105,6 +106,7 @@ public class BenchmarkPinotDataBitSet {
   int[] unalignedUnpacked16Bit = new int[49];
 
   int[] docIdsWithGaps = new int[NUM_DOCIDS_WITH_GAPS];
+  int[] docIdsWithSparseGaps = new int[NUM_DOCIDS_WITH_GAPS];
   int[] unpackedWithGaps = new int[NUM_DOCIDS_WITH_GAPS];
 
   @Setup(Level.Trial)
@@ -119,16 +121,19 @@ public class BenchmarkPinotDataBitSet {
     rawFile4.delete();
     rawFile8.delete();
     rawFile16.delete();
+    rawFile32.delete();
 
     twoBitEncodedFile.delete();
     fourBitEncodedFile.delete();
     eightBitEncodedFile.delete();
     sixteenBitEncodedFile.delete();
+    thirtyTwoBitEncodedFile.delete();
 
     _pinotDataBuffer2.close();
     _pinotDataBuffer4.close();
     _pinotDataBuffer8.close();
     _pinotDataBuffer16.close();
+    _pinotDataBuffer32.close();
   }
 
   private void generateRawFile()
@@ -137,12 +142,14 @@ public class BenchmarkPinotDataBitSet {
     BufferedWriter bw4 = new BufferedWriter(new FileWriter(rawFile4));
     BufferedWriter bw8 = new BufferedWriter(new FileWriter(rawFile8));
     BufferedWriter bw16 = new BufferedWriter(new FileWriter(rawFile16));
+    BufferedWriter bw32 = new BufferedWriter(new FileWriter(rawFile32));
     Random r = new Random();
     for (int i = 0; i < ROWS; i++) {
       rawValues2[i] =  r.nextInt(CARDINALITY_2_BITS);
       rawValues4[i] =  r.nextInt(CARDINALITY_4_BITS);
       rawValues8[i] =  r.nextInt(CARDINALITY_8_BITS);
       rawValues16[i] =  r.nextInt(CARDINALITY_16_BITS);
+      rawValues32[i] =  r.nextInt(CARDINALITY_32_BITS);
       bw2.write("" + rawValues2[i]);
       bw2.write("\n");
       bw4.write("" + rawValues4[i]);
@@ -151,11 +158,14 @@ public class BenchmarkPinotDataBitSet {
       bw8.write("\n");
       bw16.write("" + rawValues16[i]);
       bw16.write("\n");
+      bw32.write("" + rawValues32[i]);
+      bw32.write("\n");
     }
     bw2.close();
     bw4.close();
     bw8.close();
     bw16.close();
+    bw32.close();
   }
 
   private void generateBitEncodedFwdIndex() throws Exception {
@@ -163,34 +173,33 @@ public class BenchmarkPinotDataBitSet {
     generateFwdIndexHelper(rawFile4, fourBitEncodedFile, 4);
     generateFwdIndexHelper(rawFile8, eightBitEncodedFile, 8);
     generateFwdIndexHelper(rawFile16, sixteenBitEncodedFile, 16);
+    generateFwdIndexHelper(rawFile32, thirtyTwoBitEncodedFile, 32);
 
     _pinotDataBuffer2 = PinotDataBuffer.loadBigEndianFile(twoBitEncodedFile);
-    _bitSet2Fast = PinotDataBitSetV2.createBitSet(_pinotDataBuffer2, 2);
     _bit2ReaderFast = new FixedBitIntReaderWriterV2(_pinotDataBuffer2, ROWS, 2);
-    _bitSet2 = new PinotDataBitSet(_pinotDataBuffer2);
-    _bit2Reader = new FixedBitSingleValueReader(_pinotDataBuffer2, ROWS, 2);
+    _bit2Reader = new FixedBitIntReaderWriter(_pinotDataBuffer2, ROWS, 2);
 
     _pinotDataBuffer4 = PinotDataBuffer.loadBigEndianFile(fourBitEncodedFile);
-    _bitSet4Fast = PinotDataBitSetV2.createBitSet(_pinotDataBuffer4, 4);
     _bit4ReaderFast = new FixedBitIntReaderWriterV2(_pinotDataBuffer4, ROWS, 4);
-    _bitSet4 = new PinotDataBitSet(_pinotDataBuffer4);
-    _bit4Reader = new FixedBitSingleValueReader(_pinotDataBuffer4, ROWS, 4);
+    _bit4Reader = new FixedBitIntReaderWriter(_pinotDataBuffer4, ROWS, 4);
 
     _pinotDataBuffer8 = PinotDataBuffer.loadBigEndianFile(eightBitEncodedFile);
-    _bitSet8Fast = PinotDataBitSetV2.createBitSet(_pinotDataBuffer8, 8);
     _bit8ReaderFast = new FixedBitIntReaderWriterV2(_pinotDataBuffer8, ROWS, 8);
-    _bitSet8 = new PinotDataBitSet(_pinotDataBuffer8);
-    _bit8Reader = new FixedBitSingleValueReader(_pinotDataBuffer8, ROWS, 8);
+    _bit8Reader = new FixedBitIntReaderWriter(_pinotDataBuffer8, ROWS, 8);
 
     _pinotDataBuffer16 = PinotDataBuffer.loadBigEndianFile(sixteenBitEncodedFile);
-    _bitSet16Fast = PinotDataBitSetV2.createBitSet(_pinotDataBuffer16, 16);
     _bit16ReaderFast = new FixedBitIntReaderWriterV2(_pinotDataBuffer16, ROWS, 16);
-    _bitSet16 = new PinotDataBitSet(_pinotDataBuffer16);
-    _bit16Reader = new FixedBitSingleValueReader(_pinotDataBuffer16, ROWS, 16);
+    _bit16Reader = new FixedBitIntReaderWriter(_pinotDataBuffer16, ROWS, 16);
+
+    _pinotDataBuffer32 = PinotDataBuffer.loadBigEndianFile(thirtyTwoBitEncodedFile);
+    _bit32ReaderFast = new FixedBitIntReaderWriterV2(_pinotDataBuffer32, ROWS, 32);
+    _bit32Reader = new FixedBitIntReaderWriter(_pinotDataBuffer32, ROWS, 32);
 
     docIdsWithGaps[0] = 0;
+    docIdsWithSparseGaps[0] = 0;
     for (int i = 1; i < NUM_DOCIDS_WITH_GAPS; i++) {
       docIdsWithGaps[i] = docIdsWithGaps[i - 1] + 2;
+      docIdsWithSparseGaps[i] = docIdsWithSparseGaps[i - 1] + 10;
     }
   }
 
@@ -209,9 +218,9 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void twoBitContiguous() {
+  public void bit2Contiguous() {
     for (int startIndex = 0; startIndex < ROWS; startIndex++) {
-      _bitSet2.readInt(startIndex, 2);
+      _bit2Reader.readInt(startIndex);
     }
   }
 
@@ -220,9 +229,9 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void twoBitContiguousFast() {
+  public void bit2ContiguousFast() {
     for (int startIndex = 0; startIndex < ROWS; startIndex++) {
-      _bitSet2Fast.readInt(startIndex);
+      _bit2ReaderFast.readInt(startIndex);
     }
   }
 
@@ -230,9 +239,9 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void twoBitBulkContiguous() {
+  public void bit2BulkContiguous() {
     for (int startIndex = 0; startIndex < ROWS; startIndex += 32) {
-      _bitSet2.readInt(startIndex, 2, 32, unpacked);
+      _bit2Reader.readInt(startIndex, 32, unpacked);
     }
   }
 
@@ -241,9 +250,9 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void twoBitBulkContiguousFast() {
+  public void bit2BulkContiguousFast() {
     for (int startIndex = 0; startIndex < ROWS; startIndex += 32) {
-      _bitSet2Fast.readInt(startIndex, 32, unpacked);
+      _bit2ReaderFast.readInt(startIndex, 32, unpacked);
     }
   }
 
@@ -252,7 +261,7 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.Throughput)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void twoBitBulkWithGaps() {
+  public void bit2BulkWithGaps() {
     _bit2Reader.readValues(docIdsWithGaps, 0, NUM_DOCIDS_WITH_GAPS, unpackedWithGaps, 0);
   }
 
@@ -261,18 +270,38 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.Throughput)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void twoBitBulkWithGapsFast() {
+  public void bit2BulkWithGapsFast() {
     _bit2ReaderFast.readValues(docIdsWithGaps, 0, NUM_DOCIDS_WITH_GAPS, unpackedWithGaps, 0);
   }
 
+  // 2-bit: test multi integer decode for a set of monotonically
+  // increasing docIds with sparse gaps
+  @Benchmark
+  @BenchmarkMode(Mode.Throughput)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void bit2BulkWithSparseGaps() {
+    _bit2Reader.readValues(docIdsWithSparseGaps, 0, NUM_DOCIDS_WITH_GAPS, unpackedWithGaps, 0);
+  }
+
+  // 2-bit: test multi integer decode for a set of monotonically
+  // increasing docIds with sparse gaps with optimized API
+  // this won't use the vectorized bulk read due to sparseness
+  // but will still leverage the efficient single read unpacking API
+  @Benchmark
+  @BenchmarkMode(Mode.Throughput)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void bit2BulkWithSparseGapsFast() {
+    _bit2ReaderFast.readValues(docIdsWithSparseGaps, 0, NUM_DOCIDS_WITH_GAPS, unpackedWithGaps, 0);
+  }
+
   // 2-bit: test multi integer decode for a range of contiguous docIds
   // starting at unaligned boundary and spilling over to unaligned boundary
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void twoBitBulkContiguousUnaligned() {
+  public void bit2BulkContiguousUnaligned() {
     for (int startIndex = 1; startIndex < ROWS - 50; startIndex += 50) {
-      _bitSet2.readInt(startIndex, 2, 50, unalignedUnpacked2Bit);
+      _bit2Reader.readInt(startIndex, 50, unalignedUnpacked2Bit);
     }
   }
 
@@ -282,9 +311,9 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void twoBitBulkContiguousUnalignedFast() {
+  public void bit2BulkContiguousUnalignedFast() {
     for (int startIndex = 1; startIndex < ROWS - 50; startIndex += 50) {
-      _bitSet2Fast.readInt(startIndex, 50, unalignedUnpacked2Bit);
+      _bit2ReaderFast.readInt(startIndex, 50, unalignedUnpacked2Bit);
     }
   }
 
@@ -292,9 +321,9 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void fourBitContiguous() {
+  public void bit4Contiguous() {
     for (int startIndex = 0; startIndex < ROWS; startIndex++) {
-      _bitSet4.readInt(startIndex, 4);
+      _bit4Reader.readInt(startIndex);
     }
   }
 
@@ -303,9 +332,9 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void fourBitContiguousFast() {
+  public void bit4ContiguousFast() {
     for (int startIndex = 0; startIndex < ROWS; startIndex++) {
-      _bitSet4Fast.readInt(startIndex);
+      _bit4ReaderFast.readInt(startIndex);
     }
   }
 
@@ -313,9 +342,9 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void fourBitBulkContiguous() {
+  public void bit4BulkContiguous() {
     for (int startIndex = 0; startIndex < ROWS; startIndex += 32) {
-      _bitSet4.readInt(startIndex, 4, 32, unpacked);
+      _bit4Reader.readInt(startIndex, 32, unpacked);
     }
   }
 
@@ -324,9 +353,9 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void fourBitBulkContiguousFast() {
+  public void bit4BulkContiguousFast() {
     for (int startIndex = 0; startIndex < ROWS; startIndex += 32) {
-      _bitSet4Fast.readInt(startIndex, 32, unpacked);
+      _bit4ReaderFast.readInt(startIndex, 32, unpacked);
     }
   }
 
@@ -335,7 +364,7 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.Throughput)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void fourBitBulkWithGaps() {
+  public void bit4BulkWithGaps() {
     _bit4Reader.readValues(docIdsWithGaps, 0, NUM_DOCIDS_WITH_GAPS, unpackedWithGaps, 0);
   }
 
@@ -344,18 +373,38 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.Throughput)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void fourBitBulkWithGapsFast() {
+  public void bit4BulkWithGapsFast() {
     _bit4ReaderFast.readValues(docIdsWithGaps, 0, NUM_DOCIDS_WITH_GAPS, unpackedWithGaps, 0);
   }
 
+  // 4-bit: test multi integer decode for a set of monotonically
+  // increasing docIds with gaps
+  @Benchmark
+  @BenchmarkMode(Mode.Throughput)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void bit4BulkWithSparseGaps() {
+    _bit4Reader.readValues(docIdsWithSparseGaps, 0, NUM_DOCIDS_WITH_GAPS, unpackedWithGaps, 0);
+  }
+
+  // 4-bit: test multi integer decode for a set of monotonically
+  // increasing docIds with gaps with optimized API
+  // this won't use the vectorized bulk read due to sparseness
+  // but will still leverage the efficient single read unpacking API
+  @Benchmark
+  @BenchmarkMode(Mode.Throughput)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void bit4BulkWithSparseGapsFast() {
+    _bit4ReaderFast.readValues(docIdsWithSparseGaps, 0, NUM_DOCIDS_WITH_GAPS, unpackedWithGaps, 0);
+  }
+
   // 4-bit: test multi integer decode for a range of contiguous docIds
   // starting at unaligned boundary and spilling over to unaligned boundary
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void fourBitBulkContiguousUnaligned() {
+  public void bit4BulkContiguousUnaligned() {
     for (int startIndex = 1; startIndex < ROWS - 48; startIndex += 48) {
-      _bitSet4.readInt(startIndex, 4, 48, unalignedUnpacked4Bit);
+      _bit4Reader.readInt(startIndex, 48, unalignedUnpacked4Bit);
     }
   }
 
@@ -365,9 +414,9 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void fourBitBulkContiguousUnalignedFast() {
+  public void bit4BulkContiguousUnalignedFast() {
     for (int startIndex = 1; startIndex < ROWS - 48; startIndex += 48) {
-      _bitSet4Fast.readInt(startIndex, 48, unalignedUnpacked8Bit);
+      _bit4ReaderFast.readInt(startIndex, 48, unalignedUnpacked8Bit);
     }
   }
 
@@ -375,9 +424,9 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void eightBitContiguous() {
+  public void bit8Contiguous() {
     for (int startIndex = 0; startIndex < ROWS; startIndex++) {
-      _bitSet8.readInt(startIndex, 8);
+      _bit8Reader.readInt(startIndex);
     }
   }
 
@@ -386,9 +435,9 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void eightBitContiguousFast() {
+  public void bit8ContiguousFast() {
     for (int startIndex = 0; startIndex < ROWS; startIndex++) {
-      _bitSet8Fast.readInt(startIndex);
+      _bit8ReaderFast.readInt(startIndex);
     }
   }
 
@@ -396,9 +445,9 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void eightBitBulkContiguous() {
+  public void bit8BulkContiguous() {
     for (int startIndex = 0; startIndex < ROWS; startIndex += 32) {
-      _bitSet8.readInt(startIndex, 8, 32, unpacked);
+      _bit8Reader.readInt(startIndex, 32, unpacked);
     }
   }
 
@@ -407,9 +456,9 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void eightBitBulkContiguousFast() {
+  public void bit8BulkContiguousFast() {
     for (int startIndex = 0; startIndex < ROWS; startIndex += 32) {
-      _bitSet8Fast.readInt(startIndex, 32, unpacked);
+      _bit8ReaderFast.readInt(startIndex, 32, unpacked);
     }
   }
 
@@ -418,7 +467,7 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.Throughput)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void eightBitBulkWithGaps() {
+  public void bit8BulkWithGaps() {
     _bit8Reader.readValues(docIdsWithGaps, 0, NUM_DOCIDS_WITH_GAPS, unpackedWithGaps, 0);
   }
 
@@ -427,18 +476,38 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.Throughput)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void eightBitBulkWithGapsFast() {
+  public void bit8BulkWithGapsFast() {
     _bit8ReaderFast.readValues(docIdsWithGaps, 0, NUM_DOCIDS_WITH_GAPS, unpackedWithGaps, 0);
   }
 
+  // 8-bit: test multi integer decode for a set of monotonically
+  // increasing docIds with gaps
+  @Benchmark
+  @BenchmarkMode(Mode.Throughput)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void bit8BulkWithSparseGaps() {
+    _bit8Reader.readValues(docIdsWithSparseGaps, 0, NUM_DOCIDS_WITH_GAPS, unpackedWithGaps, 0);
+  }
+
+  // 8-bit: test multi integer decode for a set of monotonically
+  // increasing docIds with gaps with optimized API
+  // this won't use the vectorized bulk read due to sparseness
+  // but will still leverage the efficient single read unpacking API
+  @Benchmark
+  @BenchmarkMode(Mode.Throughput)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void bit8BulkWithSparseGapsFast() {
+    _bit8ReaderFast.readValues(docIdsWithSparseGaps, 0, NUM_DOCIDS_WITH_GAPS, unpackedWithGaps, 0);
+  }
+
   // 8-bit: test multi integer decode for a range of contiguous docIds
   // starting at unaligned boundary and spilling over to unaligned boundary
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void eightBitBulkContiguousUnaligned() {
+  public void bit8BulkContiguousUnaligned() {
     for (int startIndex = 1; startIndex < ROWS - 51; startIndex += 51) {
-      _bitSet8.readInt(startIndex, 8, 51, unalignedUnpacked8Bit);
+      _bit8Reader.readInt(startIndex, 51, unalignedUnpacked8Bit);
     }
   }
 
@@ -448,9 +517,9 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void eightBitBulkContiguousUnalignedFast() {
+  public void bit8BulkContiguousUnalignedFast() {
     for (int startIndex = 1; startIndex < ROWS - 51; startIndex += 51) {
-      _bitSet8Fast.readInt(startIndex, 51, unalignedUnpacked8Bit);
+      _bit8ReaderFast.readInt(startIndex, 51, unalignedUnpacked8Bit);
     }
   }
 
@@ -458,9 +527,9 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void sixteenBitContiguous() {
+  public void bit16Contiguous() {
     for (int startIndex = 0; startIndex < ROWS; startIndex++) {
-      _bitSet16.readInt(startIndex, 16);
+      _bit16Reader.readInt(startIndex);
     }
   }
 
@@ -469,9 +538,9 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void sixteenBitContiguousFast() {
+  public void bit16ContiguousFast() {
     for (int startIndex = 0; startIndex < ROWS; startIndex++) {
-      _bitSet16Fast.readInt(startIndex);
+      _bit16ReaderFast.readInt(startIndex);
     }
   }
 
@@ -479,20 +548,20 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void sixteenBitBulkContiguous() {
+  public void bit16BulkContiguous() {
     for (int startIndex = 0; startIndex < ROWS; startIndex += 32) {
-      _bitSet16.readInt(startIndex, 16, 32, unpacked);
+      _bit16Reader.readInt(startIndex, 32, unpacked);
     }
   }
 
-  // 2-bit: test multi integer decode for a range of contiguous docIds
+  // 16-bit: test multi integer decode for a range of contiguous docIds
   // with optimized API
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void sixteenBitBulkContiguousFast() {
+  public void bit16BulkContiguousFast() {
     for (int startIndex = 0; startIndex < ROWS; startIndex += 32) {
-      _bitSet16Fast.readInt(startIndex, 32, unpacked);
+      _bit16ReaderFast.readInt(startIndex, 32, unpacked);
     }
   }
 
@@ -501,7 +570,7 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.Throughput)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void sixteenBitBulkWithGaps() {
+  public void bit16BulkWithGaps() {
     _bit16Reader.readValues(docIdsWithGaps, 0, NUM_DOCIDS_WITH_GAPS, unpackedWithGaps, 0);
   }
 
@@ -510,8 +579,26 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.Throughput)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void sixteenBitBulkWithGapsFast() {
+  public void bit16BulkWithGapsFast() {
     _bit16ReaderFast.readValues(docIdsWithGaps, 0, NUM_DOCIDS_WITH_GAPS, unpackedWithGaps, 0);
+  }
+
+  // 16-bit: test multi integer decode for a set of monotonically
+  // increasing docIds with gaps
+  @Benchmark
+  @BenchmarkMode(Mode.Throughput)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void bit16BulkWithSparseGaps() {
+    _bit16Reader.readValues(docIdsWithSparseGaps, 0, NUM_DOCIDS_WITH_GAPS, unpackedWithGaps, 0);
+  }
+
+  // 16-bit: test multi integer decode for a set of monotonically
+  // increasing docIds with gaps with optimized API
+  @Benchmark
+  @BenchmarkMode(Mode.Throughput)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void bit16BulkWithSparseGapsFast() {
+    _bit16ReaderFast.readValues(docIdsWithSparseGaps, 0, NUM_DOCIDS_WITH_GAPS, unpackedWithGaps, 0);
   }
 
   // 16-bit: test multi integer decode for a range of contiguous docIds
@@ -519,9 +606,9 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void sixteenBitBulkContiguousUnaligned() {
+  public void bit16BulkContiguousUnaligned() {
     for (int startIndex = 1; startIndex < ROWS - 49; startIndex += 49) {
-      _bitSet16.readInt(startIndex, 16, 51, unalignedUnpacked16Bit);
+      _bit16Reader.readInt(startIndex, 49, unalignedUnpacked16Bit);
     }
   }
 
@@ -531,16 +618,94 @@ public class BenchmarkPinotDataBitSet {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void sixteenBitBulkContiguousUnalignedFast() {
+  public void bit16BulkContiguousUnalignedFast() {
     for (int startIndex = 1; startIndex < ROWS - 49; startIndex += 49) {
-      _bitSet16Fast.readInt(startIndex, 49, unalignedUnpacked16Bit);
+      _bit16ReaderFast.readInt(startIndex, 49, unalignedUnpacked16Bit);
     }
+  }
+
+  // 32-bit: test single integer decode in a contiguous manner one docId at a time
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void bit32Contiguous() {
+    for (int startIndex = 0; startIndex < ROWS; startIndex++) {
+      _bit32Reader.readInt(startIndex);
+    }
+  }
+
+  // 32-bit: test single integer decode in a contiguous manner one docId at a time
+  // with optimized API
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void bit32ContiguousFast() {
+    for (int startIndex = 0; startIndex < ROWS; startIndex++) {
+      _bit32ReaderFast.readInt(startIndex);
+    }
+  }
+
+  // 32-bit: test multi integer decode for a range of contiguous docIds
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void bit32BulkContiguous() {
+    for (int startIndex = 0; startIndex < ROWS; startIndex += 32) {
+      _bit32Reader.readInt(startIndex, 32, unpacked);
+    }
+  }
+
+  // 32-bit: test multi integer decode for a range of contiguous docIds
+  // with optimized API
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void bit32BulkContiguousFast() {
+    for (int startIndex = 0; startIndex < ROWS; startIndex += 32) {
+      _bit32ReaderFast.readInt(startIndex, 32, unpacked);
+    }
+  }
+
+  // 32-bit: test multi integer decode for a set of monotonically
+  // increasing docIds with gaps
+  @Benchmark
+  @BenchmarkMode(Mode.Throughput)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void bit32BulkWithGaps() {
+    _bit32Reader.readValues(docIdsWithGaps, 0, NUM_DOCIDS_WITH_GAPS, unpackedWithGaps, 0);
+  }
+
+  // 32-bit: test multi integer decode for a set of monotonically
+  // increasing docIds with gaps with optimized API
+  @Benchmark
+  @BenchmarkMode(Mode.Throughput)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void bit32BulkWithGapsFast() {
+    _bit32ReaderFast.readValues(docIdsWithGaps, 0, NUM_DOCIDS_WITH_GAPS, unpackedWithGaps, 0);
+  }
+
+  // 32-bit: test multi integer decode for a set of monotonically
+  // increasing docIds with gaps
+  @Benchmark
+  @BenchmarkMode(Mode.Throughput)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void bit32BulkWithSparseGaps() {
+    _bit16Reader.readValues(docIdsWithSparseGaps, 0, NUM_DOCIDS_WITH_GAPS, unpackedWithGaps, 0);
+  }
+
+  // 32-bit: test multi integer decode for a set of monotonically
+  // increasing docIds with gaps with optimized API
+  @Benchmark
+  @BenchmarkMode(Mode.Throughput)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void bit32BulkWithSparseGapsFast() {
+    _bit16ReaderFast.readValues(docIdsWithSparseGaps, 0, NUM_DOCIDS_WITH_GAPS, unpackedWithGaps, 0);
   }
 
   public static void main(String[] args)
       throws Exception {
     ChainedOptionsBuilder opt = new OptionsBuilder().include(BenchmarkPinotDataBitSet.class.getSimpleName())
-        .warmupIterations(1).measurementIterations(3);
+        .warmupIterations(1).measurementIterations(1);
     new Runner(opt.build()).run();
   }
 }


### PR DESCRIPTION
## Description
In PR https://github.com/apache/incubator-pinot/pull/5409, we implemented efficient vectorized bit unpacking reader (no format change, just new unpack algorithms) for dictionary encoded bit-compressed forward index.

This PR starts the integration process which is divided into multiple parts

- **Part 1:** Use for SV reader, MV reader for power of 2 bit encodings. Fallback to older reader for non power of 2 encodings. Since the format hasn't changed, we can leverage the new reader on existing format/segments. This PR is for Part 1
- **Part 2:** Part 2 can be divided as follows:
   - **Part 2.1** Create a new writer that going forward uses LITTLE ENDIAN format. We need to move all our storage structures to native byte order (LE on pretty much all systems). See PR https://github.com/apache/incubator-pinot/pull/5511. This new writer can be a good starting point to get going with LE format.
   - **Part 2.2** The new writer can either choose to only have power of 2 bit encodings. So going forward for new segments, we will round up to nearest power of 2. The other alternative is to support non power of 2 upto 16 and from there on round off to 32. Either way, there is no impact on existing segments -- due to fallback implemented in Part 1 (this PR)
- **Part 3** -  Change the scan code to start using the bulk API to fetch dictIds for predicate evaluation. The scan code will already benefit from the new efficient single read API. But we can leverage the bulk contiguous too.

Refer to PR https://github.com/apache/incubator-pinot/pull/5409 for performance numbers when vectorized bit unpacking was implemented. Here is the latest after wiring:


Benchmark | Score | Unit
-- | -- | --
BenchmarkPinotDataBitSet.bit2Contiguous | 33.166 | ms/op
BenchmarkPinotDataBitSet.bit2ContiguousFast | 18.205 | ms/op
BenchmarkPinotDataBitSet.bit4Contiguous | 29 | ms/op
BenchmarkPinotDataBitSet.bit4ContiguousFast | 15.898 | ms/op
BenchmarkPinotDataBitSet.bit8Contiguous | 30.236 | ms/op
BenchmarkPinotDataBitSet.bit8ContiguousFast | 16.702 | ms/op
BenchmarkPinotDataBitSet.bit16Contiguous | 52.347 | ms/op
BenchmarkPinotDataBitSet.bit16ContiguousFast | 19.708 | ms/op
BenchmarkPinotDataBitSet.bit32Contiguous | 122.751 | ms/op
BenchmarkPinotDataBitSet.bit32ContiguousFast | 16.287 | ms/op
  |   |  
BenchmarkPinotDataBitSet.bit2BulkContiguous | 30.333 | ms/op
BenchmarkPinotDataBitSet.bit2BulkContiguousFast | 14.306 | ms/op
BenchmarkPinotDataBitSet.bit4BulkContiguous | 31.881 | ms/op
BenchmarkPinotDataBitSet.bit4BulkContiguousFast | 15.687 | ms/op
BenchmarkPinotDataBitSet.bit8BulkContiguous | 38.648 | ms/op
BenchmarkPinotDataBitSet.bit8BulkContiguousFast | 17.252 | ms/op
BenchmarkPinotDataBitSet.bit16BulkContiguous | 63.883 | ms/op
BenchmarkPinotDataBitSet.bit16BulkContiguousFast | 18.757 | ms/op
BenchmarkPinotDataBitSet.bit32BulkContiguous | 137.234 | ms/op
BenchmarkPinotDataBitSet.bit32BulkContiguousFast | 25.108 | ms/op
  |   |  
BenchmarkPinotDataBitSet.bit2BulkContiguousUnaligned | 37.952 | ms/op
BenchmarkPinotDataBitSet.bit2BulkContiguousUnalignedFast | 14.289 | ms/op
BenchmarkPinotDataBitSet.bit4BulkContiguousUnaligned | 37.921 | ms/op
BenchmarkPinotDataBitSet.bit4BulkContiguousUnalignedFast | 16.385 | ms/op
BenchmarkPinotDataBitSet.bit8BulkContiguousUnaligned | 38.333 | ms/op
BenchmarkPinotDataBitSet.bit8BulkContiguousUnalignedFast | 14.872 | ms/op
BenchmarkPinotDataBitSet.bit16BulkContiguousUnaligned | 58.655 | ms/op
BenchmarkPinotDataBitSet.bit16BulkContiguousUnalignedFast | 18.367 | ms/op
  |   |  
BenchmarkPinotDataBitSet.bit2BulkWithGaps | 39.505 | ops/ms
BenchmarkPinotDataBitSet.bit2BulkWithGapsFast | 46.261 | ops/ms
BenchmarkPinotDataBitSet.bit4BulkWithGaps | 42.074 | ops/ms
BenchmarkPinotDataBitSet.bit4BulkWithGapsFast | 48.871 | ops/ms
BenchmarkPinotDataBitSet.bit8BulkWithGaps | 41.416 | ops/ms
BenchmarkPinotDataBitSet.bit8BulkWithGapsFast | 52.018 | ops/ms
BenchmarkPinotDataBitSet.bit16BulkWithGaps | 31.613 | ops/ms
BenchmarkPinotDataBitSet.bit16BulkWithGapsFast | 47.611 | ops/ms
BenchmarkPinotDataBitSet.bit32BulkWithGaps | 18.545 | ops/ms
BenchmarkPinotDataBitSet.bit32BulkWithGapsFast | 38.503 | ops/ms
  |   |  
BenchmarkPinotDataBitSet.bit2BulkWithSparseGaps | 44.544 | ops/ms
BenchmarkPinotDataBitSet.bit2BulkWithSparseGapsFast | 53.478 | ops/ms
BenchmarkPinotDataBitSet.bit4BulkWithSparseGaps | 44.629 | ops/ms
BenchmarkPinotDataBitSet.bit4BulkWithSparseGapsFast | 64.09 | ops/ms
BenchmarkPinotDataBitSet.bit8BulkWithSparseGaps | 41.044 | ops/ms
BenchmarkPinotDataBitSet.bit8BulkWithSparseGapsFast | 65.554 | ops/ms
BenchmarkPinotDataBitSet.bit16BulkWithSparseGaps | 31.628 | ops/ms
BenchmarkPinotDataBitSet.bit16BulkWithSparseGapsFast | 56.263 | ops/ms
BenchmarkPinotDataBitSet.bit32BulkWithSparseGaps | 31.04 | ops/ms
BenchmarkPinotDataBitSet.bit32BulkWithSparseGapsFast | 57.947 | ops/ms




## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
No

Does this PR fix a zero-downtime upgrade introduced earlier?
No

Does this PR otherwise need attention when creating release notes? Things to consider:
No
## Release Notes
None

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
