### PR TITLE
Make group trim size configurable for better accuracy

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationGroupByOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationGroupByOrderByOperator.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.operator.query;
 
 import java.util.Collection;
-import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.data.table.IntermediateRecord;
@@ -35,9 +34,6 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByExecutor;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.startree.executor.StarTreeGroupByExecutor;
 import org.apache.pinot.core.util.GroupByUtils;
-import org.apache.pinot.core.util.QueryOptions;
-
-import static org.apache.pinot.core.util.GroupByUtils.getTableCapacity;
 
 
 /**
@@ -52,7 +48,7 @@ public class AggregationGroupByOrderByOperator extends BaseOperator<Intermediate
   private final ExpressionContext[] _groupByExpressions;
   private final int _maxInitialResultHolderCapacity;
   private final int _numGroupsLimit;
-  private final int _minSegmentTrimSize;
+  private final int _minGroupTrimSize;
   private final TransformOperator _transformOperator;
   private final long _numTotalDocs;
   private final boolean _useStarTree;
@@ -63,17 +59,17 @@ public class AggregationGroupByOrderByOperator extends BaseOperator<Intermediate
 
   public AggregationGroupByOrderByOperator(AggregationFunction[] aggregationFunctions,
       ExpressionContext[] groupByExpressions, int maxInitialResultHolderCapacity, int numGroupsLimit,
-      int minSegmentTrimSize, TransformOperator transformOperator, long numTotalDocs, QueryContext queryContext,
+      int minGroupTrimSize, TransformOperator transformOperator, long numTotalDocs, QueryContext queryContext,
       boolean useStarTree) {
     _aggregationFunctions = aggregationFunctions;
     _groupByExpressions = groupByExpressions;
     _maxInitialResultHolderCapacity = maxInitialResultHolderCapacity;
     _numGroupsLimit = numGroupsLimit;
+    _minGroupTrimSize = minGroupTrimSize;
     _transformOperator = transformOperator;
     _numTotalDocs = numTotalDocs;
     _useStarTree = useStarTree;
     _queryContext = queryContext;
-    _minSegmentTrimSize = minSegmentTrimSize;
 
     // NOTE: The indexedTable expects that the the data schema will have group by columns before aggregation columns
     int numGroupByExpressions = groupByExpressions.length;
@@ -120,21 +116,22 @@ public class AggregationGroupByOrderByOperator extends BaseOperator<Intermediate
       groupByExecutor.process(transformBlock);
     }
 
-    int minSegmentTrimSize = calculateMinSegmentTrimSize();
-    // There is no OrderBy or minSegmentTrimSize is set to be negative or 0
-    if (_queryContext.getOrderByExpressions() == null || minSegmentTrimSize <= 0) {
-      // Build intermediate result block based on aggregation group-by result from the executor
-      return new IntermediateResultsBlock(_aggregationFunctions, groupByExecutor.getResult(), _dataSchema);
+    // Trim the groups when iff:
+    // - Query has ORDER BY clause
+    // - Segment group trim is enabled
+    // - There are more groups than the trim size
+    // TODO: Currently the groups are not trimmed if there is no ordering specified. Consider ordering on group-by
+    //       columns if no ordering is specified.
+    if (_queryContext.getOrderByExpressions() != null && _minGroupTrimSize > 0) {
+      int trimSize = GroupByUtils.getTableCapacity(_queryContext.getLimit(), _minGroupTrimSize);
+      if (groupByExecutor.getNumGroups() > trimSize) {
+        TableResizer tableResizer = new TableResizer(_dataSchema, _queryContext);
+        Collection<IntermediateRecord> intermediateRecords = groupByExecutor.trimGroupByResult(trimSize, tableResizer);
+        return new IntermediateResultsBlock(_aggregationFunctions, intermediateRecords, _dataSchema);
+      }
     }
-    int trimSize = getTableCapacity(_queryContext.getLimit(), minSegmentTrimSize);
-    // Num of groups hasn't reached the threshold
-    if (groupByExecutor.getNumGroups() <= trimSize) {
-      return new IntermediateResultsBlock(_aggregationFunctions, groupByExecutor.getResult(), _dataSchema);
-    }
-    // Trim
-    TableResizer tableResizer = new TableResizer(_dataSchema, _queryContext);
-    Collection<IntermediateRecord> intermediateRecords = groupByExecutor.trimGroupByResult(trimSize, tableResizer);
-    return new IntermediateResultsBlock(_aggregationFunctions, intermediateRecords, _dataSchema);
+
+    return new IntermediateResultsBlock(_aggregationFunctions, groupByExecutor.getResult(), _dataSchema);
   }
 
   @Override
@@ -148,24 +145,5 @@ public class AggregationGroupByOrderByOperator extends BaseOperator<Intermediate
     long numEntriesScannedPostFilter = (long) _numDocsScanned * _transformOperator.getNumColumnsProjected();
     return new ExecutionStatistics(_numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter,
         _numTotalDocs);
-  }
-
-  /**
-   * In query option, if a positive min trim size is given, we use it to override the server settings. Otherwise
-   * check if a simple boolean option is given and use default trim size.
-   */
-  private int calculateMinSegmentTrimSize() {
-    Map<String, String> options = _queryContext.getQueryOptions();
-    if (options == null) {
-      return _minSegmentTrimSize;
-    }
-    boolean queryOptionEnableTrim = QueryOptions.isEnableSegmentTrim(options);
-    int queryOptionTrimSize = QueryOptions.getMinSegmentTrimSize(options);
-    if (queryOptionTrimSize > 0) {
-      return queryOptionTrimSize;
-    } else if (queryOptionEnableTrim && _minSegmentTrimSize <= 0) {
-      return GroupByUtils.DEFAULT_MIN_NUM_GROUPS;
-    }
-    return _minSegmentTrimSize;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptions.java
@@ -33,26 +33,20 @@ public class QueryOptions {
   private final boolean _responseFormatSQL;
   private final boolean _preserveType;
   private final boolean _skipUpsert;
-  private final boolean _enableSegmentTrim;
-  private final int _minSegmentTrimSize;
 
   public QueryOptions(@Nullable Map<String, String> queryOptions) {
     if (queryOptions != null) {
       _timeoutMs = getTimeoutMs(queryOptions);
-      _groupByModeSQL = Request.SQL.equalsIgnoreCase(queryOptions.get(Request.QueryOptionKey.GROUP_BY_MODE));
+      _groupByModeSQL = isGroupByModeSQL(queryOptions);
       _responseFormatSQL = Request.SQL.equalsIgnoreCase(queryOptions.get(Request.QueryOptionKey.RESPONSE_FORMAT));
       _preserveType = Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.PRESERVE_TYPE));
       _skipUpsert = Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.SKIP_UPSERT));
