### PR TITLE
make getColumnIndices accurate

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
@@ -108,10 +108,13 @@ class FilePerIndexDirectory extends ColumnIndexDirectory {
 
   @Override
   public Set<String> getColumnsWithIndex(ColumnIndexType type) {
+    // _indexBuffers is just a cache of index files, thus not reliable as
+    // the source of truth about which indices exist in the directory.
+    // Call hasIndexFor() to check if a column-index exists for sure.
     Set<String> columns = new HashSet<>();
-    for (IndexKey indexKey : _indexBuffers.keySet()) {
-      if (indexKey._type == type) {
-        columns.add(indexKey._name);
+    for (String column : _segmentMetadata.getAllColumns()) {
+      if (hasIndexFor(column, type)) {
+        columns.add(column);
       }
     }
     return columns;
@@ -187,6 +190,9 @@ class FilePerIndexDirectory extends ColumnIndexDirectory {
         break;
       case JSON_INDEX:
         fileExtension = V1Constants.Indexes.JSON_INDEX_FILE_EXTENSION;
+        break;
+      case H3_INDEX:
+        fileExtension = V1Constants.Indexes.H3_INDEX_FILE_EXTENSION;
         break;
       default:
         throw new IllegalStateException("Unsupported index type: " + indexType);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
@@ -386,6 +386,15 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
   @Override
   public Set<String> getColumnsWithIndex(ColumnIndexType type) {
     Set<String> columns = new HashSet<>();
+    // TEXT_INDEX is not tracked via _columnEntries, so handled separately.
+    if (type == ColumnIndexType.TEXT_INDEX) {
+      for (String column : _segmentMetadata.getAllColumns()) {
+        if (TextIndexUtils.hasTextIndex(_segmentDirectory, column)) {
+          columns.add(column);
+        }
+      }
+      return columns;
+    }
     for (IndexKey indexKey : _columnEntries.keySet()) {
       if (indexKey._type == type) {
         columns.add(indexKey._name);


### PR DESCRIPTION
1. make getColumnIndices accurate
2. makes V1's findIndex() aware of H3 index

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
