### PR TITLE
Allow for Object Return type from Aggregation functions

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -389,6 +389,8 @@ public class DataSchema {
           }
         case STRING_ARRAY:
           return (String[]) value;
+        case OBJECT:
+          return (Serializable) value;
         default:
           throw new IllegalStateException(String.format("Cannot convert: '%s' to type: %s", value, this));
       }
@@ -477,6 +479,8 @@ public class DataSchema {
           }
         case STRING_ARRAY:
           return (String[]) value;
+        case OBJECT:
+          return (Serializable) value;
         default:
           throw new IllegalStateException(String.format("Cannot convert and format: '%s' to type: %s", value, this));
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.common;
 
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
+import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import com.tdunning.math.stats.MergingDigest;
 import com.tdunning.math.stats.TDigest;
@@ -97,7 +98,8 @@ public class ObjectSerDeUtils {
     BytesSet(19),
     IdSet(20),
     List(21),
-    BigDecimal(22);
+    BigDecimal(22),
+    Int(23);
     private final int _value;
 
     ObjectType(int value) {
@@ -111,6 +113,8 @@ public class ObjectSerDeUtils {
     public static ObjectType getObjectType(Object value) {
       if (value instanceof String) {
         return ObjectType.String;
+      } else if (value instanceof Integer) {
+        return ObjectType.Int;
       } else if (value instanceof Long) {
         return ObjectType.Long;
       } else if (value instanceof Double) {
@@ -204,6 +208,24 @@ public class ObjectSerDeUtils {
       byte[] bytes = new byte[byteBuffer.remaining()];
       byteBuffer.get(bytes);
       return StringUtil.decodeUtf8(bytes);
+    }
+  };
+
+  public static final ObjectSerDe<Integer> INT_SER_DE = new ObjectSerDe<Integer>() {
+
+    @Override
+    public byte[] serialize(Integer value) {
+      return Ints.toByteArray(value);
+    }
+
+    @Override
+    public Integer deserialize(byte[] bytes) {
+      return Ints.fromByteArray(bytes);
+    }
+
+    @Override
+    public Integer deserialize(ByteBuffer byteBuffer) {
+      return byteBuffer.getInt();
     }
   };
 
@@ -899,7 +921,8 @@ public class ObjectSerDeUtils {
       BYTES_SET_SER_DE,
       ID_SET_SER_DE,
       LIST_SER_DE,
-      BIGDECIMAL_SER_DE
+      BIGDECIMAL_SER_DE,
+      INT_SER_DE
   };
   //@formatter:on
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/ObjectSerDeUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/ObjectSerDeUtilsTest.java
@@ -57,6 +57,18 @@ public class ObjectSerDeUtilsTest {
   }
 
   @Test
+  public void testInt() {
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+      Integer expected = RANDOM.nextInt();
+
+      byte[] bytes = ObjectSerDeUtils.serialize(expected);
+      Integer actual = ObjectSerDeUtils.deserialize(bytes, ObjectSerDeUtils.ObjectType.Int);
+
+      assertEquals(actual, expected, ERROR_MESSAGE);
+    }
+  }
+
+  @Test
   public void testLong() {
     for (int i = 0; i < NUM_ITERATIONS; i++) {
       Long expected = RANDOM.nextLong();


### PR DESCRIPTION
## Description
Pre work: For Mode function (#6439 ) to work on both Numbers and String types, It would have to return ColumnDataType.OBJECT. This allow for this, we would need to OBJECT case to DataSchama class. Also since the value of the result can be Integer, added a serializer/de-serializer for Int type.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
