### PR TITLE
add method to get column indices created in segment folder

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
@@ -110,15 +110,17 @@ class FilePerIndexDirectory extends ColumnIndexDirectory {
   }
 
   @Override
-  public Map<ColumnIndexType, Set<String>> getColumnIndices() {
+  public Set<String> getColumnsWithIndex(ColumnIndexType type) {
     if (_indexBuffers.isEmpty()) {
-      return Collections.emptyMap();
+      return Collections.emptySet();
     }
-    Map<ColumnIndexType, Set<String>> colIdx = new HashMap<>();
+    Set<String> columns = new HashSet<>();
     for (IndexKey entry : _indexBuffers.keySet()) {
-      colIdx.computeIfAbsent(entry.type, t -> new HashSet<>()).add(entry.name);
+      if (entry.type == type) {
+        columns.add(entry.name);
+      }
     }
-    return colIdx;
+    return columns;
   }
 
   private PinotDataBuffer getReadBufferFor(IndexKey key)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
@@ -23,7 +23,6 @@ import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteOrder;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
@@ -111,13 +111,10 @@ class FilePerIndexDirectory extends ColumnIndexDirectory {
 
   @Override
   public Set<String> getColumnsWithIndex(ColumnIndexType type) {
-    if (_indexBuffers.isEmpty()) {
-      return Collections.emptySet();
-    }
     Set<String> columns = new HashSet<>();
-    for (IndexKey entry : _indexBuffers.keySet()) {
-      if (entry.type == type) {
-        columns.add(entry.name);
+    for (IndexKey indexKey : _indexBuffers.keySet()) {
+      if (indexKey.type == type) {
+        columns.add(indexKey.name);
       }
     }
     return columns;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
@@ -24,6 +24,9 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.io.FileUtils;
@@ -165,6 +168,14 @@ public class SegmentLocalFSDirectory extends SegmentDirectory {
       }
       return size;
     }
+  }
+
+  @Override
+  public Map<ColumnIndexType, Set<String>> getColumnIndices() {
+    if (_columnIndexDirectory == null) {
+      return Collections.emptyMap();
+    }
+    return _columnIndexDirectory.getColumnIndices();
   }
 
   public Reader createReader()

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
@@ -25,7 +25,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collections;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.commons.configuration.ConfigurationException;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
@@ -171,11 +171,11 @@ public class SegmentLocalFSDirectory extends SegmentDirectory {
   }
 
   @Override
-  public Map<ColumnIndexType, Set<String>> getColumnIndices() {
+  public Set<String> getColumnsWithIndex(ColumnIndexType type) {
     if (_columnIndexDirectory == null) {
-      return Collections.emptyMap();
+      return Collections.emptySet();
     }
-    return _columnIndexDirectory.getColumnIndices();
+    return _columnIndexDirectory.getColumnsWithIndex(type);
   }
 
   public Reader createReader()

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
@@ -375,13 +375,10 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
 
   @Override
   public Set<String> getColumnsWithIndex(ColumnIndexType type) {
-    if (_columnEntries.isEmpty()) {
-      return Collections.emptySet();
-    }
     Set<String> columns = new HashSet<>();
-    for (IndexKey entry : _columnEntries.keySet()) {
-      if (entry.type == type) {
-        columns.add(entry.name);
+    for (IndexKey indexKey : _columnEntries.keySet()) {
+      if (indexKey.type == type) {
+        columns.add(indexKey.name);
       }
     }
     return columns;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
@@ -374,15 +374,17 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
   }
 
   @Override
-  public Map<ColumnIndexType, Set<String>> getColumnIndices() {
+  public Set<String> getColumnsWithIndex(ColumnIndexType type) {
     if (_columnEntries.isEmpty()) {
-      return Collections.emptyMap();
+      return Collections.emptySet();
     }
-    Map<ColumnIndexType, Set<String>> colIdx = new HashMap<>();
+    Set<String> columns = new HashSet<>();
     for (IndexKey entry : _columnEntries.keySet()) {
-      colIdx.computeIfAbsent(entry.type, t -> new HashSet<>()).add(entry.name);
+      if (entry.type == type) {
+        columns.add(entry.name);
+      }
     }
-    return colIdx;
+    return columns;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
@@ -27,9 +27,12 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import org.apache.commons.configuration.ConfigurationException;
@@ -232,8 +235,8 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
       String propertyName = key.substring(lastSeparatorPos + 1);
 
       int indexSeparatorPos = key.lastIndexOf(MAP_KEY_SEPARATOR, lastSeparatorPos - 1);
-      Preconditions
-          .checkState(indexSeparatorPos != -1, "Index separator not found: " + key + " , segment: " + _segmentDirectory);
+      Preconditions.checkState(indexSeparatorPos != -1,
+          "Index separator not found: " + key + " , segment: " + _segmentDirectory);
       String indexName = key.substring(indexSeparatorPos + 1, lastSeparatorPos);
       String columnName = key.substring(0, indexSeparatorPos);
       IndexKey indexKey = new IndexKey(columnName, ColumnIndexType.getValue(indexName));
@@ -368,6 +371,18 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
   @Override
   public boolean isIndexRemovalSupported() {
     return false;
+  }
+
+  @Override
+  public Map<ColumnIndexType, Set<String>> getColumnIndices() {
+    if (_columnEntries.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    Map<ColumnIndexType, Set<String>> colIdx = new HashMap<>();
+    for (IndexKey entry : _columnEntries.keySet()) {
+      colIdx.computeIfAbsent(entry.type, t -> new HashSet<>()).add(entry.name);
+    }
+    return colIdx;
   }
 
   @Override

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
@@ -20,6 +20,11 @@ package org.apache.pinot.segment.local.segment.store;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
@@ -28,10 +33,13 @@ import org.apache.pinot.segment.spi.store.ColumnIndexDirectory;
 import org.apache.pinot.segment.spi.store.ColumnIndexType;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.util.TestUtils;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 
 public class FilePerIndexDirectoryTest {
@@ -60,10 +68,10 @@ public class FilePerIndexDirectoryTest {
   @Test
   public void testEmptyDirectory()
       throws Exception {
-    Assert.assertEquals(0, TEMP_DIR.list().length, TEMP_DIR.list().toString());
+    assertEquals(0, TEMP_DIR.list().length, TEMP_DIR.list().toString());
     try (FilePerIndexDirectory fpiDir = new FilePerIndexDirectory(TEMP_DIR, segmentMetadata, ReadMode.heap);
         PinotDataBuffer buffer = fpiDir.newBuffer("col1", ColumnIndexType.DICTIONARY, 1024)) {
-      Assert.assertEquals(1, TEMP_DIR.list().length, TEMP_DIR.list().toString());
+      assertEquals(1, TEMP_DIR.list().length, TEMP_DIR.list().toString());
 
       buffer.putLong(0, 0xbadfadL);
       buffer.putInt(8, 51);
@@ -71,13 +79,13 @@ public class FilePerIndexDirectoryTest {
       buffer.putInt(101, 55);
     }
 
-    Assert.assertEquals(1, TEMP_DIR.list().length);
+    assertEquals(1, TEMP_DIR.list().length);
 
     try (FilePerIndexDirectory colDir = new FilePerIndexDirectory(TEMP_DIR, segmentMetadata, ReadMode.mmap);
         PinotDataBuffer readBuffer = colDir.getBuffer("col1", ColumnIndexType.DICTIONARY)) {
-      Assert.assertEquals(readBuffer.getLong(0), 0xbadfadL);
-      Assert.assertEquals(readBuffer.getInt(8), 51);
-      Assert.assertEquals(readBuffer.getInt(101), 55);
+      assertEquals(readBuffer.getLong(0), 0xbadfadL);
+      assertEquals(readBuffer.getInt(8), 51);
+      assertEquals(readBuffer.getInt(101), 55);
     }
   }
 
@@ -139,7 +147,7 @@ public class FilePerIndexDirectoryTest {
     try (FilePerIndexDirectory fpiDirectory = new FilePerIndexDirectory(TEMP_DIR, segmentMetadata, ReadMode.mmap)) {
       PinotDataBuffer buffer = fpiDirectory.newBuffer("foo", ColumnIndexType.DICTIONARY, 1024);
       buffer.putInt(0, 100);
-      Assert.assertTrue(fpiDirectory.hasIndexFor("foo", ColumnIndexType.DICTIONARY));
+      assertTrue(fpiDirectory.hasIndexFor("foo", ColumnIndexType.DICTIONARY));
     }
   }
 
@@ -149,11 +157,36 @@ public class FilePerIndexDirectoryTest {
     try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(TEMP_DIR, segmentMetadata, ReadMode.mmap)) {
       fpi.newBuffer("col1", ColumnIndexType.FORWARD_INDEX, 1024);
       fpi.newBuffer("col2", ColumnIndexType.DICTIONARY, 100);
-      Assert.assertTrue(fpi.getFileFor("col1", ColumnIndexType.FORWARD_INDEX).exists());
-      Assert.assertTrue(fpi.getFileFor("col2", ColumnIndexType.DICTIONARY).exists());
-      Assert.assertTrue(fpi.isIndexRemovalSupported());
+      assertTrue(fpi.getFileFor("col1", ColumnIndexType.FORWARD_INDEX).exists());
+      assertTrue(fpi.getFileFor("col2", ColumnIndexType.DICTIONARY).exists());
+      assertTrue(fpi.isIndexRemovalSupported());
       fpi.removeIndex("col1", ColumnIndexType.FORWARD_INDEX);
-      Assert.assertFalse(fpi.getFileFor("col1", ColumnIndexType.FORWARD_INDEX).exists());
+      assertFalse(fpi.getFileFor("col1", ColumnIndexType.FORWARD_INDEX).exists());
+    }
+  }
+
+  @Test
+  public void testGetColumnIndices()
+      throws IOException {
+    try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(TEMP_DIR, segmentMetadata, ReadMode.mmap)) {
+      fpi.newBuffer("col1", ColumnIndexType.FORWARD_INDEX, 1024);
+      fpi.newBuffer("col2", ColumnIndexType.DICTIONARY, 100);
+      fpi.newBuffer("col3", ColumnIndexType.FORWARD_INDEX, 1024);
+      fpi.newBuffer("col4", ColumnIndexType.INVERTED_INDEX, 100);
+
+      Map<ColumnIndexType, Set<String>> colIdx = fpi.getColumnIndices();
+      assertEquals(colIdx.size(), 3);
+      assertEquals(colIdx.get(ColumnIndexType.FORWARD_INDEX), new HashSet<>(Arrays.asList("col1", "col3")));
+      assertEquals(colIdx.get(ColumnIndexType.DICTIONARY), new HashSet<>(Collections.singletonList("col2")));
+      assertEquals(colIdx.get(ColumnIndexType.INVERTED_INDEX), new HashSet<>(Collections.singletonList("col4")));
+
+      fpi.removeIndex("col1", ColumnIndexType.FORWARD_INDEX);
+      fpi.removeIndex("col2", ColumnIndexType.DICTIONARY);
+      fpi.removeIndex("col111", ColumnIndexType.DICTIONARY);
+      colIdx = fpi.getColumnIndices();
+      assertEquals(colIdx.size(), 2);
+      assertEquals(colIdx.get(ColumnIndexType.FORWARD_INDEX), new HashSet<>(Collections.singletonList("col3")));
+      assertEquals(colIdx.get(ColumnIndexType.INVERTED_INDEX), new HashSet<>(Collections.singletonList("col4")));
     }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
@@ -174,19 +174,20 @@ public class FilePerIndexDirectoryTest {
       fpi.newBuffer("col3", ColumnIndexType.FORWARD_INDEX, 1024);
       fpi.newBuffer("col4", ColumnIndexType.INVERTED_INDEX, 100);
 
-      Map<ColumnIndexType, Set<String>> colIdx = fpi.getColumnIndices();
-      assertEquals(colIdx.size(), 3);
-      assertEquals(colIdx.get(ColumnIndexType.FORWARD_INDEX), new HashSet<>(Arrays.asList("col1", "col3")));
-      assertEquals(colIdx.get(ColumnIndexType.DICTIONARY), new HashSet<>(Collections.singletonList("col2")));
-      assertEquals(colIdx.get(ColumnIndexType.INVERTED_INDEX), new HashSet<>(Collections.singletonList("col4")));
+      assertEquals(fpi.getColumnsWithIndex(ColumnIndexType.FORWARD_INDEX),
+          new HashSet<>(Arrays.asList("col1", "col3")));
+      assertEquals(fpi.getColumnsWithIndex(ColumnIndexType.DICTIONARY),
+          new HashSet<>(Collections.singletonList("col2")));
+      assertEquals(fpi.getColumnsWithIndex(ColumnIndexType.INVERTED_INDEX),
+          new HashSet<>(Collections.singletonList("col4")));
 
       fpi.removeIndex("col1", ColumnIndexType.FORWARD_INDEX);
       fpi.removeIndex("col2", ColumnIndexType.DICTIONARY);
       fpi.removeIndex("col111", ColumnIndexType.DICTIONARY);
-      colIdx = fpi.getColumnIndices();
-      assertEquals(colIdx.size(), 2);
-      assertEquals(colIdx.get(ColumnIndexType.FORWARD_INDEX), new HashSet<>(Collections.singletonList("col3")));
-      assertEquals(colIdx.get(ColumnIndexType.INVERTED_INDEX), new HashSet<>(Collections.singletonList("col4")));
+      assertEquals(fpi.getColumnsWithIndex(ColumnIndexType.FORWARD_INDEX),
+          new HashSet<>(Collections.singletonList("col3")));
+      assertEquals(fpi.getColumnsWithIndex(ColumnIndexType.INVERTED_INDEX),
+          new HashSet<>(Collections.singletonList("col4")));
     }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
@@ -23,8 +23,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
@@ -180,11 +180,12 @@ public class SingleFileIndexDirectoryTest {
       spi.newBuffer("col3", ColumnIndexType.FORWARD_INDEX, 1024);
       spi.newBuffer("col4", ColumnIndexType.INVERTED_INDEX, 100);
 
-      Map<ColumnIndexType, Set<String>> colIdx = spi.getColumnIndices();
-      assertEquals(colIdx.size(), 3);
-      assertEquals(colIdx.get(ColumnIndexType.FORWARD_INDEX), new HashSet<>(Arrays.asList("col1", "col3")));
-      assertEquals(colIdx.get(ColumnIndexType.DICTIONARY), new HashSet<>(Collections.singletonList("col2")));
-      assertEquals(colIdx.get(ColumnIndexType.INVERTED_INDEX), new HashSet<>(Collections.singletonList("col4")));
+      assertEquals(spi.getColumnsWithIndex(ColumnIndexType.FORWARD_INDEX),
+          new HashSet<>(Arrays.asList("col1", "col3")));
+      assertEquals(spi.getColumnsWithIndex(ColumnIndexType.DICTIONARY),
+          new HashSet<>(Collections.singletonList("col2")));
+      assertEquals(spi.getColumnsWithIndex(ColumnIndexType.INVERTED_INDEX),
+          new HashSet<>(Collections.singletonList("col4")));
       // TODO: implement removeIndex and test it in next RP
       // spi.removeIndex("col1", ColumnIndexType.FORWARD_INDEX);
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
@@ -21,7 +21,10 @@ package org.apache.pinot.segment.local.segment.store;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
@@ -32,10 +35,12 @@ import org.apache.pinot.segment.spi.store.ColumnIndexType;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.util.TestUtils;
 import org.mockito.Mockito;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 
 
 public class SingleFileIndexDirectoryTest {
@@ -75,7 +80,7 @@ public class SingleFileIndexDirectoryTest {
   public void testWithEmptyDir()
       throws Exception {
     // segmentDir does not have anything to begin with
-    Assert.assertEquals(TEMP_DIR.list().length, 0);
+    assertEquals(TEMP_DIR.list().length, 0);
     SingleFileIndexDirectory columnDirectory = new SingleFileIndexDirectory(TEMP_DIR, segmentMetadata, ReadMode.mmap);
     PinotDataBuffer writtenBuffer = columnDirectory.newBuffer("foo", ColumnIndexType.DICTIONARY, 1024);
     String data = "This is a test string";
@@ -89,11 +94,11 @@ public class SingleFileIndexDirectoryTest {
     Mockito.when(segmentMetadata.getAllColumns()).thenReturn(new HashSet<String>(Arrays.asList("foo")));
     try (SingleFileIndexDirectory directoryReader = new SingleFileIndexDirectory(TEMP_DIR, segmentMetadata,
         ReadMode.mmap); PinotDataBuffer readBuffer = directoryReader.getBuffer("foo", ColumnIndexType.DICTIONARY)) {
-      Assert.assertEquals(1024, readBuffer.size());
+      assertEquals(1024, readBuffer.size());
       int length = dataBytes.length;
       for (int i = 0; i < length; i++) {
         byte b = readBuffer.getByte(i);
-        Assert.assertEquals(dataBytes[i], b);
+        assertEquals(dataBytes[i], b);
       }
     }
   }
@@ -161,8 +166,27 @@ public class SingleFileIndexDirectoryTest {
       throws IOException, ConfigurationException {
     try (SingleFileIndexDirectory sfd = new SingleFileIndexDirectory(TEMP_DIR, segmentMetadata, ReadMode.mmap)) {
       sfd.newBuffer("col1", ColumnIndexType.DICTIONARY, 1024);
-      Assert.assertFalse(sfd.isIndexRemovalSupported());
+      assertFalse(sfd.isIndexRemovalSupported());
       sfd.removeIndex("col1", ColumnIndexType.DICTIONARY);
+    }
+  }
+
+  @Test
+  public void testGetColumnIndices()
+      throws Exception {
+    try (SingleFileIndexDirectory spi = new SingleFileIndexDirectory(TEMP_DIR, segmentMetadata, ReadMode.mmap)) {
+      spi.newBuffer("col1", ColumnIndexType.FORWARD_INDEX, 1024);
+      spi.newBuffer("col2", ColumnIndexType.DICTIONARY, 100);
+      spi.newBuffer("col3", ColumnIndexType.FORWARD_INDEX, 1024);
+      spi.newBuffer("col4", ColumnIndexType.INVERTED_INDEX, 100);
+
+      Map<ColumnIndexType, Set<String>> colIdx = spi.getColumnIndices();
+      assertEquals(colIdx.size(), 3);
+      assertEquals(colIdx.get(ColumnIndexType.FORWARD_INDEX), new HashSet<>(Arrays.asList("col1", "col3")));
+      assertEquals(colIdx.get(ColumnIndexType.DICTIONARY), new HashSet<>(Collections.singletonList("col2")));
+      assertEquals(colIdx.get(ColumnIndexType.INVERTED_INDEX), new HashSet<>(Collections.singletonList("col4")));
+      // TODO: implement removeIndex and test it in next RP
+      // spi.removeIndex("col1", ColumnIndexType.FORWARD_INDEX);
     }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
@@ -23,8 +23,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/ColumnIndexDirectory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/ColumnIndexDirectory.java
@@ -21,7 +21,6 @@ package org.apache.pinot.segment.spi.store;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/ColumnIndexDirectory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/ColumnIndexDirectory.java
@@ -21,6 +21,8 @@ package org.apache.pinot.segment.spi.store;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 
@@ -84,6 +86,12 @@ public abstract class ColumnIndexDirectory implements Closeable {
    * @return true if the index removal is supported
    */
   public abstract boolean isIndexRemovalSupported();
+
+  /**
+   * Get the column-indices loaded by column index directory.
+   * @return a map from index type to the set of columns with such index.
+   */
+  public abstract Map<ColumnIndexType, Set<String>> getColumnIndices();
 
   /**
    * Fetch the buffer for this column

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/ColumnIndexDirectory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/ColumnIndexDirectory.java
@@ -88,10 +88,10 @@ public abstract class ColumnIndexDirectory implements Closeable {
   public abstract boolean isIndexRemovalSupported();
 
   /**
-   * Get the column-indices loaded by column index directory.
-   * @return a map from index type to the set of columns with such index.
+   * Get the columns with specific index type, loaded by column index directory.
+   * @return a set of columns with such index type.
    */
-  public abstract Map<ColumnIndexType, Set<String>> getColumnIndices();
+  public abstract Set<String> getColumnsWithIndex(ColumnIndexType type);
 
   /**
    * Fetch the buffer for this column

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/SegmentDirectory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/SegmentDirectory.java
@@ -22,6 +22,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.Map;
 import java.util.Set;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
@@ -107,6 +108,12 @@ public abstract class SegmentDirectory implements Closeable {
   public abstract Path getPath();
 
   public abstract long getDiskSizeBytes();
+
+  /**
+   * Get column-indices in this local segment directory.
+   * @return a map from index type to the set of columns with such index.
+   */
+  public abstract Map<ColumnIndexType, Set<String>> getColumnIndices();
 
   /**
    * This is a hint to the the implementation, to prefetch buffers for specified columns

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/SegmentDirectory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/SegmentDirectory.java
@@ -110,10 +110,10 @@ public abstract class SegmentDirectory implements Closeable {
   public abstract long getDiskSizeBytes();
 
   /**
-   * Get column-indices in this local segment directory.
-   * @return a map from index type to the set of columns with such index.
+   * Get the columns with specific index type, in this local segment directory.
+   * @return a set of columns with such index type.
    */
-  public abstract Map<ColumnIndexType, Set<String>> getColumnIndices();
+  public abstract Set<String> getColumnsWithIndex(ColumnIndexType type);
 
   /**
    * This is a hint to the the implementation, to prefetch buffers for specified columns

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/SegmentDirectory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/SegmentDirectory.java
@@ -22,7 +22,6 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
-import java.util.Map;
 import java.util.Set;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;


### PR DESCRIPTION
## Description
This method expose the column indices created in local segment folder, which can be compared with indices in table config to decide which indices to remove as to be implemented in https://github.com/apache/pinot/pull/7286. 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
