### PR TITLE
quick clean to reduce size of later PRs

### DIFF
--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
@@ -58,10 +58,11 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
 
 
 public class SegmentPreProcessorTest {
@@ -133,29 +134,35 @@ public class SegmentPreProcessorTest {
 
     ClassLoader classLoader = getClass().getClassLoader();
     URL resourceUrl = classLoader.getResource(AVRO_DATA);
-    Assert.assertNotNull(resourceUrl);
+    assertNotNull(resourceUrl);
     _avroFile = new File(resourceUrl.getFile());
 
     // For newColumnsSchema, we add 4 different data type metric columns with one user-defined default null value, and
     // 3 different data type dimension columns with one user-defined default null value and one multi-value column.
     resourceUrl = classLoader.getResource(SCHEMA);
-    Assert.assertNotNull(resourceUrl);
+    assertNotNull(resourceUrl);
     _schema = Schema.fromFile(new File(resourceUrl.getFile()));
     resourceUrl = classLoader.getResource(NEW_COLUMNS_SCHEMA1);
-    Assert.assertNotNull(resourceUrl);
+    assertNotNull(resourceUrl);
     _newColumnsSchema1 = Schema.fromFile(new File(resourceUrl.getFile()));
     resourceUrl = classLoader.getResource(NEW_COLUMNS_SCHEMA2);
-    Assert.assertNotNull(resourceUrl);
+    assertNotNull(resourceUrl);
     _newColumnsSchema2 = Schema.fromFile(new File(resourceUrl.getFile()));
     resourceUrl = classLoader.getResource(NEW_COLUMNS_SCHEMA3);
-    Assert.assertNotNull(resourceUrl);
+    assertNotNull(resourceUrl);
     _newColumnsSchema3 = Schema.fromFile(new File(resourceUrl.getFile()));
     resourceUrl = classLoader.getResource(NEW_COLUMNS_SCHEMA_WITH_TEXT);
-    Assert.assertNotNull(resourceUrl);
+    assertNotNull(resourceUrl);
     _newColumnsSchemaWithText = Schema.fromFile(new File(resourceUrl.getFile()));
     resourceUrl = classLoader.getResource(NEW_COLUMNS_SCHEMA4);
-    Assert.assertNotNull(resourceUrl);
+    assertNotNull(resourceUrl);
     _newColumnsSchema4 = Schema.fromFile(new File(resourceUrl.getFile()));
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws Exception {
+    FileUtils.deleteQuietly(INDEX_DIR);
   }
 
   private void constructV1Segment()
@@ -207,7 +214,7 @@ public class SegmentPreProcessorTest {
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
     ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_STRING_COL_RAW);
     // should be null since column does not exist in the schema
-    Assert.assertNull(columnMetadata);
+    assertNull(columnMetadata);
     checkTextIndexCreation(NEWLY_ADDED_STRING_COL_RAW, 1, 1, _newColumnsSchemaWithText, true, true, true, 4);
 
     // Create a segment in V1, add a new raw column with text index enabled
@@ -215,7 +222,7 @@ public class SegmentPreProcessorTest {
     segmentMetadata = new SegmentMetadataImpl(_indexDir);
     columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_STRING_COL_RAW);
     // should be null since column does not exist in the schema
-    Assert.assertNull(columnMetadata);
+    assertNull(columnMetadata);
     checkTextIndexCreation(NEWLY_ADDED_STRING_COL_RAW, 1, 1, _newColumnsSchemaWithText, true, true, true, 4);
   }
 
@@ -231,14 +238,14 @@ public class SegmentPreProcessorTest {
         SegmentDirectoryLoaderRegistry.getLocalSegmentDirectoryLoader().load(_indexDir.toURI(), _configuration);
     SegmentPreProcessor v3Processor =
         new SegmentPreProcessor(segmentDirectory, _indexLoadingConfig, _newColumnsSchema4);
-    Assert.expectThrows(UnsupportedOperationException.class, () -> v3Processor.process());
+    expectThrows(UnsupportedOperationException.class, () -> v3Processor.process());
 
     constructV1Segment();
     segmentDirectory =
         SegmentDirectoryLoaderRegistry.getLocalSegmentDirectoryLoader().load(_indexDir.toURI(), _configuration);
     SegmentPreProcessor v1Processor =
         new SegmentPreProcessor(segmentDirectory, _indexLoadingConfig, _newColumnsSchema4);
-    Assert.expectThrows(UnsupportedOperationException.class, () -> v1Processor.process());
+    expectThrows(UnsupportedOperationException.class, () -> v1Processor.process());
   }
 
   @Test
@@ -265,13 +272,13 @@ public class SegmentPreProcessorTest {
     constructV3Segment();
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
     ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_DICT);
-    Assert.assertNotNull(columnMetadata);
+    assertNotNull(columnMetadata);
     checkFSTIndexCreation(EXISTING_STRING_COL_DICT, 9, 4, _newColumnsSchema4, false, false, 26);
 
     constructV1Segment();
     segmentMetadata = new SegmentMetadataImpl(_indexDir);
     columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_DICT);
-    Assert.assertNotNull(columnMetadata);
+    assertNotNull(columnMetadata);
     checkFSTIndexCreation(EXISTING_STRING_COL_DICT, 9, 4, _newColumnsSchema4, false, false, 26);
   }
 
@@ -295,7 +302,7 @@ public class SegmentPreProcessorTest {
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
     ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_STRING_COL_RAW);
     // should be null since column does not exist in the schema
