### PR TITLE
Offset based realtime consumption status checker

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
@@ -250,8 +250,8 @@ public class ServiceStatus {
         //      - uncomment the status & statusDescription lines
         LOGGER.info("All consuming segments have reached their latest offsets! "
             + "Finished {} msec earlier than time threshold.", _endWaitTime - now);
-//        _statusDescription = "Consuming segments status GOOD as all consuming segments have reached the latest offset";
-//        return Status.GOOD;
+//      _statusDescription = "Consuming segments status GOOD as all consuming segments have reached the latest offset";
+//      return Status.GOOD;
       }
       _statusDescription =
           String.format("Waiting for consuming segments to catchup, timeRemaining=%dms", _endWaitTime - now);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
@@ -242,11 +242,12 @@ public class ServiceStatus {
         return _serviceStatus;
       }
       long now = System.currentTimeMillis();
+      int numConsumingSegmentsNotCaughtUp = _getNumConsumingSegmentsNotReachedTheirLatestOffset.get();
       if (now >= _endWaitTime) {
-        _statusDescription = String.format("Consuming segments status GOOD since %dms", _endWaitTime);
+        _statusDescription = String.format("Consuming segments status GOOD since %dms "
+            + "(numConsumingSegmentsNotCaughtUp=%d)", _endWaitTime, numConsumingSegmentsNotCaughtUp);
         return Status.GOOD;
       }
