### PR TITLE
Updating maven binary download link in Pinot Docker file

### DIFF
--- a/docker/images/pinot/Dockerfile
+++ b/docker/images/pinot/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update && \
 
 # install maven
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && wget https://www-us.apache.org/dist/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -P /tmp \
+  && wget https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz -P /tmp \
   && tar -xzf /tmp/apache-maven-*.tar.gz -C /usr/share/maven --strip-components=1 \
   && rm -f /tmp/apache-maven-*.tar.gz \
   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn


### PR DESCRIPTION
## Description
The previous maven download link is no longer reachable. Tested that the new download link works:

```
wget https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
--2021-07-26 16:37:18--  https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz
Resolving downloads.apache.org (downloads.apache.org)... 2a01:4f9:3a:2725::2, 2a01:4f9:3a:2c57::2, 2a01:4f8:10a:201a::2, ...
Connecting to downloads.apache.org (downloads.apache.org)|2a01:4f9:3a:2725::2|:443... connected.
HTTP request sent, awaiting response... 200 OK
Length: 9506321 (9.1M) [application/x-gzip]
Saving to: ‘apache-maven-3.6.3-bin.tar.gz’

apache-maven-3.6.3-bin.tar.gz                        100%[======================================================================================================================>]   9.07M  3.43MB/s    in 2.6s    

2021-07-26 16:37:21 (3.43 MB/s) - ‘apache-maven-3.6.3-bin.tar.gz’ saved [9506321/9506321]
```

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)
