### PR TITLE
extend Reload rest API with option to force download segment

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/messages/SegmentRefreshMessage.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/messages/SegmentRefreshMessage.java
@@ -40,12 +40,22 @@ public class SegmentRefreshMessage extends Message {
 
   private static final String TABLE_NAME_KEY = "tableName";
   private static final String SEGMENT_NAME_KEY = "segmentName";
+  private static final String FORCE_DOWNLOAD_KEY = "forceDownload";
 
   /**
    * Constructor for the sender.
    */
   public SegmentRefreshMessage(String tableNameWithType, String segmentName) {
     super(MessageType.USER_DEFINE_MSG, UUID.randomUUID().toString());
+    init(tableNameWithType, segmentName, false);
+  }
+
+  public SegmentRefreshMessage(String tableNameWithType, String segmentName, boolean forceDownload) {
+    super(MessageType.USER_DEFINE_MSG, UUID.randomUUID().toString());
+    init(tableNameWithType, segmentName, forceDownload);
+  }
+
+  private void init(String tableNameWithType, String segmentName, boolean forceDownload) {
     setMsgSubType(REFRESH_SEGMENT_MSG_SUB_TYPE);
     // Give it infinite time to process the message, as long as session is alive
     setExecutionTimeout(-1);
@@ -55,6 +65,7 @@ public class SegmentRefreshMessage extends Message {
     ZNRecord znRecord = getRecord();
     znRecord.setSimpleField(TABLE_NAME_KEY, tableNameWithType);
     znRecord.setSimpleField(SEGMENT_NAME_KEY, segmentName);
+    znRecord.setBooleanField(FORCE_DOWNLOAD_KEY, forceDownload);
   }
 
   /**
@@ -76,5 +87,9 @@ public class SegmentRefreshMessage extends Message {
 
   public String getSegmentName() {
     return getRecord().getSimpleField(SEGMENT_NAME_KEY);
+  }
+
+  public boolean getForceDownload() {
+    return getRecord().getBooleanField(FORCE_DOWNLOAD_KEY, false);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/messages/SegmentRefreshMessage.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/messages/SegmentRefreshMessage.java
@@ -40,22 +40,12 @@ public class SegmentRefreshMessage extends Message {
 
   private static final String TABLE_NAME_KEY = "tableName";
   private static final String SEGMENT_NAME_KEY = "segmentName";
-  private static final String FORCE_DOWNLOAD_KEY = "forceDownload";
 
   /**
    * Constructor for the sender.
    */
   public SegmentRefreshMessage(String tableNameWithType, String segmentName) {
     super(MessageType.USER_DEFINE_MSG, UUID.randomUUID().toString());
-    init(tableNameWithType, segmentName, false);
-  }
-
-  public SegmentRefreshMessage(String tableNameWithType, String segmentName, boolean forceDownload) {
-    super(MessageType.USER_DEFINE_MSG, UUID.randomUUID().toString());
-    init(tableNameWithType, segmentName, forceDownload);
-  }
-
-  private void init(String tableNameWithType, String segmentName, boolean forceDownload) {
     setMsgSubType(REFRESH_SEGMENT_MSG_SUB_TYPE);
     // Give it infinite time to process the message, as long as session is alive
     setExecutionTimeout(-1);
@@ -65,7 +55,6 @@ public class SegmentRefreshMessage extends Message {
     ZNRecord znRecord = getRecord();
     znRecord.setSimpleField(TABLE_NAME_KEY, tableNameWithType);
     znRecord.setSimpleField(SEGMENT_NAME_KEY, segmentName);
-    znRecord.setBooleanField(FORCE_DOWNLOAD_KEY, forceDownload);
   }
 
   /**
@@ -87,9 +76,5 @@ public class SegmentRefreshMessage extends Message {
 
   public String getSegmentName() {
     return getRecord().getSimpleField(SEGMENT_NAME_KEY);
-  }
-
-  public boolean getForceDownload() {
-    return getRecord().getBooleanField(FORCE_DOWNLOAD_KEY, false);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/messages/SegmentReloadMessage.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/messages/SegmentReloadMessage.java
@@ -56,7 +56,7 @@ public class SegmentReloadMessage extends Message {
         "Invalid message sub type: " + msgSubType + " for SegmentReloadMessage");
   }
 
-  public boolean getForceDownload() {
+  public boolean shouldForceDownload() {
     return getRecord().getBooleanField(FORCE_DOWNLOAD_KEY, false);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/messages/SegmentReloadMessage.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/messages/SegmentReloadMessage.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import java.util.UUID;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import org.apache.helix.ZNRecord;
 import org.apache.helix.model.Message;
 
 
@@ -32,7 +33,9 @@ import org.apache.helix.model.Message;
 public class SegmentReloadMessage extends Message {
   public static final String RELOAD_SEGMENT_MSG_SUB_TYPE = "RELOAD_SEGMENT";
 
-  public SegmentReloadMessage(@Nonnull String tableNameWithType, @Nullable String segmentName) {
+  private static final String FORCE_DOWNLOAD_KEY = "forceDownload";
+
+  public SegmentReloadMessage(@Nonnull String tableNameWithType, @Nullable String segmentName, boolean forceDownload) {
     super(MessageType.USER_DEFINE_MSG, UUID.randomUUID().toString());
     setResourceName(tableNameWithType);
     if (segmentName != null) {
@@ -41,6 +44,9 @@ public class SegmentReloadMessage extends Message {
     setMsgSubType(RELOAD_SEGMENT_MSG_SUB_TYPE);
     // Give it infinite time to process the message, as long as session is alive
     setExecutionTimeout(-1);
+
+    ZNRecord znRecord = getRecord();
+    znRecord.setBooleanField(FORCE_DOWNLOAD_KEY, forceDownload);
   }
 
   public SegmentReloadMessage(Message message) {
@@ -48,5 +54,9 @@ public class SegmentReloadMessage extends Message {
     String msgSubType = message.getMsgSubType();
     Preconditions.checkArgument(msgSubType.equals(RELOAD_SEGMENT_MSG_SUB_TYPE),
         "Invalid message sub type: " + msgSubType + " for SegmentReloadMessage");
+  }
+
+  public boolean getForceDownload() {
+    return getRecord().getBooleanField(FORCE_DOWNLOAD_KEY, false);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -362,7 +362,7 @@ public class PinotSegmentRestletResource {
     if (tableType != TableType.OFFLINE) {
       throw new ControllerApplicationException(LOGGER, String
           .format("Unable to refresh segment: %s of table: %s of type: %s. OFFLINE table is expected", segmentName,
-              tableName, tableType), Status.BAD_REQUEST);
+              tableName, tableType), Status.FORBIDDEN);
     }
     String tableNameWithType =
         ResourceUtils.getExistingTableNamesWithType(_pinotHelixResourceManager, tableName, tableType, LOGGER).get(0);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -189,6 +189,13 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", _baseUrl, "segments", tableName, query);
   }
 
+  public String forTableRefresh(String tableName, String segmentName, boolean forceDownload)
+      throws UnsupportedEncodingException {
+    String query = "refresh?forceDownload=" + forceDownload;
+    String segName = URLEncoder.encode(segmentName, StandardCharsets.UTF_8.toString());
+    return StringUtil.join("/", _baseUrl, "segments", tableName, segName, query);
+  }
+
   public String forTableSize(String tableName) {
     return StringUtil.join("/", _baseUrl, "tables", tableName, "size");
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceConfigConstants;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 
 
@@ -179,19 +180,14 @@ public class ControllerRequestURLBuilder {
     return stringBuilder.toString();
   }
 
-  public String forTableReload(String tableName, String tableType) {
-    String query = "reload?type=" + tableType;
-    return StringUtil.join("/", _baseUrl, "tables", tableName, "segments", query);
-  }
-
-  public String forTableRefresh(String tableName, boolean forceDownload) {
-    String query = "refresh?forceDownload=" + forceDownload;
+  public String forTableReload(String tableName, TableType tableType, boolean forceDownload) {
+    String query = String.format("reload?forceDownload=%s&type=%s", forceDownload, tableType.name());
     return StringUtil.join("/", _baseUrl, "segments", tableName, query);
   }
 
-  public String forTableRefresh(String tableName, String segmentName, boolean forceDownload)
+  public String forSegmentReload(String tableName, String segmentName, boolean forceDownload)
       throws UnsupportedEncodingException {
-    String query = "refresh?forceDownload=" + forceDownload;
+    String query = "reload?forceDownload=" + forceDownload;
     String segName = URLEncoder.encode(segmentName, StandardCharsets.UTF_8.toString());
     return StringUtil.join("/", _baseUrl, "segments", tableName, segName, query);
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -184,6 +184,15 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", _baseUrl, "tables", tableName, "segments", query);
   }
 
+  public String forTableRefresh(String tableName, boolean forceDownload) {
+    String query = "refresh?forceDownload=" + forceDownload;
+    return StringUtil.join("/", _baseUrl, "segments", tableName, query);
+  }
+
+  public String forTableSize(String tableName) {
+    return StringUtil.join("/", _baseUrl, "tables", tableName, "size");
+  }
+
   public String forTableUpdateIndexingConfigs(String tableName) {
     return StringUtil.join("/", _baseUrl, "tables", tableName, "indexingConfigs");
   }
@@ -211,6 +220,7 @@ public class ControllerRequestURLBuilder {
     }
     return url;
   }
+
   public String forTableSchemaGet(String tableName) {
     return StringUtil.join("/", _baseUrl, "tables", tableName, "schema");
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1781,7 +1781,9 @@ public class PinotHelixResourceManager {
 
     if (forceDownload) {
       TableType tt = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
-      Preconditions.checkArgument(tt == TableType.OFFLINE, "OFFLINE table is required to force segment download");
+      // TODO: support to force download immutable segments from RealTime table.
+      Preconditions.checkArgument(tt == TableType.OFFLINE,
+          "Table: %s is not an OFFLINE table, which is required to force to download segments", tableNameWithType);
     }
 
     Criteria recipientCriteria = new Criteria();
@@ -1810,7 +1812,10 @@ public class PinotHelixResourceManager {
 
     if (forceDownload) {
       TableType tt = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
-      Preconditions.checkArgument(tt == TableType.OFFLINE, "OFFLINE table is required to force segment download");
+      // TODO: support to force download immutable segments from RealTime table.
+      Preconditions.checkArgument(tt == TableType.OFFLINE,
+          "Table: %s is not an OFFLINE table, which is required to force to download segment: %s", tableNameWithType,
+          segmentName);
     }
 
     Criteria recipientCriteria = new Criteria();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1753,6 +1753,17 @@ public class PinotHelixResourceManager {
     return ZKMetadataProvider.setOfflineSegmentZKMetadata(_propertyStore, offlineTableName, segmentMetadata);
   }
 
+  /**
+   * Set segment metadata in ZK, and require servers and brokers to refresh segment for an offline table.
+   * SegmentRefreshMessage is sent to servers and brokers for them to check out the new metadata in ZK and
+   * act accordingly.
+   *
+   * @param offlineTableName name of the OFFLINE table, for which the segment is to be refreshed
+   * @param segmentMetadata metadata extracted from the newly uploaded segment
+   * @param offlineSegmentZKMetadata existing segment metadata from Zookeeper
+   * @param downloadUrl where to download the new segment, like from deep store
+   * @param crypter crypterClassName as set in TableConfig
+   */
   public void refreshSegment(String offlineTableName, SegmentMetadata segmentMetadata,
       OfflineSegmentZKMetadata offlineSegmentZKMetadata, String downloadUrl, @Nullable String crypter) {
     String segmentName = segmentMetadata.getName();
@@ -1774,6 +1785,65 @@ public class PinotHelixResourceManager {
 
     // Send a message to servers and brokers hosting the table to refresh the segment
     sendSegmentRefreshMessage(offlineTableName, segmentName, true, true);
+  }
+
+  /**
+   * Refreshes segment on servers for an offline table. This method assumes the segment metadata has been set in ZK,
+   * and segment can be retrieved via the downloadUri set in the metadata. Flag forceDownload can be set to force
+   * servers to download segment, rebuild index and load it in memory even if local CRC equals with the one in ZK.
+   *
+   * @param offlineTableName name of the OFFLINE table, for which the segment is to be refreshed
+   * @param segmentName the segment to be refreshed
+   * @param forceDownload if set to true, server is required to download the segment, regardless of CRC
+   * @return number of segmentRefreshMessages sent out
+   */
+  public int refreshSegment(String offlineTableName, String segmentName, boolean forceDownload) {
+    LOGGER.info("Sending refresh message for segment: {} in table: {} with force download: {}", segmentName,
+        offlineTableName, forceDownload);
+
+    // Send segment refresh message to servers
+    Criteria recipientCriteria = new Criteria();
+    recipientCriteria.setRecipientInstanceType(InstanceType.PARTICIPANT);
+    recipientCriteria.setInstanceName("%");
+    recipientCriteria.setSessionSpecific(true);
+    recipientCriteria.setResource(offlineTableName);
+    recipientCriteria.setPartition(segmentName);
+
+    // Send message with no callback and infinite timeout on the recipient
+    ClusterMessagingService messagingService = _helixZkManager.getMessagingService();
+    SegmentRefreshMessage segmentRefreshMessage =
+        new SegmentRefreshMessage(offlineTableName, segmentName, forceDownload);
+    int numMessagesSent = messagingService.send(recipientCriteria, segmentRefreshMessage, null, -1);
+    if (numMessagesSent > 0) {
+      LOGGER.info("Sent {} segment refresh messages to servers for segment: {} of table: {}", numMessagesSent,
+          segmentName, offlineTableName);
+    } else {
+      LOGGER.warn("No segment refresh message sent to servers for segment: {} of table: {}", segmentName,
+          offlineTableName);
+    }
+    return numMessagesSent;
+  }
+
+  public int refreshAllSegments(String offlineTableName, boolean forceDownload) {
+    LOGGER.info("Sending refresh message for table: {} with force download: {}", offlineTableName, forceDownload);
+
+    // Send segment refresh message to servers
+    Criteria recipientCriteria = new Criteria();
+    recipientCriteria.setRecipientInstanceType(InstanceType.PARTICIPANT);
+    recipientCriteria.setInstanceName("%");
+    recipientCriteria.setSessionSpecific(true);
+    recipientCriteria.setResource(offlineTableName);
+
+    // Send message with no callback and infinite timeout on the recipient
+    ClusterMessagingService messagingService = _helixZkManager.getMessagingService();
+    SegmentRefreshMessage segmentRefreshMessage = new SegmentRefreshMessage(offlineTableName, null, forceDownload);
+    int numMessagesSent = messagingService.send(recipientCriteria, segmentRefreshMessage, null, -1);
+    if (numMessagesSent > 0) {
+      LOGGER.info("Sent {} segment refresh messages to servers for table: {}", numMessagesSent, offlineTableName);
+    } else {
+      LOGGER.warn("No segment refresh message sent to servers for table: {}", offlineTableName);
+    }
+    return numMessagesSent;
   }
 
   public int reloadAllSegments(String tableNameWithType) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.helix;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Preconditions;
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
@@ -77,6 +78,7 @@ import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
@@ -560,8 +562,17 @@ public abstract class ControllerTest {
         _controllerRequestURLBuilder.forSegmentDeleteAllAPI(tableName, tableType.toString()));
   }
 
+  protected long getTableSize(String tableName) throws IOException {
+    JsonNode response = JsonUtils.stringToJsonNode(sendGetRequest(_controllerRequestURLBuilder.forTableSize(tableName)));
+    return Long.parseLong(response.get("reportedSizeInBytes").asText());
+  }
+
   protected void reloadOfflineTable(String tableName) throws IOException {
     sendPostRequest(_controllerRequestURLBuilder.forTableReload(tableName, TableType.OFFLINE.name()), null);
+  }
+
+  protected void refreshOfflineTable(String tableName, boolean forceDownload) throws IOException {
+    sendPostRequest(_controllerRequestURLBuilder.forTableRefresh(tableName, forceDownload), null);
   }
 
   protected void reloadRealtimeTable(String tableName) throws IOException {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -568,19 +568,19 @@ public abstract class ControllerTest {
   }
 
   protected void reloadOfflineTable(String tableName) throws IOException {
-    sendPostRequest(_controllerRequestURLBuilder.forTableReload(tableName, TableType.OFFLINE.name()), null);
+    reloadOfflineTable(tableName, false);
   }
 
-  protected void refreshOfflineTable(String tableName, boolean forceDownload) throws IOException {
-    sendPostRequest(_controllerRequestURLBuilder.forTableRefresh(tableName, forceDownload), null);
+  protected void reloadOfflineTable(String tableName, boolean forceDownload) throws IOException {
+    sendPostRequest(_controllerRequestURLBuilder.forTableReload(tableName, TableType.OFFLINE, forceDownload), null);
   }
 
-  protected void refreshOfflineTable(String tableName, String segmentName, boolean forceDownload) throws IOException {
-    sendPostRequest(_controllerRequestURLBuilder.forTableRefresh(tableName, segmentName, forceDownload), null);
+  protected void reloadOfflineSegment(String tableName, String segmentName, boolean forceDownload) throws IOException {
+    sendPostRequest(_controllerRequestURLBuilder.forSegmentReload(tableName, segmentName, forceDownload), null);
   }
 
   protected void reloadRealtimeTable(String tableName) throws IOException {
-    sendPostRequest(_controllerRequestURLBuilder.forTableReload(tableName, TableType.REALTIME.name()), null);
+    sendPostRequest(_controllerRequestURLBuilder.forTableReload(tableName, TableType.REALTIME, false), null);
   }
 
   protected String getBrokerTenantRequestPayload(String tenantName, int numBrokers) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -575,6 +575,10 @@ public abstract class ControllerTest {
     sendPostRequest(_controllerRequestURLBuilder.forTableRefresh(tableName, forceDownload), null);
   }
 
+  protected void refreshOfflineTable(String tableName, String segmentName, boolean forceDownload) throws IOException {
+    sendPostRequest(_controllerRequestURLBuilder.forTableRefresh(tableName, segmentName, forceDownload), null);
+  }
+
   protected void reloadRealtimeTable(String tableName) throws IOException {
     sendPostRequest(_controllerRequestURLBuilder.forTableReload(tableName, TableType.REALTIME.name()), null);
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -35,6 +35,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.exception.QueryException;
@@ -347,6 +348,116 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         throw new RuntimeException(e);
       }
     }, 600_000L, "Failed to generate inverted index");
+  }
+
+  @Test
+  public void testRefreshTable()
+      throws Exception {
+    long numTotalDocs = getCountStarResult();
+
+    // Without index on DivActualElapsedTime, all docs are scanned at filtering stage.
+    JsonNode queryResponse = postQuery(TEST_UPDATED_INVERTED_INDEX_QUERY);
+    assertEquals(queryResponse.get("numEntriesScannedInFilter").asLong(), numTotalDocs);
+
+    long tableSizeNoIndex = getTableSize(getTableName());
+
+    // Update table config to add inverted index on DivActualElapsedTime column, and
+    // reload the table to get config change into effect and add the inverted index.
+    TableConfig tableConfig = getOfflineTableConfig();
+    tableConfig.getIndexingConfig().setInvertedIndexColumns(UPDATED_INVERTED_INDEX_COLUMNS);
+    updateTableConfig(tableConfig);
+    reloadOfflineTable(getTableName());
+
+    // It takes a while to reload multiple segments, thus we retry the query for some time.
+    // After all segments are reloaded, the inverted index is added on DivActualElapsedTime.
+    // It's expected to have numEntriesScannedInFilter equal to 0, i.e. no docs is scanned
+    // at filtering stage when inverted index can answer the predicate directly.
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        JsonNode queryResponse1 = postQuery(TEST_UPDATED_INVERTED_INDEX_QUERY);
+        // Total docs should not change during reload
+        assertEquals(queryResponse1.get("totalDocs").asLong(), numTotalDocs);
+        return queryResponse1.get("numEntriesScannedInFilter").asLong() == 0L;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, 600_000L, "Failed to generate inverted index");
+
+    long tableSizeWithIndex = getTableSize(getTableName());
+    assertTrue(tableSizeWithIndex > tableSizeNoIndex);
+
+    // Update table config to remove all inverted index.
+    tableConfig = getOfflineTableConfig();
+    tableConfig.getIndexingConfig().setInvertedIndexColumns(Collections.emptyList());
+    updateTableConfig(tableConfig);
+    reloadOfflineTable(getTableName());
+
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        JsonNode queryResponse2 = postQuery(TEST_UPDATED_INVERTED_INDEX_QUERY);
+        // Total docs should not change during reload
+        assertEquals(queryResponse2.get("totalDocs").asLong(), numTotalDocs);
+        return queryResponse2.get("numEntriesScannedInFilter").asLong() == numTotalDocs;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, 600_000L, "Failed to disable indices");
+
+    // Reload table just disables those indices, not clean them physically.
+    final long tableSizeAfterReload = getTableSize(getTableName());
+    assertEquals(tableSizeAfterReload, tableSizeWithIndex);
+
+    // Refresh table cleans indices up physically.
+    refreshOfflineTable(getTableName(), true);
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        JsonNode queryResponse3 = postQuery(TEST_UPDATED_INVERTED_INDEX_QUERY);
+        assertEquals(queryResponse3.get("totalDocs").asLong(), numTotalDocs);
+        long tableSizeAfterRefresh = getTableSize(getTableName());
+        return tableSizeAfterRefresh < tableSizeAfterReload;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, 600_000L, "Failed to clean up obsolete indices");
+  }
+
+  @Test
+  public void testRefreshTableButSkipDownload()
+      throws Exception {
+    long numTotalDocs = getCountStarResult();
+
+    // Without index on DivActualElapsedTime, all docs are scanned at filtering stage.
+    JsonNode queryResponse = postQuery(TEST_UPDATED_INVERTED_INDEX_QUERY);
+    assertEquals(queryResponse.get("numEntriesScannedInFilter").asLong(), numTotalDocs);
+
+    long tableSizeNoIndex = getTableSize(getTableName());
+
+    // Update table config to remove all inverted index, but "DivActualElapsedTime"
+    // So that we can detect when segments are refreshed.
+    TableConfig tableConfig = getOfflineTableConfig();
+    tableConfig.getIndexingConfig().setInvertedIndexColumns(Collections.singletonList("DivActualElapsedTime"));
+    updateTableConfig(tableConfig);
+
+    // Refreshing table w/o forcing download doesn't clean indices. In fact,
+    // because local and remote CRCs match, table is not loaded with
+    // new table config either, i.e. the new column is not indexed.
+    refreshOfflineTable(getTableName(), false);
+    AtomicLong tableSizeAfterRefresh = new AtomicLong(0);
+    try {
+      TestUtils.waitForCondition(aVoid -> {
+        try {
+          JsonNode queryResponse3 = postQuery(TEST_UPDATED_INVERTED_INDEX_QUERY);
+          assertEquals(queryResponse3.get("totalDocs").asLong(), numTotalDocs);
+          tableSizeAfterRefresh.set(getTableSize(getTableName()));
+          return tableSizeAfterRefresh.longValue() < tableSizeNoIndex; // should never happen
+        } catch (Exception e) {
+          throw new RuntimeException(e);
+        }
+      }, 3_000L, "error is expected");
+      fail();
+    } catch (AssertionError e) {
+      assertEquals(tableSizeAfterRefresh.longValue(), tableSizeNoIndex);
+    }
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -432,7 +432,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
     long tableSizeNoIndex = getTableSize(getTableName());
 
-    // Update table config to remove all inverted index, but "DivActualElapsedTime"
+    // Update table config to remove all inverted index.
     TableConfig tableConfig = getOfflineTableConfig();
     tableConfig.getIndexingConfig().setInvertedIndexColumns(Collections.emptyList());
     updateTableConfig(tableConfig);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -356,7 +356,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       }
     }, 600_000L, "Failed to generate inverted index");
 