-      int numConsumingSegmentsNotCaughtUp = _getNumConsumingSegmentsNotReachedTheirLatestOffset.get();
       if (_consumptionNotYetCaughtUp && numConsumingSegmentsNotCaughtUp > 0) {
         // TODO: Once the performance of offset based consumption checker is validated:
         //      - remove the log line

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
@@ -218,6 +218,8 @@ public class ServiceStatus {
     private final Supplier<Boolean> _allConsumingSegmentsHaveReachedLatestOffset;
     String _statusDescription = STATUS_DESCRIPTION_INIT;
 
+    private boolean _consumptionNotYetCaughtUp = true;
+
     /**
      * Realtime consumption catchup service which adds a static wait time for consuming segments to catchup
      */
@@ -244,10 +246,12 @@ public class ServiceStatus {
         _statusDescription = String.format("Consuming segments status GOOD since %dms", _endWaitTime);
         return Status.GOOD;
       }
-      if (_allConsumingSegmentsHaveReachedLatestOffset.get()) {
+      if (_consumptionNotYetCaughtUp && _allConsumingSegmentsHaveReachedLatestOffset.get()) {
         // TODO: Once the performance of offset based consumption checker is validated:
         //      - remove the log line
         //      - uncomment the status & statusDescription lines
+        //      - remove boolean flag _consumptionNotYetCaughtUp
+        _consumptionNotYetCaughtUp = false;
         LOGGER.info("All consuming segments have reached their latest offsets! "
             + "Finished {} msec earlier than time threshold.", _endWaitTime - now);
 //      _statusDescription = "Consuming segments status GOOD as all consuming segments have reached the latest offset";

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
@@ -252,7 +252,7 @@ public class ServiceStatus {
         // TODO: Once the performance of offset based consumption checker is validated:
         //      - remove the log line
         //      - uncomment the status & statusDescription lines
-        //      - remove boolean flag _consumptionNotYetCaughtUp
+        //      - remove variable _consumptionNotYetCaughtUp
         _consumptionNotYetCaughtUp = false;
         LOGGER.info("All consuming segments have reached their latest offsets! "
             + "Finished {} msec earlier than time threshold.", _endWaitTime - now);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStatus.java
@@ -248,7 +248,8 @@ public class ServiceStatus {
         // TODO: Once the performance of offset based consumption checker is validated:
         //      - remove the log line
         //      - uncomment the status & statusDescription lines
-        LOGGER.info("All consuming segments have reached their latest offsets!");
+        LOGGER.info("All consuming segments have reached their latest offsets! "
+            + "Finished {} msec earlier than time threshold.", _endWaitTime - now);
 //        _statusDescription = "Consuming segments status GOOD as all consuming segments have reached the latest offset";
 //        return Status.GOOD;
       }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -257,8 +257,8 @@ public abstract class BaseServerStarter implements ServiceStartable {
             _instanceId, resourcesToMonitor, minResourcePercentForStartup));
     if (checkRealtime && foundConsuming) {
       OffsetBasedConsumptionStatusChecker consumptionStatusChecker =
-          new OffsetBasedConsumptionStatusChecker(_serverInstance.getInstanceDataManager(), _helixAdmin, _helixClusterName,
-              _instanceId);
+          new OffsetBasedConsumptionStatusChecker(_serverInstance.getInstanceDataManager(), _helixAdmin,
+              _helixClusterName, _instanceId);
       serviceStatusCallbackListBuilder.add(
           new ServiceStatus.RealtimeConsumptionCatchupServiceStatusCallback(_helixManager, _helixClusterName,
               _instanceId, realtimeConsumptionCatchupWaitMs,

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -261,7 +261,7 @@ public abstract class BaseServerStarter implements ServiceStartable {
       serviceStatusCallbackListBuilder.add(
           new ServiceStatus.RealtimeConsumptionCatchupServiceStatusCallback(_helixManager, _helixClusterName,
               _instanceId, realtimeConsumptionCatchupWaitMs,
-              consumptionStatusChecker::haveAllConsumingSegmentsReachedStreamLatestOffset));
+              consumptionStatusChecker::getNumConsumingSegmentsNotReachedTheirLatestOffset));
     }
     LOGGER.info("Registering service status handler");
     ServiceStatus.setServiceStatusCallback(_instanceId,

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -256,9 +256,13 @@ public abstract class BaseServerStarter implements ServiceStartable {
         new ServiceStatus.IdealStateAndExternalViewMatchServiceStatusCallback(_helixManager, _helixClusterName,
             _instanceId, resourcesToMonitor, minResourcePercentForStartup));
     if (checkRealtime && foundConsuming) {
+      OffsetBasedConsumptionStatusChecker consumptionStatusChecker =
+          new OffsetBasedConsumptionStatusChecker(_serverInstance.getInstanceDataManager(), _helixAdmin, _helixClusterName,
+              _instanceId);
       serviceStatusCallbackListBuilder.add(
           new ServiceStatus.RealtimeConsumptionCatchupServiceStatusCallback(_helixManager, _helixClusterName,
-              _instanceId, realtimeConsumptionCatchupWaitMs));
+              _instanceId, realtimeConsumptionCatchupWaitMs,
+              consumptionStatusChecker::haveAllConsumingSegmentsReachedStreamLatestOffset));
     }
     LOGGER.info("Registering service status handler");
     ServiceStatus.setServiceStatusCallback(_instanceId,

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusChecker.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusChecker.java
@@ -51,7 +51,7 @@ import org.slf4j.LoggerFactory;
  */
 public class OffsetBasedConsumptionStatusChecker {
   private static final Logger LOGGER = LoggerFactory.getLogger(OffsetBasedConsumptionStatusChecker.class);
-  private static final long MAX_WAIT_TIME_MS = 5000; // for fetching latest stream offset
+  static final long MAX_WAIT_TIME_MS = 5000; // for fetching latest stream offset
 
   private final InstanceDataManager _instanceDataManager;
   private Supplier<Set<String>> _consumingSegmentFinder;

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusChecker.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusChecker.java
@@ -19,14 +19,8 @@
 
 package org.apache.pinot.server.starter.helix;
 
-import com.google.common.annotations.VisibleForTesting;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
-import java.util.function.Supplier;
-import org.apache.helix.HelixAdmin;
-import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager;
@@ -34,7 +28,6 @@ import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
-import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -44,37 +37,28 @@ import org.slf4j.LoggerFactory;
  * This class is used at startup time to have a more accurate estimate of the catchup period in which no query execution
  * happens and consumers try to catch up to the latest messages available in streams.
  * To achieve this, every time status check is called, {@link #haveAllConsumingSegmentsReachedStreamLatestOffset},
- * list of consuming segments is gathered and then for each segment, we check if segment's latest ingested offset has
- * reached the latest stream offset. To prevent chasing a moving target, once the latest stream offset is fetched, it
- * will not be fetched again and subsequent status check calls compare latest ingested offset with the already fetched
- * stream offset.
+ * for each consuming segment, we check if segment's latest ingested offset has reached the latest stream offset.
+ * To prevent chasing a moving target, once the latest stream offset is fetched, it will not be fetched again and
+ * subsequent status check calls compare latest ingested offset with the already fetched stream offset.
  */
 public class OffsetBasedConsumptionStatusChecker {
   private static final Logger LOGGER = LoggerFactory.getLogger(OffsetBasedConsumptionStatusChecker.class);
-  static final long MAX_WAIT_TIME_MS = 5000; // for fetching latest stream offset
 
+  // constructor parameters
   private final InstanceDataManager _instanceDataManager;
-  private Supplier<Set<String>> _consumingSegmentFinder;
+  private final Set<String> _consumingSegments;
 
-  private Set<String> _caughtUpSegments = new HashSet<>();
-  private Map<String, StreamPartitionMsgOffset> _segmentNameToLatestStreamOffset = new HashMap<>();
+  // helper variable
+  private final Set<String> _caughtUpSegments = new HashSet<>();
 
-  public OffsetBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager, HelixAdmin helixAdmin,
-      String helixClusterName, String instanceId) {
-    this(instanceDataManager, () -> findConsumingSegments(helixAdmin, helixClusterName, instanceId));
-  }
-
-  @VisibleForTesting
-  OffsetBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager,
-      Supplier<Set<String>> consumingSegmentFinder) {
+  public OffsetBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager, Set<String> consumingSegments) {
     _instanceDataManager = instanceDataManager;
-    _consumingSegmentFinder = consumingSegmentFinder;
+    _consumingSegments = consumingSegments;
   }
 
   public boolean haveAllConsumingSegmentsReachedStreamLatestOffset() {
     boolean allSegsReachedLatest = true;
-    Set<String> consumingSegmentNames = _consumingSegmentFinder.get();
-    for (String segName : consumingSegmentNames) {
+    for (String segName : _consumingSegments) {
       if (_caughtUpSegments.contains(segName)) {
         continue;
       }
@@ -89,19 +73,16 @@ public class OffsetBasedConsumptionStatusChecker {
         return false;
       }
       if (!(segmentDataManager instanceof LLRealtimeSegmentDataManager)) {
-        // There's a small chance that after getting the list of consuming segment names at the beginning of this method
-        // up to this point, a consuming segment gets converted to a committed segment. In that case status check is
-        // returned as false and in the next round the new consuming segment will be used for fetching offsets.
-        LOGGER
-            .info("Segment {} is already committed. Will check consumption status later on the next segment", segName);
+        // There's a possibility that a consuming segment has converted to a committed segment. If that's the case,
+        // segment data manager will not be of type LLRealtime.
+        LOGGER.info("Segment {} is already committed and is considered caught up.", segName);
+        _caughtUpSegments.add(segName);
         releaseSegment(tableDataManager, segmentDataManager);
-        return false;
+        continue;
       }
       LLRealtimeSegmentDataManager rtSegmentDataManager = (LLRealtimeSegmentDataManager) segmentDataManager;
       StreamPartitionMsgOffset latestIngestedOffset = rtSegmentDataManager.getCurrentOffset();
-      StreamPartitionMsgOffset latestStreamOffset = _segmentNameToLatestStreamOffset.containsKey(segName)
-          ? _segmentNameToLatestStreamOffset.get(segName)
-          : rtSegmentDataManager.fetchLatestStreamOffset(MAX_WAIT_TIME_MS);
+      StreamPartitionMsgOffset latestStreamOffset = rtSegmentDataManager.getLatestStreamOffsetAtStartupTime();
       releaseSegment(tableDataManager, segmentDataManager);
       if (latestStreamOffset == null || latestIngestedOffset == null) {
         LOGGER.info("Null offset found for segment {} - latest stream offset: {}, latest ingested offset: {}. "
@@ -111,7 +92,6 @@ public class OffsetBasedConsumptionStatusChecker {
       if (latestIngestedOffset.compareTo(latestStreamOffset) < 0) {
         LOGGER.info("Latest ingested offset {} in segment {} is smaller than stream latest available offset {} ",
             latestIngestedOffset, segName, latestStreamOffset);
-        _segmentNameToLatestStreamOffset.put(segName, latestStreamOffset);
         allSegsReachedLatest = false;
         continue;
       }
@@ -135,28 +115,5 @@ public class OffsetBasedConsumptionStatusChecker {
     String tableName = llcSegmentName.getTableName();
     String tableNameWithType = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(tableName);
     return _instanceDataManager.getTableDataManager(tableNameWithType);
-  }
-
-  private static Set<String> findConsumingSegments(HelixAdmin helixAdmin, String helixClusterName, String instanceId) {
-    Set<String> consumingSegments = new HashSet<>();
-    for (String resourceName : helixAdmin.getResourcesInCluster(helixClusterName)) {
-      if (TableNameBuilder.isRealtimeTableResource(resourceName)) {
-        IdealState idealState = helixAdmin.getResourceIdealState(helixClusterName, resourceName);
-        if (idealState.isEnabled()) {
-          for (String segName : idealState.getPartitionSet()) {
-            if (CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING
-                .equals(idealState.getInstanceStateMap(segName).get(instanceId))) {
-              consumingSegments.add(segName);
-            }
-          }
-        }
-      }
-    }
-    return consumingSegments;
-  }
-
-  @VisibleForTesting
-  void setConsumingSegmentFinder(Supplier<Set<String>> consumingSegmentFinder) {
-    _consumingSegmentFinder = consumingSegmentFinder;
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusChecker.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusChecker.java
@@ -1,0 +1,154 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.server.starter.helix;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.model.IdealState;
+import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.core.data.manager.InstanceDataManager;
+import org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager;
+import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
+import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * This class is used at startup time to have a more accurate estimate of the catchup period in which no query execution
+ * happens and consumers try to catch up to the latest messages available in streams.
+ * To achieve this, every time status check is called, {@link #haveAllConsumingSegmentsReachedStreamLatestOffset},
+ * list of consuming segments is gathered and then for each segment, we check if segment's latest ingested offset has
+ * reached the latest stream offset. To prevent chasing a moving target, once the latest stream offset is fetched, it
+ * will not be fetched again and subsequent status check calls compare latest ingested offset with the already fetched
+ * stream offset.
+ */
+public class OffsetBasedConsumptionStatusChecker {
+  private static final Logger LOGGER = LoggerFactory.getLogger(OffsetBasedConsumptionStatusChecker.class);
+
+  private final InstanceDataManager _instanceDataManager;
+  private Supplier<Set<String>> _consumingSegmentFinder;
+
+  private Set<String> _alreadyProcessedSegments = new HashSet<>();
+  private Map<String, StreamPartitionMsgOffset> _segmentNameToLatestStreamOffset = new HashMap<>();
+
+  public OffsetBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager, HelixAdmin helixAdmin,
+      String helixClusterName, String instanceId) {
+    this(instanceDataManager, () -> findConsumingSegments(helixAdmin, helixClusterName, instanceId));
+  }
+
+  @VisibleForTesting
+  OffsetBasedConsumptionStatusChecker(InstanceDataManager instanceDataManager,
+      Supplier<Set<String>> consumingSegmentFinder) {
+    _instanceDataManager = instanceDataManager;
+    _consumingSegmentFinder = consumingSegmentFinder;
+  }
+
+  public boolean haveAllConsumingSegmentsReachedStreamLatestOffset() {
+    boolean allSegsReachedLatest = true;
+    Set<String> consumingSegmentNames = _consumingSegmentFinder.get();
+    for (String segName : consumingSegmentNames) {
+      if (_alreadyProcessedSegments.contains(segName)) {
+        continue;
+      }
+      TableDataManager tableDataManager = getTableDataManager(segName);
+      if (tableDataManager == null) {
+        LOGGER.info("TableDataManager is not yet setup for segment {}. Will check consumption status later", segName);
+        return false;
+      }
+      SegmentDataManager segmentDataManager = tableDataManager.acquireSegment(segName);
+      if (segmentDataManager == null) {
+        LOGGER.info("SegmentDataManager is not yet setup for segment {}. Will check consumption status later", segName);
+        return false;
+      }
+      if (!(segmentDataManager instanceof LLRealtimeSegmentDataManager)) {
+        // There's a small chance that after getting the list of consuming segment names at the beginning of this method
+        // up to this point, a consuming segment gets converted to a committed segment. In that case status check is
+        // returned as false and in the next round the new consuming segment will be used for fetching offsets.
+        LOGGER.info("Segment {} is already committed. Will check consumption status later", segName);
+        tableDataManager.releaseSegment(segmentDataManager);
+        return false;
+      }
+      LLRealtimeSegmentDataManager rtSegmentDataManager = (LLRealtimeSegmentDataManager) segmentDataManager;
+      StreamPartitionMsgOffset latestIngestedOffset = rtSegmentDataManager.getCurrentOffset();
+      StreamPartitionMsgOffset latestStreamOffset = _segmentNameToLatestStreamOffset.containsKey(segName)
+          ? _segmentNameToLatestStreamOffset.get(segName)
+          : rtSegmentDataManager.fetchLatestStreamOffset();
+      tableDataManager.releaseSegment(segmentDataManager);
+      if (latestStreamOffset == null || latestIngestedOffset == null) {
+        LOGGER.info("Null offset found for segment {} - latest stream offset: {}, latest ingested offset: {}. "
+            + "Will check consumption status later", segName, latestStreamOffset, latestIngestedOffset);
+        return false;
+      }
+      if (latestIngestedOffset.compareTo(latestStreamOffset) < 0) {
+        LOGGER.info("Latest ingested offset {} in segment {} is smaller than stream latest available offset {} ",
+            latestIngestedOffset, segName, latestStreamOffset);
+        _segmentNameToLatestStreamOffset.put(segName, latestStreamOffset);
+        allSegsReachedLatest = false;
+        continue;
+      }
+      LOGGER.info("Segment {} with latest ingested offset {} has caught up to the latest stream offset {}", segName,
+            latestIngestedOffset, latestStreamOffset);
+      _alreadyProcessedSegments.add(segName);
+    }
+    return allSegsReachedLatest;
+  }
+
+  private TableDataManager getTableDataManager(String segmentName) {
+    LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
+    String tableName = llcSegmentName.getTableName();
+    String tableNameWithType = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(tableName);
+    return _instanceDataManager.getTableDataManager(tableNameWithType);
+  }
+
+  private static Set<String> findConsumingSegments(HelixAdmin helixAdmin, String helixClusterName, String instanceId) {
+    Set<String> consumingSegments = new HashSet<>();
+    for (String resourceName : helixAdmin.getResourcesInCluster(helixClusterName)) {
+      if (TableNameBuilder.isTableResource(resourceName)) {
+        IdealState idealState = helixAdmin.getResourceIdealState(helixClusterName, resourceName);
+        if (idealState.isEnabled()) {
+          if (TableNameBuilder.isRealtimeTableResource(resourceName)) {
+            for (String segName : idealState.getPartitionSet()) {
+              if (CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING
+                  .equals(idealState.getInstanceStateMap(segName).get(instanceId))) {
+                consumingSegments.add(segName);
+              }
+            }
+          }
+        }
+      }
+    }
+    return consumingSegments;
+  }
+
+  @VisibleForTesting
+  void setConsumingSegmentFinder(Supplier<Set<String>> consumingSegmentFinder) {
+    _consumingSegmentFinder = consumingSegmentFinder;
+  }
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusChecker.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusChecker.java
@@ -36,10 +36,9 @@ import org.slf4j.LoggerFactory;
 /**
  * This class is used at startup time to have a more accurate estimate of the catchup period in which no query execution
  * happens and consumers try to catch up to the latest messages available in streams.
- * To achieve this, every time status check is called, {@link #haveAllConsumingSegmentsReachedStreamLatestOffset},
- * for each consuming segment, we check if segment's latest ingested offset has reached the latest stream offset.
- * To prevent chasing a moving target, once the latest stream offset is fetched, it will not be fetched again and
- * subsequent status check calls compare latest ingested offset with the already fetched stream offset.
+ * To achieve this, every time status check is called - {@link #getNumConsumingSegmentsNotReachedTheirLatestOffset} -
+ * for each consuming segment, we check if segment's latest ingested offset has reached the latest stream offset that's
+ * fetched once at startup time.
  */
 public class OffsetBasedConsumptionStatusChecker {
   private static final Logger LOGGER = LoggerFactory.getLogger(OffsetBasedConsumptionStatusChecker.class);
@@ -56,8 +55,7 @@ public class OffsetBasedConsumptionStatusChecker {
     _consumingSegments = consumingSegments;
   }
 
-  public boolean haveAllConsumingSegmentsReachedStreamLatestOffset() {
-    boolean allSegsReachedLatest = true;
+  public int getNumConsumingSegmentsNotReachedTheirLatestOffset() {
     for (String segName : _consumingSegments) {
       if (_caughtUpSegments.contains(segName)) {
         continue;
@@ -65,49 +63,46 @@ public class OffsetBasedConsumptionStatusChecker {
       TableDataManager tableDataManager = getTableDataManager(segName);
       if (tableDataManager == null) {
         LOGGER.info("TableDataManager is not yet setup for segment {}. Will check consumption status later", segName);
-        return false;
-      }
-      SegmentDataManager segmentDataManager = tableDataManager.acquireSegment(segName);
-      if (segmentDataManager == null) {
-        LOGGER.info("SegmentDataManager is not yet setup for segment {}. Will check consumption status later", segName);
-        return false;
-      }
-      if (!(segmentDataManager instanceof LLRealtimeSegmentDataManager)) {
-        // There's a possibility that a consuming segment has converted to a committed segment. If that's the case,
-        // segment data manager will not be of type LLRealtime.
-        LOGGER.info("Segment {} is already committed and is considered caught up.", segName);
-        _caughtUpSegments.add(segName);
-        releaseSegment(tableDataManager, segmentDataManager);
         continue;
       }
-      LLRealtimeSegmentDataManager rtSegmentDataManager = (LLRealtimeSegmentDataManager) segmentDataManager;
-      StreamPartitionMsgOffset latestIngestedOffset = rtSegmentDataManager.getCurrentOffset();
-      StreamPartitionMsgOffset latestStreamOffset = rtSegmentDataManager.getLatestStreamOffsetAtStartupTime();
-      releaseSegment(tableDataManager, segmentDataManager);
-      if (latestStreamOffset == null || latestIngestedOffset == null) {
-        LOGGER.info("Null offset found for segment {} - latest stream offset: {}, latest ingested offset: {}. "
-            + "Will check consumption status later", segName, latestStreamOffset, latestIngestedOffset);
-        return false;
-      }
-      if (latestIngestedOffset.compareTo(latestStreamOffset) < 0) {
-        LOGGER.info("Latest ingested offset {} in segment {} is smaller than stream latest available offset {} ",
-            latestIngestedOffset, segName, latestStreamOffset);
-        allSegsReachedLatest = false;
-        continue;
-      }
-      LOGGER.info("Segment {} with latest ingested offset {} has caught up to the latest stream offset {}", segName,
+      SegmentDataManager segmentDataManager = null;
+      try {
+        segmentDataManager = tableDataManager.acquireSegment(segName);
+        if (segmentDataManager == null) {
+          LOGGER
+              .info("SegmentDataManager is not yet setup for segment {}. Will check consumption status later", segName);
+          continue;
+        }
+        if (!(segmentDataManager instanceof LLRealtimeSegmentDataManager)) {
+          // There's a possibility that a consuming segment has converted to a committed segment. If that's the case,
+          // segment data manager will not be of type LLRealtime.
+          LOGGER.info("Segment {} is already committed and is considered caught up.", segName);
+          _caughtUpSegments.add(segName);
+          continue;
+        }
+        LLRealtimeSegmentDataManager rtSegmentDataManager = (LLRealtimeSegmentDataManager) segmentDataManager;
+        StreamPartitionMsgOffset latestIngestedOffset = rtSegmentDataManager.getCurrentOffset();
+        StreamPartitionMsgOffset latestStreamOffset = rtSegmentDataManager.getLatestStreamOffsetAtStartupTime();
+        if (latestStreamOffset == null || latestIngestedOffset == null) {
+          LOGGER.info("Null offset found for segment {} - latest stream offset: {}, latest ingested offset: {}. "
+              + "Will check consumption status later", segName, latestStreamOffset, latestIngestedOffset);
+          continue;
+        }
+        if (latestIngestedOffset.compareTo(latestStreamOffset) < 0) {
+          LOGGER.info("Latest ingested offset {} in segment {} is smaller than stream latest available offset {} ",
+              latestIngestedOffset, segName, latestStreamOffset);
+          continue;
+        }
+        LOGGER.info("Segment {} with latest ingested offset {} has caught up to the latest stream offset {}", segName,
             latestIngestedOffset, latestStreamOffset);
-      _caughtUpSegments.add(segName);
+        _caughtUpSegments.add(segName);
+      } finally {
+        if (segmentDataManager != null) {
+          tableDataManager.releaseSegment(segmentDataManager);
+        }
+      }
     }
-    return allSegsReachedLatest;
-  }
-
-  void releaseSegment(TableDataManager tableDataManager, SegmentDataManager segmentDataManager) {
-    try {
-      tableDataManager.releaseSegment(segmentDataManager);
-    } catch (Exception e) {
-      LOGGER.error("Cannot release segment data manager for segment " + segmentDataManager.getSegmentName(), e);
-    }
+    return _consumingSegments.size() - _caughtUpSegments.size();
   }
 
   private TableDataManager getTableDataManager(String segmentName) {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusChecker.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusChecker.java
@@ -143,12 +143,10 @@ public class OffsetBasedConsumptionStatusChecker {
       if (TableNameBuilder.isRealtimeTableResource(resourceName)) {
         IdealState idealState = helixAdmin.getResourceIdealState(helixClusterName, resourceName);
         if (idealState.isEnabled()) {
-          if (TableNameBuilder.isRealtimeTableResource(resourceName)) {
-            for (String segName : idealState.getPartitionSet()) {
-              if (CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING
-                  .equals(idealState.getInstanceStateMap(segName).get(instanceId))) {
-                consumingSegments.add(segName);
-              }
+          for (String segName : idealState.getPartitionSet()) {
+            if (CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING
+                .equals(idealState.getInstanceStateMap(segName).get(instanceId))) {
+              consumingSegments.add(segName);
             }
           }
         }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusChecker.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusChecker.java
@@ -140,7 +140,7 @@ public class OffsetBasedConsumptionStatusChecker {
   private static Set<String> findConsumingSegments(HelixAdmin helixAdmin, String helixClusterName, String instanceId) {
     Set<String> consumingSegments = new HashSet<>();
     for (String resourceName : helixAdmin.getResourcesInCluster(helixClusterName)) {
-      if (TableNameBuilder.isTableResource(resourceName)) {
+      if (TableNameBuilder.isRealtimeTableResource(resourceName)) {
         IdealState idealState = helixAdmin.getResourceIdealState(helixClusterName, resourceName);
         if (idealState.isEnabled()) {
           if (TableNameBuilder.isRealtimeTableResource(resourceName)) {

--- a/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusCheckerTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusCheckerTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.server.starter.helix;
 
 import com.google.common.collect.ImmutableSet;
 import java.util.Set;
-import java.util.function.Supplier;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
 import org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager;
@@ -29,7 +28,6 @@ import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.server.starter.helix.OffsetBasedConsumptionStatusChecker.MAX_WAIT_TIME_MS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
@@ -43,10 +41,10 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     String segA0 = "tableA__0__0__123Z";
     String segA1 = "tableA__1__0__123Z";
     String segB0 = "tableB__0__0__123Z";
-    Supplier<Set<String>> consumingSegmentProvider = () -> ImmutableSet.of(segA0, segA1, segB0);
+    Set<String> consumingSegments = ImmutableSet.of(segA0, segA1, segB0);
     InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
     OffsetBasedConsumptionStatusChecker statusChecker =
-        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegmentProvider);
+        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments);
 
     // setup TableDataMangers
     TableDataManager tableDataManagerA = mock(TableDataManager.class);
@@ -61,6 +59,9 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     when(tableDataManagerA.acquireSegment(segA0)).thenReturn(segMngrA0);
     when(tableDataManagerA.acquireSegment(segA1)).thenReturn(segMngrA1);
     when(tableDataManagerB.acquireSegment(segB0)).thenReturn(segMngrB0);
+    when(segMngrA0.getLatestStreamOffsetAtStartupTime()).thenReturn(new LongMsgOffset(15));
+    when(segMngrA1.getLatestStreamOffsetAtStartupTime()).thenReturn(new LongMsgOffset(150));
+    when(segMngrB0.getLatestStreamOffsetAtStartupTime()).thenReturn(new LongMsgOffset(1500));
 
     //           latest ingested offset    latest stream offset
     // segA0              10                       15
@@ -69,21 +70,15 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(10));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(100));
     when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(1000));
-    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(15));
-    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(150));
-    when(segMngrB0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(1500));
     assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
 
-    //           latest ingested offset     latest stream offset     already observed latest stream offset
-    // segA0              20                       25                         15
-    // segA1              200                      250                        150
-    // segB0              2000                     2500                       1500
+    //           latest ingested offset     latest stream offset
+    // segA0              20                       15
+    // segA1              200                      150
+    // segB0              2000                     1500
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(20));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(200));
     when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(2000));
-    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(25));
-    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(250));
-    when(segMngrB0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(2500));
     assertTrue(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
   }
 
@@ -93,11 +88,11 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     String segA0 = "tableA__0__0__123Z";
     String segA1 = "tableA__1__0__123Z";
     String segB0 = "tableB__0__0__123Z";
-    Supplier<Set<String>> consumingSegmentProvider = () -> ImmutableSet.of(segA0, segA1, segB0);
+    Set<String> consumingSegments = ImmutableSet.of(segA0, segA1, segB0);
     InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
 
     OffsetBasedConsumptionStatusChecker statusChecker =
-        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegmentProvider);
+        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments);
 
     // TableDataManager is not set up yet
     assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
@@ -120,36 +115,31 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     // segB0           not setup yet              1500
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(10));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(100));
-    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(15));
-    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(150));
+    when(segMngrA0.getLatestStreamOffsetAtStartupTime()).thenReturn(new LongMsgOffset(15));
+    when(segMngrA1.getLatestStreamOffsetAtStartupTime()).thenReturn(new LongMsgOffset(150));
     assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
 
     // setup the remaining SegmentDataManager
     LLRealtimeSegmentDataManager segMngrB0 = mock(LLRealtimeSegmentDataManager.class);
     when(tableDataManagerB.acquireSegment(segB0)).thenReturn(segMngrB0);
 
-    //           latest ingested offset     latest stream offset     already observed latest stream offset
-    // segA0           20                           25                         15
-    // segA1           200                          250                        150
-    // segB0           2000                         2500                       -
+    //           latest ingested offset     latest stream offset
+    // segA0               20                      15
+    // segA1               200                     150
+    // segB0               1000                    1500
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(20));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(200));
-    when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(2000));
-    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(25));
-    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(250));
-    when(segMngrB0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(2500));
+    when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(1000));
+    when(segMngrB0.getLatestStreamOffsetAtStartupTime()).thenReturn(new LongMsgOffset(1500));
     assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
 
-    //           latest ingested offset     latest stream offset     already observed latest stream offset
-    // segA0              30                        35                         15
-    // segA1              300                       350                        150
-    // segB0              3000                      3500                       2500
+    //           latest ingested offset     latest stream offset
+    // segA0               30                      15
+    // segA1               300                     150
+    // segB0               2000                    1500
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(30));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(300));
-    when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(3000));
-    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(35));
-    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(350));
-    when(segMngrB0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(3500));
+    when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(2000));
     assertTrue(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
   }
 
@@ -159,10 +149,10 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     String segA0 = "tableA__0__0__123Z";
     String segA1 = "tableA__1__0__123Z";
     String segB0 = "tableB__0__0__123Z";
-    Supplier<Set<String>> consumingSegmentProvider = () -> ImmutableSet.of(segA0, segA1, segB0);
+    Set<String> consumingSegments = ImmutableSet.of(segA0, segA1, segB0);
     InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
     OffsetBasedConsumptionStatusChecker statusChecker =
-        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegmentProvider);
+        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments);
 
     // setup TableDataMangers
     TableDataManager tableDataManagerA = mock(TableDataManager.class);
