### PR TITLE
update Slack Pinot community invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ bin/quick-start-batch.sh
 Please refer to [Running Pinot on Kubernetes](https://docs.pinot.apache.org/basics/getting-started/kubernetes-quickstart) in our project documentation. Pinot also provides Kubernetes integrations with the interactive query engine, [Presto](kubernetes/helm/presto-coordinator.yaml), and the data visualization tool, [Apache Superset](kubernetes/helm/superset.yaml).
 
 ## Join the Community
- - Ask questions on [Apache Pinot Slack](https://communityinviter.com/apps/apache-pinot/apache-pinot)
+ - Ask questions on [Apache Pinot Slack](https://join.slack.com/t/apache-pinot/shared_invite/zt-5z7pav2f-yYtjZdVA~EDmrGkho87Vzw)
  - Please join Apache Pinot mailing lists  
    dev-subscribe@pinot.apache.org (subscribe to pinot-dev mailing list)  
    dev@pinot.apache.org (posting to pinot-dev mailing list)  


### PR DESCRIPTION
## Description
We use Slack Community Inviter, a free invite service to onboard a new community member. The service often breaks, which yields failed community invites. Fortunately, Slack added the community invites feature. Hence we are switching from a third-party community inviter to the native Slack onboarding process. 

## Upgrade Notes

If the previous community inviter link is used in places other than the GitHub README file, it requires an update.

## Release Notes

None

## Documentation

Please note that as per the Slack documentation, for every 2000 users, the community inviter link expires and would require an update.
