### PR TITLE
Cmd+enter shortcut to run query in Pinot data explorer query console

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -185,6 +185,13 @@ const QueryPage = () => {
   const handleOutputDataChange = (editor, data, value) => {
     setInputQuery(value);
   };
+  
+  const handleQueryInterfaceKeyDown = (editor, event) => {
+    // Map Cmd + Enter KeyPress to executing the query
+    if (event.metaKey == true && event.keyCode == 13) {
+      handleRunNow(editor.getValue())
+    }
+  }
 
   const handleRunNow = async (query?: string) => {
     setQueryLoader(true);
@@ -347,6 +354,7 @@ const QueryPage = () => {
                 }}
                 value={inputQuery}
                 onChange={handleOutputDataChange}
+                onKeyDown={handleQueryInterfaceKeyDown}
                 className={classes.codeMirror}
                 autoCursor={false}
               />


### PR DESCRIPTION
## Description
Add a shortcut (Cmd + Enter) that can be used to run the query when you are focused on the code editor in the pinot controller query console.
Cmd + Enter is pretty standard in query application tools I've used before.
Just a nice to have and makes running queries feel a bit easier.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
n/a

Does this PR fix a zero-downtime upgrade introduced earlier?
n/a

Does this PR otherwise need attention when creating release notes? Things to consider:
n/a

## Release Notes
n/a

-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