@@ -173,12 +163,11 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     // setup SegmentDataManagers
     LLRealtimeSegmentDataManager segMngrA0 = mock(LLRealtimeSegmentDataManager.class);
     LLRealtimeSegmentDataManager segMngrA1 = mock(LLRealtimeSegmentDataManager.class);
+    LLRealtimeSegmentDataManager segMngrB0 = mock(LLRealtimeSegmentDataManager.class);
     when(tableDataManagerA.acquireSegment(segA0)).thenReturn(segMngrA0);
     when(tableDataManagerA.acquireSegment(segA1)).thenReturn(segMngrA1);
-
-    // segB0 is committed; ImmutableSegmentDataManager is returned by table data manager
-    ImmutableSegmentDataManager segMngrB0 = mock(ImmutableSegmentDataManager.class);
     when(tableDataManagerB.acquireSegment(segB0)).thenReturn(segMngrB0);
+
 
     //           latest ingested offset    latest stream offset
     // segA0              10                       15
@@ -186,40 +175,22 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     // segB0              1000                     1500
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(10));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(100));
-    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(15));
-    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(150));
+    when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(1000));
+    when(segMngrA0.getLatestStreamOffsetAtStartupTime()).thenReturn(new LongMsgOffset(15));
+    when(segMngrA1.getLatestStreamOffsetAtStartupTime()).thenReturn(new LongMsgOffset(150));
+    when(segMngrB0.getLatestStreamOffsetAtStartupTime()).thenReturn(new LongMsgOffset(1500));
     assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
 
