### PR TITLE
Showing partial status of segment and counting CONSUMING state as good segment status

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -345,6 +345,15 @@ export default function CustomizedTables({
         />
       );
     }
+    if (str?.toLowerCase()?.search('partial-') !== -1) {
+      return (
+        <StyledChip
+          label={str?.replace('Partial-','')}
+          className={classes.cellStatusConsuming}
+          variant="outlined"
+        />
+      );
+    }
     return str.toString();
   };
 

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -462,12 +462,34 @@ const getSegmentList = (tableName) => {
       records: Object.keys(idealStateObj).map((key) => {
         return [
           key,
-          _.isEqual(idealStateObj[key], externalViewObj[key]) ? 'Good' : 'Bad',
+          getSegmentStatus(idealStateObj[key], externalViewObj[key])
         ];
       }),
       externalViewObj
     };
   });
+};
+
+const getSegmentStatus = (idealSegment, externalViewSegment) => {
+  if(_.isEqual(idealSegment, externalViewSegment)){
+    return 'Good';
+  }
+  let goodCount = 0;
+  const totalCount = Object.keys(externalViewSegment).length;
+  Object.keys(idealSegment).map((replicaName)=>{
+    const idealReplicaState = idealSegment[replicaName];
+    const externalReplicaState = externalViewSegment[replicaName];
+    if(idealReplicaState === externalReplicaState || (externalReplicaState === 'CONSUMING')){
+      goodCount += 1;
+    }
+  });
+  if(goodCount === 0){
+    return 'Bad';
+  } else if(goodCount === totalCount){
+    return  'Good';
+  } else {
+    return `Partial-${goodCount}/${totalCount}`;
+  }
 };
 
 // This method is used to display JSON format of a particular tenant table
@@ -779,6 +801,7 @@ export default {
   getAllTableDetails,
   getTableSummaryData,
   getSegmentList,
+  getSegmentStatus,
   getTableDetails,
   getSegmentDetails,
   getClusterName,


### PR DESCRIPTION
## Description
Fix for https://github.com/apache/pinot/issues/7313
As per conversation with  @xiangfu0, segment status are as follows:
-  Good - If all Ideal segment matches with the external view
-  Bad - If none Ideal segment matches with the external view
- n/x - n  denotes good replicas out of total x replicas showing how many are in a good state instead of all Bad

<img width="798" alt="Screenshot 2021-08-19 at 5 15 26 AM" src="https://user-images.githubusercontent.com/6761317/129986470-078e375a-302a-4508-b871-5074f1883697.png">
