### PR TITLE
cast to Number to convert value between numeric types

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
@@ -201,27 +201,27 @@ public enum PinotDataType {
   SHORT {
     @Override
     public int toInt(Object value) {
-      return ((Short) value).intValue();
+      return ((Number) value).intValue();
     }
 
     @Override
     public long toLong(Object value) {
-      return ((Short) value).longValue();
+      return ((Number) value).longValue();
     }
 
     @Override
     public float toFloat(Object value) {
-      return ((Short) value).floatValue();
+      return ((Number) value).floatValue();
     }
 
     @Override
     public double toDouble(Object value) {
-      return ((Short) value).doubleValue();
+      return ((Number) value).doubleValue();
     }
 
     @Override
     public boolean toBoolean(Object value) {
-      return (Short) value != 0;
+      return ((Number) value).doubleValue() != 0;
     }
 
     @Override
@@ -243,27 +243,27 @@ public enum PinotDataType {
   INTEGER {
     @Override
     public int toInt(Object value) {
-      return (Integer) value;
+      return ((Number) value).intValue();
     }
 
     @Override
     public long toLong(Object value) {
-      return ((Integer) value).longValue();
+      return ((Number) value).longValue();
     }
 
     @Override
     public float toFloat(Object value) {
-      return ((Integer) value).floatValue();
+      return ((Number) value).floatValue();
     }
 
     @Override
     public double toDouble(Object value) {
-      return ((Integer) value).doubleValue();
+      return ((Number) value).doubleValue();
     }
 
     @Override
     public boolean toBoolean(Object value) {
-      return (Integer) value != 0;
+      return ((Number) value).doubleValue() != 0;
     }
 
     @Override
@@ -290,27 +290,27 @@ public enum PinotDataType {
   LONG {
     @Override
     public int toInt(Object value) {
-      return ((Long) value).intValue();
+      return ((Number) value).intValue();
     }
 
     @Override
     public long toLong(Object value) {
-      return (Long) value;
+      return ((Number) value).longValue();
     }
 
     @Override
     public float toFloat(Object value) {
-      return ((Long) value).floatValue();
+      return ((Number) value).floatValue();
     }
 
     @Override
     public double toDouble(Object value) {
-      return ((Long) value).doubleValue();
+      return ((Number) value).doubleValue();
     }
 
     @Override
     public boolean toBoolean(Object value) {
-      return (Long) value != 0;
+      return ((Number) value).doubleValue() != 0;
     }
 
     @Override
@@ -337,27 +337,27 @@ public enum PinotDataType {
   FLOAT {
     @Override
     public int toInt(Object value) {
-      return ((Float) value).intValue();
+      return ((Number) value).intValue();
     }
 
     @Override
     public long toLong(Object value) {
-      return ((Float) value).longValue();
+      return ((Number) value).longValue();
     }
 
     @Override
     public float toFloat(Object value) {
-      return (Float) value;
+      return ((Number) value).floatValue();
     }
 
     @Override
     public double toDouble(Object value) {
-      return ((Float) value).doubleValue();
+      return ((Number) value).doubleValue();
     }
 
     @Override
     public boolean toBoolean(Object value) {
-      return (Float) value != 0;
+      return ((Number) value).doubleValue() != 0;
     }
 
     @Override
@@ -384,27 +384,27 @@ public enum PinotDataType {
   DOUBLE {
     @Override
     public int toInt(Object value) {
-      return ((Double) value).intValue();
+      return ((Number) value).intValue();
     }
 
     @Override
     public long toLong(Object value) {
-      return ((Double) value).longValue();
+      return ((Number) value).longValue();
     }
 
     @Override
     public float toFloat(Object value) {
-      return ((Double) value).floatValue();
+      return ((Number) value).floatValue();
     }
 
     @Override
     public double toDouble(Object value) {
-      return (Double) value;
+      return ((Number) value).doubleValue();
     }
 
     @Override
     public boolean toBoolean(Object value) {
-      return (Double) value != 0;
+      return ((Number) value).doubleValue() != 0;
     }
 
     @Override

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
@@ -45,6 +45,15 @@ public class PinotDataTypeTest {
           (byte) 123), Character.toString((char) 123), Short.toString((short) 123), Integer.toString(
           123), Long.toString(123L), Float.toString(123f), Double.toString(123d), " 123"};
 
+  // To check cases where array for MV column contains values of mixing numeric types.
+  private static final PinotDataType[] SOURCE_ARRAY_TYPES =
+      {SHORT_ARRAY, INTEGER_ARRAY, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY};
+  private static final Object[] SOURCE_ARRAY_VALUES =
+      {new Object[]{(short) 123, 4, 5L, 6f, 7d}, new Object[]{123, 4, 5L, 6f, 7d}, new Object[]{123L, 4, 5L, 6f, 7d}, new Object[]{123f, 4, 5L, 6f, 7d}, new Object[]{123d, 4, 5L, 6f, 7d},};
+  private static final PinotDataType[] DEST_ARRAY_TYPES = {INTEGER_ARRAY, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY};
+  private static final Object[] EXPECTED_DEST_ARRAY_VALUES =
+      {new Object[]{123, 4, 5, 6, 7}, new Object[]{123L, 4L, 5L, 6L, 7L}, new Object[]{123f, 4f, 5f, 6f, 7f}, new Object[]{123d, 4d, 5d, 6d, 7d}};
+
   @Test
   public void testNumberConversion() {
     int numDestTypes = DEST_TYPES.length;
@@ -54,6 +63,20 @@ public class PinotDataTypeTest {
       int numSourceTypes = SOURCE_TYPES.length;
       for (int j = 0; j < numSourceTypes; j++) {
         Object actualDestValue = destType.convert(SOURCE_VALUES[j], SOURCE_TYPES[j]);
+        assertEquals(actualDestValue, expectedDestValue);
+      }
+    }
+  }
+
+  @Test
+  public void testNumberConversionWithMixTypes() {
+    int numDestTypes = DEST_ARRAY_TYPES.length;
+    for (int i = 0; i < numDestTypes; i++) {
+      PinotDataType destType = DEST_ARRAY_TYPES[i];
+      Object expectedDestValue = EXPECTED_DEST_ARRAY_VALUES[i];
+      int numSourceTypes = SOURCE_ARRAY_TYPES.length;
+      for (int j = 0; j < numSourceTypes; j++) {
+        Object actualDestValue = destType.convert(SOURCE_ARRAY_VALUES[j], SOURCE_ARRAY_TYPES[j]);
         assertEquals(actualDestValue, expectedDestValue);
       }
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
@@ -159,6 +159,29 @@ public class RecordTransformerTest {
   }
 
   @Test
+  public void testDataTypeTransformerWithMixingTypesInMV() {
+    RecordTransformer transformer = new DataTypeTransformer(SCHEMA);
+    GenericRow record = getRecord();
+    record.putValue("mvInt", new Object[]{123L, 456.789f});
+    record.putValue("mvLong", new Object[]{123.456f, 789L});
+    record.putValue("mvFloat", new Object[]{123L, 456.789f});
+    record.putValue("mvDouble", new Object[]{123.0f, 789L});
+    record.putValue("mvString1", new Object[]{"123", 123L, 123f, 123.0d});
+    record.putValue("mvString2", new Object[]{123, 123L, 123f, "123.0"});
+    for (int i = 0; i < NUM_ROUNDS; i++) {
+      record = transformer.transform(record);
+      assertNotNull(record);
+      assertEquals(record.getValue("mvInt"), new Object[]{123, 456});
+      assertEquals(record.getValue("mvLong"), new Object[]{123L, 789L});
+      assertEquals(record.getValue("mvFloat"), new Object[]{123f, 456.789f});
+      assertEquals(record.getValue("mvDouble"), new Object[]{123.0d, 789.0d});
+      // NOTE: We identify the array type by the first element, so data type conversion only applied to 'mvString2'
+      assertEquals(record.getValue("mvString1"), new Object[]{"123", 123L, 123f, 123.0d});
+      assertEquals(record.getValue("mvString2"), new Object[]{"123", "123", "123.0", "123.0"});
+    }
+  }
+
+  @Test
   public void testSanitationTransformer() {
     RecordTransformer transformer = new SanitizationTransformer(SCHEMA);
     GenericRow record = getRecord();


### PR DESCRIPTION
During ingestion, the array to put in MV column can contain mixing types. This fix would allow mixing numeric types in an array to be put in a numeric MV column. 

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
