### PR TITLE
Add cleanup method for HadoopSegmentCreationJob

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/HadoopSegmentCreationJob.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/HadoopSegmentCreationJob.java
@@ -134,9 +134,7 @@ public class HadoopSegmentCreationJob extends SegmentCreationJob {
 
     moveSegmentsToOutputDir();
 
-    // Delete the staging directory
-    _logger.info("Deleting the staging directory: {}", _stagingDir);
-    _outputDirFileSystem.delete(new Path(_stagingDir), true);
+    cleanup(job);
   }
 
   protected void validateTableConfig(TableConfig tableConfig) {
@@ -176,5 +174,15 @@ public class HadoopSegmentCreationJob extends SegmentCreationJob {
       throws IOException {
     Path segmentTarDir = new Path(new Path(_stagingDir, "output"), JobConfigConstants.SEGMENT_TAR_DIR);
     movePath(_outputDirFileSystem, segmentTarDir.toString(), _outputDir, true);
+  }
+
+  /**
+   * Cleans up after the job completes.
+   */
+  protected void cleanup(Job job)
+      throws Exception {
+    // Delete the staging directory
+    _logger.info("Deleting the staging directory: {}", _stagingDir);
+    _outputDirFileSystem.delete(new Path(_stagingDir), true);
   }
 }


### PR DESCRIPTION
## Description
This method adds cleanup method for HadoopSegmentCreationJob. 
The method didn't get added to the base class as not all the subclasses that extend the base class create a Job object (e.g. SegmentTarPushJob doesn’t initialize a job object). 
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
