### PR TITLE
Support get metadata and indexes API for REALTIME tables.

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -598,10 +598,6 @@ public class PinotSegmentRestletResource {
       @ApiParam(value = "Columns name", allowMultiple = true) @QueryParam("columns") @DefaultValue("") List<String> columns) {
     LOGGER.info("Received a request to fetch metadata for all segments for table {}", tableName);
     TableType tableType = Constants.validateTableType(tableTypeStr);
-    if (tableType == TableType.REALTIME) {
-      throw new ControllerApplicationException(LOGGER, "Table type : " + tableTypeStr + " not yet supported.",
-          Status.NOT_IMPLEMENTED);
-    }
 
     String tableNameWithType =
         ResourceUtils.getExistingTableNamesWithType(_pinotHelixResourceManager, tableName, tableType, LOGGER).get(0);

--- a/pinot-controller/src/main/resources/app/requests/index.ts
+++ b/pinot-controller/src/main/resources/app/requests/index.ts
@@ -133,7 +133,7 @@ export const reloadAllSegments = (tableName: string, tableType: string): Promise
   baseApi.post(`/segments/${tableName}/reload?type=${tableType}`, null, {headers});
 
 export const reloadStatus = (tableName: string, tableType: string): Promise<AxiosResponse<OperationResponse>> =>
-  baseApi.get(`/segments/${tableName}/metadata?type=${tableType}`);
+  baseApi.get(`/segments/${tableName}/metadata?type=${tableType}&columns=*`);
 
 export const deleteSegment = (tableName: string, instanceName: string): Promise<AxiosResponse<OperationResponse>> =>
   baseApi.delete(`/segments/${tableName}/${instanceName}`, {headers});

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -193,8 +193,4 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
       throw new RuntimeException("Failed to use PinotSegmentRecordReader to read immutable segment");
     }
   }
-
-  public Map<String, ColumnIndexContainer> getIndexContainerMap() {
-    return _indexContainerMap;
-  }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/SegmentMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/SegmentMetadataImpl.java
@@ -400,7 +400,7 @@ public class SegmentMetadataImpl implements SegmentMetadata {
       segmentMetadata.put("endTimeReadable", _timeInterval.getEnd().toString());
     }
 
-    segmentMetadata.put("segmentVersion", _segmentVersion.toString());
+    segmentMetadata.put("segmentVersion", ((_segmentVersion != null) ? _segmentVersion.toString() : null));
     segmentMetadata.put("creatorName", _creatorName);
 
     ObjectNode customConfigs = JsonUtils.newObjectNode();

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
@@ -117,15 +117,19 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertTrue(jsonResponse.has("endTimeReadable"));
     Assert.assertTrue(jsonResponse.has("creationTimeReadable"));
     Assert.assertEquals(jsonResponse.get("columns").size(), 0);
+    Assert.assertEquals(jsonResponse.get("indexes").size(), 0);
 
     jsonResponse = JsonUtils.stringToJsonNode(
         _webTarget.path(segmentMetadataPath).queryParam("columns", "column1").queryParam("columns", "column2").request()
             .get(String.class));
     Assert.assertEquals(jsonResponse.get("columns").size(), 2);
+    Assert.assertEquals(jsonResponse.get("indexes").size(), 2);
 
     jsonResponse = JsonUtils.stringToJsonNode(
         (_webTarget.path(segmentMetadataPath).queryParam("columns", "*").request().get(String.class)));
-    Assert.assertEquals(jsonResponse.get("columns").size(), segmentMetadata.getAllColumns().size());
+    int physicalColumnCount = defaultSegment.getPhysicalColumnNames().size();
+    Assert.assertEquals(jsonResponse.get("columns").size(), physicalColumnCount);
+    Assert.assertEquals(jsonResponse.get("indexes").size(), physicalColumnCount);
 
     Response response = _webTarget.path("/tables/UNKNOWN_TABLE/segments/" + defaultSegment.getSegmentName()).request()
         .get(Response.class);
@@ -264,18 +268,20 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertTrue(jsonResponse.has("endTimeReadable"));
     Assert.assertTrue(jsonResponse.has("creationTimeReadable"));
     Assert.assertEquals(jsonResponse.get("columns").size(), 0);
-    Assert.assertEquals(jsonResponse.get("indexes").size(), 17);
+    Assert.assertEquals(jsonResponse.get("indexes").size(), 0);
 
     jsonResponse = JsonUtils.stringToJsonNode(
         _webTarget.path(segmentMetadataPath).queryParam("columns", "column1").queryParam("columns", "column2").request()
             .get(String.class));
     Assert.assertEquals(jsonResponse.get("columns").size(), 2);
-    Assert.assertEquals(jsonResponse.get("indexes").size(), 17);
+    Assert.assertEquals(jsonResponse.get("indexes").size(), 2);
     Assert.assertEquals(jsonResponse.get("star-tree-index").size(), 0);
 
     jsonResponse = JsonUtils.stringToJsonNode(
         (_webTarget.path(segmentMetadataPath).queryParam("columns", "*").request().get(String.class)));
-    Assert.assertEquals(jsonResponse.get("columns").size(), segmentMetadata.getAllColumns().size());
+    int physicalColumnCount = defaultSegment.getPhysicalColumnNames().size();
+    Assert.assertEquals(jsonResponse.get("columns").size(), physicalColumnCount);
+    Assert.assertEquals(jsonResponse.get("indexes").size(), physicalColumnCount);
 
     Response response = _webTarget.path("/tables/UNKNOWN_TABLE/segments/" + defaultSegment.getSegmentName()).request()
         .get(Response.class);


### PR DESCRIPTION
## Description
- Used segment.getDataSource(columnName) API which is implemented for both Mutable and Immutable segments.
- Removed the exposed private data API for ImmutableSegment.

Sample output for a REALTIME table segment (truncated json output)
```
{
  "airlineStats__8__0__20210716T1729Z": {
    "segmentName": "airlineStats__8__0__20210716T1729Z",
    "schemaName": "airlineStats",
    "crc": -9223372036854776000,
    "creationTimeMillis": 1626456582715,
    "creationTimeReadable": "2021-07-16T17:29:42:715 UTC",
    "timeGranularitySec": null,
    "startTimeMillis": null,
    "startTimeReadable": null,
    "endTimeMillis": null,
    "endTimeReadable": null,
    "segmentVersion": null,
    "creatorName": null,
    "custom": {},
    "indexes": {
      "FlightNum": {
        "bloom-filter": "NO",
        "dictionary": "YES",
        "forward-index": "YES",
        "inverted-index": "NO",
        "null-value-vector-reader": "NO",
        "range-index": "NO",
        "json-index": "NO"
      },
      "Origin": {
        "bloom-filter": "NO",
        "dictionary": "YES",
        "forward-index": "YES",
        "inverted-index": "NO",
        "null-value-vector-reader": "NO",
        "range-index": "NO",
        "json-index": "NO"
      },
      "Quarter": {
        "bloom-filter": "NO",
        "dictionary": "YES",
        "forward-index": "YES",
        "inverted-index": "NO",
        "null-value-vector-reader": "NO",
        "range-index": "NO",
        "json-index": "NO"
      },
    },
    "star-tree-index": null
  }
}
```
 
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
