### PR TITLE
Cache ~/.m2/repository to speed up CI speed

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -50,6 +50,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
+      # Step that does that actual cache save and restore
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Unit Test
         env:
           RUN_INTEGRATION_TESTS: false
@@ -72,6 +79,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
+      # Step that does that actual cache save and restore
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Integration Test
         env:
           RUN_INTEGRATION_TESTS: true
@@ -95,6 +109,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      # Step that does that actual cache save and restore
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Pinot Compatibility Regression Testing
         env:
           OLD_COMMIT: ${{ matrix.old_commit }}
@@ -115,6 +136,13 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: ${{ matrix.java }}
+      # Step that does that actual cache save and restore
+      - uses: actions/cache@v1
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
       - name: Quickstart on JDK ${{ matrix.java }}
         run: .github/workflows/scripts/.pinot_quickstart.sh
 

--- a/.github/workflows/scripts/.pinot_test.sh
+++ b/.github/workflows/scripts/.pinot_test.sh
@@ -27,7 +27,7 @@ netstat -i
 
 if [ "$RUN_INTEGRATION_TESTS" != false ]; then
   # Integration Tests
-  mvn install -DskipTests -am -B -pl 'pinot-integration-tests' -T 16 || exit 1
+  mvn clean install -DskipTests -am -B -pl 'pinot-integration-tests' -T 16 || exit 1
   if [ "$RUN_TEST_SET" == "1" ]; then
     mvn test -am -B \
         -pl 'pinot-integration-tests' \
@@ -43,7 +43,7 @@ if [ "$RUN_INTEGRATION_TESTS" != false ]; then
 else
   # Unit Tests
   if [ "$RUN_TEST_SET" == "1" ]; then
-    mvn install -am -B \
+    mvn clean install -am -B \
         -pl 'pinot-spi' \
         -pl 'pinot-segment-spi' \
         -pl 'pinot-common' \
@@ -59,7 +59,7 @@ else
         -P github-actions,no-integration-tests && exit 0 || exit 1
   fi
   if [ "$RUN_TEST_SET" == "2" ]; then
-    mvn install -DskipTests -T 16 || exit 1
+    mvn clean install -DskipTests -T 16 || exit 1
     mvn test -am -B \
         -pl '!pinot-spi' \
         -pl '!pinot-segment-spi' \
@@ -76,3 +76,5 @@ else
         -P github-actions,no-integration-tests && exit 0 || exit 1
   fi
 fi
+
+mvn clean > /dev/null


### PR DESCRIPTION
## Description
Not significant, but slightly better:
before:
![image](https://user-images.githubusercontent.com/1202120/132566834-51ae23b6-316d-49de-9d5f-798aa0160329.png)

after:
![image](https://user-images.githubusercontent.com/1202120/132566807-92de025b-3836-4724-92ab-22ea431275da.png)


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
