### PR TITLE
Add server configuration to lazy load files from deep storage. 

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -451,12 +451,14 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
   private void validateNumSegments(Map<ServerInstance, List<String>> offlineRoutingTable,
       Map<ServerInstance, List<String>> realtimeRoutingTable, int querySegmentLimit) {
-    int numOffline = offlineRoutingTable == null ? 0 : offlineRoutingTable.values().stream().mapToInt(List::size).sum();
-    int numRealtime =
-        realtimeRoutingTable == null ? 0 : realtimeRoutingTable.values().stream().mapToInt(List::size).sum();
-    int numSegments = numOffline + numRealtime;
-    if (numSegments > querySegmentLimit) {
-      throw new IllegalStateException(String.format("Query exceeds segment limit of %d", querySegmentLimit));
+    if (_querySegmentLimit > 0) {
+      int numOffline = offlineRoutingTable == null ? 0 : offlineRoutingTable.values().stream().mapToInt(List::size).sum();
+      int numRealtime =
+          realtimeRoutingTable == null ? 0 : realtimeRoutingTable.values().stream().mapToInt(List::size).sum();
+      int numSegments = numOffline + numRealtime;
+      if (numSegments > querySegmentLimit) {
+        throw new IllegalStateException(String.format("Query exceeds segment limit of %d", querySegmentLimit));
+      }
     }
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -117,6 +117,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   private final int _defaultHllLog2m;
   private final boolean _enableQueryLimitOverride;
   private final boolean _enableDistinctCountBitmapOverride;
+  private final int _querySegmentLimit;
 
   public BaseBrokerRequestHandler(PinotConfiguration config, RoutingManager routingManager,
       AccessControlFactory accessControlFactory, QueryQuotaManager queryQuotaManager, TableCache tableCache,
@@ -138,6 +139,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     _brokerTimeoutMs = config.getProperty(Broker.CONFIG_OF_BROKER_TIMEOUT_MS, Broker.DEFAULT_BROKER_TIMEOUT_MS);
     _queryResponseLimit =
         config.getProperty(Broker.CONFIG_OF_BROKER_QUERY_RESPONSE_LIMIT, Broker.DEFAULT_BROKER_QUERY_RESPONSE_LIMIT);
+    _querySegmentLimit =
+        config.getProperty(Broker.CONFIG_OF_QUERY_SEGMENT_LIMIT, Broker.DEFAULT_CONFIG_OF_QUERY_SEGMENT_LIMIT);
     _queryLogLength =
         config.getProperty(Broker.CONFIG_OF_BROKER_QUERY_LOG_LENGTH, Broker.DEFAULT_BROKER_QUERY_LOG_LENGTH);
     _queryLogRateLimiter = RateLimiter.create(config.getProperty(Broker.CONFIG_OF_BROKER_QUERY_LOG_MAX_RATE_PER_SECOND,
@@ -379,6 +382,16 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       return new BrokerResponseNative(QueryException.getException(QueryException.BROKER_TIMEOUT_ERROR, errorMessage));
     }
 
+    // Validate the request
+    try {
+      validateNumSegments(offlineRoutingTable, realtimeRoutingTable, _querySegmentLimit);
+    } catch (Exception e) {
+      LOGGER.info("Caught exception while validating request {}: {}, {}", requestId, query, e.getMessage());
+      requestStatistics.setErrorCode(QueryException.QUERY_VALIDATION_ERROR_CODE);
+      _brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.QUERY_VALIDATION_EXCEPTIONS, 1);
+      return new BrokerResponseNative(QueryException.getException(QueryException.QUERY_VALIDATION_ERROR, e));
+    }
+
     // Execute the query
     ServerStats serverStats = new ServerStats();
     BrokerResponse brokerResponse =
@@ -434,6 +447,17 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       _numDroppedLog.incrementAndGet();
     }
     return brokerResponse;
+  }
+
+  private void validateNumSegments(Map<ServerInstance, List<String>> offlineRoutingTable,
+      Map<ServerInstance, List<String>> realtimeRoutingTable, int querySegmentLimit) {
+    int numOffline = offlineRoutingTable == null ? 0 : offlineRoutingTable.values().stream().mapToInt(List::size).sum();
+    int numRealtime =
+        realtimeRoutingTable == null ? 0 : realtimeRoutingTable.values().stream().mapToInt(List::size).sum();
+    int numSegments = numOffline + numRealtime;
+    if (numSegments > querySegmentLimit) {
+      throw new IllegalStateException(String.format("Query exceeds segment limit of %d", querySegmentLimit));
+    }
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -152,6 +152,8 @@ public class CommonConstants {
 
     public static final String CONFIG_OF_BROKER_QUERY_RESPONSE_LIMIT = "pinot.broker.query.response.limit";
     public static final int DEFAULT_BROKER_QUERY_RESPONSE_LIMIT = Integer.MAX_VALUE;
+    public static final String CONFIG_OF_QUERY_SEGMENT_LIMIT = "pinot.broker.query.segment.limit";
+    public static final int DEFAULT_CONFIG_OF_QUERY_SEGMENT_LIMIT = Integer.MAX_VALUE;
     public static final String CONFIG_OF_BROKER_QUERY_LOG_LENGTH = "pinot.broker.query.log.length";
     public static final int DEFAULT_BROKER_QUERY_LOG_LENGTH = Integer.MAX_VALUE;
     public static final String CONFIG_OF_BROKER_QUERY_LOG_MAX_RATE_PER_SECOND =

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/CommonConstants.java
@@ -152,8 +152,9 @@ public class CommonConstants {
 
     public static final String CONFIG_OF_BROKER_QUERY_RESPONSE_LIMIT = "pinot.broker.query.response.limit";
     public static final int DEFAULT_BROKER_QUERY_RESPONSE_LIMIT = Integer.MAX_VALUE;
+    // Limit the number of segments allowed to be accessed in a single query. -1 will disable this check
     public static final String CONFIG_OF_QUERY_SEGMENT_LIMIT = "pinot.broker.query.segment.limit";
-    public static final int DEFAULT_CONFIG_OF_QUERY_SEGMENT_LIMIT = Integer.MAX_VALUE;
+    public static final int DEFAULT_CONFIG_OF_QUERY_SEGMENT_LIMIT = -1;
     public static final String CONFIG_OF_BROKER_QUERY_LOG_LENGTH = "pinot.broker.query.log.length";
     public static final int DEFAULT_BROKER_QUERY_LOG_LENGTH = Integer.MAX_VALUE;
     public static final String CONFIG_OF_BROKER_QUERY_LOG_MAX_RATE_PER_SECOND =

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -167,6 +167,17 @@
       <groupId>org.locationtech.jts</groupId>
       <artifactId>jts-core</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.github.ben-manes.caffeine</groupId>
+      <artifactId>caffeine</artifactId>
+      <version>2.8.6</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
     <!-- test -->
     <dependency>
       <groupId>org.apache.pinot</groupId>

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
@@ -18,13 +18,10 @@
  */
 package org.apache.pinot.core.data.manager;
 
-import java.io.File;
 import java.util.List;
 import java.util.Set;
-
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
-
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.helix.HelixManager;
 import org.apache.helix.ZNRecord;
@@ -48,6 +45,8 @@ public interface InstanceDataManager {
   void init(PinotConfiguration config, HelixManager helixManager, ServerMetrics serverMetrics)
       throws ConfigurationException;
 
+  void setFetcherAndLoader(OfflineSegmentFetcherAndLoader segmentFetcherAndLoader);
+
   /**
    * Starts the data manager.
    * <p>Should be called only once after data manager gets initialized but before calling any other method.
@@ -63,7 +62,7 @@ public interface InstanceDataManager {
   /**
    * Adds a segment from local disk into an OFFLINE table.
    */
-  void addOfflineSegment(String offlineTableName, String segmentName, File indexDir)
+  void addOrReplaceOfflineSegment(String offlineTableName, String segmentName)
       throws Exception;
 
   /**
@@ -109,8 +108,14 @@ public interface InstanceDataManager {
   SegmentMetadata getSegmentMetadata(String tableNameWithType, String segmentName);
 
   /**
-   * Returns the metadata for all segments in the given table.
+   * Returns the segment data manager for the given table, or <code>null</code> if it does not exist.
    */
+  @Nullable
+  public SegmentDataManager getSegmentDataManager(String tableNameWithType, String segmentName);
+
+    /**
+     * Returns the metadata for all segments in the given table.
+     */
   List<SegmentMetadata> getAllSegmentsMetadata(String tableNameWithType);
 
   /**
@@ -122,6 +127,8 @@ public interface InstanceDataManager {
    * Returns the directory for tarred segment files.
    */
   String getSegmentFileDirectory();
+
+  int maxSegmentDiscUsageMb();
 
   /**
    * Returns the maximum number of segments allowed to refresh in parallel.

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/SegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/SegmentDataManager.java
@@ -63,8 +63,9 @@ public abstract class SegmentDataManager {
   }
 
   /**
-   * Indicates whether this segment is physically in memory or downloaded to disc.
-   * @return
+   * Indicates whether this segment is downloaded to local disc
+   *
+   * @return Whether the segment is present on the local disc
    */
   public boolean hasLocalData() {
     return true;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/SegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/SegmentDataManager.java
@@ -33,6 +33,8 @@ public abstract class SegmentDataManager {
     return _referenceCount;
   }
 
+  // If ref count is = 1, then we can delete it and set hasData to false again.
+  // like the UI.
   /**
    * Increases the reference count. Should be called when acquiring the segment.
    *
@@ -60,6 +62,14 @@ public abstract class SegmentDataManager {
       _referenceCount--;
       return false;
     }
+  }
+
+  /**
+   * Indicates whether this segment is physically in memory or downloaded to disc.
+   * @return
+   */
+  public boolean hasLocalData() {
+    return true;
   }
 
   public abstract String getSegmentName();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/SegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/SegmentDataManager.java
@@ -33,8 +33,6 @@ public abstract class SegmentDataManager {
     return _referenceCount;
   }
 
-  // If ref count is = 1, then we can delete it and set hasData to false again.
-  // like the UI.
   /**
    * Increases the reference count. Should be called when acquiring the segment.
    *

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/SegmentLocks.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/SegmentLocks.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.server.starter.helix;
+package org.apache.pinot.core.data.manager;
 
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/TableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/TableDataManager.java
@@ -64,7 +64,7 @@ public interface TableDataManager {
   /**
    * Adds a segment from local disk into the OFFLINE table.
    */
-  void addSegment(File indexDir, IndexLoadingConfig indexLoadingConfig)
+  void addSegment(String segmentName, IndexLoadingConfig indexLoadingConfig)
       throws Exception;
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/config/InstanceDataManagerConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/config/InstanceDataManagerConfig.java
@@ -41,6 +41,12 @@ public interface InstanceDataManagerConfig {
 
   String getAvgMultiValueCount();
 
+  boolean shouldLazyLoadSegments();
+
+  boolean shouldPurgeOnStart();
+
+  int maxSegmentDiscUsageMb();
+
   boolean isEnableSplitCommit();
 
   boolean isEnableSplitCommitEndWithMetadata();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/OfflineSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/OfflineSegmentDataManager.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager.offline;
+
+import javax.annotation.Nullable;
+import org.apache.pinot.core.data.manager.OfflineSegmentFetcherAndLoader;
+import org.apache.pinot.core.data.manager.SegmentDataManager;
+import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
+import org.apache.pinot.core.segment.index.loader.IndexLoadingConfig;
+
+
+/**
+ * Segment data manager for immutable segment.
+ */
+public class OfflineSegmentDataManager extends SegmentDataManager {
+
+  private ImmutableSegment _immutableSegment;
+  private String _segmentName;
+  private IndexLoadingConfig _indexLoadingConfig;
+  OfflineSegmentFetcherAndLoader _fetcherAndLoader;
+  private String _tableNameWithType;
+  private SegmentCacheManager _cacheManager;
+
+  @Override
+  public boolean hasLocalData() {
+    return _immutableSegment != null;
+  }
+
+  public OfflineSegmentDataManager(String tableNameWithType, String segmentName,
+      OfflineSegmentFetcherAndLoader fetcherAndLoader, @Nullable SegmentCacheManager cacheManager,
+      IndexLoadingConfig indexLoadingConfig) {
+    _tableNameWithType = tableNameWithType;
+    _cacheManager = cacheManager;
+    _fetcherAndLoader = fetcherAndLoader;
+    _segmentName = segmentName;
+    _indexLoadingConfig = indexLoadingConfig;
+    if (cacheManager == null) { // Must be eager loading
+      loadSegment();
+    }
+  }
+
+  @Override
+  public String getSegmentName() {
+    return _segmentName;
+  }
+
+  public String getTableNameWithType() {
+    return _tableNameWithType;
+  }
+
+  public void loadSegment() {
+    _immutableSegment = _fetcherAndLoader.fetchAndLoadOfflineSegment(_tableNameWithType, _segmentName, _indexLoadingConfig);
+    if (_cacheManager != null) {
+      _cacheManager.register(this);
+    }
+  }
+
+  @Override
+  public ImmutableSegment getSegment() {
+    if (_immutableSegment == null) {
+      loadSegment();
+    }
+
+    return _immutableSegment;
+  }
+
+  public void releaseSegment() {
+    _immutableSegment = null;
+    _fetcherAndLoader.deleteOfflineSegment(_tableNameWithType, _segmentName);
+  }
+
+  @Override
+  public void destroy() {
+    _immutableSegment.destroy();
+  }
+
+  @Override
+  public String toString() {
+    return "ImmutableSegmentDataManager(" + _immutableSegment.getSegmentName() + ")";
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/OfflineTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/OfflineTableDataManager.java
@@ -18,12 +18,10 @@
  */
 package org.apache.pinot.core.data.manager.offline;
 
-import java.io.File;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
-import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.core.data.manager.BaseTableDataManager;
-import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.core.data.manager.OfflineSegmentFetcherAndLoader;
 import org.apache.pinot.core.segment.index.loader.IndexLoadingConfig;
 
 
@@ -32,6 +30,15 @@ import org.apache.pinot.core.segment.index.loader.IndexLoadingConfig;
  */
 @ThreadSafe
 public class OfflineTableDataManager extends BaseTableDataManager {
+
+  private OfflineSegmentFetcherAndLoader _segmentFetcherAndLoader;
+  private SegmentCacheManager _cacheManager;
+
+  public OfflineTableDataManager(OfflineSegmentFetcherAndLoader segmentFetcherAndLoader,
+      @Nullable SegmentCacheManager cacheManager) {
+    _segmentFetcherAndLoader = segmentFetcherAndLoader;
+    _cacheManager = cacheManager;
+  }
 
   @Override
   protected void doInit() {
@@ -46,9 +53,9 @@ public class OfflineTableDataManager extends BaseTableDataManager {
   }
 
   @Override
-  public void addSegment(File indexDir, IndexLoadingConfig indexLoadingConfig)
-      throws Exception {
-    Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
-    addSegment(ImmutableSegmentLoader.load(indexDir, indexLoadingConfig, schema));
+  public void addSegment(String segmentName, IndexLoadingConfig indexLoadingConfig) {
+    addSegmentManager(
+        new OfflineSegmentDataManager(_tableNameWithType, segmentName, _segmentFetcherAndLoader, _cacheManager,
+            indexLoadingConfig));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/SegmentCacheManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/SegmentCacheManager.java
@@ -1,0 +1,99 @@
+package org.apache.pinot.core.data.manager.offline;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.RemovalCause;
+import com.github.benmanes.caffeine.cache.RemovalListener;
+import com.github.benmanes.caffeine.cache.Scheduler;
+import com.github.benmanes.caffeine.cache.Weigher;
+import java.io.File;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.core.data.manager.InstanceDataManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class SegmentCacheManager {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentCacheManager.class);
+  private InstanceDataManager _instanceDataManager;
+
+  class SegmentIdentifer {
+    private final String _tableNameWithType;
+    private final String _segmentName;
+
+    @Override
+    public int hashCode() {
+      return getSegmentName().hashCode() + getTableNameWithType().hashCode();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj.getClass().isInstance(SegmentIdentifer.class)) {
+        SegmentIdentifer other = (SegmentIdentifer) obj;
+        return getTableNameWithType().equals(other.getTableNameWithType()) && getSegmentName()
+            .equals(other.getSegmentName());
+      }
+
+      return false;
+    }
+
+    public SegmentIdentifer(String tableNameWithType, String segmentName) {
+      _tableNameWithType = tableNameWithType;
+      _segmentName = segmentName;
+    }
+
+    public String getSegmentName() {
+      return _segmentName;
+    }
+
+    public String getTableNameWithType() {
+      return _tableNameWithType;
+    }
+  }
+
+  private final Weigher<SegmentIdentifer, OfflineSegmentDataManager> segmentSizeInMb =
+      (SegmentIdentifer identifier, OfflineSegmentDataManager segment) -> {
+        File indexDir = new File(getSegmentLocalDirectory(identifier));
+        long fileSizeBytes = FileUtils.sizeOfDirectory(indexDir);
+        return (int) Math.ceil((double) fileSizeBytes / FileUtils.ONE_MB);
+      };
+  private final RemovalListener<SegmentIdentifer, OfflineSegmentDataManager> segmentRemovalListener =
+      (SegmentIdentifer identifier, OfflineSegmentDataManager segmentManager, RemovalCause cause) -> {
+        LOGGER.info("Evicting segment {} of table {} with cause {}", segmentManager.getSegmentName(),
+            identifier.getTableNameWithType(), cause.toString());
+        segmentManager.releaseSegment();
+      };
+
+  private Cache<SegmentIdentifer, OfflineSegmentDataManager> _lazyLoadedSegmentCache;
+
+  public SegmentCacheManager(InstanceDataManager instanceDataManager) {
+    _instanceDataManager = instanceDataManager;
+    this.initCache();
+  }
+
+  private void initCache() {
+    int maxDiscUsage = _instanceDataManager.maxSegmentDiscUsageMb();
+    ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor();
+    Scheduler scheduler = Scheduler.forScheduledExecutorService(scheduledExecutorService);
+    LOGGER.info("Creating segment cache with max disc usage {}Mb", maxDiscUsage);
+    _lazyLoadedSegmentCache = Caffeine.newBuilder()
+        .maximumWeight(maxDiscUsage)
+        .weigher(segmentSizeInMb)
+        .removalListener(segmentRemovalListener)
+        .scheduler(scheduler)
+        .build();
+  }
+
+  public String getSegmentLocalDirectory(SegmentIdentifer segmentIdentifer) {
+    return _instanceDataManager.getSegmentDataDirectory() + "/" + segmentIdentifer.getTableNameWithType() + "/"
+        + segmentIdentifer.getSegmentName();
+  }
+
+  public void register(OfflineSegmentDataManager segmentDataManager) {
+    _lazyLoadedSegmentCache
+        .put(new SegmentIdentifer(segmentDataManager.getTableNameWithType(), segmentDataManager.getSegmentName()),
+            segmentDataManager);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/SegmentCacheManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/SegmentCacheManager.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.data.manager.offline;
 
 import com.github.benmanes.caffeine.cache.Cache;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/ImmutableSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/ImmutableSegmentDataManager.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.core.data.manager.offline;
+package org.apache.pinot.core.data.manager.realtime;
 
 import org.apache.pinot.core.data.manager.SegmentDataManager;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/CompositeTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/CompositeTransformer.java
@@ -77,7 +77,7 @@ public class CompositeTransformer implements RecordTransformer {
 
   @Nullable
   @Override
-  public GenericRow transform(GenericRow record) {
+  public GenericRow transform(GenericRow record) throws Exception {
     for (RecordTransformer transformer : _transformers) {
       record = transformer.transform(record);
       if (record == null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/DataTypeTransformer.java
@@ -44,12 +44,6 @@ public class DataTypeTransformer implements RecordTransformer {
   private static final Map<Class, PinotDataType> SINGLE_VALUE_TYPE_MAP = new HashMap<>();
   private static final Map<Class, PinotDataType> MULTI_VALUE_TYPE_MAP = new HashMap<>();
 
-  class DataTypeConversionException extends Exception {
-    public DataTypeConversionException(String column, PinotDataType source, PinotDataType target, Exception cause) {
-      super(String.format("Error converting column %s from %s to %s", column, source, target), cause);
-    }
-  }
-
   static {
     SINGLE_VALUE_TYPE_MAP.put(Boolean.class, PinotDataType.BOOLEAN);
     SINGLE_VALUE_TYPE_MAP.put(Byte.class, PinotDataType.BYTE);
@@ -83,7 +77,7 @@ public class DataTypeTransformer implements RecordTransformer {
   }
 
   @Override
-  public GenericRow transform(GenericRow record) throws DataTypeConversionException {
+  public GenericRow transform(GenericRow record) {
     for (Map.Entry<String, PinotDataType> entry : _dataTypes.entrySet()) {
       String column = entry.getKey();
       Object value = record.getValue(column);
@@ -115,11 +109,7 @@ public class DataTypeTransformer implements RecordTransformer {
         }
       }
       if (source != dest) {
-        try {
-          value = dest.convert(value, source);
-        } catch (Exception e) {
-          throw new DataTypeConversionException(column, source, dest, e);
-        }
+        value = dest.convert(value, source);
       }
 
       record.putValue(column, value);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/RecordTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/recordtransformer/RecordTransformer.java
@@ -34,5 +34,5 @@ public interface RecordTransformer {
    * @return Transformed record, or {@code null} if the record does not follow certain rules.
    */
   @Nullable
-  GenericRow transform(GenericRow record);
+  GenericRow transform(GenericRow record) throws Exception;
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -34,8 +34,9 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.data.manager.config.TableDataManagerConfig;
-import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
 import org.apache.pinot.core.data.manager.offline.OfflineTableDataManager;
+import org.apache.pinot.core.data.manager.offline.SegmentCacheManager;
+import org.apache.pinot.core.data.manager.realtime.ImmutableSegmentDataManager;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
 import org.apache.pinot.core.segment.index.metadata.SegmentMetadata;
 import org.testng.Assert;
@@ -101,7 +102,8 @@ public class BaseTableDataManagerTest {
 
   private TableDataManager makeTestableManager()
       throws Exception {
-    TableDataManager tableDataManager = new OfflineTableDataManager();
+    TableDataManager tableDataManager =
+        new OfflineTableDataManager(mock(OfflineSegmentFetcherAndLoader.class), mock(SegmentCacheManager.class));
     TableDataManagerConfig config;
     {
       config = mock(TableDataManagerConfig.class);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/OfflineSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/OfflineSegmentDataManagerTest.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager.offline;
+
+import org.apache.pinot.core.data.manager.OfflineSegmentFetcherAndLoader;
+import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
+import org.apache.pinot.core.segment.index.loader.IndexLoadingConfig;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+
+public class OfflineSegmentDataManagerTest {
+  @Test
+  void testLazyLoad() {
+    ImmutableSegment segment = mock(ImmutableSegment.class);
+    when(segment.getSegmentName()).thenReturn("foo");
+    SegmentCacheManager cacheManager = mock(SegmentCacheManager.class);
+    OfflineSegmentFetcherAndLoader fetcherAndLoader = mock(OfflineSegmentFetcherAndLoader.class);
+    IndexLoadingConfig indexLoadingConfig = mock(IndexLoadingConfig.class);
+    ImmutableSegment immutableSegment = mock(ImmutableSegment.class);
+    OfflineSegmentDataManager manager =
+        new OfflineSegmentDataManager("foo", "bar", fetcherAndLoader, cacheManager, indexLoadingConfig);
+
+    Mockito.when(fetcherAndLoader.fetchAndLoadOfflineSegment("foo", "bar", indexLoadingConfig)).thenReturn(immutableSegment);
+
+    // Should not have materialized yet
+    Assert.assertFalse(manager.hasLocalData());
+
+    // Should be able to get name without materializing
+    Assert.assertEquals(manager.getSegmentName(), "bar");
+
+    // Should trigger a materialize
+    Assert.assertEquals(manager.getSegment(), immutableSegment);
+    Assert.assertTrue(manager.hasLocalData());
+
+    // Trigger a dematerialize
+    manager.releaseSegment();
+    Assert.assertFalse(manager.hasLocalData());
+    Mockito.verify(fetcherAndLoader, times(1)).deleteOfflineSegment("foo", "bar");
+
+    // Make sure we loaded the correct segment
+    Mockito.verify(fetcherAndLoader, times(1))
+        .fetchAndLoadOfflineSegment("foo", "bar", indexLoadingConfig);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/ExpressionTransformerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/ExpressionTransformerTest.java
@@ -43,7 +43,7 @@ import org.testng.annotations.Test;
 public class ExpressionTransformerTest {
 
   @Test
-  public void testTransformConfigsFromTableConfig() {
+  public void testTransformConfigsFromTableConfig() throws Exception {
     Schema pinotSchema = new Schema.SchemaBuilder().addSingleValueDimension("userId", FieldSpec.DataType.LONG)
         .addSingleValueDimension("fullName", FieldSpec.DataType.STRING)
         .addMultiValueDimension("bids", FieldSpec.DataType.INT)

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/RecordTransformerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/recordtransformer/RecordTransformerTest.java
@@ -74,7 +74,7 @@ public class RecordTransformerTest {
   }
 
   @Test
-  public void testFilterTransformer() {
+  public void testFilterTransformer() throws Exception {
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
 
     // expression false, not filtered
@@ -118,7 +118,7 @@ public class RecordTransformerTest {
   }
 
   @Test
-  public void testDataTypeTransformer() {
+  public void testDataTypeTransformer() throws Exception {
     RecordTransformer transformer = new DataTypeTransformer(SCHEMA);
     GenericRow record = getRecord();
     for (int i = 0; i < NUM_ROUNDS; i++) {
@@ -141,7 +141,7 @@ public class RecordTransformerTest {
   }
 
   @Test
-  public void testSanitationTransformer() {
+  public void testSanitationTransformer() throws Exception {
     RecordTransformer transformer = new SanitizationTransformer(SCHEMA);
     GenericRow record = getRecord();
     for (int i = 0; i < NUM_ROUNDS; i++) {
@@ -155,7 +155,7 @@ public class RecordTransformerTest {
   }
 
   @Test
-  public void testNullValueTransformer() {
+  public void testNullValueTransformer() throws Exception {
     RecordTransformer transformer = new NullValueTransformer(SCHEMA);
     GenericRow record = new GenericRow();
     for (int i = 0; i < NUM_ROUNDS; i++) {
@@ -197,7 +197,7 @@ public class RecordTransformerTest {
   }
 
   @Test
-  public void testDefaultTransformer() {
+  public void testDefaultTransformer() throws Exception {
     RecordTransformer transformer = CompositeTransformer.getDefaultTransformer(TABLE_CONFIG, SCHEMA);
     GenericRow record = getRecord();
     for (int i = 0; i < NUM_ROUNDS; i++) {
@@ -241,7 +241,7 @@ public class RecordTransformerTest {
   }
 
   @Test
-  public void testPassThroughTransformer() {
+  public void testPassThroughTransformer() throws Exception {
     RecordTransformer transformer = CompositeTransformer.getPassThroughTransformer();
     GenericRow record = getRecord();
     for (int i = 0; i < NUM_ROUNDS; i++) {

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/SegmentMetadataFetcher.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/SegmentMetadataFetcher.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import org.apache.pinot.core.data.manager.SegmentDataManager;
-import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
+import org.apache.pinot.core.data.manager.realtime.ImmutableSegmentDataManager;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentImpl;
 import org.apache.pinot.core.segment.index.column.ColumnIndexContainer;

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableSizeResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableSizeResource.java
@@ -40,7 +40,7 @@ import org.apache.pinot.common.restlet.resources.TableSizeInfo;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.SegmentDataManager;
 import org.apache.pinot.core.data.manager.TableDataManager;
-import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
+import org.apache.pinot.core.data.manager.realtime.ImmutableSegmentDataManager;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
 import org.apache.pinot.server.starter.ServerInstance;
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
@@ -28,6 +28,7 @@ import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.common.metrics.MetricsHelper;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
+import org.apache.pinot.core.data.manager.OfflineSegmentFetcherAndLoader;
 import org.apache.pinot.core.operator.transform.function.TransformFunction;
 import org.apache.pinot.core.operator.transform.function.TransformFunctionFactory;
 import org.apache.pinot.core.query.executor.QueryExecutor;
@@ -114,6 +115,10 @@ public class ServerInstance {
     TransformFunctionFactory.init(transformFunctionClasses);
 
     LOGGER.info("Finish initializing server instance");
+  }
+
+  public void setFetcherAndLoader(OfflineSegmentFetcherAndLoader segmentFetcherAndLoader) {
+    _instanceDataManager.setFetcherAndLoader(segmentFetcherAndLoader);
   }
 
   public synchronized void start() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -173,6 +173,13 @@ public class HelixInstanceDataManager implements InstanceDataManager {
   public void reloadSegment(String tableNameWithType, String segmentName)
       throws Exception {
     LOGGER.info("Reloading single segment: {} in table: {}", segmentName, tableNameWithType);
+    SegmentDataManager segmentDataManager = getSegmentDataManager(tableNameWithType, segmentName);
+    if (!segmentDataManager.hasLocalData()) {
+      LOGGER.info("Segment has not been lazily loaded. Skip reloading segment {} in table: {}", segmentName,
+          tableNameWithType);
+      return;
+    }
+
     SegmentMetadata segmentMetadata = getSegmentMetadata(tableNameWithType, segmentName);
     if (segmentMetadata == null) {
       LOGGER.info("Segment metadata is null. Skip reloading segment: {} in table: {}", segmentName, tableNameWithType);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.server.starter.helix;
 
 import java.util.Optional;
-
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.common.utils.CommonConstants.Server;
@@ -60,6 +59,20 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   public static final String SEGMENT_FORMAT_VERSION = "segment.format.version";
   // Key of whether to enable reloading consuming segments
   public static final String INSTANCE_RELOAD_CONSUMING_SEGMENT = "reload.consumingSegment";
+
+  // Whether or not to lazy load segments
+  public static final String LAZY_LOAD_SEGMENTS = "lazyLoadSegments";
+  // When lazy loading segments, to watch disc space, you may want to automatically clear the segments dir when
+  // a server boots back up. That way you don't accidentally use more disc space than maxSegmentDiscUsageMb
+  public static final String PURGE_ON_START = "purgeOnStart";
+  // Only when lazy loading
+  public static final String MAX_SEGMENT_DISC_USAGE_MB = "maxSegmentDiscUsageMb";
+  public static final int DEFAULT_MAX_SEGMENT_DISC_USAGE_MB = 1000;
+  // Causes the server to lazily pull segments from the controller.
+  public static final boolean DEFAULT_LAZY_LOAD_SEGMENTS = false;
+  // Purging the segment directory on start is a dangerous operation, so it should be explicitly enabled
+  public static final boolean DEFAULT_PURGE_ON_START = false;
+
 
   // Key of how many parallel realtime segments can be built.
   // A value of <= 0 indicates unlimited.
@@ -157,6 +170,21 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   }
 
   @Override
+  public boolean shouldLazyLoadSegments() {
+    return _instanceDataManagerConfiguration.getProperty(LAZY_LOAD_SEGMENTS, DEFAULT_LAZY_LOAD_SEGMENTS);
+  }
+
+  @Override
+  public boolean shouldPurgeOnStart() {
+    return _instanceDataManagerConfiguration.getProperty(PURGE_ON_START, DEFAULT_PURGE_ON_START);
+  }
+
+  @Override
+  public int maxSegmentDiscUsageMb() {
+    return _instanceDataManagerConfiguration.getProperty(MAX_SEGMENT_DISC_USAGE_MB, DEFAULT_MAX_SEGMENT_DISC_USAGE_MB);
+  }
+
+  @Override
   public boolean isEnableSplitCommit() {
     return _instanceDataManagerConfiguration.getProperty(ENABLE_SPLIT_COMMIT, false);
   }
@@ -193,6 +221,7 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   public int getMaxParallelSegmentBuilds() {
     return _instanceDataManagerConfiguration.getProperty(MAX_PARALLEL_SEGMENT_BUILDS, 0);
   }
+
 
   @Override
   public String toString() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
@@ -34,7 +34,9 @@ import org.apache.pinot.common.metadata.segment.RealtimeSegmentZKMetadata;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.SegmentName;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
+import org.apache.pinot.core.data.manager.OfflineSegmentFetcherAndLoader;
 import org.apache.pinot.core.data.manager.SegmentDataManager;
+import org.apache.pinot.core.data.manager.SegmentLocks;
 import org.apache.pinot.core.data.manager.TableDataManager;
 import org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager;
 import org.apache.pinot.spi.config.table.TableType;
@@ -52,10 +54,10 @@ import org.slf4j.LoggerFactory;
 public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<StateModel> {
   private final String _instanceId;
   private final InstanceDataManager _instanceDataManager;
-  private final SegmentFetcherAndLoader _fetcherAndLoader;
+  private final OfflineSegmentFetcherAndLoader _fetcherAndLoader;
 
   public SegmentOnlineOfflineStateModelFactory(String instanceId, InstanceDataManager instanceDataManager,
-      SegmentFetcherAndLoader fetcherAndLoader) {
+      OfflineSegmentFetcherAndLoader fetcherAndLoader) {
     _instanceId = instanceId;
     _instanceDataManager = instanceDataManager;
     _fetcherAndLoader = fetcherAndLoader;
@@ -159,7 +161,7 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
         TableType tableType = TableNameBuilder.getTableTypeFromTableName(message.getResourceName());
         Preconditions.checkNotNull(tableType);
         if (tableType == TableType.OFFLINE) {
-          _fetcherAndLoader.addOrReplaceOfflineSegment(tableNameWithType, segmentName);
+          _instanceDataManager.addOrReplaceOfflineSegment(tableNameWithType, segmentName);
         } else {
           _instanceDataManager.addRealtimeSegment(tableNameWithType, segmentName);
         }

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
@@ -33,9 +33,11 @@ import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.segment.ReadMode;
 import org.apache.pinot.common.utils.CommonConstants;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
+import org.apache.pinot.core.data.manager.OfflineSegmentFetcherAndLoader;
 import org.apache.pinot.core.data.manager.TableDataManager;
 import org.apache.pinot.core.data.manager.config.TableDataManagerConfig;
 import org.apache.pinot.core.data.manager.offline.OfflineTableDataManager;
+import org.apache.pinot.core.data.manager.offline.SegmentCacheManager;
 import org.apache.pinot.core.indexsegment.generator.SegmentGeneratorConfig;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegment;
 import org.apache.pinot.core.indexsegment.immutable.ImmutableSegmentLoader;
@@ -147,7 +149,8 @@ public abstract class BaseResourceTest {
     when(tableDataManagerConfig.getDataDir()).thenReturn(INDEX_DIR.getAbsolutePath());
     // NOTE: Use OfflineTableDataManager for both OFFLINE and REALTIME table because RealtimeTableDataManager requires
     //       table config.
-    TableDataManager tableDataManager = new OfflineTableDataManager();
+    TableDataManager tableDataManager =
+        new OfflineTableDataManager(mock(OfflineSegmentFetcherAndLoader.class), mock(SegmentCacheManager.class));
     tableDataManager
         .init(tableDataManagerConfig, "testInstance", mock(ZkHelixPropertyStore.class), mock(ServerMetrics.class),
             mock(HelixManager.class));

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/BaseRecordExtractor.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/BaseRecordExtractor.java
@@ -18,12 +18,14 @@
  */
 package org.apache.pinot.spi.data.readers;
 
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.avro.generic.GenericData;
 
 
 /**
@@ -186,6 +188,10 @@ public abstract class BaseRecordExtractor<T> implements RecordExtractor<T> {
     }
     if (value instanceof Number || value instanceof byte[]) {
       return value;
+    }
+    if (value instanceof GenericData.Fixed) {
+      GenericData.Fixed fixed = (GenericData.Fixed) value;
+      return new BigInteger(fixed.bytes());
     }
     return value.toString();
   }


### PR DESCRIPTION
## Description
Addresses https://github.com/apache/incubator-pinot/issues/6187 and https://github.com/apache/incubator-pinot/pull/6250

New configurations on the server include:

|Option | Default | Description
|-------|--------|------------
|pinot.server.instance.lazyLoadSegments | false | Enables segment lazy loading from deep storage. This will keep segments from being stored on the local file system until they are needed for a query.
|pinot.server.instance.maxSegmentDiscUsageMb | Integer.MAX_VALUE | Sets a maximum bound before cached segments should be cleaned up. This should be set below the maximum disc space on the particular server. 
|pinot.server.instance.purgeOnStart | false | After the server has crashed, there's no guarantee the cached segments are up to date. Rather than refresh them all, you can optionally just purge all existing segments from the local disc when the server starts. 

New configurations from the broker include:

|Option | Default | Description|
|-------|--------|-----------
|pinot.broker.query.segment.limit | Integer.MAX_VALUE | Because we are lazy loading segment, materializing a large number of unpruned segments can cause massive resource usage and disc pressure. This acts as a safeguard against `select *` queries with no `where` clause.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [*] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

This PR will require release notes and updates to the pinot docs gitbook which appears to be a separate repo. 

* [*] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes

See above configuration options, and below documentation.

## Documentation
TODO
