### PR TITLE
Enable hit counter and max hit rate tracker in broker

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManager.java
@@ -51,7 +51,6 @@ import org.slf4j.LoggerFactory;
  * This class is to support the qps quota feature.
  * It depends on the broker source change to update the dynamic rate limit,
  *  which means it only gets updated when a new table added or a broker restarted.
- * TODO: support adding new rate limiter for existing tables without restarting the broker.
  */
 public class HelixExternalViewBasedQueryQuotaManager implements ClusterChangeHandler, QueryQuotaManager {
   private static final Logger LOGGER = LoggerFactory.getLogger(HelixExternalViewBasedQueryQuotaManager.class);
@@ -82,9 +81,8 @@ public class HelixExternalViewBasedQueryQuotaManager implements ClusterChangeHan
 
   @Override
   public void processClusterChange(HelixConstants.ChangeType changeType) {
-    Preconditions
-        .checkState(changeType == HelixConstants.ChangeType.EXTERNAL_VIEW
-            || changeType == HelixConstants.ChangeType.INSTANCE_CONFIG, "Illegal change type: " + changeType);
+    Preconditions.checkState(changeType == HelixConstants.ChangeType.EXTERNAL_VIEW
+        || changeType == HelixConstants.ChangeType.INSTANCE_CONFIG, "Illegal change type: " + changeType);
     if (changeType == HelixConstants.ChangeType.EXTERNAL_VIEW) {
       ExternalView brokerResourceEV = HelixHelper
           .getExternalViewForResource(_helixManager.getClusterManagmentTool(), _helixManager.getClusterName(),
@@ -106,20 +104,18 @@ public class HelixExternalViewBasedQueryQuotaManager implements ClusterChangeHan
   /**
    * Initialize or update dynamic rate limiter with table query quota.
    * @param tableConfig table config.
-   * @param brokerResource broker resource which stores all the broker states of each table.
+   * @param brokerResourceEV broker resource which stores all the broker states of each table.
    */
-  public void initOrUpdateTableQueryQuota(TableConfig tableConfig, ExternalView brokerResource) {
+  public void initOrUpdateTableQueryQuota(TableConfig tableConfig, ExternalView brokerResourceEV) {
+    if (tableConfig == null) {
+      LOGGER.info("No query quota to update since table config is null");
+      return;
+    }
     String tableNameWithType = tableConfig.getTableName();
     LOGGER.info("Initializing rate limiter for table {}", tableNameWithType);
 
     // Create rate limiter if query quota config is specified.
-    QuotaConfig quotaConfig = tableConfig.getQuotaConfig();
-    if (quotaConfig == null || quotaConfig.getMaxQueriesPerSecond() == null) {
-      LOGGER.info("No qps config specified for table: {}", tableNameWithType);
-      removeRateLimiter(tableNameWithType);
-    } else {
-      createOrUpdateRateLimiter(tableNameWithType, brokerResource, quotaConfig);
-    }
+    createOrUpdateRateLimiter(tableNameWithType, brokerResourceEV, tableConfig.getQuotaConfig());
   }
 
   /**
@@ -136,10 +132,6 @@ public class HelixExternalViewBasedQueryQuotaManager implements ClusterChangeHan
    */
   private void removeRateLimiter(String tableNameWithType) {
     _rateLimiterMap.remove(tableNameWithType);
-  }
-
-  public boolean containsRateLimiterForTable(String tableNameWithType) {
-    return _rateLimiterMap.containsKey(tableNameWithType);
   }
 
   /**
@@ -165,11 +157,13 @@ public class HelixExternalViewBasedQueryQuotaManager implements ClusterChangeHan
       QuotaConfig quotaConfig) {
     if (quotaConfig == null || quotaConfig.getMaxQueriesPerSecond() == null) {
       LOGGER.info("No qps config specified for table: {}", tableNameWithType);
+      buildEmptyOrResetRateLimiterInQueryQuotaEntity(tableNameWithType);
       return;
     }
 
     if (brokerResource == null) {
       LOGGER.warn("Failed to init qps quota for table {}. No broker resource connected!", tableNameWithType);
+      buildEmptyOrResetRateLimiterInQueryQuotaEntity(tableNameWithType);
       return;
     }
 
@@ -207,7 +201,15 @@ public class HelixExternalViewBasedQueryQuotaManager implements ClusterChangeHan
           "Rate limiter for table: {} has been initialized. Overall rate: {}. Per-broker rate: {}. Number of online broker instances: {}. Table config stat version: {}",
           tableNameWithType, overallRate, perBrokerRate, onlineCount, stat.getVersion());
     } else {
-      queryQuotaEntity.getRateLimiter().setRate(perBrokerRate);
+      RateLimiter rateLimiter = queryQuotaEntity.getRateLimiter();
+      if (rateLimiter == null) {
+        // Query quota is just added to the table.
+        rateLimiter = RateLimiter.create(perBrokerRate);
+        queryQuotaEntity.setRateLimiter(rateLimiter);
+      } else {
+        // Query quota gets updated to a new value.
+        rateLimiter.setRate(perBrokerRate);
+      }
       queryQuotaEntity.setNumOnlineBrokers(onlineCount);
       queryQuotaEntity.setOverallRate(overallRate);
       queryQuotaEntity.setTableConfigStatVersion(stat.getVersion());
@@ -215,13 +217,36 @@ public class HelixExternalViewBasedQueryQuotaManager implements ClusterChangeHan
           "Rate limiter for table: {} has been updated. Overall rate: {}. Per-broker rate: {}. Number of online broker instances: {}. Table config stat version: {}",
           tableNameWithType, overallRate, perBrokerRate, onlineCount, stat.getVersion());
     }
-
-    final QueryQuotaEntity finalQueryQuotaEntity = queryQuotaEntity;
-    _brokerMetrics.addCallbackTableGaugeIfNeeded(tableNameWithType, BrokerGauge.MAX_BURST_QPS,
-        () -> (long) finalQueryQuotaEntity.getMaxQpsTracker().getMaxCountPerBucket());
+    addMaxBurstQPSCallbackTableGaugeIfNeeded(tableNameWithType, queryQuotaEntity);
     if (isQueryRateLimitDisabled()) {
       LOGGER.info("Query rate limiting is currently disabled for this broker. So it won't take effect immediately.");
     }
+  }
+
+  /**
+   * Build an empty rate limiter in the new query quota entity, or set the rate limiter to null in an existing query quota entity.
+   */
+  private void buildEmptyOrResetRateLimiterInQueryQuotaEntity(String tableNameWithType) {
+    QueryQuotaEntity queryQuotaEntity = _rateLimiterMap.get(tableNameWithType);
+    if (queryQuotaEntity == null) {
+      // Create an QueryQuotaEntity object without setting a rate limiter.
+      queryQuotaEntity = new QueryQuotaEntity(null, new HitCounter(ONE_SECOND_TIME_RANGE_IN_SECOND),
+          new MaxHitRateTracker(ONE_MINUTE_TIME_RANGE_IN_SECOND), 0, 0, 0);
+      _rateLimiterMap.put(tableNameWithType, queryQuotaEntity);
+    } else {
+      // Set rate limiter to null for an existing QueryQuotaEntity object.
+      queryQuotaEntity.setRateLimiter(null);
+    }
+    addMaxBurstQPSCallbackTableGaugeIfNeeded(tableNameWithType, queryQuotaEntity);
+  }
+
+  /**
+   * Add the max burst QPS callback table gauge to the metric system if it doesn't exist.
+   */
+  private void addMaxBurstQPSCallbackTableGaugeIfNeeded(String tableNameWithType, QueryQuotaEntity queryQuotaEntity) {
+    final QueryQuotaEntity finalQueryQuotaEntity = queryQuotaEntity;
+    _brokerMetrics.addCallbackTableGaugeIfNeeded(tableNameWithType, BrokerGauge.MAX_BURST_QPS,
+        () -> (long) finalQueryQuotaEntity.getMaxQpsTracker().getMaxCountPerBucket());
   }
 
   /**
@@ -276,6 +301,10 @@ public class HelixExternalViewBasedQueryQuotaManager implements ClusterChangeHan
     queryQuotaEntity.getMaxQpsTracker().hit();
 
     RateLimiter rateLimiter = queryQuotaEntity.getRateLimiter();
+    // Return true if no rate limiter is initialized.
+    if (rateLimiter == null) {
+      return true;
+    }
     double perBrokerRate = rateLimiter.getRate();
 
     // Emit the qps capacity utilization rate.
@@ -302,6 +331,11 @@ public class HelixExternalViewBasedQueryQuotaManager implements ClusterChangeHan
   }
 
   @VisibleForTesting
+  public QueryQuotaEntity getRateLimiterForTable(String tableNameWithType) {
+    return _rateLimiterMap.get(tableNameWithType);
+  }
+
+  @VisibleForTesting
   public void cleanUpRateLimiterMap() {
     _rateLimiterMap.clear();
   }
@@ -309,15 +343,15 @@ public class HelixExternalViewBasedQueryQuotaManager implements ClusterChangeHan
   /**
    * Process query quota change when number of online brokers has changed.
    */
-  public void processQueryRateLimitingExternalViewChange(ExternalView currentBrokerResource) {
+  public void processQueryRateLimitingExternalViewChange(ExternalView currentBrokerResourceEV) {
     LOGGER.info("Start processing qps quota change.");
     long startTime = System.currentTimeMillis();
 
-    if (currentBrokerResource == null) {
+    if (currentBrokerResourceEV == null) {
       LOGGER.warn("Finish processing qps quota change: external view for broker resource is null!");
       return;
     }
-    int currentVersionNumber = currentBrokerResource.getRecord().getVersion();
+    int currentVersionNumber = currentBrokerResourceEV.getRecord().getVersion();
     if (currentVersionNumber == _lastKnownBrokerResourceVersion.get()) {
       LOGGER.info("No qps quota change: external view for broker resource remains the same.");
       return;
@@ -328,9 +362,13 @@ public class HelixExternalViewBasedQueryQuotaManager implements ClusterChangeHan
       Map.Entry<String, QueryQuotaEntity> entry = it.next();
       String tableNameWithType = entry.getKey();
       QueryQuotaEntity queryQuotaEntity = entry.getValue();
+      if (queryQuotaEntity.getRateLimiter() == null) {
+        // No rate limiter set, skip this table.
+        continue;
+      }
 
       // Get number of online brokers.
-      Map<String, String> stateMap = currentBrokerResource.getStateMap(tableNameWithType);
+      Map<String, String> stateMap = currentBrokerResourceEV.getStateMap(tableNameWithType);
       if (stateMap == null) {
         LOGGER.info("No broker resource for Table {}. Removing its rate limit.", tableNameWithType);
         it.remove();
@@ -406,12 +444,14 @@ public class HelixExternalViewBasedQueryQuotaManager implements ClusterChangeHan
 
   private void getQueryQuotaEnabledFlagFromInstanceConfig() {
     try {
-      Map<String, String> instanceConfigsMap =
-          HelixHelper.getInstanceConfigsMapFor(_instanceId, _helixManager.getClusterName(), _helixManager.getClusterManagmentTool());
-      String queryRateLimitDisabled = instanceConfigsMap.getOrDefault(CommonConstants.Helix.QUERY_RATE_LIMIT_DISABLED, "false");
+      Map<String, String> instanceConfigsMap = HelixHelper
+          .getInstanceConfigsMapFor(_instanceId, _helixManager.getClusterName(),
+              _helixManager.getClusterManagmentTool());
+      String queryRateLimitDisabled =
+          instanceConfigsMap.getOrDefault(CommonConstants.Helix.QUERY_RATE_LIMIT_DISABLED, "false");
       _queryRateLimitDisabled = Boolean.parseBoolean(queryRateLimitDisabled);
-      LOGGER.info("Set query rate limiting to: {} for all {} tables in this broker.", _queryRateLimitDisabled ? "DISABLED" : "ENABLED",
-          _rateLimiterMap.size());
+      LOGGER.info("Set query rate limiting to: {} for all {} tables in this broker.",
+          _queryRateLimitDisabled ? "DISABLED" : "ENABLED", _rateLimiterMap.size());
     } catch (ZkNoNodeException e) {
       // It's a brand new broker. Skip checking instance config.
       _queryRateLimitDisabled = false;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/QueryQuotaEntity.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/QueryQuotaEntity.java
@@ -40,6 +40,10 @@ public class QueryQuotaEntity {
     _tableConfigStatVersion = tableConfigStatVersion;
   }
 
+  public void setRateLimiter(RateLimiter rateLimiter) {
+    _rateLimiter = rateLimiter;
+  }
+
   public RateLimiter getRateLimiter() {
     return _rateLimiter;
   }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManagerTest.java
@@ -165,7 +165,9 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
     ExternalView brokerResource = generateBrokerResource(OFFLINE_TABLE_NAME);
     TableConfig tableConfig = generateDefaultTableConfig(OFFLINE_TABLE_NAME);
     _queryQuotaManager.initOrUpdateTableQueryQuota(tableConfig, brokerResource);
-    Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 0);
+    Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 1);
+    QueryQuotaEntity queryQuotaEntity = _queryQuotaManager.getRateLimiterForTable(OFFLINE_TABLE_NAME);
+    Assert.assertNull(queryQuotaEntity.getRateLimiter());
   }
 
   @Test
@@ -182,7 +184,9 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
     ExternalView brokerResource = generateBrokerResource(OFFLINE_TABLE_NAME);
     TableConfig tableConfig = generateDefaultTableConfig(OFFLINE_TABLE_NAME);
     _queryQuotaManager.initOrUpdateTableQueryQuota(tableConfig, brokerResource);
-    Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 0);
+    Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 1);
+    QueryQuotaEntity queryQuotaEntity = _queryQuotaManager.getRateLimiterForTable(OFFLINE_TABLE_NAME);
+    Assert.assertNull(queryQuotaEntity.getRateLimiter());
 
     // Nothing happened since it doesn't have qps quota.
     _queryQuotaManager.dropTableQueryQuota(OFFLINE_TABLE_NAME);
@@ -203,7 +207,9 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
     ExternalView brokerResource = generateBrokerResource(REALTIME_TABLE_NAME);
     TableConfig tableConfig = generateDefaultTableConfig(OFFLINE_TABLE_NAME);
     _queryQuotaManager.initOrUpdateTableQueryQuota(tableConfig, brokerResource);
-    Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 0);
+    Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 1);
+    QueryQuotaEntity queryQuotaEntity = _queryQuotaManager.getRateLimiterForTable(OFFLINE_TABLE_NAME);
+    Assert.assertNull(queryQuotaEntity.getRateLimiter());
 
     // Drop the offline table won't have any affect since it is table type specific.
     _queryQuotaManager.dropTableQueryQuota(OFFLINE_TABLE_NAME);
@@ -292,7 +298,9 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
     ExternalView brokerResource = generateBrokerResource(REALTIME_TABLE_NAME);
     TableConfig tableConfig = generateDefaultTableConfig(REALTIME_TABLE_NAME);
     _queryQuotaManager.initOrUpdateTableQueryQuota(tableConfig, brokerResource);
-    Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 0);
+    Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 1);
+    QueryQuotaEntity queryQuotaEntity = _queryQuotaManager.getRateLimiterForTable(REALTIME_TABLE_NAME);
+    Assert.assertNull(queryQuotaEntity.getRateLimiter());
   }
 
   @Test
@@ -309,7 +317,9 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
     ExternalView brokerResource = generateBrokerResource(REALTIME_TABLE_NAME);
     TableConfig tableConfig = generateDefaultTableConfig(REALTIME_TABLE_NAME);
     _queryQuotaManager.initOrUpdateTableQueryQuota(tableConfig, brokerResource);
-    Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 0);
+    Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 1);
+    QueryQuotaEntity queryQuotaEntity = _queryQuotaManager.getRateLimiterForTable(REALTIME_TABLE_NAME);
+    Assert.assertNull(queryQuotaEntity.getRateLimiter());
   }
 
   @Test
