### PR TITLE
allow to extract values from array of objects with jsonPathArray

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/JsonFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/JsonFunctions.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.common.function.scalar;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.annotations.VisibleForTesting;
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
 import com.jayway.jsonpath.Option;
@@ -114,12 +115,11 @@ public class JsonFunctions {
   }
 
   @ScalarFunction
-  public static Object[] jsonPathArrayDefaultEmpty(Object object, String jsonPath)
-      throws JsonProcessingException {
+  public static Object[] jsonPathArrayDefaultEmpty(Object object, String jsonPath) {
     try {
       return jsonPathArray(object, jsonPath);
     } catch (Exception e) {
-      return new Object[]{};
+      return new Object[0];
     }
   }
 
@@ -208,6 +208,7 @@ public class JsonFunctions {
     }
   }
 
+  @VisibleForTesting
   static class ArrayAwareJacksonJsonProvider extends JacksonJsonProvider {
     @Override
     public boolean isArray(Object obj) {
@@ -220,18 +221,6 @@ public class JsonFunctions {
         return ((Object[]) obj)[idx];
       }
       return super.getArrayIndex(obj, idx);
-    }
-
-    @Override
-    public void setArrayIndex(Object obj, int index, Object newValue) {
-      if (obj instanceof Object[]) {
-        if (index < ((Object[]) obj).length) {
-          ((Object[]) obj)[index] = newValue;
-          return;
-        }
-        throw new UnsupportedOperationException("List is required to grow the capacity");
-      }
-      super.setArrayIndex(obj, index, newValue);
     }
 
     @Override

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/ArrayAwareJacksonJsonProviderTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/ArrayAwareJacksonJsonProviderTest.java
@@ -87,47 +87,6 @@ public class ArrayAwareJacksonJsonProviderTest {
   }
 
   @Test
-  public void testSetArrayIndex() {
-    JsonFunctions.ArrayAwareJacksonJsonProvider jp = new JsonFunctions.ArrayAwareJacksonJsonProvider();
-    Object[] dataInAry = new Object[]{"123", "456"};
-    Object[] newDataInAry = new Object[]{"one", "two"};
-    for (int i = 0; i < dataInAry.length; i++) {
-      jp.setArrayIndex(dataInAry, i, newDataInAry[i]);
-    }
-    for (int i = 0; i < dataInAry.length; i++) {
-      assertEquals(jp.getArrayIndex(dataInAry, i), newDataInAry[i]);
-    }
-    try {
-      jp.setArrayIndex(dataInAry, dataInAry.length, "three");
-      fail();
-    } catch (UnsupportedOperationException e) {
-      assertEquals(e.getMessage(), "List is required to grow the capacity");
-    }
-
-    // Use ArrayList for a modifiable list.
-    List<Object> dataInList = new ArrayList<>(Arrays.asList("abc", "efg", "hij"));
-    List<Object> newDataInList = Arrays.asList("ABC", "EFG", "HIJ");
-    for (int i = 0; i < dataInList.size(); i++) {
-      jp.setArrayIndex(dataInList, i, newDataInList.get(i));
-    }
-    for (int i = 0; i < dataInList.size(); i++) {
-      assertEquals(jp.getArrayIndex(dataInList, i), newDataInList.get(i));
-    }
-    try {
-      jp.setArrayIndex(dataInList, dataInList.size(), "LMN");
-    } catch (Exception e) {
-      fail();
-    }
-
-    try {
-      jp.setArrayIndex(null, 0, null);
-      fail();
-    } catch (UnsupportedOperationException e) {
-      assertNull(e.getMessage());
-    }
-  }
-
-  @Test
   public void testToIterable() {
     JsonFunctions.ArrayAwareJacksonJsonProvider jp = new JsonFunctions.ArrayAwareJacksonJsonProvider();
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/ArrayAwareJacksonJsonProviderTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/ArrayAwareJacksonJsonProviderTest.java
@@ -1,0 +1,155 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function.scalar;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class ArrayAwareJacksonJsonProviderTest {
+  @Test
+  public void testIsArray() {
+    JsonFunctions.ArrayAwareJacksonJsonProvider jp = new JsonFunctions.ArrayAwareJacksonJsonProvider();
+
+    assertFalse(jp.isArray(null));
+    assertTrue(jp.isArray(new Object[0]));
+    assertTrue(jp.isArray(new ArrayList<>(0)));
+    assertFalse(jp.isArray("I'm a list"));
+    assertFalse(jp.isArray(new HashMap<String, String>()));
+  }
+
+  @Test
+  public void testArrayLength() {
+    JsonFunctions.ArrayAwareJacksonJsonProvider jp = new JsonFunctions.ArrayAwareJacksonJsonProvider();
+
+    Object[] dataInAry = new Object[]{"123", "456"};
+    assertEquals(jp.length(dataInAry), 2);
+
+    List<Object> dataInList = Arrays.asList("abc", "efg", "hij");
+    assertEquals(jp.length(dataInList), 3);
+
+    try {
+      jp.length(null);
+      fail();
+    } catch (NullPointerException e) {
+      // It's supposed to get a JsonPathException, but JsonPath library actually
+      // has a bug leading to NullPointerException while creating the JsonPathException.
+      assertNull(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testGetArrayIndex() {
+    JsonFunctions.ArrayAwareJacksonJsonProvider jp = new JsonFunctions.ArrayAwareJacksonJsonProvider();
+
+    Object[] dataInAry = new Object[]{"123", "456"};
+    for (int i = 0; i < dataInAry.length; i++) {
+      assertEquals(jp.getArrayIndex(dataInAry, i), dataInAry[i]);
+    }
+    try {
+      jp.getArrayIndex(dataInAry, dataInAry.length);
+      fail();
+    } catch (IndexOutOfBoundsException e) {
+      assertEquals(e.getMessage(), "Index 2 out of bounds for length 2");
+    }
+
+    List<Object> dataInList = Arrays.asList("abc", "efg", "hij");
+    for (int i = 0; i < dataInList.size(); i++) {
+      assertEquals(jp.getArrayIndex(dataInList, i), dataInList.get(i));
+    }
+    try {
+      jp.getArrayIndex(dataInList, dataInList.size());
+      fail();
+    } catch (IndexOutOfBoundsException e) {
+      assertEquals(e.getMessage(), "Index 3 out of bounds for length 3");
+    }
+  }
+
+  @Test
+  public void testSetArrayIndex() {
+    JsonFunctions.ArrayAwareJacksonJsonProvider jp = new JsonFunctions.ArrayAwareJacksonJsonProvider();
+    Object[] dataInAry = new Object[]{"123", "456"};
+    Object[] newDataInAry = new Object[]{"one", "two"};
+    for (int i = 0; i < dataInAry.length; i++) {
+      jp.setArrayIndex(dataInAry, i, newDataInAry[i]);
+    }
+    for (int i = 0; i < dataInAry.length; i++) {
+      assertEquals(jp.getArrayIndex(dataInAry, i), newDataInAry[i]);
+    }
+    try {
+      jp.setArrayIndex(dataInAry, dataInAry.length, "three");
+      fail();
+    } catch (UnsupportedOperationException e) {
+      assertEquals(e.getMessage(), "List is required to grow the capacity");
+    }
+
+    // Use ArrayList for a modifiable list.
+    List<Object> dataInList = new ArrayList<>(Arrays.asList("abc", "efg", "hij"));
+    List<Object> newDataInList = Arrays.asList("ABC", "EFG", "HIJ");
+    for (int i = 0; i < dataInList.size(); i++) {
+      jp.setArrayIndex(dataInList, i, newDataInList.get(i));
+    }
+    for (int i = 0; i < dataInList.size(); i++) {
+      assertEquals(jp.getArrayIndex(dataInList, i), newDataInList.get(i));
+    }
+    try {
+      jp.setArrayIndex(dataInList, dataInList.size(), "LMN");
+    } catch (Exception e) {
+      fail();
+    }
+
+    try {
+      jp.setArrayIndex(null, 0, null);
+      fail();
+    } catch (UnsupportedOperationException e) {
+      assertNull(e.getMessage());
+    }
+  }
+
+  @Test
+  public void testToIterable() {
+    JsonFunctions.ArrayAwareJacksonJsonProvider jp = new JsonFunctions.ArrayAwareJacksonJsonProvider();
+
+    Object[] dataInAry = new Object[]{"123", "456"};
+    int idx = 0;
+    for (Object v : jp.toIterable(dataInAry)) {
+      assertEquals(v, dataInAry[idx++]);
+    }
+
+    List<Object> dataInList = Arrays.asList("abc", "efg", "hij");
+    idx = 0;
+    for (Object v : jp.toIterable(dataInList)) {
+      assertEquals(v, dataInList.get(idx++));
+    }
+
+    try {
+      jp.toIterable(null);
+      fail();
+    } catch (NullPointerException e) {
+      // It's supposed to get a JsonPathException, but JsonPath library actually
+      // has a bug leading to NullPointerException while creating the JsonPathException.
+      assertNull(e.getMessage());
+    }
+  }
+}


### PR DESCRIPTION
Allow to extract values from array of objects with jsonPathArray. 
And add jsonPathArrayDefaultEmpty to allow skip json records without target path, instead of aborting the ingestion.

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
