### PR TITLE
ignore query json parse errors

### DIFF
--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -209,7 +209,11 @@ const getTableSchemaData = (tableName) => {
 
 const getAsObject = (str: SQLResult) => {
   if (typeof str === 'string' || str instanceof String) {
-    return JSON.parse(JSON.stringify(str));
+    try {
+      return JSONbig.parse(str);
+    } catch(e) {
+      return JSON.parse(JSON.stringify(str));
+    }
   }
   return str;
 };
@@ -219,9 +223,7 @@ const getAsObject = (str: SQLResult) => {
 // Expected Output: {columns: [], records: []}
 const getQueryResults = (params, url, checkedOptions) => {
   return getQueryResult(params, url).then(({ data }) => {
-    data = JSONbig.parse(data);
     let queryResponse = null;
-
     queryResponse = getAsObject(data);
 
     // if sql api throws error, handle here
@@ -301,13 +303,13 @@ const getQueryResults = (params, url, checkedOptions) => {
       },
       queryStats: {
         columns: columnStats,
-        records: [[data.timeUsedMs, data.numDocsScanned, data.totalDocs, data.numServersQueried, data.numServersResponded,
-          data.numSegmentsQueried, data.numSegmentsProcessed, data.numSegmentsMatched, data.numConsumingSegmentsQueried,
-          data.numEntriesScannedInFilter, data.numEntriesScannedPostFilter, data.numGroupsLimitReached,
-          data.partialResponse ? data.partialResponse : '-', data.minConsumingFreshnessTimeMs,
-          data.offlineThreadCpuTimeNs, data.realtimeThreadCpuTimeNs]]
+        records: [[queryResponse.timeUsedMs, queryResponse.numDocsScanned, queryResponse.totalDocs, queryResponse.numServersQueried, queryResponse.numServersResponded,
+          queryResponse.numSegmentsQueried, queryResponse.numSegmentsProcessed, queryResponse.numSegmentsMatched, queryResponse.numConsumingSegmentsQueried,
+          queryResponse.numEntriesScannedInFilter, queryResponse.numEntriesScannedPostFilter, queryResponse.numGroupsLimitReached,
+          queryResponse.partialResponse ? queryResponse.partialResponse : '-', queryResponse.minConsumingFreshnessTimeMs,
+          queryResponse.offlineThreadCpuTimeNs, queryResponse.realtimeThreadCpuTimeNs]]
       },
-      data,
+      data: queryResponse,
     };
   });
 };


### PR DESCRIPTION
## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
This addresses the same issue as #7161 but offers a quick fix first rather than changing the backend response. #7120 added json-bigint parsing which fails on strings. Previously we would just return the string anyway which was handled further down in the code.

Unfortunately there's no test files here, so this is just tested by running the controller via quickstart locally. I sent it both working queries and failing queries, and they all return results in the UI now.
