### PR TITLE
add a artifact upload step to compatibility verifier job

### DIFF
--- a/.github/workflows/pinot_compatibility_tests.yml
+++ b/.github/workflows/pinot_compatibility_tests.yml
@@ -50,3 +50,15 @@ jobs:
           TEST_SUITE: ${{ matrix.test_suite }}
           MAVEN_OPTS: -Xmx2G -DskipShade -DfailIfNoTests=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
         run: .github/workflows/scripts/.pinot_compatibility_verifier.sh
+      - name: Archive artifacts into zip
+        if: always()
+        run: |
+          zip -1 -r artifacts.zip /tmp/compatibility-verifier/*
+      - uses: actions/upload-artifact@v2
+        name: Store compatibility verifier work directory
+        if: always()
+        with:
+          ## TODO: currently matrix.test_suite cannot be used as part of name due to invalid path character.
+          name: compatibility_verifier_work_dir
+          retention-days: 3
+          path: artifacts.zip

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -123,6 +123,18 @@ jobs:
           TEST_SUITE: ${{ matrix.test_suite }}
           MAVEN_OPTS: -Xmx2G -DskipShade -DfailIfNoTests=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
         run: .github/workflows/scripts/.pinot_compatibility_verifier.sh
+      - name: Archive artifacts into zip
+        if: always()
+        run: |
+          zip -1 -r artifacts.zip /tmp/compatibility-verifier/*
+      - uses: actions/upload-artifact@v2
+        name: Store compatibility verifier work directory
+        if: always()
+        with:
+          ## TODO: currently matrix.test_suite cannot be used as part of name due to invalid path character.
+          name: compatibility_verifier_work_dir_${{ matrix.old_commit }}
+          retention-days: 3
+          path: artifacts.zip
 
   quickstarts:
     runs-on: ubuntu-latest

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -123,18 +123,6 @@ jobs:
           TEST_SUITE: ${{ matrix.test_suite }}
           MAVEN_OPTS: -Xmx2G -DskipShade -DfailIfNoTests=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
         run: .github/workflows/scripts/.pinot_compatibility_verifier.sh
-      - name: Archive artifacts into zip
-        if: always()
-        run: |
-          zip -1 -r artifacts.zip /tmp/compatibility-verifier/*
-      - uses: actions/upload-artifact@v2
-        name: Store compatibility verifier work directory
-        if: always()
-        with:
-          ## TODO: currently matrix.test_suite cannot be used as part of name due to invalid path character.
-          name: compatibility_verifier_work_dir_${{ matrix.old_commit }}
-          retention-days: 3
-          path: artifacts.zip
 
   quickstarts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description
making it easier to debug compatibility test results by uploading the compiled working directory as an artifact. 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
NO

Does this PR fix a zero-downtime upgrade introduced earlier?
NO

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed

NO

## Release Notes
N/A

## Documentation
N/A

## Concerns
Do we pay for these github action artifact store?
