### PR TITLE
Fix segment conversion executor for in-place conversion

### DIFF
--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
@@ -127,13 +127,6 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
       Preconditions.checkState(workingDir.mkdir());
       List<SegmentConversionResult> segmentConversionResults = convert(pinotTaskConfig, inputSegmentDirs, workingDir);
 
-      // Delete the input segments
-      for (File inputSegmentDir : inputSegmentDirs) {
-        if (!FileUtils.deleteQuietly(inputSegmentDir)) {
-          LOGGER.warn("Failed to delete input segment: {}", inputSegmentDir.getAbsolutePath());
-        }
-      }
-
       // Create a directory for converted tarred segment files
       File convertedTarredSegmentDir = new File(tempDataDir, "convertedTarredSegmentDir");
       Preconditions.checkState(convertedTarredSegmentDir.mkdir());
@@ -149,6 +142,15 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
         tarredSegmentFiles.add(convertedSegmentTarFile);
         if (!FileUtils.deleteQuietly(convertedSegmentDir)) {
           LOGGER.warn("Failed to delete converted segment: {}", convertedSegmentDir.getAbsolutePath());
+        }
+      }
+
+      // Delete the input segments
+      // NOTE: Delete the input segments after tarring the converted segments to avoid deleting the converted segment
+      //       when the conversion happens in-place
+      for (File inputSegmentDir : inputSegmentDirs) {
+        if (inputSegmentDir.exists() && !FileUtils.deleteQuietly(inputSegmentDir)) {
+          LOGGER.warn("Failed to delete input segment: {}", inputSegmentDir.getAbsolutePath());
         }
       }
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
@@ -145,9 +145,9 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
         }
       }
 
-      // Delete the input segments
-      // NOTE: Delete the input segments after tarring the converted segments to avoid deleting the converted segment
-      //       when the conversion happens in-place
+      // Delete the input segment after tarring the converted segment to avoid deleting the converted segment when the
+      // conversion happens in-place (converted segment dir is the same as input segment dir). It could also happen when
+      // the conversion is not required, and the input segment dir is returned as the result.
       for (File inputSegmentDir : inputSegmentDirs) {
         if (inputSegmentDir.exists() && !FileUtils.deleteQuietly(inputSegmentDir)) {
           LOGGER.warn("Failed to delete input segment: {}", inputSegmentDir.getAbsolutePath());

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
@@ -106,11 +106,6 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
           "Converted segment name: %s does not match original segment name: %s",
           segmentConversionResult.getSegmentName(), segmentName);
 
-      // Delete the input segment
-      if (!FileUtils.deleteQuietly(indexDir)) {
-        LOGGER.warn("Failed to delete input segment: {}", indexDir.getAbsolutePath());
-      }
-
       // Tar the converted segment
       File convertedSegmentDir = segmentConversionResult.getFile();
       File convertedTarredSegmentFile =
@@ -118,6 +113,13 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
       TarGzCompressionUtils.createTarGzFile(convertedSegmentDir, convertedTarredSegmentFile);
       if (!FileUtils.deleteQuietly(convertedSegmentDir)) {
         LOGGER.warn("Failed to delete converted segment: {}", convertedSegmentDir.getAbsolutePath());
+      }
+
+      // Delete the input segment
+      // NOTE: Delete the input segment after tarring the converted segment to avoid deleting the converted segment when
+      //       the conversion happens in-place
+      if (indexDir.exists() && !FileUtils.deleteQuietly(indexDir)) {
+        LOGGER.warn("Failed to delete input segment: {}", indexDir.getAbsolutePath());
       }
 
       // Check whether the task get cancelled before uploading the segment

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
@@ -115,9 +115,9 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
         LOGGER.warn("Failed to delete converted segment: {}", convertedSegmentDir.getAbsolutePath());
       }
 
-      // Delete the input segment
-      // NOTE: Delete the input segment after tarring the converted segment to avoid deleting the converted segment when
-      //       the conversion happens in-place
+      // Delete the input segment after tarring the converted segment to avoid deleting the converted segment when the
+      // conversion happens in-place (converted segment dir is the same as input segment dir). It could also happen when
+      // the conversion is not required, and the input segment dir is returned as the result.
       if (indexDir.exists() && !FileUtils.deleteQuietly(indexDir)) {
         LOGGER.warn("Failed to delete input segment: {}", indexDir.getAbsolutePath());
       }


### PR DESCRIPTION
Currently the segment conversion executor deletes the input segments before tarring the converted segments. In case when the conversion happens in-place, this can mistakenly delete the converted segment.
Fix this bug by moving the input segment deletion after tarring the converted segments.

Will add tests for the conversion executor in a separate PR