### PR TITLE
Add new partition group metadata at the time of segment commit

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -595,6 +595,21 @@ public class PinotLLCRealtimeSegmentManager {
     //  Ensure that multiple committing segments don't create multiple new segment metadata and ideal state entries
     //  for the same partitionGroup
 
+    Map<Integer, LLCRealtimeSegmentZKMetadata> latestSegmentZKMetadataMap =
+        getLatestSegmentZKMetadataMap(realtimeTableName);
+
+    Map<String, Map<String, String>> instanceStatesMap = idealState.getRecord().getMapFields();
+    for (PartitionGroupMetadata partitionGroupMetadata : newPartitionGroupMetadataList) {
+      int partitionGroupId = partitionGroupMetadata.getPartitionGroupId();
+      if (!latestSegmentZKMetadataMap.containsKey(partitionGroupId)) {
+        String newSegmentName =
+            setupNewPartitionGroup(tableConfig, streamConfig, partitionGroupMetadata, getCurrentTimeMs(), instancePartitions, numPartitionGroups,
+                numReplicas);
+        updateInstanceStatesForNewConsumingSegment(instanceStatesMap, null, newSegmentName, segmentAssignment,
+            instancePartitionsMap);
+      }
+    }
+
     // Trigger the metadata event notifier
     _metadataEventNotifierFactory.create().notifyOnSegmentFlush(tableConfig);
   }
@@ -1273,6 +1288,7 @@ public class PinotLLCRealtimeSegmentManager {
 
   private int getMaxNumPartitionsPerInstance(InstancePartitions instancePartitions, int numPartitions,
       int numReplicas) {
+    int numInstances = instancePartitions.getInstances(0, 0).size();
     if (instancePartitions.getNumReplicaGroups() == 1) {
       // Non-replica-group based assignment:
       // Uniformly spray the partitions and replicas across the instances.
@@ -1281,7 +1297,6 @@ public class PinotLLCRealtimeSegmentManager {
       //         p0r0 p0r1 p0r2 p0r3 p1r0 p1r1
       //         p1r2 p1r3 p2r0 p2r1 p2r2 p2r3
 
-      int numInstances = instancePartitions.getInstances(0, 0).size();
       return (numPartitions * numReplicas + numInstances - 1) / numInstances;
     } else {
       // Replica-group based assignment:
@@ -1291,8 +1306,7 @@ public class PinotLLCRealtimeSegmentManager {
       //         p0  p1  p2
       //         p3  p4  p5
 
-      int numInstancesPerReplicaGroup = instancePartitions.getInstances(0, 0).size();
-      return (numPartitions + numInstancesPerReplicaGroup - 1) / numInstancesPerReplicaGroup;
+      return (numPartitions + numInstances - 1) / numInstances;
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -618,8 +618,12 @@ public class PinotLLCRealtimeSegmentManager {
         String newSegmentName =
             setupNewPartitionGroup(tableConfig, streamConfig, partitionGroupMetadata, getCurrentTimeMs(),
                 instancePartitions, numPartitionGroups, numReplicas, newPartitionGroupMetadataList, true);
-        updateInstanceStatesForNewConsumingSegment(instanceStatesMap, null, newSegmentName, segmentAssignment,
-            instancePartitionsMap);
+        try {
+          updateInstanceStatesForNewConsumingSegment(instanceStatesMap, null, newSegmentName, segmentAssignment,
+              instancePartitionsMap);
+        } catch (HelixHelper.PermanentUpdaterException e) {
+          LOGGER.warn("Caught exception while updating ideal state for new partition groups", e);
+        }
       }
     }
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1257,7 +1257,7 @@ public class PinotLLCRealtimeSegmentManager {
    * Sets up a new partition group.
    * <p>Persists the ZK metadata for the first CONSUMING segment, and returns the segment name.
    */
-  private String setupNewPartitionGroup(TableConfig tableConfig, PartitionLevelStreamConfig streamConfig,
+  private synchronized String setupNewPartitionGroup(TableConfig tableConfig, PartitionLevelStreamConfig streamConfig,
       PartitionGroupMetadata partitionGroupMetadata, long creationTimeMs, InstancePartitions instancePartitions,
       int numPartitionGroups, int numReplicas, List<PartitionGroupMetadata> partitionGroupMetadataList,
       boolean isLiveTable) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -899,7 +899,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
   public void testCommitSegmentMetadata() {
     // Set up a new table with 2 replicas, 5 instances, 4 partition
     FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager();
-    setUpNewTable(segmentManager, 2, 5, 4);
+    int intialNumPartitions = 4;
+    setUpNewTable(segmentManager, 2, 5, intialNumPartitions);
 
     // Test case 1: segment location with vip format.
     // Commit a segment for partition group 0
@@ -914,6 +915,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
         segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, committingSegment, null);
     Assert.assertEquals(segmentZKMetadata.getDownloadUrl(), segmentLocationVIP);
 
+    Map<String, Map<String, String>> mp = segmentManager.getIdealState(REALTIME_TABLE_NAME).getRecord().getMapFields();
+
     // Test case 2: segment location with peer format: peer://segment1, verify that an empty string is stored in zk.
     committingSegment = new LLCSegmentName(RAW_TABLE_NAME, 0, 1, CURRENT_TIME_MS).getSegmentName();
     String peerSegmentLocation = CommonConstants.Segment.PEER_SEGMENT_DOWNLOAD_SCHEME + "/segment1";
@@ -924,6 +927,31 @@ public class PinotLLCRealtimeSegmentManagerTest {
 
     segmentZKMetadata = segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, committingSegment, null);
     Assert.assertEquals(segmentZKMetadata.getDownloadUrl(), "");
+
+    // Test case 3, Add new partitions
+    segmentManager._numPartitions = 6;
+    committingSegment = new LLCSegmentName(RAW_TABLE_NAME, 0, 2, CURRENT_TIME_MS).getSegmentName();
+    CommittingSegmentDescriptor committingSegmentDescriptor1 = new CommittingSegmentDescriptor(committingSegment,
+        new LongMsgOffset(PARTITION_OFFSET.getOffset() + NUM_DOCS).toString(), 0L, segmentLocationVIP);
+    committingSegmentDescriptor1.setSegmentMetadata(mockSegmentMetadata());
+    segmentManager.commitSegmentMetadata(REALTIME_TABLE_NAME, committingSegmentDescriptor1);
+
+    Map<String, Map<String, String>> instanceStatesMap =
+        segmentManager.getIdealState(REALTIME_TABLE_NAME).getRecord().getMapFields();
+
+    Assert.assertEquals(instanceStatesMap.size(),
+        segmentManager._numPartitions + 3); // Since we have committed 3 segments previously
+
+    for (String segmentName : instanceStatesMap.keySet()) {
+      LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
+      if (llcSegmentName.getPartitionGroupId() >= intialNumPartitions) {
+        SegmentZKMetadata updatedSegmentZKMetadata =
+            segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentName, null);
+
+        Assert.assertNotNull(updatedSegmentZKMetadata);
+        Assert.assertEquals(updatedSegmentZKMetadata.getStatus(), Status.IN_PROGRESS);
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
Creates new partition groups while creating commitingSegment metadata instead of waiting till the RealtimeSegmentValidationManager runs
e.g. If current state is A, B, C, and newPartitionGroupMetadataList contains B, C, D, E, then metadata/idealstate entries for D, E are created along with the committing partition's entries.

This is required for new connectors like Kinesis where the number of shards/partitions can change on the fly.