### PR TITLE
Optimize heap-sort in TableResizer

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/Key.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/Key.java
@@ -43,6 +43,10 @@ public class Key {
     _values = values;
   }
 
+  public Object[] getValues() {
+    return _values;
+  }
+
   // NOTE: Not check class for performance concern
   @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
@@ -155,6 +155,6 @@ public class DefaultGroupByExecutor implements GroupByExecutor {
 
   @Override
   public Collection<IntermediateRecord> trimGroupByResult(int trimSize, TableResizer tableResizer) {
-    return tableResizer.trimInSegmentResults(_groupKeyGenerator.getGroupKeys(), _groupByResultHolders, trimSize);
+    return tableResizer.trimInSegmentResults(_groupKeyGenerator, _groupByResultHolders, trimSize);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGenerator.java
@@ -298,11 +298,14 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
         private int _currentGroupId;
         private final GroupKey _groupKey = new GroupKey();
 
-        @Override
-        public boolean hasNext() {
+        {
           while (_currentGroupId < _globalGroupIdUpperBound && !_flags[_currentGroupId]) {
             _currentGroupId++;
           }
+        }
+
+        @Override
+        public boolean hasNext() {
           return _currentGroupId < _globalGroupIdUpperBound;
         }
 
@@ -311,6 +314,9 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
           _groupKey._groupId = _currentGroupId;
           _groupKey._keys = getKeys(_currentGroupId);
           _currentGroupId++;
+          while (_currentGroupId < _globalGroupIdUpperBound && !_flags[_currentGroupId]) {
+            _currentGroupId++;
+          }
           return _groupKey;
         }
 
@@ -327,11 +333,14 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
         private int _currentGroupId;
         private final StringGroupKey _groupKey = new StringGroupKey();
 
-        @Override
-        public boolean hasNext() {
+        {
           while (_currentGroupId < _globalGroupIdUpperBound && !_flags[_currentGroupId]) {
             _currentGroupId++;
           }
+        }
+
+        @Override
+        public boolean hasNext() {
           return _currentGroupId < _globalGroupIdUpperBound;
         }
 
@@ -340,6 +349,9 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
           _groupKey._groupId = _currentGroupId;
           _groupKey._stringKey = getStringKey(_currentGroupId);
           _currentGroupId++;
+          while (_currentGroupId < _globalGroupIdUpperBound && !_flags[_currentGroupId]) {
+            _currentGroupId++;
+          }
           return _groupKey;
         }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/compat/tests/SqlResultComparator.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/compat/tests/SqlResultComparator.java
@@ -206,8 +206,8 @@ public class SqlResultComparator {
       String expectedOrderByColumnValues = "";
       String actualOtherColumnValues = "";
       String expectOtherColumnValues = "";
-      ArrayNode actualValue = (ArrayNode) actualElements.get(i).get(FIELD_VALUE);
-      ArrayNode expectedValue = (ArrayNode) expectedElements.get(i).get(FIELD_VALUE);
+      ArrayNode actualValue = (ArrayNode) actualElements.get(i);
+      ArrayNode expectedValue = (ArrayNode) expectedElements.get(i);
 
       for (int j = 0; j < actualValue.size(); j++) {
         if (orderByColumnIndexs.contains(j)) {


### PR DESCRIPTION
## Description
Optimize the heap-sort in TableResizer by replacing the java PriorityQueue with the custom heap implementation to:
- Optimize the initialization of the heap (bulk heapify)
- Optimize the top value replacement
- Eliminate the redundant checks

For the default setting (size 5000 heap), observe 10-20% latency reduction for the sorting.