### PR TITLE
Sort columns by dependency before groovy transformation

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/ExpressionTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/ExpressionTransformer.java
@@ -18,8 +18,14 @@
  */
 package org.apache.pinot.core.data.recordtransformer;
 
+import com.google.common.collect.ImmutableList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import org.apache.calcite.util.graph.DefaultDirectedGraph;
+import org.apache.calcite.util.graph.DefaultEdge;
+import org.apache.calcite.util.graph.DirectedGraph;
+import org.apache.calcite.util.graph.TopologicalOrderIterator;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -38,6 +44,10 @@ public class ExpressionTransformer implements RecordTransformer {
 
   private final Map<String, FunctionEvaluator> _expressionEvaluators = new HashMap<>();
 
+  /** the order of column to be evaluated */
+  private final List<String> _ordered;
+
+
   public ExpressionTransformer(TableConfig tableConfig, Schema schema) {
     if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getTransformConfigs() != null) {
       for (TransformConfig transformConfig : tableConfig.getIngestionConfig().getTransformConfigs()) {
@@ -54,13 +64,29 @@ public class ExpressionTransformer implements RecordTransformer {
         }
       }
     }
+
+    // compute the dependencies of each column to be evaluated
+    final DirectedGraph<String, DefaultEdge> columnDependencies = DefaultDirectedGraph.create();
+
+    for (Map.Entry<String, FunctionEvaluator> entry: _expressionEvaluators.entrySet()) {
+      for (String arg:entry.getValue().getArguments()) {
+        columnDependencies.addVertex(entry.getKey());
+        columnDependencies.addVertex(arg);
+        // an edge (u -> v) means u needs to happen before v (v depends on u)
+        columnDependencies.addEdge(arg, entry.getKey());
+      }
+    }
+    _ordered = ImmutableList.copyOf(new TopologicalOrderIterator<>(columnDependencies));
   }
 
   @Override
   public GenericRow transform(GenericRow record) {
-    for (Map.Entry<String, FunctionEvaluator> entry : _expressionEvaluators.entrySet()) {
-      String column = entry.getKey();
-      FunctionEvaluator transformFunctionEvaluator = entry.getValue();
+    for (String column : _ordered) {
+      FunctionEvaluator transformFunctionEvaluator = _expressionEvaluators.get(column);
+      // if not column to be evaluated
+      if (transformFunctionEvaluator == null) {
+        continue;
+      }
       // Skip transformation if column value already exist.
       // NOTE: column value might already exist for OFFLINE data
       if (record.getValue(column) == null) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/ExpressionTransformerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/ExpressionTransformerTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.data.recordtransformer;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -228,5 +229,35 @@ public class ExpressionTransformerTest {
     // no transformation
     expressionTransformer.transform(genericRow);
     Assert.assertEquals(genericRow.getValue("outgoing"), "123");
+  }
+
+  /**
+   * Reorder transformations so that all dependencies can be pre-evaluated.
+   * https://github.com/apache/incubator-pinot/issues/5351
+   */
+  @Test
+  public void testReorderBasedOnDependencies() {
+    Schema pinotSchema = new Schema.SchemaBuilder()
+        .addMultiValueDimension("expenses", FieldSpec.DataType.INT)
+        .addMultiValueDimension("headCounts", FieldSpec.DataType.INT)
+        .build();
+
+
+    List<TransformConfig> transformConfigs = new ArrayList<>();
+    transformConfigs.add(new TransformConfig("averageExpense", "Groovy({totalExpense / totalHeadCount}, totalExpense, totalHeadCount)"));
+    transformConfigs.add(new TransformConfig("totalExpense", "Groovy({expenses.sum()}, expenses)"));
+    transformConfigs.add(new TransformConfig("totalHeadCount", "Groovy({headCounts.sum()}, headCounts)"));
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTransformFunctions")
+        .setIngestionConfig(new IngestionConfig(null, transformConfigs)).build();
+
+    ExpressionTransformer expressionTransformer = new ExpressionTransformer(tableConfig, pinotSchema);
+
+    GenericRow genericRow = new GenericRow();
+    genericRow.putValue("expenses", Arrays.asList(1, 1, 1));
+    genericRow.putValue("headCounts", Arrays.asList(2, 2, 2));
+
+    expressionTransformer.transform(genericRow);
+    Assert.assertEquals(genericRow.getValue("totalExpense"), 3);
+    Assert.assertEquals(genericRow.getValue("averageExpense"), BigDecimal.valueOf(.5));
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/ExpressionTransformerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/ExpressionTransformerTest.java
@@ -260,4 +260,25 @@ public class ExpressionTransformerTest {
     Assert.assertEquals(genericRow.getValue("totalExpense"), 3);
     Assert.assertEquals(genericRow.getValue("averageExpense"), BigDecimal.valueOf(.5));
   }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testCyclicDependencies() {
+    Schema pinotSchema = new Schema.SchemaBuilder()
+        .addMultiValueDimension("a", FieldSpec.DataType.INT)
+        .build();
+
+    List<TransformConfig> transformConfigs = new ArrayList<>();
+    transformConfigs.add(new TransformConfig("b", "Groovy({a + d}, a, d)"));
+    transformConfigs.add(new TransformConfig("c", "Groovy({b}, b)"));
+    transformConfigs.add(new TransformConfig("d", "Groovy({c}, c)"));
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTransformFunctions")
+        .setIngestionConfig(new IngestionConfig(null, transformConfigs)).build();
+
+    ExpressionTransformer expressionTransformer = new ExpressionTransformer(tableConfig, pinotSchema);
+
+    GenericRow genericRow = new GenericRow();
+    genericRow.putValue("a", 1);
+
+    expressionTransformer.transform(genericRow);
+  }
 }


### PR DESCRIPTION
This PR aims to solve the  problem with transformation dependencies https://github.com/apache/incubator-pinot/issues/5351
We try to build the dependency graph between columns and sort them topologically before applying the transformation

## Description
Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release.

If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text

## Documentation
If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
