### PR TITLE
Delete metadata properly on table deletion

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/lineage/SegmentLineageAccessHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/lineage/SegmentLineageAccessHelper.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.lineage;
 
+import org.I0Itec.zkclient.exception.ZkBadVersionException;
 import org.apache.helix.AccessOption;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -77,6 +78,22 @@ public class SegmentLineageAccessHelper {
       int expectedVersion) {
     String tableNameWithType = segmentLineage.getTableNameWithType();
     String path = ZKMetadataProvider.constructPropertyStorePathForSegmentLineage(tableNameWithType);
-    return propertyStore.set(path, segmentLineage.toZNRecord(), expectedVersion, AccessOption.PERSISTENT);
+    try {
+      return propertyStore.set(path, segmentLineage.toZNRecord(), expectedVersion, AccessOption.PERSISTENT);
+    } catch (ZkBadVersionException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Delete the segment lineage from the property store
+   *
+   * @param propertyStore a property store
+   * @param tableNameWithType a table name with type
+   * @return true if delete is successful. false otherwise.
+   */
+  public static boolean deleteSegmentLineage(ZkHelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType) {
+    String path = ZKMetadataProvider.constructPropertyStorePathForSegmentLineage(tableNameWithType);
+    return propertyStore.remove(path, AccessOption.PERSISTENT);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
@@ -40,7 +40,7 @@ public final class MinionTaskMetadataUtils {
    * Fetches the ZNRecord for the given minion task and tableName, from MINION_TASK_METADATA/taskName/tableNameWthType
    */
   @Nullable
-  public static ZNRecord fetchMinionTaskMetadataZNRecord(HelixPropertyStore<ZNRecord> propertyStore, String taskType,
+  public static ZNRecord fetchTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore, String taskType,
       String tableNameWithType) {
     String path = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(taskType, tableNameWithType);
     Stat stat = new Stat();
@@ -49,6 +49,17 @@ public final class MinionTaskMetadataUtils {
       znRecord.setVersion(stat.getVersion());
     }
     return znRecord;
+  }
+
+  /**
+   * Deletes the ZNRecord for the given minion task and tableName, from MINION_TASK_METADATA/taskName/tableNameWthType
+   */
+  public static void deleteTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore, String taskType,
+      String tableNameWithType) {
+    String path = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(taskType, tableNameWithType);
+    if (!propertyStore.remove(path, AccessOption.PERSISTENT)) {
+      throw new ZkException("Failed to delete task metadata: " + taskType + ", " + tableNameWithType);
+    }
   }
 
   /**
@@ -63,18 +74,6 @@ public final class MinionTaskMetadataUtils {
     if (!propertyStore.set(path, mergeRollupTaskMetadata.toZNRecord(), expectedVersion, AccessOption.PERSISTENT)) {
       throw new ZkException("Failed to persist minion MergeRollupTask metadata: " + mergeRollupTaskMetadata);
     }
-  }
-
-  /**
-   * Fetches the ZNRecord for RealtimeToOfflineSegmentsTask for given tableNameWithType from
-   * MINION_TASK_METADATA/RealtimeToOfflineSegmentsTask/tableNameWthType
-   * and converts it to a {@link RealtimeToOfflineSegmentsTaskMetadata} object
-   */
-  @Nullable
-  public static RealtimeToOfflineSegmentsTaskMetadata getRealtimeToOfflineSegmentsTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore,
-      String taskType, String tableNameWithType) {
-    ZNRecord znRecord = fetchMinionTaskMetadataZNRecord(propertyStore, taskType, tableNameWithType);
-    return znRecord != null ? RealtimeToOfflineSegmentsTaskMetadata.fromZNRecord(znRecord) : null;
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
@@ -94,7 +94,7 @@ public class ClusterInfoAccessor {
    * @param tableNameWithType table name with type
    */
   public ZNRecord getMinionMergeRollupTaskZNRecord(String tableNameWithType) {
-    return MinionTaskMetadataUtils.fetchMinionTaskMetadataZNRecord(_pinotHelixResourceManager.getPropertyStore(),
+    return MinionTaskMetadataUtils.fetchTaskMetadata(_pinotHelixResourceManager.getPropertyStore(),
         MinionConstants.MergeRollupTask.TASK_TYPE, tableNameWithType);
   }
 
@@ -125,9 +125,9 @@ public class ClusterInfoAccessor {
    */
   public RealtimeToOfflineSegmentsTaskMetadata getMinionRealtimeToOfflineSegmentsTaskMetadata(
       String tableNameWithType) {
-    return MinionTaskMetadataUtils
-        .getRealtimeToOfflineSegmentsTaskMetadata(_pinotHelixResourceManager.getPropertyStore(),
-            MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE, tableNameWithType);
+    ZNRecord znRecord = MinionTaskMetadataUtils.fetchTaskMetadata(_pinotHelixResourceManager.getPropertyStore(),
+        MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE, tableNameWithType);
+    return znRecord != null ? RealtimeToOfflineSegmentsTaskMetadata.fromZNRecord(znRecord) : null;
   }
 
   /**

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/MinionTaskZkMetadataManager.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/MinionTaskZkMetadataManager.java
@@ -40,7 +40,7 @@ public class MinionTaskZkMetadataManager {
    */
   public ZNRecord getRealtimeToOfflineSegmentsTaskZNRecord(String tableNameWithType) {
     return MinionTaskMetadataUtils
-        .fetchMinionTaskMetadataZNRecord(_helixManager.getHelixPropertyStore(), RealtimeToOfflineSegmentsTask.TASK_TYPE,
+        .fetchTaskMetadata(_helixManager.getHelixPropertyStore(), RealtimeToOfflineSegmentsTask.TASK_TYPE,
             tableNameWithType);
   }
 


### PR DESCRIPTION
Some of minion tasks interact with the extra metadata
including segment lineage and task specific metadata.
Those need to be clean up on table deletion.