### PR TITLE
Bump up the "grpc-protobuf-lite" version to 1.19.0 in Apache Pulsar

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/pom.xml
@@ -52,7 +52,7 @@
     <codehaus-annotations.version>1.17</codehaus-annotations.version>
     <javax.annotation-api.version>1.2</javax.annotation-api.version>
     <commons-collections.version>4.1</commons-collections.version>
-    <grpc-protobuf-lite.version>1.18.0</grpc-protobuf-lite.version>
+    <grpc-protobuf-lite.version>1.19.0</grpc-protobuf-lite.version>
     <swagger-annotations.version>1.5.21</swagger-annotations.version>
     <okio.version>1.6.0</okio.version>
   </properties>
@@ -178,6 +178,14 @@
         <exclusion>
           <groupId>io.grpc</groupId>
           <artifactId>grpc-protobuf-lite</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.opencensus</groupId>
+          <artifactId>opencensus-contrib-grpc-metrics</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.opencensus</groupId>
+          <artifactId>opencensus-api</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
gprc-protobuf-lite:1.18.0 pulls the "org.checkerframework:checker-compat-qual"
library which is based on GPL v2. GPL v2 is one of category X licenses that
are not allowed to include in Apache release. Bumping up the library to
1.19.0 resolves the issue.