-    Assert.assertNull(columnMetadata);
+    assertNull(columnMetadata);
     checkTextIndexCreation(NEWLY_ADDED_STRING_COL_DICT, 1, 1, _newColumnsSchemaWithText, true, true, true, 4);
 
     // Create a segment in V1, add a new dict encoded column with text index enabled
@@ -303,7 +310,7 @@ public class SegmentPreProcessorTest {
     segmentMetadata = new SegmentMetadataImpl(_indexDir);
     columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_STRING_COL_RAW);
     // should be null since column does not exist in the schema
-    Assert.assertNull(columnMetadata);
+    assertNull(columnMetadata);
     checkTextIndexCreation(NEWLY_ADDED_STRING_COL_DICT, 1, 1, _newColumnsSchemaWithText, true, true, true, 4);
   }
 
@@ -324,14 +331,14 @@ public class SegmentPreProcessorTest {
     constructV3Segment();
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
     ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_RAW);
-    Assert.assertNotNull(columnMetadata);
+    assertNotNull(columnMetadata);
     checkTextIndexCreation(EXISTING_STRING_COL_RAW, 5, 3, _schema, false, false, false, 0);
 
     // Create a segment in V1, add a new column with text index enabled
     constructV1Segment();
     segmentMetadata = new SegmentMetadataImpl(_indexDir);
     columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_RAW);
-    Assert.assertNotNull(columnMetadata);
+    assertNotNull(columnMetadata);
     checkTextIndexCreation(EXISTING_STRING_COL_RAW, 5, 3, _schema, false, false, false, 0);
   }
 
@@ -353,7 +360,7 @@ public class SegmentPreProcessorTest {
     constructV3Segment();
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
     ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_RAW);
-    Assert.assertNotNull(columnMetadata);
+    assertNotNull(columnMetadata);
     // SegmentPreprocessor should have created the text index using TextIndexHandler
     checkTextIndexCreation(EXISTING_STRING_COL_DICT, 9, 4, _schema, false, true, false, 26);
 
@@ -361,7 +368,7 @@ public class SegmentPreProcessorTest {
     constructV1Segment();
     segmentMetadata = new SegmentMetadataImpl(_indexDir);
     columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_RAW);
-    Assert.assertNotNull(columnMetadata);
+    assertNotNull(columnMetadata);
     // SegmentPreprocessor should have created the text index using TextIndexHandler
     checkTextIndexCreation(EXISTING_STRING_COL_DICT, 9, 4, _schema, false, true, false, 26);
   }
@@ -390,27 +397,27 @@ public class SegmentPreProcessorTest {
       processor.process();
       SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
       ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(column);
-      Assert.assertEquals(columnMetadata.getFieldSpec(), new DimensionFieldSpec(column, DataType.STRING, true));
-      Assert.assertEquals(columnMetadata.getCardinality(), cardinality);
-      Assert.assertEquals(columnMetadata.getTotalDocs(), 100000);
-      Assert.assertEquals(columnMetadata.getBitsPerElement(), bits);
-      Assert.assertEquals(columnMetadata.getColumnMaxLength(), dictionaryElementSize);
-      Assert.assertEquals(columnMetadata.isSorted(), isSorted);
-      Assert.assertEquals(columnMetadata.hasDictionary(), hasDictionary);
-      Assert.assertEquals(columnMetadata.getMaxNumberOfMultiValues(), 0);
-      Assert.assertEquals(columnMetadata.getTotalNumberOfEntries(), 100000);
-      Assert.assertEquals(columnMetadata.isAutoGenerated(), isAutoGenerated);
+      assertEquals(columnMetadata.getFieldSpec(), new DimensionFieldSpec(column, DataType.STRING, true));
+      assertEquals(columnMetadata.getCardinality(), cardinality);
+      assertEquals(columnMetadata.getTotalDocs(), 100000);
+      assertEquals(columnMetadata.getBitsPerElement(), bits);
+      assertEquals(columnMetadata.getColumnMaxLength(), dictionaryElementSize);
+      assertEquals(columnMetadata.isSorted(), isSorted);
+      assertEquals(columnMetadata.hasDictionary(), hasDictionary);
+      assertEquals(columnMetadata.getMaxNumberOfMultiValues(), 0);
+      assertEquals(columnMetadata.getTotalNumberOfEntries(), 100000);
+      assertEquals(columnMetadata.isAutoGenerated(), isAutoGenerated);
 
       try (SegmentDirectory segmentDirectory1 = SegmentDirectoryLoaderRegistry.getLocalSegmentDirectoryLoader()
           .load(_indexDir.toURI(), _configuration); SegmentDirectory.Reader reader = segmentDirectory1.createReader()) {
-        Assert.assertTrue(reader.hasIndexFor(column, indexType));
-        Assert.assertTrue(reader.hasIndexFor(column, ColumnIndexType.FORWARD_INDEX));
+        assertTrue(reader.hasIndexFor(column, indexType));
+        assertTrue(reader.hasIndexFor(column, ColumnIndexType.FORWARD_INDEX));
         // if the text index is enabled on a new column with dictionary,
         // then dictionary should be created by the default column handler
         if (hasDictionary) {
-          Assert.assertTrue(reader.hasIndexFor(column, ColumnIndexType.DICTIONARY));
+          assertTrue(reader.hasIndexFor(column, ColumnIndexType.DICTIONARY));
         } else {
-          Assert.assertFalse(reader.hasIndexFor(column, ColumnIndexType.DICTIONARY));
+          assertFalse(reader.hasIndexFor(column, ColumnIndexType.DICTIONARY));
         }
       }
     }