-    // segB1 replaces segB0 in set of consuming segments
-    String segB1 = "tableB__0__1__123Z";
-    statusChecker.setConsumingSegmentFinder(() -> ImmutableSet.of(segA0, segA1, segB1));
-    LLRealtimeSegmentDataManager segMngrB1 = mock(LLRealtimeSegmentDataManager.class);
-    when(tableDataManagerB.acquireSegment(segB1)).thenReturn(segMngrB1);
+    // segB0 is now committed; ImmutableSegmentDataManager is returned by table data manager
+    ImmutableSegmentDataManager immSegMngrB0 = mock(ImmutableSegmentDataManager.class);
+    when(tableDataManagerB.acquireSegment(segB0)).thenReturn(immSegMngrB0);
 
-    //           latest ingested offset     latest stream offset     already observed latest stream offset
-    // segA0              20                        25                         15
-    // segA1              200                       250                        150
-    // segB0              1000                      2500                       -
-    // segB1              2000                      2500                       -
+    //           latest ingested offset     latest stream offset
+    // segA0              20                        15
+    // segA1              200                       150
+    // segB0        committed at 1200               1500
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(20));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(200));
-    when(segMngrB1.getCurrentOffset()).thenReturn(new LongMsgOffset(2000));
-    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(25));
-    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(250));
-    when(segMngrB1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(2500));
-    assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
-
-    //           latest ingested offset     latest stream offset     already observed latest stream offset
-    // segA0              30                        35                         15
-    // segA1              300                       350                        150
-    // segB0              1000                      3500                       -
-    // segB1              3000                      3500                       2500
-    when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(30));
-    when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(300));
-    when(segMngrB1.getCurrentOffset()).thenReturn(new LongMsgOffset(3000));
-    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(35));
-    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(350));
-    when(segMngrB1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(3500));
     assertTrue(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
   }
 
