### PR TITLE
Allow uploading a segment with a different name from HTTP header

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -57,6 +57,7 @@ import javax.ws.rs.core.StreamingOutput;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.metrics.ControllerMeter;
@@ -190,8 +191,9 @@ public class PinotSegmentUploadDownloadRestletResource {
     String crypterClassNameInHeader = null;
     String downloadUri = null;
     String ingestionDescriptor = null;
+    String segmentName = null;
     if (headers != null) {
-      extractHttpHeader(headers, CommonConstants.Controller.SEGMENT_NAME_HTTP_HEADER);
+      segmentName = extractHttpHeader(headers, CommonConstants.Controller.SEGMENT_NAME_HTTP_HEADER);
       extractHttpHeader(headers, CommonConstants.Controller.TABLE_NAME_HTTP_HEADER);
       ingestionDescriptor = extractHttpHeader(headers, CommonConstants.Controller.INGESTION_DESCRIPTOR);
       uploadTypeStr = extractHttpHeader(headers, FileUploadDownloadClient.CustomHeaders.UPLOAD_TYPE);
@@ -235,7 +237,10 @@ public class PinotSegmentUploadDownloadRestletResource {
       SegmentMetadata segmentMetadata = getSegmentMetadata(tempDecryptedFile, tempSegmentDir, metadataProviderClass);
 
       // Fetch segment name
-      String segmentName = segmentMetadata.getName();
+      if (!StringUtils.isEmpty(segmentName)) {
+        segmentMetadata.setName(segmentName);
+      }
+      segmentName = segmentMetadata.getName();
 
       // Fetch table name. Try to derive the table name from the parameter and then from segment metadata
       String rawTableName;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentMetadata.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentMetadata.java
@@ -47,6 +47,8 @@ public interface SegmentMetadata {
 
   String getName();
 
+  void setName(String segmentName);
+
   String getTimeColumn();
 
   long getStartTime();

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/SegmentMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/SegmentMetadataImpl.java
@@ -278,6 +278,11 @@ public class SegmentMetadataImpl implements SegmentMetadata {
   }
 
   @Override
+  public void setName(String segmentName) {
+    _segmentName = segmentName;
+  }
+
+  @Override
   public String getTimeColumn() {
     return _timeColumn;
   }


### PR DESCRIPTION
## Description
Allow uploading a segment with a different name from HTTP header

Sample request for batch quickstarts:
```
curl -X POST -H 'Pinot-Table-Name:baseballStats'  -H 'DOWNLOAD_URI:http://192.168.1.110:9000/segments/baseballStats/baseballStats_OFFLINE_0' -H 'UPLOAD_TYPE:METADATA'  -H "Pinot-Segment-Name:baseballStats_OFFLINE_1" -F baseballStats_OFFLINE_1=@examples/batch/baseballStats/segments/baseballStats_OFFLINE_0.tar.gz localhost:9000/segments
```
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
