### PR TITLE
upload missing LLC segment to segment store by controller periodic task

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -73,12 +73,6 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   // Percentage of segments we failed to get size for
   TABLE_STORAGE_EST_MISSING_SEGMENT_PERCENT("TableStorageEstMissingSegmentPercent", false),
 
-  // Number of errors during segment store upload retry of LLC segment
-  NUMBER_OF_ERRORS_FOR_LLC_SEGMENTS_DEEP_STORE_UPLOAD_RETRY("LLCSegmentDeepStoreUploadRetryError", false),
-
-  // Number of errors when pre-fetching the LLC segment ZK metadata for fixing missing segment store copy
-  NUMBER_OF_ERRORS_FOR_LLC_SEGMENTS_ZK_METADATA_PREFETCH("LLCSegmentZKMetadataPrefetchError", false),
-
   // Number of scheduled Cron jobs
   CRON_SCHEDULER_JOB_SCHEDULED("cronSchedulerJobScheduled", false),
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -73,6 +73,12 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   // Percentage of segments we failed to get size for
   TABLE_STORAGE_EST_MISSING_SEGMENT_PERCENT("TableStorageEstMissingSegmentPercent", false),
 
+  // Number of errors during segment store upload retry of LLC segment
+  NUMBER_OF_ERRORS_FOR_LLC_SEGMENTS_DEEP_STORE_UPLOAD_RETRY("LLCSegmentDeepStoreUploadRetryError", false),
+
+  // Number of errors when pre-fetching the LLC segment ZK metadata for fixing missing segment store copy
+  NUMBER_OF_ERRORS_FOR_LLC_SEGMENTS_ZK_METADATA_PREFETCH("LLCSegmentZKMetadataPrefetchError", false),
+
   // Number of scheduled Cron jobs
   CRON_SCHEDULER_JOB_SCHEDULED("cronSchedulerJobScheduled", false),
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -49,8 +49,7 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   NUMBER_TIMES_SCHEDULE_TASKS_CALLED("tasks", true),
   NUMBER_TASKS_SUBMITTED("tasks", false),
   NUMBER_SEGMENT_UPLOAD_TIMEOUT_EXCEEDED("SegmentUploadTimeouts", true),
-  CRON_SCHEDULER_JOB_TRIGGERED("cronSchedulerJobTriggered", false),
-  NUMBER_LLC_SEGMENTS_DEEP_STORE_UPLOAD_FIX_ERROR("llcSegmentDeepStoreUploadFixError", true);
+  CRON_SCHEDULER_JOB_TRIGGERED("cronSchedulerJobTriggered", false);
 
   private final String _brokerMeterName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -50,8 +50,7 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   NUMBER_TASKS_SUBMITTED("tasks", false),
   NUMBER_SEGMENT_UPLOAD_TIMEOUT_EXCEEDED("SegmentUploadTimeouts", true),
   CRON_SCHEDULER_JOB_TRIGGERED("cronSchedulerJobTriggered", false),
-  LLC_SEGMENTS_DEEP_STORE_UPLOAD_RETRY_ERROR("LLCSegmentDeepStoreUploadRetryError", false),
-  LLC_SEGMENTS_ZK_METADATA_PREFETCH_ERROR("LLCSegmentZKMetadataPrefetchError", false);
+  LLC_SEGMENTS_DEEP_STORE_UPLOAD_RETRY_ERROR("LLCSegmentDeepStoreUploadRetryError", false);
 
 
   private final String _brokerMeterName;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -49,7 +49,10 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   NUMBER_TIMES_SCHEDULE_TASKS_CALLED("tasks", true),
   NUMBER_TASKS_SUBMITTED("tasks", false),
   NUMBER_SEGMENT_UPLOAD_TIMEOUT_EXCEEDED("SegmentUploadTimeouts", true),
-  CRON_SCHEDULER_JOB_TRIGGERED("cronSchedulerJobTriggered", false);
+  CRON_SCHEDULER_JOB_TRIGGERED("cronSchedulerJobTriggered", false),
+  LLC_SEGMENTS_DEEP_STORE_UPLOAD_RETRY_ERROR("LLCSegmentDeepStoreUploadRetryError", false),
+  LLC_SEGMENTS_ZK_METADATA_PREFETCH_ERROR("LLCSegmentZKMetadataPrefetchError", false);
+
 
   private final String _brokerMeterName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -49,7 +49,8 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   NUMBER_TIMES_SCHEDULE_TASKS_CALLED("tasks", true),
   NUMBER_TASKS_SUBMITTED("tasks", false),
   NUMBER_SEGMENT_UPLOAD_TIMEOUT_EXCEEDED("SegmentUploadTimeouts", true),