@@ -229,10 +200,10 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     String segA0 = "tableA__0__0__123Z";
     String segA1 = "tableA__1__0__123Z";
     String segB0 = "tableB__0__0__123Z";
-    Supplier<Set<String>> consumingSegmentProvider = () -> ImmutableSet.of(segA0, segA1, segB0);
+    Set<String> consumingSegments = ImmutableSet.of(segA0, segA1, segB0);
     InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
     OffsetBasedConsumptionStatusChecker statusChecker =
-        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegmentProvider);
+        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments);
 
     // setup TableDataMangers
     TableDataManager tableDataManagerA = mock(TableDataManager.class);
@@ -251,37 +222,31 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     //           latest ingested offset    latest stream offset
     // segA0              10                       15
     // segA1              100                      150
-    // segB0              1000                     null - transiently cannot get the latest offset from stream
+    // segB0              1000                     null - could not get the latest offset from stream at startup
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(10));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(100));
     when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(1000));
-    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(15));
-    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(150));
-    when(segMngrB0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(null);
+    when(segMngrA0.getLatestStreamOffsetAtStartupTime()).thenReturn(new LongMsgOffset(15));
+    when(segMngrA1.getLatestStreamOffsetAtStartupTime()).thenReturn(new LongMsgOffset(150));
+    when(segMngrB0.getLatestStreamOffsetAtStartupTime()).thenReturn(null);
     assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
 
-    //           latest ingested offset     latest stream offset     already observed latest stream offset
-    // segA0              20                        25                         15
-    // segA1              200                       250                        150
-    // segB0              2000                      2500                       -
+    //           latest ingested offset     latest stream offset
+    // segA0              20                        15
+    // segA1              200                       150
+    // segB0              2000                      null - could not get the latest offset from stream at startup
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(20));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(200));
     when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(2000));