@@ -422,7 +429,7 @@ public class SegmentPreProcessorTest {
     constructV1Segment();
 
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    Assert.assertEquals(segmentMetadata.getVersion(), SegmentVersion.v1);
+    assertEquals(segmentMetadata.getVersion(), SegmentVersion.v1);
 
     String col1FileName = COLUMN1_NAME + V1Constants.Indexes.BITMAP_INVERTED_INDEX_FILE_EXTENSION;
     String col7FileName = COLUMN7_NAME + V1Constants.Indexes.BITMAP_INVERTED_INDEX_FILE_EXTENSION;
@@ -433,10 +440,10 @@ public class SegmentPreProcessorTest {
     File col7File = new File(_indexDir, col7FileName);
     File col13File = new File(_indexDir, col13FileName);
     File badColFile = new File(_indexDir, badColFileName);
-    Assert.assertFalse(col1File.exists());
-    Assert.assertTrue(col7File.exists());
-    Assert.assertFalse(col13File.exists());
-    Assert.assertFalse(badColFile.exists());
+    assertFalse(col1File.exists());
+    assertTrue(col7File.exists());
+    assertFalse(col13File.exists());
+    assertFalse(badColFile.exists());
     FileTime col7LastModifiedTime = Files.getLastModifiedTime(col7File.toPath());
 
     // Sleep 2 seconds to prevent the same last modified time when modifying the file.
@@ -444,11 +451,11 @@ public class SegmentPreProcessorTest {
 
     // Create inverted index the first time.
     checkInvertedIndexCreation(false);
-    Assert.assertTrue(col1File.exists());
-    Assert.assertTrue(col7File.exists());
-    Assert.assertTrue(col13File.exists());
-    Assert.assertFalse(badColFile.exists());
-    Assert.assertEquals(Files.getLastModifiedTime(col7File.toPath()), col7LastModifiedTime);
+    assertTrue(col1File.exists());
+    assertTrue(col7File.exists());
+    assertTrue(col13File.exists());
+    assertFalse(badColFile.exists());
+    assertEquals(Files.getLastModifiedTime(col7File.toPath()), col7LastModifiedTime);
 
     // Update inverted index file last modified time.
     FileTime col1LastModifiedTime = Files.getLastModifiedTime(col1File.toPath());
@@ -459,13 +466,13 @@ public class SegmentPreProcessorTest {
 
     // Create inverted index the second time.
     checkInvertedIndexCreation(true);
-    Assert.assertTrue(col1File.exists());
-    Assert.assertTrue(col7File.exists());
-    Assert.assertTrue(col13File.exists());
-    Assert.assertFalse(badColFile.exists());
-    Assert.assertEquals(Files.getLastModifiedTime(col1File.toPath()), col1LastModifiedTime);
-    Assert.assertEquals(Files.getLastModifiedTime(col7File.toPath()), col7LastModifiedTime);
-    Assert.assertEquals(Files.getLastModifiedTime(col13File.toPath()), col13LastModifiedTime);
+    assertTrue(col1File.exists());
+    assertTrue(col7File.exists());
+    assertTrue(col13File.exists());
+    assertFalse(badColFile.exists());
+    assertEquals(Files.getLastModifiedTime(col1File.toPath()), col1LastModifiedTime);
+    assertEquals(Files.getLastModifiedTime(col7File.toPath()), col7LastModifiedTime);
+    assertEquals(Files.getLastModifiedTime(col13File.toPath()), col13LastModifiedTime);
   }
 
   @Test
@@ -474,7 +481,7 @@ public class SegmentPreProcessorTest {
     constructV3Segment();
 
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    Assert.assertEquals(segmentMetadata.getVersion(), SegmentVersion.v3);
+    assertEquals(segmentMetadata.getVersion(), SegmentVersion.v3);
 
     File segmentDirectoryPath = SegmentDirectoryPaths.segmentDirectoryFor(_indexDir, SegmentVersion.v3);
     File singleFileIndex = new File(segmentDirectoryPath, "columns.psf");
@@ -494,17 +501,17 @@ public class SegmentPreProcessorTest {
       addedLength += reader.getIndexFor(COLUMN13_NAME, ColumnIndexType.INVERTED_INDEX).size() + 8;
     }
     FileTime newLastModifiedTime = Files.getLastModifiedTime(singleFileIndex.toPath());
-    Assert.assertTrue(newLastModifiedTime.compareTo(lastModifiedTime) > 0);
+    assertTrue(newLastModifiedTime.compareTo(lastModifiedTime) > 0);
     long newFileSize = singleFileIndex.length();
-    Assert.assertEquals(fileSize + addedLength, newFileSize);
+    assertEquals(fileSize + addedLength, newFileSize);
 
     // Sleep 2 seconds to prevent the same last modified time when modifying the file.
     Thread.sleep(2000);
 
     // Create inverted index the second time.
     checkInvertedIndexCreation(true);
-    Assert.assertEquals(Files.getLastModifiedTime(singleFileIndex.toPath()), newLastModifiedTime);
-    Assert.assertEquals(singleFileIndex.length(), newFileSize);
+    assertEquals(Files.getLastModifiedTime(singleFileIndex.toPath()), newLastModifiedTime);
+    assertEquals(singleFileIndex.length(), newFileSize);
   }
 
   private void checkInvertedIndexCreation(boolean reCreate)
@@ -512,15 +519,15 @@ public class SegmentPreProcessorTest {
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getLocalSegmentDirectoryLoader()
         .load(_indexDir.toURI(), _configuration); SegmentDirectory.Reader reader = segmentDirectory.createReader()) {
       if (reCreate) {
-        Assert.assertTrue(reader.hasIndexFor(COLUMN1_NAME, ColumnIndexType.INVERTED_INDEX));
-        Assert.assertTrue(reader.hasIndexFor(COLUMN13_NAME, ColumnIndexType.INVERTED_INDEX));
-        Assert.assertTrue(reader.hasIndexFor(COLUMN7_NAME, ColumnIndexType.INVERTED_INDEX));
-        Assert.assertFalse(reader.hasIndexFor(NO_SUCH_COLUMN_NAME, ColumnIndexType.INVERTED_INDEX));
+        assertTrue(reader.hasIndexFor(COLUMN1_NAME, ColumnIndexType.INVERTED_INDEX));
+        assertTrue(reader.hasIndexFor(COLUMN13_NAME, ColumnIndexType.INVERTED_INDEX));
+        assertTrue(reader.hasIndexFor(COLUMN7_NAME, ColumnIndexType.INVERTED_INDEX));
+        assertFalse(reader.hasIndexFor(NO_SUCH_COLUMN_NAME, ColumnIndexType.INVERTED_INDEX));
       } else {
-        Assert.assertFalse(reader.hasIndexFor(COLUMN1_NAME, ColumnIndexType.INVERTED_INDEX));
-        Assert.assertTrue(reader.hasIndexFor(COLUMN7_NAME, ColumnIndexType.INVERTED_INDEX));
-        Assert.assertFalse(reader.hasIndexFor(COLUMN13_NAME, ColumnIndexType.INVERTED_INDEX));
-        Assert.assertFalse(reader.hasIndexFor(NO_SUCH_COLUMN_NAME, ColumnIndexType.INVERTED_INDEX));
+        assertFalse(reader.hasIndexFor(COLUMN1_NAME, ColumnIndexType.INVERTED_INDEX));
+        assertTrue(reader.hasIndexFor(COLUMN7_NAME, ColumnIndexType.INVERTED_INDEX));
+        assertFalse(reader.hasIndexFor(COLUMN13_NAME, ColumnIndexType.INVERTED_INDEX));
+        assertFalse(reader.hasIndexFor(NO_SUCH_COLUMN_NAME, ColumnIndexType.INVERTED_INDEX));
       }
     }
 
@@ -532,10 +539,10 @@ public class SegmentPreProcessorTest {
 
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getLocalSegmentDirectoryLoader()
         .load(_indexDir.toURI(), _configuration); SegmentDirectory.Reader reader = segmentDirectory.createReader()) {
-      Assert.assertTrue(reader.hasIndexFor(COLUMN1_NAME, ColumnIndexType.INVERTED_INDEX));
-      Assert.assertTrue(reader.hasIndexFor(COLUMN13_NAME, ColumnIndexType.INVERTED_INDEX));
-      Assert.assertTrue(reader.hasIndexFor(COLUMN7_NAME, ColumnIndexType.INVERTED_INDEX));
-      Assert.assertFalse(reader.hasIndexFor(NO_SUCH_COLUMN_NAME, ColumnIndexType.INVERTED_INDEX));
+      assertTrue(reader.hasIndexFor(COLUMN1_NAME, ColumnIndexType.INVERTED_INDEX));
+      assertTrue(reader.hasIndexFor(COLUMN13_NAME, ColumnIndexType.INVERTED_INDEX));
+      assertTrue(reader.hasIndexFor(COLUMN7_NAME, ColumnIndexType.INVERTED_INDEX));
+      assertFalse(reader.hasIndexFor(NO_SUCH_COLUMN_NAME, ColumnIndexType.INVERTED_INDEX));
     }
   }
 
@@ -561,17 +568,17 @@ public class SegmentPreProcessorTest {
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
     ColumnMetadata hllMetricMetadata = segmentMetadata.getColumnMetadataFor(NEW_HLL_BYTE_METRIC_COLUMN_NAME);
     FieldSpec expectedHllMetricFieldSpec = _newColumnsSchema3.getFieldSpecFor(NEW_HLL_BYTE_METRIC_COLUMN_NAME);
-    Assert.assertEquals(hllMetricMetadata.getFieldSpec(), expectedHllMetricFieldSpec);
+    assertEquals(hllMetricMetadata.getFieldSpec(), expectedHllMetricFieldSpec);
     ByteArray expectedDefaultValue = new ByteArray((byte[]) expectedHllMetricFieldSpec.getDefaultNullValue());
-    Assert.assertEquals(hllMetricMetadata.getMinValue(), expectedDefaultValue);
-    Assert.assertEquals(hllMetricMetadata.getMaxValue(), expectedDefaultValue);
+    assertEquals(hllMetricMetadata.getMinValue(), expectedDefaultValue);
+    assertEquals(hllMetricMetadata.getMaxValue(), expectedDefaultValue);
 
     ColumnMetadata tDigestMetricMetadata = segmentMetadata.getColumnMetadataFor(NEW_TDIGEST_BYTE_METRIC_COLUMN_NAME);
     FieldSpec expectedTDigestMetricFieldSpec = _newColumnsSchema3.getFieldSpecFor(NEW_TDIGEST_BYTE_METRIC_COLUMN_NAME);
-    Assert.assertEquals(tDigestMetricMetadata.getFieldSpec(), expectedTDigestMetricFieldSpec);
+    assertEquals(tDigestMetricMetadata.getFieldSpec(), expectedTDigestMetricFieldSpec);
     expectedDefaultValue = new ByteArray((byte[]) expectedTDigestMetricFieldSpec.getDefaultNullValue());
-    Assert.assertEquals(tDigestMetricMetadata.getMinValue(), expectedDefaultValue);
-    Assert.assertEquals(tDigestMetricMetadata.getMaxValue(), expectedDefaultValue);
+    assertEquals(tDigestMetricMetadata.getMinValue(), expectedDefaultValue);
+    assertEquals(tDigestMetricMetadata.getMaxValue(), expectedDefaultValue);
   }
 
   private void checkUpdateDefaultColumns()
@@ -588,82 +595,79 @@ public class SegmentPreProcessorTest {
     // Check column metadata.
     // Check all field for one column, and do necessary checks for other columns.
     ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(NEW_INT_METRIC_COLUMN_NAME);
-    Assert.assertEquals(columnMetadata.getFieldSpec(), _newColumnsSchema1.getFieldSpecFor(NEW_INT_METRIC_COLUMN_NAME));
-    Assert.assertEquals(columnMetadata.getCardinality(), 1);
-    Assert.assertEquals(columnMetadata.getTotalDocs(), 100000);
-    Assert.assertEquals(columnMetadata.getBitsPerElement(), 1);
-    Assert.assertEquals(columnMetadata.getColumnMaxLength(), 0);
-    Assert.assertTrue(columnMetadata.isSorted());
-    Assert.assertTrue(columnMetadata.hasDictionary());
-    Assert.assertEquals(columnMetadata.getMaxNumberOfMultiValues(), 0);
-    Assert.assertEquals(columnMetadata.getTotalNumberOfEntries(), 100000);
-    Assert.assertTrue(columnMetadata.isAutoGenerated());
-    Assert.assertEquals(columnMetadata.getMinValue(), 1);
-    Assert.assertEquals(columnMetadata.getMaxValue(), 1);
+    assertEquals(columnMetadata.getFieldSpec(), _newColumnsSchema1.getFieldSpecFor(NEW_INT_METRIC_COLUMN_NAME));
+    assertEquals(columnMetadata.getCardinality(), 1);
+    assertEquals(columnMetadata.getTotalDocs(), 100000);
+    assertEquals(columnMetadata.getBitsPerElement(), 1);
+    assertEquals(columnMetadata.getColumnMaxLength(), 0);
+    assertTrue(columnMetadata.isSorted());
+    assertTrue(columnMetadata.hasDictionary());
+    assertEquals(columnMetadata.getMaxNumberOfMultiValues(), 0);
+    assertEquals(columnMetadata.getTotalNumberOfEntries(), 100000);
+    assertTrue(columnMetadata.isAutoGenerated());
+    assertEquals(columnMetadata.getMinValue(), 1);
+    assertEquals(columnMetadata.getMaxValue(), 1);
 
     columnMetadata = segmentMetadata.getColumnMetadataFor(NEW_LONG_METRIC_COLUMN_NAME);
-    Assert.assertEquals(columnMetadata.getFieldSpec(), _newColumnsSchema1.getFieldSpecFor(NEW_LONG_METRIC_COLUMN_NAME));
-    Assert.assertEquals(columnMetadata.getMinValue(), 0L);
-    Assert.assertEquals(columnMetadata.getMaxValue(), 0L);
+    assertEquals(columnMetadata.getFieldSpec(), _newColumnsSchema1.getFieldSpecFor(NEW_LONG_METRIC_COLUMN_NAME));
+    assertEquals(columnMetadata.getMinValue(), 0L);
+    assertEquals(columnMetadata.getMaxValue(), 0L);
 
     columnMetadata = segmentMetadata.getColumnMetadataFor(NEW_FLOAT_METRIC_COLUMN_NAME);
-    Assert
-        .assertEquals(columnMetadata.getFieldSpec(), _newColumnsSchema1.getFieldSpecFor(NEW_FLOAT_METRIC_COLUMN_NAME));
-    Assert.assertEquals(columnMetadata.getMinValue(), 0f);
-    Assert.assertEquals(columnMetadata.getMaxValue(), 0f);
+    assertEquals(columnMetadata.getFieldSpec(), _newColumnsSchema1.getFieldSpecFor(NEW_FLOAT_METRIC_COLUMN_NAME));
+    assertEquals(columnMetadata.getMinValue(), 0f);
+    assertEquals(columnMetadata.getMaxValue(), 0f);
 
     columnMetadata = segmentMetadata.getColumnMetadataFor(NEW_DOUBLE_METRIC_COLUMN_NAME);
-    Assert
-        .assertEquals(columnMetadata.getFieldSpec(), _newColumnsSchema1.getFieldSpecFor(NEW_DOUBLE_METRIC_COLUMN_NAME));
-    Assert.assertEquals(columnMetadata.getMinValue(), 0.0);
-    Assert.assertEquals(columnMetadata.getMaxValue(), 0.0);
+    assertEquals(columnMetadata.getFieldSpec(), _newColumnsSchema1.getFieldSpecFor(NEW_DOUBLE_METRIC_COLUMN_NAME));
+    assertEquals(columnMetadata.getMinValue(), 0.0);
+    assertEquals(columnMetadata.getMaxValue(), 0.0);
 
     columnMetadata = segmentMetadata.getColumnMetadataFor(NEW_BOOLEAN_SV_DIMENSION_COLUMN_NAME);
-    Assert.assertEquals(columnMetadata.getFieldSpec(),
+    assertEquals(columnMetadata.getFieldSpec(),
         _newColumnsSchema1.getFieldSpecFor(NEW_BOOLEAN_SV_DIMENSION_COLUMN_NAME));
-    Assert.assertEquals(columnMetadata.getColumnMaxLength(), 0);
-    Assert.assertEquals(columnMetadata.getMinValue(), 0);
-    Assert.assertEquals(columnMetadata.getMaxValue(), 0);
+    assertEquals(columnMetadata.getColumnMaxLength(), 0);
+    assertEquals(columnMetadata.getMinValue(), 0);
+    assertEquals(columnMetadata.getMaxValue(), 0);
 
     columnMetadata = segmentMetadata.getColumnMetadataFor(NEW_STRING_MV_DIMENSION_COLUMN_NAME);
-    Assert.assertEquals(columnMetadata.getFieldSpec(),
+    assertEquals(columnMetadata.getFieldSpec(),
         _newColumnsSchema1.getFieldSpecFor(NEW_STRING_MV_DIMENSION_COLUMN_NAME));
-    Assert.assertEquals(columnMetadata.getColumnMaxLength(), 4);
-    Assert.assertFalse(columnMetadata.isSorted());
-    Assert.assertEquals(columnMetadata.getMaxNumberOfMultiValues(), 1);
-    Assert.assertEquals(columnMetadata.getTotalNumberOfEntries(), 100000);
-    Assert.assertEquals(columnMetadata.getMinValue(), "null");
-    Assert.assertEquals(columnMetadata.getMaxValue(), "null");
+    assertEquals(columnMetadata.getColumnMaxLength(), 4);
+    assertFalse(columnMetadata.isSorted());
+    assertEquals(columnMetadata.getMaxNumberOfMultiValues(), 1);
+    assertEquals(columnMetadata.getTotalNumberOfEntries(), 100000);
+    assertEquals(columnMetadata.getMinValue(), "null");
+    assertEquals(columnMetadata.getMaxValue(), "null");
 
     // Derived column
     columnMetadata = segmentMetadata.getColumnMetadataFor(NEW_INT_SV_DIMENSION_COLUMN_NAME);
-    Assert.assertEquals(columnMetadata.getFieldSpec(),
-        _newColumnsSchema1.getFieldSpecFor(NEW_INT_SV_DIMENSION_COLUMN_NAME));
-    Assert.assertTrue(columnMetadata.isAutoGenerated());
+    assertEquals(columnMetadata.getFieldSpec(), _newColumnsSchema1.getFieldSpecFor(NEW_INT_SV_DIMENSION_COLUMN_NAME));
+    assertTrue(columnMetadata.isAutoGenerated());
     ColumnMetadata originalColumnMetadata = segmentMetadata.getColumnMetadataFor(COLUMN1_NAME);
-    Assert.assertEquals(columnMetadata.getCardinality(), originalColumnMetadata.getCardinality());
-    Assert.assertEquals(columnMetadata.getBitsPerElement(), originalColumnMetadata.getBitsPerElement());
-    Assert.assertEquals(columnMetadata.isSorted(), originalColumnMetadata.isSorted());
-    Assert.assertEquals(columnMetadata.getMinValue(), (int) originalColumnMetadata.getMinValue() + 1);
-    Assert.assertEquals(columnMetadata.getMaxValue(), (int) originalColumnMetadata.getMaxValue() + 1);
+    assertEquals(columnMetadata.getCardinality(), originalColumnMetadata.getCardinality());
+    assertEquals(columnMetadata.getBitsPerElement(), originalColumnMetadata.getBitsPerElement());
+    assertEquals(columnMetadata.isSorted(), originalColumnMetadata.isSorted());
+    assertEquals(columnMetadata.getMinValue(), (int) originalColumnMetadata.getMinValue() + 1);
+    assertEquals(columnMetadata.getMaxValue(), (int) originalColumnMetadata.getMaxValue() + 1);
 
     // Check dictionary and forward index exist.
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getLocalSegmentDirectoryLoader()
         .load(_indexDir.toURI(), _configuration); SegmentDirectory.Reader reader = segmentDirectory.createReader()) {
-      Assert.assertTrue(reader.hasIndexFor(NEW_INT_METRIC_COLUMN_NAME, ColumnIndexType.DICTIONARY));
-      Assert.assertTrue(reader.hasIndexFor(NEW_INT_METRIC_COLUMN_NAME, ColumnIndexType.FORWARD_INDEX));
-      Assert.assertTrue(reader.hasIndexFor(NEW_LONG_METRIC_COLUMN_NAME, ColumnIndexType.DICTIONARY));
-      Assert.assertTrue(reader.hasIndexFor(NEW_LONG_METRIC_COLUMN_NAME, ColumnIndexType.FORWARD_INDEX));
-      Assert.assertTrue(reader.hasIndexFor(NEW_FLOAT_METRIC_COLUMN_NAME, ColumnIndexType.DICTIONARY));
-      Assert.assertTrue(reader.hasIndexFor(NEW_FLOAT_METRIC_COLUMN_NAME, ColumnIndexType.FORWARD_INDEX));
-      Assert.assertTrue(reader.hasIndexFor(NEW_DOUBLE_METRIC_COLUMN_NAME, ColumnIndexType.DICTIONARY));
-      Assert.assertTrue(reader.hasIndexFor(NEW_DOUBLE_METRIC_COLUMN_NAME, ColumnIndexType.FORWARD_INDEX));
-      Assert.assertTrue(reader.hasIndexFor(NEW_BOOLEAN_SV_DIMENSION_COLUMN_NAME, ColumnIndexType.DICTIONARY));
-      Assert.assertTrue(reader.hasIndexFor(NEW_BOOLEAN_SV_DIMENSION_COLUMN_NAME, ColumnIndexType.FORWARD_INDEX));
-      Assert.assertTrue(reader.hasIndexFor(NEW_INT_SV_DIMENSION_COLUMN_NAME, ColumnIndexType.DICTIONARY));
-      Assert.assertTrue(reader.hasIndexFor(NEW_INT_SV_DIMENSION_COLUMN_NAME, ColumnIndexType.FORWARD_INDEX));
-      Assert.assertTrue(reader.hasIndexFor(NEW_STRING_MV_DIMENSION_COLUMN_NAME, ColumnIndexType.DICTIONARY));
-      Assert.assertTrue(reader.hasIndexFor(NEW_STRING_MV_DIMENSION_COLUMN_NAME, ColumnIndexType.FORWARD_INDEX));
+      assertTrue(reader.hasIndexFor(NEW_INT_METRIC_COLUMN_NAME, ColumnIndexType.DICTIONARY));
+      assertTrue(reader.hasIndexFor(NEW_INT_METRIC_COLUMN_NAME, ColumnIndexType.FORWARD_INDEX));
+      assertTrue(reader.hasIndexFor(NEW_LONG_METRIC_COLUMN_NAME, ColumnIndexType.DICTIONARY));
+      assertTrue(reader.hasIndexFor(NEW_LONG_METRIC_COLUMN_NAME, ColumnIndexType.FORWARD_INDEX));
+      assertTrue(reader.hasIndexFor(NEW_FLOAT_METRIC_COLUMN_NAME, ColumnIndexType.DICTIONARY));
+      assertTrue(reader.hasIndexFor(NEW_FLOAT_METRIC_COLUMN_NAME, ColumnIndexType.FORWARD_INDEX));
+      assertTrue(reader.hasIndexFor(NEW_DOUBLE_METRIC_COLUMN_NAME, ColumnIndexType.DICTIONARY));
+      assertTrue(reader.hasIndexFor(NEW_DOUBLE_METRIC_COLUMN_NAME, ColumnIndexType.FORWARD_INDEX));
+      assertTrue(reader.hasIndexFor(NEW_BOOLEAN_SV_DIMENSION_COLUMN_NAME, ColumnIndexType.DICTIONARY));
+      assertTrue(reader.hasIndexFor(NEW_BOOLEAN_SV_DIMENSION_COLUMN_NAME, ColumnIndexType.FORWARD_INDEX));
+      assertTrue(reader.hasIndexFor(NEW_INT_SV_DIMENSION_COLUMN_NAME, ColumnIndexType.DICTIONARY));
+      assertTrue(reader.hasIndexFor(NEW_INT_SV_DIMENSION_COLUMN_NAME, ColumnIndexType.FORWARD_INDEX));
+      assertTrue(reader.hasIndexFor(NEW_STRING_MV_DIMENSION_COLUMN_NAME, ColumnIndexType.DICTIONARY));
+      assertTrue(reader.hasIndexFor(NEW_STRING_MV_DIMENSION_COLUMN_NAME, ColumnIndexType.FORWARD_INDEX));
     }
 
     // Use the second schema and update default value again.
@@ -679,14 +683,14 @@ public class SegmentPreProcessorTest {
 
     // Check column metadata.
     columnMetadata = segmentMetadata.getColumnMetadataFor(NEW_INT_METRIC_COLUMN_NAME);
-    Assert.assertEquals(columnMetadata.getMinValue(), 2);
-    Assert.assertEquals(columnMetadata.getMaxValue(), 2);
-    Assert.assertEquals(columnMetadata.getFieldSpec().getDefaultNullValue(), 2);
+    assertEquals(columnMetadata.getMinValue(), 2);
+    assertEquals(columnMetadata.getMaxValue(), 2);
+    assertEquals(columnMetadata.getFieldSpec().getDefaultNullValue(), 2);
 
     columnMetadata = segmentMetadata.getColumnMetadataFor(NEW_STRING_MV_DIMENSION_COLUMN_NAME);
-    Assert.assertEquals(columnMetadata.getMinValue(), "abcd");
-    Assert.assertEquals(columnMetadata.getMaxValue(), "abcd");
-    Assert.assertEquals(columnMetadata.getFieldSpec().getDefaultNullValue(), "abcd");
+    assertEquals(columnMetadata.getMinValue(), "abcd");
+    assertEquals(columnMetadata.getMaxValue(), "abcd");
+    assertEquals(columnMetadata.getFieldSpec().getDefaultNullValue(), "abcd");
   }
 
   @Test
@@ -717,12 +721,12 @@ public class SegmentPreProcessorTest {
     ColumnMetadata timeColumnMetadata = segmentMetadata.getColumnMetadataFor("daysSinceEpoch");
     ColumnMetadata dimensionColumnMetadata = segmentMetadata.getColumnMetadataFor("column1");
     ColumnMetadata metricColumnMetadata = segmentMetadata.getColumnMetadataFor("count");
-    Assert.assertNull(timeColumnMetadata.getMinValue());
-    Assert.assertNull(timeColumnMetadata.getMaxValue());
-    Assert.assertNull(dimensionColumnMetadata.getMinValue());
-    Assert.assertNull(dimensionColumnMetadata.getMaxValue());
-    Assert.assertNull(metricColumnMetadata.getMinValue());
-    Assert.assertNull(metricColumnMetadata.getMaxValue());
+    assertNull(timeColumnMetadata.getMinValue());
+    assertNull(timeColumnMetadata.getMaxValue());
+    assertNull(dimensionColumnMetadata.getMinValue());
+    assertNull(dimensionColumnMetadata.getMaxValue());
+    assertNull(metricColumnMetadata.getMinValue());
+    assertNull(metricColumnMetadata.getMaxValue());
 
     indexLoadingConfig.setColumnMinMaxValueGeneratorMode(ColumnMinMaxValueGeneratorMode.TIME);
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getLocalSegmentDirectoryLoader()
@@ -734,12 +738,12 @@ public class SegmentPreProcessorTest {
     timeColumnMetadata = segmentMetadata.getColumnMetadataFor("daysSinceEpoch");
     dimensionColumnMetadata = segmentMetadata.getColumnMetadataFor("column5");
     metricColumnMetadata = segmentMetadata.getColumnMetadataFor("count");
-    Assert.assertEquals(timeColumnMetadata.getMinValue(), 1756015683);
-    Assert.assertEquals(timeColumnMetadata.getMaxValue(), 1756015683);
-    Assert.assertNull(dimensionColumnMetadata.getMinValue());
-    Assert.assertNull(dimensionColumnMetadata.getMaxValue());
-    Assert.assertNull(metricColumnMetadata.getMinValue());
-    Assert.assertNull(metricColumnMetadata.getMaxValue());
+    assertEquals(timeColumnMetadata.getMinValue(), 1756015683);
+    assertEquals(timeColumnMetadata.getMaxValue(), 1756015683);
+    assertNull(dimensionColumnMetadata.getMinValue());
+    assertNull(dimensionColumnMetadata.getMaxValue());
+    assertNull(metricColumnMetadata.getMinValue());
+    assertNull(metricColumnMetadata.getMaxValue());
 
     indexLoadingConfig.setColumnMinMaxValueGeneratorMode(ColumnMinMaxValueGeneratorMode.NON_METRIC);
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getLocalSegmentDirectoryLoader()
@@ -751,12 +755,12 @@ public class SegmentPreProcessorTest {
     timeColumnMetadata = segmentMetadata.getColumnMetadataFor("daysSinceEpoch");
     dimensionColumnMetadata = segmentMetadata.getColumnMetadataFor("column5");
     metricColumnMetadata = segmentMetadata.getColumnMetadataFor("count");
-    Assert.assertEquals(timeColumnMetadata.getMinValue(), 1756015683);
-    Assert.assertEquals(timeColumnMetadata.getMaxValue(), 1756015683);
-    Assert.assertEquals(dimensionColumnMetadata.getMinValue(), "AKXcXcIqsqOJFsdwxZ");
-    Assert.assertEquals(dimensionColumnMetadata.getMaxValue(), "yQkJTLOQoOqqhkAClgC");
-    Assert.assertNull(metricColumnMetadata.getMinValue());
-    Assert.assertNull(metricColumnMetadata.getMaxValue());
+    assertEquals(timeColumnMetadata.getMinValue(), 1756015683);
+    assertEquals(timeColumnMetadata.getMaxValue(), 1756015683);
+    assertEquals(dimensionColumnMetadata.getMinValue(), "AKXcXcIqsqOJFsdwxZ");
+    assertEquals(dimensionColumnMetadata.getMaxValue(), "yQkJTLOQoOqqhkAClgC");
+    assertNull(metricColumnMetadata.getMinValue());
+    assertNull(metricColumnMetadata.getMaxValue());
 
     indexLoadingConfig.setColumnMinMaxValueGeneratorMode(ColumnMinMaxValueGeneratorMode.ALL);
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getLocalSegmentDirectoryLoader()
@@ -768,17 +772,11 @@ public class SegmentPreProcessorTest {
     timeColumnMetadata = segmentMetadata.getColumnMetadataFor("daysSinceEpoch");
     dimensionColumnMetadata = segmentMetadata.getColumnMetadataFor("column5");
     metricColumnMetadata = segmentMetadata.getColumnMetadataFor("count");
-    Assert.assertEquals(timeColumnMetadata.getMinValue(), 1756015683);
-    Assert.assertEquals(timeColumnMetadata.getMaxValue(), 1756015683);
-    Assert.assertEquals(dimensionColumnMetadata.getMinValue(), "AKXcXcIqsqOJFsdwxZ");
-    Assert.assertEquals(dimensionColumnMetadata.getMaxValue(), "yQkJTLOQoOqqhkAClgC");
-    Assert.assertEquals(metricColumnMetadata.getMinValue(), 890662862);
-    Assert.assertEquals(metricColumnMetadata.getMaxValue(), 890662862);
-  }
-
-  @AfterClass
-  public void tearDown()
-      throws Exception {
-    FileUtils.deleteQuietly(INDEX_DIR);
+    assertEquals(timeColumnMetadata.getMinValue(), 1756015683);
+    assertEquals(timeColumnMetadata.getMaxValue(), 1756015683);
+    assertEquals(dimensionColumnMetadata.getMinValue(), "AKXcXcIqsqOJFsdwxZ");
+    assertEquals(dimensionColumnMetadata.getMaxValue(), "yQkJTLOQoOqqhkAClgC");
+    assertEquals(metricColumnMetadata.getMinValue(), 890662862);
+    assertEquals(metricColumnMetadata.getMaxValue(), 890662862);
   }
 }


### PR DESCRIPTION
## Description
Just clean up to reduce size of next PR on SegmentPreprocessor. 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
