### PR TITLE
Allow any column as the upsert comparison column

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -246,7 +246,7 @@ public class TableConfigSerDeTest {
     }
     {
       // with upsert config
-      UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL, null);
+      UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL, null, "comparison");
 
       TableConfig tableConfig = tableConfigBuilder.setUpsertConfig(upsertConfig).build();
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotResourceManagerTest.java
@@ -50,7 +50,8 @@ public class PinotResourceManagerTest {
   private static final String PARTITION_COLUMN = "Partition_Column";
 
   @BeforeClass
-  public void setUp() throws Exception {
+  public void setUp()
+      throws Exception {
     ControllerTestUtils.setupClusterAndValidate();
 
     // Adding an offline table
@@ -61,12 +62,13 @@ public class PinotResourceManagerTest {
     Schema dummySchema = ControllerTestUtils.createDummySchema(REALTIME_TABLE_NAME);
     ControllerTestUtils.addSchema(dummySchema);
     Map<String, String> streamConfigs = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap();
-    TableConfig realtimeTableConfig = new TableConfigBuilder(TableType.REALTIME).setStreamConfigs(streamConfigs).
-        setTableName(REALTIME_TABLE_NAME).setSchemaName(dummySchema.getSchemaName()).build();
+    TableConfig realtimeTableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setStreamConfigs(streamConfigs).setTableName(REALTIME_TABLE_NAME)
+            .setSchemaName(dummySchema.getSchemaName()).build();
     realtimeTableConfig.getValidationConfig().setReplicasPerPartition(NUM_REPLICAS_STRING);
     realtimeTableConfig.getValidationConfig()
         .setReplicaGroupStrategyConfig(new ReplicaGroupStrategyConfig(PARTITION_COLUMN, 1));
-    realtimeTableConfig.setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL, null));
+    realtimeTableConfig.setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL, null, null));
     ControllerTestUtils.getHelixResourceManager().addTable(realtimeTableConfig);
   }
 
@@ -76,22 +78,22 @@ public class PinotResourceManagerTest {
     segmentZKMetadata.setSegmentName("testSegment");
 
     // Segment ZK metadata does not exist
-    Assert.assertFalse(
-        ControllerTestUtils.getHelixResourceManager().updateZkMetadata(OFFLINE_TABLE_NAME + "_OFFLINE", segmentZKMetadata, 0));
+    Assert.assertFalse(ControllerTestUtils.getHelixResourceManager()
+        .updateZkMetadata(OFFLINE_TABLE_NAME + "_OFFLINE", segmentZKMetadata, 0));
 
     // Set segment ZK metadata
-    Assert.assertTrue(
-        ControllerTestUtils.getHelixResourceManager().updateZkMetadata(OFFLINE_TABLE_NAME + "_OFFLINE", segmentZKMetadata));
+    Assert.assertTrue(ControllerTestUtils.getHelixResourceManager()
+        .updateZkMetadata(OFFLINE_TABLE_NAME + "_OFFLINE", segmentZKMetadata));
 
     // Update ZK metadata
-    Assert.assertEquals(
-        ControllerTestUtils.getHelixResourceManager().getSegmentMetadataZnRecord(OFFLINE_TABLE_NAME + "_OFFLINE", "testSegment").getVersion(), 0);
-    Assert.assertTrue(
-        ControllerTestUtils.getHelixResourceManager().updateZkMetadata(OFFLINE_TABLE_NAME + "_OFFLINE", segmentZKMetadata, 0));
-    Assert.assertEquals(
-        ControllerTestUtils.getHelixResourceManager().getSegmentMetadataZnRecord(OFFLINE_TABLE_NAME + "_OFFLINE", "testSegment").getVersion(), 1);
-    Assert.assertFalse(
-        ControllerTestUtils.getHelixResourceManager().updateZkMetadata(OFFLINE_TABLE_NAME + "_OFFLINE", segmentZKMetadata, 0));
+    Assert.assertEquals(ControllerTestUtils.getHelixResourceManager()
+        .getSegmentMetadataZnRecord(OFFLINE_TABLE_NAME + "_OFFLINE", "testSegment").getVersion(), 0);
+    Assert.assertTrue(ControllerTestUtils.getHelixResourceManager()
+        .updateZkMetadata(OFFLINE_TABLE_NAME + "_OFFLINE", segmentZKMetadata, 0));
+    Assert.assertEquals(ControllerTestUtils.getHelixResourceManager()
+        .getSegmentMetadataZnRecord(OFFLINE_TABLE_NAME + "_OFFLINE", "testSegment").getVersion(), 1);
+    Assert.assertFalse(ControllerTestUtils.getHelixResourceManager()
+        .updateZkMetadata(OFFLINE_TABLE_NAME + "_OFFLINE", segmentZKMetadata, 0));
   }
 
   /**
@@ -103,25 +105,26 @@ public class PinotResourceManagerTest {
    */
 
   @Test
-  public void testBasicAndConcurrentAddingAndDeletingSegments() throws Exception {
+  public void testBasicAndConcurrentAddingAndDeletingSegments()
+      throws Exception {
     final String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(OFFLINE_TABLE_NAME);
 
     // Basic add/delete case
     for (int i = 1; i <= 2; i++) {
-      ControllerTestUtils.getHelixResourceManager().addNewSegment(
-          OFFLINE_TABLE_NAME, SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME),
-          "downloadUrl");
+      ControllerTestUtils.getHelixResourceManager()
+          .addNewSegment(OFFLINE_TABLE_NAME, SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME),
+              "downloadUrl");
     }
-    IdealState idealState = ControllerTestUtils
-        .getHelixAdmin().getResourceIdealState(ControllerTestUtils.getHelixClusterName(), offlineTableName);
+    IdealState idealState = ControllerTestUtils.getHelixAdmin()
+        .getResourceIdealState(ControllerTestUtils.getHelixClusterName(), offlineTableName);
     Set<String> segments = idealState.getPartitionSet();
     Assert.assertEquals(segments.size(), 2);
 
     for (String segmentName : segments) {
       ControllerTestUtils.getHelixResourceManager().deleteSegment(offlineTableName, segmentName);
     }
-    idealState = ControllerTestUtils
-        .getHelixAdmin().getResourceIdealState(ControllerTestUtils.getHelixClusterName(), offlineTableName);
+    idealState = ControllerTestUtils.getHelixAdmin()
+        .getResourceIdealState(ControllerTestUtils.getHelixClusterName(), offlineTableName);
     Assert.assertEquals(idealState.getPartitionSet().size(), 0);
 
     // Concurrent segment deletion
