### PR TITLE
Add consumption rate limiter for LLConsumer

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1257,7 +1257,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
         indexLoadingConfig.isRealtimeOffHeapAllocation(), indexLoadingConfig.isDirectRealtimeOffHeapAllocation(),
         serverMetrics);
 
-    _rateLimiter = RealtimeConsumptionRateManager.getInstance().createRateLimiter(_partitionLevelStreamConfig);
+    _rateLimiter = RealtimeConsumptionRateManager.getInstance()
+        .createRateLimiter(_partitionLevelStreamConfig, _tableNameWithType);
 
     List<String> sortedColumns = indexLoadingConfig.getSortedColumns();
     if (sortedColumns.isEmpty()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1257,8 +1257,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
         indexLoadingConfig.isRealtimeOffHeapAllocation(), indexLoadingConfig.isDirectRealtimeOffHeapAllocation(),
         serverMetrics);
 
-    _rateLimiter = RealtimeConsumptionRateManager.getInstance()
-        .createRateLimiterForMultiPartitionTopic(_partitionLevelStreamConfig);
+    _rateLimiter = RealtimeConsumptionRateManager.getInstance().createRateLimiter(_partitionLevelStreamConfig);
 
     List<String> sortedColumns = indexLoadingConfig.getSortedColumns();
     if (sortedColumns.isEmpty()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
@@ -45,7 +45,7 @@ public class RealtimeConsumptionRateManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeConsumptionRateManager.class);
   private static final int CACHE_ENTRY_EXPIRATION_TIME_IN_MINUTES = 10;
 
-  private static volatile RealtimeConsumptionRateManager INSTANCE;
+  private static volatile RealtimeConsumptionRateManager _instance;
 
   // stream config object is required for fetching the partition count from the stream
   private final LoadingCache<StreamConfig, Integer> _streamConfigToTopicPartitionCountMap;
