### PR TITLE
modify segment generator to not return illegal filenames

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/FixedSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/FixedSegmentNameGenerator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.spi.creator.name;
 
+import com.google.common.base.Preconditions;
 import javax.annotation.Nullable;
 
 /**
@@ -28,6 +29,8 @@ public class FixedSegmentNameGenerator implements SegmentNameGenerator {
   private final String _segmentName;
 
   public FixedSegmentNameGenerator(String segmentName) {
+    Preconditions.checkArgument(
+        segmentName != null && !segmentName.matches(INVALID_SEGMENT_NAME_REGEX));
     _segmentName = segmentName;
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/FixedSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/FixedSegmentNameGenerator.java
@@ -30,7 +30,7 @@ public class FixedSegmentNameGenerator implements SegmentNameGenerator {
 
   public FixedSegmentNameGenerator(String segmentName) {
     Preconditions.checkArgument(
-        segmentName != null && !segmentName.matches(INVALID_SEGMENT_NAME_REGEX));
+        segmentName != null && !INVALID_SEGMENT_NAME_REGEX.matcher(segmentName).matches());
     _segmentName = segmentName;
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/FixedSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/FixedSegmentNameGenerator.java
@@ -29,8 +29,7 @@ public class FixedSegmentNameGenerator implements SegmentNameGenerator {
   private final String _segmentName;
 
   public FixedSegmentNameGenerator(String segmentName) {
-    Preconditions.checkArgument(
-        segmentName != null && isValidSegmentName(segmentName));
+    Preconditions.checkArgument(segmentName != null && isValidSegmentName(segmentName));
     _segmentName = segmentName;
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/FixedSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/FixedSegmentNameGenerator.java
@@ -30,7 +30,7 @@ public class FixedSegmentNameGenerator implements SegmentNameGenerator {
 
   public FixedSegmentNameGenerator(String segmentName) {
     Preconditions.checkArgument(
-        segmentName != null && !INVALID_SEGMENT_NAME_REGEX.matcher(segmentName).matches());
+        segmentName != null && isValidSegmentName(segmentName));
     _segmentName = segmentName;
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGenerator.java
@@ -54,7 +54,7 @@ public class NormalizedDateSegmentNameGenerator implements SegmentNameGenerator 
       @Nullable DateTimeFormatSpec dateTimeFormatSpec) {
     _segmentNamePrefix = segmentNamePrefix != null ? segmentNamePrefix.trim() : tableName;
     Preconditions.checkArgument(
-        _segmentNamePrefix == null || isValidSegmentName(_segmentNamePrefix));
+        _segmentNamePrefix != null && isValidSegmentName(_segmentNamePrefix));
     _excludeSequenceId = excludeSequenceId;
     _appendPushType = "APPEND".equalsIgnoreCase(pushType);
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGenerator.java
@@ -54,7 +54,7 @@ public class NormalizedDateSegmentNameGenerator implements SegmentNameGenerator 
       @Nullable DateTimeFormatSpec dateTimeFormatSpec) {
     _segmentNamePrefix = segmentNamePrefix != null ? segmentNamePrefix.trim() : tableName;
     Preconditions.checkArgument(
-        _segmentNamePrefix == null || !INVALID_SEGMENT_NAME_REGEX.matcher(_segmentNamePrefix).matches());
+        _segmentNamePrefix == null || isValidSegmentName(_segmentNamePrefix));
     _excludeSequenceId = excludeSequenceId;
     _appendPushType = "APPEND".equalsIgnoreCase(pushType);
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGenerator.java
@@ -52,11 +52,9 @@ public class NormalizedDateSegmentNameGenerator implements SegmentNameGenerator 
   public NormalizedDateSegmentNameGenerator(String tableName, @Nullable String segmentNamePrefix,
       boolean excludeSequenceId, @Nullable String pushType, @Nullable String pushFrequency,
       @Nullable DateTimeFormatSpec dateTimeFormatSpec) {
-    Preconditions.checkArgument(
-        tableName != null && !tableName.matches(INVALID_SEGMENT_NAME_REGEX));
-    Preconditions.checkArgument(
-        segmentNamePrefix == null || !segmentNamePrefix.matches(INVALID_SEGMENT_NAME_REGEX));
     _segmentNamePrefix = segmentNamePrefix != null ? segmentNamePrefix.trim() : tableName;
+    Preconditions.checkArgument(
+        _segmentNamePrefix == null || !INVALID_SEGMENT_NAME_REGEX.matcher(_segmentNamePrefix).matches());
     _excludeSequenceId = excludeSequenceId;
     _appendPushType = "APPEND".equalsIgnoreCase(pushType);
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGenerator.java
@@ -52,6 +52,10 @@ public class NormalizedDateSegmentNameGenerator implements SegmentNameGenerator 
   public NormalizedDateSegmentNameGenerator(String tableName, @Nullable String segmentNamePrefix,
       boolean excludeSequenceId, @Nullable String pushType, @Nullable String pushFrequency,
       @Nullable DateTimeFormatSpec dateTimeFormatSpec) {
+    Preconditions.checkArgument(
+        tableName != null && !tableName.matches(INVALID_SEGMENT_NAME_REGEX));
+    Preconditions.checkArgument(
+        segmentNamePrefix == null || !segmentNamePrefix.matches(INVALID_SEGMENT_NAME_REGEX));
     _segmentNamePrefix = segmentNamePrefix != null ? segmentNamePrefix.trim() : tableName;
     _excludeSequenceId = excludeSequenceId;
     _appendPushType = "APPEND".equalsIgnoreCase(pushType);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SegmentNameGenerator.java
@@ -20,6 +20,7 @@ package org.apache.pinot.segment.spi.creator.name;
 
 import com.google.common.base.Joiner;
 import java.io.Serializable;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 
@@ -27,7 +28,7 @@ import javax.annotation.Nullable;
  * Interface for segment name generator based on the segment sequence id and time range.
  */
 public interface SegmentNameGenerator extends Serializable {
-  String INVALID_SEGMENT_NAME_REGEX = ".*[\\\\/:\\*?\"<>|].*";
+  Pattern INVALID_SEGMENT_NAME_REGEX = Pattern.compile(".*[\\\\/:\\*?\"<>|].*");
   Joiner JOINER = Joiner.on('_').skipNulls();
 
   /**

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SegmentNameGenerator.java
@@ -32,6 +32,16 @@ public interface SegmentNameGenerator extends Serializable {
   Joiner JOINER = Joiner.on('_').skipNulls();
 
   /**
+   * A handy util to validate if segment name is valid.
+   *
+   * @param segmentName provide segment name
+   * @return true if segmentName is valid.
+   */
+  default boolean isValidSegmentName(String segmentName) {
+    return !INVALID_SEGMENT_NAME_REGEX.matcher(segmentName).matches();
+  }
+
+  /**
    * Generates the segment name.
    *
    * @param sequenceId Segment sequence id (negative value means INVALID)

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SegmentNameGenerator.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
  * Interface for segment name generator based on the segment sequence id and time range.
  */
 public interface SegmentNameGenerator extends Serializable {
+  String INVALID_SEGMENT_NAME_REGEX = ".*[\\\\/:\\*?\"<>|].*";
   Joiner JOINER = Joiner.on('_').skipNulls();
 
   /**

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.spi.creator.name;
 
+import com.google.common.base.Preconditions;
 import javax.annotation.Nullable;
 
 
@@ -39,12 +40,20 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
   private final String _segmentNamePostfix;
 
   public SimpleSegmentNameGenerator(String segmentNamePrefix, @Nullable String segmentNamePostfix) {
+    Preconditions.checkArgument(
+        segmentNamePrefix != null && !segmentNamePrefix.matches(INVALID_SEGMENT_NAME_REGEX));
+    Preconditions.checkArgument(
+        segmentNamePostfix == null || !segmentNamePostfix.matches(INVALID_SEGMENT_NAME_REGEX));
     _segmentNamePrefix = segmentNamePrefix;
     _segmentNamePostfix = segmentNamePostfix;
   }
 
   @Override
   public String generateSegmentName(int sequenceId, @Nullable Object minTimeValue, @Nullable Object maxTimeValue) {
+    Preconditions.checkArgument(
+        minTimeValue == null  || !minTimeValue.toString().matches(INVALID_SEGMENT_NAME_REGEX));
+    Preconditions.checkArgument(
+        maxTimeValue == null  || !maxTimeValue.toString().matches(INVALID_SEGMENT_NAME_REGEX));
     return JOINER
         .join(_segmentNamePrefix, minTimeValue, maxTimeValue, _segmentNamePostfix, sequenceId >= 0 ? sequenceId : null);
   }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
@@ -41,9 +41,9 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
 
   public SimpleSegmentNameGenerator(String segmentNamePrefix, @Nullable String segmentNamePostfix) {
     Preconditions.checkArgument(
-        segmentNamePrefix != null && !segmentNamePrefix.matches(INVALID_SEGMENT_NAME_REGEX));
+        segmentNamePrefix != null && !INVALID_SEGMENT_NAME_REGEX.matcher(segmentNamePrefix).matches());
     Preconditions.checkArgument(
-        segmentNamePostfix == null || !segmentNamePostfix.matches(INVALID_SEGMENT_NAME_REGEX));
+        segmentNamePostfix == null || !INVALID_SEGMENT_NAME_REGEX.matcher(segmentNamePostfix).matches());
     _segmentNamePrefix = segmentNamePrefix;
     _segmentNamePostfix = segmentNamePostfix;
   }
@@ -51,9 +51,9 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
   @Override
   public String generateSegmentName(int sequenceId, @Nullable Object minTimeValue, @Nullable Object maxTimeValue) {
     Preconditions.checkArgument(
-        minTimeValue == null  || !minTimeValue.toString().matches(INVALID_SEGMENT_NAME_REGEX));
+        minTimeValue == null || !INVALID_SEGMENT_NAME_REGEX.matcher(minTimeValue.toString()).matches());
     Preconditions.checkArgument(
-        maxTimeValue == null  || !maxTimeValue.toString().matches(INVALID_SEGMENT_NAME_REGEX));
+        maxTimeValue == null || !INVALID_SEGMENT_NAME_REGEX.matcher(maxTimeValue.toString()).matches());
     return JOINER
         .join(_segmentNamePrefix, minTimeValue, maxTimeValue, _segmentNamePostfix, sequenceId >= 0 ? sequenceId : null);
   }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
@@ -41,9 +41,9 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
 
   public SimpleSegmentNameGenerator(String segmentNamePrefix, @Nullable String segmentNamePostfix) {
     Preconditions.checkArgument(
-        segmentNamePrefix != null && !INVALID_SEGMENT_NAME_REGEX.matcher(segmentNamePrefix).matches());
+        segmentNamePrefix != null && isValidSegmentName(segmentNamePrefix));
     Preconditions.checkArgument(
-        segmentNamePostfix == null || !INVALID_SEGMENT_NAME_REGEX.matcher(segmentNamePostfix).matches());
+        segmentNamePostfix == null || isValidSegmentName(segmentNamePostfix));
     _segmentNamePrefix = segmentNamePrefix;
     _segmentNamePostfix = segmentNamePostfix;
   }
@@ -51,9 +51,9 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
   @Override
   public String generateSegmentName(int sequenceId, @Nullable Object minTimeValue, @Nullable Object maxTimeValue) {
     Preconditions.checkArgument(
-        minTimeValue == null || !INVALID_SEGMENT_NAME_REGEX.matcher(minTimeValue.toString()).matches());
+        minTimeValue == null || isValidSegmentName(minTimeValue.toString()));
     Preconditions.checkArgument(
-        maxTimeValue == null || !INVALID_SEGMENT_NAME_REGEX.matcher(maxTimeValue.toString()).matches());
+        maxTimeValue == null || isValidSegmentName(maxTimeValue.toString()));
     return JOINER
         .join(_segmentNamePrefix, minTimeValue, maxTimeValue, _segmentNamePostfix, sequenceId >= 0 ? sequenceId : null);
   }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGeneratorTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGeneratorTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.segment.spi.creator.name;
 
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -27,13 +28,16 @@ import static org.testng.Assert.assertEquals;
 
 public class NormalizedDateSegmentNameGeneratorTest {
   private static final String TABLE_NAME = "myTable";
+  private static final String MALFORMED_TABLE_NAME = "my/Table";
   private static final String SEGMENT_NAME_PREFIX = "myTable_daily";
+  private static final String MALFORMED_SEGMENT_NAME_PREFIX = "myTable\\daily";
   private static final String APPEND_PUSH_TYPE = "APPEND";
   private static final String REFRESH_PUSH_TYPE = "REFRESH";
   private static final String EPOCH_TIME_FORMAT = "EPOCH";
   private static final String SIMPLE_DATE_TIME_FORMAT = "SIMPLE_DATE_FORMAT";
   private static final String LONG_SIMPLE_DATE_FORMAT = "yyyyMMdd";
   private static final String STRING_SIMPLE_DATE_FORMAT = "yyyy-MM-dd";
+  private static final String STRING_SLASH_DATE_FORMAT = "yyyy/MM/dd";
   private static final String DAILY_PUSH_FREQUENCY = "daily";
   private static final String HOURLY_PUSH_FREQUENCY = "hourly";
   private static final int INVALID_SEQUENCE_ID = -1;
@@ -144,6 +148,39 @@ public class NormalizedDateSegmentNameGeneratorTest {
     assertEquals(segmentNameGenerator.generateSegmentName(INVALID_SEQUENCE_ID, "1970-01-02", "1970-01-04"),
         "myTable_1970-01-02_1970-01-04");
     assertEquals(segmentNameGenerator.generateSegmentName(VALID_SEQUENCE_ID, "1970-01-02", "1970-01-04"),
+        "myTable_1970-01-02_1970-01-04_1");
+  }
+
+  @Test
+  public void testMalFormedTableNameAndSegmentNamePrefix() {
+    try {
+      new NormalizedDateSegmentNameGenerator(MALFORMED_TABLE_NAME, null, false, APPEND_PUSH_TYPE, DAILY_PUSH_FREQUENCY,
+          new DateTimeFormatSpec(1, TimeUnit.DAYS.toString(), SIMPLE_DATE_TIME_FORMAT, STRING_SLASH_DATE_FORMAT));
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+    try {
+      new NormalizedDateSegmentNameGenerator(
+          TABLE_NAME, MALFORMED_SEGMENT_NAME_PREFIX, false, APPEND_PUSH_TYPE, DAILY_PUSH_FREQUENCY,
+          new DateTimeFormatSpec(1, TimeUnit.DAYS.toString(), SIMPLE_DATE_TIME_FORMAT, STRING_SLASH_DATE_FORMAT));
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+  }
+
+  @Test
+  public void testMalFormedDateFormatAndTimeValue() {
+    SegmentNameGenerator segmentNameGenerator =
+        new NormalizedDateSegmentNameGenerator(TABLE_NAME, null, false, APPEND_PUSH_TYPE, DAILY_PUSH_FREQUENCY,
+            new DateTimeFormatSpec(1, TimeUnit.DAYS.toString(), SIMPLE_DATE_TIME_FORMAT, STRING_SLASH_DATE_FORMAT));
+    assertEquals(segmentNameGenerator.toString(),
+        "NormalizedDateSegmentNameGenerator: segmentNamePrefix=myTable, "
+            + "appendPushType=true, outputSDF=yyyy-MM-dd, inputSDF=yyyy/MM/dd");
+    assertEquals(segmentNameGenerator.generateSegmentName(INVALID_SEQUENCE_ID, "1970/01/02", "1970/01/04"),
+        "myTable_1970-01-02_1970-01-04");
+    assertEquals(segmentNameGenerator.generateSegmentName(VALID_SEQUENCE_ID, "1970/01/02", "1970/01/04"),
         "myTable_1970-01-02_1970-01-04_1");
   }
 

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGeneratorTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGeneratorTest.java
@@ -18,18 +18,22 @@
  */
 package org.apache.pinot.segment.spi.creator.name;
 
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 
 
 public class SimpleSegmentNameGeneratorTest {
+  private static final String MALFORMED_TABLE_NAME = "test/Table";
   private static final String TABLE_NAME = "testTable";
   private static final String SEGMENT_NAME_POSTFIX = "postfix";
+  private static final String MALFORMED_SEGMENT_NAME_POSTFIX = "post*fix";
   private static final int INVALID_SEQUENCE_ID = -1;
   private static final int VALID_SEQUENCE_ID = 0;
   private static final long MIN_TIME_VALUE = 1234L;
   private static final long MAX_TIME_VALUE = 5678L;
+  private static final String MALFORMED_TIME_VALUE = "12|34";
 
   @Test
   public void testWithoutSegmentNamePostfix() {
@@ -54,5 +58,28 @@ public class SimpleSegmentNameGeneratorTest {
     assertEquals(segmentNameGenerator.generateSegmentName(VALID_SEQUENCE_ID, null, null), "testTable_postfix_0");
     assertEquals(segmentNameGenerator.generateSegmentName(VALID_SEQUENCE_ID, MIN_TIME_VALUE, MAX_TIME_VALUE),
         "testTable_1234_5678_postfix_0");
+  }
+
+  @Test
+  public void testWithMalFormedTableNameSegmentNamePostfixTimeValue() {
+    try {
+      new SimpleSegmentNameGenerator(MALFORMED_TABLE_NAME, SEGMENT_NAME_POSTFIX);
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+    try {
+      new SimpleSegmentNameGenerator(TABLE_NAME, MALFORMED_SEGMENT_NAME_POSTFIX);
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+    try {
+      SegmentNameGenerator segmentNameGenerator = new SimpleSegmentNameGenerator(TABLE_NAME, SEGMENT_NAME_POSTFIX);
+      segmentNameGenerator.generateSegmentName(VALID_SEQUENCE_ID, MIN_TIME_VALUE, MALFORMED_TIME_VALUE);
+      Assert.fail();
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
   }
 }


### PR DESCRIPTION
## Description
Add logic in `SegmentNameGenerator`s to no allow illegal filename characters
This fixes #6772.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
Nope

Does this PR fix a zero-downtime upgrade introduced earlier?
Nope

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options - No
- Deprecation of configurations - No 
- Signature changes to public methods/interfaces - No
- New plugins added or old plugins removed - No 

## Documentation
N/A 
