### PR TITLE
Data and query generator bytes-column support

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroSchemaUtil.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroSchemaUtil.java
@@ -69,6 +69,9 @@ public class AvroSchemaUtil {
       case STRING:
         jsonSchema.set("type", convertStringsToJsonArray("null", "string"));
         return jsonSchema;
+      case BYTES:
+        jsonSchema.set("type", convertStringsToJsonArray("null", "bytes"));
+        return jsonSchema;
       default:
         throw new UnsupportedOperationException();
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/GenerateDataCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/GenerateDataCommand.java
@@ -127,6 +127,7 @@ public class GenerateDataCommand extends AbstractBaseAdminCommand implements Com
     List<String> columns = new LinkedList<>();
     final HashMap<String, DataType> dataTypes = new HashMap<>();
     final HashMap<String, FieldType> fieldTypes = new HashMap<>();
+    final HashMap<String, Boolean> singleValueFlags = new HashMap<>();
     final HashMap<String, TimeUnit> timeUnits = new HashMap<>();
 
     final HashMap<String, Integer> cardinality = new HashMap<>();
@@ -136,7 +137,7 @@ public class GenerateDataCommand extends AbstractBaseAdminCommand implements Com
     buildCardinalityRangeMaps(_schemaAnnFile, cardinality, range, pattern);
 
     final DataGeneratorSpec spec =
-        buildDataGeneratorSpec(schema, columns, dataTypes, fieldTypes, timeUnits, cardinality, range, pattern);
+        buildDataGeneratorSpec(schema, columns, dataTypes, fieldTypes, singleValueFlags, timeUnits, cardinality, range, pattern);
 
     final DataGenerator gen = new DataGenerator();
     gen.init(spec);
@@ -175,14 +176,16 @@ public class GenerateDataCommand extends AbstractBaseAdminCommand implements Com
   }
 
   private DataGeneratorSpec buildDataGeneratorSpec(Schema schema, List<String> columns,
-      HashMap<String, DataType> dataTypes, HashMap<String, FieldType> fieldTypes, HashMap<String, TimeUnit> timeUnits,
-      HashMap<String, Integer> cardinality, HashMap<String, IntRange> range, HashMap<String, Map<String, Object>> pattern) {
+      HashMap<String, DataType> dataTypes, HashMap<String, FieldType> fieldTypes, HashMap<String, Boolean> singleValueFlags,
+      HashMap<String, TimeUnit> timeUnits, HashMap<String, Integer> cardinality, HashMap<String, IntRange> range,
+      HashMap<String, Map<String, Object>> pattern) {
     for (final FieldSpec fs : schema.getAllFieldSpecs()) {
       String col = fs.getName();
 
       columns.add(col);
       dataTypes.put(col, fs.getDataType());
       fieldTypes.put(col, fs.getFieldType());
+      singleValueFlags.put(col, fs.isSingleValueField());
 
       switch (fs.getFieldType()) {
         case DIMENSION:
@@ -215,8 +218,8 @@ public class GenerateDataCommand extends AbstractBaseAdminCommand implements Com
       }
     }
 
-    return new DataGeneratorSpec(columns, cardinality, range, pattern, dataTypes, fieldTypes, timeUnits, FileFormat.AVRO,
-        _outDir, _overwrite);
+    return new DataGeneratorSpec(columns, cardinality, range, pattern, dataTypes, fieldTypes, singleValueFlags,
+            timeUnits, FileFormat.AVRO, _outDir, _overwrite);
   }
 
   public static void main(String[] args)

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/data/generator/DataGenerator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/data/generator/DataGenerator.java
@@ -156,7 +156,7 @@ public class DataGenerator {
 
     spec.setName(column);
     spec.setDataType(dataType);
-    spec.setSingleValueField(true);
+    spec.setSingleValueField(genSpec.getSingleValueFlagsMap().getOrDefault(column, true));
 
     return spec;
   }
@@ -178,8 +178,8 @@ public class DataGenerator {
       cardinality.put(col, 1000);
     }
     final DataGeneratorSpec spec =
