### PR TITLE
support large payload in zk put API

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ZookeeperResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ZookeeperResource.java
@@ -146,10 +146,16 @@ public class ZookeeperResource {
       @Nullable Payload payload
   ) {
 
-    if (payload != null) {
+    if (payload != null && payload.getPath() != null) {
       path = payload.getPath();
+    }
+    if (payload != null && payload.getData() != null) {
       content = payload.getData();
+    }
+    if (payload != null && payload.getExpectedVersion() != null) {
       expectedVersion = payload.getExpectedVersion();
+    }
+    if (payload != null && payload.getAccessOption() != null) {
       accessOption = payload.getAccessOption();
     }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -385,4 +385,8 @@ public class ControllerRequestURLBuilder {
   public String forAppConfigs() {
     return StringUtil.join("/", _baseUrl, "appconfigs");
   }
+
+  public String forZkPut() {
+    return StringUtil.join("/", _baseUrl, "zk/put");
+  }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerTestUtils.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerTestUtils.java
@@ -567,6 +567,26 @@ public abstract class ControllerTestUtils {
     return constructResponse(httpConnection.getInputStream());
   }
 
+  public static String sendPutRequest(String urlString, Map<String, String> headers, String payload)
+      throws IOException {
+    HttpURLConnection httpConnection = (HttpURLConnection) new URL(urlString).openConnection();
+    httpConnection.setDoOutput(true);
+    httpConnection.setRequestMethod("PUT");
+    if (headers != null) {
+      for (Map.Entry<String, String> kv : headers.entrySet()) {
+        httpConnection.setRequestProperty(kv.getKey(), kv.getValue());
+      }
+    }
+
+    try (BufferedWriter writer = new BufferedWriter(
+        new OutputStreamWriter(httpConnection.getOutputStream(), StandardCharsets.UTF_8))) {
+      writer.write(payload);
+      writer.flush();
+    }
+
+    return constructResponse(httpConnection.getInputStream());
+  }
+
   public static String sendPutRequest(String urlString)
       throws IOException {
     HttpURLConnection httpConnection = (HttpURLConnection) new URL(urlString).openConnection();

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/ZookeeperResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/ZookeeperResourceTest.java
@@ -1,0 +1,101 @@
+package org.apache.pinot.controller.api;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.controller.ControllerTestUtils;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class ZookeeperResourceTest {
+
+  @BeforeClass
+  public void setUp() throws Exception {
+    ControllerTestUtils.setupClusterAndValidate();
+  }
+
+  @Test
+  public void testZkPutDataWithLargePayload() {
+    String url = ControllerTestUtils.getControllerRequestURLBuilder().forZkPut();
+    String path = "/zookeeper";
+    String _data = "{\"id\" : \"QuickStartCluster\"," + "  \"simpleFields\" : {\n"
+        + "    \"allowParticipantAutoJoin\" : \"true\",\n" + "    \"default.hyperloglog.log2m\" : \"8\",\n"
+        + "    \"enable.case.insensitive\" : \"true\",\n"
+        + "    \"pinot.broker.enable.query.limit.override\" : \"false\"\n" + "  },\n" + "  \"mapFields\" : { },\n"
+        + "  \"listFields\" : { }\n" + "}";
+    String data = "";
+    int expectedVersion = -1;
+    int accessOption = 1;
+
+    // CASE 1: Send data in query params form using HTTP PUT
+    try {
+      String params = "path=" + URLEncoder.encode(path, StandardCharsets.UTF_8) +
+          "&data=" + URLEncoder.encode(data, StandardCharsets.UTF_8) +
+          "&expectedVersion=" + expectedVersion +
+          "&accessOption=" + accessOption;
+
+      String result = ControllerTestUtils.sendPutRequest(url + "?" + params);
+      Assert.assertTrue(result.toLowerCase().contains("successfully updated"));
+    } catch (IOException e) {
+      // Should not get here
+      Assert.fail("Update should be done successfully");
+    }
+
+    String lorem = "Loremipsumdolorsitametconsecteturadipisicingelitseddoeiusmod"
+        + "temporincididuntutlaboreetdoloremagnaaliquaUtenimadminimveniam"
+        + "quisnostrudexercitationullamcolaborisnisiutaliquipexeacommodo"
+        + "consequatDuisauteiruredolorinreprehenderitinvoluptatevelitesse"
+        + "cillumdoloreeufugiatnullapariaturExcepteursintoccaecatcupidatatnon"
+        + "proidentsuntinculpaquiofficiadeseruntmollitanimidestlaborum";
+    // make the content even more larger
+    for (int i = 0; i < 5; i++) {
+      lorem += lorem;
+    }
+
+    String largeConfig = "{\n" + "  \"id\" : \"QuickStartCluster\",\n" + "  \"simpleFields\" : {\n"
+        + "    \"allowParticipantAutoJoin\" : \"true\",\n" + "    \"default.hyperloglog.log2m\" : \"8\",\n"
+        + "    \"enable.case.insensitive\" : \"true\",\n"
+        + "    \"pinot.broker.enable.query.limit.override\" : \"false\"\n" + "  },\n" + "  \"mapFields\" : { },\n"
+        + "  \"lorem\" : " + "\"" + lorem + "\"\n" + "}";
+    String largeData = URLEncoder.encode(largeConfig, StandardCharsets.UTF_8);
+
+    // CASE 2: Fail when sending large data in query params
+    boolean isSuccessful = false;
+    try {
+      String params = "path=" + URLEncoder.encode(path, StandardCharsets.UTF_8) +
+          "&data=" + URLEncoder.encode(largeData, StandardCharsets.UTF_8) +
+          "&expectedVersion=" + expectedVersion +
+          "&accessOption=" + accessOption;
+      ControllerTestUtils.sendPutRequest(url + "?" + params);
+
+      isSuccessful = true;
+      Assert.fail("Should not get here, large payload");
+    } catch (IOException e) {
+      Assert.assertFalse(isSuccessful);
+    }
+
+    // CASE 3: Send large content data should return success
+    try {
+      ObjectNode jsonPayload = JsonUtils.newObjectNode();
+      jsonPayload.put("path", path);
+      jsonPayload.put("data", largeConfig);
+      jsonPayload.put("expectedVersion", expectedVersion);
+      jsonPayload.put("accessOption", accessOption);
+
+      Map<String, String> headers = new HashMap<>();
+      headers.put("Content-Type", "application/json");
+
+      String result = ControllerTestUtils.sendPutRequest(url, headers, jsonPayload.toString());
+      Assert.assertTrue(result.toLowerCase().contains("successfully updated"));
+    } catch (IOException e) {
+      // Should not get here
+      Assert.fail("request should be executed successfully");
+    }
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/ZookeeperResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/ZookeeperResourceTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.controller.api;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -16,7 +34,8 @@ import org.testng.annotations.Test;
 public class ZookeeperResourceTest {
 
   @BeforeClass
-  public void setUp() throws Exception {
+  public void setUp()
+      throws Exception {
     ControllerTestUtils.setupClusterAndValidate();
   }
 
@@ -24,21 +43,15 @@ public class ZookeeperResourceTest {
   public void testZkPutDataWithLargePayload() {
     String url = ControllerTestUtils.getControllerRequestURLBuilder().forZkPut();
     String path = "/zookeeper";
-    String _data = "{\"id\" : \"QuickStartCluster\"," + "  \"simpleFields\" : {\n"
-        + "    \"allowParticipantAutoJoin\" : \"true\",\n" + "    \"default.hyperloglog.log2m\" : \"8\",\n"
-        + "    \"enable.case.insensitive\" : \"true\",\n"
-        + "    \"pinot.broker.enable.query.limit.override\" : \"false\"\n" + "  },\n" + "  \"mapFields\" : { },\n"
-        + "  \"listFields\" : { }\n" + "}";
-    String data = "";
     int expectedVersion = -1;
     int accessOption = 1;
+    String data = "{\"id\" : \"QuickStartCluster\"," + "  \"data\" : { }\n" + "}";
 
     // CASE 1: Send data in query params form using HTTP PUT
     try {
-      String params = "path=" + URLEncoder.encode(path, StandardCharsets.UTF_8) +
-          "&data=" + URLEncoder.encode(data, StandardCharsets.UTF_8) +
-          "&expectedVersion=" + expectedVersion +
-          "&accessOption=" + accessOption;
+      String params = "path=" + URLEncoder.encode(path, StandardCharsets.UTF_8) + "&data=" + URLEncoder
+          .encode(data, StandardCharsets.UTF_8) + "&expectedVersion=" + expectedVersion + "&accessOption="
+          + accessOption;
 
       String result = ControllerTestUtils.sendPutRequest(url + "?" + params);
       Assert.assertTrue(result.toLowerCase().contains("successfully updated"));
@@ -53,25 +66,21 @@ public class ZookeeperResourceTest {
         + "consequatDuisauteiruredolorinreprehenderitinvoluptatevelitesse"
         + "cillumdoloreeufugiatnullapariaturExcepteursintoccaecatcupidatatnon"
         + "proidentsuntinculpaquiofficiadeseruntmollitanimidestlaborum";
+
     // make the content even more larger
     for (int i = 0; i < 5; i++) {
       lorem += lorem;
     }
 
-    String largeConfig = "{\n" + "  \"id\" : \"QuickStartCluster\",\n" + "  \"simpleFields\" : {\n"
-        + "    \"allowParticipantAutoJoin\" : \"true\",\n" + "    \"default.hyperloglog.log2m\" : \"8\",\n"
-        + "    \"enable.case.insensitive\" : \"true\",\n"
-        + "    \"pinot.broker.enable.query.limit.override\" : \"false\"\n" + "  },\n" + "  \"mapFields\" : { },\n"
-        + "  \"lorem\" : " + "\"" + lorem + "\"\n" + "}";
+    String largeConfig = "{\n" + "  \"id\" : \"QuickStartCluster\",\n" + "  \"data\" : " + "\"" + lorem + "\"\n" + "}";
     String largeData = URLEncoder.encode(largeConfig, StandardCharsets.UTF_8);
 
     // CASE 2: Fail when sending large data in query params
     boolean isSuccessful = false;
     try {
-      String params = "path=" + URLEncoder.encode(path, StandardCharsets.UTF_8) +
-          "&data=" + URLEncoder.encode(largeData, StandardCharsets.UTF_8) +
-          "&expectedVersion=" + expectedVersion +
-          "&accessOption=" + accessOption;
+      String params = "path=" + URLEncoder.encode(path, StandardCharsets.UTF_8) + "&data=" + URLEncoder
+          .encode(largeData, StandardCharsets.UTF_8) + "&expectedVersion=" + expectedVersion + "&accessOption="
+          + accessOption;
       ControllerTestUtils.sendPutRequest(url + "?" + params);
 
       isSuccessful = true;


### PR DESCRIPTION
## Description
support large payload in ZK put API, solve [issue 7305](https://github.com/apache/pinot/issues/7305)

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [x] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