-    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(25));
-    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(250));
-    when(segMngrB0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(2500));
     assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
 
-    //           latest ingested offset     latest stream offset     already observed latest stream offset
-    // segA0              30                        35                         15
-    // segA1              300                       350                        150
-    // segB0              3000                      3500                       2500
+    //           latest ingested offset     latest stream offset
+    // segA0              30                        15
+    // segA1              300                       150
+    // segB0              3000                      null - could not get the latest offset from stream at startup
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(30));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(300));
     when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(3000));
-    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(35));
-    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(350));
-    when(segMngrB0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(3500));
-    assertTrue(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+    assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
   }
 }

--- a/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusCheckerTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusCheckerTest.java
@@ -70,7 +70,7 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(10));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(100));
     when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(1000));
-    assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+    assertEquals(statusChecker.getNumConsumingSegmentsNotReachedTheirLatestOffset(), 3);
 
     //           latest ingested offset     latest stream offset
     // segA0              20                       15
@@ -79,7 +79,7 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(20));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(200));
     when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(2000));
-    assertTrue(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+    assertEquals(statusChecker.getNumConsumingSegmentsNotReachedTheirLatestOffset(), 0);
   }
 
   @Test
@@ -95,7 +95,7 @@ public class OffsetBasedConsumptionStatusCheckerTest {
         new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegments);
 
     // TableDataManager is not set up yet
-    assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+    assertEquals(statusChecker.getNumConsumingSegmentsNotReachedTheirLatestOffset(), 3);
 
     // setup TableDataMangers
     TableDataManager tableDataManagerA = mock(TableDataManager.class);
@@ -117,7 +117,7 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(100));
     when(segMngrA0.getLatestStreamOffsetAtStartupTime()).thenReturn(new LongMsgOffset(15));
     when(segMngrA1.getLatestStreamOffsetAtStartupTime()).thenReturn(new LongMsgOffset(150));
-    assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+    assertEquals(statusChecker.getNumConsumingSegmentsNotReachedTheirLatestOffset(), 3);
 
     // setup the remaining SegmentDataManager
     LLRealtimeSegmentDataManager segMngrB0 = mock(LLRealtimeSegmentDataManager.class);
@@ -131,7 +131,7 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(200));
     when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(1000));
     when(segMngrB0.getLatestStreamOffsetAtStartupTime()).thenReturn(new LongMsgOffset(1500));
-    assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+    assertEquals(statusChecker.getNumConsumingSegmentsNotReachedTheirLatestOffset(), 1);
 
     //           latest ingested offset     latest stream offset
     // segA0               30                      15
@@ -140,7 +140,7 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(30));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(300));
     when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(2000));
-    assertTrue(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+    assertEquals(statusChecker.getNumConsumingSegmentsNotReachedTheirLatestOffset(), 0);
   }
 
   @Test
@@ -168,7 +168,6 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     when(tableDataManagerA.acquireSegment(segA1)).thenReturn(segMngrA1);
     when(tableDataManagerB.acquireSegment(segB0)).thenReturn(segMngrB0);
 
-
     //           latest ingested offset    latest stream offset
     // segA0              10                       15
     // segA1              100                      150
@@ -179,7 +178,7 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     when(segMngrA0.getLatestStreamOffsetAtStartupTime()).thenReturn(new LongMsgOffset(15));
     when(segMngrA1.getLatestStreamOffsetAtStartupTime()).thenReturn(new LongMsgOffset(150));
     when(segMngrB0.getLatestStreamOffsetAtStartupTime()).thenReturn(new LongMsgOffset(1500));
-    assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+    assertEquals(statusChecker.getNumConsumingSegmentsNotReachedTheirLatestOffset(), 3);
 
     // segB0 is now committed; ImmutableSegmentDataManager is returned by table data manager
     ImmutableSegmentDataManager immSegMngrB0 = mock(ImmutableSegmentDataManager.class);
@@ -191,7 +190,7 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     // segB0        committed at 1200               1500
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(20));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(200));
-    assertTrue(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+    assertEquals(statusChecker.getNumConsumingSegmentsNotReachedTheirLatestOffset(), 0);
   }
 
   @Test
@@ -229,7 +228,7 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     when(segMngrA0.getLatestStreamOffsetAtStartupTime()).thenReturn(new LongMsgOffset(15));
     when(segMngrA1.getLatestStreamOffsetAtStartupTime()).thenReturn(new LongMsgOffset(150));
     when(segMngrB0.getLatestStreamOffsetAtStartupTime()).thenReturn(null);
-    assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+    assertEquals(statusChecker.getNumConsumingSegmentsNotReachedTheirLatestOffset(), 3);
 
     //           latest ingested offset     latest stream offset
     // segA0              20                        15
@@ -238,7 +237,7 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(20));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(200));
     when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(2000));
-    assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+    assertEquals(statusChecker.getNumConsumingSegmentsNotReachedTheirLatestOffset(), 1);
 
     //           latest ingested offset     latest stream offset
     // segA0              30                        15
@@ -247,6 +246,6 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(30));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(300));
     when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(3000));
-    assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+    assertEquals(statusChecker.getNumConsumingSegmentsNotReachedTheirLatestOffset(), 1);
   }
 }

