### PR TITLE
Cleanup: Cleanup: Make `jobType` in `SegmentGenerationJobSpec` case insensitive.

### DIFF
--- a/docker/images/pinot/examples/docker/ingestion-job-specs/airlineStats.yaml
+++ b/docker/images/pinot/examples/docker/ingestion-job-specs/airlineStats.yaml
@@ -33,12 +33,14 @@ executionFrameworkSpec:
   segmentUriPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.standalone.SegmentUriPushJobRunner'
 
 # jobType: Pinot ingestion job type.
-# Supported job types are:
+# Supported job types are defined in PinotIngestionJobType class.
 #   'SegmentCreation'
 #   'SegmentTarPush'
 #   'SegmentUriPush'
+#   'SegmentMetadataPush'
 #   'SegmentCreationAndTarPush'
 #   'SegmentCreationAndUriPush'
+#   'SegmentCreationAndMetadataPush'
 jobType: SegmentCreationAndTarPush
 
 # inputDirURI: Root directory of input data, expected to have scheme configured in PinotFS.

--- a/docker/images/pinot/examples/docker/ingestion-job-specs/baseballStats.yaml
+++ b/docker/images/pinot/examples/docker/ingestion-job-specs/baseballStats.yaml
@@ -33,12 +33,14 @@ executionFrameworkSpec:
   segmentUriPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.standalone.SegmentUriPushJobRunner'
 
 # jobType: Pinot ingestion job type.
-# Supported job types are:
+# Supported job types are defined in PinotIngestionJobType class.
 #   'SegmentCreation'
 #   'SegmentTarPush'
 #   'SegmentUriPush'
+#   'SegmentMetadataPush'
 #   'SegmentCreationAndTarPush'
 #   'SegmentCreationAndUriPush'
+#   'SegmentCreationAndMetadataPush'
 jobType: SegmentCreationAndTarPush
 
 # inputDirURI: Root directory of input data, expected to have scheme configured in PinotFS.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncher.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncher.java
@@ -18,12 +18,14 @@
  */
 package org.apache.pinot.spi.ingestion.batch;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.commons.io.FileUtils;