-        new DataGeneratorSpec(Arrays.asList(columns), cardinality, range, template, dataTypes, fieldTypes, timeUnits,
-            FileFormat.AVRO, "/tmp/out", true);
+        new DataGeneratorSpec(Arrays.asList(columns), cardinality, range, template, dataTypes, fieldTypes,
+            new HashMap<>(), timeUnits, FileFormat.AVRO, "/tmp/out", true);
 
     final DataGenerator gen = new DataGenerator();
     gen.init(spec);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/data/generator/DataGeneratorSpec.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/data/generator/DataGeneratorSpec.java
@@ -41,6 +41,7 @@ public class DataGeneratorSpec {
 
   private final Map<String, DataType> dataTypesMap;
   private final Map<String, FieldType> fieldTypesMap;
+  private final Map<String, Boolean> singleValueFlagsMap;
   private final Map<String, TimeUnit> timeUnitMap;
 
   private final FileFormat outputFileFormat;
@@ -49,13 +50,14 @@ public class DataGeneratorSpec {
 
   public DataGeneratorSpec() {
     this(new ArrayList<String>(), new HashMap<>(), new HashMap<>(), new HashMap<>(),
-        new HashMap<>(), new HashMap<>(), new HashMap<>(),
+        new HashMap<>(), new HashMap<>(), new HashMap<>(), new HashMap<>(),
         FileFormat.AVRO, "/tmp/dataGen", true);
   }
 
   public DataGeneratorSpec(List<String> columns, Map<String, Integer> cardinalityMap, Map<String, IntRange> rangeMap,
-      Map<String, Map<String, Object>> patternMap, Map<String, DataType> dataTypesMap, Map<String, FieldType> fieldTypesMap, Map<String, TimeUnit> timeUnitMap,
-      FileFormat format, String outputDir, boolean override) {
+      Map<String, Map<String, Object>> patternMap, Map<String, DataType> dataTypesMap, Map<String, FieldType> fieldTypesMap,
+      Map<String, Boolean> singleValueFlagsMap, Map<String, TimeUnit> timeUnitMap, FileFormat format, String outputDir,
+      boolean override) {
     this.columns = columns;
     this.cardinalityMap = cardinalityMap;
     this.rangeMap = rangeMap;
@@ -67,6 +69,7 @@ public class DataGeneratorSpec {
 
     this.dataTypesMap = dataTypesMap;
     this.fieldTypesMap = fieldTypesMap;
+    this.singleValueFlagsMap = singleValueFlagsMap;
     this.timeUnitMap = timeUnitMap;
   }
 
@@ -76,6 +79,10 @@ public class DataGeneratorSpec {
 
   public Map<String, FieldType> getFieldTypesMap() {
     return fieldTypesMap;
+  }
+
+  public Map<String, Boolean> getSingleValueFlagsMap() {
+    return singleValueFlagsMap;
   }
 
   public Map<String, TimeUnit> getTimeUnitMap() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/data/generator/GeneratorFactory.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/data/generator/GeneratorFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.tools.data.generator;
 
+import org.apache.commons.lang.RandomStringUtils;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 import java.util.Map;
@@ -46,6 +47,8 @@ public class GeneratorFactory {
         return new RangeFloatGenerator(start, end);
       case DOUBLE:
         return new RangeDoubleGenerator(start, end);
+      case BYTES:
+        return new RangeBytesGenerator(start, end);
       default:
         throw new RuntimeException(String.format("Invalid datatype '%s'", dataType));
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/data/generator/NumberGenerator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/data/generator/NumberGenerator.java
@@ -18,9 +18,12 @@
  */
 package org.apache.pinot.tools.data.generator;
 
+import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+
+import com.google.common.primitives.Longs;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,6 +67,8 @@ public class NumberGenerator implements Generator {
           intValues.add(new Integer(i));
         }
         break;
+      case BYTES:
+        // use long case
       case LONG:
         longValues = new ArrayList<Long>();
         final long longStart = rand.nextInt(cardinality);
@@ -113,6 +118,8 @@ public class NumberGenerator implements Generator {
         return floatValues.get(random.nextInt(cardinality));
       case DOUBLE:
         return doubleValues.get(random.nextInt(cardinality));
+      case BYTES:
+        return ByteBuffer.wrap(Longs.toByteArray(longValues.get(random.nextInt(cardinality))));
       default:
         throw new RuntimeException("number generator can only accept a column of type number and this : " + columnType
             + " is not a supported number type");

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/data/generator/RangeBytesGenerator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/data/generator/RangeBytesGenerator.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.data.generator;
+
+import com.google.common.primitives.Ints;
+
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+
+public class RangeBytesGenerator implements Generator {
+  private final int _start;
+  private final int _end;
+  private final int _delta;
+
+  Random _randGen = new Random(System.currentTimeMillis());
+
+  public RangeBytesGenerator(int r1, int r2) {
+    _start = (r1 < r2) ? r1 : r2;
+    _end = (r1 > r2) ? r1 : r2;
+
+    _delta = _end - _start;
+  }
+
+  @Override
+  public void init() {
+  }
+
+  @Override
+  public Object next() {
+    return ByteBuffer.wrap(Ints.toByteArray(_start + _randGen.nextInt(_delta)));
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
@@ -404,7 +404,12 @@ public class PerfBenchmarkDriver {
     }
 
     long start = System.currentTimeMillis();
-    URLConnection conn = new URL(_brokerBaseApiUrl + "/query").openConnection();
+    String queryUrl = _brokerBaseApiUrl + "/query";
+    if (!"pql".equals(dialect)) {
+      queryUrl = _brokerBaseApiUrl + "/query/" + dialect;
+    }
+
+    URLConnection conn = new URL(queryUrl).openConnection();
     conn.setDoOutput(true);
 
     try (BufferedWriter writer = new BufferedWriter(new OutputStreamWriter(conn.getOutputStream(),

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriverConf.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriverConf.java
@@ -72,6 +72,10 @@ public class PerfBenchmarkDriverConf {
 
   String resultsOutputDirectory;
 
+  boolean verbose = false;
+
+  String dialect = "pql";
+
   public String getClusterName() {
     return clusterName;
   }
@@ -262,5 +266,21 @@ public class PerfBenchmarkDriverConf {
 
   public void setSchemaFileNamePath(String schemaFileNamePath) {
     this.schemaFileNamePath = schemaFileNamePath;
+  }
+
+  public boolean isVerbose() {
+    return verbose;
+  }
+
+  public void setVerbose(boolean verbose) {
+    this.verbose = verbose;
+  }
+
+  public String getDialect() {
+    return dialect;
+  }
+
+  public void setDialect(String dialect) {
+    this.dialect = dialect;
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/QueryRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/QueryRunner.java
@@ -79,6 +79,10 @@ public class QueryRunner extends AbstractBaseCommand implements Command {
   private int _queueDepth = 64;
   @Option(name = "-timeout", required = false, metaVar = "<long>", usage = "Timeout in milliseconds for completing all queries (default: unlimited).")
   private long _timeout = 0;
+  @Option(name = "-verbose", required = false, usage = "Enable verbose query logging (default: false).")
+  private boolean _verbose = false;
+  @Option(name = "-dialect", required = false, metaVar = "<String>", usage = "Query dialect to use (pql|sql).")
+  private String _dialect = "pql";
   @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"}, usage = "Print this message.")
   private boolean _help;
 
@@ -144,6 +148,8 @@ public class QueryRunner extends AbstractBaseCommand implements Command {
     conf.setStartController(false);
     conf.setStartBroker(false);
     conf.setStartServer(false);
+    conf.setVerbose(_verbose);
+    conf.setDialect(_dialect);
 
     Stream<String> queries = makeQueries(
             IOUtils.readLines(new FileInputStream(_queryFile)),

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/QueryRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/QueryRunner.java
@@ -138,6 +138,11 @@ public class QueryRunner extends AbstractBaseCommand implements Command {
       printUsage();
       return false;
     }
+    if (!Arrays.asList("pql", "sql").contains(_dialect)) {
+      LOGGER.error("Argument dialect must one of either 'pql' or 'sql");
+      printUsage();
+      return false;
+    }
 
     LOGGER.info("Start query runner targeting broker: {}:{}", _brokerHost, _brokerPort);
     PerfBenchmarkDriverConf conf = new PerfBenchmarkDriverConf();


### PR DESCRIPTION
## Description
Add support for raw BYTES columns to data and query generators to expand future testing capabilities. Furthermore, support multi-value columns in the data generator and increase control over dialect and query logging in the query runner.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
**No**

Does this PR fix a zero-downtime upgrade introduced earlier?
**No**

Does this PR otherwise need attention when creating release notes? Things to consider:
**No**
