### PR TITLE
Fix misleading error msg for missing URI

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
@@ -150,7 +150,7 @@ public class HadoopPinotFS extends PinotFS {
         filePathStrings.add(file.getPath().toString());
       }
     } else {
-      throw new IllegalArgumentException("segmentUri is not valid");
+      throw new IllegalArgumentException("fileUri does not exist: " + fileUri);
     }
     String[] retArray = new String[filePathStrings.size()];
     filePathStrings.toArray(retArray);


### PR DESCRIPTION
## Description
When running a Hadoop job to build segments, if (for example) the `inputDirURI` is incorrect, the error message you get is `Caused by: java.lang.IllegalArgumentException: segmentUri is not valid`, which is both incorrect and not very informative.

The new message is `fileUri does not exist: <actual URI>`

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
No

Does this PR fix a zero-downtime upgrade introduced earlier?
No

Does this PR otherwise need attention when creating release notes? Things to consider:
No

## Documentation
N/A