@@ -95,7 +97,7 @@ public class IngestionJobLauncher {
     new Yaml().dump(spec, sw);
     LOGGER.info("SegmentGenerationJobSpec: \n{}", sw.toString());
     ExecutionFrameworkSpec executionFramework = spec.getExecutionFrameworkSpec();
-    PinotIngestionJobType jobType = PinotIngestionJobType.valueOf(spec.getJobType());
+    PinotIngestionJobType jobType = PinotIngestionJobType.fromString(spec.getJobType());
     switch (jobType) {
       case SegmentCreation:
         kickoffIngestionJob(spec, executionFramework.getSegmentGenerationJobRunnerClassName());
@@ -145,7 +147,35 @@ public class IngestionJobLauncher {
     }
   }
 
-  enum PinotIngestionJobType {
-    SegmentCreation, SegmentTarPush, SegmentUriPush, SegmentMetadataPush, SegmentCreationAndTarPush, SegmentCreationAndUriPush, SegmentCreationAndMetadataPush,
+  /**
+   * Ingestion Job type Enum.
+   */
+  public enum PinotIngestionJobType {
+    SegmentCreation,
+    SegmentTarPush,
+    SegmentUriPush,
+    SegmentMetadataPush,
+    SegmentCreationAndTarPush,
+    SegmentCreationAndUriPush,
+    SegmentCreationAndMetadataPush;
+
+    private static final Map<String, PinotIngestionJobType> VALUE_MAP = new HashMap<>();
+
+    static {
+      for (PinotIngestionJobType jobType : PinotIngestionJobType.values()) {
+        // Use case-insensitive naming.
+        VALUE_MAP.put(jobType.name().toLowerCase(), jobType);
+      }
+    }
+
+    @JsonCreator
+    public static PinotIngestionJobType fromString(String name) {
+      PinotIngestionJobType jobType = VALUE_MAP.get(name.toLowerCase());
+
+      if (jobType == null) {
+        throw new IllegalArgumentException("No enum constant for: " + name);
+      }
+      return jobType;
+    }
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
@@ -33,15 +33,9 @@ public class SegmentGenerationJobSpec implements Serializable {
    */
   private ExecutionFrameworkSpec _executionFrameworkSpec;
 
+
   /**
-   * Supported job types are:
-   *  'SegmentCreation'
-   *  'SegmentTarPush'
-   *  'SegmentUriPush'
-   *  'SegmentMetadataPush'
-   *  'SegmentCreationAndTarPush'
-   *  'SegmentCreationAndUriPush'
-   *  'SegmentCreationAndMetadataPush'
+   * Supported job types are {@link org.apache.pinot.spi.ingestion.batch.IngestionJobLauncher.PinotIngestionJobType}
    */
   private String _jobType;
 
@@ -144,13 +138,8 @@ public class SegmentGenerationJobSpec implements Serializable {
   }
 
   /**
-   * Supported job types are:
-   *    'SegmentCreation'
-   *    'SegmentTarPush'
-   *    'SegmentUriPush'
-   *    'SegmentCreationAndTarPush'
-   *    'SegmentCreationAndUriPush'
-   * @param jobType
+   * Set the job type for the ingestion job.
+   * @param jobType Job type for the ingestion job.
    */
   public void setJobType(String jobType) {
     _jobType = jobType;

--- a/pinot-tools/src/main/resources/examples/batch/airlineStats/hadoopIngestionJobSpec.yaml
+++ b/pinot-tools/src/main/resources/examples/batch/airlineStats/hadoopIngestionJobSpec.yaml
@@ -39,12 +39,14 @@ executionFrameworkSpec:
     stagingDir: examples/batch/airlineStats/staging
 
 # jobType: Pinot ingestion job type.
-# Supported job types are:
+# Supported job types are defined in PinotIngestionJobType class.
 #   'SegmentCreation'
 #   'SegmentTarPush'
 #   'SegmentUriPush'
+#   'SegmentMetadataPush'
 #   'SegmentCreationAndTarPush'
 #   'SegmentCreationAndUriPush'
+#   'SegmentCreationAndMetadataPush'
 jobType: SegmentCreationAndTarPush
 
 # inputDirURI: Root directory of input data, expected to have scheme configured in PinotFS.

--- a/pinot-tools/src/main/resources/examples/batch/airlineStats/ingestionJobSpec.yaml
+++ b/pinot-tools/src/main/resources/examples/batch/airlineStats/ingestionJobSpec.yaml
@@ -33,12 +33,14 @@ executionFrameworkSpec:
   segmentUriPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.standalone.SegmentUriPushJobRunner'
 
 # jobType: Pinot ingestion job type.
-# Supported job types are:
+# Supported job types are defined in PinotIngestionJobType class.
 #   'SegmentCreation'
 #   'SegmentTarPush'
 #   'SegmentUriPush'
+#   'SegmentMetadataPush'
 #   'SegmentCreationAndTarPush'
 #   'SegmentCreationAndUriPush'
+#   'SegmentCreationAndMetadataPush'
 jobType: SegmentCreationAndTarPush
 
 # inputDirURI: Root directory of input data, expected to have scheme configured in PinotFS.

--- a/pinot-tools/src/main/resources/examples/batch/airlineStats/sparkIngestionJobSpec.yaml
+++ b/pinot-tools/src/main/resources/examples/batch/airlineStats/sparkIngestionJobSpec.yaml
@@ -39,12 +39,14 @@ executionFrameworkSpec:
     stagingDir: examples/batch/airlineStats/staging
 
 # jobType: Pinot ingestion job type.
-# Supported job types are:
+# Supported job types are defined in PinotIngestionJobType class.
 #   'SegmentCreation'
 #   'SegmentTarPush'
 #   'SegmentUriPush'
+#   'SegmentMetadataPush'
 #   'SegmentCreationAndTarPush'
 #   'SegmentCreationAndUriPush'
+#   'SegmentCreationAndMetadataPush'
 jobType: SegmentCreationAndTarPush
 
 # inputDirURI: Root directory of input data, expected to have scheme configured in PinotFS.

--- a/pinot-tools/src/main/resources/examples/batch/baseballStats/ingestionJobSpec.yaml
+++ b/pinot-tools/src/main/resources/examples/batch/baseballStats/ingestionJobSpec.yaml
@@ -33,12 +33,14 @@ executionFrameworkSpec:
   segmentUriPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.standalone.SegmentUriPushJobRunner'
 
 # jobType: Pinot ingestion job type.
-# Supported job types are:
+# Supported job types are defined in PinotIngestionJobType class.
 #   'SegmentCreation'
 #   'SegmentTarPush'
 #   'SegmentUriPush'
+#   'SegmentMetadataPush'
 #   'SegmentCreationAndTarPush'
 #   'SegmentCreationAndUriPush'
+#   'SegmentCreationAndMetadataPush'
 jobType: SegmentCreationAndTarPush
 
 # inputDirURI: Root directory of input data, expected to have scheme configured in PinotFS.

--- a/pinot-tools/src/main/resources/examples/batch/baseballStats/sparkIngestionJobSpec.yaml
+++ b/pinot-tools/src/main/resources/examples/batch/baseballStats/sparkIngestionJobSpec.yaml
@@ -35,12 +35,14 @@ executionFrameworkSpec:
   extraConfigs:
 
 # jobType: Pinot ingestion job type.
-# Supported job types are:
+# Supported job types are defined in PinotIngestionJobType class.
 #   'SegmentCreation'
 #   'SegmentTarPush'
 #   'SegmentUriPush'
+#   'SegmentMetadataPush'
 #   'SegmentCreationAndTarPush'
 #   'SegmentCreationAndUriPush'
+#   'SegmentCreationAndMetadataPush'
 jobType: SegmentCreationAndTarPush
 
 # inputDirURI: Root directory of input data, expected to have scheme configured in PinotFS.

--- a/pinot-tools/src/main/resources/examples/batch/dimBaseballTeams/ingestionJobSpec.yaml
+++ b/pinot-tools/src/main/resources/examples/batch/dimBaseballTeams/ingestionJobSpec.yaml
@@ -33,12 +33,14 @@ executionFrameworkSpec:
   segmentUriPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.standalone.SegmentUriPushJobRunner'
 
 # jobType: Pinot ingestion job type.
-# Supported job types are:
+# Supported job types are defined in PinotIngestionJobType class.
 #   'SegmentCreation'
 #   'SegmentTarPush'
 #   'SegmentUriPush'
+#   'SegmentMetadataPush'
 #   'SegmentCreationAndTarPush'
 #   'SegmentCreationAndUriPush'
+#   'SegmentCreationAndMetadataPush'
 jobType: SegmentCreationAndTarPush
 
 # inputDirURI: Root directory of input data, expected to have scheme configured in PinotFS.

--- a/pinot-tools/src/main/resources/examples/batch/githubEvents/ingestionJobComplexTypeHandlingSpec.yaml
+++ b/pinot-tools/src/main/resources/examples/batch/githubEvents/ingestionJobComplexTypeHandlingSpec.yaml
@@ -33,12 +33,14 @@ executionFrameworkSpec:
   segmentUriPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.standalone.SegmentUriPushJobRunner'
 
 # jobType: Pinot ingestion job type.
-# Supported job types are:
+# Supported job types are defined in PinotIngestionJobType class.
 #   'SegmentCreation'
 #   'SegmentTarPush'
 #   'SegmentUriPush'
+#   'SegmentMetadataPush'
 #   'SegmentCreationAndTarPush'
 #   'SegmentCreationAndUriPush'
+#   'SegmentCreationAndMetadataPush'
 jobType: SegmentCreationAndTarPush
 
 # inputDirURI: Root directory of input data, expected to have scheme configured in PinotFS.

--- a/pinot-tools/src/main/resources/examples/batch/githubEvents/ingestionJobSpec.yaml
+++ b/pinot-tools/src/main/resources/examples/batch/githubEvents/ingestionJobSpec.yaml
@@ -33,12 +33,14 @@ executionFrameworkSpec:
   segmentUriPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.standalone.SegmentUriPushJobRunner'
 
 # jobType: Pinot ingestion job type.
-# Supported job types are:
+# Supported job types are defined in PinotIngestionJobType class.
 #   'SegmentCreation'
 #   'SegmentTarPush'
 #   'SegmentUriPush'
+#   'SegmentMetadataPush'
 #   'SegmentCreationAndTarPush'
 #   'SegmentCreationAndUriPush'
+#   'SegmentCreationAndMetadataPush'
 jobType: SegmentCreationAndTarPush
 
 # inputDirURI: Root directory of input data, expected to have scheme configured in PinotFS.

--- a/pinot-tools/src/main/resources/examples/batch/githubEvents/sparkIngestionJobSpec.yaml
+++ b/pinot-tools/src/main/resources/examples/batch/githubEvents/sparkIngestionJobSpec.yaml
@@ -35,12 +35,14 @@ executionFrameworkSpec:
   extraConfigs:
 
 # jobType: Pinot ingestion job type.
-# Supported job types are:
+# Supported job types are defined in PinotIngestionJobType class.
 #   'SegmentCreation'
 #   'SegmentTarPush'
 #   'SegmentUriPush'
+#   'SegmentMetadataPush'
 #   'SegmentCreationAndTarPush'
 #   'SegmentCreationAndUriPush'
+#   'SegmentCreationAndMetadataPush'
 jobType: SegmentCreationAndTarPush
 
 # inputDirURI: Root directory of input data, expected to have scheme configured in PinotFS.

--- a/pinot-tools/src/main/resources/examples/batch/starbucksStores/ingestionJobSpec.yaml
+++ b/pinot-tools/src/main/resources/examples/batch/starbucksStores/ingestionJobSpec.yaml
@@ -33,12 +33,14 @@ executionFrameworkSpec:
   segmentUriPushJobRunnerClassName: 'org.apache.pinot.plugin.ingestion.batch.standalone.SegmentUriPushJobRunner'
 
 # jobType: Pinot ingestion job type.
-# Supported job types are:
+# Supported job types are defined in PinotIngestionJobType class.
 #   'SegmentCreation'
 #   'SegmentTarPush'
 #   'SegmentUriPush'
+#   'SegmentMetadataPush'
 #   'SegmentCreationAndTarPush'
 #   'SegmentCreationAndUriPush'
+#   'SegmentCreationAndMetadataPush'
 jobType: SegmentCreationAndTarPush
 
 # inputDirURI: Root directory of input data, expected to have scheme configured in PinotFS.


### PR DESCRIPTION
## Description
The `jobType` field inside of SegmentGenerationSpec is case sensitive.
Converting it into case insensitive for better usability. Also, cleaned
up comments to be in sync with all values of `PinotIngestionJobType`.


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