@@ -57,14 +57,14 @@ public class RealtimeConsumptionRateManager {
   }
 
   public static RealtimeConsumptionRateManager getInstance() {
-    if (INSTANCE == null) {
+    if (_instance == null) {
       synchronized (RealtimeConsumptionRateManager.class) {
-        if (INSTANCE == null) {
-          INSTANCE = new RealtimeConsumptionRateManager(buildCache());
+        if (_instance == null) {
+          _instance = new RealtimeConsumptionRateManager(buildCache());
         }
       }
     }
-    return INSTANCE;
+    return _instance;
   }
 
   public void enableThrottling() {
@@ -126,7 +126,7 @@ public class RealtimeConsumptionRateManager {
 
     @Override
     public void throttle(int numMsgs) {
-      if (INSTANCE._isThrottlingAllowed && numMsgs > 0) {
+      if (_instance._isThrottlingAllowed && numMsgs > 0) {
         _rateLimiter.acquire(numMsgs);
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
@@ -19,7 +19,6 @@
 
 package org.apache.pinot.core.data.manager.realtime;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
@@ -67,7 +67,7 @@ public class RealtimeConsumptionRateManager {
   }
 
   private ConsumptionRateLimiter createRateLimiter(StreamConfig streamConfig, boolean multiPartitionTopic) {
-    if (streamConfig.getTopicConsumptionRateLimit().isEmpty()) {
+    if (!streamConfig.getTopicConsumptionRateLimit().isPresent()) {
       return NOOP_RATE_LIMITER;
     }
     int partitionCount = 1;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.core.data.manager.realtime;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.util.concurrent.RateLimiter;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.stream.StreamConsumerFactory;
+import org.apache.pinot.spi.stream.StreamConsumerFactoryProvider;
+import org.apache.pinot.spi.stream.StreamMetadataProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * This class is responsible for creating realtime consumption rate limiters. If rate limiter is used for
+ * multi-partition topics, the provided rate in StreamConfig is divided by partition count. This class leverages a
+ * cache for storing partition count for different topics as retrieving partition count from Kafka is a bit expensive
+ * and also the same count will be used of all partition consumers of the same topic.
+ */
+public class RealtimeConsumptionRateManager {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeConsumptionRateManager.class);
+  private static final RealtimeConsumptionRateManager INSTANCE = new RealtimeConsumptionRateManager();
+  private static final int CACHE_ENTRY_EXPIRATION_TIME_IN_MINUTES = 10;
+
+  private final LoadingCache<StreamConfig, Integer> _streamConfigToTopicPartitionCountMap = buildCache();
+  private boolean _isThrottlingAllowed = false;
+
+  private RealtimeConsumptionRateManager() {
+  }
+
+  public static RealtimeConsumptionRateManager getInstance() {
+    return INSTANCE;
+  }
+
+  public void enableThrottling() {
+    _isThrottlingAllowed = true;
+  }
+
+  public ConsumptionRateLimiter createRateLimiterForSinglePartitionTopic(StreamConfig streamConfig) {
+    return createRateLimiter(streamConfig, false);
+  }
+
+  public ConsumptionRateLimiter createRateLimiterForMultiPartitionTopic(StreamConfig streamConfig) {
+    return createRateLimiter(streamConfig, true);
+  }
+
+  private ConsumptionRateLimiter createRateLimiter(StreamConfig streamConfig, boolean multiPartitionTopic) {
+    if (streamConfig.getTopicConsumptionRateLimit().isEmpty()) {
+      return NOOP_RATE_LIMITER;
+    }
+    int partitionCount = 1;
+    if (multiPartitionTopic) {
+      try {
+        partitionCount = _streamConfigToTopicPartitionCountMap.get(streamConfig);
+      } catch (ExecutionException e) {
+        // Exception here means that for some reason, partition count cannot be retrieved from Kafka broker!
+        throw new RuntimeException(e);
+      }
+    }
+    double topicRateLimit = streamConfig.getTopicConsumptionRateLimit().get();
+    double partitionRateLimit = topicRateLimit / partitionCount;
+    LOGGER.info("A rate limiter is setup for topic {} with rate limit: {} (topic rate limit: {}, partition count: {})",
+        streamConfig.getTopicName(), partitionRateLimit, topicRateLimit, partitionCount);
+    return new RateLimiterImpl(partitionRateLimit);
+  }
+
+  private LoadingCache<StreamConfig, Integer> buildCache() {
+    return CacheBuilder.newBuilder().expireAfterWrite(CACHE_ENTRY_EXPIRATION_TIME_IN_MINUTES, TimeUnit.MINUTES)
+        .build(new CacheLoader<StreamConfig, Integer>() {
+          @Override
+          public Integer load(StreamConfig streamConfig)
+              throws Exception {
+            String clientId = streamConfig.getTopicName() + "-consumption.rate.manager";
+            StreamConsumerFactory factory = StreamConsumerFactoryProvider.create(streamConfig);
+            try (StreamMetadataProvider streamMetadataProvider = factory.createStreamMetadataProvider(clientId)) {
+              return streamMetadataProvider.fetchPartitionCount(/*maxWaitTimeMs*/10_000);
+            }
+          }
+        });
+  }
+
+  @FunctionalInterface
+  public interface ConsumptionRateLimiter {
+    void throttle(int numMsgs);
+  }
+
+  private static final ConsumptionRateLimiter NOOP_RATE_LIMITER = n -> {
+  };
+
+  private static class RateLimiterImpl implements ConsumptionRateLimiter {
+
+    private RateLimiter _rateLimiter;
+
+    public RateLimiterImpl(double rateLimit) {
+      _rateLimiter = RateLimiter.create(rateLimit);
+    }
+
+    @Override
+    public void throttle(int numMsgs) {
+      if (INSTANCE._isThrottlingAllowed && numMsgs > 0) {
+        _rateLimiter.acquire(numMsgs);
+      }
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
@@ -92,7 +92,7 @@ public class RealtimeConsumptionRateManager {
 
   private static LoadingCache<StreamConfig, Integer> buildCache() {
     return CacheBuilder.newBuilder().expireAfterWrite(CACHE_ENTRY_EXPIRATION_TIME_IN_MINUTES, TimeUnit.MINUTES)
-        .build(new CacheLoader<>() {
+        .build(new CacheLoader<StreamConfig, Integer>() {
           @Override
           public Integer load(StreamConfig streamConfig)
               throws Exception {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManagerTest.java
@@ -1,0 +1,55 @@
+package org.apache.pinot.core.data.manager.realtime;
+
+import com.google.common.cache.LoadingCache;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import org.apache.pinot.spi.stream.StreamConfig;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.core.data.manager.realtime.RealtimeConsumptionRateManager.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+
+public class RealtimeConsumptionRateManagerTest {
+  private static final int NUM_PARTITIONS_TOPIC_A = 10;
+  private static final int NUM_PARTITIONS_TOPIC_B = 20;
+  private static final Double RATE_LIMIT_FOR_ENTIRE_TOPIC = 50.0;
+  private static final String TABLE_NAME = "table-XYZ";
+  private static final double DELTA = 0.0001;
+  private static final StreamConfig STREAM_CONFIG_A = mock(StreamConfig.class);
+  private static final StreamConfig STREAM_CONFIG_B = mock(StreamConfig.class);
+  private static final StreamConfig STREAM_CONFIG_C = mock(StreamConfig.class);
+  private static RealtimeConsumptionRateManager consumptionRateManager;
+
+  static {
+    LoadingCache<StreamConfig, Integer> cache = mock(LoadingCache.class);
+    try {
+      when(cache.get(STREAM_CONFIG_A)).thenReturn(NUM_PARTITIONS_TOPIC_A);
+      when(cache.get(STREAM_CONFIG_B)).thenReturn(NUM_PARTITIONS_TOPIC_B);
+    } catch (ExecutionException e) {
+      e.printStackTrace();
+    }
+    when(STREAM_CONFIG_A.getTopicConsumptionRateLimit()).thenReturn(Optional.of(RATE_LIMIT_FOR_ENTIRE_TOPIC));
+    when(STREAM_CONFIG_B.getTopicConsumptionRateLimit()).thenReturn(Optional.of(RATE_LIMIT_FOR_ENTIRE_TOPIC));
+    when(STREAM_CONFIG_C.getTopicConsumptionRateLimit()).thenReturn(Optional.empty());
+    consumptionRateManager = new RealtimeConsumptionRateManager(cache);
+  }
+
+  @Test
+  public void testCreateRateLimiter() {
+    // topic A
+    ConsumptionRateLimiter rateLimiter = consumptionRateManager.createRateLimiter(STREAM_CONFIG_A, TABLE_NAME);
+    assertEquals(5.0, ((RateLimiterImpl) rateLimiter).getRate(), DELTA);
+
+    // topic B
+    rateLimiter = consumptionRateManager.createRateLimiter(STREAM_CONFIG_B, TABLE_NAME);
+    assertEquals(2.5, ((RateLimiterImpl) rateLimiter).getRate(), DELTA);
+
+    // topic C
+    rateLimiter = consumptionRateManager.createRateLimiter(STREAM_CONFIG_C, TABLE_NAME);
+    assertEquals(rateLimiter, NOOP_RATE_LIMITER);
+  }
+
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManagerTest.java
@@ -21,7 +21,7 @@ public class RealtimeConsumptionRateManagerTest {
   private static final StreamConfig STREAM_CONFIG_A = mock(StreamConfig.class);
   private static final StreamConfig STREAM_CONFIG_B = mock(StreamConfig.class);
   private static final StreamConfig STREAM_CONFIG_C = mock(StreamConfig.class);
-  private static RealtimeConsumptionRateManager consumptionRateManager;
+  private static RealtimeConsumptionRateManager _consumptionRateManager;
 
   static {
     LoadingCache<StreamConfig, Integer> cache = mock(LoadingCache.class);
@@ -34,21 +34,21 @@ public class RealtimeConsumptionRateManagerTest {
     when(STREAM_CONFIG_A.getTopicConsumptionRateLimit()).thenReturn(Optional.of(RATE_LIMIT_FOR_ENTIRE_TOPIC));
     when(STREAM_CONFIG_B.getTopicConsumptionRateLimit()).thenReturn(Optional.of(RATE_LIMIT_FOR_ENTIRE_TOPIC));
     when(STREAM_CONFIG_C.getTopicConsumptionRateLimit()).thenReturn(Optional.empty());
-    consumptionRateManager = new RealtimeConsumptionRateManager(cache);
+    _consumptionRateManager = new RealtimeConsumptionRateManager(cache);
   }
 
   @Test
   public void testCreateRateLimiter() {
     // topic A
-    ConsumptionRateLimiter rateLimiter = consumptionRateManager.createRateLimiter(STREAM_CONFIG_A, TABLE_NAME);
+    ConsumptionRateLimiter rateLimiter = _consumptionRateManager.createRateLimiter(STREAM_CONFIG_A, TABLE_NAME);
     assertEquals(5.0, ((RateLimiterImpl) rateLimiter).getRate(), DELTA);
 
     // topic B
-    rateLimiter = consumptionRateManager.createRateLimiter(STREAM_CONFIG_B, TABLE_NAME);
+    rateLimiter = _consumptionRateManager.createRateLimiter(STREAM_CONFIG_B, TABLE_NAME);
     assertEquals(2.5, ((RateLimiterImpl) rateLimiter).getRate(), DELTA);
 
     // topic C
-    rateLimiter = consumptionRateManager.createRateLimiter(STREAM_CONFIG_C, TABLE_NAME);
+    rateLimiter = _consumptionRateManager.createRateLimiter(STREAM_CONFIG_C, TABLE_NAME);
     assertEquals(rateLimiter, NOOP_RATE_LIMITER);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManagerTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.data.manager.realtime;
 
 import com.google.common.cache.LoadingCache;

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -60,6 +60,7 @@ import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.core.common.datatable.DataTableBuilder;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
+import org.apache.pinot.core.data.manager.realtime.RealtimeConsumptionRateManager;
 import org.apache.pinot.core.query.request.context.ThreadTimer;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.transport.TlsConfig;
@@ -488,6 +489,9 @@ public abstract class BaseServerStarter implements ServiceStartable {
     }
     _helixAdmin.setConfig(_instanceConfigScope,
         Collections.singletonMap(Helix.IS_SHUTDOWN_IN_PROGRESS, Boolean.toString(false)));
+
+    // Throttling for realtime consumption is disabled up to this point to allow maximum consumption during startup time
+    RealtimeConsumptionRateManager.getInstance().enableThrottling();
 
     // Set the system resource info (CPU, Memory, etc) in the InstanceConfig.
     setInstanceResourceInfo(_helixAdmin, _helixClusterName, _instanceId, new SystemResourceInfo().toMap());

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
@@ -47,6 +47,7 @@ public class StreamConfigProperties {
   public static final String DECODER_PROPS_PREFIX = "decoder.prop";
   public static final String GROUP_ID = "hlc.group.id";
   public static final String PARTITION_MSG_OFFSET_FACTORY_CLASS = "partition.offset.factory.class.name";
+  public static final String TOPIC_CONSUMPTION_RATE_LIMIT = "topic.consumption.rate.limit";
 
   /**
    * Time threshold that will keep the realtime segment open for before we complete the segment


### PR DESCRIPTION
## Description
Having a consumption rate limiter for a table is beneficial in two ways:
1. Currently offline tables can be configured to have storage quota. The storage quota for tables safegaurds the pinot cluster hosting those tables in case of excessive uploads of offline segments so that the cluster won't be under provisioned. Consumption rate limiter can play similar role for hybrid tables and realtime-only tables as it limits the amount of data being ingested into the realtime tables.
2. Bursty pattern of incoming Kafka events introduces long time GC pauses on Pinot server. This behavior has been observed in some tables in LinkedIn. It's also been reported in this issue: #6138.

This PR introduces rate limit on Kafka consumption which can be configured in StreamConfig. The consumption rate limit parameter is defined for the whole topic and the rate limit for each partition will be simply topic rate limit divided by the partition count of that topic.

## Testing Done
- Locally added consumption rate limit to `LLCRealtimeClusterIntegrationTest` and verified the consumption rate was limited the the amount set in the table config.
- Deployed to a perf cluster with two servers, one with rate limit enabled and one without. Here are some chart comparing a few metrics on the two hosts (red: w/o consumption rate limit, blue: w/ consumption rate limit):
1) Ingestion rate for a period of two hours when incoming message rate was more than the consumption rate limit specified in the table config:
![image](https://user-images.githubusercontent.com/8548220/151083771-40074150-41b8-4287-9498-4eec712757aa.png)
2) Young generation GC collection time for the same time period.
![image](https://user-images.githubusercontent.com/8548220/151084300-b1c4f7d0-d1a0-49ad-b75d-077dcaf69563.png)
3) Young generation GC count for the same time period.
![image](https://user-images.githubusercontent.com/8548220/151084394-51a0c332-fed5-41ed-949e-6fc6bf56d9bc.png)
4) other metrics like old gen gc metrics, cpu utilization, ... were pretty much identical.