### PR TITLE
Remove pinot-pulsar module from the binary release

### DIFF
--- a/pinot-distribution/pinot-assembly.xml
+++ b/pinot-distribution/pinot-assembly.xml
@@ -55,10 +55,14 @@
       <source>${pinot.root}/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/target/pinot-kinesis-${project.version}-shaded.jar</source>
       <destName>plugins/pinot-stream-ingestion/pinot-kinesis/pinot-kinesis-${project.version}-shaded.jar</destName>
     </file>
+
+    <!-- TODO: fix the runtime issue for Apache Pulsar plug-in and add this back. (https://github.com/apache/pinot/issues/7270)
     <file>
       <source>${pinot.root}/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/target/pinot-pulsar-${project.version}-shaded.jar</source>
       <destName>plugins/pinot-stream-ingestion/pinot-pulsar/pinot-pulsar-${project.version}-shaded.jar</destName>
     </file>
+    -->
+
     <!-- End Include Pinot Stream Ingestion Plugins-->
     <!-- Start Include Pinot Batch Ingestion Plugins-->
     <file>


### PR DESCRIPTION
Currently, pinot-pulsar module is reported to have some
issues on runtime. This PR removes the pinot-pulsar module
from the binary release.

https://github.com/apache/pinot/issues/7270