### PR TITLE
Enable maven checkstyle plugins by default for all new pinot components and fix pinot-spi styling

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -26,9 +26,16 @@
 <module name="Checker">
   <property name="severity" value="${checkstyle.severity}" default="warning"/>
 
-  <module name="TreeWalker">
-    <module name="FileContentsHolder"/>
+  <!-- LENGTHS -->
 
+  <!-- Desired line length is 120 but allow some overrun beyond that -->
+  <module name="LineLength">
+    <property name="max" value="160"/>
+    <message key="maxLineLen"
+             value="Line is longer than {0,number,integer} characters (found {1,number,integer}). Try to keep lines under 120 characters."/>
+  </module>
+
+  <module name="TreeWalker">
     <!-- ANNOTATIONS -->
 
     <!-- No trailing empty parenthesis or commas -->
@@ -149,15 +156,6 @@
     <!-- Type names must be camel case starting with an uppercase letter -->
     <module name="TypeName"/>
 
-    <!-- LENGTHS -->
-
-    <!-- Desired line length is 120 but allow some overrun beyond that -->
-    <module name="LineLength">
-      <property name="max" value="160"/>
-      <message key="maxLineLen"
-               value="Line is longer than {0,number,integer} characters (found {1,number,integer}). Try to keep lines under 120 characters."/>
-    </module>
-
     <!-- WHITESPACE -->
 
     <module name="GenericWhitespace"/>
@@ -179,6 +177,11 @@
       <property name="format" value="[\s]+arg[\d]+[,\)]"/>
       <property name="message" value="Replace argN with a meaningful parameter name"/>
     </module>
+
+    <!-- Allow Checkstyle warnings to be suppressed using trailing comments -->
+    <module name="SuppressWithNearbyCommentFilter"/>
+    <!-- Allow Checkstyle warnings to be suppressed using block comments -->
+    <module name="SuppressionCommentFilter"/>
   </module>
 
   <!-- Do not allow tab characters in source files -->
@@ -204,8 +207,4 @@
   <module name="SuppressionFilter">
     <property name="file" value="${config_loc}/suppressions.xml"/>
   </module>
-  <!-- Allow Checkstyle warnings to be suppressed using trailing comments -->
-  <module name="SuppressWithNearbyCommentFilter"/>
-  <!-- Allow Checkstyle warnings to be suppressed using block comments -->
-  <module name="SuppressionCommentFilter"/>
 </module>

--- a/pinot-broker/pom.xml
+++ b/pinot-broker/pom.xml
@@ -33,6 +33,9 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <build>
     <plugins>

--- a/pinot-clients/pinot-java-client/pom.xml
+++ b/pinot-clients/pinot-java-client/pom.xml
@@ -33,6 +33,9 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../..</pinot.root>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <build>
     <plugins>

--- a/pinot-clients/pinot-jdbc-client/pom.xml
+++ b/pinot-clients/pinot-jdbc-client/pom.xml
@@ -33,6 +33,9 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../..</pinot.root>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <build>
     <plugins>

--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -33,6 +33,9 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <build>
     <!-- Antlr stuff -->

--- a/pinot-connectors/pinot-spark-connector/pom.xml
+++ b/pinot-connectors/pinot-spark-connector/pom.xml
@@ -39,6 +39,9 @@
         <jackson.module.scala.version>2.10.0</jackson.module.scala.version>
         <scalaxml.version>1.3.0</scalaxml.version>
         <scalatest.version>3.1.1</scalatest.version>
+
+        <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+        <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
     </properties>
 
     <profiles>

--- a/pinot-controller/pom.xml
+++ b/pinot-controller/pom.xml
@@ -33,6 +33,9 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -33,6 +33,9 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <build>
     <plugins>

--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -35,6 +35,9 @@
     <pinot.root>${basedir}/..</pinot.root>
     <localstack-utils.version>0.2.11</localstack-utils.version>
     <awaitility.version>3.0.0</awaitility.version>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <build>
     <plugins>

--- a/pinot-minion/pom.xml
+++ b/pinot-minion/pom.xml
@@ -33,6 +33,9 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <build>
     <plugins>

--- a/pinot-perf/pom.xml
+++ b/pinot-perf/pom.xml
@@ -33,6 +33,9 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/pom.xml
@@ -36,5 +36,8 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>none</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
 </project>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/pom.xml
@@ -37,6 +37,9 @@
     <pinot.root>${basedir}/../../..</pinot.root>
     <hadoop.version>2.7.0</hadoop.version>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/pom.xml
@@ -36,6 +36,9 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
 
   <dependencies>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/pom.xml
@@ -36,6 +36,9 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/pom.xml
@@ -34,6 +34,9 @@
   <properties>
     <pinot.root>${basedir}/../../../..</pinot.root>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <profiles>
     <profile>

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-ingestion-common/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-ingestion-common/pom.xml
@@ -36,6 +36,9 @@
   <properties>
     <pinot.root>${basedir}/../../../..</pinot.root>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
 
   <dependencies>

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-spark/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-spark/pom.xml
@@ -38,6 +38,9 @@
     <scala.version>2.11.11</scala.version>
     <hadoop.version>2.8.3</hadoop.version>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <profiles>
     <profile>

--- a/pinot-plugins/pinot-environment/pom.xml
+++ b/pinot-plugins/pinot-environment/pom.xml
@@ -37,6 +37,9 @@
   <properties>
     <pinot.root>${basedir}/../..</pinot.root>
     <plugin.type>pinot-environment</plugin.type>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
 
   <modules>

--- a/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
@@ -34,6 +34,9 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-file-system/pinot-gcs/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/pom.xml
@@ -36,6 +36,9 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-file-system/pinot-hdfs/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/pom.xml
@@ -34,6 +34,9 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
@@ -42,6 +42,9 @@
     <s3mock.version>2.1.19</s3mock.version>
     <javax.version>3.1.0</javax.version>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
 
   <dependencyManagement>

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/pom.xml
@@ -35,6 +35,9 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-input-format/pinot-avro/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-avro/pom.xml
@@ -35,6 +35,9 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-input-format/pinot-confluent-avro/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-confluent-avro/pom.xml
@@ -37,6 +37,9 @@
     <kafka.lib.version>2.0.0</kafka.lib.version>
     <confluent.version>5.3.1</confluent.version>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <repositories>
     <repository>

--- a/pinot-plugins/pinot-input-format/pinot-csv/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-csv/pom.xml
@@ -35,6 +35,9 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-input-format/pinot-json/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-json/pom.xml
@@ -35,6 +35,9 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
@@ -36,6 +36,9 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
@@ -35,6 +35,9 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/pom.xml
@@ -37,6 +37,9 @@
     <pinot.root>${basedir}/../../..</pinot.root>
     <proto.version>3.11.4</proto.version>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-input-format/pinot-thrift/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-thrift/pom.xml
@@ -35,6 +35,9 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-metrics/pinot-dropwizard/pom.xml
+++ b/pinot-plugins/pinot-metrics/pinot-dropwizard/pom.xml
@@ -35,6 +35,9 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
 
   <build>

--- a/pinot-plugins/pinot-metrics/pinot-yammer/pom.xml
+++ b/pinot-plugins/pinot-metrics/pinot-yammer/pom.xml
@@ -35,6 +35,9 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
 
   <build>

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/pom.xml
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/pom.xml
@@ -35,6 +35,9 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>none</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
 
   <build>

--- a/pinot-plugins/pinot-segment-uploader/pom.xml
+++ b/pinot-plugins/pinot-segment-uploader/pom.xml
@@ -36,6 +36,9 @@
   <properties>
     <pinot.root>${basedir}/../..</pinot.root>
     <plugin.type>pinot-segment-uploader</plugin.type>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
 
   <modules>

--- a/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/pom.xml
+++ b/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/pom.xml
@@ -36,6 +36,9 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>none</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
 
   <dependencies>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/pom.xml
@@ -38,6 +38,9 @@
     <kafka.lib.version>0.9.0.1</kafka.lib.version>
     <kafka.scala.version>2.10</kafka.scala.version>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
 
   <dependencies>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/pom.xml
@@ -37,6 +37,9 @@
     <pinot.root>${basedir}/../../..</pinot.root>
     <kafka.lib.version>2.0.0</kafka.lib.version>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
 
   <dependencies>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/pom.xml
@@ -36,6 +36,9 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>package</phase.prop>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
@@ -39,6 +39,9 @@
     <aws.version>2.14.28</aws.version>
     <easymock.version>4.2</easymock.version>
     <reactive.version>1.0.2</reactive.version>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
 
   <dependencyManagement>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/pom.xml
@@ -56,6 +56,9 @@
     <grpc-protobuf-lite.version>1.19.0</grpc-protobuf-lite.version>
     <swagger-annotations.version>1.5.21</swagger-annotations.version>
     <okio.version>1.6.0</okio.version>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
 
   <dependencies>

--- a/pinot-segment-local/pom.xml
+++ b/pinot-segment-local/pom.xml
@@ -34,6 +34,9 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
 
   <build>

--- a/pinot-segment-spi/pom.xml
+++ b/pinot-segment-spi/pom.xml
@@ -34,6 +34,9 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
 
   <build>

--- a/pinot-server/pom.xml
+++ b/pinot-server/pom.xml
@@ -33,6 +33,9 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -33,6 +33,9 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <build>
     <plugins>

--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -33,9 +33,6 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
-
-    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
-    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <build>
     <plugins>

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/annotations/InterfaceStability.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/annotations/InterfaceStability.java
@@ -40,7 +40,7 @@ import java.lang.annotation.Documented;
  *              Deprecate the method(s) first and remove the method in a major release.</li>
  *         <li> Similar to earlier point, method signature cannot change.</li>
  *         <li> New methods cannot be added to interfaces without providing default implementation for minor version
- *              releases.</li></ul>
+ *              releases.</li>
  *       </ul>
  *    </li>
  * </ul>

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/annotations/metrics/PinotMetricsFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/annotations/metrics/PinotMetricsFactory.java
@@ -25,6 +25,7 @@ import org.apache.pinot.spi.metrics.PinotJmxReporter;
 import org.apache.pinot.spi.metrics.PinotMetricName;
 import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
 