@@ -131,8 +134,9 @@ public class PinotResourceManagerTest {
         @Override
         public void run() {
           for (int i = 0; i < 10; i++) {
-            ControllerTestUtils.getHelixResourceManager().addNewSegment(OFFLINE_TABLE_NAME,
-                SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME), "downloadUrl");
+            ControllerTestUtils.getHelixResourceManager()
+                .addNewSegment(OFFLINE_TABLE_NAME, SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME),
+                    "downloadUrl");
           }
         }
       });
@@ -140,8 +144,8 @@ public class PinotResourceManagerTest {
     addSegmentExecutor.shutdown();
     addSegmentExecutor.awaitTermination(1, TimeUnit.MINUTES);
 
-    idealState = ControllerTestUtils
-        .getHelixAdmin().getResourceIdealState(ControllerTestUtils.getHelixClusterName(), offlineTableName);
+    idealState = ControllerTestUtils.getHelixAdmin()
+        .getResourceIdealState(ControllerTestUtils.getHelixClusterName(), offlineTableName);
     Assert.assertEquals(idealState.getPartitionSet().size(), 30);
 
     ExecutorService deleteSegmentExecutor = Executors.newFixedThreadPool(3);
@@ -156,8 +160,8 @@ public class PinotResourceManagerTest {
     deleteSegmentExecutor.shutdown();
     deleteSegmentExecutor.awaitTermination(1, TimeUnit.MINUTES);
 
-    idealState = ControllerTestUtils
-        .getHelixAdmin().getResourceIdealState(ControllerTestUtils.getHelixClusterName(), offlineTableName);
+    idealState = ControllerTestUtils.getHelixAdmin()
+        .getResourceIdealState(ControllerTestUtils.getHelixClusterName(), offlineTableName);
     Assert.assertEquals(idealState.getPartitionSet().size(), 0);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1259,7 +1259,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
             .setStatsHistory(realtimeTableDataManager.getStatsHistory())
             .setAggregateMetrics(indexingConfig.isAggregateMetrics()).setNullHandlingEnabled(_nullHandlingEnabled)
             .setConsumerDir(consumerDir).setUpsertMode(tableConfig.getUpsertMode())
-            .setPartitionUpsertMetadataManager(partitionUpsertMetadataManager);
+            .setPartitionUpsertMetadataManager(partitionUpsertMetadataManager)
+            .setUpsertComparisonColumn(tableConfig.getUpsertComparisonColumn());
 
     // Create message decoder
     Set<String> fieldsToRead = IngestionUtils.getFieldsForRecordExtractor(_tableConfig.getIngestionConfig(), _schema);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -62,7 +62,6 @@ import org.apache.pinot.segment.local.segment.virtualcolumn.VirtualColumnProvide
 import org.apache.pinot.segment.local.upsert.PartialUpsertHandler;
 import org.apache.pinot.segment.local.upsert.PartitionUpsertMetadataManager;
 import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManager;
-import org.apache.pinot.segment.local.utils.IngestionUtils;
 import org.apache.pinot.segment.local.utils.SchemaUtils;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.index.ThreadSafeMutableRoaringBitmap;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -409,7 +409,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
             PrimaryKey primaryKey = new PrimaryKey(values);
             Object timeValue = columnToReaderMap.get(_upsertComparisonColumn).getValue(_docId);
             Preconditions.checkArgument(timeValue instanceof Comparable, "time column shall be comparable");
-            long timestamp = IngestionUtils.extractTimeValue((Comparable) timeValue);
+            Comparable timestamp = IngestionUtils.extractTimeValueIfPossible((Comparable) timeValue);
             return new PartitionUpsertMetadataManager.RecordInfo(primaryKey, _docId++, timestamp);
           }
         };

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -115,7 +115,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   private UpsertConfig.Mode _upsertMode;
   private TableUpsertMetadataManager _tableUpsertMetadataManager;
   private List<String> _primaryKeyColumns;
-  private String _timeColumnName;
+  private String _upsertComparisonColumn;
 
   public RealtimeTableDataManager(Semaphore segmentBuildSemaphore) {
     _segmentBuildSemaphore = segmentBuildSemaphore;
@@ -174,7 +174,9 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       _primaryKeyColumns = schema.getPrimaryKeyColumns();
       Preconditions.checkState(!CollectionUtils.isEmpty(_primaryKeyColumns),
           "Primary key columns must be configured for upsert");
-      _timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
+      String comparisonColumn = upsertConfig.getComparisonColumn();
+      _upsertComparisonColumn =
+          comparisonColumn != null ? comparisonColumn : tableConfig.getValidationConfig().getTimeColumnName();
     }
 
     if (consumerDir.exists()) {
@@ -381,7 +383,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     for (String primaryKeyColumn : _primaryKeyColumns) {
       columnToReaderMap.put(primaryKeyColumn, new PinotSegmentColumnReader(immutableSegment, primaryKeyColumn));
     }
-    columnToReaderMap.put(_timeColumnName, new PinotSegmentColumnReader(immutableSegment, _timeColumnName));
+    columnToReaderMap
+        .put(_upsertComparisonColumn, new PinotSegmentColumnReader(immutableSegment, _upsertComparisonColumn));
     int numTotalDocs = immutableSegment.getSegmentMetadata().getTotalDocs();
     int numPrimaryKeyColumns = _primaryKeyColumns.size();
     Iterator<PartitionUpsertMetadataManager.RecordInfo> recordInfoIterator =
@@ -404,7 +407,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
               values[i] = value;
             }
             PrimaryKey primaryKey = new PrimaryKey(values);
-            Object timeValue = columnToReaderMap.get(_timeColumnName).getValue(_docId);
+            Object timeValue = columnToReaderMap.get(_upsertComparisonColumn).getValue(_docId);
             Preconditions.checkArgument(timeValue instanceof Comparable, "time column shall be comparable");
             long timestamp = IngestionUtils.extractTimeValue((Comparable) timeValue);
             return new PartitionUpsertMetadataManager.RecordInfo(primaryKey, _docId++, timestamp);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -407,10 +407,10 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
               values[i] = value;
             }
             PrimaryKey primaryKey = new PrimaryKey(values);
-            Object timeValue = columnToReaderMap.get(_upsertComparisonColumn).getValue(_docId);
-            Preconditions.checkArgument(timeValue instanceof Comparable, "time column shall be comparable");
-            Comparable timestamp = IngestionUtils.extractTimeValueIfPossible((Comparable) timeValue);
-            return new PartitionUpsertMetadataManager.RecordInfo(primaryKey, _docId++, timestamp);
+            Object upsertComparisonValue = columnToReaderMap.get(_upsertComparisonColumn).getValue(_docId);
+            Preconditions.checkArgument(upsertComparisonValue instanceof Comparable, "time column shall be comparable");
+            return new PartitionUpsertMetadataManager.RecordInfo(primaryKey, _docId++,
+                (Comparable) upsertComparisonValue);
           }
         };
     partitionUpsertMetadataManager.addSegment(immutableSegment, recordInfoIterator);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -407,7 +407,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
             }
             PrimaryKey primaryKey = new PrimaryKey(values);
             Object upsertComparisonValue = columnToReaderMap.get(_upsertComparisonColumn).getValue(_docId);
