### PR TITLE
Allow logical identifier in filter

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -1068,7 +1068,7 @@ public class CalciteSqlParser {
         Expression childAndExpression = compileAndExpression((SqlBasicCall) childNode);
         operands.addAll(childAndExpression.getFunctionCall().getOperands());
       } else {
-        operands.add(compileFunctionExpression((SqlBasicCall) childNode));
+        operands.add(toExpression(childNode));
       }
     }
     Expression andExpression = RequestUtils.getFunctionExpression(SqlKind.AND.name());
@@ -1086,7 +1086,7 @@ public class CalciteSqlParser {
         Expression childAndExpression = compileOrExpression((SqlBasicCall) childNode);
         operands.addAll(childAndExpression.getFunctionCall().getOperands());
       } else {
-        operands.add(compileFunctionExpression((SqlBasicCall) childNode));
+        operands.add(toExpression(childNode));
       }
     }
     Expression andExpression = RequestUtils.getFunctionExpression(SqlKind.OR.name());

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -2039,6 +2039,21 @@ public class CalciteSqlCompilerTest {
     }
 
     {
+      String query = "SELECT * FROM foo WHERE col1 > 0 AND (col2 AND col3 > 0) AND col4";
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      Function functionCall = pinotQuery.getFilterExpression().getFunctionCall();
+      Assert.assertEquals(functionCall.getOperator(), SqlKind.AND.name());
+      List<Expression> operands = functionCall.getOperands();
+      Assert.assertEquals(operands.size(), 4);
+      Assert.assertEquals(operands.get(0).getFunctionCall().getOperator(), SqlKind.GREATER_THAN.name());
+      Assert.assertEquals(operands.get(1).getIdentifier().getName(), "col2");
+      Assert.assertEquals(operands.get(2).getFunctionCall().getOperator(), SqlKind.GREATER_THAN.name());
+      Assert.assertEquals(operands.get(3).getIdentifier().getName(), "col4");
+
+      // NOTE: PQL does not support logical identifier
+    }
+
+    {
       String query = "SELECT * FROM foo WHERE col1 <= 0 OR col2 <= 0 OR (col3 <= 0 OR col4 <= 0)";
       PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
       Function functionCall = pinotQuery.getFilterExpression().getFunctionCall();
@@ -2060,9 +2075,23 @@ public class CalciteSqlCompilerTest {
     }
 
     {
-      String query =
-          "SELECT * FROM foo WHERE col1 > 0 AND ((col2 > 0 AND col3 > 0) AND (col1 <= 0 OR (col2 <= 0 OR (col3 <= 0 OR"
-              + " col4 <= 0) OR (col3 > 0 AND col4 > 0))))";
+      String query = "SELECT * FROM foo WHERE col1 <= 0 OR col2 OR (col3 <= 0 OR col4)";
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      Function functionCall = pinotQuery.getFilterExpression().getFunctionCall();
+      Assert.assertEquals(functionCall.getOperator(), SqlKind.OR.name());
+      List<Expression> operands = functionCall.getOperands();
+      Assert.assertEquals(operands.size(), 4);
+      Assert.assertEquals(operands.get(0).getFunctionCall().getOperator(), SqlKind.LESS_THAN_OR_EQUAL.name());
+      Assert.assertEquals(operands.get(1).getIdentifier().getName(), "col2");
+      Assert.assertEquals(operands.get(2).getFunctionCall().getOperator(), SqlKind.LESS_THAN_OR_EQUAL.name());
+      Assert.assertEquals(operands.get(3).getIdentifier().getName(), "col4");
+
+      // NOTE: PQL does not support logical identifier
+    }
+
+    {
+      String query = "SELECT * FROM foo WHERE col1 > 0 AND ((col2 > 0 AND col3 > 0) AND (col1 <= 0 OR (col2 <= 0 OR "
+          + "(col3 <= 0 OR col4 <= 0) OR (col3 > 0 AND col4 > 0))))";
       PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
       Function functionCall = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(functionCall.getOperator(), SqlKind.AND.name());


### PR DESCRIPTION
## Description
Allow logical identifier (`BOOLEAN` column) in the filter during query parsing