### PR TITLE
Introduce resultSize in IndexedTable

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByOrderByCombineOperator.java
@@ -133,14 +133,16 @@ public class GroupByOrderByCombineOperator extends BaseCombineOperator {
       try {
         if (_dataSchema == null) {
           _dataSchema = intermediateResultsBlock.getDataSchema();
+          // NOTE: Use trimSize as resultSize on server size.
           if (_trimThreshold >= MAX_TRIM_THRESHOLD) {
             // special case of trim threshold where it is set to max value.
             // there won't be any trimming during upsert in this case.
             // thus we can avoid the overhead of read-lock and write-lock
             // in the upsert method.
-            _indexedTable = new UnboundedConcurrentIndexedTable(_dataSchema, _queryContext, _trimSize, _trimThreshold);
+            _indexedTable = new UnboundedConcurrentIndexedTable(_dataSchema, _queryContext, _trimSize);
           } else {
-            _indexedTable = new ConcurrentIndexedTable(_dataSchema, _queryContext, _trimSize, _trimThreshold);
+            _indexedTable =
+                new ConcurrentIndexedTable(_dataSchema, _queryContext, _trimSize, _trimSize, _trimThreshold);
           }
         }
       } finally {

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/GroupByUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/GroupByUtils.java
@@ -18,9 +18,6 @@
  */
 package org.apache.pinot.core.util;
 
-import org.apache.pinot.core.query.request.context.QueryContext;
-
-
 public final class GroupByUtils {
   private GroupByUtils() {
   }
@@ -28,9 +25,8 @@ public final class GroupByUtils {
   public static final int DEFAULT_MIN_NUM_GROUPS = 5000;
 
   /**
-   * (For PQL semantic) Returns the capacity of the table required by the given query.
-   * NOTE: It returns {@code max(limit * 5, 5000)} to ensure the result accuracy because the results are always ordered
-   *       in PQL semantic.
+   * Returns the capacity of the table required by the given query.
+   * NOTE: It returns {@code max(limit * 5, 5000)} to ensure the result accuracy.
    */
   public static int getTableCapacity(int limit) {
     return Math.max(limit * 5, DEFAULT_MIN_NUM_GROUPS);
@@ -38,26 +34,10 @@ public final class GroupByUtils {
 
   /**
    * Returns the capacity of the table required by the given query.
-   * NOTE: It returns {@code max(limit * 5, minNumGroups)} where minNumGroups is configured by the user
-   *      (Default: 5000)
+   * NOTE: It returns {@code max(limit * 5, minNumGroups)} where minNumGroups is configurable to tune the table size and
+   *       result accuracy.
    */
   public static int getTableCapacity(int limit, int minNumGroups) {
     return Math.max(limit * 5, minNumGroups);
-  }
-
-  /**
-   * (For SQL semantic) Returns the capacity of the table required by the given query.
-   * <ul>
-   *   <li>For GROUP-BY with ORDER-BY or HAVING, returns {@code max(limit * 5, 5000)} to ensure the result accuracy</li>
-   *   <li>For GROUP-BY without ORDER-BY or HAVING, returns the limit</li>
-   * </ul>
-   */
-  public static int getTableCapacity(QueryContext queryContext) {
-    int limit = queryContext.getLimit();
-    if (queryContext.getOrderByExpressions() != null || queryContext.getHavingFilter() != null) {
-      return Math.max(limit * 5, DEFAULT_MIN_NUM_GROUPS);
-    } else {
-      return limit;
-    }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
@@ -43,18 +43,18 @@ import org.testng.annotations.Test;
  */
 @SuppressWarnings({"rawtypes"})
 public class IndexedTableTest {
-
+  private static final int TRIM_SIZE = 10;
   private static final int TRIM_THRESHOLD = 20;
 
   @Test
   public void testConcurrentIndexedTable()
       throws InterruptedException, TimeoutException, ExecutionException {
-    QueryContext queryContext = QueryContextConverterUtils
-        .getQueryContextFromSQL("SELECT SUM(m1), MAX(m2) FROM testTable GROUP BY d1, d2, d3 ORDER BY SUM(m1)");
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL(
+        "SELECT SUM(m1), MAX(m2) FROM testTable GROUP BY d1, d2, d3 ORDER BY SUM(m1)");
     DataSchema dataSchema = new DataSchema(new String[]{"d1", "d2", "d3", "sum(m1)", "max(m2)"}, new ColumnDataType[]{
         ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE
     });
-    IndexedTable indexedTable = new ConcurrentIndexedTable(dataSchema, queryContext, 5, TRIM_THRESHOLD);
+    IndexedTable indexedTable = new ConcurrentIndexedTable(dataSchema, queryContext, 5, TRIM_SIZE, TRIM_THRESHOLD);
 
     // 3 threads upsert together
     // a inserted 6 times (60), b inserted 5 times (50), d inserted 2 times (20)
@@ -118,24 +118,24 @@ public class IndexedTableTest {
 
   @Test(dataProvider = "initDataProvider")
   public void testNonConcurrentIndexedTable(String orderBy, List<String> survivors) {
-    QueryContext queryContext = QueryContextConverterUtils
-        .getQueryContextFromSQL("SELECT SUM(m1), MAX(m2) FROM testTable GROUP BY d1, d2, d3, d4 ORDER BY " + orderBy);
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL(
+        "SELECT SUM(m1), MAX(m2) FROM testTable GROUP BY d1, d2, d3, d4 ORDER BY " + orderBy);
     DataSchema dataSchema =
         new DataSchema(new String[]{"d1", "d2", "d3", "d4", "sum(m1)", "max(m2)"}, new ColumnDataType[]{
-            ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.DOUBLE, ColumnDataType.INT, ColumnDataType.DOUBLE,
-            ColumnDataType.DOUBLE
+            ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.DOUBLE, ColumnDataType.INT,
+            ColumnDataType.DOUBLE, ColumnDataType.DOUBLE
         });
 
     // Test SimpleIndexedTable
-    IndexedTable indexedTable = new SimpleIndexedTable(dataSchema, queryContext, 5, TRIM_THRESHOLD);
-    IndexedTable mergeTable = new SimpleIndexedTable(dataSchema, queryContext, 10, TRIM_THRESHOLD);
+    IndexedTable indexedTable = new SimpleIndexedTable(dataSchema, queryContext, 5, TRIM_SIZE, TRIM_THRESHOLD);
+    IndexedTable mergeTable = new SimpleIndexedTable(dataSchema, queryContext, 10, TRIM_SIZE, TRIM_THRESHOLD);
     testNonConcurrent(indexedTable, mergeTable);
     indexedTable.finish(true);
     checkSurvivors(indexedTable, survivors);
 
     // Test ConcurrentIndexedTable
-    indexedTable = new ConcurrentIndexedTable(dataSchema, queryContext, 5, TRIM_THRESHOLD);
-    mergeTable = new SimpleIndexedTable(dataSchema, queryContext, 10, TRIM_THRESHOLD);
+    indexedTable = new ConcurrentIndexedTable(dataSchema, queryContext, 5, TRIM_SIZE, TRIM_THRESHOLD);
+    mergeTable = new SimpleIndexedTable(dataSchema, queryContext, 10, TRIM_SIZE, TRIM_THRESHOLD);
     testNonConcurrent(indexedTable, mergeTable);
     indexedTable.finish(true);
     checkSurvivors(indexedTable, survivors);
@@ -250,10 +250,10 @@ public class IndexedTableTest {
         ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE
     });
 
-    IndexedTable indexedTable = new SimpleIndexedTable(dataSchema, queryContext, 5, TRIM_THRESHOLD);
+    IndexedTable indexedTable = new SimpleIndexedTable(dataSchema, queryContext, 5, TRIM_SIZE, TRIM_THRESHOLD);
     testNoMoreNewRecordsInTable(indexedTable);
 
-    indexedTable = new ConcurrentIndexedTable(dataSchema, queryContext, 5, TRIM_THRESHOLD);
+    indexedTable = new ConcurrentIndexedTable(dataSchema, queryContext, 5, TRIM_SIZE, TRIM_THRESHOLD);
     testNoMoreNewRecordsInTable(indexedTable);
   }
 

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkCombineGroupBy.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkCombineGroupBy.java
@@ -97,8 +97,8 @@ public class BenchmarkCombineGroupBy {
       _d2.add(i);
     }
 
-    _queryContext = QueryContextConverterUtils
-        .getQueryContextFromSQL("SELECT sum(m1), max(m2) FROM testTable GROUP BY d1, d2 ORDER BY sum(m1) LIMIT 500");
+    _queryContext = QueryContextConverterUtils.getQueryContextFromSQL(
+        "SELECT sum(m1), max(m2) FROM testTable GROUP BY d1, d2 ORDER BY sum(m1) LIMIT 500");
     _aggregationFunctions = _queryContext.getAggregationFunctions();
     assert _aggregationFunctions != null;
     _dataSchema = new DataSchema(new String[]{"d1", "d2", "sum(m1)", "max(m2)"}, new DataSchema.ColumnDataType[]{
@@ -134,10 +134,10 @@ public class BenchmarkCombineGroupBy {
   @OutputTimeUnit(TimeUnit.MICROSECONDS)
   public void concurrentIndexedTableForCombineGroupBy()
       throws InterruptedException, ExecutionException, TimeoutException {
-    int trimSize = GroupByUtils.getTableCapacity(_queryContext);
+    int trimSize = GroupByUtils.getTableCapacity(_queryContext.getLimit());
 
     // make 1 concurrent table
-    IndexedTable concurrentIndexedTable = new ConcurrentIndexedTable(_dataSchema, _queryContext, trimSize,
+    IndexedTable concurrentIndexedTable = new ConcurrentIndexedTable(_dataSchema, _queryContext, trimSize, trimSize,
         InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
 
     List<Callable<Void>> innerSegmentCallables = new ArrayList<>(NUM_SEGMENTS);

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIndexedTable.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIndexedTable.java
@@ -86,8 +86,8 @@ public class BenchmarkIndexedTable {
       _d2.add(i);
     }
 
-    _queryContext = QueryContextConverterUtils
-        .getQueryContextFromSQL("SELECT sum(m1), max(m2) FROM testTable GROUP BY d1, d2 ORDER BY sum(m1) LIMIT 500");
+    _queryContext = QueryContextConverterUtils.getQueryContextFromSQL(
+        "SELECT sum(m1), max(m2) FROM testTable GROUP BY d1, d2 ORDER BY sum(m1) LIMIT 500");
     _dataSchema = new DataSchema(new String[]{"d1", "d2", "sum(m1)", "max(m2)"}, new DataSchema.ColumnDataType[]{
         DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.DOUBLE,
         DataSchema.ColumnDataType.DOUBLE
@@ -118,7 +118,7 @@ public class BenchmarkIndexedTable {
 
     // make 1 concurrent table
     IndexedTable concurrentIndexedTable =
-        new ConcurrentIndexedTable(_dataSchema, _queryContext, TRIM_SIZE, TRIM_THRESHOLD);
+        new ConcurrentIndexedTable(_dataSchema, _queryContext, TRIM_SIZE, TRIM_SIZE, TRIM_THRESHOLD);
 
     // 10 parallel threads putting 10k records into the table
 
@@ -166,7 +166,8 @@ public class BenchmarkIndexedTable {
     for (int i = 0; i < numSegments; i++) {
 
       // make 10 indexed tables
-      IndexedTable simpleIndexedTable = new SimpleIndexedTable(_dataSchema, _queryContext, TRIM_SIZE, TRIM_THRESHOLD);
+      IndexedTable simpleIndexedTable =
+          new SimpleIndexedTable(_dataSchema, _queryContext, TRIM_SIZE, TRIM_SIZE, TRIM_THRESHOLD);
       simpleIndexedTables.add(simpleIndexedTable);
 
       // put 10k records in each indexed table, in parallel


### PR DESCRIPTION
Introduce resultSize (number of records kept after calling finish()) in IndexedTable which can be different from the trimSize.
On the broker side, we only need to keep limit records in the final result because the groups are already fully merged. This can significantly reduce the cost of final record sorting.
Also separate the logic for queries with/without order-by and move the common methods into the IndexedTable to reduce the duplicate code.