### PR TITLE
Check schema backward-compatibility when updating schema through addSchema with override

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/exception/SchemaAlreadyExistsException.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/exception/SchemaAlreadyExistsException.java
@@ -1,0 +1,26 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.exception;
+
+public class SchemaAlreadyExistsException extends Exception {
+
+  public SchemaAlreadyExistsException(String message) {
+    super(message);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -244,6 +244,10 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", _baseUrl, "schemas", schemaName);
   }
 
+  public String forSchemaDelete(String schemaName) {
+    return StringUtil.join("/", _baseUrl, "schemas", schemaName);
+  }
+
   public String forTableConfigsCreate() {
     return StringUtil.join("/", _baseUrl, "tableConfigs");
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSchemaRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSchemaRestletResourceTest.java
@@ -25,7 +25,7 @@ import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.httpclient.methods.PutMethod;
 import org.apache.pinot.controller.ControllerTestUtils;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -93,48 +93,106 @@ public class PinotSchemaRestletResourceTest {
       throws IOException {
     String schemaName = "testSchema";
     Schema schema = ControllerTestUtils.createDummySchema(schemaName);
-    String url = ControllerTestUtils.getControllerRequestURLBuilder().forSchemaCreate();
-    PostMethod postMethod = ControllerTestUtils.sendMultipartPostRequest(url, schema.toSingleLineJsonString());
+
+    // Add the schema
+    String addSchemaUrl = ControllerTestUtils.getControllerRequestURLBuilder().forSchemaCreate();
+    PostMethod postMethod = ControllerTestUtils.sendMultipartPostRequest(addSchemaUrl, schema.toSingleLineJsonString());
     Assert.assertEquals(postMethod.getStatusCode(), 200);
 
-    schema.addField(new DimensionFieldSpec("NewColumn", FieldSpec.DataType.STRING, true));
-    postMethod = ControllerTestUtils.sendMultipartPostRequest(url, schema.toSingleLineJsonString());
+    // Add a new column
+    DimensionFieldSpec newColumnFieldSpec = new DimensionFieldSpec("newColumn", DataType.STRING, true);
+    schema.addField(newColumnFieldSpec);
+
+    // Update the schema with addSchema api and override off
+    postMethod =
+        ControllerTestUtils.sendMultipartPostRequest(addSchemaUrl + "?override=false", schema.toSingleLineJsonString());
+    Assert.assertEquals(postMethod.getStatusCode(), 409);
+
+    // Update the schema with addSchema api and override on
+    postMethod = ControllerTestUtils.sendMultipartPostRequest(addSchemaUrl, schema.toSingleLineJsonString());
     Assert.assertEquals(postMethod.getStatusCode(), 200);
 
-    String schemaStr = ControllerTestUtils
-        .sendGetRequest(ControllerTestUtils.getControllerRequestURLBuilder().forSchemaGet(schemaName));
-    Schema readSchema = Schema.fromString(schemaStr);
-    Schema inputSchema = Schema.fromString(schema.toSingleLineJsonString());
-    Assert.assertEquals(readSchema, inputSchema);
-    Assert.assertTrue(readSchema.getFieldSpecMap().containsKey("NewColumn"));
+    // Get the schema and verify the new column exists
+    String getSchemaUrl = ControllerTestUtils.getControllerRequestURLBuilder().forSchemaGet(schemaName);
+    Schema remoteSchema = Schema.fromString(ControllerTestUtils.sendGetRequest(getSchemaUrl));
+    Assert.assertEquals(remoteSchema, schema);
+    Assert.assertTrue(remoteSchema.hasColumn(newColumnFieldSpec.getName()));
 
-    final String yetAnotherColumn = "YetAnotherColumn";
-    Assert.assertFalse(readSchema.getFieldSpecMap().containsKey(yetAnotherColumn));
-    schema.addField(new DimensionFieldSpec(yetAnotherColumn, FieldSpec.DataType.STRING, true));
-    PutMethod putMethod = ControllerTestUtils
-        .sendMultipartPutRequest(ControllerTestUtils.getControllerRequestURLBuilder().forSchemaUpdate(schemaName),
-            schema.toSingleLineJsonString());
+    // Add another new column
+    DimensionFieldSpec newColumnFieldSpec2 = new DimensionFieldSpec("newColumn2", DataType.STRING, true);
+    schema.addField(newColumnFieldSpec2);
+
+    // Update the schema with updateSchema api
+    String updateSchemaUrl = ControllerTestUtils.getControllerRequestURLBuilder().forSchemaUpdate(schemaName);
+    PutMethod putMethod = ControllerTestUtils.sendMultipartPutRequest(updateSchemaUrl, schema.toSingleLineJsonString());
     Assert.assertEquals(putMethod.getStatusCode(), 200);
-    // verify some more...
-    schemaStr = ControllerTestUtils
-        .sendGetRequest(ControllerTestUtils.getControllerRequestURLBuilder().forSchemaGet(schemaName));
-    readSchema = Schema.fromString(schemaStr);
-    inputSchema = Schema.fromString(schema.toSingleLineJsonString());
-    Assert.assertEquals(readSchema, inputSchema);
-    Assert.assertTrue(readSchema.getFieldSpecMap().containsKey(yetAnotherColumn));
 
-    // error cases
-    putMethod = ControllerTestUtils
-        .sendMultipartPutRequest(ControllerTestUtils.getControllerRequestURLBuilder().forSchemaUpdate(schemaName),
-            schema.toSingleLineJsonString().substring(1));
-    // invalid json
+    // Get the schema and verify both the new columns exist
+    remoteSchema = Schema.fromString(ControllerTestUtils.sendGetRequest(getSchemaUrl));
+    Assert.assertEquals(remoteSchema, schema);
+    Assert.assertTrue(remoteSchema.hasColumn(newColumnFieldSpec.getName()));
+    Assert.assertTrue(remoteSchema.hasColumn(newColumnFieldSpec2.getName()));
+
+    // Change the column data type - backward-incompatible change
+    newColumnFieldSpec.setDataType(DataType.INT);
+
+    // Update the schema with addSchema api and override on
+    postMethod = ControllerTestUtils.sendMultipartPostRequest(addSchemaUrl, schema.toSingleLineJsonString());
+    Assert.assertEquals(postMethod.getStatusCode(), 400);
+
+    // Update the schema with updateSchema api
+    putMethod = ControllerTestUtils.sendMultipartPutRequest(updateSchemaUrl, schema.toSingleLineJsonString());
     Assert.assertEquals(putMethod.getStatusCode(), 400);
 
-    schema.setSchemaName("differentSchemaName");
-    putMethod = ControllerTestUtils
-        .sendMultipartPutRequest(ControllerTestUtils.getControllerRequestURLBuilder().forSchemaUpdate(schemaName),
-            schema.toSingleLineJsonString());
+    // Change the column data type from STRING to BOOLEAN
+    newColumnFieldSpec.setDataType(DataType.BOOLEAN);
+
+    // Update the schema with addSchema api and override on
+    postMethod = ControllerTestUtils.sendMultipartPostRequest(addSchemaUrl, schema.toSingleLineJsonString());
+    Assert.assertEquals(postMethod.getStatusCode(), 200);
+
+    // Change another column data type from STRING to BOOLEAN
+    newColumnFieldSpec2.setDataType(DataType.BOOLEAN);
+
+    // Update the schema with updateSchema api
+    putMethod = ControllerTestUtils.sendMultipartPutRequest(updateSchemaUrl, schema.toSingleLineJsonString());
+    Assert.assertEquals(putMethod.getStatusCode(), 200);
+
+    // Get the schema and verify the data types are not changed
+    remoteSchema = Schema.fromString(ControllerTestUtils.sendGetRequest(getSchemaUrl));
+    Assert.assertEquals(remoteSchema.getFieldSpecFor(newColumnFieldSpec.getName()).getDataType(), DataType.STRING);
+    Assert.assertEquals(remoteSchema.getFieldSpecFor(newColumnFieldSpec2.getName()).getDataType(), DataType.STRING);
+
+    // Add a new BOOLEAN column
+    DimensionFieldSpec newColumnFieldSpec3 = new DimensionFieldSpec("newColumn3", DataType.BOOLEAN, true);
+    schema.addField(newColumnFieldSpec3);
+
+    // Update the schema with updateSchema api
+    putMethod = ControllerTestUtils.sendMultipartPutRequest(updateSchemaUrl, schema.toSingleLineJsonString());
+    Assert.assertEquals(putMethod.getStatusCode(), 200);
+
+    // Get the schema and verify the new column has BOOLEAN data type
+    remoteSchema = Schema.fromString(ControllerTestUtils.sendGetRequest(getSchemaUrl));
+    Assert.assertEquals(remoteSchema.getFieldSpecFor(newColumnFieldSpec3.getName()).getDataType(), DataType.BOOLEAN);
+
+    // Post invalid schema string
+    String invalidSchemaString = schema.toSingleLineJsonString().substring(1);
+    postMethod = ControllerTestUtils.sendMultipartPostRequest(addSchemaUrl, invalidSchemaString);
+    Assert.assertEquals(postMethod.getStatusCode(), 400);
+    putMethod = ControllerTestUtils.sendMultipartPutRequest(updateSchemaUrl, invalidSchemaString);
     Assert.assertEquals(putMethod.getStatusCode(), 400);
+
+    // Update schema with non-matching schema name
+    String newSchemaName = "newSchemaName";
+    schema.setSchemaName(newSchemaName);
+    putMethod = ControllerTestUtils.sendMultipartPutRequest(updateSchemaUrl, schema.toSingleLineJsonString());
+    Assert.assertEquals(putMethod.getStatusCode(), 400);
+
+    // Update non-existing schema
+    putMethod = ControllerTestUtils.sendMultipartPutRequest(
+        ControllerTestUtils.getControllerRequestURLBuilder().forSchemaUpdate(newSchemaName),
+        schema.toSingleLineJsonString());
+    Assert.assertEquals(putMethod.getStatusCode(), 404);
   }
 
   @AfterClass

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -71,10 +71,6 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.tenant.Tenant;
 import org.apache.pinot.spi.config.tenant.TenantRole;
-import org.apache.pinot.spi.data.DateTimeFieldSpec;
-import org.apache.pinot.spi.data.DimensionFieldSpec;
-import org.apache.pinot.spi.data.FieldSpec;
-import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -499,22 +495,6 @@ public abstract class ControllerTest {
     }
   }
 
-  protected Schema createDummySchema(String tableName) {
-    Schema schema = new Schema();
-    schema.setSchemaName(tableName);
-    schema.addField(new DimensionFieldSpec("dimA", FieldSpec.DataType.STRING, true, ""));
-    schema.addField(new DimensionFieldSpec("dimB", FieldSpec.DataType.STRING, true, 0));
-    schema.addField(new MetricFieldSpec("metricA", FieldSpec.DataType.INT, 0));
-    schema.addField(new MetricFieldSpec("metricB", FieldSpec.DataType.DOUBLE, -1));
-    schema.addField(new DateTimeFieldSpec("timeColumn", FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:DAYS"));
-    return schema;
-  }
-
-  protected void addDummySchema(String tableName)
-      throws IOException {
-    addSchema(createDummySchema(tableName));
-  }
-
   /**
    * Add a schema to the controller.
    */
@@ -529,6 +509,11 @@ public abstract class ControllerTest {
     Schema schema = _helixResourceManager.getSchema(schemaName);
     assertNotNull(schema);
     return schema;
+  }
+
+  protected void deleteSchema(String schemaName)
+      throws IOException {
+    sendDeleteRequest(_controllerRequestURLBuilder.forSchemaDelete(schemaName));
   }
 
   protected void addTableConfig(TableConfig tableConfig)

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -764,6 +764,9 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     TableConfig tableConfig = getOfflineTableConfig();
     tableConfig.setIngestionConfig(null);
     updateTableConfig(tableConfig);
+
+    // Need to first delete then add the schema because removing columns is backward-incompatible change
+    deleteSchema(getSchemaName());
     _schemaFileName = SCHEMA_FILE_NAME_WITH_MISSING_COLUMNS;
     addSchema(createSchema());
 


### PR DESCRIPTION
## Description
Currently `addSchema()` with override on will by-pass the backward-compatibility check, which can cause bad schema change. Fix it by adding the check when override is triggered.
Also refined the error code when schema cannot be updated.