### PR TITLE
Split tests to multiple test set for github action

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        testset: [ 1, 2, 3, 4 ]
+        testset: [ 1, 2 ]
     name: Pinot Integration Test Set ${{ matrix.testset }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -82,6 +82,27 @@ jobs:
         run: |
           bash <(curl -s https://codecov.io/bash) -cF integration${{ matrix.testset }}
 
+  compatibility-verifier:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test_suite: [ "compatibility-verifier/sample-test-suite" ]
+        old_commit: [ "release-0.7.1", "master" ]
+    name: Pinot Compatibility Regression Testing against ${{ matrix.old_commit }} on ${{ matrix.test_suite }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Pinot Compatibility Regression Testing
+        env:
+          OLD_COMMIT: ${{ matrix.old_commit }}
+          WORKING_DIR: /tmp/compatibility-verifier
+          TEST_SUITE: ${{ matrix.test_suite }}
+          MAVEN_OPTS: -Xmx2G -DskipShade -DfailIfNoTests=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
+        run: .github/workflows/scripts/.pinot_compatibility_verifier.sh
+
   quickstarts:
     runs-on: ubuntu-latest
     strategy:
@@ -96,3 +117,4 @@ jobs:
           java-version: ${{ matrix.java }}
       - name: Quickstart on JDK ${{ matrix.java }}
         run: .github/workflows/scripts/.pinot_quickstart.sh
+

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -40,6 +40,10 @@ on:
 jobs:
   unit-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        testset: [ 1, 2 ]
+    name: Pinot Unit Test Set ${{ matrix.testset }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
@@ -49,14 +53,19 @@ jobs:
       - name: Unit Test
         env:
           RUN_INTEGRATION_TESTS: false
-          MAVEN_OPTS: -Xmx2G -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
+          RUN_TEST_SET: ${{ matrix.testset }}
+          MAVEN_OPTS: -Xmx2G -DskipShade -DfailIfNoTests=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
         run: .github/workflows/scripts/.pinot_test.sh
       - name: Upload coverage to Codecov
         run: |
-          bash <(curl -s https://codecov.io/bash) -cF unittests
+          bash <(curl -s https://codecov.io/bash) -cF unittests${{ matrix.testset }}
 
   integration-test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        testset: [ 1, 2, 3, 4 ]
+    name: Pinot Integration Test Set ${{ matrix.testset }}
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11
@@ -66,11 +75,12 @@ jobs:
       - name: Integration Test
         env:
           RUN_INTEGRATION_TESTS: true
-          MAVEN_OPTS: -Xmx2G -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
+          RUN_TEST_SET: ${{ matrix.testset }}
+          MAVEN_OPTS: -Xmx2G -DskipShade -DfailIfNoTests=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
         run: .github/workflows/scripts/.pinot_test.sh
       - name: Upload coverage to Codecov
         run: |
-          bash <(curl -s https://codecov.io/bash) -cF integration
+          bash <(curl -s https://codecov.io/bash) -cF integration${{ matrix.testset }}
 
   quickstarts:
     runs-on: ubuntu-latest

--- a/.github/workflows/scripts/.pinot_compatibility_verifier.sh
+++ b/.github/workflows/scripts/.pinot_compatibility_verifier.sh
@@ -1,0 +1,32 @@
+#!/bin/bash -x
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Java version
+java -version
+
+# Check network
+ifconfig
+netstat -i
+
+df -h
+
+compatibility-verifier/checkoutAndBuild.sh -w $WORKING_DIR -o $OLD_COMMIT
+
+compatibility-verifier/compCheck.sh -w $WORKING_DIR -t $TEST_SUITE

--- a/.github/workflows/scripts/.pinot_test.sh
+++ b/.github/workflows/scripts/.pinot_test.sh
@@ -25,29 +25,23 @@ java -version
 ifconfig
 netstat -i
 
-# The overhead of building repo is about 12 min.
-mvn install -DskipTests -T 1C
-
 if [ "$RUN_INTEGRATION_TESTS" != false ]; then
   # Integration Tests
+  mvn install -DskipTests -am -B -pl 'pinot-integration-tests' -T 16
   if [ "$RUN_TEST_SET" == "1" ]; then
-    mvn test -B -pl 'pinot-integration-tests' -Dtest='R*Test,B*Test' -P github-actions,integration-tests-only && exit 0 || exit 1
+    mvn test -am -B -pl 'pinot-integration-tests' -Dtest='C*Test,L*Test,M*Test,R*Test,S*Test' -P github-actions,integration-tests-only && exit 0 || exit 1
   fi
   if [ "$RUN_TEST_SET" == "2" ]; then
-    mvn test -B -pl 'pinot-integration-tests' -Dtest='C*Test,M*Test' -P github-actions,integration-tests-only && exit 0 || exit 1
-  fi
-  if [ "$RUN_TEST_SET" == "3" ]; then
-    mvn test -B -pl 'pinot-integration-tests' -Dtest='A*Test,L*Test,S*Test' -P github-actions,integration-tests-only && exit 0 || exit 1
-  fi
-  if [ "$RUN_TEST_SET" == "4" ]; then
-    mvn test -B -pl 'pinot-integration-tests' -Dtest='!A*Test,!B*Test,!C*Test,!L*Test,!M*Test,!R*Test,!S*Test' -P github-actions,integration-tests-only && exit 0 || exit 1
+    mvn test -am -B -pl 'pinot-integration-tests' -Dtest='!C*Test,!L*Test,!M*Test,!R*Test,!S*Test' -P github-actions,integration-tests-only && exit 0 || exit 1
   fi
 else
   # Unit Tests
   if [ "$RUN_TEST_SET" == "1" ]; then
-    mvn test -B -pl 'pinot-controller'  -pl 'pinot-broker'  -pl 'pinot-server'  -pl 'pinot-segment-local'  -P github-actions,no-integration-tests && exit 0 || exit 1
+    mvn install -DskipTests -am -B -pl 'pinot-core,pinot-segment-local' -T 16
+    mvn test -am -B -pl 'pinot-spi,pinot-segment-spi,pinot-common,pinot-segment-local,pinot-core' -P github-actions,no-integration-tests && exit 0 || exit 1
   fi
   if [ "$RUN_TEST_SET" == "2" ]; then
-    mvn test -B -pl '!pinot-controller' -pl '!pinot-broker' -pl '!pinot-server' -pl '!pinot-segment-local' -P github-actions,no-integration-tests && exit 0 || exit 1
+    mvn install -DskipTests -T 16
+    mvn test -am -B -pl '!pinot-spi,!pinot-segment-spi,!pinot-common,!pinot-segment-local,!pinot-core' -P github-actions,no-integration-tests && exit 0 || exit 1
   fi
 fi

--- a/.github/workflows/scripts/.pinot_test.sh
+++ b/.github/workflows/scripts/.pinot_test.sh
@@ -27,21 +27,52 @@ netstat -i
 
 if [ "$RUN_INTEGRATION_TESTS" != false ]; then
   # Integration Tests
-  mvn install -DskipTests -am -B -pl 'pinot-integration-tests' -T 16
+  mvn install -DskipTests -am -B -pl 'pinot-integration-tests' -T 16 || exit 1
   if [ "$RUN_TEST_SET" == "1" ]; then
-    mvn test -am -B -pl 'pinot-integration-tests' -Dtest='C*Test,L*Test,M*Test,R*Test,S*Test' -P github-actions,integration-tests-only && exit 0 || exit 1
+    mvn test -am -B \
+        -pl 'pinot-integration-tests' \
+        -Dtest='C*Test,L*Test,M*Test,R*Test,S*Test' \
+        -P github-actions,integration-tests-only && exit 0 || exit 1
   fi
   if [ "$RUN_TEST_SET" == "2" ]; then
-    mvn test -am -B -pl 'pinot-integration-tests' -Dtest='!C*Test,!L*Test,!M*Test,!R*Test,!S*Test' -P github-actions,integration-tests-only && exit 0 || exit 1
+    mvn test -am -B \
+        -pl 'pinot-integration-tests' \
+        -Dtest='!C*Test,!L*Test,!M*Test,!R*Test,!S*Test' \
+        -P github-actions,integration-tests-only && exit 0 || exit 1
   fi
 else
   # Unit Tests
   if [ "$RUN_TEST_SET" == "1" ]; then
-    mvn install -DskipTests -am -B -pl 'pinot-core,pinot-segment-local' -T 16
-    mvn test -am -B -pl 'pinot-spi,pinot-segment-spi,pinot-common,pinot-segment-local,pinot-core' -P github-actions,no-integration-tests && exit 0 || exit 1
+    mvn install -am -B \
+        -pl 'pinot-spi' \
+        -pl 'pinot-segment-spi' \
+        -pl 'pinot-common' \
+        -pl 'pinot-segment-local' \
+        -pl 'pinot-core' \
+        -pl 'pinot-server' \
+        -pl ':pinot-yammer' \
+        -pl ':pinot-avro-base' \
+        -pl ':pinot-avro' \
+        -pl ':pinot-csv' \
+        -pl ':pinot-json' \
+        -pl ':pinot-segment-uploader-default' \
+        -P github-actions,no-integration-tests && exit 0 || exit 1
   fi
   if [ "$RUN_TEST_SET" == "2" ]; then
-    mvn install -DskipTests -T 16
-    mvn test -am -B -pl '!pinot-spi,!pinot-segment-spi,!pinot-common,!pinot-segment-local,!pinot-core' -P github-actions,no-integration-tests && exit 0 || exit 1
+    mvn install -DskipTests -T 16 || exit 1
+    mvn test -am -B \
+        -pl '!pinot-spi' \
+        -pl '!pinot-segment-spi' \
+        -pl '!pinot-common' \
+        -pl '!pinot-segment-local' \
+        -pl '!pinot-core' \
+        -pl '!pinot-server' \
+        -pl '!:pinot-yammer' \
+        -pl '!:pinot-avro-base' \
+        -pl '!:pinot-avro' \
+        -pl '!:pinot-csv' \
+        -pl '!:pinot-json' \
+        -pl '!:pinot-segment-uploader-default' \
+        -P github-actions,no-integration-tests && exit 0 || exit 1
   fi
 fi

--- a/.github/workflows/scripts/.pinot_test.sh
+++ b/.github/workflows/scripts/.pinot_test.sh
@@ -25,9 +25,29 @@ java -version
 ifconfig
 netstat -i
 
-# Only run integration tests if needed
+# The overhead of building repo is about 12 min.
+mvn install -DskipTests -T 1C
+
 if [ "$RUN_INTEGRATION_TESTS" != false ]; then
-  mvn test -B -P github-actions,integration-tests-only && exit 0 || exit 1
+  # Integration Tests
+  if [ "$RUN_TEST_SET" == "1" ]; then
+    mvn test -B -pl 'pinot-integration-tests' -Dtest='R*Test,B*Test' -P github-actions,integration-tests-only && exit 0 || exit 1
+  fi
+  if [ "$RUN_TEST_SET" == "2" ]; then
+    mvn test -B -pl 'pinot-integration-tests' -Dtest='C*Test,M*Test' -P github-actions,integration-tests-only && exit 0 || exit 1
+  fi
+  if [ "$RUN_TEST_SET" == "3" ]; then
+    mvn test -B -pl 'pinot-integration-tests' -Dtest='A*Test,L*Test,S*Test' -P github-actions,integration-tests-only && exit 0 || exit 1
+  fi
+  if [ "$RUN_TEST_SET" == "4" ]; then
+    mvn test -B -pl 'pinot-integration-tests' -Dtest='!A*Test,!B*Test,!C*Test,!L*Test,!M*Test,!R*Test,!S*Test' -P github-actions,integration-tests-only && exit 0 || exit 1
+  fi
 else
-  mvn test -B -P github-actions,no-integration-tests && exit 0 || exit 1
+  # Unit Tests
+  if [ "$RUN_TEST_SET" == "1" ]; then
+    mvn test -B -pl 'pinot-controller'  -pl 'pinot-broker'  -pl 'pinot-server'  -pl 'pinot-segment-local'  -P github-actions,no-integration-tests && exit 0 || exit 1
+  fi
+  if [ "$RUN_TEST_SET" == "2" ]; then
+    mvn test -B -pl '!pinot-controller' -pl '!pinot-broker' -pl '!pinot-server' -pl '!pinot-segment-local' -P github-actions,no-integration-tests && exit 0 || exit 1
+  fi
 fi

--- a/compatibility-verifier/checkoutAndBuild.sh
+++ b/compatibility-verifier/checkoutAndBuild.sh
@@ -74,6 +74,21 @@ function build() {
   local repoOption=""
   local versionOption="-Djdk.version=8"
 
+  mkdir -p ${MVN_CACHE_DIR}
+  echo "<settings xmlns=\"http://maven.apache.org/SETTINGS/1.0.0\""> ../settings.xml
+  echo "      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"">> ../settings.xml
+  echo "      xsi:schemaLocation=\"http://maven.apache.org/SETTINGS/1.0.0">> ../settings.xml
+  echo "                          https://maven.apache.org/xsd/settings-1.0.0.xsd\">">> ../settings.xml
+  echo "  <mirrors>">> ../settings.xml
+  echo "    <mirror>">> ../settings.xml
+  echo "      <id>confluent-mirror</id>">> ../settings.xml
+  echo "      <mirrorOf>confluent</mirrorOf>">> ../settings.xml
+  echo "      <url>https://packages.confluent.io/maven/</url>">> ../settings.xml
+  echo "      <blocked>false</blocked>">> ../settings.xml
+  echo "    </mirror>">> ../settings.xml
+  echo "  </mirrors>">> ../settings.xml
+  echo "</settings>">> ../settings.xml
+
   if [ ${buildId} -gt 0 ]; then
     # Build it in a different env under different version so that maven cache does
     # not collide
@@ -83,12 +98,12 @@ function build() {
     repoOption="-Dmaven.repo.local=${mvnCache}/${buildId}"
   fi
 
-  mvn install package -DskipTests -Pbin-dist ${versionOption} ${repoOption} ${PINOT_MAVEN_OPTS} 1>${outFile} 2>&1
+  mvn install package -s ../settings.xml -DskipTests -Pbin-dist ${versionOption} ${repoOption} ${PINOT_MAVEN_OPTS} 1>${outFile} 2>&1
   if [ $? -ne 0 ]; then exit 1; fi
-  mvn -pl pinot-tools package -DskipTests ${versionOption} ${repoOption} ${PINOT_MAVEN_OPTS} 1>>${outFile} 2>&1
+  mvn -pl pinot-tools package -s ../settings.xml -DskipTests ${versionOption} ${repoOption} ${PINOT_MAVEN_OPTS} 1>>${outFile} 2>&1
   if [ $? -ne 0 ]; then exit 1; fi
   if [ $buildTests -eq 1 ]; then
-    mvn -pl pinot-integration-tests package -DskipTests ${versionOption} ${repoOption} ${PINOT_MAVEN_OPTS} 1>>${outFile} 2>&1
+    mvn -pl pinot-integration-tests package -s ../settings.xml -DskipTests ${versionOption} ${repoOption} ${PINOT_MAVEN_OPTS} 1>>${outFile} 2>&1
     if [ $? -ne 0 ]; then exit 1; fi
   fi
 }
@@ -259,6 +274,7 @@ if [ ${oldBuildStatus} -eq 0 ]; then
   echo Old version build completed successfully
 else
   echo Old version build failed. See ${oldBuildOutFile}
+  cat ${oldBuildOutFile}
   exitStatus=1
 fi
 
@@ -266,6 +282,7 @@ if [ ${curBuildStatus} -eq 0 ]; then
   echo Compat checker build completed successfully
 else
   echo Compat checker build failed. See ${curBuildOutFile}
+  cat ${curBuildOutFile}
 fi
 
 if [ ${buildNewTarget} -eq 1 ]; then
@@ -273,6 +290,7 @@ if [ ${buildNewTarget} -eq 1 ]; then
     echo New version build completed successfully
   else
     echo New version build failed. See ${newBuildOutFile}
+    cat ${newBuildOutFile}
     exitStatus=1
   fi
 fi


### PR DESCRIPTION
## Description
1. Split unit tests and integration tests into multiple sets.
    - Each set will be punished by building pinot once(12 mins right now).
    - The time to run CI will reduce from 1h20m to 45m
2. Add compatibility verification tests to test against previous release and master branch on JDK 8 right now.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
