### PR TITLE
Fixing user permission for api calls

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthPrincipal.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthPrincipal.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.auth;
 
 import java.util.Set;
+import java.util.stream.Collectors;
 
 
 /**
@@ -34,7 +35,7 @@ public class BasicAuthPrincipal {
     _name = name;
     _token = token;
     _tables = tables;
-    _permissions = permissions;
+    _permissions = permissions.stream().map(s -> s.toLowerCase()).collect(Collectors.toSet());
   }
 
   public String getName() {
@@ -50,6 +51,6 @@ public class BasicAuthPrincipal {
   }
 
   public boolean hasPermission(String permission) {
-    return _permissions.isEmpty() || _permissions.contains(permission);
+    return _permissions.isEmpty() || _permissions.contains(permission.toLowerCase());
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/auth/BasicAuthTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/auth/BasicAuthTest.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.auth;
+
+import com.google.common.collect.ImmutableSet;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class BasicAuthTest {
+
+  @Test
+  public void testBasicAuthPrincipal()
+      throws Exception {
+    Assert.assertTrue(new BasicAuthPrincipal("name", "token", ImmutableSet.of("myTable"), ImmutableSet.of("READ"))
+        .hasTable("myTable"));
+    Assert.assertTrue(
+        new BasicAuthPrincipal("name", "token", ImmutableSet.of("myTable", "myTable1"), ImmutableSet.of("Read"))
+            .hasTable("myTable1"));
+    Assert.assertFalse(new BasicAuthPrincipal("name", "token", ImmutableSet.of("myTable"), ImmutableSet.of("read"))
+        .hasTable("myTable1"));
+    Assert.assertFalse(
+        new BasicAuthPrincipal("name", "token", ImmutableSet.of("myTable", "myTable1"), ImmutableSet.of("read"))
+            .hasTable("myTable2"));
+
+    Assert.assertTrue(new BasicAuthPrincipal("name", "token", ImmutableSet.of("myTable"), ImmutableSet.of("READ"))
+        .hasPermission("read"));
+    Assert.assertTrue(new BasicAuthPrincipal("name", "token", ImmutableSet.of("myTable"), ImmutableSet.of("Read"))
+        .hasPermission("READ"));
+    Assert.assertTrue(new BasicAuthPrincipal("name", "token", ImmutableSet.of("myTable"), ImmutableSet.of("read"))
+        .hasPermission("Read"));
+    Assert.assertFalse(new BasicAuthPrincipal("name", "token", ImmutableSet.of("myTable"), ImmutableSet.of("read"))
+        .hasPermission("write"));
+  }
+}


### PR DESCRIPTION
## Description
Per https://github.com/apache/pinot/issues/7323, current quick-start-auth.sh has error fetching table schema, as the permission configured is `read` in controller conf file, but `READ` when sending from query console UI.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
