### PR TITLE
Fixed pinot java client to add zkClient close

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerSelector.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerSelector.java
@@ -25,4 +25,9 @@ public interface BrokerSelector {
    * @return
    */
   String selectBroker(String table);
+
+  /**
+   * Close any resources
+   */
+  void close();
 }

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
@@ -182,6 +182,7 @@ public class Connection {
   public void close()
       throws PinotClientException {
     _transport.close();
+    _brokerSelector.close();
   }
 
   private static class ResultSetGroupFuture implements Future<ResultSetGroup> {

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/SimpleBrokerSelector.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/SimpleBrokerSelector.java
@@ -39,4 +39,8 @@ public class SimpleBrokerSelector implements BrokerSelector {
   public String selectBroker(String table) {
     return _brokerList.get(_random.nextInt(_brokerList.size()));
   }
+
+  @Override
+  public void close() {
+  }
 }


### PR DESCRIPTION
## Description
Fixed the issue where zkClient connection was not being closed in pinot java client's connection close


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
