### PR TITLE
Fix maven settings file collision

### DIFF
--- a/.github/workflows/scripts/.pinot_compatibility_verifier.sh
+++ b/.github/workflows/scripts/.pinot_compatibility_verifier.sh
@@ -27,6 +27,21 @@ netstat -i
 
 df -h
 
+echo "<settings xmlns=\"http://maven.apache.org/SETTINGS/1.0.0\""> ../settings.xml
+echo "      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"">> ../settings.xml
+echo "      xsi:schemaLocation=\"http://maven.apache.org/SETTINGS/1.0.0">> ../settings.xml
+echo "                          https://maven.apache.org/xsd/settings-1.0.0.xsd\">">> ../settings.xml
+echo "  <mirrors>">> ../settings.xml
+echo "    <mirror>">> ../settings.xml
+echo "      <id>confluent-mirror</id>">> ../settings.xml
+echo "      <mirrorOf>confluent</mirrorOf>">> ../settings.xml
+echo "      <url>https://packages.confluent.io/maven/</url>">> ../settings.xml
+echo "      <blocked>false</blocked>">> ../settings.xml
+echo "    </mirror>">> ../settings.xml
+echo "  </mirrors>">> ../settings.xml
+echo "</settings>">> ../settings.xml
+
+export PINOT_MAVEN_OPTS="-s $(pwd)/settings.xml"
 compatibility-verifier/checkoutAndBuild.sh -w $WORKING_DIR -o $OLD_COMMIT
 
 compatibility-verifier/compCheck.sh -w $WORKING_DIR -t $TEST_SUITE

--- a/compatibility-verifier/checkoutAndBuild.sh
+++ b/compatibility-verifier/checkoutAndBuild.sh
@@ -75,19 +75,6 @@ function build() {
   local versionOption="-Djdk.version=8"
 
   mkdir -p ${MVN_CACHE_DIR}
-  echo "<settings xmlns=\"http://maven.apache.org/SETTINGS/1.0.0\""> ../settings.xml
-  echo "      xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"">> ../settings.xml
-  echo "      xsi:schemaLocation=\"http://maven.apache.org/SETTINGS/1.0.0">> ../settings.xml
-  echo "                          https://maven.apache.org/xsd/settings-1.0.0.xsd\">">> ../settings.xml
-  echo "  <mirrors>">> ../settings.xml
-  echo "    <mirror>">> ../settings.xml
-  echo "      <id>confluent-mirror</id>">> ../settings.xml
-  echo "      <mirrorOf>confluent</mirrorOf>">> ../settings.xml
-  echo "      <url>https://packages.confluent.io/maven/</url>">> ../settings.xml
-  echo "      <blocked>false</blocked>">> ../settings.xml
-  echo "    </mirror>">> ../settings.xml
-  echo "  </mirrors>">> ../settings.xml
-  echo "</settings>">> ../settings.xml
 
   if [ ${buildId} -gt 0 ]; then
     # Build it in a different env under different version so that maven cache does
@@ -98,12 +85,12 @@ function build() {
     repoOption="-Dmaven.repo.local=${mvnCache}/${buildId}"
   fi
 
-  mvn install package -s ../settings.xml -DskipTests -Pbin-dist ${versionOption} ${repoOption} ${PINOT_MAVEN_OPTS} 1>${outFile} 2>&1
+  mvn install package -DskipTests -Pbin-dist ${versionOption} ${repoOption} ${PINOT_MAVEN_OPTS} 1>${outFile} 2>&1
   if [ $? -ne 0 ]; then exit 1; fi
-  mvn -pl pinot-tools package -s ../settings.xml -DskipTests ${versionOption} ${repoOption} ${PINOT_MAVEN_OPTS} 1>>${outFile} 2>&1
+  mvn -pl pinot-tools package -DskipTests ${versionOption} ${repoOption} ${PINOT_MAVEN_OPTS} 1>>${outFile} 2>&1
   if [ $? -ne 0 ]; then exit 1; fi
   if [ $buildTests -eq 1 ]; then
-    mvn -pl pinot-integration-tests package -s ../settings.xml -DskipTests ${versionOption} ${repoOption} ${PINOT_MAVEN_OPTS} 1>>${outFile} 2>&1
+    mvn -pl pinot-integration-tests package -DskipTests ${versionOption} ${repoOption} ${PINOT_MAVEN_OPTS} 1>>${outFile} 2>&1
     if [ $? -ne 0 ]; then exit 1; fi
   fi
 }
@@ -274,7 +261,7 @@ if [ ${oldBuildStatus} -eq 0 ]; then
   echo Old version build completed successfully
 else
   echo Old version build failed. See ${oldBuildOutFile}
-  cat ${oldBuildOutFile}
+  tail -250 ${oldBuildOutFile}
   exitStatus=1
 fi
 
@@ -282,7 +269,7 @@ if [ ${curBuildStatus} -eq 0 ]; then
   echo Compat checker build completed successfully
 else
   echo Compat checker build failed. See ${curBuildOutFile}
-  cat ${curBuildOutFile}
+  tail -250 ${curBuildOutFile}
   exitStatus=1
 fi
 
@@ -291,7 +278,7 @@ if [ ${buildNewTarget} -eq 1 ]; then
     echo New version build completed successfully
   else
     echo New version build failed. See ${newBuildOutFile}
-    cat ${newBuildOutFile}
+    tail -250 ${newBuildOutFile}
     exitStatus=1
   fi
 fi


### PR DESCRIPTION
It is intended that a CI pipeline passes its own maven settings file
into the checkoutAndBuild command as an env variable rather than
creating a hard-coded setting file inside the script.

Creating a new settings file broke the CICD build pipeline in our
organization.

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