@@ -326,7 +336,9 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
     ExternalView brokerResource = generateBrokerResource(OFFLINE_TABLE_NAME);
     TableConfig tableConfig = generateDefaultTableConfig(REALTIME_TABLE_NAME);
     _queryQuotaManager.initOrUpdateTableQueryQuota(tableConfig, brokerResource);
-    Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 0);
+    Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 1);
+    QueryQuotaEntity queryQuotaEntity = _queryQuotaManager.getRateLimiterForTable(REALTIME_TABLE_NAME);
+    Assert.assertNull(queryQuotaEntity.getRateLimiter());
   }
 
   @Test
@@ -335,7 +347,9 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
     TableConfig tableConfig = generateDefaultTableConfig(OFFLINE_TABLE_NAME);
     setQps(tableConfig);
     _queryQuotaManager.initOrUpdateTableQueryQuota(tableConfig, null);
-    Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 0);
+    Assert.assertEquals(_queryQuotaManager.getRateLimiterMapSize(), 1);
+    QueryQuotaEntity queryQuotaEntity = _queryQuotaManager.getRateLimiterForTable(OFFLINE_TABLE_NAME);
+    Assert.assertNull(queryQuotaEntity.getRateLimiter());
   }
 
   @Test


### PR DESCRIPTION
## Description
This PR enables hit counter and max hit rate tracker. 
These two hit counters are useful to track the actual qps in the system, regardless of whether the query quota is set or not.

Performance shouldn't be an issue here since the logic of acquire method has been in use for some high QPS low latency cases (2k qps per broker, P99th 50ms). 
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