-            Preconditions.checkArgument(upsertComparisonValue instanceof Comparable, "time column shall be comparable");
+            Preconditions.checkState(upsertComparisonValue instanceof Comparable,
+                "Upsert comparison column: %s must be comparable", _upsertComparisonColumn);
             return new PartitionUpsertMetadataManager.RecordInfo(primaryKey, _docId++,
                 (Comparable) upsertComparisonValue);
           }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -386,7 +386,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
         .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
         .setSegmentPartitionConfig(new SegmentPartitionConfig(columnPartitionConfigMap))
         .setReplicaGroupStrategyConfig(new ReplicaGroupStrategyConfig(primaryKeyColumn, 1))
-        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL, null)).build();
+        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL, null, null)).build();
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -514,7 +514,7 @@ public class MutableSegmentImpl implements MutableSegment {
     Object timeValue = row.getValue(_upsertComparisonColumn);
     Preconditions.checkArgument(timeValue instanceof Comparable,
         String.format("column %s shall be comparable", _upsertComparisonColumn));
-    long timestamp = IngestionUtils.extractTimeValue((Comparable) timeValue);
+    Comparable timestamp = IngestionUtils.extractTimeValueIfPossible((Comparable) timeValue);
     return _partitionUpsertMetadataManager
         .updateRecord(this, new PartitionUpsertMetadataManager.RecordInfo(primaryKey, docId, timestamp), row);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -512,8 +512,8 @@ public class MutableSegmentImpl implements MutableSegment {
   private GenericRow handleUpsert(GenericRow row, int docId) {
     PrimaryKey primaryKey = row.getPrimaryKey(_schema.getPrimaryKeyColumns());
     Object upsertComparisonValue = row.getValue(_upsertComparisonColumn);
-    Preconditions.checkArgument(upsertComparisonValue instanceof Comparable,
-        String.format("column %s shall be comparable", _upsertComparisonColumn));
+    Preconditions.checkState(upsertComparisonValue instanceof Comparable,
+        "Upsert comparison column: %s must be comparable", _upsertComparisonColumn);
     return _partitionUpsertMetadataManager.updateRecord(this,
         new PartitionUpsertMetadataManager.RecordInfo(primaryKey, docId, (Comparable) upsertComparisonValue), row);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -511,12 +511,11 @@ public class MutableSegmentImpl implements MutableSegment {
 
   private GenericRow handleUpsert(GenericRow row, int docId) {
     PrimaryKey primaryKey = row.getPrimaryKey(_schema.getPrimaryKeyColumns());
-    Object timeValue = row.getValue(_upsertComparisonColumn);
-    Preconditions.checkArgument(timeValue instanceof Comparable,
+    Object upsertComparisonValue = row.getValue(_upsertComparisonColumn);
+    Preconditions.checkArgument(upsertComparisonValue instanceof Comparable,
         String.format("column %s shall be comparable", _upsertComparisonColumn));
-    Comparable timestamp = IngestionUtils.extractTimeValueIfPossible((Comparable) timeValue);
-    return _partitionUpsertMetadataManager
-        .updateRecord(this, new PartitionUpsertMetadataManager.RecordInfo(primaryKey, docId, timestamp), row);
+    return _partitionUpsertMetadataManager.updateRecord(this,
+        new PartitionUpsertMetadataManager.RecordInfo(primaryKey, docId, (Comparable) upsertComparisonValue), row);
   }
 
   private void updateDictionary(GenericRow row) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -150,6 +150,7 @@ public class MutableSegmentImpl implements MutableSegment {
   private final Map<String, FieldSpec> _newlyAddedPhysicalColumnsFieldMap = new ConcurrentHashMap();
 
   private final UpsertConfig.Mode _upsertMode;
+  private final String _upsertComparisonColumn;
   private final PartitionUpsertMetadataManager _partitionUpsertMetadataManager;
   // The valid doc ids are maintained locally instead of in the upsert metadata manager because:
   // 1. There is only one consuming segment per partition, the committed segments do not need to modify the valid doc
@@ -371,9 +372,12 @@ public class MutableSegmentImpl implements MutableSegment {
       Preconditions.checkState(!_aggregateMetrics, "Metrics aggregation and upsert cannot be enabled together");
       _partitionUpsertMetadataManager = config.getPartitionUpsertMetadataManager();
       _validDocIds = new ThreadSafeMutableRoaringBitmap();
+      String upsertComparisonColumn = config.getUpsertComparisonColumn();
+      _upsertComparisonColumn = upsertComparisonColumn != null ? upsertComparisonColumn : _timeColumnName;
     } else {
       _partitionUpsertMetadataManager = null;
       _validDocIds = null;
+      _upsertComparisonColumn = null;
     }
   }
 
@@ -507,8 +511,9 @@ public class MutableSegmentImpl implements MutableSegment {
 
   private GenericRow handleUpsert(GenericRow row, int docId) {
     PrimaryKey primaryKey = row.getPrimaryKey(_schema.getPrimaryKeyColumns());
-    Object timeValue = row.getValue(_timeColumnName);
-    Preconditions.checkArgument(timeValue instanceof Comparable, "time column shall be comparable");
+    Object timeValue = row.getValue(_upsertComparisonColumn);
+    Preconditions.checkArgument(timeValue instanceof Comparable,
+        String.format("column %s shall be comparable", _upsertComparisonColumn));
     long timestamp = IngestionUtils.extractTimeValue((Comparable) timeValue);
     return _partitionUpsertMetadataManager
         .updateRecord(this, new PartitionUpsertMetadataManager.RecordInfo(primaryKey, docId, timestamp), row);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentConfig.java
@@ -69,8 +69,8 @@ public class RealtimeSegmentConfig {
       RealtimeSegmentZKMetadata realtimeSegmentZKMetadata, boolean offHeap, PinotDataBufferMemoryManager memoryManager,
       RealtimeSegmentStatsHistory statsHistory, String partitionColumn, PartitionFunction partitionFunction,
       int partitionId, boolean aggregateMetrics, boolean nullHandlingEnabled, String consumerDir,
-      UpsertConfig.Mode upsertMode, PartitionUpsertMetadataManager partitionUpsertMetadataManager,
-      String upsertComparisonColumn) {
+      UpsertConfig.Mode upsertMode, String upsertComparisonColumn,
+      PartitionUpsertMetadataManager partitionUpsertMetadataManager) {
     _tableNameWithType = tableNameWithType;
     _segmentName = segmentName;
     _streamName = streamName;
@@ -239,8 +239,8 @@ public class RealtimeSegmentConfig {
     private boolean _nullHandlingEnabled = false;
     private String _consumerDir;
     private UpsertConfig.Mode _upsertMode;
-    private PartitionUpsertMetadataManager _partitionUpsertMetadataManager;
     private String _upsertComparisonColumn;
+    private PartitionUpsertMetadataManager _partitionUpsertMetadataManager;
 
     public Builder() {
     }
@@ -378,13 +378,13 @@ public class RealtimeSegmentConfig {
       return this;
     }
 
-    public Builder setPartitionUpsertMetadataManager(PartitionUpsertMetadataManager partitionUpsertMetadataManager) {
-      _partitionUpsertMetadataManager = partitionUpsertMetadataManager;
-      return this;
-    }
-
     public Builder setUpsertComparisonColumn(String upsertComparisonColumn) {
       _upsertComparisonColumn = upsertComparisonColumn;
+      return this;
+    }
+    
+    public Builder setPartitionUpsertMetadataManager(PartitionUpsertMetadataManager partitionUpsertMetadataManager) {
+      _partitionUpsertMetadataManager = partitionUpsertMetadataManager;
       return this;
     }
 
@@ -393,7 +393,7 @@ public class RealtimeSegmentConfig {
           _capacity, _avgNumMultiValues, _noDictionaryColumns, _varLengthDictionaryColumns, _invertedIndexColumns,
           _textIndexColumns, _fstIndexColumns, _jsonIndexColumns, _h3IndexConfigs, _realtimeSegmentZKMetadata, _offHeap,
           _memoryManager, _statsHistory, _partitionColumn, _partitionFunction, _partitionId, _aggregateMetrics,
-          _nullHandlingEnabled, _consumerDir, _upsertMode, _partitionUpsertMetadataManager, _upsertComparisonColumn);
+          _nullHandlingEnabled, _consumerDir, _upsertMode, _upsertComparisonColumn, _partitionUpsertMetadataManager);
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentConfig.java
@@ -57,6 +57,7 @@ public class RealtimeSegmentConfig {
   private final boolean _aggregateMetrics;
   private final boolean _nullHandlingEnabled;
   private final UpsertConfig.Mode _upsertMode;
+  private final String _upsertComparisonColumn;
   private final PartitionUpsertMetadataManager _partitionUpsertMetadataManager;
   private final String _consumerDir;
 
@@ -68,7 +69,8 @@ public class RealtimeSegmentConfig {
       RealtimeSegmentZKMetadata realtimeSegmentZKMetadata, boolean offHeap, PinotDataBufferMemoryManager memoryManager,
       RealtimeSegmentStatsHistory statsHistory, String partitionColumn, PartitionFunction partitionFunction,
       int partitionId, boolean aggregateMetrics, boolean nullHandlingEnabled, String consumerDir,
-      UpsertConfig.Mode upsertMode, PartitionUpsertMetadataManager partitionUpsertMetadataManager) {
+      UpsertConfig.Mode upsertMode, PartitionUpsertMetadataManager partitionUpsertMetadataManager,
+      String upsertComparisonColumn) {
     _tableNameWithType = tableNameWithType;
     _segmentName = segmentName;
     _streamName = streamName;
@@ -94,6 +96,7 @@ public class RealtimeSegmentConfig {
     _nullHandlingEnabled = nullHandlingEnabled;
     _consumerDir = consumerDir;
     _upsertMode = upsertMode != null ? upsertMode : UpsertConfig.Mode.NONE;
+    _upsertComparisonColumn = upsertComparisonColumn;
     _partitionUpsertMetadataManager = partitionUpsertMetadataManager;
   }
 
@@ -202,6 +205,10 @@ public class RealtimeSegmentConfig {
     return _upsertMode;
   }
 
+  public String getUpsertComparisonColumn() {
+    return _upsertComparisonColumn;
+  }
+
   public PartitionUpsertMetadataManager getPartitionUpsertMetadataManager() {
     return _partitionUpsertMetadataManager;
   }
@@ -233,6 +240,7 @@ public class RealtimeSegmentConfig {
     private String _consumerDir;
     private UpsertConfig.Mode _upsertMode;
     private PartitionUpsertMetadataManager _partitionUpsertMetadataManager;
+    private String _upsertComparisonColumn;
 
     public Builder() {
     }
@@ -375,12 +383,17 @@ public class RealtimeSegmentConfig {
       return this;
     }
 
+    public Builder setUpsertComparisonColumn(String upsertComparisonColumn) {
+      _upsertComparisonColumn = upsertComparisonColumn;
+      return this;
+    }
+
     public RealtimeSegmentConfig build() {
       return new RealtimeSegmentConfig(_tableNameWithType, _segmentName, _streamName, _schema, _timeColumnName,
           _capacity, _avgNumMultiValues, _noDictionaryColumns, _varLengthDictionaryColumns, _invertedIndexColumns,
           _textIndexColumns, _fstIndexColumns, _jsonIndexColumns, _h3IndexConfigs, _realtimeSegmentZKMetadata, _offHeap,
           _memoryManager, _statsHistory, _partitionColumn, _partitionFunction, _partitionId, _aggregateMetrics,
-          _nullHandlingEnabled, _consumerDir, _upsertMode, _partitionUpsertMetadataManager);
+          _nullHandlingEnabled, _consumerDir, _upsertMode, _partitionUpsertMetadataManager, _upsertComparisonColumn);
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
@@ -102,10 +102,10 @@ public class PartitionUpsertMetadataManager {
           // will return records with incremental doc ids.
           IndexSegment currentSegment = currentRecordLocation.getSegment();
           if (segment == currentSegment) {
-            if (recordInfo._timestamp.compareTo(currentRecordLocation.getTimestamp()) >= 0) {
+            if (recordInfo._comparisonValue.compareTo(currentRecordLocation.getComparisonValue()) >= 0) {
               validDocIds.remove(currentRecordLocation.getDocId());
               validDocIds.add(recordInfo._docId);
-              return new RecordLocation(segment, recordInfo._docId, recordInfo._timestamp);
+              return new RecordLocation(segment, recordInfo._docId, recordInfo._comparisonValue);
             } else {
               return currentRecordLocation;
             }
@@ -118,9 +118,9 @@ public class PartitionUpsertMetadataManager {
           // segment because it has not been replaced yet.
           String currentSegmentName = currentSegment.getSegmentName();
           if (segmentName.equals(currentSegmentName)) {
-            if (recordInfo._timestamp.compareTo(currentRecordLocation.getTimestamp()) >= 0) {
+            if (recordInfo._comparisonValue.compareTo(currentRecordLocation.getComparisonValue()) >= 0) {
               validDocIds.add(recordInfo._docId);
-              return new RecordLocation(segment, recordInfo._docId, recordInfo._timestamp);
+              return new RecordLocation(segment, recordInfo._docId, recordInfo._comparisonValue);
             } else {
               return currentRecordLocation;
             }
@@ -129,8 +129,8 @@ public class PartitionUpsertMetadataManager {
           // The current record is in a different segment
           // Update the record location when getting a newer timestamp, or the timestamp is the same as the current
           // timestamp, but the segment has a larger sequence number (the segment is newer than the current segment).
-          if (recordInfo._timestamp.compareTo(currentRecordLocation.getTimestamp()) > 0 || (
-              recordInfo._timestamp == currentRecordLocation.getTimestamp() && LLCSegmentName
+          if (recordInfo._comparisonValue.compareTo(currentRecordLocation.getComparisonValue()) > 0 || (
+              recordInfo._comparisonValue == currentRecordLocation.getComparisonValue() && LLCSegmentName
                   .isLowLevelConsumerSegmentName(segmentName) && LLCSegmentName
                   .isLowLevelConsumerSegmentName(currentSegmentName)
                   && LLCSegmentName.getSequenceNumber(segmentName) > LLCSegmentName
@@ -138,14 +138,14 @@ public class PartitionUpsertMetadataManager {
             assert currentSegment.getValidDocIds() != null;
             currentSegment.getValidDocIds().remove(currentRecordLocation.getDocId());
             validDocIds.add(recordInfo._docId);
-            return new RecordLocation(segment, recordInfo._docId, recordInfo._timestamp);
+            return new RecordLocation(segment, recordInfo._docId, recordInfo._comparisonValue);
           } else {
             return currentRecordLocation;
           }
         } else {
           // New primary key
           validDocIds.add(recordInfo._docId);
-          return new RecordLocation(segment, recordInfo._docId, recordInfo._timestamp);
+          return new RecordLocation(segment, recordInfo._docId, recordInfo._comparisonValue);
         }
       });
     }
@@ -180,7 +180,7 @@ public class PartitionUpsertMetadataManager {
 
         // Update the record location when the new timestamp is greater than or equal to the current timestamp. Update
         // the record location when there is a tie to keep the newer record.
-        if (recordInfo._timestamp.compareTo(currentRecordLocation.getTimestamp()) >= 0) {
+        if (recordInfo._comparisonValue.compareTo(currentRecordLocation.getComparisonValue()) >= 0) {
           IndexSegment currentSegment = currentRecordLocation.getSegment();
           if (_partialUpsertHandler != null) {
             // Partial upsert
@@ -191,12 +191,12 @@ public class PartitionUpsertMetadataManager {
           currentSegment.getValidDocIds().remove(currentRecordLocation.getDocId());
           assert segment.getValidDocIds() != null;
           segment.getValidDocIds().add(recordInfo._docId);
-          return new RecordLocation(segment, recordInfo._docId, recordInfo._timestamp);
+          return new RecordLocation(segment, recordInfo._docId, recordInfo._comparisonValue);
         } else {
           if (_partialUpsertHandler != null) {
             LOGGER.warn(
                 "Got late event for partial upsert: {} (current timestamp: {}, record timestamp: {}), skipping updating the record",
-                record, currentRecordLocation.getTimestamp(), recordInfo._timestamp);
+                record, currentRecordLocation.getComparisonValue(), recordInfo._comparisonValue);
           }
           return currentRecordLocation;
         }
@@ -204,7 +204,7 @@ public class PartitionUpsertMetadataManager {
         // New primary key
         assert segment.getValidDocIds() != null;
         segment.getValidDocIds().add(recordInfo._docId);
-        return new RecordLocation(segment, recordInfo._docId, recordInfo._timestamp);
+        return new RecordLocation(segment, recordInfo._docId, recordInfo._comparisonValue);
       }
     });
     // Update metrics
@@ -239,12 +239,12 @@ public class PartitionUpsertMetadataManager {
   public static final class RecordInfo {
     private final PrimaryKey _primaryKey;
     private final int _docId;
-    private final Comparable _timestamp;
+    private final Comparable _comparisonValue;
 
-    public RecordInfo(PrimaryKey primaryKey, int docId, Comparable timestamp) {
+    public RecordInfo(PrimaryKey primaryKey, int docId, Comparable comparisonValue) {
       _primaryKey = primaryKey;
       _docId = docId;
-      _timestamp = timestamp;
+      _comparisonValue = comparisonValue;
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
@@ -102,7 +102,7 @@ public class PartitionUpsertMetadataManager {
           // will return records with incremental doc ids.
           IndexSegment currentSegment = currentRecordLocation.getSegment();
           if (segment == currentSegment) {
-            if (recordInfo._timestamp >= currentRecordLocation.getTimestamp()) {
+            if (recordInfo._timestamp.compareTo(currentRecordLocation.getTimestamp()) >= 0) {
               validDocIds.remove(currentRecordLocation.getDocId());
               validDocIds.add(recordInfo._docId);
               return new RecordLocation(segment, recordInfo._docId, recordInfo._timestamp);
@@ -118,7 +118,7 @@ public class PartitionUpsertMetadataManager {
           // segment because it has not been replaced yet.
           String currentSegmentName = currentSegment.getSegmentName();
           if (segmentName.equals(currentSegmentName)) {
-            if (recordInfo._timestamp >= currentRecordLocation.getTimestamp()) {
+            if (recordInfo._timestamp.compareTo(currentRecordLocation.getTimestamp()) >= 0) {
               validDocIds.add(recordInfo._docId);
               return new RecordLocation(segment, recordInfo._docId, recordInfo._timestamp);
             } else {
@@ -129,7 +129,7 @@ public class PartitionUpsertMetadataManager {
           // The current record is in a different segment
           // Update the record location when getting a newer timestamp, or the timestamp is the same as the current
           // timestamp, but the segment has a larger sequence number (the segment is newer than the current segment).
-          if (recordInfo._timestamp > currentRecordLocation.getTimestamp() || (
+          if (recordInfo._timestamp.compareTo(currentRecordLocation.getTimestamp()) > 0 || (
               recordInfo._timestamp == currentRecordLocation.getTimestamp() && LLCSegmentName
                   .isLowLevelConsumerSegmentName(segmentName) && LLCSegmentName
                   .isLowLevelConsumerSegmentName(currentSegmentName)
@@ -180,7 +180,7 @@ public class PartitionUpsertMetadataManager {
 
         // Update the record location when the new timestamp is greater than or equal to the current timestamp. Update
         // the record location when there is a tie to keep the newer record.
-        if (recordInfo._timestamp >= currentRecordLocation.getTimestamp()) {
+        if (recordInfo._timestamp.compareTo(currentRecordLocation.getTimestamp()) >= 0) {
           IndexSegment currentSegment = currentRecordLocation.getSegment();
           if (_partialUpsertHandler != null) {
             // Partial upsert
@@ -239,9 +239,9 @@ public class PartitionUpsertMetadataManager {
   public static final class RecordInfo {
     private final PrimaryKey _primaryKey;
     private final int _docId;
-    private final long _timestamp;
+    private final Comparable _timestamp;
 
-    public RecordInfo(PrimaryKey primaryKey, int docId, long timestamp) {
+    public RecordInfo(PrimaryKey primaryKey, int docId, Comparable timestamp) {
       _primaryKey = primaryKey;
       _docId = docId;
       _timestamp = timestamp;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/RecordLocation.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/RecordLocation.java
@@ -27,12 +27,13 @@ import org.apache.pinot.segment.spi.IndexSegment;
 public class RecordLocation {
   private final IndexSegment _segment;
   private final int _docId;
-  private final Comparable _timestamp;
+  /** value used to denote the order */
+  private final Comparable _comparisonValue;
 
   public RecordLocation(IndexSegment indexSegment, int docId, Comparable timestamp) {
     _segment = indexSegment;
     _docId = docId;
-    _timestamp = timestamp;
+    _comparisonValue = timestamp;
   }
 
   public IndexSegment getSegment() {
@@ -43,7 +44,7 @@ public class RecordLocation {
     return _docId;
   }
 
-  public Comparable getTimestamp() {
-    return _timestamp;
+  public Comparable getComparisonValue() {
+    return _comparisonValue;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/RecordLocation.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/RecordLocation.java
@@ -30,10 +30,10 @@ public class RecordLocation {
   /** value used to denote the order */
   private final Comparable _comparisonValue;
 
-  public RecordLocation(IndexSegment indexSegment, int docId, Comparable timestamp) {
+  public RecordLocation(IndexSegment indexSegment, int docId, Comparable comparisonValue) {
     _segment = indexSegment;
     _docId = docId;
-    _comparisonValue = timestamp;
+    _comparisonValue = comparisonValue;
   }
 
   public IndexSegment getSegment() {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/RecordLocation.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/RecordLocation.java
@@ -27,9 +27,9 @@ import org.apache.pinot.segment.spi.IndexSegment;
 public class RecordLocation {
   private final IndexSegment _segment;
   private final int _docId;
-  private final long _timestamp;
+  private final Comparable _timestamp;
 
-  public RecordLocation(IndexSegment indexSegment, int docId, long timestamp) {
+  public RecordLocation(IndexSegment indexSegment, int docId, Comparable timestamp) {
     _segment = indexSegment;
     _docId = docId;
     _timestamp = timestamp;
@@ -43,7 +43,7 @@ public class RecordLocation {
     return _docId;
   }
 
-  public long getTimestamp() {
+  public Comparable getTimestamp() {
     return _timestamp;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
@@ -385,18 +385,4 @@ public final class IngestionUtils {
     }
     return null;
   }
-
-  public static Comparable extractTimeValueIfPossible(Comparable time) {
-    if (time != null) {
-      if (time instanceof Number) {
-        return ((Number) time).longValue();
-      } else {
-        String stringValue = time.toString();
-        if (StringUtils.isNumeric(stringValue)) {
-          return Long.parseLong(stringValue);
-        }
-      }
-    }
-    return null;
-  }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
@@ -385,4 +385,18 @@ public final class IngestionUtils {
     }
     return null;
   }
+
+  public static Comparable extractTimeValueIfPossible(Comparable time) {
+    if (time != null) {
+      if (time instanceof Number) {
+        return ((Number) time).longValue();
+      } else {
+        String stringValue = time.toString();
+        if (StringUtils.isNumeric(stringValue)) {
+          return Long.parseLong(stringValue);
+        }
+      }
+    }
+    return null;
+  }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -319,7 +319,7 @@ public final class TableConfigUtils {
    *  - the primary key exists on the schema
    *  - strict replica-group is configured for routing type
    *  - consumer type must be low-level
-   *   - comparison column exists
+   *  - comparison column exists
    */
   @VisibleForTesting
   static void validateUpsertConfig(TableConfig tableConfig, Schema schema) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -319,6 +319,7 @@ public final class TableConfigUtils {
    *  - the primary key exists on the schema
    *  - strict replica-group is configured for routing type
    *  - consumer type must be low-level
+   *   - comparison column exists
    */
   @VisibleForTesting
   static void validateUpsertConfig(TableConfig tableConfig, Schema schema) {
@@ -345,6 +346,11 @@ public final class TableConfigUtils {
     Preconditions.checkState(
         CollectionUtils.isEmpty(tableConfig.getIndexingConfig().getStarTreeIndexConfigs()) && !tableConfig
             .getIndexingConfig().isEnableDefaultStarTree(), "The upsert table cannot have star-tree index.");
+    // comparison column exists
+    if (tableConfig.getUpsertConfig().getComparisonColumn() != null) {
+      String comparisonCol = tableConfig.getUpsertConfig().getComparisonColumn();
+      Preconditions.checkState(schema.hasColumn(comparisonCol), "The comparison column does not exist on schema");
+    }
   }
 
   /**

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplTestUtils.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplTestUtils.java
@@ -70,7 +70,8 @@ public class MutableSegmentImplTestUtils {
             .setRealtimeSegmentZKMetadata(new RealtimeSegmentZKMetadata())
             .setMemoryManager(new DirectMemoryManager(SEGMENT_NAME)).setStatsHistory(statsHistory)
             .setAggregateMetrics(aggregateMetrics).setNullHandlingEnabled(nullHandlingEnabled).setUpsertMode(upsertMode)
-            .setPartitionUpsertMetadataManager(partitionUpsertMetadataManager).build();
+            .setPartitionUpsertMetadataManager(partitionUpsertMetadataManager)
+            .setUpsertComparisonColumn(upsertConfig.getComparisonColumn()).build();
     return new MutableSegmentImpl(realtimeSegmentConfig, null);
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplTestUtils.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplTestUtils.java
@@ -62,6 +62,7 @@ public class MutableSegmentImplTestUtils {
     when(statsHistory.getEstimatedAvgColSize(anyString())).thenReturn(32);
 
     UpsertConfig.Mode upsertMode = upsertConfig == null ? UpsertConfig.Mode.NONE : upsertConfig.getMode();
+    String comparisonColumn = upsertConfig == null ? null : upsertConfig.getComparisonColumn();
     RealtimeSegmentConfig realtimeSegmentConfig =
         new RealtimeSegmentConfig.Builder().setTableNameWithType(TABLE_NAME_WITH_TYPE).setSegmentName(SEGMENT_NAME)
             .setStreamName(STEAM_NAME).setSchema(schema).setTimeColumnName(timeColumnName).setCapacity(100000)
@@ -71,7 +72,7 @@ public class MutableSegmentImplTestUtils {
             .setMemoryManager(new DirectMemoryManager(SEGMENT_NAME)).setStatsHistory(statsHistory)
             .setAggregateMetrics(aggregateMetrics).setNullHandlingEnabled(nullHandlingEnabled).setUpsertMode(upsertMode)
             .setPartitionUpsertMetadataManager(partitionUpsertMetadataManager)
-            .setUpsertComparisonColumn(upsertConfig.getComparisonColumn()).build();
+            .setUpsertComparisonColumn(comparisonColumn).build();
     return new MutableSegmentImpl(realtimeSegmentConfig, null);
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplTestUtils.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplTestUtils.java
@@ -71,8 +71,9 @@ public class MutableSegmentImplTestUtils {
             .setRealtimeSegmentZKMetadata(new RealtimeSegmentZKMetadata())
             .setMemoryManager(new DirectMemoryManager(SEGMENT_NAME)).setStatsHistory(statsHistory)
             .setAggregateMetrics(aggregateMetrics).setNullHandlingEnabled(nullHandlingEnabled).setUpsertMode(upsertMode)
+            .setUpsertComparisonColumn(comparisonColumn)
             .setPartitionUpsertMetadataManager(partitionUpsertMetadataManager)
-            .setUpsertComparisonColumn(comparisonColumn).build();
+            .build();
     return new MutableSegmentImpl(realtimeSegmentConfig, null);
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
@@ -41,9 +41,9 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 
-public class MutableSegmentImplUpsertTest {
-  private static final String SCHEMA_FILE_PATH = "data/test_upsert_schema.json";
-  private static final String DATA_FILE_PATH = "data/test_upsert_data.json";
+public class MutableSegmentImplUpsertComparisonColTest {
+  private static final String SCHEMA_FILE_PATH = "data/test_upsert_comparison_col_schema.json";
+  private static final String DATA_FILE_PATH = "data/test_upsert_comparison_col_data.json";
   private static CompositeTransformer _recordTransformer;
   private static Schema _schema;
   private static TableConfig _tableConfig;
@@ -57,7 +57,7 @@ public class MutableSegmentImplUpsertTest {
     URL dataResourceUrl = this.getClass().getClassLoader().getResource(DATA_FILE_PATH);
     _schema = Schema.fromFile(new File(schemaResourceUrl.getFile()));
     _tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testTable")
-        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL, null, null)).build();
+        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL, null, "offset")).build();
     _recordTransformer = CompositeTransformer.getDefaultTransformer(_tableConfig, _schema);
     File jsonFile = new File(dataResourceUrl.getFile());
     _partitionUpsertMetadataManager =
@@ -65,7 +65,7 @@ public class MutableSegmentImplUpsertTest {
             .getOrCreatePartitionManager(0);
     _mutableSegmentImpl = MutableSegmentImplTestUtils
         .createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(), Collections.emptySet(),
-            false, true, new UpsertConfig(UpsertConfig.Mode.FULL, null, null), "secondsSinceEpoch",
+            false, true, new UpsertConfig(UpsertConfig.Mode.FULL, null, "offset"), "secondsSinceEpoch",
             _partitionUpsertMetadataManager);
     GenericRow reuse = new GenericRow();
     try (RecordReader recordReader = RecordReaderFactory
@@ -82,6 +82,7 @@ public class MutableSegmentImplUpsertTest {
   @Test
   public void testUpsertIngestion() {
     ImmutableRoaringBitmap bitmap = _mutableSegmentImpl.getValidDocIds().getMutableRoaringBitmap();
+    // note offset column is used for determining sequence but not time column
     Assert.assertFalse(bitmap.contains(0));
     Assert.assertTrue(bitmap.contains(1));
     Assert.assertTrue(bitmap.contains(2));

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManagerTest.java
@@ -136,7 +136,7 @@ public class PartitionUpsertMetadataManagerTest {
     assertNotNull(recordLocation);
     assertSame(recordLocation.getSegment(), segment);
     assertEquals(recordLocation.getDocId(), docId);
-    assertEquals(recordLocation.getTimestamp(), timestamp);
+    assertEquals(recordLocation.getComparisonValue(), timestamp);
   }
 
   @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManagerTest.java
@@ -131,7 +131,7 @@ public class PartitionUpsertMetadataManagerTest {
   }
 
   private static void checkRecordLocation(Map<PrimaryKey, RecordLocation> recordLocationMap, int keyValue,
-      IndexSegment segment, int docId, long timestamp) {
+      IndexSegment segment, int docId, int timestamp) {
     RecordLocation recordLocation = recordLocationMap.get(getPrimaryKey(keyValue));
     assertNotNull(recordLocation);
     assertSame(recordLocation.getSegment(), segment);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -1036,7 +1036,7 @@ public class TableConfigUtilsTest {
         new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
             .build();
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL, null)).build();
+        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL, null, null)).build();
     try {
       TableConfigUtils.validateUpsertConfig(tableConfig, schema);
       Assert.fail();
@@ -1045,7 +1045,7 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL, null)).build();
+        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL, null, null)).build();
     try {
       TableConfigUtils.validateUpsertConfig(tableConfig, schema);
       Assert.fail();
@@ -1066,7 +1066,7 @@ public class TableConfigUtilsTest {
 
     Map<String, String> streamConfigs = getStreamConfigs();
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL, null)).setStreamConfigs(streamConfigs).build();
+        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL, null, null)).setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validateUpsertConfig(tableConfig, schema);
       Assert.fail();
@@ -1076,7 +1076,7 @@ public class TableConfigUtilsTest {
 
     streamConfigs.put("stream.kafka.consumer.type", "simple");
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL, null)).setStreamConfigs(streamConfigs).build();
+        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL, null, null)).setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validateUpsertConfig(tableConfig, schema);
       Assert.fail();
@@ -1086,7 +1086,7 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL, null))
+        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL, null, null))
         .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
         .setStreamConfigs(streamConfigs).build();
     TableConfigUtils.validateUpsertConfig(tableConfig, schema);
@@ -1094,7 +1094,7 @@ public class TableConfigUtilsTest {
     StarTreeIndexConfig starTreeIndexConfig = new StarTreeIndexConfig(Lists.newArrayList("myCol"), null, Collections
         .singletonList(new AggregationFunctionColumnPair(AggregationFunctionType.COUNT, "myCol").toColumnName()), 10);
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL, null))
+        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL, null, null))
         .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
         .setStarTreeIndexConfigs(Lists.newArrayList(starTreeIndexConfig)).setStreamConfigs(streamConfigs).build();
     try {
@@ -1119,7 +1119,7 @@ public class TableConfigUtilsTest {
     partialUpsertStratgies.put("myCol1", UpsertConfig.Strategy.INCREMENT);
 
     TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.PARTIAL, partialUpsertStratgies))
+        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.PARTIAL, partialUpsertStratgies, null))
         .setNullHandlingEnabled(false)
         .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
         .setStreamConfigs(streamConfigs).build();

--- a/pinot-segment-local/src/test/resources/data/test_upsert_comparison_col_data.json
+++ b/pinot-segment-local/src/test/resources/data/test_upsert_comparison_col_data.json
@@ -1,0 +1,26 @@
+[
+  {
+    "event_id": "aa",
+    "description" : "first",
+    "offset": 100,
+    "secondsSinceEpoch": 1567205394
+  },
+  {
+    "event_id": "bb",
+    "description" : "first",
+    "offset": 300,
+    "secondsSinceEpoch": 1567205396
+  },
+  {
+    "event_id": "aa",
+    "description" : "update",
+    "offset": 200,
+    "secondsSinceEpoch": 1567205390
+  },
+  {
+    "event_id": "bb",
+    "description" : "late arrival",
+    "offset": 140,
+    "secondsSinceEpoch": 1567205398
+  }
+]

--- a/pinot-segment-local/src/test/resources/data/test_upsert_comparison_col_schema.json
+++ b/pinot-segment-local/src/test/resources/data/test_upsert_comparison_col_schema.json
@@ -1,0 +1,25 @@
+{
+  "schemaName": "test_pinot_table",
+  "dimensionFieldSpecs": [
+    {
+      "name": "event_id",
+      "dataType": "STRING"
+    },
+    {
+      "name": "description",
+      "dataType": "STRING"
+    },
+    {
+      "name": "offset",
+      "dataType": "LONG"
+    }
+  ],
+  "timeFieldSpec": {
+    "incomingGranularitySpec": {
+      "name": "secondsSinceEpoch",
+      "dataType": "LONG",
+      "timeType": "SECONDS"
+    }
+  },
+  "primaryKeyColumns": ["event_id"]
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
@@ -293,7 +293,7 @@ public class TableConfig extends BaseJsonConfig {
   @JsonIgnore
   @Nullable
   public String getUpsertComparisonColumn() {
-    return _upsertConfig.getComparisonColumn();
+    return _upsertConfig == null ? null : _upsertConfig.getComparisonColumn();
   }
 
   @JsonProperty(TUNER_CONFIG)

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
@@ -290,6 +290,12 @@ public class TableConfig extends BaseJsonConfig {
     return _upsertConfig == null ? UpsertConfig.Mode.NONE : _upsertConfig.getMode();
   }
 
+  @JsonIgnore
+  @Nullable
+  public String getUpsertComparisonColumn() {
+    return _upsertConfig.getComparisonColumn();
+  }
+
   @JsonProperty(TUNER_CONFIG)
   public TunerConfig getTunerConfig() {
     return _tunerConfig;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.BaseJsonConfig;
 
+
 /** Class representing upsert configuration of a table. */
 public class UpsertConfig extends BaseJsonConfig {
 
@@ -45,9 +46,13 @@ public class UpsertConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Partial update strategies.")
   private final Map<String, Strategy> _partialUpsertStrategies;
 
+  @JsonPropertyDescription("Column for upsert comparison, default to time column")
+  private final String _comparisonColumn;
+
   @JsonCreator
   public UpsertConfig(@JsonProperty(value = "mode", required = true) Mode mode,
-      @JsonProperty("partialUpsertStrategies") @Nullable Map<String, Strategy> partialUpsertStrategies) {
+      @JsonProperty("partialUpsertStrategies") @Nullable Map<String, Strategy> partialUpsertStrategies,
+      @JsonProperty("comparisonColumn") @Nullable String comparisonColumn) {
     Preconditions.checkArgument(mode != null, "Upsert mode must be configured");
     _mode = mode;
 
@@ -56,6 +61,8 @@ public class UpsertConfig extends BaseJsonConfig {
     } else {
       _partialUpsertStrategies = null;
     }
+
+    _comparisonColumn = comparisonColumn;
   }
 
   public Mode getMode() {
@@ -65,5 +72,9 @@ public class UpsertConfig extends BaseJsonConfig {
   @Nullable
   public Map<String, Strategy> getPartialUpsertStrategies() {
     return _partialUpsertStrategies;
+  }
+
+  public String getComparisonColumn() {
+    return _comparisonColumn;
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/UpsertConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/UpsertConfigTest.java
@@ -29,12 +29,15 @@ public class UpsertConfigTest {
 
   @Test
   public void testUpsertConfig() {
-    UpsertConfig upsertConfig1 = new UpsertConfig(UpsertConfig.Mode.FULL, null);
+    UpsertConfig upsertConfig1 = new UpsertConfig(UpsertConfig.Mode.FULL, null, null);
     assertEquals(upsertConfig1.getMode(), UpsertConfig.Mode.FULL);
+
+    upsertConfig1 = new UpsertConfig(UpsertConfig.Mode.FULL, null, "comparison");
+    assertEquals(upsertConfig1.getComparisonColumn(), "comparison");
 
     Map<String, UpsertConfig.Strategy> partialUpsertStratgies = new HashMap<>();
     partialUpsertStratgies.put("myCol", UpsertConfig.Strategy.INCREMENT);
-    UpsertConfig upsertConfig2 = new UpsertConfig(UpsertConfig.Mode.PARTIAL, partialUpsertStratgies);
+    UpsertConfig upsertConfig2 = new UpsertConfig(UpsertConfig.Mode.PARTIAL, partialUpsertStratgies, null);
     assertEquals(upsertConfig2.getPartialUpsertStrategies(), partialUpsertStratgies);
   }
 }


### PR DESCRIPTION
## Description
https://github.com/apache/pinot/issues/6523

Today upsert uses the time column for comparison. This PR allows using any column for comparison, such as the kafka offset.

## Release Notes
This PR introduces a new optional field `comparisonColumn ` under upsert config for specifying the column used for upsert comparison. When this is not provided, the time column is used as default.

