### PR TITLE
Adding a flag `-healthCheckServices` in PinotServiceManager to allow health check includes internal components

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
@@ -69,12 +69,12 @@ public class StartServiceManagerCommand extends AbstractBaseAdminCommand impleme
   private String _clusterName = DEFAULT_CLUSTER_NAME;
   @Option(name = "-port", required = true, metaVar = "<int>", usage = "Pinot service manager admin port, -1 means disable, 0 means a random available port.")
   private int _port;
-  @Option(name = "-healthCheckAllComponents", metaVar = "<boolean>", usage = "Pinot service manager health check returns the all components health check. The health check returns OK when all the components are returning OK.")
-  private boolean _healthCheckAllComponents;
   @Option(name = "-bootstrapConfigPaths", handler = StringArrayOptionHandler.class, required = false, usage = "A list of Pinot service config file paths. Each config file requires an extra config: 'pinot.service.role' to indicate which service to start.", forbids = {"-bootstrapServices"})
   private String[] _bootstrapConfigPaths;
   @Option(name = "-bootstrapServices", handler = StringArrayOptionHandler.class, required = false, usage = "A list of Pinot service roles to start with default config. E.g. CONTROLLER/BROKER/SERVER", forbids = {"-bootstrapConfigPaths"})
   private String[] _bootstrapServices = BOOTSTRAP_SERVICES;
+  @Option(name = "-healthCheckServices", handler = StringArrayOptionHandler.class, required = false, usage = "A list of Pinot service roles to be included in health check. E.g. CONTROLLER/BROKER/SERVER")
+  private String[] _healthCheckServices = BOOTSTRAP_SERVICES;
 
   private PinotServiceManager _pinotServiceManager;
 
@@ -120,6 +120,15 @@ public class StartServiceManagerCommand extends AbstractBaseAdminCommand impleme
 
   public StartServiceManagerCommand setBootstrapServices(String[] bootstrapServices) {
     _bootstrapServices = bootstrapServices;
+    return this;
+  }
+
+  public String[] getHealthCheckServices() {
+    return _healthCheckServices;
+  }
+
+  public StartServiceManagerCommand setHealthCheckServices(String[] healthCheckServices) {
+    _healthCheckServices = healthCheckServices;
     return this;
   }
 
@@ -197,7 +206,7 @@ public class StartServiceManagerCommand extends AbstractBaseAdminCommand impleme
   }
 
   private String startServiceManager() {
-    _pinotServiceManager = new PinotServiceManager(_zkAddress, _clusterName, _port, _healthCheckAllComponents);
+    _pinotServiceManager = new PinotServiceManager(_zkAddress, _clusterName, _port, _healthCheckServices);
     _pinotServiceManager.start();
     return _pinotServiceManager.getInstanceId();
   }
@@ -304,13 +313,5 @@ public class StartServiceManagerCommand extends AbstractBaseAdminCommand impleme
     config.put(PINOT_SERVICE_ROLE, role.toString()); // Ensure config has role key
     _bootstrapConfigurations.add(new SimpleImmutableEntry<>(role, config));
     return this;
