### PR TITLE
add underscore to obj vars in IndexKey and IndexEntry

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
@@ -112,8 +112,8 @@ class FilePerIndexDirectory extends ColumnIndexDirectory {
   public Set<String> getColumnsWithIndex(ColumnIndexType type) {
     Set<String> columns = new HashSet<>();
     for (IndexKey indexKey : _indexBuffers.keySet()) {
-      if (indexKey.type == type) {
-        columns.add(indexKey.name);
+      if (indexKey._type == type) {
+        columns.add(indexKey._name);
       }
     }
     return columns;
@@ -125,13 +125,13 @@ class FilePerIndexDirectory extends ColumnIndexDirectory {
       return _indexBuffers.get(key);
     }
 
-    File file = getFileFor(key.name, key.type);
+    File file = getFileFor(key._name, key._type);
     if (!file.exists()) {
       throw new RuntimeException(
-          "Could not find index for column: " + key.name + ", type: " + key.type + ", segment: " + _segmentDirectory
+          "Could not find index for column: " + key._name + ", type: " + key._type + ", segment: " + _segmentDirectory
               .toString());
     }
-    PinotDataBuffer buffer = mapForReads(file, key.type.toString() + ".reader");
+    PinotDataBuffer buffer = mapForReads(file, key._type.toString() + ".reader");
     _indexBuffers.put(key, buffer);
     return buffer;
   }
@@ -142,8 +142,8 @@ class FilePerIndexDirectory extends ColumnIndexDirectory {
       return _indexBuffers.get(key);
     }
 
-    File filename = getFileFor(key.name, key.type);
-    PinotDataBuffer buffer = mapForWrites(filename, sizeBytes, key.type.toString() + ".writer");
+    File filename = getFileFor(key._name, key._type);
+    PinotDataBuffer buffer = mapForWrites(filename, sizeBytes, key._type.toString() + ".writer");
     _indexBuffers.put(key, buffer);
     return buffer;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/IndexEntry.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/IndexEntry.java
@@ -27,17 +27,17 @@ import org.slf4j.LoggerFactory;
 class IndexEntry {
   private static Logger LOGGER = LoggerFactory.getLogger(IndexEntry.class);
 
-  IndexKey key;
-  long startOffset = -1;
-  long size = -1;
-  PinotDataBuffer buffer;
+  IndexKey _key;
+  long _startOffset = -1;
+  long _size = -1;
+  PinotDataBuffer _buffer;
 
   public IndexEntry(IndexKey key) {
-    this.key = key;
+    _key = key;
   }
 
   @Override
   public String toString() {
-    return key.toString() + " : [" + startOffset + "," + (startOffset + size) + ")";
+    return _key.toString() + " : [" + _startOffset + "," + (_startOffset + _size) + ")";
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/IndexKey.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/IndexKey.java
@@ -29,16 +29,16 @@ import org.slf4j.LoggerFactory;
 public class IndexKey {
   private static Logger LOGGER = LoggerFactory.getLogger(IndexKey.class);
 
-  String name;
-  ColumnIndexType type;
+  String _name;
+  ColumnIndexType _type;
 
   /**
    * @param name column name
    * @param type index type
    */
   public IndexKey(String name, ColumnIndexType type) {
-    this.name = name;
-    this.type = type;
+    _name = name;
+    _type = type;
   }
 
   @Override
@@ -52,21 +52,21 @@ public class IndexKey {
 
     IndexKey indexKey = (IndexKey) o;
 
-    if (!name.equals(indexKey.name)) {
+    if (!_name.equals(indexKey._name)) {
       return false;
     }
-    return type == indexKey.type;
+    return _type == indexKey._type;
   }
 
   @Override
   public int hashCode() {
-    int result = name.hashCode();
-    result = 31 * result + type.hashCode();
+    int result = _name.hashCode();
+    result = 31 * result + _type.hashCode();
     return result;
   }
 
   @Override
   public String toString() {
-    return name + "." + type.getIndexName();
+    return _name + "." + _type.getIndexName();
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
@@ -349,7 +349,7 @@ public class SegmentLocalFSDirectory extends SegmentDirectory {
 
     private PinotDataBuffer getNewIndexBuffer(IndexKey key, long sizeBytes)
         throws IOException {
-      return _columnIndexDirectory.newBuffer(key.name, key.type, sizeBytes);
+      return _columnIndexDirectory.newBuffer(key._name, key._type, sizeBytes);
     }
 
     @Override


### PR DESCRIPTION
## Description
Rename vars in IndexKey and IndexEntry in this PR to keep https://github.com/apache/pinot/pull/7301 short. 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
