### PR TITLE
[7187] Validate CSV Header For Configured Delimiter

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
@@ -85,10 +85,8 @@ public class CSVRecordReader implements RecordReader {
       if (csvHeader == null) {
         format = format.withHeader();
       } else {
-        //we assume that the record delimiter also delimits the header
-        if (delimiterNotPresentInHeader(delimiter, csvHeader)) {
-          throw new IllegalArgumentException("Supplied header does not contain the configured delimiter");
-        }
+        //validate header for the delimiter before splitting
+        validateHeaderForDelimiter(delimiter, csvHeader, format);
         format = format.withHeader(StringUtils.split(csvHeader, delimiter));
       }
       Character commentMarker = config.getCommentMarker();
@@ -105,6 +103,19 @@ public class CSVRecordReader implements RecordReader {
     recordExtractorConfig.setMultiValueDelimiter(multiValueDelimiter);
     recordExtractorConfig.setColumnNames(_parser.getHeaderMap().keySet());
     _recordExtractor.init(fieldsToRead, recordExtractorConfig);
+  }
+
+  private void validateHeaderForDelimiter(char delimiter, String csvHeader, CSVFormat format)
+      throws IOException {
+    CSVParser parser = format.parse(RecordReaderUtils.getBufferedReader(_dataFile));
+    CSVRecord firstRecord = parser.getRecords().get(0);
+    if (recordHasMultipleValues(firstRecord) && delimiterNotPresentInHeader(delimiter, csvHeader)) {
+      throw new IllegalArgumentException("Supplied header does not contain the configured delimiter");
+    }
+  }
+
+  private boolean recordHasMultipleValues(CSVRecord firstRecord) {
+    return null != firstRecord && firstRecord.size() > 1;
   }
 
   private boolean delimiterNotPresentInHeader(char delimiter, String csvHeader) {

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
@@ -89,8 +89,7 @@ public class CSVRecordReader implements RecordReader {
         if (delimiterNotPresentInHeader(delimiter, csvHeader)) {
           throw new IllegalArgumentException("Supplied header does not contain the supplied delimiter");
         }
-        String[] columns = StringUtils.split(csvHeader, delimiter);
-        format = format.withHeader(columns);
+        format = format.withHeader(StringUtils.split(csvHeader, delimiter));
       }
       Character commentMarker = config.getCommentMarker();
       format = format.withCommentMarker(commentMarker);

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
@@ -114,8 +114,8 @@ public class CSVRecordReader implements RecordReader {
     }
   }
 
-  private boolean recordHasMultipleValues(CSVRecord firstRecord) {
-    return null != firstRecord && firstRecord.size() > 1;
+  private boolean recordHasMultipleValues(CSVRecord record) {
+    return null != record && record.size() > 1;
   }
 
   private boolean delimiterNotPresentInHeader(char delimiter, String csvHeader) {

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
@@ -87,7 +87,7 @@ public class CSVRecordReader implements RecordReader {
       } else {
         //we assume that the record delimiter also delimits the header
         if (delimiterNotPresentInHeader(delimiter, csvHeader)) {
-          throw new IllegalArgumentException("Supplied header does not contain the supplied delimiter");
+          throw new IllegalArgumentException("Supplied header does not contain the configured delimiter");
         }
         format = format.withHeader(StringUtils.split(csvHeader, delimiter));
       }

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
@@ -108,14 +108,15 @@ public class CSVRecordReader implements RecordReader {
   private void validateHeaderForDelimiter(char delimiter, String csvHeader, CSVFormat format)
       throws IOException {
     CSVParser parser = format.parse(RecordReaderUtils.getBufferedReader(_dataFile));
-    CSVRecord firstRecord = parser.getRecords().get(0);
-    if (recordHasMultipleValues(firstRecord) && delimiterNotPresentInHeader(delimiter, csvHeader)) {
+    Iterator<CSVRecord> iterator = parser.iterator();
+    if (iterator.hasNext() && recordHasMultipleValues(iterator.next()) && delimiterNotPresentInHeader(delimiter,
+        csvHeader)) {
       throw new IllegalArgumentException("Configured header does not contain the configured delimiter");
     }
   }
 
   private boolean recordHasMultipleValues(CSVRecord record) {
-    return null != record && record.size() > 1;
+    return record.size() > 1;
   }
 
   private boolean delimiterNotPresentInHeader(char delimiter, String csvHeader) {

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
@@ -85,7 +85,12 @@ public class CSVRecordReader implements RecordReader {
       if (csvHeader == null) {
         format = format.withHeader();
       } else {
-        format = format.withHeader(StringUtils.split(csvHeader, delimiter));
+        //we assume that the record delimiter also delimits the header.
+        if (delimiterNotPresentInHeader(delimiter, csvHeader)) {
+          throw new IllegalArgumentException("Supplied header does not contain the supplied delimiter");
+        }
+        String[] columns = StringUtils.split(csvHeader, delimiter);
+        format = format.withHeader(columns);
       }
       Character commentMarker = config.getCommentMarker();
       format = format.withCommentMarker(commentMarker);
@@ -101,6 +106,10 @@ public class CSVRecordReader implements RecordReader {
     recordExtractorConfig.setMultiValueDelimiter(multiValueDelimiter);
     recordExtractorConfig.setColumnNames(_parser.getHeaderMap().keySet());
     _recordExtractor.init(fieldsToRead, recordExtractorConfig);
+  }
+
+  private boolean delimiterNotPresentInHeader(char delimiter, String csvHeader) {
+    return !StringUtils.contains(csvHeader, delimiter);
   }
 
   private void init()

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
@@ -85,7 +85,7 @@ public class CSVRecordReader implements RecordReader {
       if (csvHeader == null) {
         format = format.withHeader();
       } else {
-        //we assume that the record delimiter also delimits the header.
+        //we assume that the record delimiter also delimits the header
         if (delimiterNotPresentInHeader(delimiter, csvHeader)) {
           throw new IllegalArgumentException("Supplied header does not contain the supplied delimiter");
         }

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
@@ -110,7 +110,7 @@ public class CSVRecordReader implements RecordReader {
     CSVParser parser = format.parse(RecordReaderUtils.getBufferedReader(_dataFile));
     CSVRecord firstRecord = parser.getRecords().get(0);
     if (recordHasMultipleValues(firstRecord) && delimiterNotPresentInHeader(delimiter, csvHeader)) {
-      throw new IllegalArgumentException("Supplied header does not contain the configured delimiter");
+      throw new IllegalArgumentException("Configured header does not contain the configured delimiter");
     }
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderTest.java
@@ -23,7 +23,6 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVPrinter;
 import org.apache.commons.lang3.StringUtils;
@@ -118,8 +117,6 @@ public class CSVRecordReaderTest extends AbstractRecordReaderTest {
     //execution and assertion
     Assert.assertThrows(IllegalArgumentException.class,
         () -> csvRecordReader.init(_dataFile, null, csvRecordReaderConfig));
-    Assert.assertThrows(IllegalArgumentException.class,
-        () -> csvRecordReader.init(_dataFile, Set.of(), csvRecordReaderConfig));
   }
 
   @Test

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderTest.java
@@ -32,6 +32,7 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.testng.Assert;
+import org.testng.annotations.Test;
 
 
 public class CSVRecordReaderTest extends AbstractRecordReaderTest {
@@ -102,5 +103,18 @@ public class CSVRecordReaderTest extends AbstractRecordReaderTest {
       }
     }
     Assert.assertFalse(recordReader.hasNext());
+  }
+
+  @Test
+  public void whenConfiguredHeaderDoesNotContainConfiguredDelimiterThenExceptionShouldBeThrown() {
+    //setup
+    CSVRecordReaderConfig csvRecordReaderConfig = new CSVRecordReaderConfig();
+    csvRecordReaderConfig.setMultiValueDelimiter(CSV_MULTI_VALUE_DELIMITER);
+    csvRecordReaderConfig.setHeader("col1;col2;col3;col4;col5;col6;col7;col8;col9;col10");
+    csvRecordReaderConfig.setDelimiter(',');
+    CSVRecordReader csvRecordReader = new CSVRecordReader();
+    //execution and assertion
+    Assert.assertThrows(IllegalArgumentException.class,
+        () -> csvRecordReader.init(_dataFile, _sourceFields, csvRecordReaderConfig));
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.plugin.inputformat.csv;
 
-import com.google.common.collect.Sets;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -35,7 +34,6 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.testng.Assert;
-import org.testng.annotations.Parameters;
 import org.testng.annotations.Test;
 
 

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderTest.java
@@ -110,19 +110,6 @@ public class CSVRecordReaderTest extends AbstractRecordReaderTest {
   }
 
   @Test
-  public void testIncorrectHeaderDelimiterWhenSourceFieldsAreSpecified() {
-    //setup
-    CSVRecordReaderConfig csvRecordReaderConfig = new CSVRecordReaderConfig();
-    csvRecordReaderConfig.setMultiValueDelimiter(CSV_MULTI_VALUE_DELIMITER);
-    csvRecordReaderConfig.setHeader("col1;col2;col3;col4;col5;col6;col7;col8;col9;col10");
-    csvRecordReaderConfig.setDelimiter(',');
-    CSVRecordReader csvRecordReader = new CSVRecordReader();
-    //execution and assertion
-    Assert.assertThrows(IllegalArgumentException.class,
-        () -> csvRecordReader.init(_dataFile, _sourceFields, csvRecordReaderConfig));
-  }
-
-  @Test
   public void testInvalidDelimiterInHeader() {
     //setup
     CSVRecordReaderConfig csvRecordReaderConfig = new CSVRecordReaderConfig();

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderTest.java
@@ -159,9 +159,7 @@ public class CSVRecordReaderTest extends AbstractRecordReaderTest {
         CSVPrinter csvPrinter = new CSVPrinter(fileWriter, CSVFormat.DEFAULT.withHeader(column))) {
       for (Map<String, Object> r : _records) {
         Object[] record = new Object[1];
-        for (int i = 0; i < 1; i++) {
-          record[i] = r.get(column);
-        }
+        record[0] = r.get(column);
         csvPrinter.printRecord(record);
       }
     }


### PR DESCRIPTION
## Description
Relevant discussion in the [issue](https://github.com/apache/pinot/issues/7187). Currently, it is assumed that the configured delimiter in the ingestion job spec also works for the header. This PR simply adds an explicit check that throws an exception if the header does not contain the delimiter.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes

Does this PR otherwise need attention when creating release notes? 
* [ ] Yes 
