### PR TITLE
Fix parsing error messages returned to FileUploadDownloadClient

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -509,7 +509,7 @@ public class FileUploadDownloadClient implements Closeable {
     StatusLine statusLine = response.getStatusLine();
     String reason;
     try {
-      reason = JsonUtils.stringToJsonNode(EntityUtils.toString(response.getEntity())).get("error").asText();
+      reason = JsonUtils.stringToJsonNode(EntityUtils.toString(response.getEntity())).get("_error").asText();
     } catch (Exception e) {
       reason = "Failed to get reason";
     }


### PR DESCRIPTION
## Description
`FileUploadDownloadClient` uses a wrong field name to extract the error message from Entity of HttpResponse. 
Sample response entity:
```json
{
  "_code": 403,
  "_error": "Quota check failed for segment: mytable_16405_16435_2 % of table: mytable_OFFLINE, reason: Storage quota exceeded for Table mytable_OFFLINE. New estimated size: 1.43M > total allowed storage size: 1K, where new estimated size = existing estimated uncompressed size of all replicas: 0B - existing segment sizes of all replicas: 0B + (incoming uncompressed segment size: 1.43M * number replicas: 1), total allowed storage size = configured quota: 1K * number replicas: 1"
}
```
This PR uses the correct field name.

## Testing Done
Modified `OfflineClusterIntegrationTest` to generate a quota error.
Error message before the fix:
```
Got error status code: 403 (Forbidden) with reason: "Failed to get reason" while sending request: http://localhost:18998/v2/segments?tableName=mytable
```
Error message after the fix:
```
Got error status code: 403 (Forbidden) with reason: "Quota check failed for segment: mytable_16374_16404_1 % of table: mytable_OFFLINE, reason: Storage quota exceeded for Table mytable_OFFLINE. New estimated size: 1.33M > total allowed storage size: 1K, where new estimated size = existing estimated uncompressed size of all replicas: 0B - existing segment sizes of all replicas: 0B + (incoming uncompressed segment size: 1.33M * number replicas: 1), total allowed storage size = configured quota: 1K * number replicas: 1" while sending request: http://localhost:18998/v2/segments?tableName=mytable
