### PR TITLE
Add additionalMatchLabels to helm chart.

### DIFF
--- a/kubernetes/helm/pinot/templates/_helpers.tpl
+++ b/kubernetes/helm/pinot/templates/_helpers.tpl
@@ -55,8 +55,10 @@ Match Selector labels
 */}}
 {{- define "pinot.matchLabels" -}}
 app: {{ include "pinot.name" . }}
-chart: {{ include "pinot.chart" . }}
 release: {{ .Release.Name }}
+{{- range $key, $value := .Values.additionalMatchLabels }}
+{{ $key }}: {{ $value }}
+{{- end }}
 {{- end }}
 
 {{/*

--- a/kubernetes/helm/pinot/values.yaml
+++ b/kubernetes/helm/pinot/values.yaml
@@ -52,6 +52,8 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+additionalMatchLabels: {}
+
 # ------------------------------------------------------------------------------
 # Pinot Controller:
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Description
Adds `additionalMatchLabels` to the helm values to allow customization of the StatefulSets matchLabels. This configuration will allow for a safe upgrade from chart version 0.2.3 -> 0.2.5 as-is, but also allow for safe upgrades from 0.2.4 -> 0.2.5 with the addition of a `additionalMatchLabels` option.

Resolves issue: https://github.com/apache/incubator-pinot/issues/7176

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [x] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [x] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
This PR adds a `additionalMatchLabels` option to customize the StatefulSet match labels. This can be used to maintain multiple StatefulSets within the same kubernetes namespace or to simply maintain tighter control over the  associated match labels. Special consideration should be taken when using the `additionalMatchLabels` option as is can break backwards compatibility.

If upgrading from chart version <0.2.3 then no additional configuration is needed.

If upgrading from chart verion 0.2.4 then the following option needs to be added to `values.yaml` to upgrade with zero-downtime.
```
additionalMatchLabels:
  chart: pinot-0.2.4
```

<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
