### PR TITLE
Remove prefetch query option, since the whole prefetch-acquire-release is already within an instance option

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -152,8 +152,6 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     List<PlanNode> planNodes = new ArrayList<>(indexSegments.size());
 
     if (_enableBufferAcquireRelease) {
-      boolean prefetch =
-          queryContext.getQueryOptions() != null && QueryOptions.isPrefetchBuffers(queryContext.getQueryOptions());
       List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
       for (IndexSegment indexSegment : indexSegments) {
         Set<String> columns;
@@ -162,9 +160,7 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
         } else {
           columns = queryContext.getColumns();
         }
-        if (prefetch) {
-          indexSegment.prefetch(columns);
-        }
+        indexSegment.prefetch(columns);
         planNodes.add(
             new AcquireReleaseColumnsSegmentPlanNode(makeSegmentPlanNode(indexSegment, queryContext), indexSegment,
                 columns));

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptions.java
@@ -98,8 +98,4 @@ public class QueryOptions {
     String minServerGroupTrimSizeString = queryOptions.get(Request.QueryOptionKey.MIN_SERVER_GROUP_TRIM_SIZE);
     return minServerGroupTrimSizeString != null ? Integer.parseInt(minServerGroupTrimSizeString) : null;
   }
-
-  public static boolean isPrefetchBuffers(Map<String, String> queryOptions) {
-    return Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.PREFETCH_BUFFERS));
-  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -226,7 +226,6 @@ public class CommonConstants {
         public static final String SKIP_UPSERT = "skipUpsert";
         public static final String MIN_SEGMENT_GROUP_TRIM_SIZE = "minSegmentGroupTrimSize";
         public static final String MIN_SERVER_GROUP_TRIM_SIZE = "minServerGroupTrimSize";
-        public static final String PREFETCH_BUFFERS = "prefetchBuffers";
       }
     }
   }


### PR DESCRIPTION
Having double options to control this is cumbersome and confusing. Will add `prefetch` option back if it feels necessary. Right now it is safe to remove as no one has started using this option, and it has not made it to any release.