### PR TITLE
Broker Performance Improvement when there are 10k+ segments

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingManager.java
@@ -47,6 +47,7 @@ import org.apache.pinot.broker.routing.segmentpruner.SegmentPruner;
 import org.apache.pinot.broker.routing.segmentpruner.SegmentPrunerFactory;
 import org.apache.pinot.broker.routing.segmentselector.SegmentSelector;
 import org.apache.pinot.broker.routing.segmentselector.SegmentSelectorFactory;
+import org.apache.pinot.broker.routing.segmentselector.SelectedSegments;
 import org.apache.pinot.broker.routing.timeboundary.TimeBoundaryInfo;
 import org.apache.pinot.broker.routing.timeboundary.TimeBoundaryManager;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
@@ -570,14 +571,14 @@ public class RoutingManager implements ClusterChangeHandler {
     }
 
     InstanceSelector.SelectionResult calculateRouting(BrokerRequest brokerRequest) {
-      Set<String> selectedSegments = _segmentSelector.select(brokerRequest);
-      if (!selectedSegments.isEmpty()) {
+      SelectedSegments selectedSegments = _segmentSelector.select(brokerRequest);
+      if (!selectedSegments.getSegments().isEmpty()) {
         for (SegmentPruner segmentPruner : _segmentPruners) {
           selectedSegments = segmentPruner.prune(brokerRequest, selectedSegments);
         }
       }
-      if (!selectedSegments.isEmpty()) {
-        return _instanceSelector.select(brokerRequest, new ArrayList<>(selectedSegments));
+      if (!selectedSegments.getSegments().isEmpty()) {
+        return _instanceSelector.select(brokerRequest, new ArrayList<>(selectedSegments.getSegments()));
       } else {
         return new InstanceSelector.SelectionResult(Collections.emptyMap(), Collections.emptyList());
       }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/EmptySegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/EmptySegmentPruner.java
@@ -30,6 +30,7 @@ import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.broker.routing.segmentselector.SelectedSegments;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -122,12 +123,12 @@ public class EmptySegmentPruner implements SegmentPruner {
    * Prune out segments which are empty
    */
   @Override
-  public Set<String> prune(BrokerRequest brokerRequest, Set<String> segments) {
+  public SelectedSegments prune(BrokerRequest brokerRequest, SelectedSegments segments) {
     if (_emptySegments.isEmpty()) {
       return segments;
     }
-    Set<String> selectedSegments = new HashSet<>(segments);
-    selectedSegments.removeAll(_emptySegments);
-    return selectedSegments;
+    Set<String> pruned = new HashSet<>(segments.getSegments());
+    pruned.removeAll(_emptySegments);
+    return new SelectedSegments(pruned, true);
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/EmptySegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/EmptySegmentPruner.java
@@ -123,6 +123,9 @@ public class EmptySegmentPruner implements SegmentPruner {
    */
   @Override
   public Set<String> prune(BrokerRequest brokerRequest, Set<String> segments) {
+    if (_emptySegments.isEmpty()) {
+      return segments;
+    }
     Set<String> selectedSegments = new HashSet<>(segments);
     selectedSegments.removeAll(_emptySegments);
     return selectedSegments;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/PartitionSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/PartitionSegmentPruner.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.broker.routing.segmentpruner;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -29,10 +32,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
-
-import com.google.common.cache.CacheBuilder;
-import com.google.common.cache.CacheLoader;
-import com.google.common.cache.LoadingCache;
 import org.apache.helix.AccessOption;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPruner.java
@@ -21,6 +21,7 @@ package org.apache.pinot.broker.routing.segmentpruner;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
+import org.apache.pinot.broker.routing.segmentselector.SelectedSegments;
 import org.apache.pinot.common.request.BrokerRequest;
 
 
@@ -50,5 +51,5 @@ public interface SegmentPruner {
   /**
    * Prunes the segments queried by the given broker request, returns the selected segments to be queried.
    */
-  Set<String> prune(BrokerRequest brokerRequest, Set<String> segments);
+  SelectedSegments prune(BrokerRequest brokerRequest, SelectedSegments segments);
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerFactory.java
@@ -84,7 +84,7 @@ public class SegmentPrunerFactory {
     }
     // EmptySegmentPruner tries to create a copy of all the lists, in some cases if the
     // segments has 10k+ items in it, it may waste a lot of CPU cycle for several empty segment.
-    // Moving it to the end may help some test cases.
+    // Moving it to the end may help some scenario in performance.
     segmentPruners.add(new EmptySegmentPruner(tableConfig, propertyStore));
     return segmentPruners;
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerFactory.java
@@ -47,8 +47,6 @@ public class SegmentPrunerFactory {
       ZkHelixPropertyStore<ZNRecord> propertyStore) {
     RoutingConfig routingConfig = tableConfig.getRoutingConfig();
     List<SegmentPruner> segmentPruners = new ArrayList<>();
-    // Always prune out empty segments first
-    segmentPruners.add(new EmptySegmentPruner(tableConfig, propertyStore));
 
     if (routingConfig != null) {
       List<String> segmentPrunerTypes = routingConfig.getSegmentPrunerTypes();
@@ -84,6 +82,8 @@ public class SegmentPrunerFactory {
         }
       }
     }
+    // Always prune out empty segments first
+    segmentPruners.add(new EmptySegmentPruner(tableConfig, propertyStore));
     return segmentPruners;
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerFactory.java
@@ -82,7 +82,9 @@ public class SegmentPrunerFactory {
         }
       }
     }
-    // Always prune out empty segments first
+    // EmptySegmentPruner tries to create a copy of all the lists, in some cases if the
+    // segments has 10k+ items in it, it may waste a lot of CPU cycle for several empty segment.
+    // Moving it to the end may help some test cases.
     segmentPruners.add(new EmptySegmentPruner(tableConfig, propertyStore));
     return segmentPruners;
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
@@ -36,6 +36,7 @@ import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.broker.routing.segmentpruner.interval.Interval;
 import org.apache.pinot.broker.routing.segmentpruner.interval.IntervalTree;
+import org.apache.pinot.broker.routing.segmentselector.SelectedSegments;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.Expression;
@@ -154,7 +155,7 @@ public class TimeSegmentPruner implements SegmentPruner {
    *       M: # of qualified intersected segments).
    */
   @Override
-  public Set<String> prune(BrokerRequest brokerRequest, Set<String> segments) {
+  public SelectedSegments prune(BrokerRequest brokerRequest, SelectedSegments segments) {
     IntervalTree<String> intervalTree = _intervalTree;
 
     List<Interval> intervals;
@@ -179,18 +180,18 @@ public class TimeSegmentPruner implements SegmentPruner {
       return segments;
     }
     if (intervals.isEmpty()) { // invalid query time interval
-      return Collections.emptySet();
+      return new SelectedSegments(Collections.emptySet(), true);
     }
 
     Set<String> selectedSegments = new HashSet<>();
     for (Interval interval : intervals) {
       for (String segment : intervalTree.searchAll(interval)) {
-        if (segments.contains(segment)) {
+        if (segments.getSegments().contains(segment)) {
           selectedSegments.add(segment);
         }
       }
     }
-    return selectedSegments;
+    return new SelectedSegments(selectedSegments, false);
   }
 
   /**

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/OfflineSegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/OfflineSegmentSelector.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.broker.routing.segmentselector;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/OfflineSegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/OfflineSegmentSelector.java
@@ -29,7 +29,7 @@ import org.apache.pinot.common.request.BrokerRequest;
  * Segment selector for offline table.
  */
 public class OfflineSegmentSelector implements SegmentSelector {
-  private volatile Set<String> _segments;
+  private volatile SelectedSegments selectedSegments = new SelectedSegments(Collections.emptySet(), true);
 
   @Override
   public void init(ExternalView externalView, IdealState idealState, Set<String> onlineSegments) {
@@ -41,11 +41,11 @@ public class OfflineSegmentSelector implements SegmentSelector {
     // TODO: for new added segments, before all replicas are up, consider not selecting them to avoid causing
     //       hotspot servers
 
-    _segments = Collections.unmodifiableSet(onlineSegments);
+    selectedSegments = new SelectedSegments(Collections.unmodifiableSet(onlineSegments), true);
   }
 
   @Override
-  public Set<String> select(BrokerRequest brokerRequest) {
-    return _segments;
+  public SelectedSegments select(BrokerRequest brokerRequest) {
+    return selectedSegments;
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/OfflineSegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/OfflineSegmentSelector.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.broker.routing.segmentselector;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
@@ -41,7 +42,7 @@ public class OfflineSegmentSelector implements SegmentSelector {
     // TODO: for new added segments, before all replicas are up, consider not selecting them to avoid causing
     //       hotspot servers
 
-    _segments = Collections.unmodifiableSet(onlineSegments);
+    _segments = Collections.unmodifiableSet(new HashSet<>(onlineSegments));
   }
 
   @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/OfflineSegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/OfflineSegmentSelector.java
@@ -42,7 +42,7 @@ public class OfflineSegmentSelector implements SegmentSelector {
     // TODO: for new added segments, before all replicas are up, consider not selecting them to avoid causing
     //       hotspot servers
 
-    _segments = Collections.unmodifiableSet(new HashSet<>(onlineSegments));
+    _segments = Collections.unmodifiableSet(onlineSegments);
   }
 
   @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelector.java
@@ -59,5 +59,5 @@ public interface SegmentSelector {
    * Selects the segments queried by the given broker request. The segments selected should cover the whole dataset
    * (table) without overlap.
    */
-  Set<String> select(BrokerRequest brokerRequest);
+  SelectedSegments select(BrokerRequest brokerRequest);
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/SelectedSegments.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/SelectedSegments.java
@@ -1,0 +1,79 @@
+package org.apache.pinot.broker.routing.segmentselector;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
+import org.apache.commons.codec.digest.DigestUtils;
+
+/**
+ * The SelectedSegments has a strict (Sha256 for now) hash for all the segments in it.
+ * It can be used to quickly compare whether the two segment sets are identical.
+ * It will be helpful for high QPS queries for tables with lots of segments
+ */
+public class SelectedSegments {
+  private final Set<String> _segments;
+  private final String _segmentHash;
+  private final boolean _hasHash;
+  public static final String EMPTY_HASH = "";
+
+  /**
+   * Note that computing Hash involves sorting, so it is O(N*LogN) complexity
+   * @param segments the segments
+   * @param computeHash whether we compute the hash for quick comparison.
+   *                    Note that computing Hash involves sorting, so it is O(N*LogN) complexity
+   */
+  public SelectedSegments(Set<String> segments, boolean computeHash){
+      this(segments, computeHash ? computeHash(segments) : EMPTY_HASH);
+  }
+
+  public SelectedSegments(Set<String> segments, String segmentHash) {
+    _segments = segments;
+    _segmentHash = segmentHash;
+    _hasHash = !segmentHash.equals(EMPTY_HASH);
+  }
+
+  /**
+   * Gets the segment set
+   * @return the set of all segments
+   */
+  public Set<String> getSegments() {
+    return _segments;
+  }
+
+  /**
+   * Gets the checksum of all the segments in it. Mostly used for quick comparison of sets
+   * @return The string representation of hash
+   */
+  public String getSegmentHash() {
+    return _segmentHash;
+  }
+
+  /**
+   * Gets whether the hash is valid and usable
+   * @return a flag that whether the hash is valid
+   */
+  public boolean hasHash() {
+    return _hasHash;
+  }
+
+  /**
+   * Compute the hash checksum for all segments
+   * @param segments the set for all segments
+   * @return string digest of byte arrays
+   */
+  public static String computeHash(Set<String> segments) {
+    SortedSet<String> sorted = new TreeSet<>(segments);
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    try {
+    for (String segment: sorted) {
+      outputStream.write(segment.getBytes());
+    }
+    } catch (IOException ex) {
+      throw new RuntimeException("Byte Output Stream should not throw exceptions", ex);
+    }
+    return DigestUtils.sha256Hex(outputStream.toByteArray());
+  }
+
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/SelectedSegments.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/SelectedSegments.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.broker.routing.segmentselector;
 
 import java.io.ByteArrayOutputStream;

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerTest.java
@@ -152,8 +152,8 @@ public class SegmentPrunerTest {
     columnPartitionConfigMap.put(PARTITION_COLUMN, new ColumnPartitionConfig("Modulo", 5));
     segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
     assertEquals(segmentPruners.size(), 2);
-    assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
-    assertTrue(segmentPruners.get(1) instanceof PartitionSegmentPruner);
+    assertTrue(segmentPruners.get(1) instanceof EmptySegmentPruner);
+    assertTrue(segmentPruners.get(0) instanceof PartitionSegmentPruner);
 
     // Do not allow multiple partition columns
     columnPartitionConfigMap.put("anotherPartitionColumn", new ColumnPartitionConfig("Modulo", 5));
@@ -172,15 +172,15 @@ public class SegmentPrunerTest {
         .thenReturn(SegmentPrunerFactory.LEGACY_PARTITION_AWARE_OFFLINE_ROUTING);
     segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
     assertEquals(segmentPruners.size(), 2);
-    assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
-    assertTrue(segmentPruners.get(1) instanceof PartitionSegmentPruner);
+    assertTrue(segmentPruners.get(1) instanceof EmptySegmentPruner);
+    assertTrue(segmentPruners.get(0) instanceof PartitionSegmentPruner);
     when(tableConfig.getTableType()).thenReturn(TableType.REALTIME);
     when(routingConfig.getRoutingTableBuilderName())
         .thenReturn(SegmentPrunerFactory.LEGACY_PARTITION_AWARE_REALTIME_ROUTING);
     segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
     assertEquals(segmentPruners.size(), 2);
-    assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
-    assertTrue(segmentPruners.get(1) instanceof PartitionSegmentPruner);
+    assertTrue(segmentPruners.get(1) instanceof EmptySegmentPruner);
+    assertTrue(segmentPruners.get(0) instanceof PartitionSegmentPruner);
   }
 
   @Test
@@ -219,8 +219,8 @@ public class SegmentPrunerTest {
     when(validationConfig.getTimeColumnName()).thenReturn(TIME_COLUMN);
     segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
     assertEquals(segmentPruners.size(), 2);
-    assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
-    assertTrue(segmentPruners.get(1) instanceof TimeSegmentPruner);
+    assertTrue(segmentPruners.get(1) instanceof EmptySegmentPruner);
+    assertTrue(segmentPruners.get(0) instanceof TimeSegmentPruner);
   }
 
   @DataProvider

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelectorTest.java
@@ -69,7 +69,7 @@ public class SegmentSelectorTest {
     RealtimeSegmentSelector segmentSelector = new RealtimeSegmentSelector();
     segmentSelector.init(externalView, idealState, onlineSegments);
     BrokerRequest brokerRequest = mock(BrokerRequest.class);
-    assertTrue(segmentSelector.select(brokerRequest).getSegmentHash().isEmpty());
+    assertTrue(segmentSelector.select(brokerRequest).getSegments().isEmpty());
 
     // For HLC segments, only one group of segments should be selected
     int numHLCGroups = 3;

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelectorTest.java
@@ -69,7 +69,7 @@ public class SegmentSelectorTest {
     RealtimeSegmentSelector segmentSelector = new RealtimeSegmentSelector();
     segmentSelector.init(externalView, idealState, onlineSegments);
     BrokerRequest brokerRequest = mock(BrokerRequest.class);
-    assertTrue(segmentSelector.select(brokerRequest).isEmpty());
+    assertTrue(segmentSelector.select(brokerRequest).getSegmentHash().isEmpty());
 
     // For HLC segments, only one group of segments should be selected
     int numHLCGroups = 3;
@@ -89,7 +89,7 @@ public class SegmentSelectorTest {
     segmentSelector.onExternalViewChange(externalView, idealState, onlineSegments);
 
     // Only HLC segments exist, should select the HLC segments from the first group
-    assertEqualsNoOrder(segmentSelector.select(brokerRequest).toArray(), hlcSegments[0]);
+    assertEqualsNoOrder(segmentSelector.select(brokerRequest).getSegments().toArray(), hlcSegments[0]);
 
     // For LLC segments, only the first CONSUMING segment for each partition should be selected
     int numLLCPartitions = 3;
@@ -113,11 +113,11 @@ public class SegmentSelectorTest {
     segmentSelector.onExternalViewChange(externalView, idealState, onlineSegments);
 
     // Both HLC and LLC segments exist, should select the LLC segments
-    assertEqualsNoOrder(segmentSelector.select(brokerRequest).toArray(), expectedSelectedLLCSegments);
+    assertEqualsNoOrder(segmentSelector.select(brokerRequest).getSegments().toArray(), expectedSelectedLLCSegments);
 
     // When HLC is forced, should select the HLC segments from the second group
     when(brokerRequest.getDebugOptions()).thenReturn(Collections.singletonMap(ROUTING_OPTIONS_KEY, FORCE_HLC));
-    assertEqualsNoOrder(segmentSelector.select(brokerRequest).toArray(), hlcSegments[1]);
+    assertEqualsNoOrder(segmentSelector.select(brokerRequest).getSegments().toArray(), hlcSegments[1]);
 
     // Remove all the HLC segments from ideal state, should select the LLC segments even when HLC is forced
     for (String[] hlcSegmentsForGroup : hlcSegments) {
@@ -126,6 +126,6 @@ public class SegmentSelectorTest {
       }
     }
     segmentSelector.onExternalViewChange(externalView, idealState, onlineSegments);
-    assertEqualsNoOrder(segmentSelector.select(brokerRequest).toArray(), expectedSelectedLLCSegments);
+    assertEqualsNoOrder(segmentSelector.select(brokerRequest).getSegments().toArray(), expectedSelectedLLCSegments);
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentselector/SelectedSegmentsTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentselector/SelectedSegmentsTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.broker.routing.segmentselector;
 
 import com.google.common.collect.ImmutableSet;

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentselector/SelectedSegmentsTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentselector/SelectedSegmentsTest.java
@@ -11,5 +11,6 @@ public class SelectedSegmentsTest {
     SelectedSegments s1 = new SelectedSegments(ImmutableSet.of("seg1", "seg2"), true);
     SelectedSegments s2 = new SelectedSegments(ImmutableSet.of("seg2", "seg1"), true);
     Assert.assertEquals(s1.getSegmentHash(), s2.getSegmentHash());
+    Assert.assertTrue(s1.hasHash());
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentselector/SelectedSegmentsTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentselector/SelectedSegmentsTest.java
@@ -1,0 +1,15 @@
+package org.apache.pinot.broker.routing.segmentselector;
+
+import com.google.common.collect.ImmutableSet;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class SelectedSegmentsTest {
+  @Test
+  public void testHashComputation() {
+    SelectedSegments s1 = new SelectedSegments(ImmutableSet.of("seg1", "seg2"), true);
+    SelectedSegments s2 = new SelectedSegments(ImmutableSet.of("seg2", "seg1"), true);
+    Assert.assertEquals(s1.getSegmentHash(), s2.getSegmentHash());
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/MurmurPartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/MurmurPartitionFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.segment.spi.partition;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import java.util.Objects;
 import org.apache.pinot.spi.utils.StringUtils;
 
 
@@ -103,5 +104,19 @@ public class MurmurPartitionFunction implements PartitionFunction {
     h ^= h >>> 15;
 
     return h;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || ! (o instanceof MurmurPartitionFunction)) return false;
+    MurmurPartitionFunction that = (MurmurPartitionFunction) o;
+    return _numPartitions == that._numPartitions;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_numPartitions);
   }
 }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
@@ -91,6 +91,9 @@ public class PartitionFunctionTest {
    */
   @Test
   public void testMurmurPartitioner() {
+    MurmurPartitionFunction func = new MurmurPartitionFunction(100);
+    Assert.assertEquals(func, new MurmurPartitionFunction(100));
+    Assert.assertNotEquals(func, new MurmurPartitionFunction(200));
     long seed = System.currentTimeMillis();
     Random random = new Random(seed);
 


### PR DESCRIPTION
## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
When there are 10k+ segments present, and the partition-based pruner is present (which should be a popular case), the Broker performance is bottlenecked at broker CPU. This PR improved the performance on that case and thus increased our high QPS performance by 7x~8x.

There is more detailed information for the analysis of call stacks and the reason behind in the google doc. We are now able to easily achieve 3k QPS per hosts based on AWS `m5.2xlarge` hosts ([8vPU, spec](https://instances.vantage.sh/?filter=m5.2x&region=us-west-2&cost_duration=annually&reserved_term=yrTerm3Standard.noUpfront))

## How do we improve performance
The hot CPU stacks show that the bottleneck is when the pruner tries to loop through all segments and see if there is segment match. For 10k+ segments, it is an O(n) loop of 10k+ items.

In this PR we try to build and maintain a reverse lookup map of (partition -> list(segments)) in the pruner. Whenever there is a change in the segment list, we rebuild this lookup map. By this change we are able to do O(1) lookup instead of O(n) loop.

Second optimization is that, EmptySegmentPruner is also trying to duplicate the whole segment list. It is not a significant slow down but it shows up in the hot stack list. In our test avoiding this duplication improved QPS from 60k to 80k

## Improvements for our Data Set with 30k+ segments, partitioned
**Before**
<img width="926" alt="Screen Shot 2021-07-27 at 5 39 36 PM" src="https://user-images.githubusercontent.com/11821736/127939752-fd9a0174-9574-4a1c-9912-34ea4eb0810a.png">
**After** **Updated after latest PR change**
<img width="1742" alt="Screen Shot 2021-08-11 at 9 56 18 AM" src="https://user-images.githubusercontent.com/11821736/129071234-9caf2f57-8f1c-4178-a0a1-2f40836caaeb.png">


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->
Significantly improved Broker CPU performance when partition-pruner is selected for 10k+ segments.

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