-  }
-
-  public boolean isHealthCheckAllComponents() {
-    return _healthCheckAllComponents;
-  }
-
-  public void setHealthCheckAllComponents(boolean healthCheckAllComponents) {
-    _healthCheckAllComponents = healthCheckAllComponents;
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
@@ -69,6 +69,8 @@ public class StartServiceManagerCommand extends AbstractBaseAdminCommand impleme
   private String _clusterName = DEFAULT_CLUSTER_NAME;
   @Option(name = "-port", required = true, metaVar = "<int>", usage = "Pinot service manager admin port, -1 means disable, 0 means a random available port.")
   private int _port;
+  @Option(name = "-healthCheckAllComponents", metaVar = "<boolean>", usage = "Pinot service manager health check returns the all components health check. The health check returns OK when all the components are returning OK.")
+  private boolean _healthCheckAllComponents;
   @Option(name = "-bootstrapConfigPaths", handler = StringArrayOptionHandler.class, required = false, usage = "A list of Pinot service config file paths. Each config file requires an extra config: 'pinot.service.role' to indicate which service to start.", forbids = {"-bootstrapServices"})
   private String[] _bootstrapConfigPaths;
   @Option(name = "-bootstrapServices", handler = StringArrayOptionHandler.class, required = false, usage = "A list of Pinot service roles to start with default config. E.g. CONTROLLER/BROKER/SERVER", forbids = {"-bootstrapConfigPaths"})
@@ -195,7 +197,7 @@ public class StartServiceManagerCommand extends AbstractBaseAdminCommand impleme
   }
 
   private String startServiceManager() {
-    _pinotServiceManager = new PinotServiceManager(_zkAddress, _clusterName, _port);
+    _pinotServiceManager = new PinotServiceManager(_zkAddress, _clusterName, _port, _healthCheckAllComponents);
     _pinotServiceManager.start();
     return _pinotServiceManager.getInstanceId();
   }
@@ -302,5 +304,13 @@ public class StartServiceManagerCommand extends AbstractBaseAdminCommand impleme
     config.put(PINOT_SERVICE_ROLE, role.toString()); // Ensure config has role key
     _bootstrapConfigurations.add(new SimpleImmutableEntry<>(role, config));
     return this;
+  }
+
+  public boolean isHealthCheckAllComponents() {
+    return _healthCheckAllComponents;
+  }
+
+  public void setHealthCheckAllComponents(boolean healthCheckAllComponents) {
+    _healthCheckAllComponents = healthCheckAllComponents;
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManager.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManager.java
@@ -54,18 +54,19 @@ public class PinotServiceManager {
   private final String _clusterName;
   private final int _port;
   private final String _instanceId;
+  private final boolean _healthCheckAllComponents;
   private PinotServiceManagerAdminApiApplication _pinotServiceManagerAdminApplication;
   private boolean _isStarted = false;
 
   public PinotServiceManager(String zkAddress, String clusterName) {
-    this(zkAddress, clusterName, 0);
+    this(zkAddress, clusterName, 0, false);
   }
 
-  public PinotServiceManager(String zkAddress, String clusterName, int port) {
-    this(zkAddress, clusterName, null, port);
+  public PinotServiceManager(String zkAddress, String clusterName, int port, boolean healthCheckAllComponents) {
+    this(zkAddress, clusterName, null, port, healthCheckAllComponents);
   }
 
-  public PinotServiceManager(String zkAddress, String clusterName, String hostname, int port) {
+  public PinotServiceManager(String zkAddress, String clusterName, String hostname, int port, boolean healthCheckAllComponents) {
     _zkAddress = zkAddress;
     _clusterName = clusterName;
     if (port == 0) {
@@ -76,10 +77,11 @@ public class PinotServiceManager {
       hostname = NetUtil.getHostnameOrAddress();
     }
     _instanceId = String.format("ServiceManager_%s_%d", hostname, port);
+    _healthCheckAllComponents = healthCheckAllComponents;
   }
 
   public static void main(String[] args) {
-    PinotServiceManager pinotServiceManager = new PinotServiceManager("localhost:2181", "pinot-demo", 8085);
+    PinotServiceManager pinotServiceManager = new PinotServiceManager("localhost:2181", "pinot-demo", 8085, false);
     pinotServiceManager.start();
   }
 
@@ -227,5 +229,9 @@ public class PinotServiceManager {
 
   public boolean stopPinotInstanceById(String instanceName) {
     return stopPinotInstance(_runningInstanceMap.get(instanceName));
+  }
+
+  public boolean isHealthCheckAllComponents() {
+    return _healthCheckAllComponents;
   }
 }


### PR DESCRIPTION
## Description
- Adding a flag `-healthCheckServices`in PinotServiceManager to allow user add more services into health check.