### PR TITLE
Add output format converter in pinot-tools

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
@@ -221,18 +221,25 @@ public class Quickstart extends QuickStartBase {
     printStatus(Color.YELLOW, prettyPrintResponse(runner.runQuery(q3)));
     printStatus(Color.GREEN, "***************************************************");
 
+    File quickstartTmpOutputDir = new File(_tmpDir, String.valueOf(System.currentTimeMillis()));
+    Preconditions.checkState(quickstartTmpOutputDir.mkdirs());
+
+    File output4 = new File(quickstartTmpOutputDir, "q4_result.json");
     String q4 =
         "select playerName, sum(runs) from baseballStats where yearID>=2000 group by playerName order by sum(runs) "
             + "desc limit 10";
     printStatus(Color.YELLOW, "Top 10 run scorers after 2000");
     printStatus(Color.CYAN, "Query : " + q4);
-    printStatus(Color.YELLOW, prettyPrintResponse(runner.runQuery(q4)));
+    printStatus(Color.YELLOW, prettyPrintResponse(runner.runQuery(q4, output4.getPath(), null)));
+    printStatus(Color.YELLOW, "Results are also stored in: " + output4);
     printStatus(Color.GREEN, "***************************************************");
 
+    File output5 = new File(quickstartTmpOutputDir, "q5_result.csv");
     String q5 = "select playerName, runs, homeRuns from baseballStats order by yearID limit 10";
     printStatus(Color.YELLOW, "Print playerName,runs,homeRuns for 10 records from the table and order them by yearID");
     printStatus(Color.CYAN, "Query : " + q5);
-    printStatus(Color.YELLOW, prettyPrintResponse(runner.runQuery(q5)));
+    printStatus(Color.YELLOW, prettyPrintResponse(runner.runQuery(q5, output5.getPath(), "CSV")));
+    printStatus(Color.YELLOW, "Results are also stored in: " + output5);
     printStatus(Color.GREEN, "***************************************************");
 
     printStatus(Color.GREEN, "You can always go to http://localhost:9000 to play around in the query console");

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
@@ -18,9 +18,7 @@
  */
 package org.apache.pinot.tools.admin.command;
 
-import java.io.IOException;
 import java.util.Collections;
-
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request;
@@ -167,7 +165,7 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
       try {
         BrokerResponseNative response = JsonUtils.stringToObject(brokerResponse, BrokerResponseNative.class);
         OutputFormatUtils.saveResponse(response, _outputPath, _outputFormat);
-      } catch (IOException | UnsupportedOperationException e) {
+      } catch (Exception e) {
         e.printStackTrace();
       }
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
@@ -247,9 +247,15 @@ public class QuickstartRunner {
 
   public JsonNode runQuery(String query)
       throws Exception {
+    return runQuery(query, null, null);
+  }
+
+  public JsonNode runQuery(String query, String outputPath, String outputFormat)
+      throws Exception {
     int brokerPort = _brokerPorts.get(RANDOM.nextInt(_brokerPorts.size()));
     return JsonUtils.stringToJsonNode(new PostQueryCommand().setBrokerPort(String.valueOf(brokerPort))
-        .setQueryType(CommonConstants.Broker.Request.SQL).setAuthToken(_authToken).setQuery(query).run());
+        .setQueryType(CommonConstants.Broker.Request.SQL).setAuthToken(_authToken)
+        .setOutputPath(outputPath).setOutputFormat(outputFormat).setQuery(query).run());
   }
 
   public static void registerDefaultPinotFS() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/OutputFormatUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/OutputFormatUtils.java
@@ -19,17 +19,19 @@
 package org.apache.pinot.tools.utils;
 
 import com.google.common.base.Joiner;
-import org.apache.pinot.common.response.broker.BrokerResponseNative;
-import org.apache.pinot.common.response.broker.ResultTable;
-import org.apache.pinot.spi.utils.JsonUtils;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.spi.utils.JsonUtils;
 
 public class OutputFormatUtils {
   private static final Joiner CSV_JOINER = Joiner.on(',').skipNulls();
+  private enum OutputFormat {
+    JSON, CSV
+  }
 
   private OutputFormatUtils() {
   }
@@ -48,12 +50,13 @@ public class OutputFormatUtils {
   public static void saveResponse(
       BrokerResponseNative brokerResponse,
       String outputPath,
-      String outputFormat) throws IOException {
-    outputFormat = outputFormat == null ? "JSON" : outputFormat;
-    String outputContent = null;
-    switch (outputFormat.toUpperCase()) {
-      case "CSV": outputContent = convertResultTableToCsv(brokerResponse.getResultTable()); break;
-      case "JSON":
+      String outputFormat) throws IOException, IllegalArgumentException {
+    OutputFormat format = outputFormat == null ? OutputFormat.JSON :
+        OutputFormat.valueOf(outputFormat.toUpperCase());
+    String outputContent;
+    switch (format) {
+      case CSV: outputContent = convertResultTableToCsv(brokerResponse.getResultTable()); break;
+      case JSON:
       default: outputContent = JsonUtils.objectToString(brokerResponse.getResultTable()); break;
     }
     Files.write(new File(outputPath).toPath(), outputContent.getBytes(StandardCharsets.UTF_8));

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/OutputFormatUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/OutputFormatUtils.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.utils;
+
+import com.google.common.base.Joiner;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.spi.utils.JsonUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
+public class OutputFormatUtils {
+  private static final Joiner CSV_JOINER = Joiner.on(',').skipNulls();
+
+  private OutputFormatUtils() {
+  }
+
+  private static String convertResultTableToCsv(ResultTable resultTable) {
+    StringBuilder sb = new StringBuilder();
+    sb.append(CSV_JOINER.join(resultTable.getDataSchema().getColumnNames()));
+    sb.append("\n");
+    for (Object[] rows : resultTable.getRows()) {
+      sb.append(CSV_JOINER.join(rows));
+      sb.append("\n");
+    }
+    return sb.toString();
+  }
+
+  public static void saveResponse(
+      BrokerResponseNative brokerResponse,
+      String outputPath,
+      String outputFormat) throws IOException {
+    outputFormat = outputFormat == null ? "JSON" : outputFormat;
+    String outputContent = null;
+    switch (outputFormat.toUpperCase()) {
+      case "CSV": outputContent = convertResultTableToCsv(brokerResponse.getResultTable()); break;
+      case "JSON":
+      default: outputContent = JsonUtils.objectToString(brokerResponse.getResultTable()); break;
+    }
+    Files.write(new File(outputPath).toPath(), outputContent.getBytes(StandardCharsets.UTF_8));
+  }
+}


### PR DESCRIPTION
## Description
This PR adds support to write query results to a file with JSON/CSV format. This should address 2 of the items in #6939: support output format and support write to file. 

Note: 
I've also tried implementing this option on PinotClientRequest and directly encode the BrokerResponse in the desired format. This might not be a good idea considering
1.  it is already in a very byte-wise efficient format (ResultTable)
2. it requires more API changes which creates additional longer-term maintenance cost
However it would be good to revisit once we decided to support compression algorithms, since it could potentially reduce the BrokerResponse size transfer over the wire.


Follow up TODOs
- [ ] Support other output writters (such as S3)
- [ ] Support other output format (via dynamic SPI loading? this meant it can also include user-defined compression algorithms) 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* NO

Does this PR fix a zero-downtime upgrade introduced earlier?
* NO

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options NO
- Deprecation of configurations NO
- Signature changes to public methods/interfaces YES
- New plugins added or old plugins removed NO

## Release Notes
- Added support for selecting output format and output path to local directory

## Documentation
Not documented, please advice which file to document this feature. 
