### PR TITLE
Move PinotSM shutdown hook to cleanup method

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
@@ -149,6 +149,7 @@ public class StartServiceManagerCommand extends AbstractBaseAdminCommand impleme
 
   @Override
   public void cleanup() {
+    _pinotServiceManager.stopAll();
   }
 
   @Override
@@ -182,7 +183,6 @@ public class StartServiceManagerCommand extends AbstractBaseAdminCommand impleme
       if (!startBootstrapServices()) {
         return false;
       }
-      Runtime.getRuntime().addShutdownHook(new Thread(() -> _pinotServiceManager.stopAll()));
       String pidFile = ".pinotAdminService-" + System.currentTimeMillis() + ".pid";
       savePID(System.getProperty("java.io.tmpdir") + File.separator + pidFile);
       return true;


### PR DESCRIPTION
## Description
Move PinotSM shutdown hook to the `cleanup` method, which already has a shutdown hook registered by `AbstractBaseAdminCommand`. So no need to register a new Shutdownhook.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
