### PR TITLE
Add github action workflow for ad-hoc compatibility test

### DIFF
--- a/.github/workflows/pinot_compatibility_tests.yml
+++ b/.github/workflows/pinot_compatibility_tests.yml
@@ -1,0 +1,52 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+name: Pinot Compatibility Regression Test
+
+on:
+  workflow_dispatch:
+    inputs:
+      oldCommit:
+        description: "Git hash (or tag) for old commit. (required)"
+        required: true
+      newCommit:
+        description: "Git hash (or tag) for new commit. (required)"
+        required: true
+
+jobs:
+  compatibility-verifier:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        test_suite: [ "compatibility-verifier/sample-test-suite" ]
+    name: Pinot Compatibility Regression Testing against ${{ github.event.inputs.oldCommit }} and ${{ github.event.inputs.newCommit }} on ${{ matrix.test_suite }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Pinot Compatibility Regression Testing
+        if : ${{github.event_name == 'workflow_dispatch'}}
+        env:
+          OLD_COMMIT: ${{ github.event.inputs.oldCommit }}
+          NEW_COMMIT: ${{ github.event.inputs.newCommit }}
+          WORKING_DIR: /tmp/compatibility-verifier
+          TEST_SUITE: ${{ matrix.test_suite }}
+          MAVEN_OPTS: -Xmx2G -DskipShade -DfailIfNoTests=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
+        run: .github/workflows/scripts/.pinot_compatibility_verifier.sh

--- a/.github/workflows/scripts/.pinot_compatibility_verifier.sh
+++ b/.github/workflows/scripts/.pinot_compatibility_verifier.sh
@@ -45,6 +45,13 @@ echo "</settings>">> ${SETTINGS_FILE}
 
 # PINOT_MAVEN_OPTS is used to provide additional maven options to the checkoutAndBuild.sh command
 export PINOT_MAVEN_OPTS="-s $(pwd)/${SETTINGS_FILE}"
-compatibility-verifier/checkoutAndBuild.sh -w $WORKING_DIR -o $OLD_COMMIT
+
+if [ -z "$newerCommit" ]; then
+  echo "Running compatibility regression test against \"${olderCommit}\""
+  compatibility-verifier/checkoutAndBuild.sh -w $WORKING_DIR -o $OLD_COMMIT
+else
+  echo "Running compatibility regression test against \"${olderCommit}\" and \"${newerCommit}\""
+  compatibility-verifier/checkoutAndBuild.sh -w $WORKING_DIR -o $OLD_COMMIT -n $NEW_OLD_COMMIT
+fi
 
 compatibility-verifier/compCheck.sh -w $WORKING_DIR -t $TEST_SUITE


### PR DESCRIPTION
We currently run the compatibility regression test for every git commit.
On the other hand, we currently don't support to submit the test on
ad-hoc basis. This PR adds the way to submit the test and it also
allows the user to submit 2 inputs for old and new commits. This will
be used as part of Apache release process (comparing 2 releases).

In order to run the test, we can use the Github Action UI that will be
created after this PR.
https://github.com/apache/pinot/actions/workflows/pinot_compatibility_tests.yml