-  CRON_SCHEDULER_JOB_TRIGGERED("cronSchedulerJobTriggered", false);
+  CRON_SCHEDULER_JOB_TRIGGERED("cronSchedulerJobTriggered", false),
+  NUMBER_LLC_SEGMENTS_DEEP_STORE_UPLOAD_FIX_ERROR("llcSegmentDeepStoreUploadFixError", true);
 
   private final String _brokerMeterName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -797,6 +797,27 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   /**
+   * Used by controllers to send requests to servers: Controller periodic task uses this endpoint to ask servers to upload committed llc segment to segment store if missing.
+   * @param uri The uri to ask servers to upload segment to segment store
+   * @return the uploaded segment download url from segment store
+   * @throws URISyntaxException
+   * @throws IOException
+   * @throws HttpErrorStatusException
+   */
+  public String uploadToSegmentStore(String uri)
+      throws URISyntaxException, IOException, HttpErrorStatusException {
+    RequestBuilder requestBuilder = RequestBuilder.post(new URI(uri)).setVersion(HttpVersion.HTTP_1_1);
+    setTimeout(requestBuilder, DEFAULT_SOCKET_TIMEOUT_MS);
+    // sendRequest checks the response status code
+    SimpleHttpResponse response = sendRequest(requestBuilder.build());
+    String downloadUrl = response.getResponse();
+    if (downloadUrl.isEmpty()) {
+      throw new HttpErrorStatusException(String.format("Returned segment download url is empty after requesting servers to upload by the path: %s", uri), response.getStatusCode());
+    }
+    return downloadUrl;
+  }
+
+  /**
    * Send segment uri.
    *
    * Note: table name has to be set as a parameter.

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -798,7 +798,8 @@ public class FileUploadDownloadClient implements Closeable {
 
   /**
    * Used by controllers to send requests to servers:
-   * Controller periodic task uses this endpoint to ask servers to upload committed llc segment to segment store if missing.
+   * Controller periodic task uses this endpoint to ask servers
+   * to upload committed llc segment to segment store if missing.
    * @param uri The uri to ask servers to upload segment to segment store
    * @return the uploaded segment download url from segment store
    * @throws URISyntaxException
@@ -814,7 +815,9 @@ public class FileUploadDownloadClient implements Closeable {
     String downloadUrl = response.getResponse();
     if (downloadUrl.isEmpty()) {
       throw new HttpErrorStatusException(
-          String.format("Returned segment download url is empty after requesting servers to upload by the path: %s", uri),
+          String.format(
+              "Returned segment download url is empty after requesting servers to upload by the path: %s",
+              uri),
           response.getStatusCode());
     }
     return downloadUrl;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -797,7 +797,8 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   /**
-   * Used by controllers to send requests to servers: Controller periodic task uses this endpoint to ask servers to upload committed llc segment to segment store if missing.
+   * Used by controllers to send requests to servers:
+   * Controller periodic task uses this endpoint to ask servers to upload committed llc segment to segment store if missing.
    * @param uri The uri to ask servers to upload segment to segment store
    * @return the uploaded segment download url from segment store
    * @throws URISyntaxException
@@ -812,7 +813,9 @@ public class FileUploadDownloadClient implements Closeable {
     SimpleHttpResponse response = sendRequest(requestBuilder.build());
     String downloadUrl = response.getResponse();
     if (downloadUrl.isEmpty()) {
-      throw new HttpErrorStatusException(String.format("Returned segment download url is empty after requesting servers to upload by the path: %s", uri), response.getStatusCode());
+      throw new HttpErrorStatusException(
+          String.format("Returned segment download url is empty after requesting servers to upload by the path: %s", uri),
+          response.getStatusCode());
     }
     return downloadUrl;
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -797,23 +797,6 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   /**
-   * Controller periodic task uses this endpoint to ask servers to upload committed llc segment to segment store if missing.
-   * @param uri The uri to ask servers to upload segment to segment store
-   * @return the uploaded segment download url from segment store
-   * @throws URISyntaxException
-   * @throws IOException
-   * @throws HttpErrorStatusException
-   */
-  public String uploadToSegmentStore(String uri)
-      throws URISyntaxException, IOException, HttpErrorStatusException {
-    RequestBuilder requestBuilder = RequestBuilder.post(new URI(uri)).setVersion(HttpVersion.HTTP_1_1);
-    setTimeout(requestBuilder, DEFAULT_SOCKET_TIMEOUT_MS);
-    // sendRequest checks the response status code
-    SimpleHttpResponse response = sendRequest(requestBuilder.build());
-    return response.getResponse();
-  }
-
-  /**
    * Send segment uri.
    *
    * Note: table name has to be set as a parameter.

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -797,6 +797,23 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   /**
+   * Controller periodic task uses this endpoint to ask servers to upload committed llc segment to segment store if missing.
+   * @param uri The uri to ask servers to upload segment to segment store
+   * @return the uploaded segment download url from segment store
+   * @throws URISyntaxException
+   * @throws IOException
+   * @throws HttpErrorStatusException
+   */
+  public String uploadToSegmentStore(String uri)
+      throws URISyntaxException, IOException, HttpErrorStatusException {
+    RequestBuilder requestBuilder = RequestBuilder.post(new URI(uri)).setVersion(HttpVersion.HTTP_1_1);
+    setTimeout(requestBuilder, DEFAULT_SOCKET_TIMEOUT_MS);
+    // sendRequest checks the response status code
+    SimpleHttpResponse response = sendRequest(requestBuilder.build());
+    return response.getResponse();
+  }
+
+  /**
    * Send segment uri.
    *
    * Note: table name has to be set as a parameter.

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -805,6 +805,8 @@ public class FileUploadDownloadClient implements Closeable {
    * @throws URISyntaxException
    * @throws IOException
    * @throws HttpErrorStatusException
+   *
+   * TODO: migrate this method to another class
    */
   public String uploadToSegmentStore(String uri)
       throws URISyntaxException, IOException, HttpErrorStatusException {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
@@ -20,7 +20,6 @@ package org.apache.pinot.common.utils;
 
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
@@ -56,8 +55,7 @@ public class LLCSegmentName extends SegmentName implements Comparable {
     _partitionGroupId = partitionGroupId;
     _sequenceNumber = sequenceNumber;
     // ISO8601 date: 20160120T1234Z
-    DateTime dateTime = new DateTime(msSinceEpoch, DateTimeZone.UTC);
-    _creationTime = dateTime.toString(DATE_FORMAT);
+    _creationTime = DATE_FORMATTER.print(msSinceEpoch);
     _segmentName = tableName + SEPARATOR + partitionGroupId + SEPARATOR + sequenceNumber + SEPARATOR + _creationTime;
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
@@ -21,10 +21,14 @@ package org.apache.pinot.common.utils;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
 
 
 public class LLCSegmentName extends SegmentName implements Comparable {
   private final static String DATE_FORMAT = "yyyyMMdd'T'HHmm'Z'";
+  private final static DateTimeFormatter DATE_FORMATTER = DateTimeFormat.forPattern(DATE_FORMAT).withZoneUTC();
+
   private final String _tableName;
   private final int _partitionGroupId;
   private final int _sequenceNumber;
@@ -91,6 +95,11 @@ public class LLCSegmentName extends SegmentName implements Comparable {
 
   public String getCreationTime() {
     return _creationTime;
+  }
+
+  public long getCreationTimeMs() {
+    DateTime dateTime = DATE_FORMATTER.parseDateTime(_creationTime);
+    return dateTime.getMillis();
   }
 
   @Override

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/SegmentNameBuilderTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/SegmentNameBuilderTest.java
@@ -123,12 +123,14 @@ public class SegmentNameBuilderTest {
     final int sequenceNumber = 27;
     final long msSinceEpoch = 1466200248000L;
     final String creationTime = "20160617T2150Z";
+    final long creationTimeInMs = 1466200200000L;
     final String segmentName = "myTable__4__27__" + creationTime;
 
     LLCSegmentName segName1 = new LLCSegmentName(tableName, partitionGroupId, sequenceNumber, msSinceEpoch);
     Assert.assertEquals(segName1.getSegmentName(), segmentName);
     Assert.assertEquals(segName1.getPartitionGroupId(), partitionGroupId);
     Assert.assertEquals(segName1.getCreationTime(), creationTime);
+    Assert.assertEquals(segName1.getCreationTimeMs(), creationTimeInMs);
     Assert.assertEquals(segName1.getSequenceNumber(), sequenceNumber);
     Assert.assertEquals(segName1.getTableName(), tableName);
 
@@ -136,6 +138,7 @@ public class SegmentNameBuilderTest {
     Assert.assertEquals(segName2.getSegmentName(), segmentName);
     Assert.assertEquals(segName2.getPartitionGroupId(), partitionGroupId);
     Assert.assertEquals(segName2.getCreationTime(), creationTime);
+    Assert.assertEquals(segName2.getCreationTimeMs(), creationTimeInMs);
     Assert.assertEquals(segName2.getSequenceNumber(), sequenceNumber);
     Assert.assertEquals(segName2.getTableName(), tableName);
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -175,11 +175,11 @@ public class ControllerConf extends PinotConfiguration {
     public static final String SEGMENT_RELOCATOR_INITIAL_DELAY_IN_SECONDS =
         "controller.segmentRelocator.initialDelayInSeconds";
 
-    // configs for uploading missing LLC segments copy to segment store
-    public static final String ENABLE_UPLOAD_MISSING_LLC_SEGMENT_TO_SEGMENT_STORE =
-        "controller.realtime.segment.uploadToSegmentStoreIfMissing";
-    public static final String VALIDATION_RANGE_IN_DAYS_TO_CHECK_MISSING_SEGMENT_STORE_COPY =
-        "controller.realtime.segment.validationRangeInDaysToCheckMissingSegmentStoreCopy";
+    // configs for uploading missing LLC segments to deep store
+    public static final String ENABLE_DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT =
+        "controller.realtime.segment.deepStoreUploadRetryEnabled";
+    public static final String DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT_CREATED_IN_DAYS =
+        "controller.realtime.segment.deepStoreUploadRetryRangeInDays";
 
     public static final int MIN_INITIAL_DELAY_IN_SECONDS = 120;
     public static final int MAX_INITIAL_DELAY_IN_SECONDS = 300;
@@ -206,7 +206,7 @@ public class ControllerConf extends PinotConfiguration {
     private static final int DEFAULT_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS = 24 * 60 * 60;
     private static final int DEFAULT_SEGMENT_RELOCATOR_FREQUENCY_IN_SECONDS = 60 * 60;
 
-    private static final int DEFAULT_VALIDATION_RANGE_IN_DAYS_TO_CHECK_MISSING_SEGMENT_STORE_COPY = 3;
+    private static final int DEFAULT_DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT_CREATED_IN_DAYS = 3;
   }
 
   private static final String SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS = "server.request.timeoutSeconds";
@@ -768,13 +768,13 @@ public class ControllerConf extends PinotConfiguration {
         getPeriodicTaskInitialDelayInSeconds());
   }
 
-  public boolean isUploadingRealtimeMissingSegmentStoreCopyEnabled() {
-    return getProperty(ControllerPeriodicTasksConf.ENABLE_UPLOAD_MISSING_LLC_SEGMENT_TO_SEGMENT_STORE, false);
+  public boolean isDeepStoreRetryUploadLLCSegmentEnabled() {
+    return getProperty(ControllerPeriodicTasksConf.ENABLE_DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT, false);
   }
 
-  public int getValidationRangeInDaysToCheckMissingSegmentStoreCopy() {
-    return getProperty(ControllerPeriodicTasksConf.VALIDATION_RANGE_IN_DAYS_TO_CHECK_MISSING_SEGMENT_STORE_COPY,
-        ControllerPeriodicTasksConf.DEFAULT_VALIDATION_RANGE_IN_DAYS_TO_CHECK_MISSING_SEGMENT_STORE_COPY);
+  public int getDeepStoreRetryUploadLLCSegmentCreatedInDays() {
+    return getProperty(ControllerPeriodicTasksConf.DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT_CREATED_IN_DAYS,
+        ControllerPeriodicTasksConf.DEFAULT_DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT_CREATED_IN_DAYS);
   }
 
   public long getPinotTaskManagerInitialDelaySeconds() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -95,6 +95,8 @@ public class ControllerConf extends PinotConfiguration {
         "controller.realtime.segment.validation.frequencyPeriod";
     public static final String REALTIME_SEGMENT_VALIDATION_INITIAL_DELAY_IN_SECONDS =
         "controller.realtime.segment.validation.initialDelayInSeconds";
+    public static final String REALTIME_SEGMENT_UPLOAD_TO_SEGMENT_STORE_IF_MISSING =
+        "controller.realtime.segment.validation.uploadToSegmentStoreIfMissing";
     // Deprecated as of 0.8.0
     @Deprecated
     public static final String DEPRECATED_BROKER_RESOURCE_VALIDATION_FREQUENCY_IN_SECONDS =
@@ -756,6 +758,10 @@ public class ControllerConf extends PinotConfiguration {
   public long getRealtimeSegmentValidationManagerInitialDelaySeconds() {
     return getProperty(ControllerPeriodicTasksConf.REALTIME_SEGMENT_VALIDATION_INITIAL_DELAY_IN_SECONDS,
         getPeriodicTaskInitialDelayInSeconds());
+  }
+
+  public boolean isUploadingRealtimeMissingSegmentStoreCopyEnabled() {
+    return getProperty(ControllerPeriodicTasksConf.REALTIME_SEGMENT_UPLOAD_TO_SEGMENT_STORE_IF_MISSING, false);
   }
 
   public long getPinotTaskManagerInitialDelaySeconds() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -177,11 +177,6 @@ public class ControllerConf extends PinotConfiguration {
     // Default value is false.
     public static final String ENABLE_DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT =
         "controller.realtime.segment.deepStoreUploadRetryEnabled";
-    // For realtime ingestion, we care more about recent data. This config indicates the fix range for missing LLC
-    // segment deep store copy, i.e. controller periodic job will only fix the segments created within this
-    // range. Note that smaller value puts less pressure on servers and zookeeper.
-    public static final String DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT_CREATED_IN_DAYS =
-        "controller.realtime.segment.deepStoreUploadRetryRangeInDays";
 
     public static final int MIN_INITIAL_DELAY_IN_SECONDS = 120;
     public static final int MAX_INITIAL_DELAY_IN_SECONDS = 300;
@@ -207,8 +202,6 @@ public class ControllerConf extends PinotConfiguration {
 
     private static final int DEFAULT_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS = 24 * 60 * 60;
     private static final int DEFAULT_SEGMENT_RELOCATOR_FREQUENCY_IN_SECONDS = 60 * 60;
-
-    private static final int DEFAULT_DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT_CREATED_IN_DAYS = 3;
   }
 
   private static final String SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS = "server.request.timeoutSeconds";
@@ -772,11 +765,6 @@ public class ControllerConf extends PinotConfiguration {
 
   public boolean isDeepStoreRetryUploadLLCSegmentEnabled() {
     return getProperty(ControllerPeriodicTasksConf.ENABLE_DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT, false);
-  }
-
-  public int getDeepStoreRetryUploadLLCSegmentCreatedInDays() {
-    return getProperty(ControllerPeriodicTasksConf.DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT_CREATED_IN_DAYS,
-        ControllerPeriodicTasksConf.DEFAULT_DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT_CREATED_IN_DAYS);
   }
 
   public long getPinotTaskManagerInitialDelaySeconds() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -95,8 +95,6 @@ public class ControllerConf extends PinotConfiguration {
         "controller.realtime.segment.validation.frequencyPeriod";
     public static final String REALTIME_SEGMENT_VALIDATION_INITIAL_DELAY_IN_SECONDS =
         "controller.realtime.segment.validation.initialDelayInSeconds";
-    public static final String REALTIME_SEGMENT_UPLOAD_TO_SEGMENT_STORE_IF_MISSING =
-        "controller.realtime.segment.validation.uploadToSegmentStoreIfMissing";
     // Deprecated as of 0.8.0
     @Deprecated
     public static final String DEPRECATED_BROKER_RESOURCE_VALIDATION_FREQUENCY_IN_SECONDS =

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -173,9 +173,13 @@ public class ControllerConf extends PinotConfiguration {
     public static final String SEGMENT_RELOCATOR_INITIAL_DELAY_IN_SECONDS =
         "controller.segmentRelocator.initialDelayInSeconds";
 
-    // configs for uploading missing LLC segments to deep store
+    // The flag to indicate if controller periodic job will fix the missing LLC segment deep store copy.
+    // Default value is false.
     public static final String ENABLE_DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT =
         "controller.realtime.segment.deepStoreUploadRetryEnabled";
+    // For realtime ingestion, we care more about recent data. This config indicates the fix range for missing LLC
+    // segment deep store copy, i.e. controller periodic job will only fix the segments created within this
+    // range. Note that smaller value puts less pressure on servers and zookeeper.
     public static final String DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT_CREATED_IN_DAYS =
         "controller.realtime.segment.deepStoreUploadRetryRangeInDays";
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -175,6 +175,12 @@ public class ControllerConf extends PinotConfiguration {
     public static final String SEGMENT_RELOCATOR_INITIAL_DELAY_IN_SECONDS =
         "controller.segmentRelocator.initialDelayInSeconds";
 
+    // configs for uploading missing LLC segments copy to segment store
+    public static final String ENABLE_UPLOAD_MISSING_LLC_SEGMENT_TO_SEGMENT_STORE =
+        "controller.realtime.segment.uploadToSegmentStoreIfMissing";
+    public static final String VALIDATION_RANGE_IN_DAYS_TO_CHECK_MISSING_SEGMENT_STORE_COPY =
+        "controller.realtime.segment.validationRangeInDaysToCheckMissingSegmentStoreCopy";
+
     public static final int MIN_INITIAL_DELAY_IN_SECONDS = 120;
     public static final int MAX_INITIAL_DELAY_IN_SECONDS = 300;
 
@@ -199,6 +205,8 @@ public class ControllerConf extends PinotConfiguration {
 
     private static final int DEFAULT_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS = 24 * 60 * 60;
     private static final int DEFAULT_SEGMENT_RELOCATOR_FREQUENCY_IN_SECONDS = 60 * 60;
+
+    private static final int DEFAULT_VALIDATION_RANGE_IN_DAYS_TO_CHECK_MISSING_SEGMENT_STORE_COPY = 3;
   }
 
   private static final String SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS = "server.request.timeoutSeconds";
@@ -761,7 +769,12 @@ public class ControllerConf extends PinotConfiguration {
   }
 
   public boolean isUploadingRealtimeMissingSegmentStoreCopyEnabled() {
-    return getProperty(ControllerPeriodicTasksConf.REALTIME_SEGMENT_UPLOAD_TO_SEGMENT_STORE_IF_MISSING, false);
+    return getProperty(ControllerPeriodicTasksConf.ENABLE_UPLOAD_MISSING_LLC_SEGMENT_TO_SEGMENT_STORE, false);
+  }
+
+  public int getValidationRangeInDaysToCheckMissingSegmentStoreCopy() {
+    return getProperty(ControllerPeriodicTasksConf.VALIDATION_RANGE_IN_DAYS_TO_CHECK_MISSING_SEGMENT_STORE_COPY,
+        ControllerPeriodicTasksConf.DEFAULT_VALIDATION_RANGE_IN_DAYS_TO_CHECK_MISSING_SEGMENT_STORE_COPY);
   }
 
   public long getPinotTaskManagerInitialDelaySeconds() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -120,6 +120,8 @@ import org.slf4j.LoggerFactory;
  *   <li>prefetchLLCSegmentsWithoutDeepStoreCopy(): From lead controller only</li>
  *   <li>uploadToDeepStoreIfMissing(): From lead controller only</li>
  * </ul>
+ *
+ * TODO: migrate code in this class to other places for better readability
  */
 public class PinotLLCRealtimeSegmentManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotLLCRealtimeSegmentManager.class);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1334,7 +1334,7 @@ public class PinotLLCRealtimeSegmentManager {
           }
 
           LLCRealtimeSegmentZKMetadata segmentZKMetadata = getSegmentZKMetadata(tableNameWithType, segmentName, new Stat());
-          // Cache the committed llc segments without segment store download url
+          // Cache the committed LLC segments without segment store download url
           if (segmentZKMetadata.getStatus() == Status.DONE && CommonConstants.Segment.METADATA_URI_FOR_PEER_DOWNLOAD.equals(segmentZKMetadata.getDownloadUrl())) {
             cacheLLCSegmentNameForUpload(tableNameWithType, segmentName);
           }
@@ -1371,9 +1371,9 @@ public class PinotLLCRealtimeSegmentManager {
     // Store the segments to be fixed again in the case of fix failure, or skip in this round
     Queue<String> segmentsNotFixed = new LinkedList<>();
 
-    // Iterate through llc segments and upload missing segment store copy by following steps:
+    // Iterate through LLC segments and upload missing segment store copy by following steps:
     //  1. Ask servers which have online segment replica to upload to segment store. Servers return segment store download url after successful uploading.
-    //  2. Update the llc segment ZK metadata by adding segment store download url.
+    //  2. Update the LLC segment ZK metadata by adding segment store download url.
     while (!segmentQueue.isEmpty()) {
       String segmentName = segmentQueue.poll();
       // Check if it's null in case of the while condition doesn't stand true anymore in the step of dequeue. Dequeue returns null if queue is empty.
@@ -1393,7 +1393,7 @@ public class PinotLLCRealtimeSegmentManager {
           segmentsNotFixed.offer(segmentName);
           continue;
         }
-        LOGGER.info("Fixing llc segment {} whose segment store copy is unavailable", segmentName);
+        LOGGER.info("Fixing LLC segment {} whose segment store copy is unavailable", segmentName);
 
         // Find servers which have online replica
         List<URI> peerSegmentURIs = PeerServerSegmentFinder
@@ -1405,13 +1405,13 @@ public class PinotLLCRealtimeSegmentManager {
         // Randomly ask one server to upload
         URI uri = peerSegmentURIs.get(RANDOM.nextInt(peerSegmentURIs.size()));
         String serverUploadRequestUrl = StringUtil.join("/", uri.toString(), "upload");
-        LOGGER.info("Ask server to upload llc segment {} to segment store by this path: {}", segmentName, serverUploadRequestUrl);
+        LOGGER.info("Ask server to upload LLC segment {} to segment store by this path: {}", segmentName, serverUploadRequestUrl);
         String segmentDownloadUrl = _fileUploadDownloadClient.uploadToSegmentStore(serverUploadRequestUrl);
         LOGGER.info("Updating segment {} download url in ZK to be {}", segmentName, segmentDownloadUrl);
         // Update segment ZK metadata by adding the download URL
         segmentZKMetadata.setDownloadUrl(segmentDownloadUrl);
         persistSegmentZKMetadata(realtimeTableName, segmentZKMetadata, stat.getVersion());
-        LOGGER.info("Successfully uploaded llc segment {} to segment store with download url: {}", segmentName, segmentDownloadUrl);
+        LOGGER.info("Successfully uploaded LLC segment {} to segment store with download url: {}", segmentName, segmentDownloadUrl);
       } catch (Exception e) {
         segmentsNotFixed.offer(segmentName);
         _controllerMetrics.addMeteredTableValue(realtimeTableName, ControllerMeter.NUMBER_LLC_SEGMENTS_DEEP_STORE_UPLOAD_FIX_ERROR, 1L);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -81,8 +81,6 @@ import org.apache.pinot.segment.spi.creator.SegmentVersion;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.segment.spi.partition.metadata.ColumnPartitionMetadata;
-import org.apache.pinot.segment.local.segment.index.metadata.ColumnMetadata;
-import org.apache.pinot.segment.local.segment.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.core.util.PeerServerSegmentFinder;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1399,12 +1399,6 @@ public class PinotLLCRealtimeSegmentManager {
     //  2. Update the LLC segment ZK metadata by adding segment store download url.
     while (!segmentQueue.isEmpty()) {
       String segmentName = segmentQueue.poll();
-      // Check if it's null in case of the while condition doesn't stand true anymore in the step of dequeue.
-      // Dequeue returns null if queue is empty.
-      if (segmentName == null) {
-        break;
-      }
-
       try {
         // Only fix recently created segment. Validate segment creation time based on name.
         LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1358,8 +1358,8 @@ public class PinotLLCRealtimeSegmentManager {
             cacheLLCSegmentNameForUpload(tableNameWithType, segmentName);
           }
         } catch (Exception e) {
-          _controllerMetrics.addValueToTableGauge(tableNameWithType,
-              ControllerGauge.NUMBER_OF_ERRORS_FOR_LLC_SEGMENTS_ZK_METADATA_PREFETCH, 1L);
+          _controllerMetrics.addMeteredTableValue(tableNameWithType,
+              ControllerMeter.LLC_SEGMENTS_ZK_METADATA_PREFETCH_ERROR, 1L);
           LOGGER.error("Failed to fetch the LLC segment {} ZK metadata", segmentName);
         }
       }
@@ -1463,8 +1463,8 @@ public class PinotLLCRealtimeSegmentManager {
             segmentName, segmentDownloadUrl);
       } catch (Exception e) {
         segmentsNotFixed.offer(segmentName);
-        _controllerMetrics.addValueToTableGauge(realtimeTableName,
-            ControllerGauge.NUMBER_OF_ERRORS_FOR_LLC_SEGMENTS_DEEP_STORE_UPLOAD_RETRY, 1L);
+        _controllerMetrics.addMeteredTableValue(realtimeTableName,
+            ControllerMeter.LLC_SEGMENTS_DEEP_STORE_UPLOAD_RETRY_ERROR, 1L);
         LOGGER.error("Failed to upload segment {} to segment store", segmentName, e);
       }
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1376,13 +1376,13 @@ public class PinotLLCRealtimeSegmentManager {
    */
   public void uploadToSegmentStoreIfMissing(TableConfig tableConfig) {
     String realtimeTableName = tableConfig.getTableName();
-    if (_isStopping) {
-      LOGGER.info("Skipped fixing segment store copy of LLC segments for table {}, because segment manager is stopping.", realtimeTableName);
+    Queue<String> segmentQueue = _llcSegmentMapForUpload.get(realtimeTableName);
+    if (segmentQueue == null || segmentQueue.isEmpty()) {
       return;
     }
 
-    Queue<String> segmentQueue = _llcSegmentMapForUpload.get(realtimeTableName);
-    if (segmentQueue == null || segmentQueue.isEmpty()) {
+    if (_isStopping) {
+      LOGGER.info("Skipped fixing segment store copy of LLC segments for table {}, because segment manager is stopping.", realtimeTableName);
       return;
     }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -141,9 +141,9 @@ public class PinotLLCRealtimeSegmentManager {
    */
   private static final long MAX_SEGMENT_COMPLETION_TIME_MILLIS = 300_000L; // 5 MINUTES
   /**
-   * Controller waits this amount of time before asking servers to upload LLC segments without deep store copy.
+   * Controller waits this amount of time before asking servers to upload LLC segments missing in deep store.
    * The reason is after step 1 of segment completion is done (segment ZK metadata status changed to be DONE),
-   * servers may be still in the process of loading segments.
+   * servers may be still in the process of transitioning segments from CONSUMING to ONLINE states.
    * Only after that segments are in ONLINE status in external view for the controller to discover.
    */
   private static final long MIN_TIME_BEFORE_FIXING_SEGMENT_STORE_COPY_MILLIS = 300_000L; // 5 MINUTES
@@ -167,10 +167,10 @@ public class PinotLLCRealtimeSegmentManager {
   private AtomicInteger _numCompletingSegments = new AtomicInteger(0);
   private FileUploadDownloadClient _fileUploadDownloadClient;
   /**
-   * Map caching the LLC segment names without deep store download uri.
-   * Controller gets the LLC segment names from this map, and asks servers to upload the segments to segment store.
-   * This helps to alleviates excessive ZK access when fetching LLC segment list.
-   * Key: table name; Value: LLC segment names to be uploaded to segment store.
+   * Map caching the LLC segment names that are missing deep store download uri in segment metadata.
+   * Controller gets the LLC segment names from this map, and asks servers to upload the segments to deep store.
+   * This helps to alleviate excessive ZK access when fetching LLC segment list.
+   * Key: table name; Value: LLC segment names to be uploaded to deep store.
    */
   private Map<String, Queue<String>> _llcSegmentMapForUpload;
   // Fix the missing deep store copy of LLC segments created within this range

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1291,7 +1291,7 @@ public class PinotLLCRealtimeSegmentManager {
     for (LLCRealtimeSegmentZKMetadata segmentZKMetadata : segmentZKMetadataList) {
       String segmentName = segmentZKMetadata.getSegmentName();
       // Only fix the committed llc segment without segment store copy
-      if (segmentZKMetadata.getStatus() == Status.DONE && (segmentZKMetadata.getDownloadUrl() == null || segmentZKMetadata.getDownloadUrl().isEmpty() || segmentZKMetadata.getDownloadUrl().equals(CommonConstants.Segment.METADATA_URI_FOR_PEER_DOWNLOAD))) {
+      if (segmentZKMetadata.getStatus() == Status.DONE && segmentZKMetadata.getDownloadUrl().equals(CommonConstants.Segment.METADATA_URI_FOR_PEER_DOWNLOAD)) {
         try {
           if (!isExceededMaxSegmentCompletionTime(realtimeTableName, segmentName, getCurrentTimeMs())) {
             continue;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1444,6 +1444,9 @@ public class PinotLLCRealtimeSegmentManager {
         }
         // Delay the fix to next round if not enough time elapsed since segment metadata update
         if (!isExceededMinTimeToFixDeepStoreCopy(stat)) {
+          LOGGER.info(
+              "Delay fix for {} to next round due to not enough time elapsed since segment metadata update",
+              segmentName);
           segmentsNotFixed.offer(segmentName);
           continue;
         }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1380,6 +1380,8 @@ public class PinotLLCRealtimeSegmentManager {
    * @see <a href="
    * https://cwiki.apache.org/confluence/display/PINOT/By-passing+deep-store+requirement+for+Realtime+segment+completion
    * "> By-passing deep-store requirement for Realtime segment completion:Failure cases and handling</a>
+   *
+   * TODO: Add an on-demand way to upload LLC segment to deep store for a specific table.
    */
   public void uploadToDeepStoreIfMissing(TableConfig tableConfig) {
     String realtimeTableName = tableConfig.getTableName();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -653,7 +653,7 @@ public class PinotLLCRealtimeSegmentManager {
 
     persistSegmentZKMetadata(realtimeTableName, committingSegmentZKMetadata, stat.getVersion());
 
-    // cache peer download segment for fix
+    // Add segments not successfully uploaded to deep store to a queue managed by Pinot controller for upload retry later.
     if (isUploadingRealtimeMissingSegmentStoreCopyEnabled() && isPeerURL(committingSegmentDescriptor.getSegmentLocation())) {
       cacheLLCSegmentNameForUpload(realtimeTableName, segmentName);
     }
@@ -1306,7 +1306,7 @@ public class PinotLLCRealtimeSegmentManager {
     }
   }
 
-  // Pre-fetch the LLC segment without deep store copy.
+  // Pre-fetch the LLC segments without deep store copy.
   public void prefetchLLCSegmentsWithoutDeepStoreCopy(String tableNameWithType) {
       TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
       if (tableType != TableType.REALTIME) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -138,9 +138,9 @@ public class PinotLLCRealtimeSegmentManager {
    */
   private static final long MAX_SEGMENT_COMPLETION_TIME_MILLIS = 300_000L; // 5 MINUTES
   /**
-   * Controller waits this amount of time before asking servers to upload LLC segments without deep store copy. The reason is after step 1 of segment completion is done (segment ZK metadata status changed to be DONE), servers are still in the process of loading segments. Only after that segments are in ONLINE status in external view.
+   * Controller waits this amount of time before asking servers to upload LLC segments without deep store copy. The reason is after step 1 of segment completion is done (segment ZK metadata status changed to be DONE), servers are still in the process of loading segments. Only after that segments are in ONLINE status in external view for the controller to discover.
    */
-  private static final long MIN_TIME_BEFORE_FIX_SEGMENT_STORE_COPY_MILLIS = 300_000L; // 5 MINUTES
+  private static final long MIN_TIME_BEFORE_FIXING_SEGMENT_STORE_COPY_MILLIS = 300_000L; // 5 MINUTES
   private static final Random RANDOM = new Random();
 
   private final HelixAdmin _helixAdmin;
@@ -1303,8 +1303,8 @@ public class PinotLLCRealtimeSegmentManager {
     }
   }
 
-  // Pre fetch the LLC segment without deep store copy.
-  public void prefetchLLCSegmentWithoutDeepStoreCopy(String tableNameWithType) {
+  // Pre-fetch the LLC segment without deep store copy.
+  public void prefetchLLCSegmentsWithoutDeepStoreCopy(String tableNameWithType) {
       TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
       if (tableType == TableType.REALTIME) {
         TableConfig tableConfig = _helixResourceManager.getTableConfig(tableNameWithType);
@@ -1404,10 +1404,10 @@ public class PinotLLCRealtimeSegmentManager {
   }
 
   /**
-   * Returns true if more than {@link PinotLLCRealtimeSegmentManager#MIN_TIME_BEFORE_FIX_SEGMENT_STORE_COPY_MILLIS} ms have elapsed since segment metadata update
+   * Returns true if more than {@link PinotLLCRealtimeSegmentManager#MIN_TIME_BEFORE_FIXING_SEGMENT_STORE_COPY_MILLIS} ms have elapsed since segment metadata update
    */
   @VisibleForTesting
   boolean isExceededMinTimeToFixSegmentStoreCopy(Stat stat) {
-    return getCurrentTimeMs() > stat.getMtime() + MIN_TIME_BEFORE_FIX_SEGMENT_STORE_COPY_MILLIS;
+    return getCurrentTimeMs() > stat.getMtime() + MIN_TIME_BEFORE_FIXING_SEGMENT_STORE_COPY_MILLIS;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -44,7 +44,7 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Validates realtime ideal states and segment metadata, fixing any partitions which have stopped consuming,
- * and uploading segments to segment store if segment download url is missing in the metadata.
+ * and uploading segments to deep store if segment download url is missing in the metadata.
  */
 public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<RealtimeSegmentValidationManager.Context> {
   private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeSegmentValidationManager.class);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * Validates realtime ideal states and segment metadata, fixing any partitions which have stopped consuming
+ * Validates realtime ideal states and segment metadata, fixing any partitions which have stopped consuming, and uploading segments to segment store if missing.
  */
 public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<RealtimeSegmentValidationManager.Context> {
   private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeSegmentValidationManager.class);
@@ -100,6 +100,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
           IngestionConfigUtils.getStreamConfigMap(tableConfig));
       if (streamConfig.hasLowLevelConsumerType()) {
         _llcRealtimeSegmentManager.ensureAllPartitionsConsuming(tableConfig, streamConfig);
+        _llcRealtimeSegmentManager.uploadToSegmentStoreIfMissing(tableConfig);
       }
     }
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -43,7 +43,8 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * Validates realtime ideal states and segment metadata, fixing any partitions which have stopped consuming, and uploading segments to segment store if segment download url is missing in the metadata.
+ * Validates realtime ideal states and segment metadata, fixing any partitions which have stopped consuming,
+ * and uploading segments to segment store if segment download url is missing in the metadata.
  */
 public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<RealtimeSegmentValidationManager.Context> {
   private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeSegmentValidationManager.class);
@@ -67,6 +68,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
     Preconditions.checkState(_segmentLevelValidationIntervalInSeconds > 0);
   }
 
+  // TODO: Fix the race condition when controller leadership may not be decided by the time the method is called
   @Override
   protected void setUpTask() {
     // Prefetch the LLC segment without segment store copy from ZK, which helps to alleviate ZK access.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * Validates realtime ideal states and segment metadata, fixing any partitions which have stopped consuming, and uploading segments to segment store if missing.
+ * Validates realtime ideal states and segment metadata, fixing any partitions which have stopped consuming, and uploading segments to segment store if segment download url is missing in the metadata.
  */
 public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<RealtimeSegmentValidationManager.Context> {
   private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeSegmentValidationManager.class);
@@ -74,7 +74,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
       for (String tableNameWithType : _pinotHelixResourceManager.getAllTables()) {
         try {
           if (_leadControllerManager.isLeaderForTable(tableNameWithType)) {
-            _llcRealtimeSegmentManager.prefetchLLCSegmentWithoutDeepStoreCopy(tableNameWithType);
+            _llcRealtimeSegmentManager.prefetchLLCSegmentsWithoutDeepStoreCopy(tableNameWithType);
           }
         } catch (Exception e) {
           LOGGER.error("Failed to pre fetch LLC segment for table {}", tableNameWithType);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -69,6 +69,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
   }
 
   // TODO: Fix the race condition when controller leadership may not be decided by the time the method is called
+  //  The detailed description is in https://github.com/apache/pinot/issues/7415.
   @Override
   protected void setUpTask() {
     // Prefetch the LLC segment without deep store copy from ZK, which helps to alleviate ZK access.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -53,7 +53,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
   private final ValidationMetrics _validationMetrics;
 
   private final int _segmentLevelValidationIntervalInSeconds;
-  private long _lastUpdateRealtimeDocumentCountTimeMs = 0L;
+  private long _lastSegmentLevelValidationRunTimeMs = 0L;
 
   public RealtimeSegmentValidationManager(ControllerConf config, PinotHelixResourceManager pinotHelixResourceManager,
       LeadControllerManager leadControllerManager, PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager,
@@ -71,13 +71,13 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
   @Override
   protected Context preprocess() {
     Context context = new Context();
-    // Update realtime document counts only if certain time has passed after previous run
+    // Run segment level validation only if certain time has passed after previous run
     long currentTimeMs = System.currentTimeMillis();
-    if (TimeUnit.MILLISECONDS.toSeconds(currentTimeMs - _lastUpdateRealtimeDocumentCountTimeMs)
+    if (TimeUnit.MILLISECONDS.toSeconds(currentTimeMs - _lastSegmentLevelValidationRunTimeMs)
         >= _segmentLevelValidationIntervalInSeconds) {
       LOGGER.info("Run segment-level validation");
-      context._updateRealtimeDocumentCount = true;
-      _lastUpdateRealtimeDocumentCountTimeMs = currentTimeMs;
+      context._runSegmentLevelValidation = true;
+      _lastSegmentLevelValidationRunTimeMs = currentTimeMs;
     }
     return context;
   }
@@ -93,22 +93,19 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
         return;
       }
 
-      if (context._updateRealtimeDocumentCount) {
-        updateRealtimeDocumentCount(tableConfig);
+      if (context._runSegmentLevelValidation) {
+        runSegmentLevelValidation(tableConfig);
       }
 
       PartitionLevelStreamConfig streamConfig = new PartitionLevelStreamConfig(tableConfig.getTableName(),
           IngestionConfigUtils.getStreamConfigMap(tableConfig));
       if (streamConfig.hasLowLevelConsumerType()) {
         _llcRealtimeSegmentManager.ensureAllPartitionsConsuming(tableConfig, streamConfig);
-        if (_llcRealtimeSegmentManager.isDeepStoreLLCSegmentUploadRetryEnabled()) {
-          _llcRealtimeSegmentManager.uploadToDeepStoreIfMissing(tableConfig);
-        }
       }
     }
   }
 
-  private void updateRealtimeDocumentCount(TableConfig tableConfig) {
+  private void runSegmentLevelValidation(TableConfig tableConfig) {
     String realtimeTableName = tableConfig.getTableName();
     List<SegmentZKMetadata> segmentsZKMetadata = _pinotHelixResourceManager.getSegmentsZKMetadata(realtimeTableName);
     boolean countHLCSegments = true;  // false if this table has ONLY LLC segments (i.e. fully migrated)
@@ -120,6 +117,11 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
     // Update the gauge to contain the total document count in the segments
     _validationMetrics.updateTotalDocumentCountGauge(tableConfig.getTableName(),
         computeRealtimeTotalDocumentInSegments(segmentsZKMetadata, countHLCSegments));
+
+    if (streamConfig.hasLowLevelConsumerType()
+        && _llcRealtimeSegmentManager.isDeepStoreLLCSegmentUploadRetryEnabled()) {
+      _llcRealtimeSegmentManager.uploadToDeepStoreIfMissing(tableConfig, segmentsZKMetadata);
+    }
   }
 
   @VisibleForTesting
@@ -161,7 +163,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
   }
 
   public static final class Context {
-    private boolean _updateRealtimeDocumentCount;
+    private boolean _runSegmentLevelValidation;
   }
 
   @VisibleForTesting

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -102,7 +102,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
   @Override
   protected void processTable(String tableNameWithType, Context context) {
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
-    if (tableType == TableType.REALTIME) {
+    if (tableType == TableType.REALTIME && _leadControllerManager.isLeaderForTable(tableNameWithType)) {
 
       TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
       if (tableConfig == null) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -71,8 +71,8 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
   // TODO: Fix the race condition when controller leadership may not be decided by the time the method is called
   @Override
   protected void setUpTask() {
-    // Prefetch the LLC segment without segment store copy from ZK, which helps to alleviate ZK access.
-    if (_llcRealtimeSegmentManager.isUploadingRealtimeMissingSegmentStoreCopyEnabled()) {
+    // Prefetch the LLC segment without deep store copy from ZK, which helps to alleviate ZK access.
+    if (_llcRealtimeSegmentManager.isDeepStoreLLCSegmentUploadRetryEnabled()) {
       for (String tableNameWithType : _pinotHelixResourceManager.getAllTables()) {
         try {
           if (_leadControllerManager.isLeaderForTable(tableNameWithType)) {
@@ -118,8 +118,8 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
           IngestionConfigUtils.getStreamConfigMap(tableConfig));
       if (streamConfig.hasLowLevelConsumerType()) {
         _llcRealtimeSegmentManager.ensureAllPartitionsConsuming(tableConfig, streamConfig);
-        if (_llcRealtimeSegmentManager.isUploadingRealtimeMissingSegmentStoreCopyEnabled()) {
-          _llcRealtimeSegmentManager.uploadToSegmentStoreIfMissing(tableConfig);
+        if (_llcRealtimeSegmentManager.isDeepStoreLLCSegmentUploadRetryEnabled()) {
+          _llcRealtimeSegmentManager.uploadToDeepStoreIfMissing(tableConfig);
         }
       }
     }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -1009,7 +1009,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     List<ZNRecord> znRecords = segmentsZKMetadata.stream().map(LLCRealtimeSegmentZKMetadata::toZNRecord).collect(Collectors.toList());
     when(zkHelixPropertyStore.getChildren(anyString(), eq(null), anyInt(), anyInt(), anyInt())).thenReturn(znRecords);
     when(pinotHelixResourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(segmentManager._tableConfig);
-    segmentManager.prefetchLLCSegmentWithoutDeepStoreCopy(REALTIME_TABLE_NAME);
+    segmentManager.prefetchLLCSegmentsWithoutDeepStoreCopy(REALTIME_TABLE_NAME);
     assertEquals(segmentManager.cachedLLCSegmentNameWithoutDeepStoreCopy.size(), 3);
     assertEquals(segmentManager.cachedLLCSegmentNameWithoutDeepStoreCopy.get(0), segmentsZKMetadata.get(0).getSegmentName());
     assertEquals(segmentManager.cachedLLCSegmentNameWithoutDeepStoreCopy.get(1), segmentsZKMetadata.get(1).getSegmentName());

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -63,6 +63,7 @@ import org.apache.pinot.controller.util.SegmentCompletionUtils;
 import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
+import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
@@ -950,6 +951,10 @@ public class PinotLLCRealtimeSegmentManagerTest {
 
     // Set up a new table with 2 replicas, 5 instances, 6 partition.
     setUpNewTable(segmentManager, 2, 5, 6);
+    SegmentsValidationAndRetentionConfig segmentsValidationAndRetentionConfig = new SegmentsValidationAndRetentionConfig();
+    segmentsValidationAndRetentionConfig.setRetentionTimeUnit(TimeUnit.DAYS.toString());
+    segmentsValidationAndRetentionConfig.setRetentionTimeValue("3");
+    segmentManager._tableConfig.setValidationConfig(segmentsValidationAndRetentionConfig);
     List<LLCRealtimeSegmentZKMetadata> segmentsZKMetadata = new ArrayList<>(segmentManager._segmentZKMetadataMap.values());
     Assert.assertEquals(segmentsZKMetadata.size(), 6);
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -945,10 +945,10 @@ public class PinotLLCRealtimeSegmentManagerTest {
     // init fake PinotLLCRealtimeSegmentManager
     ControllerConf controllerConfig = new ControllerConf();
     controllerConfig.setProperty(
-        ControllerConf.ControllerPeriodicTasksConf.ENABLE_UPLOAD_MISSING_LLC_SEGMENT_TO_SEGMENT_STORE, true);
+        ControllerConf.ControllerPeriodicTasksConf.ENABLE_DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT, true);
     FakePinotLLCRealtimeSegmentManager segmentManager =
         new FakePinotLLCRealtimeSegmentManager(pinotHelixResourceManager, controllerConfig);
-    Assert.assertTrue(segmentManager.isUploadingRealtimeMissingSegmentStoreCopyEnabled());
+    Assert.assertTrue(segmentManager.isDeepStoreLLCSegmentUploadRetryEnabled());
 
     // Set up a new table with 2 replicas, 5 instances, 6 partition.
     setUpNewTable(segmentManager, 2, 5, 6);
@@ -1084,7 +1084,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     // Verify the result
     segmentManager._cachedLLCSegmentNameWithoutDeepStoreCopy.clear();
     segmentManager._exceededMinTimeToFixSegmentStoreCopy = true;
-    segmentManager.uploadToSegmentStoreIfMissing(segmentManager._tableConfig);
+    segmentManager.uploadToDeepStoreIfMissing(segmentManager._tableConfig);
     assertEquals(
         segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentNames.get(0), null).getDownloadUrl(),
         segmentDownloadUrl0);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -1083,7 +1083,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
 
     // Verify the result
     segmentManager._cachedLLCSegmentNameWithoutDeepStoreCopy.clear();
-    segmentManager._exceededMinTimeToFixSegmentStoreCopy = true;
+    segmentManager._exceededMinTimeToFixDeepStoreCopy = true;
     segmentManager.uploadToDeepStoreIfMissing(segmentManager._tableConfig);
     assertEquals(
         segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentNames.get(0), null).getDownloadUrl(),
@@ -1131,7 +1131,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     int _numPartitions;
     List<PartitionGroupMetadata> _partitionGroupMetadataList = null;
     boolean _exceededMaxSegmentCompletionTime = false;
-    boolean _exceededMinTimeToFixSegmentStoreCopy = false;
+    boolean _exceededMinTimeToFixDeepStoreCopy = false;
     FileUploadDownloadClient _mockedFileUploadDownloadClient;
     List<String> _cachedLLCSegmentNameWithoutDeepStoreCopy = new ArrayList<>();
 
@@ -1261,8 +1261,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
     }
 
     @Override
-    boolean isExceededMinTimeToFixSegmentStoreCopy(Stat stat) {
-      return _exceededMinTimeToFixSegmentStoreCopy;
+    boolean isExceededMinTimeToFixDeepStoreCopy(Stat stat) {
+      return _exceededMinTimeToFixDeepStoreCopy;
     }
 
     @Override

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -35,21 +35,27 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.Nullable;
-import javax.ws.rs.core.Response;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
+import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.http.HttpEntity;
+import org.apache.http.StatusLine;
+import org.apache.http.client.entity.EntityBuilder;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.exception.HttpErrorStatusException;
 import org.apache.pinot.common.metadata.segment.LLCRealtimeSegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerMetrics;
-import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.common.utils.URIUtils;
@@ -84,9 +90,7 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
@@ -936,16 +940,18 @@ public class PinotLLCRealtimeSegmentManagerTest {
     PinotHelixResourceManager pinotHelixResourceManager = mock(PinotHelixResourceManager.class);
     HelixManager helixManager = mock(HelixManager.class);
     HelixAdmin helixAdmin = mock(HelixAdmin.class);
+    ZkHelixPropertyStore<ZNRecord> zkHelixPropertyStore = (ZkHelixPropertyStore<ZNRecord>) mock(ZkHelixPropertyStore.class);
     when(pinotHelixResourceManager.getHelixZkManager()).thenReturn(helixManager);
     when(helixManager.getClusterManagmentTool()).thenReturn(helixAdmin);
     when(helixManager.getClusterName()).thenReturn("cluster_name");
+    when(pinotHelixResourceManager.getPropertyStore()).thenReturn(zkHelixPropertyStore);
 
     // init fake PinotLLCRealtimeSegmentManager
     FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager(pinotHelixResourceManager);
 
     // Set up a new table with 2 replicas, 5 instances, 5 partition
     setUpNewTable(segmentManager, 2, 5, 5);
-    List<Map.Entry<String, LLCRealtimeSegmentZKMetadata>> segmentsZKMetadata = new ArrayList<>(segmentManager._segmentZKMetadataMap.entrySet());
+    List<LLCRealtimeSegmentZKMetadata> segmentsZKMetadata = new ArrayList<>(segmentManager._segmentZKMetadataMap.values());
     Assert.assertEquals(segmentsZKMetadata.size(), 5);
 
     // Set up external view for this table
@@ -958,54 +964,71 @@ public class PinotLLCRealtimeSegmentManagerTest {
     when(helixAdmin.getConfig(any(HelixConfigScope.class), any(List.class))).thenReturn(instanceConfigMap);
 
     // Change 1st segment status to be DONE but without segment download url. Verify later the download url is fixed after upload success.
-    LLCRealtimeSegmentZKMetadata zkMetadata_0 = segmentsZKMetadata.get(0).getValue();
-    zkMetadata_0.setStatus(Status.DONE);
-    segmentManager._segmentZKMetadataMap.put(segmentsZKMetadata.get(0).getKey(), zkMetadata_0);
+    segmentsZKMetadata.get(0).setStatus(Status.DONE);
+    // set up the external view for 1st segment
     String instance_0 = "instance_0";
-    externalView.setState(zkMetadata_0.getSegmentName(), instance_0, "ONLINE");
+    externalView.setState(segmentsZKMetadata.get(0).getSegmentName(), instance_0, "ONLINE");
     InstanceConfig instanceConfig_0 = new InstanceConfig(instance_0);
     instanceConfig_0.setHostName(instance_0);
     when(helixAdmin.getInstanceConfig(any(String.class), eq(instance_0))).thenReturn(instanceConfig_0);
+    // mock the request for 1st segment upload
+    String serverUploadRequestUrl_0 = StringUtil
+        .join("/", CommonConstants.HTTP_PROTOCOL + "://" + instance_0 + ":" + adminPort, "segments", REALTIME_TABLE_NAME, segmentsZKMetadata.get(0).getSegmentName(), "upload");
+    HttpUriRequest request_0 = segmentManager.buildServerUploadRequest(serverUploadRequestUrl_0);
+    // mock the response for 1st segment upload
+    CloseableHttpResponse response_0 = mock(CloseableHttpResponse.class);
+    StatusLine statusLine_0 = mock(StatusLine.class);
+    when(statusLine_0.getStatusCode()).thenReturn(200);
+    when(response_0.getStatusLine()).thenReturn(statusLine_0);
     String segmentDownloadUrl = "segmentDownloadUrl";
-    when(segmentManager._mockedFileUploadDownloadClient.uploadToSegmentStore(StringUtil
-        .join("/", CommonConstants.HTTP_PROTOCOL + "://" + instance_0 + ":" + adminPort, "segments", REALTIME_TABLE_NAME, zkMetadata_0.getSegmentName(), "upload"))).thenReturn(segmentDownloadUrl);
+    HttpEntity httpEntity_0 = EntityBuilder.create().setText(segmentDownloadUrl).build();
+    when(response_0.getEntity()).thenReturn(httpEntity_0);
+    when(segmentManager._mockedHttpClient.execute(request_0)).thenReturn(response_0);
 
     // Change 2nd segment status to be DONE but without segment download url. Verify later the download url is still empty after upload failure.
-    LLCRealtimeSegmentZKMetadata zkMetadata_1 = segmentsZKMetadata.get(1).getValue();
-    zkMetadata_1.setStatus(Status.DONE);
-    segmentManager._segmentZKMetadataMap.put(segmentsZKMetadata.get(1).getKey(), zkMetadata_1);
+    segmentsZKMetadata.get(1).setStatus(Status.DONE);
+    // set up the external view for 2nd segment
     String instance_1 = "instance_1";
-    externalView.setState(zkMetadata_1.getSegmentName(), instance_1, "ONLINE");
+    externalView.setState(segmentsZKMetadata.get(1).getSegmentName(), instance_1, "ONLINE");
     InstanceConfig instanceConfig_1 = new InstanceConfig(instance_1);
     instanceConfig_1.setHostName(instance_1);
     when(helixAdmin.getInstanceConfig(any(String.class), eq(instance_1))).thenReturn(instanceConfig_1);
-    when(segmentManager._mockedFileUploadDownloadClient.uploadToSegmentStore(StringUtil
-        .join("/", CommonConstants.HTTP_PROTOCOL + "://" + instance_1 + ":" + adminPort, "segments", REALTIME_TABLE_NAME, zkMetadata_1.getSegmentName(), "upload"))).thenThrow(new HttpErrorStatusException("failed to upload segment", Response.Status.INTERNAL_SERVER_ERROR.getStatusCode()));
+    // mock the request for 2nd segment upload
+    String serverUploadRequestUrl_1 = StringUtil
+        .join("/", CommonConstants.HTTP_PROTOCOL + "://" + instance_1 + ":" + adminPort, "segments", REALTIME_TABLE_NAME, segmentsZKMetadata.get(1).getSegmentName(), "upload");
+    HttpUriRequest request_1 = segmentManager.buildServerUploadRequest(serverUploadRequestUrl_1);
+    // mock the response for 2nd segment upload
+    CloseableHttpResponse response_1 = mock(CloseableHttpResponse.class);
+    StatusLine statusLine_1 = mock(StatusLine.class);
+    when(statusLine_1.getStatusCode()).thenReturn(500);
+    when(response_1.getStatusLine()).thenReturn(statusLine_1);
+    when(response_1.getEntity()).thenReturn(null);
+    when(segmentManager._mockedHttpClient.execute(request_1)).thenReturn(response_1);
 
     // Change 3rd segment status to be DONE but without segment download url. Verify later the download url is still empty because no ONLINE replica found in any server.
-    LLCRealtimeSegmentZKMetadata zkMetadata_2 = segmentsZKMetadata.get(2).getValue();
-    zkMetadata_2.setStatus(Status.DONE);
-    segmentManager._segmentZKMetadataMap.put(segmentsZKMetadata.get(2).getKey(), zkMetadata_2);
+    segmentsZKMetadata.get(2).setStatus(Status.DONE);
+    // set up the external view for 3rd segment
     String instance_2 = "instance_2";
-    externalView.setState(zkMetadata_2.getSegmentName(), instance_2, "OFFLINE");
+    externalView.setState(segmentsZKMetadata.get(2).getSegmentName(), instance_2, "OFFLINE");
 
     // Change 4th segment status to be DONE and with segment download url. Verify later the download url is still the same.
     String defaultDownloadUrl = "canItBeDownloaded";
-    LLCRealtimeSegmentZKMetadata zkMetadata_3 = segmentsZKMetadata.get(3).getValue();
-    zkMetadata_3.setStatus(Status.DONE);
-    zkMetadata_3.setDownloadUrl(defaultDownloadUrl);
-    segmentManager._segmentZKMetadataMap.put(segmentsZKMetadata.get(3).getKey(), zkMetadata_3);
+    segmentsZKMetadata.get(3).setStatus(Status.DONE);
+    segmentsZKMetadata.get(3).setDownloadUrl(defaultDownloadUrl);
 
     // Keep 5th segment status as IN_PROGRESS. Verify later the download url is still empty.
+
+    List<ZNRecord> znRecords = segmentsZKMetadata.stream().map(LLCRealtimeSegmentZKMetadata::toZNRecord).collect(Collectors.toList());
+    when(zkHelixPropertyStore.getChildren(anyString(), eq(null), anyInt(), anyInt(), anyInt())).thenReturn(znRecords);
 
     // Verify the result
     segmentManager._exceededMaxSegmentCompletionTime = true;
     segmentManager.uploadToSegmentStoreIfMissing(segmentManager._tableConfig);
-    assertEquals(segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, zkMetadata_0.getSegmentName(), null).getDownloadUrl(), segmentDownloadUrl);
-    assertNull(segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, zkMetadata_1.getSegmentName(), null).getDownloadUrl());
-    assertNull(segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, zkMetadata_2.getSegmentName(), null).getDownloadUrl());
-    assertEquals(segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, zkMetadata_3.getSegmentName(), null).getDownloadUrl(), defaultDownloadUrl);
-    assertNull(segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentsZKMetadata.get(4).getValue().getSegmentName(), null).getDownloadUrl());
+    assertEquals(segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentsZKMetadata.get(0).getSegmentName(), null).getDownloadUrl(), segmentDownloadUrl);
+    assertNull(segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentsZKMetadata.get(1).getSegmentName(), null).getDownloadUrl());
+    assertNull(segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentsZKMetadata.get(2).getSegmentName(), null).getDownloadUrl());
+    assertEquals(segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentsZKMetadata.get(3).getSegmentName(), null).getDownloadUrl(), defaultDownloadUrl);
+    assertNull(segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentsZKMetadata.get(4).getSegmentName(), null).getDownloadUrl());
   }
 
   //////////////////////////////////////////////////////////////////////////////////
@@ -1030,7 +1053,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
     int _numPartitions;
     List<PartitionGroupMetadata> _partitionGroupMetadataList = null;
     boolean _exceededMaxSegmentCompletionTime = false;
-    FileUploadDownloadClient _mockedFileUploadDownloadClient;
+    CloseableHttpClient _mockedHttpClient;
+    Map<String, HttpUriRequest> _serverUploadRequestMap = new HashMap<>();
 
     FakePinotLLCRealtimeSegmentManager() {
       super(mock(PinotHelixResourceManager.class), CONTROLLER_CONF, mock(ControllerMetrics.class));
@@ -1069,10 +1093,24 @@ public class PinotLLCRealtimeSegmentManagerTest {
     }
 
     @Override
-    FileUploadDownloadClient initFileUploadDownloadClient() {
-      FileUploadDownloadClient fileUploadDownloadClient = mock(FileUploadDownloadClient.class);
-      this._mockedFileUploadDownloadClient = fileUploadDownloadClient;
-      return fileUploadDownloadClient;
+    CloseableHttpClient initHttpClient() {
+      CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+      _mockedHttpClient = httpClient;
+      return httpClient;
+    }
+
+    @Override
+    HttpUriRequest buildServerUploadRequest(String serverUploadRequestUrl)
+        throws URISyntaxException {
+      HttpUriRequest httpUriRequest;
+      if (!_serverUploadRequestMap.containsKey(serverUploadRequestUrl)) {
+        httpUriRequest = super.buildServerUploadRequest(serverUploadRequestUrl);
+        _serverUploadRequestMap.put(serverUploadRequestUrl, httpUriRequest);
+      } else {
+        httpUriRequest = _serverUploadRequestMap.get(serverUploadRequestUrl);
+      }
+
+      return httpUriRequest;
     }
 
     @Override

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -1036,14 +1036,11 @@ public class PinotLLCRealtimeSegmentManagerTest {
 
     List<String> segmentNames = segmentsZKMetadata.stream()
         .map(SegmentZKMetadata::getSegmentName).collect(Collectors.toList());
-    when(zkHelixPropertyStore.exists(anyString(), anyInt())).thenReturn(true);
-    when(zkHelixPropertyStore.getChildNames(anyString(), anyInt())).thenReturn(segmentNames);
     when(pinotHelixResourceManager.getTableConfig(REALTIME_TABLE_NAME))
         .thenReturn(segmentManager._tableConfig);
 
     // Verify the result
-    segmentManager._exceededMinTimeToFixDeepStoreCopy = true;
-    segmentManager.uploadToDeepStoreIfMissing(segmentManager._tableConfig);
+    segmentManager.uploadToDeepStoreIfMissing(segmentManager._tableConfig, segmentsZKMetadata);
     assertEquals(
         segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentNames.get(0), null).getDownloadUrl(),
         segmentDownloadUrl0);
@@ -1082,7 +1079,6 @@ public class PinotLLCRealtimeSegmentManagerTest {
     int _numPartitions;
     List<PartitionGroupMetadata> _partitionGroupMetadataList = null;
     boolean _exceededMaxSegmentCompletionTime = false;
-    boolean _exceededMinTimeToFixDeepStoreCopy = false;
     FileUploadDownloadClient _mockedFileUploadDownloadClient;
 
     FakePinotLLCRealtimeSegmentManager() {
@@ -1202,11 +1198,6 @@ public class PinotLLCRealtimeSegmentManagerTest {
     @Override
     boolean isExceededMaxSegmentCompletionTime(String realtimeTableName, String segmentName, long currentTimeMs) {
       return _exceededMaxSegmentCompletionTime;
-    }
-
-    @Override
-    boolean isExceededMinTimeToFixDeepStoreCopy(Stat stat) {
-      return _exceededMinTimeToFixDeepStoreCopy;
     }
 
     @Override

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -963,8 +963,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     instanceConfigMap.put(CommonConstants.Helix.Instance.ADMIN_PORT_KEY, adminPort);
     when(helixAdmin.getConfig(any(HelixConfigScope.class), any(List.class))).thenReturn(instanceConfigMap);
 
-    // Change 1st segment status to be DONE but without segment download url. Verify later the download url is fixed after upload success.
+    // Change 1st segment status to be DONE, but with default peer download url. Verify later the download url is fixed after upload success.
     segmentsZKMetadata.get(0).setStatus(Status.DONE);
+    segmentsZKMetadata.get(0).setDownloadUrl(CommonConstants.Segment.METADATA_URI_FOR_PEER_DOWNLOAD);
     // set up the external view for 1st segment
     String instance_0 = "instance_0";
     externalView.setState(segmentsZKMetadata.get(0).getSegmentName(), instance_0, "ONLINE");
@@ -985,8 +986,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     when(response_0.getEntity()).thenReturn(httpEntity_0);
     when(segmentManager._mockedHttpClient.execute(request_0)).thenReturn(response_0);
 
-    // Change 2nd segment status to be DONE but without segment download url. Verify later the download url is still empty after upload failure.
+    // Change 2nd segment status to be DONE, but with default peer download url. Verify later the download url isn't fixed after upload failure.
     segmentsZKMetadata.get(1).setStatus(Status.DONE);
+    segmentsZKMetadata.get(1).setDownloadUrl(CommonConstants.Segment.METADATA_URI_FOR_PEER_DOWNLOAD);
     // set up the external view for 2nd segment
     String instance_1 = "instance_1";
     externalView.setState(segmentsZKMetadata.get(1).getSegmentName(), instance_1, "ONLINE");
@@ -1005,8 +1007,9 @@ public class PinotLLCRealtimeSegmentManagerTest {
     when(response_1.getEntity()).thenReturn(null);
     when(segmentManager._mockedHttpClient.execute(request_1)).thenReturn(response_1);
 
-    // Change 3rd segment status to be DONE but without segment download url. Verify later the download url is still empty because no ONLINE replica found in any server.
+    // Change 3rd segment status to be DONE, but with default peer download url. Verify later the download url isn't fixed because no ONLINE replica found in any server.
     segmentsZKMetadata.get(2).setStatus(Status.DONE);
+    segmentsZKMetadata.get(2).setDownloadUrl(CommonConstants.Segment.METADATA_URI_FOR_PEER_DOWNLOAD);
     // set up the external view for 3rd segment
     String instance_2 = "instance_2";
     externalView.setState(segmentsZKMetadata.get(2).getSegmentName(), instance_2, "OFFLINE");
@@ -1025,8 +1028,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
     segmentManager._exceededMaxSegmentCompletionTime = true;
     segmentManager.uploadToSegmentStoreIfMissing(segmentManager._tableConfig);
     assertEquals(segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentsZKMetadata.get(0).getSegmentName(), null).getDownloadUrl(), segmentDownloadUrl);
-    assertNull(segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentsZKMetadata.get(1).getSegmentName(), null).getDownloadUrl());
-    assertNull(segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentsZKMetadata.get(2).getSegmentName(), null).getDownloadUrl());
+    assertEquals(segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentsZKMetadata.get(1).getSegmentName(), null).getDownloadUrl(), CommonConstants.Segment.METADATA_URI_FOR_PEER_DOWNLOAD);
+    assertEquals(segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentsZKMetadata.get(2).getSegmentName(), null).getDownloadUrl(), CommonConstants.Segment.METADATA_URI_FOR_PEER_DOWNLOAD);
     assertEquals(segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentsZKMetadata.get(3).getSegmentName(), null).getDownloadUrl(), defaultDownloadUrl);
     assertNull(segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentsZKMetadata.get(4).getSegmentName(), null).getDownloadUrl());
   }


### PR DESCRIPTION
## Description
With the new LLC segment commit protocal: [deep store bypass for realtime segment completion](https://cwiki.apache.org/confluence/display/PINOT/By-passing+deep-store+requirement+for+Realtime+segment+completion), LLC segments can be considered as committed with segment store upload failure. Using controller periodic tasks (RealtimeSegmentValidationManager) to fix the upload failure by asking servers to upload missing segments.

## Upgrade Notes
This PR introduced a new controller configs:
`controller.realtime.segment.deepStoreUploadRetryEnabled`: The flag to indicate if controller periodic job will fix the missing LLC segment deep store copy. Default value is false.


## Release Notes
This change is dependent on #6653. 

## Documentation
This change is proposed by: [By-passing deep-store requirement for Realtime segment completion#Failure cases and handling](https://cwiki.apache.org/confluence/display/PINOT/By-passing+deep-store+requirement+for+Realtime+segment+completion#BypassingdeepstorerequirementforRealtimesegmentcompletion-Failurecasesandhandling) 