-    final long tableSizeWithNewIndex = getTableSize(getTableName());
+    long tableSizeWithNewIndex = getTableSize(getTableName());
     assertTrue(tableSizeWithNewIndex > tableSizeWithDefaultIndex);
 
     // Update table config to remove all inverted index.

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentFetcherAndLoader.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentFetcherAndLoader.java
@@ -20,6 +20,7 @@ package org.apache.pinot.server.starter.helix;
 
 import com.google.common.base.Preconditions;
 import java.io.File;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.locks.Lock;
 import javax.annotation.Nullable;
@@ -71,13 +72,33 @@ public class SegmentFetcherAndLoader {
     PinotCrypterFactory.init(pinotCrypterConfig);
   }
 
+  public void addOrReplaceAllOfflineSegments(String tableNameWithType, boolean forceDownload) {
+    LOGGER.info("Refreshing all segments in table: {}", tableNameWithType);
+    List<SegmentMetadata> segMds = _instanceDataManager.getAllSegmentsMetadata(tableNameWithType);
+    for (SegmentMetadata segMd : segMds) {
+      addOrReplaceOfflineSegment(tableNameWithType, segMd.getName(), forceDownload);
+    }
+    LOGGER.info("Refreshed all segments in table: {}", tableNameWithType);
+  }
+
   public void addOrReplaceOfflineSegment(String tableNameWithType, String segmentName) {
+    addOrReplaceOfflineSegment(tableNameWithType, segmentName, false);
+  }
+
+  /**
+   * Add a new segment or replace an existing segment for offline table. The method checks
+   * the local segment CRC with the one set in ZK by controller. If both equal, the method
+   * simply loads the local segment, otherwise it downloads the new segment then load. When
+   * forceDownload is set to true, the server always downloads and replaces the local segment
+   * before building index and loading it into memory.
+   */
+  public void addOrReplaceOfflineSegment(String tableNameWithType, String segmentName, boolean forceDownload) {
     OfflineSegmentZKMetadata newSegmentZKMetadata = ZKMetadataProvider
         .getOfflineSegmentZKMetadata(_instanceDataManager.getPropertyStore(), tableNameWithType, segmentName);
     Preconditions.checkNotNull(newSegmentZKMetadata);
 
-    LOGGER.info("Adding or replacing segment {} for table {}, metadata {}", segmentName, tableNameWithType,
-        newSegmentZKMetadata);
+    LOGGER.info("Adding or replacing segment {} for table {}, metadata {}, downloadIsForced {}", segmentName,
+        tableNameWithType, newSegmentZKMetadata, forceDownload);
 
     // This method might modify the file on disk. Use segment lock to prevent race condition
     Lock segmentLock = SegmentLocks.getSegmentLock(tableNameWithType, segmentName);
@@ -108,7 +129,8 @@ public class SegmentFetcherAndLoader {
             localSegmentMetadata = null;
           }
           try {
-            if (!isNewSegmentMetadata(tableNameWithType, newSegmentZKMetadata, localSegmentMetadata)) {
+            if (!forceDownload && !isNewSegmentMetadata(tableNameWithType, newSegmentZKMetadata,
+                localSegmentMetadata)) {
               LOGGER.info("Segment metadata same as before, loading {} of table {} (crc {}) from disk", segmentName,
                   tableNameWithType, localSegmentMetadata.getCrc());
               _instanceDataManager.addOfflineSegment(tableNameWithType, segmentName, indexDir);
@@ -140,8 +162,10 @@ public class SegmentFetcherAndLoader {
       // If we get here, then either it is the case that we have the segment loaded in memory (and therefore present
       // in disk) or, we need to load from the server. In the former case, we still need to check if the metadata
       // that we have is different from that in zookeeper.
-      if (isNewSegmentMetadata(tableNameWithType, newSegmentZKMetadata, localSegmentMetadata)) {
-        if (localSegmentMetadata == null) {
+      if (forceDownload || isNewSegmentMetadata(tableNameWithType, newSegmentZKMetadata, localSegmentMetadata)) {
+        if (forceDownload) {
+          LOGGER.info("Being forced to load segment {} of table {} from controller.", segmentName, tableNameWithType);
+        } else if (localSegmentMetadata == null) {
           LOGGER.info("Loading new segment {} of table {} from controller", segmentName, tableNameWithType);
         } else {
           LOGGER.info("Trying to refresh segment {} of table {} with new data.", segmentName, tableNameWithType);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentFetcherAndLoader.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentFetcherAndLoader.java
@@ -72,13 +72,13 @@ public class SegmentFetcherAndLoader {
     PinotCrypterFactory.init(pinotCrypterConfig);
   }
 
-  public void addOrReplaceAllOfflineSegments(String tableNameWithType, boolean forceDownload) {
-    LOGGER.info("Refreshing all segments in table: {}", tableNameWithType);
+  public void replaceAllOfflineSegments(String tableNameWithType) {
+    LOGGER.info("Replacing all segments in table: {}", tableNameWithType);
     List<SegmentMetadata> segMds = _instanceDataManager.getAllSegmentsMetadata(tableNameWithType);
     for (SegmentMetadata segMd : segMds) {
-      addOrReplaceOfflineSegment(tableNameWithType, segMd.getName(), forceDownload);
+      addOrReplaceOfflineSegment(tableNameWithType, segMd.getName(), true);
     }
-    LOGGER.info("Refreshed all segments in table: {}", tableNameWithType);
+    LOGGER.info("Replaced all segments in table: {}", tableNameWithType);
   }
 
   public void addOrReplaceOfflineSegment(String tableNameWithType, String segmentName) {
@@ -89,8 +89,7 @@ public class SegmentFetcherAndLoader {
    * Add a new segment or replace an existing segment for offline table. The method checks
    * the local segment CRC with the one set in ZK by controller. If both equal, the method
    * simply loads the local segment, otherwise it downloads the new segment then load. When
-   * forceDownload is set to true, the server always downloads and replaces the local segment
-   * before building index and loading it into memory.
+   * forceDownload is set to true, the server always downloads the segment.
    */
   public void addOrReplaceOfflineSegment(String tableNameWithType, String segmentName, boolean forceDownload) {
     OfflineSegmentZKMetadata newSegmentZKMetadata = ZKMetadataProvider
@@ -164,7 +163,7 @@ public class SegmentFetcherAndLoader {
       // that we have is different from that in zookeeper.
       if (forceDownload || isNewSegmentMetadata(tableNameWithType, newSegmentZKMetadata, localSegmentMetadata)) {
         if (forceDownload) {
-          LOGGER.info("Being forced to load segment {} of table {} from controller.", segmentName, tableNameWithType);
+          LOGGER.info("Force to download segment {} of table {} from controller.", segmentName, tableNameWithType);
         } else if (localSegmentMetadata == null) {
           LOGGER.info("Loading new segment {} of table {} from controller", segmentName, tableNameWithType);
         } else {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentMessageHandlerFactory.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentMessageHandlerFactory.java
@@ -106,12 +106,9 @@ public class SegmentMessageHandlerFactory implements MessageHandlerFactory {
   }
 
   private class SegmentRefreshMessageHandler extends DefaultMessageHandler {
-    private final boolean _forceDownload;
-
     SegmentRefreshMessageHandler(SegmentRefreshMessage refreshMessage, ServerMetrics metrics,
         NotificationContext context) {
       super(refreshMessage, metrics, context);
-      _forceDownload = refreshMessage.getForceDownload();
     }
 
     @Override
@@ -120,16 +117,9 @@ public class SegmentMessageHandlerFactory implements MessageHandlerFactory {
       HelixTaskResult result = new HelixTaskResult();
       _logger.info("Handling message: {}", _message);
       try {
-        if (_segmentName.equals("")) {
-          acquireSema("ALL", _logger);
-          // NOTE: the method aborts if any segment refresh encounters an unhandled exception
-          // can lead to inconsistent state across segments
-          _fetcherAndLoader.addOrReplaceAllOfflineSegments(_tableNameWithType, _forceDownload);
-        } else {
-          acquireSema(_segmentName, _logger);
-          // The number of retry times depends on the retry count in Constants.
-          _fetcherAndLoader.addOrReplaceOfflineSegment(_tableNameWithType, _segmentName, _forceDownload);
-        }
+        acquireSema(_segmentName, _logger);
+        // The number of retry times depends on the retry count in Constants.
+        _fetcherAndLoader.addOrReplaceOfflineSegment(_tableNameWithType, _segmentName);
         result.setSuccess(true);
       } catch (Exception e) {
         _metrics.addMeteredTableValue(_tableNameWithType, ServerMeter.REFRESH_FAILURES, 1);
@@ -142,9 +132,12 @@ public class SegmentMessageHandlerFactory implements MessageHandlerFactory {
   }
 
   private class SegmentReloadMessageHandler extends DefaultMessageHandler {
+    private final boolean _forceDownload;
+
     SegmentReloadMessageHandler(SegmentReloadMessage segmentReloadMessage, ServerMetrics metrics,
         NotificationContext context) {
       super(segmentReloadMessage, metrics, context);
+      _forceDownload = segmentReloadMessage.getForceDownload();
     }
 
     @Override
@@ -155,13 +148,21 @@ public class SegmentMessageHandlerFactory implements MessageHandlerFactory {
       try {
         if (_segmentName.equals("")) {
           acquireSema("ALL", _logger);
-          // NOTE: the method aborts if any segment reload encounters an unhandled exception - can lead to inconsistent
-          // state across segments
-          _instanceDataManager.reloadAllSegments(_tableNameWithType);
+          // NOTE: the method aborts if any segment reload encounters an unhandled exception,
+          // and can lead to inconsistent state across segments
+          if (_forceDownload) {
+            _fetcherAndLoader.replaceAllOfflineSegments(_tableNameWithType);
+          } else {
+            _instanceDataManager.reloadAllSegments(_tableNameWithType);
+          }
         } else {
           // Reload one segment
           acquireSema(_segmentName, _logger);
-          _instanceDataManager.reloadSegment(_tableNameWithType, _segmentName);
+          if (_forceDownload) {
+            _fetcherAndLoader.addOrReplaceOfflineSegment(_tableNameWithType, _segmentName, true);
+          } else {
+            _instanceDataManager.reloadSegment(_tableNameWithType, _segmentName);
+          }
         }
         helixTaskResult.setSuccess(true);
       } catch (Throwable e) {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentMessageHandlerFactory.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentMessageHandlerFactory.java
@@ -137,7 +137,7 @@ public class SegmentMessageHandlerFactory implements MessageHandlerFactory {
     SegmentReloadMessageHandler(SegmentReloadMessage segmentReloadMessage, ServerMetrics metrics,
         NotificationContext context) {
       super(segmentReloadMessage, metrics, context);
-      _forceDownload = segmentReloadMessage.getForceDownload();
+      _forceDownload = segmentReloadMessage.shouldForceDownload();
     }
 
     @Override


### PR DESCRIPTION
## Description
Add an option to force download the segments when reloading the table

## Release Notes
Add a boolean query parameter `forceDownload` to the following rest APIs:
- `POST segments/{tableName}/reload`: reload a table
- `POST segments/{tableName}/{segmentName}/reload`: reload a segment