### PR TITLE
fixing pinot-presto docker image build script

### DIFF
--- a/docker/images/pinot-presto/Dockerfile
+++ b/docker/images/pinot-presto/Dockerfile
@@ -31,9 +31,11 @@ ENV PRESTO_BUILD_DIR=/home/presto/build
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential vim wget curl git \
-    gcc libpq-dev python-dev python-pip python3-dev python3-pip python3-venv python3-wheel && \
+    gcc libpq-dev python3-dev python3-pip python3-venv python3-wheel && \
     pip3 install --upgrade pip setuptools wheel && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    ln -s /usr/bin/python3 /usr/bin/python
+
 RUN groupadd -g 999 presto && \
     useradd -r -u 999 -g presto --create-home --shell /bin/bash presto
 USER presto


### PR DESCRIPTION
## Description
`python-dev` is deprecated and removed. So removed it and link python3 to python for script execution.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