--- a/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusCheckerTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusCheckerTest.java
@@ -1,0 +1,286 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.server.starter.helix;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import java.util.function.Supplier;
+import org.apache.pinot.core.data.manager.InstanceDataManager;
+import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
+import org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager;
+import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.spi.stream.LongMsgOffset;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
+
+
+public class OffsetBasedConsumptionStatusCheckerTest {
+
+  @Test
+  public void regularCase() {
+
+    String segA0 = "tableA__0__0__123Z";
+    String segA1 = "tableA__1__0__123Z";
+    String segB0 = "tableB__0__0__123Z";
+    Supplier<Set<String>> consumingSegmentProvider = () -> ImmutableSet.of(segA0, segA1, segB0);
+    InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
+    OffsetBasedConsumptionStatusChecker statusChecker =
+        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegmentProvider);
+
+    // setup TableDataMangers
+    TableDataManager tableDataManagerA = mock(TableDataManager.class);
+    TableDataManager tableDataManagerB = mock(TableDataManager.class);
+    when(instanceDataManager.getTableDataManager("tableA_REALTIME")).thenReturn(tableDataManagerA);
+    when(instanceDataManager.getTableDataManager("tableB_REALTIME")).thenReturn(tableDataManagerB);
+
+    // setup SegmentDataManagers
+    LLRealtimeSegmentDataManager segMngrA0 = mock(LLRealtimeSegmentDataManager.class);
+    LLRealtimeSegmentDataManager segMngrA1 = mock(LLRealtimeSegmentDataManager.class);
+    LLRealtimeSegmentDataManager segMngrB0 = mock(LLRealtimeSegmentDataManager.class);
+    when(tableDataManagerA.acquireSegment(segA0)).thenReturn(segMngrA0);
+    when(tableDataManagerA.acquireSegment(segA1)).thenReturn(segMngrA1);
+    when(tableDataManagerB.acquireSegment(segB0)).thenReturn(segMngrB0);
+
+    //           latest ingested offset    latest stream offset
+    // segA0              10                       15
+    // segA1              100                      150
+    // segB0              1000                     1500
+    when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(10));
+    when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(100));
+    when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(1000));
+    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(15));
+    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(150));
+    when(segMngrB0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(1500));
+    assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+
+    //           latest ingested offset     latest stream offset     already observed latest stream offset
+    // segA0              20                       25                         15
+    // segA1              200                      250                        150
+    // segB0              2000                     2500                       1500
+    when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(20));
+    when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(200));
+    when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(2000));
+    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(25));
+    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(250));
+    when(segMngrB0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(2500));
+    assertTrue(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+  }
+
+  @Test
+  public void dataMangersBeingSetup() {
+
+    String segA0 = "tableA__0__0__123Z";
+    String segA1 = "tableA__1__0__123Z";
+    String segB0 = "tableB__0__0__123Z";
+    Supplier<Set<String>> consumingSegmentProvider = () -> ImmutableSet.of(segA0, segA1, segB0);
+    InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
+
+    OffsetBasedConsumptionStatusChecker statusChecker =
+        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegmentProvider);
+
+    // TableDataManager is not set up yet
+    assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+
+    // setup TableDataMangers
+    TableDataManager tableDataManagerA = mock(TableDataManager.class);
+    TableDataManager tableDataManagerB = mock(TableDataManager.class);
+    when(instanceDataManager.getTableDataManager("tableA_REALTIME")).thenReturn(tableDataManagerA);
+    when(instanceDataManager.getTableDataManager("tableB_REALTIME")).thenReturn(tableDataManagerB);
+
+    // setup some SegmentDataManagers
+    LLRealtimeSegmentDataManager segMngrA0 = mock(LLRealtimeSegmentDataManager.class);
+    LLRealtimeSegmentDataManager segMngrA1 = mock(LLRealtimeSegmentDataManager.class);
+    when(tableDataManagerA.acquireSegment(segA0)).thenReturn(segMngrA0);
+    when(tableDataManagerA.acquireSegment(segA1)).thenReturn(segMngrA1);
+
+    //           latest ingested offset    latest stream offset
+    // segA0               10                     15
+    // segA1               100                    150
+    // segB0           not setup yet              1500
+    when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(10));
+    when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(100));
+    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(15));
+    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(150));
+    assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+
+    // setup the remaining SegmentDataManager
+    LLRealtimeSegmentDataManager segMngrB0 = mock(LLRealtimeSegmentDataManager.class);
+    when(tableDataManagerB.acquireSegment(segB0)).thenReturn(segMngrB0);
+
+    //           latest ingested offset     latest stream offset     already observed latest stream offset
+    // segA0           20                           25                         15
+    // segA1           200                          250                        150
+    // segB0           2000                         2500                       -
+    when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(20));
+    when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(200));
+    when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(2000));
+    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(25));
+    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(250));
+    when(segMngrB0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(2500));
+    assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+
+    //           latest ingested offset     latest stream offset     already observed latest stream offset
+    // segA0              30                        35                         15
+    // segA1              300                       350                        150
+    // segB0              3000                      3500                       2500
+    when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(30));
+    when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(300));
+    when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(3000));
+    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(35));
+    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(350));
+    when(segMngrB0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(3500));
+    assertTrue(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+  }
+
+  @Test
+  public void segmentsBeingCommitted() {
+
+    String segA0 = "tableA__0__0__123Z";
+    String segA1 = "tableA__1__0__123Z";
+    String segB0 = "tableB__0__0__123Z";
+    Supplier<Set<String>> consumingSegmentProvider = () -> ImmutableSet.of(segA0, segA1, segB0);
+    InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
+    OffsetBasedConsumptionStatusChecker statusChecker =
+        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegmentProvider);
+
+    // setup TableDataMangers
+    TableDataManager tableDataManagerA = mock(TableDataManager.class);
+    TableDataManager tableDataManagerB = mock(TableDataManager.class);
+    when(instanceDataManager.getTableDataManager("tableA_REALTIME")).thenReturn(tableDataManagerA);
+    when(instanceDataManager.getTableDataManager("tableB_REALTIME")).thenReturn(tableDataManagerB);
+
+    // setup SegmentDataManagers
+    LLRealtimeSegmentDataManager segMngrA0 = mock(LLRealtimeSegmentDataManager.class);
+    LLRealtimeSegmentDataManager segMngrA1 = mock(LLRealtimeSegmentDataManager.class);
+    when(tableDataManagerA.acquireSegment(segA0)).thenReturn(segMngrA0);
+    when(tableDataManagerA.acquireSegment(segA1)).thenReturn(segMngrA1);
+
+    // segB0 is committed; ImmutableSegmentDataManager is returned by table data manager
+    ImmutableSegmentDataManager segMngrB0 = mock(ImmutableSegmentDataManager.class);
+    when(tableDataManagerB.acquireSegment(segB0)).thenReturn(segMngrB0);
+
+    //           latest ingested offset    latest stream offset
+    // segA0              10                       15
+    // segA1              100                      150
+    // segB0              1000                     1500
+    when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(10));
+    when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(100));
+    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(15));
+    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(150));
+    assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+
+    // segB1 replaces segB0 in set of consuming segments
+    String segB1 = "tableB__0__1__123Z";
+    statusChecker.setConsumingSegmentFinder(() -> ImmutableSet.of(segA0, segA1, segB1));
+    LLRealtimeSegmentDataManager segMngrB1 = mock(LLRealtimeSegmentDataManager.class);
+    when(tableDataManagerB.acquireSegment(segB1)).thenReturn(segMngrB1);
+
+    //           latest ingested offset     latest stream offset     already observed latest stream offset
+    // segA0              20                        25                         15
+    // segA1              200                       250                        150
+    // segB0              1000                      2500                       -
+    // segB1              2000                      2500                       -
+    when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(20));
+    when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(200));
+    when(segMngrB1.getCurrentOffset()).thenReturn(new LongMsgOffset(2000));
+    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(25));
+    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(250));
+    when(segMngrB1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(2500));
+    assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+
+    //           latest ingested offset     latest stream offset     already observed latest stream offset
+    // segA0              30                        35                         15
+    // segA1              300                       350                        150
+    // segB0              1000                      3500                       -
+    // segB1              3000                      3500                       2500
+    when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(30));
+    when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(300));
+    when(segMngrB1.getCurrentOffset()).thenReturn(new LongMsgOffset(3000));
+    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(35));
+    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(350));
+    when(segMngrB1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(3500));
+    assertTrue(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+  }
+
+  @Test
+  public void cannotGetLatestStreamOffset() {
+
+    String segA0 = "tableA__0__0__123Z";
+    String segA1 = "tableA__1__0__123Z";
+    String segB0 = "tableB__0__0__123Z";
+    Supplier<Set<String>> consumingSegmentProvider = () -> ImmutableSet.of(segA0, segA1, segB0);
+    InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
+    OffsetBasedConsumptionStatusChecker statusChecker =
+        new OffsetBasedConsumptionStatusChecker(instanceDataManager, consumingSegmentProvider);
+
+    // setup TableDataMangers
+    TableDataManager tableDataManagerA = mock(TableDataManager.class);
+    TableDataManager tableDataManagerB = mock(TableDataManager.class);
+    when(instanceDataManager.getTableDataManager("tableA_REALTIME")).thenReturn(tableDataManagerA);
+    when(instanceDataManager.getTableDataManager("tableB_REALTIME")).thenReturn(tableDataManagerB);
+
+    // setup SegmentDataManagers
+    LLRealtimeSegmentDataManager segMngrA0 = mock(LLRealtimeSegmentDataManager.class);
+    LLRealtimeSegmentDataManager segMngrA1 = mock(LLRealtimeSegmentDataManager.class);
+    LLRealtimeSegmentDataManager segMngrB0 = mock(LLRealtimeSegmentDataManager.class);
+    when(tableDataManagerA.acquireSegment(segA0)).thenReturn(segMngrA0);
+    when(tableDataManagerA.acquireSegment(segA1)).thenReturn(segMngrA1);
+    when(tableDataManagerB.acquireSegment(segB0)).thenReturn(segMngrB0);
+
+    //           latest ingested offset    latest stream offset
+    // segA0              10                       15
+    // segA1              100                      150
+    // segB0              1000                     null - transiently cannot get the latest offset from stream
+    when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(10));
+    when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(100));
+    when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(1000));
+    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(15));
+    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(150));
+    when(segMngrB0.fetchLatestStreamOffset()).thenReturn(null);
+    assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+
+    //           latest ingested offset     latest stream offset     already observed latest stream offset
+    // segA0              20                        25                         15
+    // segA1              200                       250                        150
+    // segB0              2000                      2500                       -
+    when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(20));
+    when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(200));
+    when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(2000));
+    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(25));
+    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(250));
+    when(segMngrB0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(2500));
+    assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+
+    //           latest ingested offset     latest stream offset     already observed latest stream offset
+    // segA0              30                        35                         15
+    // segA1              300                       350                        150
+    // segB0              3000                      3500                       2500
+    when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(30));
+    when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(300));
+    when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(3000));
+    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(35));
+    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(350));
+    when(segMngrB0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(3500));
+    assertTrue(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
+  }
+}

