### PR TITLE
skip .factorypath from rat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1797,8 +1797,8 @@
             <!-- Github template files -->
             <exclude>.github/*.md</exclude>
 
-	    <!-- MISC -->
-	    <exclude>**/.factorypath</exclude>
+	      <!-- MISC -->
+	      <exclude>**/.factorypath</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1796,6 +1796,9 @@
 
             <!-- Github template files -->
             <exclude>.github/*.md</exclude>
+
+	    <!-- MISC -->
+	    <exclude>**/.factorypath</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
.factorypath shouldn't be checked by rat plugin. 