-      _enableSegmentTrim = isEnableSegmentTrim(queryOptions);
-      _minSegmentTrimSize = getMinSegmentTrimSize(queryOptions);
     } else {
       _timeoutMs = null;
       _groupByModeSQL = false;
       _responseFormatSQL = false;
       _preserveType = false;
       _skipUpsert = false;
-      _enableSegmentTrim = false;
-      _minSegmentTrimSize = -1;
     }
   }
 
@@ -78,16 +72,6 @@ public class QueryOptions {
   }
 
   @Nullable
-  public Boolean isEnableSegmentTrim() {
-    return _enableSegmentTrim;
-  }
-
-  @Nullable
-  public Integer getMinSegmentTrimSize() {
-    return _minSegmentTrimSize;
-  }
-
-  @Nullable
   public static Long getTimeoutMs(Map<String, String> queryOptions) {
     String timeoutMsString = queryOptions.get(Request.QueryOptionKey.TIMEOUT_MS);
     if (timeoutMsString != null) {
@@ -99,15 +83,19 @@ public class QueryOptions {
     }
   }
 
-  public static boolean isEnableSegmentTrim(Map<String, String> queryOptions) {
-    return Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.ENABLE_SEGMENT_TRIM));
+  public static boolean isGroupByModeSQL(Map<String, String> queryOptions) {
+    return Request.SQL.equalsIgnoreCase(queryOptions.get(Request.QueryOptionKey.GROUP_BY_MODE));
   }
 
