### PR TITLE
[WIP] Refactor broker for PartitionSegmentPruner 10x perf if we have 30k+ segments

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
@@ -37,6 +37,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.pinot.broker.routing.RoutingManager;
 import org.apache.pinot.broker.routing.RoutingTable;
+import org.apache.pinot.broker.routing.segmentmetadata.SegmentBrokerView;
 import org.apache.pinot.broker.routing.timeboundary.TimeBoundaryInfo;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
@@ -85,9 +86,9 @@ public class PinotBrokerDebug {
       @ApiResponse(code = 404, message = "Routing not found"),
       @ApiResponse(code = 500, message = "Internal server error")
   })
-  public Map<String, Map<ServerInstance, List<String>>> getRoutingTable(
+  public Map<String, Map<ServerInstance, List<SegmentBrokerView>>> getRoutingTable(
       @ApiParam(value = "Name of the table") @PathParam("tableName") String tableName) {
-    Map<String, Map<ServerInstance, List<String>>> result = new TreeMap<>();
+    Map<String, Map<ServerInstance, List<SegmentBrokerView>>> result = new TreeMap<>();
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
     if (tableType != TableType.REALTIME) {
       String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
@@ -121,7 +122,7 @@ public class PinotBrokerDebug {
       @ApiResponse(code = 404, message = "Routing not found"),
       @ApiResponse(code = 500, message = "Internal server error")
   })
-  public Map<ServerInstance, List<String>> getRoutingTableForQuery(
+  public Map<ServerInstance, List<SegmentBrokerView>> getRoutingTableForQuery(
       @ApiParam(value = "Pql query (table name should have type suffix)") @QueryParam("pql") String pql) {
     RoutingTable routingTable = _routingManager.getRoutingTable(PQL_COMPILER.compileToBrokerRequest(pql));
     if (routingTable != null) {
@@ -140,7 +141,7 @@ public class PinotBrokerDebug {
       @ApiResponse(code = 404, message = "Routing not found"),
       @ApiResponse(code = 500, message = "Internal server error")
   })
-  public Map<ServerInstance, List<String>> getRoutingTableForSQLQuery(
+  public Map<ServerInstance, List<SegmentBrokerView>> getRoutingTableForSQLQuery(
       @ApiParam(value = "SQL query (table name should have type suffix)") @QueryParam("query") String query) {
     RoutingTable routingTable = _routingManager.getRoutingTable(CALCITE_COMPILER.compileToBrokerRequest(query));
     if (routingTable != null) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -414,7 +414,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       RoutingTable routingTable = _routingManager.getRoutingTable(offlineBrokerRequest);
       if (routingTable != null) {
         numUnavailableSegments += routingTable.getUnavailableSegments().size();
-        Map<ServerInstance, List<SegmentBrokerView>> serverInstanceToSegmentsMap = routingTable.getServerInstanceToSegmentsMap();
+        Map<ServerInstance, List<SegmentBrokerView>> serverInstanceToSegmentsMap =
+            routingTable.getServerInstanceToSegmentsMap();
         if (!serverInstanceToSegmentsMap.isEmpty()) {
           offlineRoutingTable = serverInstanceToSegmentsMap;
         } else {
@@ -429,7 +430,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       RoutingTable routingTable = _routingManager.getRoutingTable(realtimeBrokerRequest);
       if (routingTable != null) {
         numUnavailableSegments += routingTable.getUnavailableSegments().size();
-        Map<ServerInstance, List<SegmentBrokerView>> serverInstanceToSegmentsMap = routingTable.getServerInstanceToSegmentsMap();
+        Map<ServerInstance, List<SegmentBrokerView>> serverInstanceToSegmentsMap =
+            routingTable.getServerInstanceToSegmentsMap();
         if (!serverInstanceToSegmentsMap.isEmpty()) {
           realtimeRoutingTable = serverInstanceToSegmentsMap;
         } else {
@@ -722,7 +724,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       RoutingTable routingTable = _routingManager.getRoutingTable(offlineBrokerRequest);
       if (routingTable != null) {
         numUnavailableSegments += routingTable.getUnavailableSegments().size();
-        Map<ServerInstance, List<SegmentBrokerView>> serverInstanceToSegmentsMap = routingTable.getServerInstanceToSegmentsMap();
+        Map<ServerInstance, List<SegmentBrokerView>> serverInstanceToSegmentsMap =
+            routingTable.getServerInstanceToSegmentsMap();
         if (!serverInstanceToSegmentsMap.isEmpty()) {
           offlineRoutingTable = serverInstanceToSegmentsMap;
         } else {
@@ -737,7 +740,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       RoutingTable routingTable = _routingManager.getRoutingTable(realtimeBrokerRequest);
       if (routingTable != null) {
         numUnavailableSegments += routingTable.getUnavailableSegments().size();
-        Map<ServerInstance, List<SegmentBrokerView>> serverInstanceToSegmentsMap = routingTable.getServerInstanceToSegmentsMap();
+        Map<ServerInstance, List<SegmentBrokerView>> serverInstanceToSegmentsMap =
+            routingTable.getServerInstanceToSegmentsMap();
         if (!serverInstanceToSegmentsMap.isEmpty()) {
           realtimeRoutingTable = serverInstanceToSegmentsMap;
         } else {
@@ -1810,9 +1814,11 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
    * Processes the optimized broker requests for both OFFLINE and REALTIME table.
    */
   protected abstract BrokerResponseNative processBrokerRequest(long requestId, BrokerRequest originalBrokerRequest,
-      @Nullable BrokerRequest offlineBrokerRequest, @Nullable Map<ServerInstance, List<SegmentBrokerView>> offlineRoutingTable,
-      @Nullable BrokerRequest realtimeBrokerRequest, @Nullable Map<ServerInstance, List<SegmentBrokerView>> realtimeRoutingTable,
-      long timeoutMs, ServerStats serverStats, RequestStatistics requestStatistics)
+      @Nullable BrokerRequest offlineBrokerRequest,
+      @Nullable Map<ServerInstance, List<SegmentBrokerView>> offlineRoutingTable,
+      @Nullable BrokerRequest realtimeBrokerRequest,
+      @Nullable Map<ServerInstance, List<SegmentBrokerView>> realtimeRoutingTable, long timeoutMs,
+      ServerStats serverStats, RequestStatistics requestStatistics)
       throws Exception;
 
   /**

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -47,6 +47,7 @@ import org.apache.pinot.broker.broker.AccessControlFactory;
 import org.apache.pinot.broker.queryquota.QueryQuotaManager;
 import org.apache.pinot.broker.routing.RoutingManager;
 import org.apache.pinot.broker.routing.RoutingTable;
+import org.apache.pinot.broker.routing.segmentmetadata.SegmentBrokerView;
 import org.apache.pinot.broker.routing.timeboundary.TimeBoundaryInfo;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.function.TransformFunctionType;
@@ -405,15 +406,15 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
     // Calculate routing table for the query
     long routingStartTimeNs = System.nanoTime();
-    Map<ServerInstance, List<String>> offlineRoutingTable = null;
-    Map<ServerInstance, List<String>> realtimeRoutingTable = null;
+    Map<ServerInstance, List<SegmentBrokerView>> offlineRoutingTable = null;
+    Map<ServerInstance, List<SegmentBrokerView>> realtimeRoutingTable = null;
     int numUnavailableSegments = 0;
     if (offlineBrokerRequest != null) {
       // NOTE: Routing table might be null if table is just removed
       RoutingTable routingTable = _routingManager.getRoutingTable(offlineBrokerRequest);
       if (routingTable != null) {
         numUnavailableSegments += routingTable.getUnavailableSegments().size();
-        Map<ServerInstance, List<String>> serverInstanceToSegmentsMap = routingTable.getServerInstanceToSegmentsMap();
+        Map<ServerInstance, List<SegmentBrokerView>> serverInstanceToSegmentsMap = routingTable.getServerInstanceToSegmentsMap();
         if (!serverInstanceToSegmentsMap.isEmpty()) {
           offlineRoutingTable = serverInstanceToSegmentsMap;
         } else {
@@ -428,7 +429,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       RoutingTable routingTable = _routingManager.getRoutingTable(realtimeBrokerRequest);
       if (routingTable != null) {
         numUnavailableSegments += routingTable.getUnavailableSegments().size();
-        Map<ServerInstance, List<String>> serverInstanceToSegmentsMap = routingTable.getServerInstanceToSegmentsMap();
+        Map<ServerInstance, List<SegmentBrokerView>> serverInstanceToSegmentsMap = routingTable.getServerInstanceToSegmentsMap();
         if (!serverInstanceToSegmentsMap.isEmpty()) {
           realtimeRoutingTable = serverInstanceToSegmentsMap;
         } else {
@@ -713,15 +714,15 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
     // Calculate routing table for the query
     long routingStartTimeNs = System.nanoTime();
-    Map<ServerInstance, List<String>> offlineRoutingTable = null;
-    Map<ServerInstance, List<String>> realtimeRoutingTable = null;
+    Map<ServerInstance, List<SegmentBrokerView>> offlineRoutingTable = null;
+    Map<ServerInstance, List<SegmentBrokerView>> realtimeRoutingTable = null;
     int numUnavailableSegments = 0;
     if (offlineBrokerRequest != null) {
       // NOTE: Routing table might be null if table is just removed
       RoutingTable routingTable = _routingManager.getRoutingTable(offlineBrokerRequest);
       if (routingTable != null) {
         numUnavailableSegments += routingTable.getUnavailableSegments().size();
-        Map<ServerInstance, List<String>> serverInstanceToSegmentsMap = routingTable.getServerInstanceToSegmentsMap();
+        Map<ServerInstance, List<SegmentBrokerView>> serverInstanceToSegmentsMap = routingTable.getServerInstanceToSegmentsMap();
         if (!serverInstanceToSegmentsMap.isEmpty()) {
           offlineRoutingTable = serverInstanceToSegmentsMap;
         } else {
@@ -736,7 +737,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       RoutingTable routingTable = _routingManager.getRoutingTable(realtimeBrokerRequest);
       if (routingTable != null) {
         numUnavailableSegments += routingTable.getUnavailableSegments().size();
-        Map<ServerInstance, List<String>> serverInstanceToSegmentsMap = routingTable.getServerInstanceToSegmentsMap();
+        Map<ServerInstance, List<SegmentBrokerView>> serverInstanceToSegmentsMap = routingTable.getServerInstanceToSegmentsMap();
         if (!serverInstanceToSegmentsMap.isEmpty()) {
           realtimeRoutingTable = serverInstanceToSegmentsMap;
         } else {
@@ -1809,8 +1810,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
    * Processes the optimized broker requests for both OFFLINE and REALTIME table.
    */
   protected abstract BrokerResponseNative processBrokerRequest(long requestId, BrokerRequest originalBrokerRequest,
-      @Nullable BrokerRequest offlineBrokerRequest, @Nullable Map<ServerInstance, List<String>> offlineRoutingTable,
-      @Nullable BrokerRequest realtimeBrokerRequest, @Nullable Map<ServerInstance, List<String>> realtimeRoutingTable,
+      @Nullable BrokerRequest offlineBrokerRequest, @Nullable Map<ServerInstance, List<SegmentBrokerView>> offlineRoutingTable,
+      @Nullable BrokerRequest realtimeBrokerRequest, @Nullable Map<ServerInstance, List<SegmentBrokerView>> realtimeRoutingTable,
       long timeoutMs, ServerStats serverStats, RequestStatistics requestStatistics)
       throws Exception;
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
@@ -77,17 +77,19 @@ public class SingleConnectionBrokerRequestHandler extends BaseBrokerRequestHandl
 
   @Override
   protected BrokerResponseNative processBrokerRequest(long requestId, BrokerRequest originalBrokerRequest,
-      @Nullable BrokerRequest offlineBrokerRequest, @Nullable Map<ServerInstance, List<SegmentBrokerView>> offlineRoutingTable,
-      @Nullable BrokerRequest realtimeBrokerRequest, @Nullable Map<ServerInstance, List<SegmentBrokerView>> realtimeRoutingTable,
-      long timeoutMs, ServerStats serverStats, RequestStatistics requestStatistics)
+      @Nullable BrokerRequest offlineBrokerRequest,
+      @Nullable Map<ServerInstance, List<SegmentBrokerView>> offlineRoutingTable,
+      @Nullable BrokerRequest realtimeBrokerRequest,
+      @Nullable Map<ServerInstance, List<SegmentBrokerView>> realtimeRoutingTable, long timeoutMs,
+      ServerStats serverStats, RequestStatistics requestStatistics)
       throws Exception {
     assert offlineBrokerRequest != null || realtimeBrokerRequest != null;
 
     String rawTableName = TableNameBuilder.extractRawTableName(originalBrokerRequest.getQuerySource().getTableName());
     long scatterGatherStartTimeNs = System.nanoTime();
     AsyncQueryResponse asyncQueryResponse = _queryRouter
-        .submitQuery(requestId, rawTableName, offlineBrokerRequest, toSegmentNames(offlineRoutingTable), realtimeBrokerRequest,
-            toSegmentNames(realtimeRoutingTable), timeoutMs);
+        .submitQuery(requestId, rawTableName, offlineBrokerRequest, toSegmentNames(offlineRoutingTable),
+            realtimeBrokerRequest, toSegmentNames(realtimeRoutingTable), timeoutMs);
     Map<ServerRoutingInstance, ServerResponse> response = asyncQueryResponse.getResponse();
     _brokerMetrics
         .addPhaseTiming(rawTableName, BrokerQueryPhase.SCATTER_GATHER, System.nanoTime() - scatterGatherStartTimeNs);
@@ -134,13 +136,16 @@ public class SingleConnectionBrokerRequestHandler extends BaseBrokerRequestHandl
 
     return brokerResponse;
   }
-  private static Map<ServerInstance, List<String>> toSegmentNames(Map<ServerInstance, List<SegmentBrokerView>> routeWithBrokerView) {
+
+  private static Map<ServerInstance, List<String>> toSegmentNames(
+      Map<ServerInstance, List<SegmentBrokerView>> routeWithBrokerView) {
     if (routeWithBrokerView == null) {
       return null;
     }
     Map<ServerInstance, List<String>> retVal = new HashMap<>(routeWithBrokerView.size());
-    for (ServerInstance instance: routeWithBrokerView.keySet()) {
-      retVal.put(instance, routeWithBrokerView.get(instance).stream().map(SegmentBrokerView::getSegmentName).collect(Collectors.toList()));
+    for (ServerInstance instance : routeWithBrokerView.keySet()) {
+      retVal.put(instance, routeWithBrokerView.get(instance).stream().map(SegmentBrokerView::getSegmentName)
+          .collect(Collectors.toList()));
     }
     return retVal;
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingManager.java
@@ -356,7 +356,8 @@ public class RoutingManager implements ClusterChangeHandler {
         IdealState offlineTableIdealState = getIdealState(offlineTableName);
         Preconditions
             .checkState(offlineTableIdealState != null, "Failed to find ideal state for table: %s", offlineTableName);
-        Set<SegmentBrokerView> offlineTableOnlineSegments = getOnlineSegments(offlineTableIdealState, tableConfig, _propertyStore);
+        Set<SegmentBrokerView> offlineTableOnlineSegments =
+            getOnlineSegments(offlineTableIdealState, tableConfig, _propertyStore);
         SegmentPreSelector offlineTableSegmentPreSelector =
             SegmentPreSelectorFactory.getSegmentPreSelector(offlineTableConfig, _propertyStore);
         Set<SegmentBrokerView> offlineTablePreSelectedOnlineSegments =
@@ -373,8 +374,8 @@ public class RoutingManager implements ClusterChangeHandler {
     Long queryTimeoutMs = queryConfig != null ? queryConfig.getTimeoutMs() : null;
 
     RoutingEntry routingEntry =
-        new RoutingEntry(tableConfig, _propertyStore, tableNameWithType, segmentPreSelector, segmentSelector, segmentPruners, instanceSelector,
-            externalViewVersion, timeBoundaryManager, queryTimeoutMs);
+        new RoutingEntry(tableConfig, _propertyStore, tableNameWithType, segmentPreSelector, segmentSelector,
+            segmentPruners, instanceSelector, externalViewVersion, timeBoundaryManager, queryTimeoutMs);
     if (_routingEntryMap.put(tableNameWithType, routingEntry) == null) {
       LOGGER.info("Built routing for table: {}", tableNameWithType);
     } else {
@@ -385,7 +386,8 @@ public class RoutingManager implements ClusterChangeHandler {
   /**
    * Returns the online segments (with ONLINE/CONSUMING instances) in the given ideal state.
    */
-  private static Set<SegmentBrokerView> getOnlineSegments(IdealState idealState, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
+  private static Set<SegmentBrokerView> getOnlineSegments(IdealState idealState, TableConfig tableConfig,
+      ZkHelixPropertyStore<ZNRecord> propertyStore) {
     Map<String, Map<String, String>> segmentAssignment = idealState.getRecord().getMapFields();
     Set<String> onlineSegments = new HashSet<>(HashUtil.getHashMapCapacity(segmentAssignment.size()));
     for (Map.Entry<String, Map<String, String>> entry : segmentAssignment.entrySet()) {
@@ -395,7 +397,8 @@ public class RoutingManager implements ClusterChangeHandler {
         onlineSegments.add(entry.getKey());
       }
     }
-    return Collections.unmodifiableSet(SegmentBrokerView.extractSegmentMetadata(tableConfig, onlineSegments, propertyStore));
+    return Collections
+        .unmodifiableSet(SegmentBrokerView.extractSegmentMetadata(tableConfig, onlineSegments, propertyStore));
   }
 
   /**
@@ -510,8 +513,9 @@ public class RoutingManager implements ClusterChangeHandler {
     // Time boundary manager is only available for the offline part of the hybrid table
     transient TimeBoundaryManager _timeBoundaryManager;
 
-    RoutingEntry(TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType, SegmentPreSelector segmentPreSelector, SegmentSelector segmentSelector,
-        List<SegmentPruner> segmentPruners, InstanceSelector instanceSelector, int lastUpdateExternalViewVersion,
+    RoutingEntry(TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType,
+        SegmentPreSelector segmentPreSelector, SegmentSelector segmentSelector, List<SegmentPruner> segmentPruners,
+        InstanceSelector instanceSelector, int lastUpdateExternalViewVersion,
         @Nullable TimeBoundaryManager timeBoundaryManager, @Nullable Long queryTimeoutMs) {
       _tableConfig = tableConfig;
       _propertyStore = propertyStore;
@@ -549,7 +553,8 @@ public class RoutingManager implements ClusterChangeHandler {
     // NOTE: The change gets applied in sequence, and before change applied to all components, there could be some
     // inconsistency between components, which is fine because the inconsistency only exists for the newly changed
     // segments and only lasts for a very short time.
-    void onExternalViewChange(ExternalView externalView, IdealState idealState, ZkHelixPropertyStore<ZNRecord> propertyStore) {
+    void onExternalViewChange(ExternalView externalView, IdealState idealState,
+        ZkHelixPropertyStore<ZNRecord> propertyStore) {
       Set<SegmentBrokerView> onlineSegments = getOnlineSegments(idealState, _tableConfig, propertyStore);
       Set<SegmentBrokerView> preSelectedOnlineSegments = _segmentPreSelector.preSelect(onlineSegments);
       _segmentSelector.onExternalViewChange(externalView, idealState, preSelectedOnlineSegments);
@@ -568,7 +573,8 @@ public class RoutingManager implements ClusterChangeHandler {
     }
 
     void refreshSegment(String segment) {
-      SegmentBrokerView segmentBrokerView = SegmentBrokerView.extractSegmentMetadata(segment, _tableConfig, _propertyStore);
+      SegmentBrokerView segmentBrokerView =
+          SegmentBrokerView.extractSegmentMetadata(segment, _tableConfig, _propertyStore);
       for (SegmentPruner segmentPruner : _segmentPruners) {
         segmentPruner.refreshSegment(segmentBrokerView);
       }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingTable.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingTable.java
@@ -28,7 +28,8 @@ public class RoutingTable {
   private final Map<ServerInstance, List<SegmentBrokerView>> _serverInstanceToSegmentsMap;
   private final List<SegmentBrokerView> _unavailableSegments;
 
-  public RoutingTable(Map<ServerInstance, List<SegmentBrokerView>> serverInstanceToSegmentsMap, List<SegmentBrokerView> unavailableSegments) {
+  public RoutingTable(Map<ServerInstance, List<SegmentBrokerView>> serverInstanceToSegmentsMap,
+      List<SegmentBrokerView> unavailableSegments) {
     _serverInstanceToSegmentsMap = serverInstanceToSegmentsMap;
     _unavailableSegments = unavailableSegments;
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingTable.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/RoutingTable.java
@@ -20,23 +20,24 @@ package org.apache.pinot.broker.routing;
 
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.broker.routing.segmentmetadata.SegmentBrokerView;
 import org.apache.pinot.core.transport.ServerInstance;
 
 
 public class RoutingTable {
-  private final Map<ServerInstance, List<String>> _serverInstanceToSegmentsMap;
-  private final List<String> _unavailableSegments;
+  private final Map<ServerInstance, List<SegmentBrokerView>> _serverInstanceToSegmentsMap;
+  private final List<SegmentBrokerView> _unavailableSegments;
 
-  public RoutingTable(Map<ServerInstance, List<String>> serverInstanceToSegmentsMap, List<String> unavailableSegments) {
+  public RoutingTable(Map<ServerInstance, List<SegmentBrokerView>> serverInstanceToSegmentsMap, List<SegmentBrokerView> unavailableSegments) {
     _serverInstanceToSegmentsMap = serverInstanceToSegmentsMap;
     _unavailableSegments = unavailableSegments;
   }
 
-  public Map<ServerInstance, List<String>> getServerInstanceToSegmentsMap() {
+  public Map<ServerInstance, List<SegmentBrokerView>> getServerInstanceToSegmentsMap() {
     return _serverInstanceToSegmentsMap;
   }
 
-  public List<String> getUnavailableSegments() {
+  public List<SegmentBrokerView> getUnavailableSegments() {
     return _unavailableSegments;
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BalancedInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BalancedInstanceSelector.java
@@ -40,8 +40,9 @@ public class BalancedInstanceSelector extends BaseInstanceSelector {
 
   @Override
   Map<SegmentBrokerView, String> select(List<SegmentBrokerView> segments, int requestId,
-                                        Map<String, List<String>> segmentToEnabledInstancesMap) {
-    Map<SegmentBrokerView, String> segmentToSelectedInstanceMap = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
+      Map<String, List<String>> segmentToEnabledInstancesMap) {
+    Map<SegmentBrokerView, String> segmentToSelectedInstanceMap =
+        new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
     for (SegmentBrokerView segment : segments) {
       List<String> enabledInstances = segmentToEnabledInstancesMap.get(segment.getSegmentName());
       // NOTE: enabledInstances can be null when there is no enabled instances for the segment, or the instance selector

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BalancedInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BalancedInstanceSelector.java
@@ -21,6 +21,7 @@ package org.apache.pinot.broker.routing.instanceselector;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.broker.routing.segmentmetadata.SegmentBrokerView;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.utils.HashUtil;
 
@@ -38,11 +39,11 @@ public class BalancedInstanceSelector extends BaseInstanceSelector {
   }
 
   @Override
-  Map<String, String> select(List<String> segments, int requestId,
-      Map<String, List<String>> segmentToEnabledInstancesMap) {
-    Map<String, String> segmentToSelectedInstanceMap = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
-    for (String segment : segments) {
-      List<String> enabledInstances = segmentToEnabledInstancesMap.get(segment);
+  Map<SegmentBrokerView, String> select(List<SegmentBrokerView> segments, int requestId,
+                                        Map<String, List<String>> segmentToEnabledInstancesMap) {
+    Map<SegmentBrokerView, String> segmentToSelectedInstanceMap = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
+    for (SegmentBrokerView segment : segments) {
+      List<String> enabledInstances = segmentToEnabledInstancesMap.get(segment.getSegmentName());
       // NOTE: enabledInstances can be null when there is no enabled instances for the segment, or the instance selector
       // has not been updated (we update all components for routing in sequence)
       if (enabledInstances != null) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
@@ -133,7 +133,8 @@ abstract class BaseInstanceSelector implements InstanceSelector {
    * {@code unavailableSegments} based on the cached states.
    */
   @Override
-  public void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<SegmentBrokerView> onlineSegments) {
+  public void onExternalViewChange(ExternalView externalView, IdealState idealState,
+      Set<SegmentBrokerView> onlineSegments) {
     int numSegments = onlineSegments.size();
     int segmentMapCapacity = HashUtil.getHashMapCapacity(numSegments);
     _segmentToOnlineInstancesMap = new HashMap<>(segmentMapCapacity);
@@ -268,5 +269,5 @@ abstract class BaseInstanceSelector implements InstanceSelector {
    * ONLINE/CONSUMING instances). If enabled instances are not {@code null}, they are sorted in alphabetical order.
    */
   abstract Map<SegmentBrokerView, String> select(List<SegmentBrokerView> segments, int requestId,
-                                                 Map<String, List<String>> segmentToEnabledInstancesMap);
+      Map<String, List<String>> segmentToEnabledInstancesMap);
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
+import org.apache.pinot.broker.routing.segmentmetadata.SegmentBrokerView;
 import org.apache.pinot.common.request.BrokerRequest;
 
 
@@ -36,7 +37,7 @@ public interface InstanceSelector {
    * (segments with ONLINE/CONSUMING instances in the ideal state and selected by the pre-selector). Should be called
    * only once before calling other methods.
    */
-  void init(Set<String> enabledInstances, ExternalView externalView, IdealState idealState, Set<String> onlineSegments);
+  void init(Set<String> enabledInstances, ExternalView externalView, IdealState idealState, Set<SegmentBrokerView> onlineSegments);
 
   /**
    * Processes the instances change. Changed instances are pre-computed based on the current and previous enabled
@@ -48,20 +49,20 @@ public interface InstanceSelector {
    * Processes the external view change based on the given ideal state and online segments (segments with
    * ONLINE/CONSUMING instances in the ideal state and selected by the pre-selector).
    */
-  void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<String> onlineSegments);
+  void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<SegmentBrokerView> onlineSegments);
 
   /**
    * Selects the server instances for the given segments queried by the given broker request, returns a map from segment
    * to selected server instance hosting the segment and a set of unavailable segments (no enabled instance or all
    * enabled instances are in ERROR state).
    */
-  SelectionResult select(BrokerRequest brokerRequest, List<String> segments);
+  SelectionResult select(BrokerRequest brokerRequest, List<SegmentBrokerView> segments);
 
   class SelectionResult {
-    private final Map<String, String> _segmentToInstanceMap;
-    private final List<String> _unavailableSegments;
+    private final Map<SegmentBrokerView, String> _segmentToInstanceMap;
+    private final List<SegmentBrokerView> _unavailableSegments;
 
-    public SelectionResult(Map<String, String> segmentToInstanceMap, List<String> unavailableSegments) {
+    public SelectionResult(Map<SegmentBrokerView, String> segmentToInstanceMap, List<SegmentBrokerView> unavailableSegments) {
       _segmentToInstanceMap = segmentToInstanceMap;
       _unavailableSegments = unavailableSegments;
     }
@@ -69,14 +70,14 @@ public interface InstanceSelector {
     /**
      * Returns the map from segment to selected server instance hosting the segment.
      */
-    public Map<String, String> getSegmentToInstanceMap() {
+    public Map<SegmentBrokerView, String> getSegmentToInstanceMap() {
       return _segmentToInstanceMap;
     }
 
     /**
      * Returns the unavailable segments (no enabled instance or all enabled instances are in ERROR state).
      */
-    public List<String> getUnavailableSegments() {
+    public List<SegmentBrokerView> getUnavailableSegments() {
       return _unavailableSegments;
     }
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
@@ -37,7 +37,8 @@ public interface InstanceSelector {
    * (segments with ONLINE/CONSUMING instances in the ideal state and selected by the pre-selector). Should be called
    * only once before calling other methods.
    */
-  void init(Set<String> enabledInstances, ExternalView externalView, IdealState idealState, Set<SegmentBrokerView> onlineSegments);
+  void init(Set<String> enabledInstances, ExternalView externalView, IdealState idealState,
+      Set<SegmentBrokerView> onlineSegments);
 
   /**
    * Processes the instances change. Changed instances are pre-computed based on the current and previous enabled
@@ -62,7 +63,8 @@ public interface InstanceSelector {
     private final Map<SegmentBrokerView, String> _segmentToInstanceMap;
     private final List<SegmentBrokerView> _unavailableSegments;
 
-    public SelectionResult(Map<SegmentBrokerView, String> segmentToInstanceMap, List<SegmentBrokerView> unavailableSegments) {
+    public SelectionResult(Map<SegmentBrokerView, String> segmentToInstanceMap,
+        List<SegmentBrokerView> unavailableSegments) {
       _segmentToInstanceMap = segmentToInstanceMap;
       _unavailableSegments = unavailableSegments;
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
@@ -50,8 +50,9 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
 
   @Override
   Map<SegmentBrokerView, String> select(List<SegmentBrokerView> segments, int requestId,
-                                        Map<String, List<String>> segmentToEnabledInstancesMap) {
-    Map<SegmentBrokerView, String> segmentToSelectedInstanceMap = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
+      Map<String, List<String>> segmentToEnabledInstancesMap) {
+    Map<SegmentBrokerView, String> segmentToSelectedInstanceMap =
+        new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
     for (SegmentBrokerView segment : segments) {
       List<String> enabledInstances = segmentToEnabledInstancesMap.get(segment);
       // NOTE: enabledInstances can be null when there is no enabled instances for the segment, or the instance selector

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
@@ -21,6 +21,7 @@ package org.apache.pinot.broker.routing.instanceselector;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.broker.routing.segmentmetadata.SegmentBrokerView;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.utils.HashUtil;
 
@@ -48,10 +49,10 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
   }
 
   @Override
-  Map<String, String> select(List<String> segments, int requestId,
-      Map<String, List<String>> segmentToEnabledInstancesMap) {
-    Map<String, String> segmentToSelectedInstanceMap = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
-    for (String segment : segments) {
+  Map<SegmentBrokerView, String> select(List<SegmentBrokerView> segments, int requestId,
+                                        Map<String, List<String>> segmentToEnabledInstancesMap) {
+    Map<SegmentBrokerView, String> segmentToSelectedInstanceMap = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
+    for (SegmentBrokerView segment : segments) {
       List<String> enabledInstances = segmentToEnabledInstancesMap.get(segment);
       // NOTE: enabledInstances can be null when there is no enabled instances for the segment, or the instance selector
       // has not been updated (we update all components for routing in sequence)

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
@@ -54,7 +54,7 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
     Map<SegmentBrokerView, String> segmentToSelectedInstanceMap =
         new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
     for (SegmentBrokerView segment : segments) {
-      List<String> enabledInstances = segmentToEnabledInstancesMap.get(segment);
+      List<String> enabledInstances = segmentToEnabledInstancesMap.get(segment.getSegmentName());
       // NOTE: enabledInstances can be null when there is no enabled instances for the segment, or the instance selector
       // has not been updated (we update all components for routing in sequence)
       if (enabledInstances != null) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
+import org.apache.pinot.broker.routing.segmentmetadata.SegmentBrokerView;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
@@ -77,7 +78,7 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
    * </pre>
    */
   @Override
-  void updateSegmentMaps(ExternalView externalView, IdealState idealState, Set<String> onlineSegments,
+  void updateSegmentMaps(ExternalView externalView, IdealState idealState, Set<SegmentBrokerView> onlineSegments,
       Map<String, List<String>> segmentToOnlineInstancesMap, Map<String, List<String>> segmentToOfflineInstancesMap,
       Map<String, List<String>> instanceToSegmentsMap) {
     // Iterate over the ideal state to fill up 'idealStateSegmentToInstancesMap' which is a map from segment to set of
@@ -87,7 +88,7 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
     for (Map.Entry<String, Map<String, String>> entry : idealState.getRecord().getMapFields().entrySet()) {
       String segment = entry.getKey();
       // Only track online segments
-      if (!onlineSegments.contains(segment)) {
+      if (!onlineSegments.contains(new SegmentBrokerView(segment))) {
         continue;
       }
       idealStateSegmentToInstancesMap.put(segment, entry.getValue().keySet());

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/Interval.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/Interval.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.broker.routing.segmentpruner.interval;
+package org.apache.pinot.broker.routing.segmentmetadata;
 
 import com.google.common.base.Preconditions;
 import javax.annotation.Nullable;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/IntervalTree.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/IntervalTree.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.broker.routing.segmentpruner.interval;
+package org.apache.pinot.broker.routing.segmentmetadata;
 
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/PartitionInfo.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/PartitionInfo.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.broker.routing.segmentmetadata;
 
 import java.util.Collections;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/PartitionInfo.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/PartitionInfo.java
@@ -1,0 +1,53 @@
+package org.apache.pinot.broker.routing.segmentmetadata;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
+import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+
+public class PartitionInfo {
+  public static final PartitionInfo INVALID_PARTITION_INFO = new PartitionInfo(null, null);
+  public final PartitionFunction _partitionFunction;
+  public final Set<Integer> _partitions;
+  private final int _hashCode;
+
+  public PartitionInfo(PartitionFunction partitionFunction, Set<Integer> partitions) {
+    _partitionFunction = partitionFunction;
+    _partitions = partitions;
+    _hashCode = Objects.hash(_partitionFunction, _partitions);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    if (hashCode() != o.hashCode()) {
+      return false;
+    }
+    PartitionInfo that = (PartitionInfo) o;
+    return Objects.equals(_partitions, that._partitions) && Objects.equals(_partitionFunction, that._partitionFunction);
+  }
+
+  @Override
+  public int hashCode() {
+    return _hashCode;
+  }
+
+  @Nullable
+  public static Set<String> getPartitionColumnFromConfig(TableConfig tableConfig) {
+    SegmentPartitionConfig segmentPartitionConfig = tableConfig.getIndexingConfig().getSegmentPartitionConfig();
+    if (segmentPartitionConfig == null) {
+      return null;
+    }
+    Map<String, ColumnPartitionConfig> columnPartitionMap = segmentPartitionConfig.getColumnPartitionMap();
+    if (columnPartitionMap == null) {
+      return Collections.emptySet();
+    }
+    return Collections.unmodifiableSet(columnPartitionMap.keySet());
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/PartitionInfo.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/PartitionInfo.java
@@ -60,9 +60,8 @@ public class PartitionInfo {
     if (_partitions.size() != that._partitions.size()) {
       return false;
     }
-    if (!(_partitionFunction.getFunctionType()
-      .equals(that._partitionFunction.getFunctionType())
-      && _partitionFunction.getNumPartitions() == that._partitionFunction.getNumPartitions())) {
+    if (!(_partitionFunction.getFunctionType().equals(that._partitionFunction.getFunctionType())
+        && _partitionFunction.getNumPartitions() == that._partitionFunction.getNumPartitions())) {
       return false;
     }
     if (_partitions.size() == 1) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/PartitionInfo.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/PartitionInfo.java
@@ -41,6 +41,10 @@ public class PartitionInfo {
     _hashCode = Objects.hash(_partitionFunction, _partitions);
   }
 
+  public Set<Integer> getPartitions() {
+    return _partitions;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -53,9 +57,20 @@ public class PartitionInfo {
       return false;
     }
     PartitionInfo that = (PartitionInfo) o;
-    return Objects.equals(_partitions, that._partitions) && _partitionFunction.getFunctionType()
-        .equals(that._partitionFunction.getFunctionType())
-        && _partitionFunction.getNumPartitions() == that._partitionFunction.getNumPartitions();
+    if (_partitions.size() != that._partitions.size()) {
+      return false;
+    }
+    if (!(_partitionFunction.getFunctionType()
+      .equals(that._partitionFunction.getFunctionType())
+      && _partitionFunction.getNumPartitions() == that._partitionFunction.getNumPartitions())) {
+      return false;
+    }
+    if (_partitions.size() == 1) {
+      if (_partitions.iterator().next().equals(that._partitions.iterator().next())) {
+        return true;
+      }
+    }
+    return _partitions.equals(that._partitions);
   }
 
   @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/PartitionInfo.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/PartitionInfo.java
@@ -53,7 +53,9 @@ public class PartitionInfo {
       return false;
     }
     PartitionInfo that = (PartitionInfo) o;
-    return Objects.equals(_partitions, that._partitions) && Objects.equals(_partitionFunction, that._partitionFunction);
+    return Objects.equals(_partitions, that._partitions) && _partitionFunction.getFunctionType()
+        .equals(that._partitionFunction.getFunctionType())
+        && _partitionFunction.getNumPartitions() == that._partitionFunction.getNumPartitions();
   }
 
   @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/PartitionInfo.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/PartitionInfo.java
@@ -10,6 +10,7 @@ import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 
+
 public class PartitionInfo {
   public static final PartitionInfo INVALID_PARTITION_INFO = new PartitionInfo(null, null);
   public final PartitionFunction _partitionFunction;
@@ -24,8 +25,12 @@ public class PartitionInfo {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
     if (hashCode() != o.hashCode()) {
       return false;
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentBrokerView.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentBrokerView.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.helix.AccessOption;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -45,9 +46,9 @@ public class SegmentBrokerView {
   public static final long MIN_START_TIME = 0;
   public static final long MAX_END_TIME = Long.MAX_VALUE;
   private static final Interval DEFAULT_INTERVAL = new Interval(MIN_START_TIME, MAX_END_TIME);
-  private Interval _segmentInterval;
+  private Interval _segmentInterval = DEFAULT_INTERVAL;
   private PartitionInfo _partitionInfo;
-  private long _totalDocs;
+  private long _totalDocs = -1;
   private final String _segmentName;
 
   public SegmentBrokerView(String segmentName) {
@@ -99,6 +100,18 @@ public class SegmentBrokerView {
   public int hashCode() {
     return Objects.hash(_segmentName);
   }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this).append("_segmentName", _segmentName).append("_segmentInterval", _segmentInterval)
+        .append("_partitionInfo", _partitionInfo).append("_totalDocs", _totalDocs).append("_segmentName", _segmentName)
+        .toString();
+  }
+
+  //  @Override
+//  public String toString() {
+//    return "SegmentBrokerView: " + _segmentName +
+//  }
 
   private static long extractTotalDocsFromSegmentZKMetaZNRecord(@Nullable ZNRecord znRecord, String segment,
       String tableNameWithType) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentBrokerView.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentBrokerView.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.broker.routing.segmentmetadata;
 
 import java.util.ArrayList;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentBrokerView.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentBrokerView.java
@@ -19,10 +19,11 @@
 package org.apache.pinot.broker.routing.segmentmetadata;
 
 import java.util.ArrayList;
-import java.util.HashSet;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -192,7 +193,7 @@ public class SegmentBrokerView {
     int numSegments = onlineSegments.size();
     List<String> segments = new ArrayList<>(numSegments);
     List<String> segmentZKMetadataPaths = new ArrayList<>(numSegments);
-    Set<SegmentBrokerView> retVal = new HashSet<>(onlineSegments.size());
+    Set<SegmentBrokerView> retVal = new TreeSet<>(Comparator.comparing(SegmentBrokerView::getSegmentName));
     for (String segment : onlineSegments) {
       segments.add(segment);
       segmentZKMetadataPaths.add(segmentZKMetadataPathPrefix + segment);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentBrokerView.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentBrokerView.java
@@ -1,0 +1,193 @@
+package org.apache.pinot.broker.routing.segmentmetadata;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import org.apache.helix.AccessOption;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
+import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
+import org.apache.pinot.segment.spi.partition.metadata.ColumnPartitionMetadata;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.pinot.broker.routing.segmentmetadata.PartitionInfo.INVALID_PARTITION_INFO;
+
+public class SegmentBrokerView {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentBrokerView.class);
+  public static final long MIN_START_TIME = 0;
+  public static final long MAX_END_TIME = Long.MAX_VALUE;
+  private static final Interval DEFAULT_INTERVAL = new Interval(MIN_START_TIME, MAX_END_TIME);
+  private Interval _interval;
+  private PartitionInfo _partitionInfo;
+  private long _totalDocs;
+  private final String _segmentName;
+  public SegmentBrokerView(String segmentName) {
+    _segmentName = segmentName;
+  }
+
+  public String getSegmentName() {
+    return _segmentName;
+  }
+
+  public Interval getInterval() {
+    return _interval;
+  }
+
+  public void setInterval(Interval _interval) {
+    this._interval = _interval;
+  }
+
+  public PartitionInfo getPartitionInfo() {
+    return _partitionInfo;
+  }
+
+  public void setPartitionInfo(PartitionInfo _partitionInfo) {
+    this._partitionInfo = _partitionInfo;
+  }
+
+  public long getTotalDocs() {
+    return _totalDocs;
+  }
+
+  public void setTotalDocs(long totalDocs) {
+    this._totalDocs = totalDocs;
+  }
+
+  // We consider segmentName as primary key and all other info irrelevant
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    SegmentBrokerView that = (SegmentBrokerView) o;
+    return Objects.equals(_segmentName, that._segmentName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_segmentName);
+  }
+
+  private static long extractTotalDocsFromSegmentZKMetaZNRecord(@Nullable ZNRecord znRecord, String segment, String tableNameWithType) {
+    if (znRecord == null) {
+      LOGGER.warn("Failed to find segment ZK metadata for segment: {}, table: {}", segment, tableNameWithType);
+      return -1;
+    }
+    return znRecord.getLongField(CommonConstants.Segment.TOTAL_DOCS, -1);
+  }
+
+  public static Interval extractIntervalFromSegmentZKMetaZNRecord(@Nullable ZNRecord znRecord, String segment, String tableNameWithType) {
+    // Segments without metadata or with invalid time interval will be set with [min_start, max_end] and will not be
+    // pruned
+    if (znRecord == null) {
+      LOGGER.warn("Failed to find segment ZK metadata for segment: {}, table: {}", segment, tableNameWithType);
+      return DEFAULT_INTERVAL;
+    }
+
+    long startTime = znRecord.getLongField(CommonConstants.Segment.START_TIME, -1);
+    long endTime = znRecord.getLongField(CommonConstants.Segment.END_TIME, -1);
+    if (startTime < 0 || endTime < 0 || startTime > endTime) {
+      LOGGER.warn("Failed to find valid time interval for segment: {}, table: {}", segment, tableNameWithType);
+      return DEFAULT_INTERVAL;
+    }
+
+    TimeUnit timeUnit = znRecord.getEnumField(CommonConstants.Segment.TIME_UNIT, TimeUnit.class, TimeUnit.DAYS);
+    return new Interval(timeUnit.toMillis(startTime), timeUnit.toMillis(endTime));
+  }
+
+  /**
+   * NOTE: Returns {@code null} when the ZNRecord is missing (could be transient Helix issue). Returns
+   *       INVALID_PARTITION_INFO when the segment does not have valid partition metadata in its ZK metadata,
+   *       in which case we won't retry later.
+   */
+  @Nullable
+  public static PartitionInfo extractPartitionInfoFromSegmentZKMetadataZNRecord(@Nullable ZNRecord znRecord, String partitionColumn, String segment, String tableNameWithType) {
+    if (znRecord == null) {
+      LOGGER.warn("Failed to find segment ZK metadata for segment: {}, table: {}", segment, tableNameWithType);
+      return null;
+    }
+
+    String partitionMetadataJson = znRecord.getSimpleField(CommonConstants.Segment.PARTITION_METADATA);
+    if (partitionMetadataJson == null) {
+      LOGGER.warn("Failed to find segment partition metadata for segment: {}, table: {}", segment, tableNameWithType);
+      return INVALID_PARTITION_INFO;
+    }
+
+    SegmentPartitionMetadata segmentPartitionMetadata;
+    try {
+      segmentPartitionMetadata = SegmentPartitionMetadata.fromJsonString(partitionMetadataJson);
+    } catch (Exception e) {
+      LOGGER.warn("Caught exception while extracting segment partition metadata for segment: {}, table: {}", segment,
+        tableNameWithType, e);
+      return INVALID_PARTITION_INFO;
+    }
+
+    ColumnPartitionMetadata columnPartitionMetadata =
+      segmentPartitionMetadata.getColumnPartitionMap().get(partitionColumn);
+    if (columnPartitionMetadata == null) {
+      LOGGER.warn("Failed to find column partition metadata for column: {}, segment: {}, table: {}", partitionColumn,
+        segment, tableNameWithType);
+      return INVALID_PARTITION_INFO;
+    }
+
+    return new PartitionInfo(PartitionFunctionFactory
+      .getPartitionFunction(columnPartitionMetadata.getFunctionName(), columnPartitionMetadata.getNumPartitions()),
+      columnPartitionMetadata.getPartitions());
+  }
+
+  public static Set<SegmentBrokerView> extractSegmentMetadata(TableConfig tableConfig, Set<String> onlineSegments, ZkHelixPropertyStore<ZNRecord> propertyStore) {
+    String tableNameWithType = tableConfig.getTableName();
+    Set<String> partitionColumns = PartitionInfo.getPartitionColumnFromConfig(tableConfig);
+    String segmentZKMetadataPathPrefix = ZKMetadataProvider.constructPropertyStorePathForResource(tableNameWithType) + "/";
+    int numSegments = onlineSegments.size();
+    List<String> segments = new ArrayList<>(numSegments);
+    List<String> segmentZKMetadataPaths = new ArrayList<>(numSegments);
+    Set<SegmentBrokerView> retVal = new HashSet<>(onlineSegments.size());
+    for (String segment : onlineSegments) {
+      segments.add(segment);
+      segmentZKMetadataPaths.add(segmentZKMetadataPathPrefix + segment);
+    }
+    List<ZNRecord> znRecords = propertyStore.get(segmentZKMetadataPaths, null, AccessOption.PERSISTENT);
+    for (int i = 0; i < numSegments; i++) {
+      String segment = segments.get(i);
+      retVal.add(extractOneSegmentMetadata(segment, tableConfig, znRecords.get(i), partitionColumns));
+    }
+    return retVal;
+  }
+
+  public static SegmentBrokerView extractSegmentMetadata(String segmentName, TableConfig tableConfig, ZkHelixPropertyStore<ZNRecord> propertyStore) {
+    List<String> segmentZKMetadataPaths = new ArrayList<>(1);
+    segmentZKMetadataPaths.add(ZKMetadataProvider.constructPropertyStorePathForResource(tableConfig.getTableName()) + "/" + segmentName);
+    ZNRecord record = propertyStore.get(segmentZKMetadataPaths, null, AccessOption.PERSISTENT).get(0);
+    return extractOneSegmentMetadata(segmentName, tableConfig, record);
+  }
+
+  public static SegmentBrokerView extractOneSegmentMetadata(String segmentName, TableConfig tableConfig, ZNRecord znRecord) {
+    Set<String> partitionColumns = PartitionInfo.getPartitionColumnFromConfig(tableConfig);
+    return extractOneSegmentMetadata(segmentName, tableConfig, znRecord, partitionColumns);
+  }
+
+  private static SegmentBrokerView extractOneSegmentMetadata(String segmentName, TableConfig tableConfig, ZNRecord znRecord, Set<String> partitionColumns) {
+    SegmentBrokerView segmentBrokerView = new SegmentBrokerView(segmentName);
+    if (partitionColumns != null && partitionColumns.size() == 1) {
+      PartitionInfo partitionInfo =
+        SegmentBrokerView.extractPartitionInfoFromSegmentZKMetadataZNRecord(
+          znRecord, partitionColumns.iterator().next(), segmentName, tableConfig.getTableName());
+      segmentBrokerView.setPartitionInfo(partitionInfo);
+    }
+    Interval interval = SegmentBrokerView.extractIntervalFromSegmentZKMetaZNRecord(znRecord, segmentName, tableConfig.getTableName());
+    segmentBrokerView.setInterval(interval);
+    long totalDocs = extractTotalDocsFromSegmentZKMetaZNRecord(znRecord, segmentName, tableConfig.getTableName());
+    segmentBrokerView.setTotalDocs(totalDocs);
+    return segmentBrokerView;
+  }
+
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpreselector/SegmentLineageBasedSegmentPreSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpreselector/SegmentLineageBasedSegmentPreSelector.java
@@ -48,10 +48,12 @@ public class SegmentLineageBasedSegmentPreSelector implements SegmentPreSelector
   Set<SegmentBrokerView> preSelectForTest(Set<String> onlineSegments) {
     return preSelect(onlineSegments.stream().map(SegmentBrokerView::new).collect(Collectors.toSet()));
   }
+
   @Override
   public Set<SegmentBrokerView> preSelect(Set<SegmentBrokerView> onlineSegments) {
     SegmentLineage segmentLineage = SegmentLineageAccessHelper.getSegmentLineage(_propertyStore, _tableNameWithType);
-    Set<String> onlineSegmentNames = onlineSegments.stream().map(SegmentBrokerView::getSegmentName).collect(Collectors.toSet());
+    Set<String> onlineSegmentNames =
+        onlineSegments.stream().map(SegmentBrokerView::getSegmentName).collect(Collectors.toSet());
     SegmentLineageUtils.filterSegmentsBasedOnLineageInplace(onlineSegmentNames, segmentLineage);
     return onlineSegments;
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpreselector/SegmentLineageBasedSegmentPreSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpreselector/SegmentLineageBasedSegmentPreSelector.java
@@ -55,6 +55,8 @@ public class SegmentLineageBasedSegmentPreSelector implements SegmentPreSelector
     Set<String> onlineSegmentNames =
         onlineSegments.stream().map(SegmentBrokerView::getSegmentName).collect(Collectors.toSet());
     SegmentLineageUtils.filterSegmentsBasedOnLineageInplace(onlineSegmentNames, segmentLineage);
-    return onlineSegments;
+    return onlineSegments.stream()
+        .filter(segmentBrokerView -> onlineSegmentNames.contains(segmentBrokerView.getSegmentName()))
+        .collect(Collectors.toSet());
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpreselector/SegmentLineageBasedSegmentPreSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpreselector/SegmentLineageBasedSegmentPreSelector.java
@@ -18,9 +18,12 @@
  */
 package org.apache.pinot.broker.routing.segmentpreselector;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.broker.routing.segmentmetadata.SegmentBrokerView;
 import org.apache.pinot.common.lineage.SegmentLineage;
 import org.apache.pinot.common.lineage.SegmentLineageAccessHelper;
 import org.apache.pinot.common.lineage.SegmentLineageUtils;
@@ -41,10 +44,15 @@ public class SegmentLineageBasedSegmentPreSelector implements SegmentPreSelector
     _propertyStore = propertyStore;
   }
 
+  @VisibleForTesting
+  Set<SegmentBrokerView> preSelectForTest(Set<String> onlineSegments) {
+    return preSelect(onlineSegments.stream().map(SegmentBrokerView::new).collect(Collectors.toSet()));
+  }
   @Override
-  public Set<String> preSelect(Set<String> onlineSegments) {
+  public Set<SegmentBrokerView> preSelect(Set<SegmentBrokerView> onlineSegments) {
     SegmentLineage segmentLineage = SegmentLineageAccessHelper.getSegmentLineage(_propertyStore, _tableNameWithType);
-    SegmentLineageUtils.filterSegmentsBasedOnLineageInplace(onlineSegments, segmentLineage);
+    Set<String> onlineSegmentNames = onlineSegments.stream().map(SegmentBrokerView::getSegmentName).collect(Collectors.toSet());
+    SegmentLineageUtils.filterSegmentsBasedOnLineageInplace(onlineSegmentNames, segmentLineage);
     return onlineSegments;
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpreselector/SegmentPreSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpreselector/SegmentPreSelector.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.broker.routing.segmentpreselector;
 
 import java.util.Set;
+import org.apache.pinot.broker.routing.segmentmetadata.SegmentBrokerView;
 
 
 /**
@@ -37,5 +38,5 @@ public interface SegmentPreSelector {
    * Pre-selects the online segments to filter out the unnecessary segments. This method might modify the online segment
    * set passed in.
    */
-  Set<String> preSelect(Set<String> onlineSegments);
+  Set<SegmentBrokerView> preSelect(Set<SegmentBrokerView> onlineSegments);
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/EmptySegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/EmptySegmentPruner.java
@@ -63,9 +63,8 @@ public class EmptySegmentPruner implements SegmentPruner {
   @Override
   public synchronized void onExternalViewChange(ExternalView externalView, IdealState idealState,
       Set<SegmentBrokerView> onlineSegments) {
-    _emptySegments = onlineSegments.stream()
-      .filter(segmentMetadata -> segmentMetadata.getTotalDocs() == 0)
-      .collect(Collectors.toSet());
+    _emptySegments = onlineSegments.stream().filter(segmentMetadata -> segmentMetadata.getTotalDocs() == 0)
+        .collect(Collectors.toSet());
   }
 
   @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/PartitionSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/PartitionSegmentPruner.java
@@ -1,16 +1,20 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
- * agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance with the License. You may obtain a
- * copy of the License at
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
- * <p>Unless required by applicable law or agreed to in writing, software distributed under the
- * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing permissions and
- * limitations under the License.
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.pinot.broker.routing.segmentpruner;
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPruner.java
@@ -21,6 +21,7 @@ package org.apache.pinot.broker.routing.segmentpruner;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
+import org.apache.pinot.broker.routing.segmentmetadata.SegmentBrokerView;
 import org.apache.pinot.common.request.BrokerRequest;
 
 
@@ -34,21 +35,21 @@ public interface SegmentPruner {
    * ONLINE/CONSUMING instances in the ideal state and selected by the pre-selector). Should be called only once before
    * calling other methods.
    */
-  void init(ExternalView externalView, IdealState idealState, Set<String> onlineSegments);
+  void init(ExternalView externalView, IdealState idealState, Set<SegmentBrokerView> onlineSegments);
 
   /**
    * Processes the external view change based on the given ideal state and online segments (segments with
    * ONLINE/CONSUMING instances in the ideal state and selected by the pre-selector).
    */
-  void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<String> onlineSegments);
+  void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<SegmentBrokerView> onlineSegments);
 
   /**
    * Refreshes the metadata for the given segment (called when segment is getting refreshed).
    */
-  void refreshSegment(String segment);
+  void refreshSegment(SegmentBrokerView segment);
 
   /**
    * Prunes the segments queried by the given broker request, returns the selected segments to be queried.
    */
-  Set<String> prune(BrokerRequest brokerRequest, Set<String> segments);
+  Set<SegmentBrokerView> prune(BrokerRequest brokerRequest, Set<SegmentBrokerView> segments);
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerFactory.java
@@ -47,6 +47,7 @@ public class SegmentPrunerFactory {
       ZkHelixPropertyStore<ZNRecord> propertyStore) {
     RoutingConfig routingConfig = tableConfig.getRoutingConfig();
     List<SegmentPruner> segmentPruners = new ArrayList<>();
+    segmentPruners.add(new EmptySegmentPruner(tableConfig, propertyStore));
 
     if (routingConfig != null) {
       List<String> segmentPrunerTypes = routingConfig.getSegmentPrunerTypes();
@@ -82,10 +83,6 @@ public class SegmentPrunerFactory {
         }
       }
     }
-    // EmptySegmentPruner tries to create a copy of all the lists, in some cases if the
-    // segments has 10k+ items in it, it may waste a lot of CPU cycle for several empty segment.
-    // Moving it to the end may help some scenario in performance.
-    segmentPruners.add(new EmptySegmentPruner(tableConfig, propertyStore));
     return segmentPruners;
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerFactory.java
@@ -104,8 +104,8 @@ public class SegmentPrunerFactory {
       return null;
     }
     String partitionColumn = partitionColumns.iterator().next();
-    LOGGER.info("Using PartitionSegmentPruner on partition column: {} for table: {}", partitionColumn,
-        tableNameWithType);
+    LOGGER
+        .info("Using PartitionSegmentPruner on partition column: {} for table: {}", partitionColumn, tableNameWithType);
     return new PartitionSegmentPruner(tableNameWithType, partitionColumn, propertyStore);
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
@@ -92,7 +92,7 @@ public class TimeSegmentPruner implements SegmentPruner {
   @Override
   public void init(ExternalView externalView, IdealState idealState, Set<SegmentBrokerView> onlineSegments) {
     // Bulk load time info for all online segments
-    for (SegmentBrokerView metadata: onlineSegments) {
+    for (SegmentBrokerView metadata : onlineSegments) {
       _intervalMap.put(metadata, metadata.getInterval());
     }
     _intervalTree = new IntervalTree<>(_intervalMap);
@@ -105,7 +105,8 @@ public class TimeSegmentPruner implements SegmentPruner {
     //       ones. The refreshed segment ZK metadata change won't be picked up.
     for (SegmentBrokerView segment : onlineSegments) {
       _intervalMap.computeIfAbsent(segment, k -> SegmentBrokerView.extractIntervalFromSegmentZKMetaZNRecord(
-          _propertyStore.get(_segmentZKMetadataPathPrefix + k, null, AccessOption.PERSISTENT), segment.getSegmentName(), _tableNameWithType));
+          _propertyStore.get(_segmentZKMetadataPathPrefix + k, null, AccessOption.PERSISTENT), segment.getSegmentName(),
+          _tableNameWithType));
     }
     _intervalMap.keySet().retainAll(onlineSegments);
     _intervalTree = new IntervalTree<>(_intervalMap);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/OfflineSegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/OfflineSegmentSelector.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
+import org.apache.pinot.broker.routing.segmentmetadata.SegmentBrokerView;
 import org.apache.pinot.common.request.BrokerRequest;
 
 
@@ -29,23 +30,22 @@ import org.apache.pinot.common.request.BrokerRequest;
  * Segment selector for offline table.
  */
 public class OfflineSegmentSelector implements SegmentSelector {
-  private volatile Set<String> _segments;
+  private volatile Set<SegmentBrokerView> _segments;
 
   @Override
-  public void init(ExternalView externalView, IdealState idealState, Set<String> onlineSegments) {
+  public void init(ExternalView externalView, IdealState idealState, Set<SegmentBrokerView> onlineSegments) {
     onExternalViewChange(externalView, idealState, onlineSegments);
   }
 
   @Override
-  public void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<String> onlineSegments) {
+  public void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<SegmentBrokerView> onlineSegments) {
     // TODO: for new added segments, before all replicas are up, consider not selecting them to avoid causing
     //       hotspot servers
-
     _segments = Collections.unmodifiableSet(onlineSegments);
   }
 
   @Override
-  public Set<String> select(BrokerRequest brokerRequest) {
+  public Set<SegmentBrokerView> select(BrokerRequest brokerRequest) {
     return _segments;
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/OfflineSegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/OfflineSegmentSelector.java
@@ -38,7 +38,8 @@ public class OfflineSegmentSelector implements SegmentSelector {
   }
 
   @Override
-  public void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<SegmentBrokerView> onlineSegments) {
+  public void onExternalViewChange(ExternalView externalView, IdealState idealState,
+      Set<SegmentBrokerView> onlineSegments) {
     // TODO: for new added segments, before all replicas are up, consider not selecting them to avoid causing
     //       hotspot servers
     _segments = Collections.unmodifiableSet(onlineSegments);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/RealtimeSegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/RealtimeSegmentSelector.java
@@ -64,12 +64,13 @@ public class RealtimeSegmentSelector implements SegmentSelector {
   }
 
   @Override
-  public void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<SegmentBrokerView> onlineSegments) {
+  public void onExternalViewChange(ExternalView externalView, IdealState idealState,
+      Set<SegmentBrokerView> onlineSegments) {
     // Group HLC segments by their group id
     // NOTE: Use TreeMap so that group ids are sorted and the result is deterministic
     Map<String, Set<SegmentBrokerView>> groupIdToHLCSegmentsMap = new TreeMap<>();
     Map<String, SegmentBrokerView> metadataMap = new HashMap<>();
-    for (SegmentBrokerView metadata: onlineSegments) {
+    for (SegmentBrokerView metadata : onlineSegments) {
       metadataMap.put(metadata.getSegmentName(), metadata);
     }
 
@@ -136,7 +137,8 @@ public class RealtimeSegmentSelector implements SegmentSelector {
           new HashSet<>(completedLLCSegments.size() + partitionIdToFirstConsumingLLCSegmentMap.size());
       llcSegments.addAll(completedLLCSegments);
       for (LLCSegmentName llcSegmentName : partitionIdToFirstConsumingLLCSegmentMap.values()) {
-        llcSegments.add(metadataMap.getOrDefault(llcSegmentName.getSegmentName(), new SegmentBrokerView(llcSegmentName.getSegmentName())));
+        llcSegments.add(metadataMap
+            .getOrDefault(llcSegmentName.getSegmentName(), new SegmentBrokerView(llcSegmentName.getSegmentName())));
       }
       _llcSegments = Collections.unmodifiableSet(llcSegments);
     } else {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelector.java
@@ -21,6 +21,7 @@ package org.apache.pinot.broker.routing.segmentselector;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
+import org.apache.pinot.broker.routing.segmentmetadata.SegmentBrokerView;
 import org.apache.pinot.common.request.BrokerRequest;
 
 
@@ -47,17 +48,17 @@ public interface SegmentSelector {
    * ONLINE/CONSUMING instances in the ideal state and selected by the pre-selector). Should be called only once before
    * calling other methods.
    */
-  void init(ExternalView externalView, IdealState idealState, Set<String> onlineSegments);
+  void init(ExternalView externalView, IdealState idealState, Set<SegmentBrokerView> onlineSegments);
 
   /**
    * Processes the external view change based on the given ideal state and online segments (segments with
    * ONLINE/CONSUMING instances in ideal state and selected by the pre-selector).
    */
-  void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<String> onlineSegments);
+  void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<SegmentBrokerView> onlineSegments);
 
   /**
    * Selects the segments queried by the given broker request. The segments selected should cover the whole dataset
    * (table) without overlap.
    */
-  Set<String> select(BrokerRequest brokerRequest);
+  Set<SegmentBrokerView> select(BrokerRequest brokerRequest);
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManager.java
@@ -171,8 +171,9 @@ public class TimeBoundaryManager {
       //       the time boundary before the new segment is picked up by the servers
       Map<String, String> instanceStateMap = externalView.getStateMap(segment.getSegmentName());
       if (instanceStateMap != null && instanceStateMap.containsValue(SegmentStateModel.ONLINE)) {
-        _endTimeMsMap.computeIfAbsent(segment.getSegmentName(), k -> extractEndTimeMsFromSegmentZKMetadataZNRecord(segment.getSegmentName(),
-            _propertyStore.get(_segmentZKMetadataPathPrefix + segment, null, AccessOption.PERSISTENT)));
+        _endTimeMsMap.computeIfAbsent(segment.getSegmentName(),
+            k -> extractEndTimeMsFromSegmentZKMetadataZNRecord(segment.getSegmentName(),
+                _propertyStore.get(_segmentZKMetadataPathPrefix + segment, null, AccessOption.PERSISTENT)));
       }
     }
     _endTimeMsMap.keySet().retainAll(onlineSegments);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManager.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.helix.AccessOption;
 import org.apache.helix.ZNRecord;
@@ -109,7 +110,7 @@ public class TimeBoundaryManager {
     List<String> segmentZKMetadataPaths = new ArrayList<>(numSegments);
     for (SegmentBrokerView segment : onlineSegments) {
       segments.add(segment.getSegmentName());
-      segmentZKMetadataPaths.add(_segmentZKMetadataPathPrefix + segment);
+      segmentZKMetadataPaths.add(_segmentZKMetadataPathPrefix + segment.getSegmentName());
     }
     List<ZNRecord> znRecords = _propertyStore.get(segmentZKMetadataPaths, null, AccessOption.PERSISTENT);
     long maxEndTimeMs = INVALID_END_TIME_MS;
@@ -166,17 +167,18 @@ public class TimeBoundaryManager {
   @SuppressWarnings("unused")
   public synchronized void onExternalViewChange(ExternalView externalView, IdealState idealState,
       Set<SegmentBrokerView> onlineSegments) {
-    for (SegmentBrokerView segment : onlineSegments) {
+    Set<String> onlineSegmentNames =
+        onlineSegments.stream().map(SegmentBrokerView::getSegmentName).collect(Collectors.toSet());
+    for (String segment : onlineSegmentNames) {
       // NOTE: Only update the segment end time when there are ONLINE instances in the external view to prevent moving
       //       the time boundary before the new segment is picked up by the servers
-      Map<String, String> instanceStateMap = externalView.getStateMap(segment.getSegmentName());
+      Map<String, String> instanceStateMap = externalView.getStateMap(segment);
       if (instanceStateMap != null && instanceStateMap.containsValue(SegmentStateModel.ONLINE)) {
-        _endTimeMsMap.computeIfAbsent(segment.getSegmentName(),
-            k -> extractEndTimeMsFromSegmentZKMetadataZNRecord(segment.getSegmentName(),
-                _propertyStore.get(_segmentZKMetadataPathPrefix + segment, null, AccessOption.PERSISTENT)));
+        _endTimeMsMap.computeIfAbsent(segment, k -> extractEndTimeMsFromSegmentZKMetadataZNRecord(segment,
+            _propertyStore.get(_segmentZKMetadataPathPrefix + segment, null, AccessOption.PERSISTENT)));
       }
     }
-    _endTimeMsMap.keySet().retainAll(onlineSegments);
+    _endTimeMsMap.keySet().retainAll(onlineSegmentNames);
     updateTimeBoundaryInfo(getMaxEndTimeMs());
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManager.java
@@ -103,14 +103,16 @@ public class TimeBoundaryManager {
    * needed in the future.
    */
   @SuppressWarnings("unused")
-  public void init(ExternalView externalView, IdealState idealState, Set<SegmentBrokerView> onlineSegments) {
+  public void init(ExternalView externalView, IdealState idealState, Set<SegmentBrokerView> onlineSegmentViews) {
     // Bulk load time info for all online segments
+    Set<String> onlineSegments =
+        onlineSegmentViews.stream().map(SegmentBrokerView::getSegmentName).collect(Collectors.toSet());
     int numSegments = onlineSegments.size();
     List<String> segments = new ArrayList<>(numSegments);
     List<String> segmentZKMetadataPaths = new ArrayList<>(numSegments);
-    for (SegmentBrokerView segment : onlineSegments) {
-      segments.add(segment.getSegmentName());
-      segmentZKMetadataPaths.add(_segmentZKMetadataPathPrefix + segment.getSegmentName());
+    for (String segment : onlineSegments) {
+      segments.add(segment);
+      segmentZKMetadataPaths.add(_segmentZKMetadataPathPrefix + segment);
     }
     List<ZNRecord> znRecords = _propertyStore.get(segmentZKMetadataPaths, null, AccessOption.PERSISTENT);
     long maxEndTimeMs = INVALID_END_TIME_MS;

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/intervalst/IntervalTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/intervalst/IntervalTest.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.broker.routing.intervalst;
 
-import org.apache.pinot.broker.routing.segmentpruner.interval.Interval;
+import org.apache.pinot.broker.routing.segmentmetadata.Interval;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/intervalst/IntervalTreeTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/intervalst/IntervalTreeTest.java
@@ -23,8 +23,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
-import org.apache.pinot.broker.routing.segmentpruner.interval.Interval;
-import org.apache.pinot.broker.routing.segmentpruner.interval.IntervalTree;
+import org.apache.pinot.broker.routing.segmentmetadata.Interval;
+import org.apache.pinot.broker.routing.segmentmetadata.IntervalTree;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpreselector/SegmentPreSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpreselector/SegmentPreSelectorTest.java
@@ -60,7 +60,7 @@ public class SegmentPreSelectorTest {
         new SegmentLineageBasedSegmentPreSelector(offlineTableName, propertyStore);
 
     // Check the case where there's no segment lineage metadata for a table
-    Assert.assertEquals(segmentPreSelector.preSelect(new HashSet<>(onlineSegments)), onlineSegments);
+    Assert.assertEquals(segmentPreSelector.preSelectForTest(new HashSet<>(onlineSegments)), onlineSegments);
 
     // Update the segment lineage
     SegmentLineage segmentLineage = new SegmentLineage(offlineTableName);
@@ -70,19 +70,19 @@ public class SegmentPreSelectorTest {
             LineageEntryState.IN_PROGRESS, System.currentTimeMillis()));
     SegmentLineageAccessHelper.writeSegmentLineage(propertyStore, segmentLineage, -1);
 
-    Assert.assertEquals(segmentPreSelector.preSelect(new HashSet<>(onlineSegments)),
+    Assert.assertEquals(segmentPreSelector.preSelectForTest(new HashSet<>(onlineSegments)),
         new HashSet<>(Arrays.asList("segment_0", "segment_1", "segment_2", "segment_3", "segment_4")));
 
     // merged_0 is added
     externalView.setStateMap("merged_0", onlineInstanceStateMap);
     onlineSegments.add("merged_0");
-    Assert.assertEquals(segmentPreSelector.preSelect(new HashSet<>(onlineSegments)),
+    Assert.assertEquals(segmentPreSelector.preSelectForTest(new HashSet<>(onlineSegments)),
         new HashSet<>(Arrays.asList("segment_0", "segment_1", "segment_2", "segment_3", "segment_4")));
 
     // merged_1 is added
     externalView.setStateMap("merged_1", onlineInstanceStateMap);
     onlineSegments.add("merged_1");
-    Assert.assertEquals(segmentPreSelector.preSelect(new HashSet<>(onlineSegments)),
+    Assert.assertEquals(segmentPreSelector.preSelectForTest(new HashSet<>(onlineSegments)),
         new HashSet<>(Arrays.asList("segment_0", "segment_1", "segment_2", "segment_3", "segment_4")));
 
     // Lineage entry gets updated to "COMPLETED"
@@ -92,7 +92,7 @@ public class SegmentPreSelectorTest {
             System.currentTimeMillis()));
     SegmentLineageAccessHelper.writeSegmentLineage(propertyStore, segmentLineage, -1);
 
-    Assert.assertEquals(segmentPreSelector.preSelect(new HashSet<>(onlineSegments)),
+    Assert.assertEquals(segmentPreSelector.preSelectForTest(new HashSet<>(onlineSegments)),
         new HashSet<>(Arrays.asList("segment_3", "segment_4", "merged_0", "merged_1")));
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelectorTest.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
+import org.apache.pinot.broker.routing.segmentmetadata.SegmentBrokerView;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.utils.HLCSegmentName;
 import org.apache.pinot.common.utils.LLCSegmentName;
@@ -61,7 +62,7 @@ public class SegmentSelectorTest {
     Map<String, Map<String, String>> segmentAssignment = externalView.getRecord().getMapFields();
     Map<String, String> onlineInstanceStateMap = Collections.singletonMap("server", ONLINE);
     Map<String, String> consumingInstanceStateMap = Collections.singletonMap("server", CONSUMING);
-    Set<String> onlineSegments = new HashSet<>();
+    Set<SegmentBrokerView> onlineSegments = new HashSet<>();
     // NOTE: Ideal state is not used in the current implementation.
     IdealState idealState = mock(IdealState.class);
 
@@ -81,7 +82,7 @@ public class SegmentSelectorTest {
       for (int j = 0; j < numHLCSegmentsPerGroup; j++) {
         String hlcSegment = new HLCSegmentName(groupId, "0", Integer.toString(j)).getSegmentName();
         segmentAssignment.put(hlcSegment, onlineInstanceStateMap);
-        onlineSegments.add(hlcSegment);
+        onlineSegments.add(new SegmentBrokerView(hlcSegment));
         hlcSegmentsForGroup[j] = hlcSegment;
       }
       hlcSegments[i] = hlcSegmentsForGroup;
@@ -104,7 +105,7 @@ public class SegmentSelectorTest {
         } else {
           externalView.setStateMap(llcSegment, consumingInstanceStateMap);
         }
-        onlineSegments.add(llcSegment);
+        onlineSegments.add(new SegmentBrokerView(llcSegment));
         if (j < numLLCSegmentsPerPartition - 1) {
           expectedSelectedLLCSegments[i * (numLLCSegmentsPerPartition - 1) + j] = llcSegment;
         }
@@ -122,7 +123,7 @@ public class SegmentSelectorTest {
     // Remove all the HLC segments from ideal state, should select the LLC segments even when HLC is forced
     for (String[] hlcSegmentsForGroup : hlcSegments) {
       for (String hlcSegment : hlcSegmentsForGroup) {
-        onlineSegments.remove(hlcSegment);
+        onlineSegments.remove(new SegmentBrokerView(hlcSegment));
       }
     }
     segmentSelector.onExternalViewChange(externalView, idealState, onlineSegments);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/ByteArrayPartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/ByteArrayPartitionFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.segment.spi.partition;
 
 import com.google.common.base.Preconditions;
 import java.util.Arrays;
+import java.util.Objects;
 
 
 /**
@@ -52,6 +53,28 @@ public class ByteArrayPartitionFunction implements PartitionFunction {
   @Override
   public String toString() {
     return NAME;
+  }
+
+  @Override
+  public PartitionFunctionType getFunctionType() {
+    return PartitionFunctionType.ByteArray;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ByteArrayPartitionFunction that = (ByteArrayPartitionFunction) o;
+    return _numPartitions == that._numPartitions;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_numPartitions, PartitionFunctionType.ByteArray);
   }
 
   private int abs(int n) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/HashCodePartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/HashCodePartitionFunction.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.spi.partition;
 
 import com.google.common.base.Preconditions;
+import java.util.Objects;
 
 
 /**
@@ -49,5 +50,27 @@ public class HashCodePartitionFunction implements PartitionFunction {
   @Override
   public String toString() {
     return NAME;
+  }
+
+  @Override
+  public PartitionFunctionType getFunctionType() {
+    return PartitionFunctionType.HashCode;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    HashCodePartitionFunction that = (HashCodePartitionFunction) o;
+    return _numPartitions == that._numPartitions;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_numPartitions, PartitionFunctionType.HashCode);
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/ModuloPartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/ModuloPartitionFunction.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.spi.partition;
 
 import com.google.common.base.Preconditions;
+import java.util.Objects;
 
 
 /**
@@ -72,5 +73,27 @@ public class ModuloPartitionFunction implements PartitionFunction {
   @Override
   public String toString() {
     return NAME;
+  }
+
+  @Override
+  public PartitionFunctionType getFunctionType() {
+    return PartitionFunctionType.Modulo;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ModuloPartitionFunction that = (ModuloPartitionFunction) o;
+    return _numPartitions == that._numPartitions;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_numPartitions, PartitionFunctionType.Modulo);
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/MurmurPartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/MurmurPartitionFunction.java
@@ -112,7 +112,9 @@ public class MurmurPartitionFunction implements PartitionFunction {
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;
-    if (o == null || ! (o instanceof MurmurPartitionFunction)) return false;
+    if (o == null || !(o instanceof MurmurPartitionFunction)) {
+      return false;
+    }
     MurmurPartitionFunction that = (MurmurPartitionFunction) o;
     return _numPartitions == that._numPartitions;
   }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/MurmurPartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/MurmurPartitionFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.segment.spi.partition;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import java.util.Objects;
 import org.apache.pinot.spi.utils.StringUtils;
 
 
@@ -105,5 +106,19 @@ public class MurmurPartitionFunction implements PartitionFunction {
     h ^= h >>> 15;
 
     return h;
+  }
+
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || ! (o instanceof MurmurPartitionFunction)) return false;
+    MurmurPartitionFunction that = (MurmurPartitionFunction) o;
+    return _numPartitions == that._numPartitions;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_numPartitions);
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/MurmurPartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/MurmurPartitionFunction.java
@@ -30,6 +30,7 @@ import org.apache.pinot.spi.utils.StringUtils;
 public class MurmurPartitionFunction implements PartitionFunction {
   private static final String NAME = "Murmur";
   private final int _numPartitions;
+  private final int _hashCode;
 
   /**
    * Constructor for the class.
@@ -38,6 +39,7 @@ public class MurmurPartitionFunction implements PartitionFunction {
   public MurmurPartitionFunction(int numPartitions) {
     Preconditions.checkArgument(numPartitions > 0, "Number of partitions must be > 0");
     _numPartitions = numPartitions;
+    _hashCode = Objects.hash(_numPartitions, PartitionFunctionType.Murmur);
   }
 
   @Override
@@ -123,6 +125,11 @@ public class MurmurPartitionFunction implements PartitionFunction {
 
   @Override
   public int hashCode() {
-    return Objects.hash(_numPartitions);
+    return _hashCode;
+  }
+
+  @Override
+  public PartitionFunctionType getFunctionType() {
+    return PartitionFunctionType.Murmur;
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/MurmurPartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/MurmurPartitionFunction.java
@@ -111,7 +111,9 @@ public class MurmurPartitionFunction implements PartitionFunction {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
+    if (this == o) {
+      return true;
+    }
     if (o == null || !(o instanceof MurmurPartitionFunction)) {
       return false;
     }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/PartitionFunctionType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/PartitionFunctionType.java
@@ -18,30 +18,12 @@
  */
 package org.apache.pinot.segment.spi.partition;
 
-import java.io.Serializable;
-
-
 /**
- * Interface for partition function.
+ * The enum for identifying a PartitionFunction quickly, instead of String Name
  */
-public interface PartitionFunction extends Serializable {
-
-  /**
-   * Returns the unique Function type
-   * @return enum of PartitionFunctionType
-   */
-  PartitionFunctionType getFunctionType();
-  /**
-   * Method to compute and return partition id for the given value.
-   *
-   * @param value Value for which to determine the partition id.
-   * @return partition id for the value.
-   */
-  int getPartition(Object value);
-
-  /**
-   * Returns the total number of possible partitions.
-   * @return Number of possible partitions.
-   */
-  int getNumPartitions();
+public enum PartitionFunctionType {
+    Murmur,
+    Modulo,
+    ByteArray,
+    HashCode
 }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
@@ -91,6 +91,9 @@ public class PartitionFunctionTest {
    */
   @Test
   public void testMurmurPartitioner() {
+    MurmurPartitionFunction func = new MurmurPartitionFunction(100);
+    Assert.assertEquals(func, new MurmurPartitionFunction(100));
+    Assert.assertNotEquals(func, new MurmurPartitionFunction(200));
     long seed = System.currentTimeMillis();
     Random random = new Random(seed);
 


### PR DESCRIPTION
## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
**Please Do Not Review yet**
This is a Work In Progress. Wish to create the PR to go through the testing before asking for Review

When brokers are doing pruning and selection, it passes SegmentName String objects around as a handle to represent Segments. This is OK when we have roughly thousands of segments.
But when we have 30k+ segments, each loop through the Segment name will create 30k+ Strings because String objects are Copy On Assignment. The CPU cost is actually high even if we have O(n) loop. 
In our written small performance test, PartitionSegmentPruner needs roughly 2~5 ms to finish iterating the whole Segment comparison.

Our changes here is to
1. Create a `SegmentBrokerView` class (because `SegmentMetadata` is taken already) to represent all the Segments in Broker, and this class will be passed around in the Broker Selector/Pruner pipeline
2. The `SegmentBrokerView` class will have all the needed information for Pruners stored in it, so there is no need to do lookup operations when doing pruning; it saves extra String copying when looping through all segments
3. The RoutingManager will be in charge of maintaining the list of all SegmentBrokerViews, and filling all information into that class
4. Refactor PartitionSegmentPruner so it will compute "ValidPartitions" first and then lookup quickly.

The Integration test shows the improvement from 150~200 pruning/second to 1200+ pruning/second. That is roughly 6-8x improvement.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
