### PR TITLE
Add mergeRollupTask delay metrics

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -504,7 +504,7 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
    * Remove callback gauge.
    * @param metricName metric name
    */
-  private void removeCallbackGauge(String metricName) {
+  public void removeCallbackGauge(String metricName) {
     PinotMetricUtils
         .removeMetric(_metricsRegistry, PinotMetricUtils.makePinotMetricName(_clazz, _metricPrefix + metricName));
   }
@@ -517,5 +517,15 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
 
   protected String getTableName(String tableName) {
     return _isTableLevelMetricsEnabled || _allowedTables.contains(tableName) ? tableName : "allTables";
+  }
+
+  /**
+   * Check if the metric name appears in the gauge value map.
+   * @param metricName metric name
+   * @return True if the metric name appears on the gauge value map. False otherwise.
+   */
+  @VisibleForTesting
+  public boolean containsGauge(String metricName) {
+    return _gaugeValues.containsKey(metricName);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -494,7 +494,7 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
    * Remove gauge from Pinot metrics.
    * @param gaugeName gauge name
    */
-  private void removeGauge(final String gaugeName) {
+  public void removeGauge(final String gaugeName) {
     if (_gaugeValues.remove(gaugeName) != null) {
       removeCallbackGauge(gaugeName);
     }
@@ -504,7 +504,7 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
    * Remove callback gauge.
    * @param metricName metric name
    */
-  public void removeCallbackGauge(String metricName) {
+  private void removeCallbackGauge(String metricName) {
     PinotMetricUtils
         .removeMetric(_metricsRegistry, PinotMetricUtils.makePinotMetricName(_clazz, _metricPrefix + metricName));
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
@@ -30,6 +30,7 @@ import org.apache.pinot.common.lineage.SegmentLineage;
 import org.apache.pinot.common.lineage.SegmentLineageAccessHelper;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.minion.MergeRollupTaskMetadata;
 import org.apache.pinot.common.minion.MinionTaskMetadataUtils;
 import org.apache.pinot.common.minion.RealtimeToOfflineSegmentsTaskMetadata;
@@ -49,12 +50,15 @@ public class ClusterInfoAccessor {
   private final PinotHelixResourceManager _pinotHelixResourceManager;
   private final PinotHelixTaskResourceManager _pinotHelixTaskResourceManager;
   private final ControllerConf _controllerConf;
+  private final ControllerMetrics _controllerMetrics;
 
   public ClusterInfoAccessor(PinotHelixResourceManager pinotHelixResourceManager,
-      PinotHelixTaskResourceManager pinotHelixTaskResourceManager, ControllerConf controllerConf) {
+      PinotHelixTaskResourceManager pinotHelixTaskResourceManager, ControllerConf controllerConf,
+      ControllerMetrics controllerMetrics) {
     _pinotHelixResourceManager = pinotHelixResourceManager;
     _pinotHelixTaskResourceManager = pinotHelixTaskResourceManager;
     _controllerConf = controllerConf;
+    _controllerMetrics = controllerMetrics;
   }
 
   /**
@@ -180,5 +184,14 @@ public class ClusterInfoAccessor {
     Map<String, String> configMap =
         _pinotHelixResourceManager.getHelixAdmin().getConfig(helixConfigScope, Collections.singletonList(configName));
     return configMap != null ? configMap.get(configName) : null;
+  }
+
+  /**
+   * Get the controller metrics.
+   *
+   * @return controller metrics
+   */
+  public ControllerMetrics getControllerMetrics() {
+    return _controllerMetrics;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
@@ -35,6 +35,7 @@ import org.apache.pinot.common.minion.MergeRollupTaskMetadata;
 import org.apache.pinot.common.minion.MinionTaskMetadataUtils;
 import org.apache.pinot.common.minion.RealtimeToOfflineSegmentsTaskMetadata;
 import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
@@ -51,14 +52,16 @@ public class ClusterInfoAccessor {
   private final PinotHelixTaskResourceManager _pinotHelixTaskResourceManager;
   private final ControllerConf _controllerConf;
   private final ControllerMetrics _controllerMetrics;
+  private final LeadControllerManager _leadControllerManager;
 
   public ClusterInfoAccessor(PinotHelixResourceManager pinotHelixResourceManager,
       PinotHelixTaskResourceManager pinotHelixTaskResourceManager, ControllerConf controllerConf,
-      ControllerMetrics controllerMetrics) {
+      ControllerMetrics controllerMetrics, LeadControllerManager leadControllerManager) {
     _pinotHelixResourceManager = pinotHelixResourceManager;
     _pinotHelixTaskResourceManager = pinotHelixTaskResourceManager;
     _controllerConf = controllerConf;
     _controllerMetrics = controllerMetrics;
+    _leadControllerManager = leadControllerManager;
   }
 
   /**
@@ -193,5 +196,14 @@ public class ClusterInfoAccessor {
    */
   public ControllerMetrics getControllerMetrics() {
     return _controllerMetrics;
+  }
+
+  /**
+   * Get the leader controller manager.
+   *
+   * @return leader controller manager
+   */
+  public LeadControllerManager getLeaderControllerManager() {
+    return _leadControllerManager;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -96,7 +96,8 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
         controllerMetrics);
     _helixTaskResourceManager = helixTaskResourceManager;
     _clusterInfoAccessor =
-        new ClusterInfoAccessor(helixResourceManager, helixTaskResourceManager, controllerConf, controllerMetrics);
+        new ClusterInfoAccessor(helixResourceManager, helixTaskResourceManager, controllerConf, controllerMetrics,
+            leadControllerManager);
     _taskGeneratorRegistry = new TaskGeneratorRegistry(_clusterInfoAccessor);
 
     if (controllerConf.isPinotTaskManagerSchedulerEnabled()) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -95,7 +95,8 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
         controllerConf.getPinotTaskManagerInitialDelaySeconds(), helixResourceManager, leadControllerManager,
         controllerMetrics);
     _helixTaskResourceManager = helixTaskResourceManager;
-    _clusterInfoAccessor = new ClusterInfoAccessor(helixResourceManager, helixTaskResourceManager, controllerConf);
+    _clusterInfoAccessor =
+        new ClusterInfoAccessor(helixResourceManager, helixTaskResourceManager, controllerConf, controllerMetrics);
     _taskGeneratorRegistry = new TaskGeneratorRegistry(_clusterInfoAccessor);
 
     if (controllerConf.isPinotTaskManagerSchedulerEnabled()) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MergeRollupMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MergeRollupMinionClusterIntegrationTest.java
@@ -50,13 +50,13 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -259,7 +259,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     //    {merged_100days_T4_1_16400_16404_1, myTable1_16405_16435_2}
     //      -> {merged_100days_T5_0_myTable1_16400_16435_0}
 
-    String sqlQuery = "SELECT count(*) FROM mytable1"; // 115545 rows for the test table
+    String sqlQuery = "SELECT count(*) FROM myTable1"; // 115545 rows for the test table
     JsonNode expectedJson = postSqlQuery(sqlQuery, _brokerBaseApiUrl);
     int[] expectedNumSubTasks = {1, 2, 2, 2, 1};
     int[] expectedNumSegmentsQueried = {13, 12, 13, 13, 12};
@@ -269,11 +269,11 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     for (String tasks = _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE);
         tasks != null; tasks =
         _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE), numTasks++) {
-      Assert.assertEquals(_helixTaskResourceManager.getTaskConfigs(tasks).size(), expectedNumSubTasks[numTasks]);
-      Assert.assertTrue(_helixTaskResourceManager.getTaskQueues()
+      assertEquals(_helixTaskResourceManager.getTaskConfigs(tasks).size(), expectedNumSubTasks[numTasks]);
+      assertTrue(_helixTaskResourceManager.getTaskQueues()
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
       // Will not schedule task if there's incomplete task
-      Assert.assertNull(
+      assertNull(
           _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       waitForTaskToComplete();
 
@@ -281,7 +281,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
       MergeRollupTaskMetadata minionTaskMetadata = MergeRollupTaskMetadata
           .fromZNRecord(_taskManager.getClusterInfoAccessor().getMinionMergeRollupTaskZNRecord(offlineTableName));
       assertNotNull(minionTaskMetadata);
-      Assert.assertEquals((long) minionTaskMetadata.getWatermarkMap().get("100days"), expectedWatermark);
+      assertEquals((long) minionTaskMetadata.getWatermarkMap().get("100days"), expectedWatermark);
       expectedWatermark += 100 * 86_400_000L;
 
       // Check metadata of merged segments
@@ -305,6 +305,9 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     }
     // Check total tasks
     assertEquals(numTasks, 5);
+
+    assertTrue(_controllerStarter.getControllerMetrics()
+        .containsGauge("mergeRollupTaskDelayInNumBuckets.myTable1_OFFLINE.100days"));
 
     // Drop the table
     dropOfflineTable(SINGLE_LEVEL_CONCAT_TEST_TABLE);
@@ -361,11 +364,11 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     for (String tasks = _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE);
         tasks != null; tasks =
         _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE), numTasks++) {
-      Assert.assertEquals(_helixTaskResourceManager.getTaskConfigs(tasks).size(), 1);
-      Assert.assertTrue(_helixTaskResourceManager.getTaskQueues()
+      assertEquals(_helixTaskResourceManager.getTaskConfigs(tasks).size(), 1);
+      assertTrue(_helixTaskResourceManager.getTaskQueues()
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
       // Will not schedule task if there's incomplete task
-      Assert.assertNull(
+      assertNull(
           _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       waitForTaskToComplete();
 
@@ -373,7 +376,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
       MergeRollupTaskMetadata minionTaskMetadata = MergeRollupTaskMetadata
           .fromZNRecord(_taskManager.getClusterInfoAccessor().getMinionMergeRollupTaskZNRecord(offlineTableName));
       assertNotNull(minionTaskMetadata);
-      Assert.assertEquals((long) minionTaskMetadata.getWatermarkMap().get("150days"), expectedWatermark);
+      assertEquals((long) minionTaskMetadata.getWatermarkMap().get("150days"), expectedWatermark);
       expectedWatermark += 150 * 86_400_000L;
 
       // Check metadata of merged segments
@@ -407,10 +410,13 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
         postSqlQuery("SELECT count(*), DaysSinceEpoch FROM myTable2 GROUP BY DaysSinceEpoch ORDER BY DaysSinceEpoch");
     for (int i = 0; i < responseJson.get("resultTable").get("rows").size(); i++) {
       int daysSinceEpoch = responseJson.get("resultTable").get("rows").get(i).get(1).asInt();
-      Assert.assertTrue(daysSinceEpoch % 7 == 0);
+      assertTrue(daysSinceEpoch % 7 == 0);
     }
     // Check total tasks
     assertEquals(numTasks, 3);
+
+    assertTrue(_controllerStarter.getControllerMetrics()
+        .containsGauge("mergeRollupTaskDelayInNumBuckets.myTable2_OFFLINE.150days"));
   }
 
   /**
@@ -497,11 +503,11 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     for (String tasks = _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE);
         tasks != null; tasks =
         _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE), numTasks++) {
-      Assert.assertEquals(_helixTaskResourceManager.getTaskConfigs(tasks).size(), expectedNumSubTasks[numTasks]);
-      Assert.assertTrue(_helixTaskResourceManager.getTaskQueues()
+      assertEquals(_helixTaskResourceManager.getTaskConfigs(tasks).size(), expectedNumSubTasks[numTasks]);
+      assertTrue(_helixTaskResourceManager.getTaskQueues()
           .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
       // Will not schedule task if there's incomplete task
-      Assert.assertNull(
+      assertNull(
           _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
       waitForTaskToComplete();
 
@@ -509,8 +515,8 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
       MergeRollupTaskMetadata minionTaskMetadata = MergeRollupTaskMetadata
           .fromZNRecord(_taskManager.getClusterInfoAccessor().getMinionMergeRollupTaskZNRecord(offlineTableName));
       assertNotNull(minionTaskMetadata);
-      Assert.assertEquals(minionTaskMetadata.getWatermarkMap().get("45days"), expectedWatermarks45Days[numTasks]);
-      Assert.assertEquals(minionTaskMetadata.getWatermarkMap().get("90days"), expectedWatermarks90Days[numTasks]);
+      assertEquals(minionTaskMetadata.getWatermarkMap().get("45days"), expectedWatermarks45Days[numTasks]);
+      assertEquals(minionTaskMetadata.getWatermarkMap().get("90days"), expectedWatermarks90Days[numTasks]);
 
       // Check metadata of merged segments
       for (SegmentZKMetadata metadata : _pinotHelixResourceManager.getSegmentsZKMetadata(offlineTableName)) {
@@ -539,6 +545,11 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     }
     // Check total tasks
     assertEquals(numTasks, 8);
+
+    assertTrue(_controllerStarter.getControllerMetrics()
+        .containsGauge("mergeRollupTaskDelayInNumBuckets.myTable3_OFFLINE.45days"));
+    assertTrue(_controllerStarter.getControllerMetrics()
+        .containsGauge("mergeRollupTaskDelayInNumBuckets.myTable3_OFFLINE.90days"));
   }
 
   protected void verifyTableDelete(String tableNameWithType) {


### PR DESCRIPTION
When operating merge/roll-up tasks in production, we should have
a metrics that indicates the progress or delay of merge/roll-up
task. mergeRollupTaskDelayInNumTimeBuckets is computed as follows:

(current_time - watermark - bufferTime) / bucketTime
