### PR TITLE
Fix the config key for TASK_MANAGER_FREQUENCY_PERIOD

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -117,7 +117,7 @@ public class ControllerConf extends PinotConfiguration {
     // Deprecated as of 0.8.0
     @Deprecated
     public static final String DEPRECATED_TASK_MANAGER_FREQUENCY_IN_SECONDS = "controller.task.frequencyInSeconds";
-    public static final String TASK_MANAGER_FREQUENCY_PERIOD = "controller.statuschecker.waitForPushTimePeriod";
+    public static final String TASK_MANAGER_FREQUENCY_PERIOD = "controller.task.frequencyPeriod";
     // Deprecated as of 0.8.0
     @Deprecated
     public static final String DEPRECATED_MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS =
@@ -182,7 +182,7 @@ public class ControllerConf extends PinotConfiguration {
     }
 
     // Default values
-    private static final int DEFAULT_RETENTION_CONTROLLER_FREQUENCY_IN_SECONDS = 6 * 60 * 60; // 6 Hours.
+    private static final int DEFAULT_RETENTION_MANAGER_FREQUENCY_IN_SECONDS = 6 * 60 * 60; // 6 Hours.
     private static final int DEFAULT_OFFLINE_SEGMENT_INTERVAL_CHECKER_FREQUENCY_IN_SECONDS = 24 * 60 * 60; // 24 Hours.
     private static final int DEFAULT_REALTIME_SEGMENT_VALIDATION_FREQUENCY_IN_SECONDS = 60 * 60; // 1 Hour.
     private static final int DEFAULT_BROKER_RESOURCE_VALIDATION_FREQUENCY_IN_SECONDS = 60 * 60; // 1 Hour.
@@ -465,7 +465,7 @@ public class ControllerConf extends PinotConfiguration {
     return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.RETENTION_MANAGER_FREQUENCY_PERIOD))
         .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(
             () -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_RETENTION_MANAGER_FREQUENCY_IN_SECONDS,
-                ControllerPeriodicTasksConf.DEFAULT_RETENTION_CONTROLLER_FREQUENCY_IN_SECONDS));
+                ControllerPeriodicTasksConf.DEFAULT_RETENTION_MANAGER_FREQUENCY_IN_SECONDS));
   }
 
   public void setRetentionControllerFrequencyInSeconds(int retentionFrequencyInSeconds) {
@@ -633,14 +633,10 @@ public class ControllerConf extends PinotConfiguration {
   }
 
   public int getTaskManagerFrequencyInSeconds() {
-    return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.TASK_MANAGER_FREQUENCY_PERIOD)).map(period -> {
-      //check if DEFAULT_TASK_MANAGER_FREQUENCY_IN_SECONDS is supplied. If yes, return it
-      if (period.equals(Integer.toString(ControllerPeriodicTasksConf.DEFAULT_TASK_MANAGER_FREQUENCY_IN_SECONDS))) {
-        return ControllerPeriodicTasksConf.DEFAULT_TASK_MANAGER_FREQUENCY_IN_SECONDS;
-      }
-      return (int) convertPeriodToSeconds(period);
-    }).orElseGet(() -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_TASK_MANAGER_FREQUENCY_IN_SECONDS,
-        ControllerPeriodicTasksConf.DEFAULT_TASK_MANAGER_FREQUENCY_IN_SECONDS));
+    return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.TASK_MANAGER_FREQUENCY_PERIOD))
+        .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(
+            () -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_TASK_MANAGER_FREQUENCY_IN_SECONDS,
+                ControllerPeriodicTasksConf.DEFAULT_TASK_MANAGER_FREQUENCY_IN_SECONDS));
   }
 
   public void setTaskManagerFrequencyInSeconds(int frequencyInSeconds) {
@@ -648,11 +644,11 @@ public class ControllerConf extends PinotConfiguration {
         Integer.toString(frequencyInSeconds));
   }
 
-  public long getMinionInstancesCleanupTaskFrequencyInSeconds() {
+  public int getMinionInstancesCleanupTaskFrequencyInSeconds() {
     return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_PERIOD))
-        .map(this::convertPeriodToSeconds).orElseGet(() -> (long) getProperty(
-            ControllerPeriodicTasksConf.DEPRECATED_MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS,
-            ControllerPeriodicTasksConf.DEFAULT_MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS));
+        .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(
+            () -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS,
+                ControllerPeriodicTasksConf.DEFAULT_MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS));
   }
 
   public void setMinionInstancesCleanupTaskFrequencyInSeconds(int frequencyInSeconds) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
@@ -144,10 +144,18 @@ public class ControllerConfTest {
   @Test
   public void shouldBeAbleToDisableUsingNewConfig() {
     Map<String, Object> controllerConfig = new HashMap<>();
-    controllerConfig.put(TASK_MANAGER_FREQUENCY_PERIOD, "-1");
     ControllerConf conf = new ControllerConf(controllerConfig);
-    int taskManagerFrequencyInSeconds = conf.getTaskManagerFrequencyInSeconds();
-    Assert.assertEquals(taskManagerFrequencyInSeconds, -1);
+    Assert.assertEquals(conf.getTaskManagerFrequencyInSeconds(), -1);
+
+    controllerConfig = new HashMap<>();
+    controllerConfig.put(TASK_MANAGER_FREQUENCY_PERIOD, "0s");
+    conf = new ControllerConf(controllerConfig);
+    Assert.assertEquals(conf.getTaskManagerFrequencyInSeconds(), 0);
+
+    controllerConfig = new HashMap<>();
+    controllerConfig.put(TASK_MANAGER_FREQUENCY_PERIOD, "-1s");
+    conf = new ControllerConf(controllerConfig);
+    Assert.assertEquals(conf.getTaskManagerFrequencyInSeconds(), -1);
   }
 
   private void assertOnDurations(ControllerConf conf, long expectedDuration, Map<String, Object> controllerConfig) {


### PR DESCRIPTION
## Description
- Fix the config key for TASK_MANAGER_FREQUENCY_PERIOD `controller.task.frequencyPeriod`
- Do not specialize `-1` for TASK_MANAGER_FREQUENCY_PERIOD. To disable a periodic task, put a non-positive period (e.g. `0s`, `-1s`)