### PR TITLE
7228 /sql REST call now compatible with auth

### DIFF
--- a/pinot-controller/src/main/resources/app/utils/axios-config.ts
+++ b/pinot-controller/src/main/resources/app/utils/axios-config.ts
@@ -53,3 +53,5 @@ baseApi.interceptors.request.use(handleConfig, handleError);
 baseApi.interceptors.response.use(handleResponse, handleError);
 
 export const transformApi = axios.create({baseURL: '/', transformResponse: [data => data]});
+transformApi.interceptors.request.use(handleConfig, handleError);
+transformApi.interceptors.response.use(handleResponse, handleError);


### PR DESCRIPTION
## Description
/sql REST call was using Axios configuration without appropriate auth headers. Once the configuration is provided with auth headers (when available), the call executes fine.

Also now, upon any network error, the UI will fail exactly the way it fails for any other network call. Graceful failure, if not available, needs to be implemented separately throughout the app.