-  public static int getMinSegmentTrimSize(Map<String, String> queryOptions) {
-    String minSegmentTrimSize = queryOptions.get(Request.QueryOptionKey.MIN_SEGMENT_TRIM_SIZE);
-    if (minSegmentTrimSize != null) {
-      return Integer.parseInt(minSegmentTrimSize);
-    }
-    return -1;
+  @Nullable
+  public static Integer getMinSegmentGroupTrimSize(Map<String, String> queryOptions) {
+    String minSegmentGroupTrimSizeString = queryOptions.get(Request.QueryOptionKey.MIN_SEGMENT_GROUP_TRIM_SIZE);
+    return minSegmentGroupTrimSizeString != null ? Integer.parseInt(minSegmentGroupTrimSizeString) : null;
+  }
+
+  @Nullable
+  public static Integer getMinServerGroupTrimSize(Map<String, String> queryOptions) {
+    String minServerGroupTrimSizeString = queryOptions.get(Request.QueryOptionKey.MIN_SERVER_GROUP_TRIM_SIZE);
+    return minServerGroupTrimSizeString != null ? Integer.parseInt(minServerGroupTrimSizeString) : null;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineSlowOperatorsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineSlowOperatorsTest.java
@@ -95,7 +95,8 @@ public class CombineSlowOperatorsTest {
     List<Operator> operators = getOperators();
     GroupByOrderByCombineOperator combineOperator = new GroupByOrderByCombineOperator(operators,
         QueryContextConverterUtils.getQueryContextFromSQL("SELECT COUNT(*) FROM testTable GROUP BY column"),
-        _executorService, TIMEOUT_MS, InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
+        _executorService, TIMEOUT_MS, InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
+        InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
     testCombineOperator(operators, combineOperator);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/SelectionCombineOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/SelectionCombineOperatorTest.java
@@ -230,7 +230,8 @@ public class SelectionCombineOperatorTest {
     }
     CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, queryContext, EXECUTOR,
         System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS,
-        InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, null, InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
+        InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
+        InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD, null);
     return combinePlanNode.run().nextBlock();
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/CombinePlanNodeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/CombinePlanNodeTest.java
@@ -59,8 +59,8 @@ public class CombinePlanNodeTest {
       }
       CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, _queryContext, _executorService,
           System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS,
-          InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, null,
-          InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
+          InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
+          InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD, null);
       combinePlanNode.run();
       Assert.assertEquals(numPlans, count.get());
     }
@@ -85,8 +85,9 @@ public class CombinePlanNodeTest {
     }
     CombinePlanNode combinePlanNode =
         new CombinePlanNode(planNodes, _queryContext, _executorService, System.currentTimeMillis() + 100,
-            InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, null,
-            InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
+            InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT,
+            InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
+            InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD, null);
     try {
       combinePlanNode.run();
     } catch (RuntimeException e) {
@@ -108,7 +109,8 @@ public class CombinePlanNodeTest {
     }
     CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, _queryContext, _executorService,
         System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS,
-        InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, null, InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
+        InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
+        InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD, null);
     try {
       combinePlanNode.run();
     } catch (RuntimeException e) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/GroupByTrimTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/GroupByTrimTest.java
@@ -20,18 +20,20 @@ package org.apache.pinot.core.query.aggregation.groupby;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.PriorityQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.core.data.table.IntermediateRecord;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
+import org.apache.pinot.core.operator.combine.GroupByOrderByCombineOperator;
 import org.apache.pinot.core.operator.query.AggregationGroupByOrderByOperator;
 import org.apache.pinot.core.plan.AggregationGroupByOrderByPlanNode;
+import org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
@@ -44,14 +46,14 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.utils.Pair;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static java.lang.Math.max;
 import static org.testng.Assert.assertEquals;
 
 
@@ -67,19 +69,18 @@ import static org.testng.Assert.assertEquals;
  * Currently tests 'max' functions, and can be easily extended to
  * test other conditions such as GroupBy without OrderBy
  */
-public class GroupByInSegmentTrimTest {
-  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "GroupByInSegmentTrimTest");
-  private static final String SEGMENT_NAME = "TestGroupByInSegment";
-
+public class GroupByTrimTest {
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "GroupByTrimTest");
+  private static final String SEGMENT_NAME = "testSegment";
   private static final String METRIC_PREFIX = "metric_";
-  private static final int NUM_ROWS = 1000;
-  private static final int NUM_COLUMN = 2;
-  private static final int MAX_INITIAL_RESULT_HOLDER_CAPACITY = 10_000;
-  private static final int NUM_GROUPS_LIMIT = 100_000;
-  private static IndexSegment _indexSegment;
-  private static String[] _columns;
-  private static double[][] _inputData;
-  private static Map<Double, Double> _resultMap;
+  private static final int NUM_COLUMNS = 2;
+  private static final int NUM_ROWS = 10000;
+
+  private final ExecutorService _executorService = Executors.newCachedThreadPool();
+  private IndexSegment _indexSegment;
+  private String[] _columns;
+  private double[][] _inputData;
+  private Map<Double, Double> _resultMap;
 
   /**
    * Initializations prior to the test:
@@ -91,36 +92,50 @@ public class GroupByInSegmentTrimTest {
   @BeforeClass
   public void setUp()
       throws Exception {
+    FileUtils.deleteQuietly(INDEX_DIR);
     _resultMap = new HashMap<>();
     // Current Schema: Columns: metrics_0(double), metrics_1(double)
-    _inputData = new double[NUM_COLUMN][NUM_ROWS];
-    _columns = new String[NUM_COLUMN];
+    _inputData = new double[NUM_COLUMNS][NUM_ROWS];
+    _columns = new String[NUM_COLUMNS];
     setupSegment();
+  }
+
+  @AfterClass
+  public void tearDown() {
+    _indexSegment.destroy();
+    _executorService.shutdown();
+    FileUtils.deleteQuietly(INDEX_DIR);
   }
 
   /**
    * Test the GroupBy OrderBy query and compute the expected results to match
    */
-  @Test(dataProvider = "QueryDataProvider")
-  void TestGroupByOrderByOperator(int trimSize, List<Pair<Double, Double>> expectedResult, QueryContext queryContext) {
-    // Create a query plan
-    AggregationGroupByOrderByPlanNode aggregationGroupByOrderByPlanNode =
-        new AggregationGroupByOrderByPlanNode(_indexSegment, queryContext, MAX_INITIAL_RESULT_HOLDER_CAPACITY,
-            NUM_GROUPS_LIMIT, trimSize);
+  @Test(dataProvider = "groupByTrimTestDataProvider")
+  void testGroupByTrim(QueryContext queryContext, int minSegmentGroupTrimSize, int minServerGroupTrimSize,
+      List<Pair<Double, Double>> expectedResult)
+      throws Exception {
+    // Create a query operator
+    AggregationGroupByOrderByOperator groupByOperator =
+        new AggregationGroupByOrderByPlanNode(_indexSegment, queryContext,
+            InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY,
+            InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, minSegmentGroupTrimSize).run();
+    GroupByOrderByCombineOperator combineOperator =
+        new GroupByOrderByCombineOperator(Collections.singletonList(groupByOperator), queryContext, _executorService,
+            System.currentTimeMillis() + CommonConstants.Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS,
+            minServerGroupTrimSize, InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
 
-    // Get the query executor
-    AggregationGroupByOrderByOperator aggregationGroupByOrderByOperator = aggregationGroupByOrderByPlanNode.run();
+    // Execute the query
+    IntermediateResultsBlock resultsBlock = combineOperator.nextBlock();
 
     // Extract the execution result
-    IntermediateResultsBlock resultsBlock = aggregationGroupByOrderByOperator.nextBlock();
-    ArrayList<Pair<Double, Double>> extractedResult = extractTestResult(resultsBlock);
+    List<Pair<Double, Double>> extractedResult = extractTestResult(resultsBlock);
 
     assertEquals(extractedResult, expectedResult);
   }
 
   /**
    * Helper method to setup the index segment on which to perform aggregation tests.
-   * - Generates a segment with {@link #NUM_COLUMN} and {@link #NUM_ROWS}
+   * - Generates a segment with {@link #NUM_COLUMNS} and {@link #NUM_ROWS}
    * - Random 'double' data filled in the metric columns. The data is also populated
    *   into the _inputData[], so it can be used to test the results.
    *
@@ -128,10 +143,6 @@ public class GroupByInSegmentTrimTest {
    */
   private void setupSegment()
       throws Exception {
-    if (INDEX_DIR.exists()) {
-      FileUtils.deleteQuietly(INDEX_DIR);
-    }
-
     // Segment Config
     SegmentGeneratorConfig config =
         new SegmentGeneratorConfig(new TableConfigBuilder(TableType.OFFLINE).setTableName("test").build(),
@@ -145,11 +156,10 @@ public class GroupByInSegmentTrimTest {
     for (int i = 0; i < NUM_ROWS; i++) {
       GenericRow genericRow = new GenericRow();
 
-      for (int j = 0; j < _columns.length; j++) {
-        String metricName = _columns[j];
+      for (int j = 0; j < NUM_COLUMNS; j++) {
         double value = baseValue + i + j;
         _inputData[j][i] = value;
-        genericRow.putValue(metricName, value);
+        genericRow.putValue(_columns[j], value);
       }
       // Compute the max result and insert into a grouped map
       computeMaxResult(_inputData[0][i], _inputData[1][i]);
@@ -172,7 +182,7 @@ public class GroupByInSegmentTrimTest {
   private Schema buildSchema() {
     Schema schema = new Schema();
 
-    for (int i = 0; i < NUM_COLUMN; i++) {
+    for (int i = 0; i < NUM_COLUMNS; i++) {
       String metricName = METRIC_PREFIX + i;
       MetricFieldSpec metricFieldSpec = new MetricFieldSpec(metricName, FieldSpec.DataType.DOUBLE);
       schema.addField(metricFieldSpec);
@@ -185,9 +195,10 @@ public class GroupByInSegmentTrimTest {
    * Helper method to compute the aggregation result grouped by the key
    *
    */
-  private void computeMaxResult(Double key, Double result) {
-    if (_resultMap.get(key) == null || _resultMap.get(key) < result) {
-      _resultMap.put(key, result);
+  private void computeMaxResult(double key, double value) {
+    Double currentValue = _resultMap.get(key);
+    if (currentValue == null || currentValue < value) {
+      _resultMap.put(key, value);
     }
   }
 
@@ -196,88 +207,57 @@ public class GroupByInSegmentTrimTest {
    *
    * @return A list of expected results
    */
-  private ArrayList<Pair<Double, Double>> extractTestResult(IntermediateResultsBlock resultsBlock) {
-    AggregationGroupByResult result = resultsBlock.getAggregationGroupByResult();
-    if (result != null) {
-      // No trim
-      return extractAggregationResult(result);
-    } else {
-      // In case of trim
-      return extractIntermediateResult(resultsBlock.getIntermediateRecords());
+  private List<Pair<Double, Double>> extractTestResult(IntermediateResultsBlock resultsBlock)
+      throws Exception {
+    DataTable dataTable = resultsBlock.getDataTable();
+    int numRows = dataTable.getNumberOfRows();
+    List<Pair<Double, Double>> result = new ArrayList<>(numRows);
+    for (int i = 0; i < numRows; i++) {
+      result.add(Pair.of(dataTable.getDouble(i, 0), dataTable.getDouble(i, 1)));
     }
-  }
-
-  /**
-   * Helper method to extract the result from AggregationGroupByResult
-   *
-   * @return A list of expected results
-   */
-  private ArrayList<Pair<Double, Double>> extractAggregationResult(AggregationGroupByResult aggregationGroupByResult) {
-    ArrayList<Pair<Double, Double>> result = new ArrayList<>();
-    Iterator<GroupKeyGenerator.GroupKey> iterator = aggregationGroupByResult.getGroupKeyIterator();
-    int i = 0;
-    while (iterator.hasNext()) {
-      GroupKeyGenerator.GroupKey groupKey = iterator.next();
-      Double key = (Double) groupKey._keys[0];
-      Double value = (Double) aggregationGroupByResult.getResultForGroupId(i, groupKey._groupId);
-      result.add(new Pair<>(key, value));
-    }
-    result.sort((o1, o2) -> (int) (o2.getSecond() - o1.getSecond()));
-    return result;
-  }
-
-  /**
-   * Helper method to extract the result from Collection<IntermediateRecord>
-   *
-   * @return A list of expected results
-   */
-  private ArrayList<Pair<Double, Double>> extractIntermediateResult(Collection<IntermediateRecord> intermediateRecord) {
-    ArrayList<Pair<Double, Double>> result = new ArrayList<>();
-    PriorityQueue<IntermediateRecord> resultPQ = new PriorityQueue<>(intermediateRecord);
-    while (!resultPQ.isEmpty()) {
-      IntermediateRecord head = resultPQ.poll();
-      result.add(new Pair<>((Double) head._record.getValues()[0], (Double) head._record.getValues()[1]));
-    }
-    Collections.reverse(result);
+    result.sort((o1, o2) -> Double.compare(o2.getRight(), o1.getRight()));
     return result;
   }
 
   @DataProvider
-  public static Object[][] QueryDataProvider() {
+  public Object[][] groupByTrimTestDataProvider() {
     List<Object[]> data = new ArrayList<>();
-    ArrayList<Pair<Double, Double>> expectedResult = computeExpectedResult();
-    // Testcase1: low limit + high trim size
+    List<Pair<Double, Double>> expectedResult = computeExpectedResult();
+
+    // Testcase1: low limit + high min trim size
     QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL(
         "SELECT metric_0, max(metric_1) FROM testTable GROUP BY metric_0 ORDER BY max(metric_1) DESC LIMIT 1");
-    int trimSize = 100;
-    int expectedSize = max(trimSize, 5 * queryContext.getLimit());
-    data.add(new Object[]{trimSize, expectedResult.subList(0, expectedSize), queryContext});
-    // Testcase2: high limit + low trim size
+    List<Pair<Double, Double>> top100 = expectedResult.subList(0, 100);
+    data.add(new Object[]{queryContext, 100, 5000, top100});
+    data.add(new Object[]{queryContext, 100, -1, top100});
+    data.add(new Object[]{queryContext, -1, 100, top100});
+    data.add(new Object[]{queryContext, 5000, 100, top100});
+
+    // Testcase2: high limit + low min trim size
     queryContext = QueryContextConverterUtils.getQueryContextFromSQL(
         "SELECT metric_0, max(metric_1) FROM testTable GROUP BY metric_0 ORDER BY max(metric_1) DESC LIMIT 50");
-    trimSize = 10;
-    expectedSize = max(trimSize, 5 * queryContext.getLimit());
-    data.add(new Object[]{trimSize, expectedResult.subList(0, expectedSize), queryContext});
-    // Testcase3: high limit + high trim size (No trim)
-    queryContext = QueryContextConverterUtils.getQueryContextFromSQL(
-        "SELECT metric_0, max(metric_1) FROM testTable GROUP BY metric_0 ORDER BY max(metric_1) DESC LIMIT 500");
-    trimSize = 1000;
-    expectedSize = 1000;
-    data.add(new Object[]{trimSize, expectedResult.subList(0, expectedSize), queryContext});
+    List<Pair<Double, Double>> top250 = expectedResult.subList(0, 250);
+    data.add(new Object[]{queryContext, 50, 5000, top250});
+    data.add(new Object[]{queryContext, 200, -1, top250});
+    data.add(new Object[]{queryContext, -1, 150, top250});
+    data.add(new Object[]{queryContext, 5000, 10, top250});
+    data.add(new Object[]{queryContext, 20, 30, top250});
 
-    // Testcase4: low limit + low server trim size + query option size
+    // Testcase3: disable trim
     queryContext = QueryContextConverterUtils.getQueryContextFromSQL(
-        "SELECT metric_0, max(metric_1) FROM testTable GROUP BY metric_0 ORDER BY max(metric_1) DESC LIMIT 50 OPTION(minSegmentTrimSize=1000)");
-    trimSize = 0;
-    expectedSize = 1000;
-    data.add(new Object[]{trimSize, expectedResult.subList(0, expectedSize), queryContext});
+        "SELECT metric_0, max(metric_1) FROM testTable GROUP BY metric_0 ORDER BY max(metric_1) DESC LIMIT 10");
+    data.add(new Object[]{queryContext, -1, -1, expectedResult});
 
-    // Testcase5: low limit + low server trim size + query option enable
+    // Testcase4: query option
     queryContext = QueryContextConverterUtils.getQueryContextFromSQL(
-        "SELECT metric_0, max(metric_1) FROM testTable GROUP BY metric_0 ORDER BY max(metric_1) DESC LIMIT 50 OPTION(enableSegmentTrim=true)");
-    trimSize = 0;
-    expectedSize = 1000;
-    data.add(new Object[]{trimSize, expectedResult.subList(0, expectedSize), queryContext});
+        "SELECT metric_0, max(metric_1) FROM testTable GROUP BY metric_0 ORDER BY max(metric_1) DESC LIMIT 1 OPTION(minSegmentGroupTrimSize=100)");
+    data.add(new Object[]{queryContext, -1, 5000, top100});
+    queryContext = QueryContextConverterUtils.getQueryContextFromSQL(
+        "SELECT metric_0, max(metric_1) FROM testTable GROUP BY metric_0 ORDER BY max(metric_1) DESC LIMIT 50 OPTION(minServerGroupTrimSize=150)");
+    data.add(new Object[]{queryContext, -1, 5000, top250});
+    queryContext = QueryContextConverterUtils.getQueryContextFromSQL(
+        "SELECT metric_0, max(metric_1) FROM testTable GROUP BY metric_0 ORDER BY max(metric_1) DESC LIMIT 10 OPTION(minSegmentGroupTrimSize=-1,minServerGroupTrimSize=-1)");
+    data.add(new Object[]{queryContext, 5000, 5000, expectedResult});
 
     return data.toArray(new Object[data.size()][]);
   }
@@ -287,12 +267,12 @@ public class GroupByInSegmentTrimTest {
    *
    * @return A list of expected results
    */
-  private static ArrayList<Pair<Double, Double>> computeExpectedResult() {
-    ArrayList<Pair<Double, Double>> result = new ArrayList<>();
+  private List<Pair<Double, Double>> computeExpectedResult() {
+    List<Pair<Double, Double>> result = new ArrayList<>(_resultMap.size());
     for (Map.Entry<Double, Double> entry : _resultMap.entrySet()) {
-      result.add(new Pair<>(entry.getKey(), entry.getValue()));
+      result.add(Pair.of(entry.getKey(), entry.getValue()));
     }
-    result.sort((o1, o2) -> (int) (o2.getSecond() - o1.getSecond()));
+    result.sort((o1, o2) -> Double.compare(o2.getRight(), o1.getRight()));
     return result;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationMultiValueQueriesTest.java
@@ -526,7 +526,10 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     assertFalse(brokerResponse.isNumGroupsLimitReached());
 
-    brokerResponse = getBrokerResponseForPqlQuery(query, new InstancePlanMakerImplV2(1000, 1000));
+    brokerResponse = getBrokerResponseForPqlQuery(query,
+        new InstancePlanMakerImplV2(1000, 1000, InstancePlanMakerImplV2.DEFAULT_MIN_SEGMENT_GROUP_TRIM_SIZE,
+            InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
+            InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD));
     assertTrue(brokerResponse.isNumGroupsLimitReached());
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationSingleValueQueriesTest.java
@@ -175,8 +175,8 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
 
     BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     //without filter, we should be using dictionary for distinctcount
-    QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 0L, 120000L,
-        new String[]{"6582", "21910"});
+    QueriesTestUtils
+        .testInterSegmentAggregationResult(brokerResponse, 120000L, 0L, 0L, 120000L, new String[]{"6582", "21910"});
 
     brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
     QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 24516L, 336536L, 49032L, 120000L,
@@ -419,7 +419,10 @@ public class InterSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
     BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
     assertFalse(brokerResponse.isNumGroupsLimitReached());
 
-    brokerResponse = getBrokerResponseForPqlQuery(query, new InstancePlanMakerImplV2(1000, 1000));
+    brokerResponse = getBrokerResponseForPqlQuery(query,
+        new InstancePlanMakerImplV2(1000, 1000, InstancePlanMakerImplV2.DEFAULT_MIN_SEGMENT_GROUP_TRIM_SIZE,
+            InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
+            InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD));
     assertTrue(brokerResponse.isNumGroupsLimitReached());
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderByMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderByMultiValueQueriesTest.java
@@ -48,7 +48,11 @@ public class InterSegmentOrderByMultiValueQueriesTest extends BaseMultiValueQuer
   @Test(dataProvider = "orderByDataProvider")
   public void testGroupByOrderByMVSegmentTrimSQLResults(String query, List<Object[]> expectedResults,
       long expectedNumEntriesScannedPostFilter, DataSchema expectedDataSchema) {
-    InstancePlanMakerImplV2 planMaker = new InstancePlanMakerImplV2(1);
+    InstancePlanMakerImplV2 planMaker =
+        new InstancePlanMakerImplV2(InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY,
+            InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, 1,
+            InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
+            InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
     BrokerResponseNative brokerResponse = getBrokerResponseForSqlQuery(query, planMaker);
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, 400000L, 0, expectedNumEntriesScannedPostFilter, 400000L,

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderBySingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentOrderBySingleValueQueriesTest.java
@@ -80,7 +80,11 @@ public class InterSegmentOrderBySingleValueQueriesTest extends BaseSingleValueQu
   public void testGroupByOrderByMVSegmentTrimSQLResults(String query, List<Object[]> expectedResults,
       long expectedNumDocsScanned, long expectedNumEntriesScannedInFilter, long expectedNumEntriesScannedPostFilter,
       long expectedNumTotalDocs, DataSchema expectedDataSchema) {
-    InstancePlanMakerImplV2 planMaker = new InstancePlanMakerImplV2(1);
+    InstancePlanMakerImplV2 planMaker =
+        new InstancePlanMakerImplV2(InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY,
+            InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, 1,
+            InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
+            InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
     BrokerResponseNative brokerResponse = getBrokerResponseForSqlQuery(query, planMaker);
     QueriesTestUtils
         .testInterSegmentResultTable(brokerResponse, expectedNumDocsScanned, expectedNumEntriesScannedInFilter,

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -225,8 +225,8 @@ public class CommonConstants {
         public static final String RESPONSE_FORMAT = "responseFormat";
         public static final String GROUP_BY_MODE = "groupByMode";
         public static final String SKIP_UPSERT = "skipUpsert";
-        public static final String ENABLE_SEGMENT_TRIM = "enableSegmentTrim";
-        public static final String MIN_SEGMENT_TRIM_SIZE = "minSegmentTrimSize";
+        public static final String MIN_SEGMENT_GROUP_TRIM_SIZE = "minSegmentGroupTrimSize";
+        public static final String MIN_SERVER_GROUP_TRIM_SIZE = "minServerGroupTrimSize";
       }
     }
   }


### PR DESCRIPTION
## Description
Make group trim size configurable for segment-level and server-level trim (both server config and query option).
Currently server-level group trim size is hard-coded to `max(limit * 5, 5000)`, which might not be good enough for certain use cases that need better accuracy. This PR make the hard-coded 5000 configurable, and allow disabling the server-level group trim to get 100% accurate result. Note that disabling the trim or using a very high value could cause memory issue (similar to setting a super high limit), so use with cautious.
Also make the segment-level group trim config keys (introduced in #7052) consistent with server-level group trim keys.

## Release Notes
In server config:
- `pinot.server.query.executor.min.segment.group.trim.size`: min segment-level group trim size, default -1 (disable segment-level trim)
- `pinot.server.query.executor.min.server.group.trim.size`: min server-level group trim size, default 5000 (backward compatible)

In query option:
- `minSegmentGroupTrimSize`: override min segment-level group trim size (replacing `minSegmentTrimSize`)
- `minServerGroupTrimSize`: override min server-level group trim size

The following configs are removed:
- `pinot.server.query.executor.enable.segment.group.trim` in server config is removed, as it is equivalent to setting min group trim size to -1
- `minSegmentTrimSize` in query option is replaced by `minSegmentGroupTrimSize`