+
 /**
  * Factory for generating objects of Pinot metrics.
  */

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/ConfigUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/ConfigUtils.java
@@ -29,6 +29,9 @@ import org.apache.pinot.spi.utils.JsonUtils;
 
 
 public class ConfigUtils {
+  private ConfigUtils() {
+  }
+
   private static final Map<String, String> ENVIRONMENT_VARIABLES = System.getenv();
 
   /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/Instance.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/Instance.java
@@ -44,8 +44,8 @@ import org.apache.pinot.spi.config.BaseJsonConfig;
  * </pre>
  */
 public class Instance extends BaseJsonConfig {
-  public static int NOT_SET_GRPC_PORT_VALUE = -1;
-  public static int NOT_SET_ADMIN_PORT_VALUE = -1;
+  public static final int NOT_SET_GRPC_PORT_VALUE = -1;
+  public static final int NOT_SET_ADMIN_PORT_VALUE = -1;
 
   private final String _host;
   private final int _port;
@@ -61,8 +61,7 @@ public class Instance extends BaseJsonConfig {
       @JsonProperty(value = "port", required = true) int port,
       @JsonProperty(value = "type", required = true) InstanceType type,
       @JsonProperty("tags") @Nullable List<String> tags, @JsonProperty("pools") @Nullable Map<String, Integer> pools,
-      @JsonProperty("grpcPort") int grpcPort,
-      @JsonProperty("adminPort") int adminPort,
+      @JsonProperty("grpcPort") int grpcPort, @JsonProperty("adminPort") int adminPort,
       @JsonProperty("queriesDisabled") boolean queriesDisabled) {
     Preconditions.checkArgument(host != null, "'host' must be configured");
     Preconditions.checkArgument(type != null, "'type' must be configured");

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/CompletionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/CompletionConfig.java
@@ -30,7 +30,9 @@ import org.apache.pinot.spi.config.BaseJsonConfig;
  */
 public class CompletionConfig extends BaseJsonConfig {
 
-  @JsonPropertyDescription("Mode to use when completing segment. DEFAULT for default strategy (build segment if segment is equivalent to the committed segment, else download). DOWNLOAD for always download the segment, never build.")
+  @JsonPropertyDescription(
+      "Mode to use when completing segment. DEFAULT for default strategy (build segment if segment is equivalent to the"
+          + " committed segment, else download). DOWNLOAD for always download the segment, never build.")
   private final String _completionMode;
 
   @JsonCreator

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -27,26 +27,26 @@ import org.apache.pinot.spi.config.BaseJsonConfig;
 
 
 public class FieldConfig extends BaseJsonConfig {
+  public static final String BLOOM_FILTER_COLUMN_KEY = "createBloomFilter";
+  public static final String ON_HEAP_DICTIONARY_COLUMN_KEY = "useOnHeapDictionary";
+  public static final String VAR_LENGTH_DICTIONARY_COLUMN_KEY = "useVarLengthDictionary";
+  public static final String DERIVE_NUM_DOCS_PER_CHUNK_RAW_INDEX_KEY = "deriveNumDocsPerChunkForRawIndex";
+  public static final String RAW_INDEX_WRITER_VERSION = "rawIndexWriterVersion";
+
+  public static final String TEXT_INDEX_REALTIME_READER_REFRESH_KEY = "textIndexRealtimeReaderRefreshThreshold";
+  // Lucene creates a query result cache if this option is enabled
+  // the cache improves performance of repeatable queries
+  public static final String TEXT_INDEX_ENABLE_QUERY_CACHE = "enableQueryCacheForTextIndex";
+  public static final String TEXT_INDEX_USE_AND_FOR_MULTI_TERM_QUERIES = "useANDForMultiTermTextIndexQueries";
+  public static final String TEXT_INDEX_NO_RAW_DATA = "noRawDataForTextIndex";
+  public static final String TEXT_INDEX_RAW_VALUE = "rawValueForTextIndex";
+  public static final String TEXT_INDEX_DEFAULT_RAW_VALUE = "n";
+
   private final String _name;
   private final EncodingType _encodingType;
   private final IndexType _indexType;
   private final CompressionCodec _compressionCodec;
   private final Map<String, String> _properties;
-
-  public static String BLOOM_FILTER_COLUMN_KEY = "createBloomFilter";
-  public static String ON_HEAP_DICTIONARY_COLUMN_KEY = "useOnHeapDictionary";
-  public static String VAR_LENGTH_DICTIONARY_COLUMN_KEY = "useVarLengthDictionary";
-  public static String DERIVE_NUM_DOCS_PER_CHUNK_RAW_INDEX_KEY = "deriveNumDocsPerChunkForRawIndex";
-  public static String RAW_INDEX_WRITER_VERSION = "rawIndexWriterVersion";
-
-  public static String TEXT_INDEX_REALTIME_READER_REFRESH_KEY = "textIndexRealtimeReaderRefreshThreshold";
-  // Lucene creates a query result cache if this option is enabled
-  // the cache improves performance of repeatable queries
-  public static String TEXT_INDEX_ENABLE_QUERY_CACHE = "enableQueryCacheForTextIndex";
-  public static String TEXT_INDEX_USE_AND_FOR_MULTI_TERM_QUERIES = "useANDForMultiTermTextIndexQueries";
-  public static String TEXT_INDEX_NO_RAW_DATA = "noRawDataForTextIndex";
-  public static String TEXT_INDEX_RAW_VALUE = "rawValueForTextIndex";
-  public static String TEXT_INDEX_DEFAULT_RAW_VALUE = "n";
 
   @JsonCreator
   public FieldConfig(@JsonProperty(value = "name", required = true) String name,

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -44,8 +44,7 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   private String _crypterClassName;
   // Possible values can be http or https. If this field is set, a Pinot server can download segments from peer servers
   // using the specified download scheme. Both realtime tables and offline tables can set this field.
-  // For more usage of this field, please refer to this design doc:
-  // https://cwiki.apache.org/confluence/display/PINOT/By-passing+deep-store+requirement+for+Realtime+segment+completion#By-passingdeep-storerequirementforRealtimesegmentcompletion-EnablebesteffortsegmentuploadinSplitSegmentCommiteranddownloadsegmentfrompeerservers.
+  // For more usage of this field, please refer to this design doc: https://tinyurl.com/f63ru4sb
   private String _peerSegmentDownloadScheme;
 
   // Number of replicas per partition of low-level consumers. This config is used for realtime tables only.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
@@ -113,8 +113,7 @@ public class TableConfig extends BaseJsonConfig {
       @JsonProperty(UPSERT_CONFIG_KEY) @Nullable UpsertConfig upsertConfig,
       @JsonProperty(INGESTION_CONFIG_KEY) @Nullable IngestionConfig ingestionConfig,
       @JsonProperty(TIER_CONFIGS_LIST_KEY) @Nullable List<TierConfig> tierConfigsList,
-      @JsonProperty(IS_DIM_TABLE_KEY) boolean dimTable,
-      @JsonProperty(TUNER_CONFIG) @Nullable TunerConfig tunerConfig) {
+      @JsonProperty(IS_DIM_TABLE_KEY) boolean dimTable, @JsonProperty(TUNER_CONFIG) @Nullable TunerConfig tunerConfig) {
     Preconditions.checkArgument(tableName != null, "'tableName' must be configured");
     Preconditions.checkArgument(!tableName.contains(TABLE_NAME_FORBIDDEN_SUBSTRING),
         "'tableName' cannot contain double underscore ('__')");

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableStatus.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableStatus.java
@@ -32,9 +32,7 @@ public class TableStatus {
   private IngestionStatus _ingestionStatus;
 
   public enum IngestionState {
-    HEALTHY,
-    UNHEALTHY,
-    UNKNOWN
+    HEALTHY, UNHEALTHY, UNKNOWN
   }
 
   @JsonIgnoreProperties(ignoreUnknown = true)
@@ -62,7 +60,7 @@ public class TableStatus {
   }
 
   public TableStatus(@JsonProperty("ingestionStatus") IngestionStatus ingestionStatus) {
-    _ingestionStatus =  ingestionStatus;
+    _ingestionStatus = ingestionStatus;
   }
 
   public IngestionStatus getIngestionStatus() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/assignment/InstanceAssignmentConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/assignment/InstanceAssignmentConfig.java
@@ -31,10 +31,12 @@ public class InstanceAssignmentConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Configuration for the instance tag and pool of the instance assignment (mandatory)")
   private final InstanceTagPoolConfig _tagPoolConfig;
 
-  @JsonPropertyDescription("Configuration for the instance constraints of the instance assignment, which filters out unqualified instances and sorts instances for picking priority")
+  @JsonPropertyDescription("Configuration for the instance constraints of the instance assignment,"
+      + " which filters out unqualified instances and sorts instances for picking priority")
   private final InstanceConstraintConfig _constraintConfig;
 
-  @JsonPropertyDescription("Configuration for the instance replica-group and partition of the instance assignment (mandatory)")
+  @JsonPropertyDescription(
+      "Configuration for the instance replica-group and partition of the instance assignment (mandatory)")
   private final InstanceReplicaGroupPartitionConfig _replicaGroupPartitionConfig;
 
   @JsonCreator

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/assignment/InstanceReplicaGroupPartitionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/assignment/InstanceReplicaGroupPartitionConfig.java
@@ -41,7 +41,8 @@ public class InstanceReplicaGroupPartitionConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Number of partitions for replica-group based selection, do not partition the replica-group (1 partition) if not specified")
   private final int _numPartitions;
 
-  @JsonPropertyDescription("Number of instances per partition (within a replica-group) for replica-group based selection, select all instances if not specified")
+  @JsonPropertyDescription(
+      "Number of instances per partition (within a replica-group) for replica-group based selection, select all instances if not specified")
   private final int _numInstancesPerPartition;
 
   @JsonCreator

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/TransformConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/TransformConfig.java
@@ -36,7 +36,8 @@ public class TransformConfig extends BaseJsonConfig {
   private final String _transformFunction;
 
   @JsonCreator
-  public TransformConfig(@JsonProperty("columnName") String columnName, @JsonProperty("transformFunction") String transformFunction) {
+  public TransformConfig(@JsonProperty("columnName") String columnName,
+      @JsonProperty("transformFunction") String transformFunction) {
     _columnName = columnName;
     _transformFunction = transformFunction;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/crypt/PinotCrypterFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/crypt/PinotCrypterFactory.java
@@ -58,7 +58,7 @@ public class PinotCrypterFactory {
     }
     for (String scheme : schemes) {
       String className = schemesConfig.getProperty(scheme);
-      
+
       LOGGER.info("Got crypter class name {}, full crypter path {}, starting to initialize", scheme, className);
 
       try {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -479,6 +479,7 @@ public final class Schema implements Serializable {
             default:
               throw new IllegalStateException("Unsupported data type: " + dataType + " in COMPLEX field: " + fieldName);
           }
+          break;
         default:
           throw new IllegalStateException("Unsupported data type: " + dataType + " for field: " + fieldName);
       }
@@ -772,7 +773,6 @@ public final class Schema implements Serializable {
 
     String innerFunction = incomingName;
     switch (incomingTimeUnit) {
-
       case MILLISECONDS:
         // do nothing
         break;
@@ -804,11 +804,12 @@ public final class Schema implements Serializable {
           innerFunction = String.format("fromEpochDays(%s)", incomingName);
         }
         break;
+      default:
+        throw new IllegalStateException("Unsupported incomingTimeUnit - " + incomingTimeUnit);
     }
 
     String outerFunction = innerFunction;
     switch (outgoingTimeUnit) {
-
       case MILLISECONDS:
         break;
       case SECONDS:
@@ -839,6 +840,8 @@ public final class Schema implements Serializable {
           outerFunction = String.format("toEpochDays(%s)", innerFunction);
         }
         break;
+      default:
+        throw new IllegalStateException("Unsupported outgoingTimeUnit - " + outgoingTimeUnit);
     }
     return outerFunction;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/SchemaValidatorFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/SchemaValidatorFactory.java
@@ -38,7 +38,8 @@ public class SchemaValidatorFactory {
   //TODO: support schema validation for more data formats like ORC.
 
   static {
-    DEFAULT_RECORD_READER_TO_SCHEMA_VALIDATOR_MAP.put(DEFAULT_AVRO_RECORD_READER_CLASS, DEFAULT_AVRO_SCHEMA_VALIDATOR_CLASS);
+    DEFAULT_RECORD_READER_TO_SCHEMA_VALIDATOR_MAP
+        .put(DEFAULT_AVRO_RECORD_READER_CLASS, DEFAULT_AVRO_SCHEMA_VALIDATOR_CLASS);
   }
 
   /**
@@ -47,7 +48,8 @@ public class SchemaValidatorFactory {
    * @param recordReaderClassName record reader class name
    * @param inputFilePath local input file path
    */
-  public static IngestionSchemaValidator getSchemaValidator(Schema pinotSchema, String recordReaderClassName, String inputFilePath)
+  public static IngestionSchemaValidator getSchemaValidator(Schema pinotSchema, String recordReaderClassName,
+      String inputFilePath)
       throws Exception {
     String schemaValidatorClassName = DEFAULT_RECORD_READER_TO_SCHEMA_VALIDATOR_MAP.get(recordReaderClassName);
     if (schemaValidatorClassName == null) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/TimeFieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/TimeFieldSpec.java
@@ -25,6 +25,7 @@ import com.google.common.base.Preconditions;
 import org.apache.pinot.spi.utils.EqualityUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
 
+
 /**
  * @deprecated Use {@link DateTimeFieldSpec} instead.
  * This should only be used in 1) tests 2) wherever required for backward compatible handling of schemas with TimeFieldSpec

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
@@ -56,8 +56,9 @@ public class GenericRow implements Serializable {
 
   /**
    * This key is used by a Decoder/RecordReader to handle 1 record to many records flattening.
-   * If a Decoder/RecordReader produces multiple GenericRows from the given record, they must be put into the destination GenericRow as a List<GenericRow> with this key
-   * The segment generation drivers handle this key as a special case and process the multiple records
+   * If a Decoder/RecordReader produces multiple GenericRows from the given record, they must be put into the
+   * destination GenericRow as a List<GenericRow> with this key.
+   * The segment generation drivers handle this key as a special case and process the multiple records.
    */
   public static final String MULTIPLE_RECORDS_KEY = "$MULTIPLE_RECORDS_KEY$";
   /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderFactory.java
@@ -38,20 +38,16 @@ public class RecordReaderFactory {
   private static final Map<String, String> DEFAULT_RECORD_READER_CONFIG_CLASS_MAP = new HashMap<>();
 
   // TODO: This could be removed once we have dynamic loading plugins supports.
-  static final String DEFAULT_AVRO_RECORD_READER_CLASS =
-      "org.apache.pinot.plugin.inputformat.avro.AvroRecordReader";
-  static final String DEFAULT_CSV_RECORD_READER_CLASS =
-      "org.apache.pinot.plugin.inputformat.csv.CSVRecordReader";
+  static final String DEFAULT_AVRO_RECORD_READER_CLASS = "org.apache.pinot.plugin.inputformat.avro.AvroRecordReader";
+  static final String DEFAULT_CSV_RECORD_READER_CLASS = "org.apache.pinot.plugin.inputformat.csv.CSVRecordReader";
   static final String DEFAULT_CSV_RECORD_READER_CONFIG_CLASS =
       "org.apache.pinot.plugin.inputformat.csv.CSVRecordReaderConfig";
-  static final String DEFAULT_JSON_RECORD_READER_CLASS =
-      "org.apache.pinot.plugin.inputformat.json.JSONRecordReader";
+  static final String DEFAULT_JSON_RECORD_READER_CLASS = "org.apache.pinot.plugin.inputformat.json.JSONRecordReader";
   static final String DEFAULT_THRIFT_RECORD_READER_CLASS =
       "org.apache.pinot.plugin.inputformat.thrift.ThriftRecordReader";
   static final String DEFAULT_THRIFT_RECORD_READER_CONFIG_CLASS =
       "org.apache.pinot.plugin.inputformat.thrift.ThriftRecordReaderConfig";
-  static final String DEFAULT_ORC_RECORD_READER_CLASS =
-      "org.apache.pinot.plugin.inputformat.orc.ORCRecordReader";
+  static final String DEFAULT_ORC_RECORD_READER_CLASS = "org.apache.pinot.plugin.inputformat.orc.ORCRecordReader";
   static final String DEFAULT_PARQUET_RECORD_READER_CLASS =
       "org.apache.pinot.plugin.inputformat.parquet.ParquetRecordReader";
   static final String DEFAULT_PARQUET_RECORD_READER_CONFIG_CLASS =

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/Environment.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/Environment.java
@@ -20,6 +20,7 @@ package org.apache.pinot.spi.env;
 
 import java.util.Map;
 
+
 public interface Environment {
   Map<String, String> getEnvironmentVariables();
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
@@ -41,7 +41,7 @@ import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
  * <p>
  * Pinot services may retreived configurations from PinotConfiguration independently from any source of configuration. 
  * {@link PinotConfiguration} currently supports configuration loaded from the following sources :
- * 
+ *
  * <ul>
  * <li>Apache Commons {@link Configuration} (see {@link #PinotConfiguration(Configuration)})</li>
  * <li>Generic key-value properties provided with a {@link Map} (see {@link PinotConfiguration#PinotConfiguration(Map)}</li>
@@ -80,7 +80,7 @@ import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
 public class PinotConfiguration {
   public static final String CONFIG_PATHS_KEY = "config.paths";
 
-  private final CompositeConfiguration configuration;
+  private final CompositeConfiguration _configuration;
 
   /**
    * Creates an empty instance.
@@ -92,17 +92,17 @@ public class PinotConfiguration {
   /**
    * Builds a new instance out of an existing Apache Commons {@link Configuration} instance. Will apply property key sanitization to enable relaxed binding.
    * Properties from the base configuration will be copied and won't be linked.
-   * 
+   *
    * @param baseConfiguration an existing {@link Configuration} for which all properties will be duplicated and sanitized for relaxed binding. 
    */
   public PinotConfiguration(Configuration baseConfiguration) {
-    this.configuration =
+    _configuration =
         new CompositeConfiguration(computeConfigurationsFromSources(baseConfiguration, new HashMap<>()));
   }
 
   /**
    * Creates a new instance with existing properties provided through a map.
-   * 
+   *
    * @param baseProperties to provide programmatically through a {@link Map}.
    */
   public PinotConfiguration(Map<String, Object> baseProperties) {
@@ -113,25 +113,24 @@ public class PinotConfiguration {
    * Creates a new instance with existing properties provided through a map as well as environment variables. 
    * Base properties will have priority offers properties defined in environment variables. Keys will be 
    * sanitized for relaxed binding. See {@link PinotConfiguration} for further details. 
-   * 
+   *
    * @param baseProperties with highest precedences (e.g. CLI arguments)
    * @param environmentVariables as a {@link Map}. Can be provided with {@link SystemEnvironment}
    */
   public PinotConfiguration(Map<String, Object> baseProperties, Map<String, String> environmentVariables) {
-    this.configuration =
+    _configuration =
         new CompositeConfiguration(computeConfigurationsFromSources(baseProperties, environmentVariables));
   }
 
   /**
    * Helper constructor to create an instance from configurations found in a PinotFSSpec instance. 
    * Intended for use by Job Runners
-   * 
+   *
    * @param pinotFSSpec
    */
   public PinotConfiguration(PinotFSSpec pinotFSSpec) {
-    this(Optional.ofNullable(pinotFSSpec.getConfigs())
-        .map(configs -> configs.entrySet().stream().collect(
-            Collectors.<Entry<String, String>, String, Object> toMap(Entry::getKey, entry -> entry.getValue())))
+    this(Optional.ofNullable(pinotFSSpec.getConfigs()).map(configs -> configs.entrySet().stream()
+        .collect(Collectors.<Entry<String, String>, String, Object>toMap(Entry::getKey, entry -> entry.getValue())))
         .orElseGet(() -> new HashMap<>()));
   }
 
@@ -219,24 +218,24 @@ public class PinotConfiguration {
 
   /**
    * Overwrites a property value in memory.
-   * 
+   *
    * @param name of the property to append in memory. Applies relaxed binding on the property name.
    * @param value to overwrite in memory
-   * 
+   *
    * @deprecated Configurations should be immutable. Prefer creating a new {@link #PinotConfiguration} with base properties to overwrite properties.
    */
   public void addProperty(String name, Object value) {
-    configuration.addProperty(relaxPropertyName(name), value);
+    _configuration.addProperty(relaxPropertyName(name), value);
   }
 
   /**
    * Creates a new instance of {@link PinotConfiguration} by closing the underlying {@link CompositeConfiguration}. 
    * Useful to mutate configurations {@link PinotConfiguration} without impacting the original configurations.
-   * 
+   *
    *  @return a new {@link PinotConfiguration} instance with a cloned {@link CompositeConfiguration}.
    */
   public PinotConfiguration clone() {
-    return new PinotConfiguration(configuration);
+    return new PinotConfiguration(_configuration);
   }
 
   /**
@@ -245,31 +244,31 @@ public class PinotConfiguration {
    * @return true if key exists.
    */
   public boolean containsKey(String key) {
-    return configuration.containsKey(relaxPropertyName(key));
+    return _configuration.containsKey(relaxPropertyName(key));
   }
 
   /**
    * @return all the sanitized keys defined in the underlying {@link CompositeConfiguration}.
    */
   public List<String> getKeys() {
-    return CommonsConfigurationUtils.getKeys(configuration);
+    return CommonsConfigurationUtils.getKeys(_configuration);
   }
 
   /**
    * Retrieves a String value with the given property name. See {@link PinotConfiguration} for supported key naming conventions.
-   * 
+   *
    * If multiple properties exists with the same key, all values will be joined as a comma separated String.
-   * 
+   *
    * @param name of the property to retrieve a value. Property name will be sanitized. 
    * @return the property String value. Null if missing.
    */
   public String getProperty(String name) {
-    return getProperty(name, configuration);
+    return getProperty(name, _configuration);
   }
 
   /**
    * Retrieves a boolean value with the given property name. See {@link PinotConfiguration} for supported key naming conventions.
-   * 
+   *
    * @param name of the property to retrieve a value. Property name will be sanitized. 
    * @return the property boolean value. Fallback to default value if missing.
    */
@@ -279,7 +278,7 @@ public class PinotConfiguration {
 
   /**
    * Retrieves a typed value with the given property name. See {@link PinotConfiguration} for supported key naming conventions.
-   * 
+   *
    * @param name of the property to retrieve a value. Property name will be sanitized.
    * @param returnType a class reference of the value type.
    * @return the typed configuration value. Null if missing. 
@@ -290,7 +289,7 @@ public class PinotConfiguration {
 
   /**
    * Retrieves a double value with the given property name. See {@link PinotConfiguration} for supported key naming conventions.
-   * 
+   *
    * @param name of the property to retrieve a value. Property name will be sanitized. 
    * @return the property double value. Fallback to default value if missing.
    */
@@ -300,7 +299,7 @@ public class PinotConfiguration {
 
   /**
    * Retrieves a integer value with the given property name. See {@link PinotConfiguration} for supported key naming conventions.
-   * 
+   *
    * @param name of the property to retrieve a value. Property name will be sanitized. 
    * @return the property integer value. Fallback to default value if missing.
    */
@@ -310,19 +309,19 @@ public class PinotConfiguration {
 
   /**
    * Retrieves a list of String values with the given property name. See {@link PinotConfiguration} for supported key naming conventions.
-   * 
+   *
    * @param name of the property to retrieve a list of values. Property name will be sanitized. 
    * @return the property String value. Fallback to the provided default values if no property is found.
    */
   public List<String> getProperty(String name, List<String> defaultValues) {
     return Optional
-        .of(Arrays.stream(configuration.getStringArray(relaxPropertyName(name))).collect(Collectors.toList()))
+        .of(Arrays.stream(_configuration.getStringArray(relaxPropertyName(name))).collect(Collectors.toList()))
         .filter(list -> !list.isEmpty()).orElse(defaultValues);
   }
 
   /**
    * Retrieves a long value with the given property name. See {@link PinotConfiguration} for supported key naming conventions.
-   * 
+   *
    * @param name of the property to retrieve a value. Property name will be sanitized. 
    * @return the property long value. Fallback to default value if missing.
    */
@@ -332,7 +331,7 @@ public class PinotConfiguration {
 
   /**
    * Retrieves a String value with the given property name. See {@link PinotConfiguration} for supported key naming conventions.
-   * 
+   *
    * @param name of the property to retrieve a value. Property name will be sanitized. 
    * @return the property String value. Fallback to default value if missing.
    */
@@ -342,7 +341,7 @@ public class PinotConfiguration {
 
   private <T> T getProperty(String name, T defaultValue, Class<T> returnType) {
     String relaxedPropertyName = relaxPropertyName(name);
-    if (!configuration.containsKey(relaxedPropertyName)) {
+    if (!_configuration.containsKey(relaxedPropertyName)) {
       return defaultValue;
     }
 
@@ -351,9 +350,9 @@ public class PinotConfiguration {
 
   /**
    * Returns the raw object stored within the underlying {@link CompositeConfiguration}. 
-   * 
+   *
    * See {@link PinotConfiguration} for supported key naming conventions.
-   * 
+   *
    * @param name of the property to retrieve a raw object value. Property name will be sanitized.
    * @return the object referenced. Null if key is not found.
    */
@@ -363,19 +362,19 @@ public class PinotConfiguration {
 
   /**
    * Returns the raw object stored within the underlying {@link CompositeConfiguration}. 
-   * 
+   *
    * See {@link PinotConfiguration} for supported key naming conventions.
-   * 
+   *
    * @param name of the property to retrieve a raw object value. Property name will be sanitized.
    * @return the object referenced. Fallback to provided default value if key is not found.
    */
   public Object getRawProperty(String name, Object defaultValue) {
     String relaxedPropertyName = relaxPropertyName(name);
-    if (!configuration.containsKey(relaxedPropertyName)) {
+    if (!_configuration.containsKey(relaxedPropertyName)) {
       return defaultValue;
     }
 
-    return configuration.getProperty(relaxedPropertyName);
+    return _configuration.getProperty(relaxedPropertyName);
   }
 
   /**
@@ -387,9 +386,8 @@ public class PinotConfiguration {
    * @deprecated Configurations should be immutable. Prefer creating a new {@link #PinotConfiguration} with base properties to overwrite properties.
    */
   public void setProperty(String name, Object value) {
-    configuration.setProperty(relaxPropertyName(name), value);
+    _configuration.setProperty(relaxPropertyName(name), value);
   }
-
 
   /**
    * Delete a property value in memory.
@@ -397,7 +395,7 @@ public class PinotConfiguration {
    * @param name of the property to remove in memory. Applies relaxed binding on the property name.
    */
   public void clearProperty(String name) {
-    configuration.clearProperty(relaxPropertyName(name));
+    _configuration.clearProperty(relaxPropertyName(name));
   }
 
   /**
@@ -406,22 +404,22 @@ public class PinotConfiguration {
    * Changes made on the source {@link PinotConfiguration} will not be available in the subset instance
    * since properties are copied.
    * </p>
-   * 
+   *
    * <p>
    * The prefix is removed from the keys in the subset. See {@link Configuration#subset(String)} for further details.
    * </p>
-   * 
+   *
    * @param prefix of the properties to copy. Applies relaxed binding on the properties prefix.
    * @return a new {@link PinotConfiguration} instance with 
    */
   public PinotConfiguration subset(String prefix) {
-    return new PinotConfiguration(configuration.subset(relaxPropertyName(prefix)));
+    return new PinotConfiguration(_configuration.subset(relaxPropertyName(prefix)));
   }
 
   /**
    * @return a key-value {@link Map} found in the underlying {@link CompositeConfiguration}
    */
   public Map<String, Object> toMap() {
-    return CommonsConfigurationUtils.toMap(configuration);
+    return CommonsConfigurationUtils.toMap(_configuration);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProvider.java
@@ -21,6 +21,7 @@ package org.apache.pinot.spi.environmentprovider;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 
+
 /**
  *  Environment Provider interface implemented by different cloud providers to customize
  *  the base pinot configuration to add environment variables & instance specific configuration
@@ -30,13 +31,13 @@ public interface PinotEnvironmentProvider {
   /**
    * Initializes the configurations specific to an environment provider.
    */
-   void init(PinotConfiguration pinotConfiguration);
+  void init(PinotConfiguration pinotConfiguration);
 
   /**
    * Method to retrieve failure domain information for a pinot instance.
    * @return failure domain information
    */
-   default String getFailureDomain() {
-     return CommonConstants.DEFAULT_FAILURE_DOMAIN;
-   }
+  default String getFailureDomain() {
+    return CommonConstants.DEFAULT_FAILURE_DOMAIN;
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProviderFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProviderFactory.java
@@ -26,22 +26,23 @@ import org.apache.pinot.spi.plugin.PluginManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 /**
  * This factory class initializes the PinotEnvironmentProvider class.
  * It creates a PinotEnvironment object based on the URI found.
  */
 public class PinotEnvironmentProviderFactory {
-  private final static PinotEnvironmentProviderFactory INSTANCE = new PinotEnvironmentProviderFactory();
+  private PinotEnvironmentProviderFactory() {
+  }
+
+  private static final PinotEnvironmentProviderFactory INSTANCE = new PinotEnvironmentProviderFactory();
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotEnvironmentProviderFactory.class);
 
   private static final String CLASS = "class";
-  private PinotEnvironmentProvider pinotEnvironmentProvider;
+  private PinotEnvironmentProvider _pinotEnvironmentProvider;
 
-  private PinotEnvironmentProviderFactory() {
-  }
-
-  public static PinotEnvironmentProviderFactory getInstance( ) {
+  public static PinotEnvironmentProviderFactory getInstance() {
     return INSTANCE;
   }
 
@@ -50,7 +51,7 @@ public class PinotEnvironmentProviderFactory {
   }
 
   public static PinotEnvironmentProvider getEnvironmentProvider(String environment) {
-   return getInstance().getEnvironmentProviderInternal(environment);
+    return getInstance().getEnvironmentProviderInternal(environment);
   }
 
   private void initInternal(PinotConfiguration environmentProviderFactoryConfig) {
@@ -72,18 +73,18 @@ public class PinotEnvironmentProviderFactory {
 
   // Utility to invoke the cloud specific environment provider.
   private PinotEnvironmentProvider getEnvironmentProviderInternal(String environment) {
-    Preconditions.checkState(pinotEnvironmentProvider != null,
+    Preconditions.checkState(_pinotEnvironmentProvider != null,
         "PinotEnvironmentProvider for environment: %s has not been initialized", environment);
-    return pinotEnvironmentProvider;
+    return _pinotEnvironmentProvider;
   }
 
   private void register(String environment, String environmentProviderClassName,
       PinotConfiguration environmentProviderConfiguration) {
     try {
-      LOGGER.info("Initializing PinotEnvironmentProvider for environment {}, classname {}",
-          environment, environmentProviderClassName);
-      pinotEnvironmentProvider = PluginManager.get().createInstance(environmentProviderClassName);
-      pinotEnvironmentProvider.init(environmentProviderConfiguration);
+      LOGGER.info("Initializing PinotEnvironmentProvider for environment {}, classname {}", environment,
+          environmentProviderClassName);
+      _pinotEnvironmentProvider = PluginManager.get().createInstance(environmentProviderClassName);
+      _pinotEnvironmentProvider.init(environmentProviderConfiguration);
     } catch (Exception ex) {
       LOGGER.error("Could not instantiate environment provider for class {} with environment {}",
           environmentProviderClassName, environment, ex);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/exception/EarlyTerminationException.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/exception/EarlyTerminationException.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.spi.exception;
 
-
 /**
  * The {@code EarlyTerminationException} can be thrown from {Operator#nextBlock()} when the operator is early
  * terminated (interrupted).

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
@@ -22,6 +22,9 @@ package org.apache.pinot.spi.ingestion.batch;
  * Defines all the keys used in the batch configs map
  */
 public class BatchConfigProperties {
+  private BatchConfigProperties() {
+  }
+
   public static final String TABLE_NAME = "tableName";
 
   public static final String INPUT_DIR_URI = "inputDirURI";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncher.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncher.java
@@ -42,6 +42,8 @@ import org.yaml.snakeyaml.Yaml;
 
 
 public class IngestionJobLauncher {
+  private IngestionJobLauncher() {
+  }
 
   public static final Logger LOGGER = LoggerFactory.getLogger(IngestionJobLauncher.class);
   public static final String JOB_SPEC_FORMAT = "job-spec-format";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/Constants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/Constants.java
@@ -19,6 +19,9 @@
 package org.apache.pinot.spi.ingestion.batch.spec;
 
 public class Constants {
+  private Constants() {
+  }
+
   /**
    * By default Pinot segments are compressed in 'tar.gz' format then pushed to controller.
    */

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
@@ -33,7 +33,6 @@ public class SegmentGenerationJobSpec implements Serializable {
    */
   private ExecutionFrameworkSpec _executionFrameworkSpec;
 
-
   /**
    * Supported job types are {@link org.apache.pinot.spi.ingestion.batch.IngestionJobLauncher.PinotIngestionJobType}
    */

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/TlsSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/TlsSpec.java
@@ -23,40 +23,40 @@ package org.apache.pinot.spi.ingestion.batch.spec;
  * (Enables access to TLS-protected controller APIs, etc.)
  */
 public class TlsSpec {
-  String keyStorePath;
-  String keyStorePassword;
-  String trustStorePath;
-  String trustStorePassword;
+  private String _keyStorePath;
+  private String _keyStorePassword;
+  private String _trustStorePath;
+  private String _trustStorePassword;
 
   public String getKeyStorePath() {
-    return keyStorePath;
+    return _keyStorePath;
   }
 
   public void setKeyStorePath(String keyStorePath) {
-    this.keyStorePath = keyStorePath;
+    _keyStorePath = keyStorePath;
   }
 
   public String getKeyStorePassword() {
-    return keyStorePassword;
+    return _keyStorePassword;
   }
 
   public void setKeyStorePassword(String keyStorePassword) {
-    this.keyStorePassword = keyStorePassword;
+    _keyStorePassword = keyStorePassword;
   }
 
   public String getTrustStorePath() {
-    return trustStorePath;
+    return _trustStorePath;
   }
 
   public void setTrustStorePath(String trustStorePath) {
-    this.trustStorePath = trustStorePath;
+    _trustStorePath = trustStorePath;
   }
 
   public String getTrustStorePassword() {
-    return trustStorePassword;
+    return _trustStorePassword;
   }
 
   public void setTrustStorePassword(String trustStorePassword) {
-    this.trustStorePassword = trustStorePassword;
+    _trustStorePassword = trustStorePassword;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/PinotMeter.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/PinotMeter.java
@@ -26,7 +26,6 @@ package org.apache.pinot.spi.metrics;
  */
 public interface PinotMeter extends PinotMetered {
 
-
   /**
    * Mark the occurrence of an event.
    */

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/PinotMetered.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/metrics/PinotMetered.java
@@ -20,6 +20,7 @@ package org.apache.pinot.spi.metrics;
 
 import java.util.concurrent.TimeUnit;
 
+
 /**
  * An object which maintains mean and exponentially-weighted rate in Pinot.
  */

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginClassLoader.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginClassLoader.java
@@ -30,11 +30,11 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 
 public class PluginClassLoader extends URLClassLoader {
 
-  private final ClassLoader classLoader;
+  private final ClassLoader _classLoader;
 
   public PluginClassLoader(URL[] urls, ClassLoader parent) {
     super(urls, parent);
-    classLoader = PluginClassLoader.class.getClassLoader();
+    _classLoader = PluginClassLoader.class.getClassLoader();
     for (URL url : urls) {
       try {
         /**
@@ -58,8 +58,8 @@ public class PluginClassLoader extends URLClassLoader {
     Class<?> loadedClass = findLoadedClass(name);
     if (loadedClass == null) {
       try {
-        if (classLoader != null) {
-          loadedClass = classLoader.loadClass(name);
+        if (_classLoader != null) {
+          loadedClass = _classLoader.loadClass(name);
         }
       } catch (ClassNotFoundException ex) {
         // class not found in system class loader... silently skipping
@@ -90,7 +90,7 @@ public class PluginClassLoader extends URLClassLoader {
     List<URL> allRes = new LinkedList<>();
 
     // load resources from sys class loader
-    Enumeration<URL> sysResources = classLoader.getResources(name);
+    Enumeration<URL> sysResources = _classLoader.getResources(name);
     if (sysResources != null) {
       while (sysResources.hasMoreElements()) {
         allRes.add(sysResources.nextElement());
@@ -114,16 +114,16 @@ public class PluginClassLoader extends URLClassLoader {
     }
 
     return new Enumeration<URL>() {
-      Iterator<URL> it = allRes.iterator();
+      Iterator<URL> _it = allRes.iterator();
 
       @Override
       public boolean hasMoreElements() {
-        return it.hasNext();
+        return _it.hasNext();
       }
 
       @Override
       public URL nextElement() {
-        return it.next();
+        return _it.next();
       }
     };
   }
@@ -131,8 +131,8 @@ public class PluginClassLoader extends URLClassLoader {
   @Override
   public URL getResource(String name) {
     URL res = null;
-    if (classLoader != null) {
-      res = classLoader.getResource(name);
+    if (_classLoader != null) {
+      res = _classLoader.getResource(name);
     }
     if (res == null) {
       res = findResource(name);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
@@ -44,25 +44,36 @@ public class PluginManager {
   public static final String DEFAULT_PLUGIN_NAME = "DEFAULT";
   private static final Logger LOGGER = LoggerFactory.getLogger(PluginManager.class);
   private static final String JAR_FILE_EXTENSION = "jar";
-  private static PluginManager PLUGIN_MANAGER = new PluginManager();
+  private static final PluginManager PLUGIN_MANAGER = new PluginManager();
 
   // For backward compatibility, this map holds a mapping from old plugins class name to its new class name.
-  private static final Map<String, String> PLUGINS_BACKWARD_COMPATIBLE_CLASS_NAME_MAP = new HashMap<String, String>(){
+  private static final Map<String, String> PLUGINS_BACKWARD_COMPATIBLE_CLASS_NAME_MAP = new HashMap<String, String>() {
     {
       // MessageDecoder
-      put("org.apache.pinot.core.realtime.stream.SimpleAvroMessageDecoder", "org.apache.pinot.plugin.inputformat.avro.SimpleAvroMessageDecoder");
-      put("org.apache.pinot.core.realtime.impl.kafka.KafkaAvroMessageDecoder", "org.apache.pinot.plugin.inputformat.avro.KafkaAvroMessageDecoder");
-      put("org.apache.pinot.core.realtime.impl.kafka.KafkaJSONMessageDecoder", "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder");
+      put("org.apache.pinot.core.realtime.stream.SimpleAvroMessageDecoder",
+          "org.apache.pinot.plugin.inputformat.avro.SimpleAvroMessageDecoder");
+      put("org.apache.pinot.core.realtime.impl.kafka.KafkaAvroMessageDecoder",
+          "org.apache.pinot.plugin.inputformat.avro.KafkaAvroMessageDecoder");
+      put("org.apache.pinot.core.realtime.impl.kafka.KafkaJSONMessageDecoder",
+          "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder");
 
       // RecordReader
-      put("org.apache.pinot.core.data.readers.AvroRecordReader", "org.apache.pinot.plugin.inputformat.avro.AvroRecordReader");
-      put("org.apache.pinot.core.data.readers.CSVRecordReader", "org.apache.pinot.plugin.inputformat.csv.CSVRecordReader");
-      put("org.apache.pinot.core.data.readers.JSONRecordReader", "org.apache.pinot.plugin.inputformat.json.JSONRecordReader");
-      put("org.apache.pinot.plugin.inputformat.json.JsonRecordReader", "org.apache.pinot.plugin.inputformat.json.JSONRecordReader");
-      put("org.apache.pinot.orc.data.readers.ORCRecordReader", "org.apache.pinot.plugin.inputformat.orc.ORCRecordReader");
-      put("org.apache.pinot.plugin.inputformat.orc.OrcRecordReader", "org.apache.pinot.plugin.inputformat.orc.ORCRecordReader");
-      put("org.apache.pinot.parquet.data.readers.ParquetRecordReader", "org.apache.pinot.plugin.inputformat.parquet.ParquetRecordReader");
-      put("org.apache.pinot.core.data.readers.ThriftRecordReader", "org.apache.pinot.plugin.inputformat.thrift.ThriftRecordReader");
+      put("org.apache.pinot.core.data.readers.AvroRecordReader",
+          "org.apache.pinot.plugin.inputformat.avro.AvroRecordReader");
+      put("org.apache.pinot.core.data.readers.CSVRecordReader",
+          "org.apache.pinot.plugin.inputformat.csv.CSVRecordReader");
+      put("org.apache.pinot.core.data.readers.JSONRecordReader",
+          "org.apache.pinot.plugin.inputformat.json.JSONRecordReader");
+      put("org.apache.pinot.plugin.inputformat.json.JsonRecordReader",
+          "org.apache.pinot.plugin.inputformat.json.JSONRecordReader");
+      put("org.apache.pinot.orc.data.readers.ORCRecordReader",
+          "org.apache.pinot.plugin.inputformat.orc.ORCRecordReader");
+      put("org.apache.pinot.plugin.inputformat.orc.OrcRecordReader",
+          "org.apache.pinot.plugin.inputformat.orc.ORCRecordReader");
+      put("org.apache.pinot.parquet.data.readers.ParquetRecordReader",
+          "org.apache.pinot.plugin.inputformat.parquet.ParquetRecordReader");
+      put("org.apache.pinot.core.data.readers.ThriftRecordReader",
+          "org.apache.pinot.plugin.inputformat.thrift.ThriftRecordReader");
 
       // PinotFS
       put("org.apache.pinot.filesystem.AzurePinotFS", "org.apache.pinot.plugin.filesystem.AzurePinotFS");
@@ -70,30 +81,34 @@ public class PluginManager {
       put("org.apache.pinot.filesystem.LocalPinotFS", "org.apache.pinot.spi.filesystem.LocalPinotFS");
 
       // StreamConsumerFactory
-      put("org.apache.pinot.core.realtime.impl.kafka.KafkaConsumerFactory", "org.apache.pinot.plugin.stream.kafka09.KafkaConsumerFactory");
-      put("org.apache.pinot.core.realtime.impl.kafka2.KafkaConsumerFactory", "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory");
+      put("org.apache.pinot.core.realtime.impl.kafka.KafkaConsumerFactory",
+          "org.apache.pinot.plugin.stream.kafka09.KafkaConsumerFactory");
+      put("org.apache.pinot.core.realtime.impl.kafka2.KafkaConsumerFactory",
+          "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory");
     }
   };
 
-  private static final Map<String, String> INPUT_FORMAT_TO_RECORD_READER_CLASS_NAME_MAP = new HashMap<String, String>(){
-    {
-      put("avro", "org.apache.pinot.plugin.inputformat.avro.AvroRecordReader");
-      put("csv", "org.apache.pinot.plugin.inputformat.csv.CSVRecordReader");
-      put("json", "org.apache.pinot.plugin.inputformat.json.JSONRecordReader");
-      put("orc", "org.apache.pinot.plugin.inputformat.orc.ORCRecordReader");
-      put("parquet", "org.apache.pinot.plugin.inputformat.parquet.ParquetRecordReader");
-      put("protobuf", "org.apache.pinot.plugin.inputformat.protobuf.ProtoBufRecordReader");
-      put("thrift", "org.apache.pinot.plugin.inputformat.thrift.ThriftRecordReader");
-    }
-  };
+  private static final Map<String, String> INPUT_FORMAT_TO_RECORD_READER_CLASS_NAME_MAP =
+      new HashMap<String, String>() {
+        {
+          put("avro", "org.apache.pinot.plugin.inputformat.avro.AvroRecordReader");
+          put("csv", "org.apache.pinot.plugin.inputformat.csv.CSVRecordReader");
+          put("json", "org.apache.pinot.plugin.inputformat.json.JSONRecordReader");
+          put("orc", "org.apache.pinot.plugin.inputformat.orc.ORCRecordReader");
+          put("parquet", "org.apache.pinot.plugin.inputformat.parquet.ParquetRecordReader");
+          put("protobuf", "org.apache.pinot.plugin.inputformat.protobuf.ProtoBufRecordReader");
+          put("thrift", "org.apache.pinot.plugin.inputformat.thrift.ThriftRecordReader");
+        }
+      };
 
-  private static final Map<String, String> INPUT_FORMAT_TO_RECORD_READER_CONFIG_CLASS_NAME_MAP = new HashMap<String, String>(){
-    {
-      put("csv", "org.apache.pinot.plugin.inputformat.csv.CSVRecordReaderConfig");
-      put("protobuf", "org.apache.pinot.plugin.inputformat.protobuf.ProtoBufRecordReaderConfig");
-      put("thrift", "org.apache.pinot.plugin.inputformat.thrift.ThriftRecordReaderConfig");
-    }
-  };
+  private static final Map<String, String> INPUT_FORMAT_TO_RECORD_READER_CONFIG_CLASS_NAME_MAP =
+      new HashMap<String, String>() {
+        {
+          put("csv", "org.apache.pinot.plugin.inputformat.csv.CSVRecordReaderConfig");
+          put("protobuf", "org.apache.pinot.plugin.inputformat.protobuf.ProtoBufRecordReaderConfig");
+          put("thrift", "org.apache.pinot.plugin.inputformat.thrift.ThriftRecordReaderConfig");
+        }
+      };
 
   private Map<Plugin, PluginClassLoader> _registry = new HashMap<>();
   private String _pluginsRootDir;
@@ -143,8 +158,8 @@ public class PluginManager {
       pluginsToLoad = Arrays.asList(pluginsInclude.split(","));
       LOGGER.info("Trying to load plugins: [{}]", Arrays.toString(pluginsToLoad.toArray()));
     } else {
-      LOGGER.info("Please use env variable '{}' to customize plugins to load. Loading all plugins: {}", PLUGINS_INCLUDE_PROPERTY_NAME,
-          Arrays.toString(jarFiles.toArray()));
+      LOGGER.info("Please use env variable '{}' to customize plugins to load. Loading all plugins: {}",
+          PLUGINS_INCLUDE_PROPERTY_NAME, Arrays.toString(jarFiles.toArray()));
     }
     for (File jarFile : jarFiles) {
       File pluginDir = jarFile.getParentFile();
@@ -291,7 +306,8 @@ public class PluginManager {
       throws Exception {
     PluginClassLoader pluginClassLoader = PLUGIN_MANAGER._registry.get(new Plugin(pluginName));
     try {
-      Class<T> loadedClass = (Class<T>) pluginClassLoader.loadClass(loadClassWithBackwardCompatibleCheck(className), true);
+      Class<T> loadedClass =
+          (Class<T>) pluginClassLoader.loadClass(loadClassWithBackwardCompatibleCheck(className), true);
       Constructor<?> constructor;
       constructor = loadedClass.getConstructor(argTypes);
       Object instance = constructor.newInstance(argValues);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/LongMsgOffset.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/LongMsgOffset.java
@@ -38,12 +38,12 @@ public class LongMsgOffset implements StreamPartitionMsgOffset {
   }
 
   public LongMsgOffset(StreamPartitionMsgOffset other) {
-    _offset = ((LongMsgOffset)other)._offset;
+    _offset = ((LongMsgOffset) other)._offset;
   }
 
   @Override
   public int compareTo(Object other) {
-    return Long.compare(_offset, ((LongMsgOffset)other)._offset);
+    return Long.compare(_offset, ((LongMsgOffset) other)._offset);
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/OffsetCriteria.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/OffsetCriteria.java
@@ -47,7 +47,6 @@ public class OffsetCriteria {
 
     // Consumes from the custom offset criteria */
     CUSTOM
-
   }
 
   private OffsetType _offsetType;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumer.java
@@ -37,7 +37,6 @@ public interface PartitionGroupConsumer extends Closeable {
    * milliseconds
    * @return An iterable containing messages fetched from the stream partition and their offsets
    */
-  MessageBatch fetchMessages(StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset endOffset,
-      int timeoutMs)
+  MessageBatch fetchMessages(StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset endOffset, int timeoutMs)
       throws TimeoutException;
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcher.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcher.java
@@ -39,7 +39,8 @@ public class PartitionGroupMetadataFetcher implements Callable<Boolean> {
   private Exception _exception;
   private final String _topicName;
 
-  public PartitionGroupMetadataFetcher(StreamConfig streamConfig, List<PartitionGroupConsumptionStatus> partitionGroupConsumptionStatusList) {
+  public PartitionGroupMetadataFetcher(StreamConfig streamConfig,
+      List<PartitionGroupConsumptionStatus> partitionGroupConsumptionStatusList) {
     _streamConsumerFactory = StreamConsumerFactoryProvider.create(streamConfig);
     _topicName = streamConfig.getTopicName();
     _streamConfig = streamConfig;
@@ -64,8 +65,8 @@ public class PartitionGroupMetadataFetcher implements Callable<Boolean> {
     String clientId = PartitionGroupMetadataFetcher.class.getSimpleName() + "-" + _topicName;
     try (
         StreamMetadataProvider streamMetadataProvider = _streamConsumerFactory.createStreamMetadataProvider(clientId)) {
-      _newPartitionGroupMetadataList = streamMetadataProvider
-          .computePartitionGroupMetadata(clientId, _streamConfig, _partitionGroupConsumptionStatusList, /*maxWaitTimeMs=*/5000);
+      _newPartitionGroupMetadataList = streamMetadataProvider.computePartitionGroupMetadata(clientId, _streamConfig,
+          _partitionGroupConsumptionStatusList, /*maxWaitTimeMs=*/5000);
       if (_exception != null) {
         // We had at least one failure, but succeeded now. Log an info
         LOGGER.info("Successfully retrieved PartitionGroupMetadata for topic {}", _topicName);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLevelConsumer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLevelConsumer.java
@@ -55,11 +55,12 @@ public interface PartitionLevelConsumer extends Closeable, PartitionGroupConsume
    * @return An iterable containing messages fetched from the stream partition and their offsets, as well as the
    * high watermark for this partition.
    */
-  default MessageBatch fetchMessages(StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset endOffset, int timeoutMillis)
+  default MessageBatch fetchMessages(StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset endOffset,
+      int timeoutMillis)
       throws java.util.concurrent.TimeoutException {
-   // TODO Issue 5359 remove this default implementation once all kafka consumers have migrated to use this API
-    long startOffsetLong = ((LongMsgOffset)startOffset).getOffset();
-    long endOffsetLong = endOffset == null ? Long.MAX_VALUE : ((LongMsgOffset)endOffset).getOffset();
+    // TODO Issue 5359 remove this default implementation once all kafka consumers have migrated to use this API
+    long startOffsetLong = ((LongMsgOffset) startOffset).getOffset();
+    long endOffsetLong = endOffset == null ? Long.MAX_VALUE : ((LongMsgOffset) endOffset).getOffset();
     return fetchMessages(startOffsetLong, endOffsetLong, timeoutMillis);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -99,7 +99,8 @@ public class StreamConfig {
     for (String consumerType : consumerTypes.split(",")) {
       if (consumerType.equals(
           SIMPLE_CONSUMER_TYPE_STRING)) { //For backward compatibility of stream configs which referred to lowlevel as simple
-        consumerType = ConsumerType.LOWLEVEL.toString();
+        _consumerTypes.add(ConsumerType.LOWLEVEL);
+        continue;
       }
       _consumerTypes.add(ConsumerType.valueOf(consumerType.toUpperCase()));
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
@@ -25,6 +25,9 @@ import com.google.common.base.Joiner;
  * Defines the keys for the stream config properties map
  */
 public class StreamConfigProperties {
+  private StreamConfigProperties() {
+  }
+
   public static final String DOT_SEPARATOR = ".";
   public static final String STREAM_PREFIX = "stream";
   // TODO: this can be removed, check all properties before doing so
@@ -75,7 +78,8 @@ public class StreamConfigProperties {
   public static final String SEGMENT_FLUSH_THRESHOLD_ROWS = "realtime.segment.flush.threshold.rows";
 
   /**
-   * @deprecated because the property key is confusing (desired size is not indicative of segment size). Use {@link StreamConfigProperties#SEGMENT_FLUSH_THRESHOLD_SEGMENT_SIZE}
+   * @deprecated because the property key is confusing (desired size is not indicative of segment size).
+   * Use {@link StreamConfigProperties#SEGMENT_FLUSH_THRESHOLD_SEGMENT_SIZE}
    *
    * The desired size of a completed realtime segment.
    * This config is used only if REALTIME_SEGMENT_FLUSH_SIZE is set

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConsumerFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConsumerFactory.java
@@ -80,5 +80,4 @@ public abstract class StreamConsumerFactory {
       PartitionGroupConsumptionStatus partitionGroupConsumptionStatus) {
     return createPartitionLevelConsumer(clientId, partitionGroupConsumptionStatus.getPartitionGroupId());
   }
-
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConsumerFactoryProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConsumerFactoryProvider.java
@@ -21,6 +21,7 @@ package org.apache.pinot.spi.stream;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.pinot.spi.plugin.PluginManager;
 
+
 /**
  * Provider class for {@link StreamConsumerFactory}
  */

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataProvider.java
@@ -29,6 +29,9 @@ import org.apache.pinot.spi.plugin.PluginManager;
  *
  */
 public class StreamDataProvider {
+  private StreamDataProvider() {
+  }
+
   public static StreamDataServerStartable getServerDataStartable(String clazz, Properties props)
       throws Exception {
     final StreamDataServerStartable streamDataServerStartable = PluginManager.get().createInstance(clazz);
@@ -38,7 +41,7 @@ public class StreamDataProvider {
 
   public static StreamDataProducer getStreamDataProducer(String clazz, Properties props)
       throws Exception {
-    final StreamDataProducer streamDataProducer = PluginManager.get().createInstance(clazz);;
+    final StreamDataProducer streamDataProducer = PluginManager.get().createInstance(clazz);
     streamDataProducer.init(props);
     return streamDataProducer;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessageMetadata.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessageMetadata.java
@@ -40,5 +40,4 @@ public class StreamMessageMetadata implements RowMetadata {
   public long getIngestionTimeMs() {
     return _ingestionTimeMs;
   }
-
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
@@ -45,6 +45,7 @@ public interface StreamMetadataProvider extends Closeable {
   @Deprecated
   long fetchPartitionOffset(@Nonnull OffsetCriteria offsetCriteria, long timeoutMillis)
       throws java.util.concurrent.TimeoutException;
+
   /**
    * Fetches the offset for a given partition and offset criteria
    * @param offsetCriteria offset criteria to fetch{@link StreamPartitionMsgOffset}.
@@ -53,7 +54,8 @@ public interface StreamMetadataProvider extends Closeable {
    * @return {@link StreamPartitionMsgOffset} based on the offset criteria provided
    * @throws java.util.concurrent.TimeoutException if timed out trying to connect and fetch from stream
    */
-  default StreamPartitionMsgOffset fetchStreamPartitionOffset(@Nonnull OffsetCriteria offsetCriteria, long timeoutMillis)
+  default StreamPartitionMsgOffset fetchStreamPartitionOffset(@Nonnull OffsetCriteria offsetCriteria,
+      long timeoutMillis)
       throws java.util.concurrent.TimeoutException {
     long offset = fetchPartitionOffset(offsetCriteria, timeoutMillis);
     return new LongMsgOffset(offset);
@@ -75,15 +77,16 @@ public interface StreamMetadataProvider extends Closeable {
     // Setting endOffset (exclusive) as the startOffset for new partition group.
     // If partition group is still in progress, this value will be null
     for (PartitionGroupConsumptionStatus currentPartitionGroupConsumptionStatus : partitionGroupConsumptionStatuses) {
-      newPartitionGroupMetadataList.add(new PartitionGroupMetadata(currentPartitionGroupConsumptionStatus.getPartitionGroupId(),
-          currentPartitionGroupConsumptionStatus.getEndOffset()));
+      newPartitionGroupMetadataList.add(
+          new PartitionGroupMetadata(currentPartitionGroupConsumptionStatus.getPartitionGroupId(),
+              currentPartitionGroupConsumptionStatus.getEndOffset()));
     }
     // Add PartitionGroupMetadata for new partitions
     // Use offset criteria from stream config
     StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.create(streamConfig);
     for (int i = partitionGroupConsumptionStatuses.size(); i < partitionCount; i++) {
-      try (StreamMetadataProvider partitionMetadataProvider =
-          streamConsumerFactory.createPartitionMetadataProvider(clientId, i)) {
+      try (StreamMetadataProvider partitionMetadataProvider = streamConsumerFactory
+          .createPartitionMetadataProvider(clientId, i)) {
         StreamPartitionMsgOffset streamPartitionMsgOffset =
             partitionMetadataProvider.fetchStreamPartitionOffset(streamConfig.getOffsetCriteria(), timeoutMillis);
         newPartitionGroupMetadataList.add(new PartitionGroupMetadata(i, streamPartitionMsgOffset));

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamPartitionMsgOffset.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamPartitionMsgOffset.java
@@ -20,6 +20,7 @@ package org.apache.pinot.spi.stream;
 
 import org.apache.pinot.spi.annotations.InterfaceStability;
 
+
 /**
  * An interface to be implemented by streams consumed using Pinot LLC consumers.
  * Pinot expects a stream partition to be a queue of messages. Each time a message

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/BooleanUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/BooleanUtils.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.spi.utils;
 
 public class BooleanUtils {
+  private BooleanUtils() {
+  }
 
   /**
    * Returns the boolean value for the given boolean string.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -22,6 +22,8 @@ import java.io.File;
 
 
 public class CommonConstants {
+  private CommonConstants() {
+  }
 
   public static final String ENVIRONMENT_IDENTIFIER = "environment";
   public static final String INSTANCE_FAILURE_DOMAIN = "failureDomain";
@@ -61,10 +63,10 @@ public class CommonConstants {
     public static final String PREFIX_OF_SERVER_INSTANCE = "Server_";
     public static final String PREFIX_OF_MINION_INSTANCE = "Minion_";
 
-    public static int CONTROLLER_INSTANCE_PREFIX_LENGTH = PREFIX_OF_CONTROLLER_INSTANCE.length();
-    public static int BROKER_INSTANCE_PREFIX_LENGTH = PREFIX_OF_BROKER_INSTANCE.length();
-    public static int SERVER_INSTANCE_PREFIX_LENGTH = PREFIX_OF_SERVER_INSTANCE.length();
-    public static int MINION_INSTANCE_PREFIX_LENGTH = PREFIX_OF_MINION_INSTANCE.length();
+    public static final int CONTROLLER_INSTANCE_PREFIX_LENGTH = PREFIX_OF_CONTROLLER_INSTANCE.length();
+    public static final int BROKER_INSTANCE_PREFIX_LENGTH = PREFIX_OF_BROKER_INSTANCE.length();
+    public static final int SERVER_INSTANCE_PREFIX_LENGTH = PREFIX_OF_SERVER_INSTANCE.length();
+    public static final int MINION_INSTANCE_PREFIX_LENGTH = PREFIX_OF_MINION_INSTANCE.length();
 
     public static final String BROKER_RESOURCE_INSTANCE = "brokerResource";
     public static final String LEAD_CONTROLLER_RESOURCE_NAME = "leadControllerResource";
@@ -523,8 +525,8 @@ public class CommonConstants {
     }
 
     public static class AssignmentStrategy {
-      public static String BALANCE_NUM_SEGMENT_ASSIGNMENT_STRATEGY = "BalanceNumSegmentAssignmentStrategy";
-      public static String REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY = "ReplicaGroupSegmentAssignmentStrategy";
+      public static final String BALANCE_NUM_SEGMENT_ASSIGNMENT_STRATEGY = "BalanceNumSegmentAssignmentStrategy";
+      public static final String REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY = "ReplicaGroupSegmentAssignmentStrategy";
     }
 
     public static class BuiltInVirtualColumn {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/DataSizeUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/DataSizeUtils.java
@@ -35,11 +35,11 @@ public class DataSizeUtils {
       Pattern.compile("^(\\d+(\\.\\d+)?)([KMGTP])?(B)?$", Pattern.CASE_INSENSITIVE);
   private static final DecimalFormat DECIMAL_FORMAT = new DecimalFormat("0.##");
 
-  private static double KB_IN_BYTES = 1024;
-  private static double MB_IN_BYTES = KB_IN_BYTES * 1024;
-  private static double GB_IN_BYTES = MB_IN_BYTES * 1024;
-  private static double TB_IN_BYTES = GB_IN_BYTES * 1024;
-  private static double PB_IN_BYTES = TB_IN_BYTES * 1024;
+  private static final double KB_IN_BYTES = 1024;
+  private static final double MB_IN_BYTES = KB_IN_BYTES * 1024;
+  private static final double GB_IN_BYTES = MB_IN_BYTES * 1024;
+  private static final double TB_IN_BYTES = GB_IN_BYTES * 1024;
+  private static final double PB_IN_BYTES = TB_IN_BYTES * 1024;
 
   /**
    * Converts human readable data size (e.g. '10.5G', '40B') to data size in bytes.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/EqualityUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/EqualityUtils.java
@@ -79,7 +79,7 @@ public class EqualityUtils {
       // TODO: comparison of sets of arbitrary objects is not specifically supported since
       // isEqualSet uses isEqualIgnoreOrder which requires sorting.
       if ((left instanceof Map) && (right instanceof Map)) {
-        return EqualityUtils.isEqualMap((Map)left, (Map)right);
+        return EqualityUtils.isEqualMap((Map) left, (Map) right);
       } else if ((left instanceof byte[]) && (right instanceof byte[])) {
         return Arrays.equals((byte[]) left, (byte[]) right);
       } else if (left.getClass().isArray() && right.getClass().isArray()) {
@@ -94,27 +94,33 @@ public class EqualityUtils {
   public static boolean isEqual(@Nullable Object[] left, @Nullable Object[] right) {
     // An effective copy of Arrays.deepEquals but using EqualityUtils.isEqual for
     // element comparison rather than .equals.
-    if (left == right)
+    if (left == right) {
       return true;
-    if (left == null || right==null)
+    }
+    if (left == null || right == null) {
       return false;
+    }
     int length = left.length;
-    if (right.length != length)
+    if (right.length != length) {
       return false;
+    }
 
     for (int i = 0; i < length; i++) {
       Object e1 = left[i];
       Object e2 = right[i];
 
-      if (e1 == e2)
+      if (e1 == e2) {
         continue;
-      if (e1 == null)
+      }
+      if (e1 == null) {
         return false;
+      }
 
       boolean eq = EqualityUtils.isEqual(e1, e2);
 
-      if (!eq)
+      if (!eq) {
         return false;
+      }
     }
 
     return true;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/GroovyTemplateUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/GroovyTemplateUtils.java
@@ -32,6 +32,9 @@ import java.util.TimeZone;
 
 
 public class GroovyTemplateUtils {
+  private GroovyTemplateUtils() {
+  }
+
   private static final SimpleTemplateEngine GROOVY_TEMPLATE_ENGINE = new SimpleTemplateEngine();
   private static final SimpleDateFormat DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd");
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
@@ -34,6 +34,9 @@ import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
  * Helper methods for extracting fields from IngestionConfig in a backward compatible manner
  */
 public final class IngestionConfigUtils {
+  private IngestionConfigUtils() {
+  }
+
   public static final String DOT_SEPARATOR = ".";
   private static final String DEFAULT_SEGMENT_NAME_GENERATOR_TYPE =
       BatchConfigProperties.SegmentNameGeneratorType.SIMPLE;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
@@ -418,7 +418,8 @@ public class JsonUtils {
       fieldsToUnnest = new ArrayList<>();
     }
     Preconditions.checkState(jsonNode.isObject(), "the JSON data shall be an object");
-    return getPinotSchemaFromJsonNode(jsonNode, fieldTypeMap, timeUnit, fieldsToUnnest, delimiter, collectionNotUnnestedToJson);
+    return getPinotSchemaFromJsonNode(jsonNode, fieldTypeMap, timeUnit, fieldsToUnnest, delimiter,
+        collectionNotUnnestedToJson);
   }
 
   public static Schema getPinotSchemaFromJsonNode(JsonNode jsonNode,
@@ -485,7 +486,8 @@ public class JsonUtils {
       case NON_PRIMITIVE:
         return !childNode.isValueNode();
       default:
-        throw new IllegalArgumentException(String.format("Unsupported collectionNotUnnestedToJson %s", collectionNotUnnestedToJson));
+        throw new IllegalArgumentException(
+            String.format("Unsupported collectionNotUnnestedToJson %s", collectionNotUnnestedToJson));
     }
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/NetUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/NetUtils.java
@@ -27,6 +27,9 @@ import java.net.UnknownHostException;
 
 
 public class NetUtils {
+  private NetUtils() {
+  }
+
   private static final String DUMMY_OUT_IP = "74.125.224.0";
 
   /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/Pair.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/Pair.java
@@ -22,30 +22,30 @@ import java.io.Serializable;
 import java.util.Objects;
 
 
-public class Pair<T1 extends Serializable, T2 extends Serializable> implements Serializable {
+public class Pair<FIRST extends Serializable, SECOND extends Serializable> implements Serializable {
   private static final long serialVersionUID = -2776898111501466320L;
 
-  private T1 _first;
-  private T2 _second;
+  private FIRST _first;
+  private SECOND _second;
 
-  public Pair(T1 first, T2 second) {
+  public Pair(FIRST first, SECOND second) {
     _first = first;
     _second = second;
   }
 
-  public T1 getFirst() {
+  public FIRST getFirst() {
     return _first;
   }
 
-  public T2 getSecond() {
+  public SECOND getSecond() {
     return _second;
   }
 
-  public void setFirst(T1 first) {
+  public void setFirst(FIRST first) {
     _first = first;
   }
 
-  public void setSecond(T2 second) {
+  public void setSecond(SECOND second) {
     _second = second;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/Pairs.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/Pairs.java
@@ -22,6 +22,8 @@ import java.util.Comparator;
 
 
 public class Pairs {
+  private Pairs() {
+  }
 
   public static IntPair intPair(int a, int b) {
     return new IntPair(a, b);
@@ -97,35 +99,34 @@ public class Pairs {
   }
 
   public static class Number2ObjectPair<T> {
-    Number a;
-
-    T b;
+    Number _a;
+    T _b;
 
     public Number2ObjectPair(Number a, T b) {
-      this.a = a;
-      this.b = b;
+      _a = a;
+      _b = b;
     }
 
     public Number getA() {
-      return a;
+      return _a;
     }
 
     public T getB() {
-      return b;
+      return _b;
     }
   }
 
   public static class AscendingNumber2ObjectPairComparator implements Comparator<Number2ObjectPair> {
     @Override
     public int compare(Number2ObjectPair o1, Number2ObjectPair o2) {
-      return new Double(o1.a.doubleValue()).compareTo(new Double(o2.a.doubleValue()));
+      return new Double(o1._a.doubleValue()).compareTo(new Double(o2._a.doubleValue()));
     }
   }
 
   public static class DescendingNumber2ObjectPairComparator implements Comparator<Number2ObjectPair> {
     @Override
     public int compare(Number2ObjectPair o1, Number2ObjectPair o2) {
-      return new Double(o2.a.doubleValue()).compareTo(new Double(o1.a.doubleValue()));
+      return new Double(o2._a.doubleValue()).compareTo(new Double(o1._a.doubleValue()));
     }
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/PinotReflectionUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/PinotReflectionUtils.java
@@ -28,6 +28,9 @@ import org.reflections.util.FilterBuilder;
 
 
 public class PinotReflectionUtils {
+  private PinotReflectionUtils() {
+  }
+
   private static final String PINOT_PACKAGE_PREFIX = "org.apache.pinot";
   private static final Object REFLECTION_LOCK = new Object();
 
@@ -35,7 +38,8 @@ public class PinotReflectionUtils {
       final Class<? extends Annotation> annotation) {
     synchronized (getReflectionLock()) {
       Reflections reflections = new Reflections(
-          new ConfigurationBuilder().setUrls(ClasspathHelper.forPackage(PINOT_PACKAGE_PREFIX)).filterInputsBy(new FilterBuilder.Include(regexPattern)).setScanners(new TypeAnnotationsScanner()));
+          new ConfigurationBuilder().setUrls(ClasspathHelper.forPackage(PINOT_PACKAGE_PREFIX))
+              .filterInputsBy(new FilterBuilder.Include(regexPattern)).setScanners(new TypeAnnotationsScanner()));
       return reflections.getTypesAnnotatedWith(annotation, true);
     }
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/ResourceFinder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/ResourceFinder.java
@@ -31,6 +31,8 @@ import java.nio.file.Paths;
  * Utility class containing helper method for accessing a particular resource
  */
 public class ResourceFinder {
+  private ResourceFinder() {
+  }
 
   /**
    * Access a resource for a particular URI

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/TimeUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/TimeUtils.java
@@ -30,6 +30,9 @@ import org.joda.time.format.PeriodFormatterBuilder;
 
 
 public class TimeUtils {
+  private TimeUtils() {
+  }
+
   public static final long VALID_MIN_TIME_MILLIS = new DateTime(1971, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC).getMillis();
   public static final long VALID_MAX_TIME_MILLIS = new DateTime(2071, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC).getMillis();
   public static final Interval VALID_TIME_INTERVAL =

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/TimestampUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/TimestampUtils.java
@@ -22,6 +22,8 @@ import java.sql.Timestamp;
 
 
 public class TimestampUtils {
+  private TimestampUtils() {
+  }
 
   /**
    * Parses the given timestamp string into {@link Timestamp}.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/BaseRetryPolicy.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/BaseRetryPolicy.java
@@ -22,7 +22,7 @@ import java.util.concurrent.Callable;
 
 
 /**
- * The <clase>BaseRetryPolicy</clase> is the base class for all retry policies. To implement a new retry policy, extends
+ * The {@link BaseRetryPolicy} is the base class for all retry policies. To implement a new retry policy, extends
  * this class and implements the method {@link #getDelayMs(int)}.
  * <p>NOTE: All the retry policies should be stateless so that they can be cached and reused.
  */

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/AbstractRecordExtractorTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/AbstractRecordExtractorTest.java
@@ -110,8 +110,7 @@ public abstract class AbstractRecordExtractorTest {
 
   private void checkValue(Object expectedValue, Object actualValue) {
     if (expectedValue instanceof Collection) {
-      List actualArray =
-          actualValue instanceof List ? (ArrayList) actualValue : Arrays.asList((Object[]) actualValue);
+      List actualArray = actualValue instanceof List ? (ArrayList) actualValue : Arrays.asList((Object[]) actualValue);
       List expectedArray = (List) expectedValue;
       for (int j = 0; j < actualArray.size(); j++) {
         checkValue(expectedArray.get(j), actualArray.get(j));

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/AbstractRecordReaderTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/AbstractRecordReaderTest.java
@@ -61,7 +61,8 @@ public abstract class AbstractRecordReaderTest {
     return records;
   }
 
-  protected static List<Object[]> generatePrimaryKeys(List<Map<String, Object>> records, List<String> primaryKeyColumns) {
+  protected static List<Object[]> generatePrimaryKeys(List<Map<String, Object>> records,
+      List<String> primaryKeyColumns) {
     List<Object[]> primaryKeys = Lists.newArrayList();
     for (Map<String, Object> record : records) {
       Object[] primaryKey = new Object[primaryKeyColumns.size()];

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/GenericRowTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/GenericRowTest.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+
 public class GenericRowTest {
 
   @Test

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/RecordReaderFactoryTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/RecordReaderFactoryTest.java
@@ -20,8 +20,20 @@ package org.apache.pinot.spi.data.readers;
 
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.spi.data.readers.RecordReaderFactory.*;
-import static org.testng.Assert.*;
+import static org.apache.pinot.spi.data.readers.RecordReaderFactory.DEFAULT_AVRO_RECORD_READER_CLASS;
+import static org.apache.pinot.spi.data.readers.RecordReaderFactory.DEFAULT_CSV_RECORD_READER_CLASS;
+import static org.apache.pinot.spi.data.readers.RecordReaderFactory.DEFAULT_CSV_RECORD_READER_CONFIG_CLASS;
+import static org.apache.pinot.spi.data.readers.RecordReaderFactory.DEFAULT_JSON_RECORD_READER_CLASS;
+import static org.apache.pinot.spi.data.readers.RecordReaderFactory.DEFAULT_ORC_RECORD_READER_CLASS;
+import static org.apache.pinot.spi.data.readers.RecordReaderFactory.DEFAULT_PARQUET_RECORD_READER_CLASS;
+import static org.apache.pinot.spi.data.readers.RecordReaderFactory.DEFAULT_PARQUET_RECORD_READER_CONFIG_CLASS;
+import static org.apache.pinot.spi.data.readers.RecordReaderFactory.DEFAULT_THRIFT_RECORD_READER_CLASS;
+import static org.apache.pinot.spi.data.readers.RecordReaderFactory.DEFAULT_THRIFT_RECORD_READER_CONFIG_CLASS;
+import static org.apache.pinot.spi.data.readers.RecordReaderFactory.getRecordReaderClassName;
+import static org.apache.pinot.spi.data.readers.RecordReaderFactory.getRecordReaderConfigClassName;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
 
 public class RecordReaderFactoryTest {
 

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/env/PinotConfigurationTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/env/PinotConfigurationTest.java
@@ -57,8 +57,8 @@ public class PinotConfigurationTest {
     Assert.assertEquals(pinotConfiguration.getProperty("config.double-missing", 20d), 20d);
     Assert.assertEquals(pinotConfiguration.getProperty("config.int", 0), 100);
     Assert.assertEquals(pinotConfiguration.getProperty("config.int-missing", 200), 200);
-    Assert.assertEquals(pinotConfiguration.getProperty("config.long", 0l), 10000000l);
-    Assert.assertEquals(pinotConfiguration.getProperty("config.long-missing", 20000000l), 20000000l);
+    Assert.assertEquals(pinotConfiguration.getProperty("config.long", 0L), 10000000L);
+    Assert.assertEquals(pinotConfiguration.getProperty("config.long-missing", 20000000L), 20000000L);
     Assert.assertEquals(pinotConfiguration.getProperty("config.string", "missing-val"), "val");
     Assert.assertEquals(pinotConfiguration.getProperty("config.string-missing", "missing-val"), "missing-val");
 
@@ -73,7 +73,6 @@ public class PinotConfigurationTest {
 
     Assert.assertFalse(pinotConfiguration.containsKey("missing-property"));
     Assert.assertNull(pinotConfiguration.getProperty("missing-property"));
-
   }
 
   @Test
@@ -124,7 +123,8 @@ public class PinotConfigurationTest {
   }
 
   @Test
-  public void assertPropertyPriorities() throws IOException {
+  public void assertPropertyPriorities()
+      throws IOException {
     Map<String, Object> baseProperties = new HashMap<>();
     Map<String, String> mockedEnvironmentVariables = new HashMap<>();
 
@@ -177,7 +177,8 @@ public class PinotConfigurationTest {
   }
 
   @Test
-  public void assertPropertiesFromBaseConfiguration() throws ConfigurationException {
+  public void assertPropertiesFromBaseConfiguration()
+      throws ConfigurationException {
     PinotConfiguration config = new PinotConfiguration(new PropertiesConfiguration(
         PropertiesConfiguration.class.getClassLoader().getResource("pinot-configuration-1.properties").getFile()));
 
@@ -206,7 +207,8 @@ public class PinotConfigurationTest {
     new PinotConfiguration(new PinotFSSpec());
   }
 
-  private void copyClasspathResource(String classpathResource, String target) throws IOException {
+  private void copyClasspathResource(String classpathResource, String target)
+      throws IOException {
     try (InputStream inputStream = PinotConfigurationTest.class.getResourceAsStream(classpathResource)) {
       Files.copy(inputStream, Paths.get(target), StandardCopyOption.REPLACE_EXISTING);
     }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProviderFactoryTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/environmentprovider/PinotEnvironmentProviderFactoryTest.java
@@ -24,6 +24,7 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+
 public class PinotEnvironmentProviderFactoryTest {
 
   @Test
@@ -37,28 +38,31 @@ public class PinotEnvironmentProviderFactoryTest {
 
     PinotEnvironmentProvider testPinotEnvironment = PinotEnvironmentProviderFactory.getEnvironmentProvider("test");
     Assert.assertTrue(testPinotEnvironment instanceof PinotEnvironmentProviderFactoryTest.TestEnvironmentProvider);
-    Assert.assertEquals(((PinotEnvironmentProviderFactoryTest.TestEnvironmentProvider)
-        testPinotEnvironment).getInitCalled(), 1);
-    Assert.assertEquals(((PinotEnvironmentProviderFactoryTest.TestEnvironmentProvider)
-        testPinotEnvironment).getConfiguration().getProperty("maxRetry"), "3");
-    Assert.assertEquals(((PinotEnvironmentProviderFactoryTest.TestEnvironmentProvider)
-        testPinotEnvironment).getConfiguration().getProperty("connectionTimeoutMillis"), "100");
-    Assert.assertEquals(((PinotEnvironmentProviderFactoryTest.TestEnvironmentProvider)
-        testPinotEnvironment).getConfiguration().getProperty("requestTimeoutMillis"), "100");
+    Assert.assertEquals(
+        ((PinotEnvironmentProviderFactoryTest.TestEnvironmentProvider) testPinotEnvironment).getInitCalled(), 1);
+    Assert.assertEquals(
+        ((PinotEnvironmentProviderFactoryTest.TestEnvironmentProvider) testPinotEnvironment).getConfiguration()
+            .getProperty("maxRetry"), "3");
+    Assert.assertEquals(
+        ((PinotEnvironmentProviderFactoryTest.TestEnvironmentProvider) testPinotEnvironment).getConfiguration()
+            .getProperty("connectionTimeoutMillis"), "100");
+    Assert.assertEquals(
+        ((PinotEnvironmentProviderFactoryTest.TestEnvironmentProvider) testPinotEnvironment).getConfiguration()
+            .getProperty("requestTimeoutMillis"), "100");
   }
 
   public static class TestEnvironmentProvider implements PinotEnvironmentProvider {
-    public int initCalled = 0;
+    public int _initCalled = 0;
     private PinotConfiguration _configuration;
 
     public int getInitCalled() {
-      return initCalled;
+      return _initCalled;
     }
 
     @Override
     public void init(PinotConfiguration configuration) {
       _configuration = configuration;
-      initCalled++;
+      _initCalled++;
     }
 
     public PinotConfiguration getConfiguration() {

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java
@@ -31,7 +31,7 @@ import static org.testng.Assert.fail;
 
 
 public class LocalPinotFSTest {
-  private File testFile;
+  private File _testFile;
   private File _absoluteTmpDirPath;
   private File _newTmpDir;
   private File _nonExistentTmpFolder;
@@ -43,8 +43,8 @@ public class LocalPinotFSTest {
     FileUtils.deleteQuietly(_absoluteTmpDirPath);
     Assert.assertTrue(_absoluteTmpDirPath.mkdir(), "Could not make directory " + _absoluteTmpDirPath.getPath());
     try {
-      testFile = new File(_absoluteTmpDirPath, "testFile");
-      Assert.assertTrue(testFile.createNewFile(), "Could not create file " + testFile.getPath());
+      _testFile = new File(_absoluteTmpDirPath, "testFile");
+      Assert.assertTrue(_testFile.createNewFile(), "Could not create file " + _testFile.getPath());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -71,7 +71,7 @@ public class LocalPinotFSTest {
   public void testFS()
       throws Exception {
     LocalPinotFS localPinotFS = new LocalPinotFS();
-    URI testFileUri = testFile.toURI();
+    URI testFileUri = _testFile.toURI();
     // Check whether a directory exists
     Assert.assertTrue(localPinotFS.exists(_absoluteTmpDirPath.toURI()));
     Assert.assertTrue(localPinotFS.lastModified(_absoluteTmpDirPath.toURI()) > 0L);

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSFactoryTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSFactoryTest.java
@@ -59,17 +59,17 @@ public class PinotFSFactoryTest {
   }
 
   public static class TestPinotFS extends PinotFS {
-    public int initCalled = 0;
+    public int _initCalled = 0;
     private PinotConfiguration _configuration;
 
     public int getInitCalled() {
-      return initCalled;
+      return _initCalled;
     }
 
     @Override
     public void init(PinotConfiguration configuration) {
       _configuration = configuration;
-      initCalled++;
+      _initCalled++;
     }
 
     public PinotConfiguration getConfiguration() {

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSTest.java
@@ -32,65 +32,67 @@ import org.testng.annotations.Test;
 
 
 public class PinotFSTest {
-  public String srcForMoveFile = "myfs://root/file1";
-  public String dstForMoveFile = "myfs://root/someDir/file1";
-  public String srcForMoveFileWithPort = "myfs://myhost1:1234/root/file1";
-  public String dstForMoveFileWithPort = "myfs://myhost2:1234/someDir/file1";
+  public String _srcForMoveFile = "myfs://root/file1";
+  public String _dstForMoveFile = "myfs://root/someDir/file1";
+  public String _srcForMoveFileWithPort = "myfs://myhost1:1234/root/file1";
+  public String _dstForMoveFileWithPort = "myfs://myhost2:1234/someDir/file1";
 
   @Test
-  public void testMoveFileUriGeneration() throws Exception {
+  public void testMoveFileUriGeneration()
+      throws Exception {
     MockRemoteFS fs = new MockRemoteFS();
     fs.init(null);
-    fs.move(new URI(srcForMoveFile), new URI(dstForMoveFile), false);
+    fs.move(new URI(_srcForMoveFile), new URI(_dstForMoveFile), false);
 
-    Assert.assertEquals(fs.mkdirCalls, 1,"should call mkdir once");
-    Assert.assertEquals(fs.mkdirArgs.get(0).toString(), "myfs://root/someDir", "should create correct parent");
+    Assert.assertEquals(fs._mkdirCalls, 1, "should call mkdir once");
+    Assert.assertEquals(fs._mkdirArgs.get(0).toString(), "myfs://root/someDir", "should create correct parent");
 
-    Assert.assertEquals(fs.doMoveCalls, 1, "doMove should be called once");
-    Map<String, URI> callArgs = fs.doMoveArgs.get(0);
-    Assert.assertEquals(callArgs.get("srcUri").toString(), srcForMoveFile, "should keep correct src");
-    Assert.assertEquals(callArgs.get("dstUri").toString(), dstForMoveFile, "should keep correct dst");
+    Assert.assertEquals(fs._doMoveCalls, 1, "doMove should be called once");
+    Map<String, URI> callArgs = fs._doMoveArgs.get(0);
+    Assert.assertEquals(callArgs.get("srcUri").toString(), _srcForMoveFile, "should keep correct src");
+    Assert.assertEquals(callArgs.get("dstUri").toString(), _dstForMoveFile, "should keep correct dst");
   }
 
   @Test
-  public void testMoveFileUriGenerationWithPort() throws Exception {
+  public void testMoveFileUriGenerationWithPort()
+      throws Exception {
     MockRemoteFS fs = new MockRemoteFS();
     fs.init(null);
-    fs.move(new URI(srcForMoveFileWithPort), new URI(dstForMoveFileWithPort), false);
+    fs.move(new URI(_srcForMoveFileWithPort), new URI(_dstForMoveFileWithPort), false);
 
-    Assert.assertEquals(fs.mkdirCalls, 1,"should call mkdir once");
-    Assert.assertEquals(fs.mkdirArgs.get(0).toString(), "myfs://myhost2:1234/someDir", "should create correct parent");
+    Assert.assertEquals(fs._mkdirCalls, 1, "should call mkdir once");
+    Assert.assertEquals(fs._mkdirArgs.get(0).toString(), "myfs://myhost2:1234/someDir", "should create correct parent");
 
-    Assert.assertEquals(fs.doMoveCalls, 1, "doMove should be called once");
-    Map<String, URI> callArgs = fs.doMoveArgs.get(0);
-    Assert.assertEquals(callArgs.get("srcUri").toString(), srcForMoveFileWithPort, "should keep correct src");
-    Assert.assertEquals(callArgs.get("dstUri").toString(), dstForMoveFileWithPort, "should keep correct dst");
+    Assert.assertEquals(fs._doMoveCalls, 1, "doMove should be called once");
+    Map<String, URI> callArgs = fs._doMoveArgs.get(0);
+    Assert.assertEquals(callArgs.get("srcUri").toString(), _srcForMoveFileWithPort, "should keep correct src");
+    Assert.assertEquals(callArgs.get("dstUri").toString(), _dstForMoveFileWithPort, "should keep correct dst");
   }
 
   /**
    * MockRemoteFS implementation used to test behavior of the Abstract class PinotFS
    */
   private class MockRemoteFS extends PinotFS {
-    public int doMoveCalls;
-    public List<Map<String, URI>> doMoveArgs;
+    public int _doMoveCalls;
+    public List<Map<String, URI>> _doMoveArgs;
 
-    public int mkdirCalls;
-    public List<URI> mkdirArgs;
+    public int _mkdirCalls;
+    public List<URI> _mkdirArgs;
 
     @Override
     public void init(PinotConfiguration config) {
-      doMoveCalls = 0;
-      doMoveArgs = new ArrayList<>();
+      _doMoveCalls = 0;
+      _doMoveArgs = new ArrayList<>();
 
-      mkdirCalls = 0;
-      mkdirArgs = new ArrayList<>();
+      _mkdirCalls = 0;
+      _mkdirArgs = new ArrayList<>();
     }
 
     @Override
     public boolean mkdir(URI uri)
         throws IOException {
-      mkdirArgs.add(uri);
-      mkdirCalls++;
+      _mkdirArgs.add(uri);
+      _mkdirCalls++;
       return true;
     }
 
@@ -106,8 +108,8 @@ public class PinotFSTest {
       HashMap<String, URI> call = new HashMap<>();
       call.put("srcUri", srcUri);
       call.put("dstUri", dstUri);
-      doMoveArgs.add(call);
-      doMoveCalls++;
+      _doMoveArgs.add(call);
+      _doMoveCalls++;
       return true;
     }
 
@@ -121,8 +123,7 @@ public class PinotFSTest {
     public boolean exists(URI fileUri)
         throws IOException {
 
-      if (fileUri.toString() == srcForMoveFile ||
-          fileUri.toString() == srcForMoveFileWithPort) {
+      if (fileUri.toString() == _srcForMoveFile || fileUri.toString() == _srcForMoveFileWithPort) {
         return true;
       }
 

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/ingestion/batch/BatchConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/ingestion/batch/BatchConfigTest.java
@@ -23,7 +23,7 @@ import java.util.Map;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 
 
 /**
@@ -75,8 +75,10 @@ public class BatchConfigTest {
     assertEquals(batchConfig.getInputFsProps().get(BatchConfigProperties.INPUT_FS_PROP_PREFIX + ".username"), username);
     assertEquals(batchConfig.getOutputFsProps().size(), 3);
     assertEquals(batchConfig.getOutputFsProps().get(BatchConfigProperties.OUTPUT_FS_PROP_PREFIX + ".region"), region);
-    assertEquals(batchConfig.getOutputFsProps().get(BatchConfigProperties.OUTPUT_FS_PROP_PREFIX + ".accessKey"), accessKey);
-    assertEquals(batchConfig.getOutputFsProps().get(BatchConfigProperties.OUTPUT_FS_PROP_PREFIX + ".secretKey"), secretKey);
+    assertEquals(batchConfig.getOutputFsProps().get(BatchConfigProperties.OUTPUT_FS_PROP_PREFIX + ".accessKey"),
+        accessKey);
+    assertEquals(batchConfig.getOutputFsProps().get(BatchConfigProperties.OUTPUT_FS_PROP_PREFIX + ".secretKey"),
+        secretKey);
     assertEquals(batchConfig.getRecordReaderProps().size(), 1);
     assertEquals(batchConfig.getRecordReaderProps().get(BatchConfigProperties.RECORD_READER_PROP_PREFIX + ".separator"),
         separator);

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerTest.java
@@ -36,23 +36,23 @@ import org.testng.annotations.Test;
 
 public class PluginManagerTest {
 
-  private final String TEST_RECORD_READER_FILE = "TestRecordReader.java";
+  private static final String TEST_RECORD_READER_FILE = "TestRecordReader.java";
 
-  private File tempDir;
-  private String jarFile;
-  private File jarDirFile;
+  private File _tempDir;
+  private String _jarFile;
+  private File _jarDirFile;
 
   @BeforeClass
   public void setup() {
 
-    tempDir = new File(System.getProperty("java.io.tmpdir"), "pinot-plugin-test");
-    tempDir.delete();
-    tempDir.mkdirs();
+    _tempDir = new File(System.getProperty("java.io.tmpdir"), "pinot-plugin-test");
+    _tempDir.delete();
+    _tempDir.mkdirs();
 
-    String jarDir = tempDir + "/" + "test-record-reader";
-    jarFile = jarDir + "/" + "test-record-reader.jar";
-    jarDirFile = new File(jarDir);
-    jarDirFile.mkdirs();
+    String jarDir = _tempDir + "/test-record-reader";
+    _jarFile = jarDir + "/test-record-reader.jar";
+    _jarDirFile = new File(jarDir);
+    _jarDirFile.mkdirs();
   }
 
   @Test
@@ -61,19 +61,19 @@ public class PluginManagerTest {
     JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
     URL javaFile = Thread.currentThread().getContextClassLoader().getResource(TEST_RECORD_READER_FILE);
     if (javaFile != null) {
-      int compileStatus = compiler.run(null, null, null, javaFile.getFile(), "-d", tempDir.getAbsolutePath());
+      int compileStatus = compiler.run(null, null, null, javaFile.getFile(), "-d", _tempDir.getAbsolutePath());
       Assert.assertTrue(compileStatus == 0, "Error when compiling resource: " + TEST_RECORD_READER_FILE);
 
       URL classFile = Thread.currentThread().getContextClassLoader().getResource("TestRecordReader.class");
 
       if (classFile != null) {
-        JarOutputStream jos = new JarOutputStream(new FileOutputStream(jarFile));
+        JarOutputStream jos = new JarOutputStream(new FileOutputStream(_jarFile));
         jos.putNextEntry(new JarEntry(new File(classFile.getFile()).getName()));
         jos.write(FileUtils.readFileToByteArray(new File(classFile.getFile())));
         jos.closeEntry();
         jos.close();
 
-        PluginManager.get().load("test-record-reader", jarDirFile);
+        PluginManager.get().load("test-record-reader", _jarDirFile);
 
         RecordReader testRecordReader = PluginManager.get().createInstance("test-record-reader", "TestRecordReader");
         testRecordReader.init(null, null, null);
@@ -142,7 +142,7 @@ public class PluginManagerTest {
 
   @AfterClass
   public void tearDown() {
-    tempDir.delete();
-    FileUtils.deleteQuietly(jarDirFile);
+    _tempDir.delete();
+    FileUtils.deleteQuietly(_jarDirFile);
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/IngestionConfigUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/IngestionConfigUtilsTest.java
@@ -101,8 +101,8 @@ public class IngestionConfigUtilsTest {
   public void testGetPushFrequency() {
     // get from ingestion config, when not present in segmentsConfig
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").build();
-    tableConfig
-        .setIngestionConfig(new IngestionConfig(new BatchIngestionConfig(null, "APPEND", "HOURLY"), null, null, null, null));
+    tableConfig.setIngestionConfig(
+        new IngestionConfig(new BatchIngestionConfig(null, "APPEND", "HOURLY"), null, null, null, null));
     Assert.assertEquals(IngestionConfigUtils.getBatchSegmentIngestionFrequency(tableConfig), "HOURLY");
 
     // get from ingestion config, even if present in segmentsConfig
@@ -126,8 +126,8 @@ public class IngestionConfigUtilsTest {
   public void testGetPushType() {
     // get from ingestion config, when not present in segmentsConfig
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").build();
-    tableConfig
-        .setIngestionConfig(new IngestionConfig(new BatchIngestionConfig(null, "APPEND", "HOURLY"), null, null, null, null));
+    tableConfig.setIngestionConfig(
+        new IngestionConfig(new BatchIngestionConfig(null, "APPEND", "HOURLY"), null, null, null, null));
     Assert.assertEquals(IngestionConfigUtils.getBatchSegmentIngestionType(tableConfig), "APPEND");
 
     // get from ingestion config, even if present in segmentsConfig

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/JsonUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/JsonUtilsTest.java
@@ -39,7 +39,7 @@ import static org.testng.Assert.assertTrue;
 
 
 public class JsonUtilsTest {
-  private static String JSON_FILE = "json_util_test.json";
+  private static final String JSON_FILE = "json_util_test.json";
 
   @Test
   public void testFlatten()
@@ -157,7 +157,8 @@ public class JsonUtilsTest {
     }
     {
       JsonNode jsonNode = JsonUtils.stringToJsonNode(
-          "{\"name\":\"adam\",\"addresses\":[{\"country\":\"us\",\"street\":\"main st\",\"number\":1},{\"country\":\"ca\",\"street\":\"second st\",\"number\":2}]}");
+          "{\"name\":\"adam\",\"addresses\":[{\"country\":\"us\",\"street\":\"main st\",\"number\":1},"
+              + "{\"country\":\"ca\",\"street\":\"second st\",\"number\":2}]}");
       List<Map<String, String>> flattenedRecords = JsonUtils.flatten(jsonNode);
       assertEquals(flattenedRecords.size(), 2);
       for (Map<String, String> flattenedRecord : flattenedRecords) {
@@ -181,7 +182,8 @@ public class JsonUtilsTest {
     }
     {
       JsonNode jsonNode = JsonUtils.stringToJsonNode(
-          "{\"name\":\"adam\",\"age\":20,\"addresses\":[{\"country\":\"us\",\"street\":\"main st\",\"number\":1},{\"country\":\"ca\",\"street\":\"second st\",\"number\":2}],\"skills\":[\"english\",\"programming\"]}");
+          "{\"name\":\"adam\",\"age\":20,\"addresses\":[{\"country\":\"us\",\"street\":\"main st\",\"number\":1},"
+              + "{\"country\":\"ca\",\"street\":\"second st\",\"number\":2}],\"skills\":[\"english\",\"programming\"]}");
       List<Map<String, String>> flattenedRecords = JsonUtils.flatten(jsonNode);
       assertEquals(flattenedRecords.size(), 4);
       for (Map<String, String> flattenedRecord : flattenedRecords) {
@@ -238,7 +240,8 @@ public class JsonUtilsTest {
     }
     {
       JsonNode jsonNode = JsonUtils.stringToJsonNode(
-          "{\"name\":\"charles\",\"addresses\":[{\"country\":\"us\",\"street\":\"main st\",\"types\":[\"home\",\"office\"]},{\"country\":\"ca\",\"street\":\"second st\"}]}");
+          "{\"name\":\"charles\",\"addresses\":[{\"country\":\"us\",\"street\":\"main st\",\"types\":[\"home\",\"office\"]},"
+              + "{\"country\":\"ca\",\"street\":\"second st\"}]}");
       List<Map<String, String>> flattenedRecords = JsonUtils.flatten(jsonNode);
       assertEquals(flattenedRecords.size(), 3);
       Map<String, String> firstFlattenedRecord = flattenedRecords.get(0);

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/builder/TableNameBuilderTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/builder/TableNameBuilderTest.java
@@ -22,7 +22,7 @@ package org.apache.pinot.spi.utils.builder;
 import com.google.common.collect.ImmutableSet;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 
 
 public class TableNameBuilderTest {

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/retry/RetryPolicyTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/retry/RetryPolicyTest.java
@@ -62,18 +62,20 @@ public class RetryPolicyTest {
         Assert.assertTrue(randomDelayRetryPolicy.getDelayMs(j) < 100);
       }
     }
-    randomDelayRetryPolicy = new RandomDelayRetryPolicy(MAX_NUM_ATTEMPTS, Integer.MAX_VALUE, (long)Integer.MAX_VALUE + 1);
+    randomDelayRetryPolicy =
+        new RandomDelayRetryPolicy(MAX_NUM_ATTEMPTS, Integer.MAX_VALUE, (long) Integer.MAX_VALUE + 1);
     for (int i = 0; i < NUM_ROUNDS; i++) {
       for (int j = 0; j < MAX_NUM_ATTEMPTS; j++) {
         Assert.assertTrue(randomDelayRetryPolicy.getDelayMs(j) >= Integer.MAX_VALUE);
-        Assert.assertTrue(randomDelayRetryPolicy.getDelayMs(j) < (long)Integer.MAX_VALUE + 1);
+        Assert.assertTrue(randomDelayRetryPolicy.getDelayMs(j) < (long) Integer.MAX_VALUE + 1);
       }
     }
-    randomDelayRetryPolicy = new RandomDelayRetryPolicy(MAX_NUM_ATTEMPTS, (long)Integer.MAX_VALUE + 1, (long)Integer.MAX_VALUE + 10);
+    randomDelayRetryPolicy =
+        new RandomDelayRetryPolicy(MAX_NUM_ATTEMPTS, (long) Integer.MAX_VALUE + 1, (long) Integer.MAX_VALUE + 10);
     for (int i = 0; i < NUM_ROUNDS; i++) {
       for (int j = 0; j < MAX_NUM_ATTEMPTS; j++) {
-        Assert.assertTrue(randomDelayRetryPolicy.getDelayMs(j) >= (long)Integer.MAX_VALUE + 1);
-        Assert.assertTrue(randomDelayRetryPolicy.getDelayMs(j) < (long)Integer.MAX_VALUE + 10);
+        Assert.assertTrue(randomDelayRetryPolicy.getDelayMs(j) >= (long) Integer.MAX_VALUE + 1);
+        Assert.assertTrue(randomDelayRetryPolicy.getDelayMs(j) < (long) Integer.MAX_VALUE + 10);
       }
     }
   }

--- a/pinot-spi/src/test/resources/TestRecordReader.java
+++ b/pinot-spi/src/test/resources/TestRecordReader.java
@@ -16,6 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;

--- a/pinot-spi/src/test/resources/log4j2.xml
+++ b/pinot-spi/src/test/resources/log4j2.xml
@@ -29,7 +29,7 @@
   </Appenders>
   <Loggers>
     <AsyncRoot level="warn" additivity="false">
-      <AppenderRef ref="console" />
+      <AppenderRef ref="console"/>
     </AsyncRoot>
   </Loggers>
 </Configuration>

--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -34,6 +34,9 @@
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
     <aws.version>2.14.28</aws.version>
+
+    <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
+    <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
   </properties>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -164,6 +164,10 @@
     <kafka.version>2.0</kafka.version>
     <protobuf.version>3.12.0</protobuf.version>
     <grpc.version>1.30.0</grpc.version>
+
+    <!-- Checkstyle violation prop.-->
+    <checkstyle.violation.severity>warning</checkstyle.violation.severity>
+    <checkstyle.fail.on.violation>true</checkstyle.fail.on.violation>
   </properties>
 
   <profiles>
@@ -1494,20 +1498,32 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>3.1.2</version>
         <configuration>
           <configLocation>${pinot.root}/config/checkstyle.xml</configLocation>
+          <suppressionsLocation>${pinot.root}/config/suppressions.xml</suppressionsLocation>
           <propertyExpansion>config_loc=${pinot.root}/config</propertyExpansion>
-          <consoleOutput>true</consoleOutput>
+          <logViolationsToConsole>true</logViolationsToConsole>
+          <violationSeverity>${checkstyle.violation.severity}</violationSeverity>
+          <failOnViolation>${checkstyle.fail.on.violation}</failOnViolation>
+          <includeTestSourceDirectory>true</includeTestSourceDirectory>
         </configuration>
-        <!--Uncomment to enable style check during build-->
-        <!--<executions>-->
-          <!--<execution>-->
-            <!--<goals>-->
-              <!--<goal>check</goal>-->
-            <!--</goals>-->
-          <!--</execution>-->
-        <!--</executions>-->
+        <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>8.45.1</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>checkstyle</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Description
- Enable maven checkstyle plugin by default with warning severity. All new pinot components should honor this code styling.
- Fix checkstyle.xml with checkstyle lib upgrade
- Fix `pinot-spi` module code styling

Right now we have violations on almost all the components, so I put the prop: `checkstyle.fail.on.violation` to all the component pom files to suppress the errors.

Then we can fix the violations and remove those props one by one. Tracking issue: https://github.com/apache/pinot/issues/7309


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
