### PR TITLE
Fix the issue with concurrent modification for segment lineage

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/lineage/SegmentLineage.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/lineage/SegmentLineage.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.lineage;
 import com.google.common.base.Preconditions;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -95,7 +96,7 @@ public class SegmentLineage {
    * @return lineage entry ids
    */
   public Set<String> getLineageEntryIds() {
-    return _lineageEntries.keySet();
+    return new HashSet<>(_lineageEntries.keySet());
   }
 
   /**

--- a/pinot-common/src/test/java/org/apache/pinot/common/lineage/SegmentLineageTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/lineage/SegmentLineageTest.java
@@ -101,5 +101,11 @@ public class SegmentLineageTest {
     Assert.assertEquals(segmentLineageFromZNRecord.getLineageEntry(id2), lineageEntry2);
     Assert.assertEquals(segmentLineageFromZNRecord.getLineageEntry(id3), lineageEntry3);
     Assert.assertEquals(segmentLineageFromZNRecord.getLineageEntry(id4), lineageEntry4);
+
+    // Try to delete by iterating through the lineage entry ids
+    for (String lineageId : segmentLineage.getLineageEntryIds()) {
+      segmentLineage.deleteLineageEntry(lineageId);
+    }
+    Assert.assertEquals(segmentLineage.getLineageEntryIds().size(), 0);
   }
 }


### PR DESCRIPTION
There has been a minor bug with the segment lineage where we
 iterate the lineage entries using `.keySet()` and we call
`map.remove()` to delete the entry. This causes to throw
`ConcurrentModificationException` and this pr addresses the issue.
