### PR TITLE
Fix pulsar connector issue with `NoSuchMethodError`

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -252,7 +252,7 @@ com.yahoo.datasketches:sketches-core:0.8.3
 com.yammer.metrics:metrics-core:2.2.0
 com.zaxxer:HikariCP-java7:2.4.13
 commons-cli:commons-cli:1.2
-commons-codec:commons-codec:1.6
+commons-codec:commons-codec:1.15
 commons-collections:commons-collections:3.2.1
 commons-configuration:commons-configuration:1.10
 commons-httpclient:commons-httpclient:3.1

--- a/pom.xml
+++ b/pom.xml
@@ -695,7 +695,7 @@
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.6</version>
+        <version>1.15</version>
       </dependency>
       <dependency>
         <groupId>com.thoughtworks.paranamer</groupId>


### PR DESCRIPTION
Pulsar is using more recent version of `apache-codec` while Pinot
code base pins it to very old version. This causes the conflict
where pulsar side code invokes the API that's not available in the
jar file that we include as part of Pinot jar. This fixes the issue.