### PR TITLE
Parallelize PinotFS file operations

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
@@ -42,6 +42,7 @@ import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.controller.helix.core.SegmentDeletionManager;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
+import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.joda.time.DateTime;
 import org.mockito.invocation.InvocationOnMock;
@@ -289,7 +290,7 @@ public class SegmentDeletionManagerTest {
     }
 
     @Override
-    protected void removeSegmentFromStore(String tableName, String segmentId) {
+    protected <T extends PinotFS> void removeSegmentFromStore(String tableName, String segmentId, PinotFS.ParallelOperationsBuilder<T> operationsBuilder) {
       segmentsRemovedFromStore.add(segmentId);
     }
 

--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
@@ -19,7 +19,9 @@
 package org.apache.pinot.plugin.filesystem;
 
 import static com.google.common.base.Preconditions.checkState;
+import static com.google.common.util.concurrent.MoreExecutors.listeningDecorator;
 import static java.util.Objects.requireNonNull;
+import static java.util.concurrent.Executors.newFixedThreadPool;
 import static joptsimple.internal.Strings.isNullOrEmpty;
 import static org.glassfish.jersey.internal.guava.Preconditions.checkArgument;
 
@@ -36,6 +38,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import com.google.common.util.concurrent.ListeningExecutorService;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
@@ -54,13 +57,27 @@ import com.google.cloud.storage.StorageOptions;
 import com.google.common.collect.ImmutableList;
 
 public class GcsPinotFS  extends PinotFS {
+  private class GcsParallelOperationsBuilder
+          extends ParallelOperationsBuilder<GcsPinotFS>
+  {
+    public void addCopyFile(URI src, URI dst) {
+      operationBuilder.add(pinotFS -> copyFile(src, dst));
+    }
+
+    public void addDeleteBlob(Blob blob) {
+      operationBuilder.add(ignored -> blob.delete());
+    }
+  }
+
   public static final String PROJECT_ID = "projectId";
   public static final String GCP_KEY = "gcpKey";
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GcsPinotFS.class);
   private static final String DELIMITER = "/";
+  private static final int DEFAULT_CONCURRENCY = 20;
   private static final int BUFFER_SIZE = 128 * 1024;
   private Storage storage;
+  private ListeningExecutorService _fileOperationExecutorService;
 
   @Override
   public void init(PinotConfiguration config) {
@@ -81,6 +98,12 @@ public class GcsPinotFS  extends PinotFS {
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
+    _fileOperationExecutorService =  listeningDecorator(newFixedThreadPool(DEFAULT_CONCURRENCY, runnable -> {
+      Thread thread = new Thread(runnable);
+      thread.setDaemon(true);
+      thread.setName("PinotGcsFileOperationExecutorService");
+      return thread;
+    }));
   }
 
   private Bucket getBucket(URI uri) {
@@ -164,9 +187,7 @@ public class GcsPinotFS  extends PinotFS {
       page = getBucket(uri).list(Storage.BlobListOption.prefix(prefix));
     }
     for (Blob blob : page.iterateAll()) {
-      if (blob.getName().equals(prefix)) {
-        continue;
-      } else {
+      if (!blob.getName().equals(prefix)) {
         isEmpty = false;
         break;
       }
@@ -180,6 +201,11 @@ public class GcsPinotFS  extends PinotFS {
     CopyWriter copyWriter = blob.copyTo(newBlob.getBlobId());
     copyWriter.getResult();
     return copyWriter.isDone();
+  }
+
+  @Override
+  protected ListeningExecutorService getFileOperationExecutorService() {
+    return _fileOperationExecutorService;
   }
 
   @Override
@@ -217,11 +243,11 @@ public class GcsPinotFS  extends PinotFS {
         } else {
           page = getBucket(segmentUri).list(Storage.BlobListOption.prefix(prefix));
         }
-        boolean deleteSucceeded = true;
+        GcsParallelOperationsBuilder operationsBuilder = new GcsParallelOperationsBuilder();
         for (Blob blob : page.iterateAll()) {
-          deleteSucceeded &= blob.delete();
+          operationsBuilder.addDeleteBlob(blob);
         }
-        return deleteSucceeded;
+        return operationsBuilder.executeDirect();
       } else {
         Blob blob = getBlob(segmentUri);
         return blob != null && blob.delete();
@@ -246,7 +272,7 @@ public class GcsPinotFS  extends PinotFS {
    * @param srcUri URI of the original file
    * @param dstUri URI of the final file location
    * @return {@code true} if copy succeeded otherwise return {@code false}
-   * @throws IOException
+   * @throws IOException on any IO error - missing file, not a file etc
    */
   @Override
   public boolean copy(URI srcUri, URI dstUri) throws IOException {
@@ -260,18 +286,18 @@ public class GcsPinotFS  extends PinotFS {
       return copyFile(srcUri, dstUri);
     }
     dstUri = normalizeToDirectoryUri(dstUri);
-    ImmutableList.Builder<URI> builder = ImmutableList.builder();
     Path srcPath = Paths.get(srcUri.getPath());
     try {
-      boolean copySucceeded = true;
+      GcsParallelOperationsBuilder operationsBuilder = new GcsParallelOperationsBuilder();
+
       for (String directoryEntry : listFiles(srcUri, true)) {
         URI src = new URI(srcUri.getScheme(), srcUri.getHost(), directoryEntry, null);
         String relativeSrcPath = srcPath.relativize(Paths.get(directoryEntry)).toString();
         String dstPath = dstUri.resolve(relativeSrcPath).getPath();
         URI dst = new URI(dstUri.getScheme(), dstUri.getHost(), dstPath, null);
-        copySucceeded &= copyFile(src, dst);
+        operationsBuilder.addCopyFile(src, dst);
       }
-      return copySucceeded;
+      return operationsBuilder.executeDirect();
     } catch (URISyntaxException e) {
       throw new IOException(e);
     }


### PR DESCRIPTION
Parallelize SegmentDeletionManager operations.
Use executors from the PinotFS file systems so
that each implementation controls the parallelism.

## Description
Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ X] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