--- a/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusCheckerTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/OffsetBasedConsumptionStatusCheckerTest.java
@@ -29,6 +29,7 @@ import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.server.starter.helix.OffsetBasedConsumptionStatusChecker.MAX_WAIT_TIME_MS;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
@@ -68,9 +69,9 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(10));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(100));
     when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(1000));
-    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(15));
-    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(150));
-    when(segMngrB0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(1500));
+    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(15));
+    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(150));
+    when(segMngrB0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(1500));
     assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
 
     //           latest ingested offset     latest stream offset     already observed latest stream offset
@@ -80,9 +81,9 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(20));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(200));
     when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(2000));
-    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(25));
-    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(250));
-    when(segMngrB0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(2500));
+    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(25));
+    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(250));
+    when(segMngrB0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(2500));
     assertTrue(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
   }
 
@@ -119,8 +120,8 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     // segB0           not setup yet              1500
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(10));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(100));
-    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(15));
-    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(150));
+    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(15));
+    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(150));
     assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
 
     // setup the remaining SegmentDataManager
@@ -134,9 +135,9 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(20));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(200));
     when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(2000));
-    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(25));
-    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(250));
-    when(segMngrB0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(2500));
+    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(25));
+    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(250));
+    when(segMngrB0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(2500));
     assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
 
     //           latest ingested offset     latest stream offset     already observed latest stream offset
@@ -146,9 +147,9 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(30));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(300));
     when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(3000));
-    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(35));
-    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(350));
-    when(segMngrB0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(3500));
+    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(35));
+    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(350));
+    when(segMngrB0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(3500));
     assertTrue(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
   }
 
@@ -185,8 +186,8 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     // segB0              1000                     1500
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(10));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(100));
-    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(15));
-    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(150));
+    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(15));
+    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(150));
     assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
 
     // segB1 replaces segB0 in set of consuming segments
@@ -203,9 +204,9 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(20));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(200));
     when(segMngrB1.getCurrentOffset()).thenReturn(new LongMsgOffset(2000));
-    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(25));
-    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(250));
-    when(segMngrB1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(2500));
+    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(25));
+    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(250));
+    when(segMngrB1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(2500));
     assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
 
     //           latest ingested offset     latest stream offset     already observed latest stream offset
@@ -216,9 +217,9 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(30));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(300));
     when(segMngrB1.getCurrentOffset()).thenReturn(new LongMsgOffset(3000));
-    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(35));
-    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(350));
-    when(segMngrB1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(3500));
+    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(35));
+    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(350));
+    when(segMngrB1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(3500));
     assertTrue(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
   }
 
@@ -254,9 +255,9 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(10));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(100));
     when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(1000));
-    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(15));
-    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(150));
-    when(segMngrB0.fetchLatestStreamOffset()).thenReturn(null);
+    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(15));
+    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(150));
+    when(segMngrB0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(null);
     assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
 
     //           latest ingested offset     latest stream offset     already observed latest stream offset
@@ -266,9 +267,9 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(20));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(200));
     when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(2000));
-    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(25));
-    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(250));
-    when(segMngrB0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(2500));
+    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(25));
+    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(250));
+    when(segMngrB0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(2500));
     assertFalse(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
 
     //           latest ingested offset     latest stream offset     already observed latest stream offset
@@ -278,9 +279,9 @@ public class OffsetBasedConsumptionStatusCheckerTest {
     when(segMngrA0.getCurrentOffset()).thenReturn(new LongMsgOffset(30));
     when(segMngrA1.getCurrentOffset()).thenReturn(new LongMsgOffset(300));
     when(segMngrB0.getCurrentOffset()).thenReturn(new LongMsgOffset(3000));
-    when(segMngrA0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(35));
-    when(segMngrA1.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(350));
-    when(segMngrB0.fetchLatestStreamOffset()).thenReturn(new LongMsgOffset(3500));
+    when(segMngrA0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(35));
+    when(segMngrA1.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(350));
+    when(segMngrB0.fetchLatestStreamOffset(MAX_WAIT_TIME_MS)).thenReturn(new LongMsgOffset(3500));
     assertTrue(statusChecker.haveAllConsumingSegmentsReachedStreamLatestOffset());
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/OffsetCriteria.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/OffsetCriteria.java
@@ -31,6 +31,9 @@ public class OffsetCriteria {
   public static final OffsetCriteria SMALLEST_OFFSET_CRITERIA =
       new OffsetCriteria.OffsetCriteriaBuilder().withOffsetSmallest();
 
+  public static final OffsetCriteria LARGEST_OFFSET_CRITERIA =
+      new OffsetCriteria.OffsetCriteriaBuilder().withOffsetLargest();
+
   /**
    * Enumerates the supported offset types
    */


### PR DESCRIPTION
## Description
This PR adds a new realtime consumption status checker which is used at startup time to have a more accurate estimate of the catchup period in which no query execution happens and consumers try to catch up to the latest messages available in streams.
 To achieve this, every time status check is called, _haveAllConsumingSegmentsReachedStreamLatestOffset_ method, list of consuming segments is gathered and then for each segment, we check if segment's latest ingested offset has reached the latest stream offset. To prevent chasing a moving target, once the latest stream offset is fetched, it will not be fetched again and subsequent status check calls compare latest ingested offset with the already fetched stream offset. 

The new status checker is being added in two phases. First phase adds the new status checker, but it doesn't apply its output. Instead it only logs its behavior. When the behavior is analysed and approved for different tables with different consumption rates, we can safely wire new status checker and use its functionality.
Another approach would be to define a new config and disable it by default. Since this feature is not urgent, @mcvsubbu suggested not to define yet another config and go with this two-phase approach.

## Testing Done
- unit tests
- modified _SegmentPartitionLLCRealtimeClusterIntegrationTest_ integration test locally and verified the expected behavior. I didn't create a new IT because they're time consuming and different edge cases are already tested in the unit tests.