### PR TITLE
Realtime to offline space saving

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
@@ -73,8 +73,13 @@ public class SegmentProcessorFramework {
         inputSegments, outputSegmentsDir.getAbsolutePath(), segmentProcessorConfig.toString());
 
     _inputSegments = inputSegments;
-    inputSegments
+    _inputSegments
         .forEach(file -> Preconditions.checkState(file.exists(), "Input path: %s must exist", file.getAbsolutePath()));
+    if (_inputSegments.size() == 0) {
+      throw new IllegalStateException("No segments found in input dir: " + _inputSegments
+          + ". Exiting SegmentProcessorFramework.");
+    }
+
     _outputSegmentsDir = outputSegmentsDir;
     Preconditions.checkState(
         _outputSegmentsDir.exists() && _outputSegmentsDir.isDirectory() && (_outputSegmentsDir.list().length == 0),
@@ -106,12 +111,6 @@ public class SegmentProcessorFramework {
    */
   public void processSegments()
       throws Exception {
-
-    // Check for input segments
-    if (_inputSegments.size() == 0) {
-      throw new IllegalStateException("No segments found in input dir: " + _inputSegments
-          + ". Exiting SegmentProcessorFramework.");
-    }
 
     // Mapper phase.
     LOGGER.info("Beginning mapper phase. Processing segments: {}", _inputSegments);

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
@@ -66,14 +66,15 @@ public class SegmentProcessorFramework {
    * @param outputSegmentsDir directory for placing the resulting segments. This should already exist.
    */
   public SegmentProcessorFramework(List<File> inputSegments, SegmentProcessorConfig segmentProcessorConfig,
-                                   File outputSegmentsDir) {
+      File outputSegmentsDir) {
 
     LOGGER.info(
         "Initializing SegmentProcessorFramework with input segments: {}, output segments dir: {} and segment processor config: {}",
         inputSegments, outputSegmentsDir.getAbsolutePath(), segmentProcessorConfig.toString());
 
     _inputSegments = inputSegments;
-    inputSegments.forEach(file -> Preconditions.checkState(file.exists(), "Input path: %s must exist", file.getAbsolutePath()));
+    inputSegments
+        .forEach(file -> Preconditions.checkState(file.exists(), "Input path: %s must exist", file.getAbsolutePath()));
     _outputSegmentsDir = outputSegmentsDir;
     Preconditions.checkState(
         _outputSegmentsDir.exists() && _outputSegmentsDir.isDirectory() && (_outputSegmentsDir.list().length == 0),

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessingFrameworkTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessingFrameworkTest.java
@@ -242,12 +242,11 @@ public class SegmentProcessingFrameworkTest {
     }
 
     // empty input dir
-    SegmentProcessorFramework framework = new SegmentProcessorFramework(Arrays.asList(_emptyInputDir.listFiles()), config, outputSegmentDir);
     try {
-      framework.processSegments();
+       new SegmentProcessorFramework(Arrays.asList(_emptyInputDir.listFiles()), config, outputSegmentDir);
       fail("Should fail for empty input");
     } catch (Exception e) {
-      framework.cleanup();
+      // expected
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessingFrameworkTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessingFrameworkTest.java
@@ -21,6 +21,8 @@ package org.apache.pinot.core.segment.processing.framework;
 import com.google.common.collect.Lists;
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -205,7 +207,7 @@ public class SegmentProcessingFrameworkTest {
     // non-existent input dir
     File nonExistent = new File(_baseDir, "non_existent");
     try {
-      new SegmentProcessorFramework(nonExistent, config, outputSegmentDir);
+      new SegmentProcessorFramework(Collections.singletonList(nonExistent), config, outputSegmentDir);
       fail("Should fail for non existent input dir");
     } catch (IllegalStateException e) {
       // expected
@@ -214,16 +216,10 @@ public class SegmentProcessingFrameworkTest {
     // file used as input dir
     File fileInput = new File(_baseDir, "file.txt");
     assertTrue(fileInput.createNewFile());
-    try {
-      new SegmentProcessorFramework(fileInput, config, outputSegmentDir);
-      fail("Should fail for file used as input dir");
-    } catch (IllegalStateException e) {
-      // expected
-    }
 
     // non existent output dir
     try {
-      new SegmentProcessorFramework(_singleDaySingleSegment, config, nonExistent);
+      new SegmentProcessorFramework(Arrays.asList(_singleDaySingleSegment.listFiles()), config, nonExistent);
       fail("Should fail for non existent output dir");
     } catch (IllegalStateException e) {
       // expected
@@ -231,7 +227,7 @@ public class SegmentProcessingFrameworkTest {
 
     // file used as output dir
     try {
-      new SegmentProcessorFramework(_singleDaySingleSegment, config, fileInput);
+      new SegmentProcessorFramework(Arrays.asList(_singleDaySingleSegment.listFiles()), config, fileInput);
       fail("Should fail for file used as output dir");
     } catch (IllegalStateException e) {
       // expected
@@ -239,14 +235,14 @@ public class SegmentProcessingFrameworkTest {
 
     // output dir not empty
     try {
-      new SegmentProcessorFramework(fileInput, config, _singleDaySingleSegment);
+      new SegmentProcessorFramework(Collections.singletonList(fileInput), config, _singleDaySingleSegment);
       fail("Should fail for output dir not empty");
     } catch (IllegalStateException e) {
       // expected
     }
 
     // empty input dir
-    SegmentProcessorFramework framework = new SegmentProcessorFramework(_emptyInputDir, config, outputSegmentDir);
+    SegmentProcessorFramework framework = new SegmentProcessorFramework(Arrays.asList(_emptyInputDir.listFiles()), config, outputSegmentDir);
     try {
       framework.processSegments();
       fail("Should fail for empty input");
@@ -268,7 +264,7 @@ public class SegmentProcessingFrameworkTest {
     FileUtils.deleteQuietly(outputSegmentDir);
     assertTrue(outputSegmentDir.mkdirs());
     SegmentProcessorFramework framework =
-        new SegmentProcessorFramework(_singleDaySingleSegment, config, outputSegmentDir);
+        new SegmentProcessorFramework(Arrays.asList(_singleDaySingleSegment.listFiles()), config, outputSegmentDir);
     framework.processSegments();
     framework.cleanup();
     assertEquals(outputSegmentDir.listFiles().length, 1);
@@ -282,7 +278,7 @@ public class SegmentProcessingFrameworkTest {
                 .setNumPartitions(3).build())).build();
     FileUtils.deleteQuietly(outputSegmentDir);
     assertTrue(outputSegmentDir.mkdirs());
-    framework = new SegmentProcessorFramework(_singleDaySingleSegment, config, outputSegmentDir);
+    framework = new SegmentProcessorFramework(Arrays.asList(_singleDaySingleSegment.listFiles()), config, outputSegmentDir);
     framework.processSegments();
     framework.cleanup();
     assertEquals(outputSegmentDir.listFiles().length, 3);
@@ -301,7 +297,7 @@ public class SegmentProcessingFrameworkTest {
                 .setFilterFunction("Groovy({campaign == \"abc\"}, campaign)").build()).build();
     FileUtils.deleteQuietly(outputSegmentDir);
     assertTrue(outputSegmentDir.mkdirs());
-    framework = new SegmentProcessorFramework(_singleDaySingleSegment, config, outputSegmentDir);
+    framework = new SegmentProcessorFramework(Arrays.asList(_singleDaySingleSegment.listFiles()), config, outputSegmentDir);
     framework.processSegments();
     framework.cleanup();
     assertEquals(outputSegmentDir.listFiles().length, 1);
@@ -315,7 +311,7 @@ public class SegmentProcessingFrameworkTest {
                 .setFilterFunction("Groovy({clicks > 0}, clicks)").build()).build();
     FileUtils.deleteQuietly(outputSegmentDir);
     assertTrue(outputSegmentDir.mkdirs());
-    framework = new SegmentProcessorFramework(_singleDaySingleSegment, config, outputSegmentDir);
+    framework = new SegmentProcessorFramework(Arrays.asList(_singleDaySingleSegment.listFiles()), config, outputSegmentDir);
     try {
       framework.processSegments();
       fail("Should fail for empty map output");
@@ -331,7 +327,7 @@ public class SegmentProcessingFrameworkTest {
             new RecordTransformerConfig.Builder().setTransformFunctionsMap(recordTransformationMap).build()).build();
     FileUtils.deleteQuietly(outputSegmentDir);
     assertTrue(outputSegmentDir.mkdirs());
-    framework = new SegmentProcessorFramework(_singleDaySingleSegment, config, outputSegmentDir);
+    framework = new SegmentProcessorFramework(Arrays.asList(_singleDaySingleSegment.listFiles()), config, outputSegmentDir);
     framework.processSegments();
     framework.cleanup();
     assertEquals(outputSegmentDir.listFiles().length, 1);
@@ -345,7 +341,7 @@ public class SegmentProcessingFrameworkTest {
             new CollectorConfig.Builder().setCollectorType(CollectorFactory.CollectorType.ROLLUP).build()).build();
     FileUtils.deleteQuietly(outputSegmentDir);
     assertTrue(outputSegmentDir.mkdirs());
-    framework = new SegmentProcessorFramework(_singleDaySingleSegment, config, outputSegmentDir);
+    framework = new SegmentProcessorFramework(Arrays.asList(_singleDaySingleSegment.listFiles()), config, outputSegmentDir);
     framework.processSegments();
     framework.cleanup();
     assertEquals(outputSegmentDir.listFiles().length, 1);
@@ -358,7 +354,7 @@ public class SegmentProcessingFrameworkTest {
         .setSegmentConfig(new SegmentConfig.Builder().setMaxNumRecordsPerSegment(4).build()).build();
     FileUtils.deleteQuietly(outputSegmentDir);
     assertTrue(outputSegmentDir.mkdirs());
-    framework = new SegmentProcessorFramework(_singleDaySingleSegment, config, outputSegmentDir);
+    framework = new SegmentProcessorFramework(Arrays.asList(_singleDaySingleSegment.listFiles()), config, outputSegmentDir);
     framework.processSegments();
     framework.cleanup();
     assertEquals(outputSegmentDir.listFiles().length, 3);
@@ -384,7 +380,7 @@ public class SegmentProcessingFrameworkTest {
     FileUtils.deleteQuietly(outputSegmentDir);
     assertTrue(outputSegmentDir.mkdirs());
     SegmentProcessorFramework framework =
-        new SegmentProcessorFramework(_multipleDaysSingleSegment, config, outputSegmentDir);
+        new SegmentProcessorFramework(Arrays.asList(_multipleDaysSingleSegment.listFiles()), config, outputSegmentDir);
     framework.processSegments();
     framework.cleanup();
     assertEquals(outputSegmentDir.listFiles().length, 1);
@@ -398,7 +394,7 @@ public class SegmentProcessingFrameworkTest {
                 .setColumnName("timeValue").build())).build();
     FileUtils.deleteQuietly(outputSegmentDir);
     assertTrue(outputSegmentDir.mkdirs());
-    framework = new SegmentProcessorFramework(_multipleDaysSingleSegment, config, outputSegmentDir);
+    framework = new SegmentProcessorFramework(Arrays.asList(_multipleDaysSingleSegment.listFiles()), config, outputSegmentDir);
     framework.processSegments();
     framework.cleanup();
     assertEquals(outputSegmentDir.listFiles().length, 10);
@@ -421,7 +417,7 @@ public class SegmentProcessingFrameworkTest {
     FileUtils.deleteQuietly(outputSegmentDir);
     assertTrue(outputSegmentDir.mkdirs());
     SegmentProcessorFramework framework =
-        new SegmentProcessorFramework(_singleDayMultipleSegments, config, outputSegmentDir);
+        new SegmentProcessorFramework(Arrays.asList(_singleDayMultipleSegments.listFiles()), config, outputSegmentDir);
     framework.processSegments();
     framework.cleanup();
     assertEquals(outputSegmentDir.listFiles().length, 1);
@@ -434,7 +430,7 @@ public class SegmentProcessingFrameworkTest {
             new CollectorConfig.Builder().setCollectorType(CollectorFactory.CollectorType.ROLLUP).build()).build();
     FileUtils.deleteQuietly(outputSegmentDir);
     assertTrue(outputSegmentDir.mkdirs());
-    framework = new SegmentProcessorFramework(_singleDayMultipleSegments, config, outputSegmentDir);
+    framework = new SegmentProcessorFramework(Arrays.asList(_singleDayMultipleSegments.listFiles()), config, outputSegmentDir);
     framework.processSegments();
     framework.cleanup();
     assertEquals(outputSegmentDir.listFiles().length, 1);
@@ -456,7 +452,7 @@ public class SegmentProcessingFrameworkTest {
     FileUtils.deleteQuietly(outputSegmentDir);
     assertTrue(outputSegmentDir.mkdirs());
     SegmentProcessorFramework framework =
-        new SegmentProcessorFramework(_multipleDaysMultipleSegments, config, outputSegmentDir);
+        new SegmentProcessorFramework(Arrays.asList(_multipleDaysMultipleSegments.listFiles()), config, outputSegmentDir);
     framework.processSegments();
     framework.cleanup();
     assertEquals(outputSegmentDir.listFiles().length, 1);
@@ -470,7 +466,7 @@ public class SegmentProcessingFrameworkTest {
                 .setTransformFunction("round(timeValue, 86400000)").build())).build();
     FileUtils.deleteQuietly(outputSegmentDir);
     assertTrue(outputSegmentDir.mkdirs());
-    framework = new SegmentProcessorFramework(_multipleDaysSingleSegment, config, outputSegmentDir);
+    framework = new SegmentProcessorFramework(Arrays.asList(_multipleDaysSingleSegment.listFiles()), config, outputSegmentDir);
     framework.processSegments();
     framework.cleanup();
     assertEquals(outputSegmentDir.listFiles().length, 3);
@@ -493,7 +489,7 @@ public class SegmentProcessingFrameworkTest {
             new CollectorConfig.Builder().setCollectorType(CollectorFactory.CollectorType.ROLLUP).build()).build();
     FileUtils.deleteQuietly(outputSegmentDir);
     assertTrue(outputSegmentDir.mkdirs());
-    framework = new SegmentProcessorFramework(_multipleDaysSingleSegment, config, outputSegmentDir);
+    framework = new SegmentProcessorFramework(Arrays.asList(_multipleDaysSingleSegment.listFiles()), config, outputSegmentDir);
     framework.processSegments();
     framework.cleanup();
     assertEquals(outputSegmentDir.listFiles().length, 3);
@@ -518,7 +514,7 @@ public class SegmentProcessingFrameworkTest {
             new CollectorConfig.Builder().setCollectorType(CollectorFactory.CollectorType.ROLLUP).build()).build();
     FileUtils.deleteQuietly(outputSegmentDir);
     assertTrue(outputSegmentDir.mkdirs());
-    SegmentProcessorFramework framework = new SegmentProcessorFramework(_multiValueSegments, config, outputSegmentDir);
+    SegmentProcessorFramework framework = new SegmentProcessorFramework(Arrays.asList(_multiValueSegments.listFiles()), config, outputSegmentDir);
     framework.processSegments();
     framework.cleanup();
     assertEquals(outputSegmentDir.listFiles().length, 1);
@@ -536,7 +532,7 @@ public class SegmentProcessingFrameworkTest {
     // default configs
     FileUtils.deleteQuietly(outputSegmentDir);
     assertTrue(outputSegmentDir.mkdirs());
-    SegmentProcessorFramework framework = new SegmentProcessorFramework(_tarredSegments, config, outputSegmentDir);
+    SegmentProcessorFramework framework = new SegmentProcessorFramework(Arrays.asList(_tarredSegments.listFiles()), config, outputSegmentDir);
     framework.processSegments();
     framework.cleanup();
     assertEquals(outputSegmentDir.listFiles().length, 1);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
@@ -108,6 +108,7 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
         // Un-tar the segment file
         File segmentDir = new File(tempDataDir, "segmentDir_" + i);
         File indexDir = TarGzCompressionUtils.untar(tarredSegmentFile, segmentDir).get(0);
+        FileUtils.deleteQuietly(tarredSegmentFile);
         inputSegmentFiles.add(indexDir);
       }
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtime_to_offline_segments/RealtimeToOfflineSegmentsTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtime_to_offline_segments/RealtimeToOfflineSegmentsTaskExecutor.java
@@ -193,18 +193,12 @@ public class RealtimeToOfflineSegmentsTaskExecutor extends BaseMultipleSegmentsC
 
     SegmentProcessorConfig segmentProcessorConfig = segmentProcessorConfigBuilder.build();
 
-    File inputSegmentsDir = new File(workingDir, INPUT_SEGMENTS_DIR);
-    Preconditions.checkState(inputSegmentsDir.mkdirs(), "Failed to create input directory: %s for task: %s",
-        inputSegmentsDir.getAbsolutePath(), taskType);
-    for (File indexDir : originalIndexDirs) {
-      FileUtils.moveDirectoryToDirectory(indexDir, inputSegmentsDir, false);
-    }
     File outputSegmentsDir = new File(workingDir, OUTPUT_SEGMENTS_DIR);
     Preconditions.checkState(outputSegmentsDir.mkdirs(), "Failed to create output directory: %s for task: %s",
         outputSegmentsDir.getAbsolutePath(), taskType);
 
     SegmentProcessorFramework segmentProcessorFramework =
-        new SegmentProcessorFramework(inputSegmentsDir, segmentProcessorConfig, outputSegmentsDir);
+        new SegmentProcessorFramework(originalIndexDirs, segmentProcessorConfig, outputSegmentsDir);
     try {
       segmentProcessorFramework.processSegments();
     } finally {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtime_to_offline_segments/RealtimeToOfflineSegmentsTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtime_to_offline_segments/RealtimeToOfflineSegmentsTaskExecutor.java
@@ -197,7 +197,7 @@ public class RealtimeToOfflineSegmentsTaskExecutor extends BaseMultipleSegmentsC
     Preconditions.checkState(inputSegmentsDir.mkdirs(), "Failed to create input directory: %s for task: %s",
         inputSegmentsDir.getAbsolutePath(), taskType);
     for (File indexDir : originalIndexDirs) {
-      FileUtils.copyDirectoryToDirectory(indexDir, inputSegmentsDir);
+      FileUtils.moveDirectoryToDirectory(indexDir, inputSegmentsDir, false);
     }
     File outputSegmentsDir = new File(workingDir, OUTPUT_SEGMENTS_DIR);
     Preconditions.checkState(outputSegmentsDir.mkdirs(), "Failed to create output directory: %s for task: %s",


### PR DESCRIPTION
## Description

We saw high disk usage when using RealtimeToOfflineSegmentsTask, and as I looked into the code I've found that it keeps lots of temporary files around until the whole task is finished. As I understand the compressed files can be deleted immediately after they are extracted, and the extracted segment files don't need to be copied. It would be even better to download/extract/process the files one by one to reduce the disk space needed for the task, but this seems like a small change with nice immediate benefits.


