### PR TITLE
refactor RangeIndexReader to make it easier to evolve its implementation

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/RangeIndexBasedFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/RangeIndexBasedFilterOperator.java
@@ -65,58 +65,52 @@ public class RangeIndexBasedFilterOperator extends BaseFilterOperator {
     int lastRangeId;
     if (_rangePredicateEvaluator instanceof SortedDictionaryBasedRangePredicateEvaluator) {
       // NOTE: End dictionary id is exclusive in OfflineDictionaryBasedRangePredicateEvaluator.
-      matches = rangeIndexReader.getMatchingDocIds(
-          ((SortedDictionaryBasedRangePredicateEvaluator) _rangePredicateEvaluator).getStartDictId(),
-          ((SortedDictionaryBasedRangePredicateEvaluator) _rangePredicateEvaluator).getEndDictId() - 1);
-      partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(
-          ((SortedDictionaryBasedRangePredicateEvaluator) _rangePredicateEvaluator).getStartDictId(),
-          ((SortedDictionaryBasedRangePredicateEvaluator) _rangePredicateEvaluator).getEndDictId() - 1);
+      int startDictId = ((SortedDictionaryBasedRangePredicateEvaluator) _rangePredicateEvaluator).getStartDictId();
+      int endDictId = ((SortedDictionaryBasedRangePredicateEvaluator) _rangePredicateEvaluator).getEndDictId() - 1;
+      matches = rangeIndexReader.getMatchingDocIds(startDictId, endDictId);
+      partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(startDictId, endDictId);
     } else {
       switch (_rangePredicateEvaluator.getDataType()) {
-        case INT:
-          matches = rangeIndexReader.getMatchingDocIds(
-              ((IntRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound(),
-              ((IntRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
-          partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(
-              ((IntRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound(),
-              ((IntRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
+        case INT: {
+          int lowerBound = ((IntRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound();
+          int upperBound = ((IntRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound();
+          matches = rangeIndexReader.getMatchingDocIds(lowerBound, upperBound);
+          partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(lowerBound, upperBound);
           break;
-        case LONG:
-          matches = rangeIndexReader.getMatchingDocIds(
-              ((LongRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound(),
-              ((LongRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
-          partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(
-              ((LongRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound(),
-              ((LongRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
+        }
+        case LONG: {
+          long lowerBound = ((LongRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound();
+          long upperBound = ((LongRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound();
+          matches = rangeIndexReader.getMatchingDocIds(lowerBound, upperBound);
+          partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(lowerBound, upperBound);
           break;
-        case FLOAT:
-          matches = rangeIndexReader.getMatchingDocIds(
-              ((FloatRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound(),
-              ((FloatRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
-          partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(
-              ((FloatRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound(),
-              ((FloatRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
+        }
+        case FLOAT: {
+          float lowerBound = ((FloatRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound();
+          float upperBound = ((FloatRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound();
+          matches = rangeIndexReader.getMatchingDocIds(lowerBound, upperBound);
+          partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(lowerBound, upperBound);
           break;
-        case DOUBLE:
-          matches = rangeIndexReader.getMatchingDocIds(
-              ((DoubleRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound(),
-              ((DoubleRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
-          partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(
-              ((DoubleRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound(),
-              ((DoubleRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
+        }
+        case DOUBLE: {
+          double lowerBound = ((DoubleRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound();
+          double upperBound = ((DoubleRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound();
+          matches = rangeIndexReader.getMatchingDocIds(lowerBound, upperBound);
+          partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(lowerBound, upperBound);
           break;
+        }
         default:
           throw new IllegalStateException("String and Bytes data type not supported for Range Indexing");
       }
     }
     // this branch is likely until RangeIndexReader reimplemented and enabled by default
-    if (null != partialMatches) {
+    if (partialMatches != null) {
       // Need to scan the first and last range as they might be partially matched
       ScanBasedFilterOperator scanBasedFilterOperator =
           new ScanBasedFilterOperator(_rangePredicateEvaluator, _dataSource, _numDocs);
       FilterBlockDocIdSet scanBasedDocIdSet = scanBasedFilterOperator.getNextBlock().getBlockDocIdSet();
       MutableRoaringBitmap docIds = ((ScanBasedDocIdIterator) scanBasedDocIdSet.iterator()).applyAnd(partialMatches);
-      if (null != matches) {
+      if (matches != null) {
         docIds.or(matches);
       }
       return new FilterBlock(new BitmapDocIdSet(docIds, _numDocs) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/RangeIndexBasedFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/RangeIndexBasedFilterOperator.java
@@ -28,8 +28,8 @@ import org.apache.pinot.core.operator.filter.predicate.RangePredicateEvaluatorFa
 import org.apache.pinot.core.operator.filter.predicate.RangePredicateEvaluatorFactory.IntRawValueBasedRangePredicateEvaluator;
 import org.apache.pinot.core.operator.filter.predicate.RangePredicateEvaluatorFactory.LongRawValueBasedRangePredicateEvaluator;
 import org.apache.pinot.core.operator.filter.predicate.RangePredicateEvaluatorFactory.SortedDictionaryBasedRangePredicateEvaluator;
-import org.apache.pinot.segment.local.segment.index.readers.RangeIndexReader;
 import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.index.reader.RangeIndexReader;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
@@ -51,74 +51,84 @@ public class RangeIndexBasedFilterOperator extends BaseFilterOperator {
 
   @Override
   protected FilterBlock getNextBlock() {
-    RangeIndexReader rangeIndexReader = (RangeIndexReader) _dataSource.getRangeIndex();
+    @SuppressWarnings("unchecked")
+    RangeIndexReader<ImmutableRoaringBitmap> rangeIndexReader =
+        (RangeIndexReader<ImmutableRoaringBitmap>) _dataSource.getRangeIndex();
     assert rangeIndexReader != null;
 
+    ImmutableRoaringBitmap matches;
+    // if the implementation cannot match the entire query exactly, it will
+    // yield partial matches, which need to be verified by scanning. If it
+    // can answer the query exactly, this will be null.
+    ImmutableRoaringBitmap partialMatches;
     int firstRangeId;
     int lastRangeId;
     if (_rangePredicateEvaluator instanceof SortedDictionaryBasedRangePredicateEvaluator) {
-      firstRangeId = rangeIndexReader
-          .findRangeId(((SortedDictionaryBasedRangePredicateEvaluator) _rangePredicateEvaluator).getStartDictId());
       // NOTE: End dictionary id is exclusive in OfflineDictionaryBasedRangePredicateEvaluator.
-      lastRangeId = rangeIndexReader
-          .findRangeId(((SortedDictionaryBasedRangePredicateEvaluator) _rangePredicateEvaluator).getEndDictId() - 1);
+      matches = rangeIndexReader.getMatchingDocIds(
+          ((SortedDictionaryBasedRangePredicateEvaluator) _rangePredicateEvaluator).getStartDictId(),
+          ((SortedDictionaryBasedRangePredicateEvaluator) _rangePredicateEvaluator).getEndDictId() - 1);
+      partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(
+          ((SortedDictionaryBasedRangePredicateEvaluator) _rangePredicateEvaluator).getStartDictId(),
+          ((SortedDictionaryBasedRangePredicateEvaluator) _rangePredicateEvaluator).getEndDictId() - 1);
     } else {
       switch (_rangePredicateEvaluator.getDataType()) {
         case INT:
-          firstRangeId = rangeIndexReader
-              .findRangeId(((IntRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound());
-          lastRangeId = rangeIndexReader
-              .findRangeId(((IntRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
+          matches = rangeIndexReader.getMatchingDocIds(
+              ((IntRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound(),
+              ((IntRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
+          partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(
+              ((IntRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound(),
+              ((IntRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
           break;
         case LONG:
-          firstRangeId = rangeIndexReader
-              .findRangeId(((LongRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound());
-          lastRangeId = rangeIndexReader
-              .findRangeId(((LongRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
+          matches = rangeIndexReader.getMatchingDocIds(
+              ((LongRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound(),
+              ((LongRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
+          partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(
+              ((LongRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound(),
+              ((LongRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
           break;
         case FLOAT:
-          firstRangeId = rangeIndexReader
-              .findRangeId(((FloatRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound());
-          lastRangeId = rangeIndexReader
-              .findRangeId(((FloatRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
+          matches = rangeIndexReader.getMatchingDocIds(
+              ((FloatRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound(),
+              ((FloatRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
+          partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(
+              ((FloatRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound(),
+              ((FloatRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
           break;
         case DOUBLE:
-          firstRangeId = rangeIndexReader
-              .findRangeId(((DoubleRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound());
-          lastRangeId = rangeIndexReader
-              .findRangeId(((DoubleRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
+          matches = rangeIndexReader.getMatchingDocIds(
+              ((DoubleRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound(),
+              ((DoubleRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
+          partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(
+              ((DoubleRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).geLowerBound(),
+              ((DoubleRawValueBasedRangePredicateEvaluator) _rangePredicateEvaluator).getUpperBound());
           break;
         default:
           throw new IllegalStateException("String and Bytes data type not supported for Range Indexing");
       }
     }
-
-    // Need to scan the first and last range as they might be partially matched
-    // TODO: Detect fully matched first and last range
-    ImmutableRoaringBitmap docIdsToScan;
-    if (firstRangeId == lastRangeId) {
-      docIdsToScan = rangeIndexReader.getDocIds(firstRangeId);
-    } else {
-      docIdsToScan =
-          ImmutableRoaringBitmap.or(rangeIndexReader.getDocIds(firstRangeId), rangeIndexReader.getDocIds(lastRangeId));
-    }
-    ScanBasedFilterOperator scanBasedFilterOperator =
-        new ScanBasedFilterOperator(_rangePredicateEvaluator, _dataSource, _numDocs);
-    FilterBlockDocIdSet scanBasedDocIdSet = scanBasedFilterOperator.getNextBlock().getBlockDocIdSet();
-    MutableRoaringBitmap docIds = ((ScanBasedDocIdIterator) scanBasedDocIdSet.iterator()).applyAnd(docIdsToScan);
-
-    // Ranges in the middle of first and last range are fully matched
-    for (int rangeId = firstRangeId + 1; rangeId < lastRangeId; rangeId++) {
-      docIds.or(rangeIndexReader.getDocIds(rangeId));
-    }
-    return new FilterBlock(new BitmapDocIdSet(docIds, _numDocs) {
-
-      // Override this method to reflect the entries scanned
-      @Override
-      public long getNumEntriesScannedInFilter() {
-        return scanBasedDocIdSet.getNumEntriesScannedInFilter();
+    // this branch is likely until RangeIndexReader reimplemented and enabled by default
+    if (null != partialMatches) {
+      // Need to scan the first and last range as they might be partially matched
+      ScanBasedFilterOperator scanBasedFilterOperator =
+          new ScanBasedFilterOperator(_rangePredicateEvaluator, _dataSource, _numDocs);
+      FilterBlockDocIdSet scanBasedDocIdSet = scanBasedFilterOperator.getNextBlock().getBlockDocIdSet();
+      MutableRoaringBitmap docIds = ((ScanBasedDocIdIterator) scanBasedDocIdSet.iterator()).applyAnd(partialMatches);
+      if (null != matches) {
+        docIds.or(matches);
       }
-    });
+      return new FilterBlock(new BitmapDocIdSet(docIds, _numDocs) {
+        // Override this method to reflect the entries scanned
+        @Override
+        public long getNumEntriesScannedInFilter() {
+          return scanBasedDocIdSet.getNumEntriesScannedInFilter();
+        }
+      });
+    } else {
+      return new FilterBlock(new BitmapDocIdSet(matches == null ? new MutableRoaringBitmap() : matches, _numDocs));
+    }
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -69,9 +69,9 @@ import org.apache.pinot.segment.spi.index.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.segment.spi.index.creator.H3IndexConfig;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.index.reader.BloomFilterReader;
-import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
 import org.apache.pinot.segment.spi.index.reader.MutableDictionary;
 import org.apache.pinot.segment.spi.index.reader.MutableForwardIndex;
+import org.apache.pinot.segment.spi.index.reader.RangeIndexReader;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
@@ -1087,7 +1087,7 @@ public class MutableSegmentImpl implements MutableSegment {
     final MutableForwardIndex _forwardIndex;
     final MutableDictionary _dictionary;
     final RealtimeInvertedIndexReader _invertedIndex;
-    final InvertedIndexReader _rangeIndex;
+    final RangeIndexReader _rangeIndex;
     final MutableH3Index _h3Index;
     final RealtimeLuceneTextIndexReader _textIndex;
     final boolean _enableFST;
@@ -1105,7 +1105,7 @@ public class MutableSegmentImpl implements MutableSegment {
     IndexContainer(FieldSpec fieldSpec, @Nullable PartitionFunction partitionFunction,
         @Nullable Set<Integer> partitions, NumValuesInfo numValuesInfo, MutableForwardIndex forwardIndex,
         @Nullable MutableDictionary dictionary, @Nullable RealtimeInvertedIndexReader invertedIndex,
-        @Nullable InvertedIndexReader rangeIndex, @Nullable RealtimeLuceneTextIndexReader textIndex, boolean enableFST,
+        @Nullable RangeIndexReader rangeIndex, @Nullable RealtimeLuceneTextIndexReader textIndex, boolean enableFST,
         @Nullable MutableJsonIndex jsonIndex, @Nullable MutableH3Index h3Index, @Nullable BloomFilterReader bloomFilter,
         @Nullable MutableNullValueVector nullValueVector) {
       _fieldSpec = fieldSpec;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/RangeIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/RangeIndexCreator.java
@@ -443,6 +443,10 @@ public final class RangeIndexCreator implements DictionaryBasedInvertedIndexCrea
     }
   }
 
+  public int getNumValuesPerRange() {
+    return _numValuesPerRange;
+  }
+
   void dump() {
     StringBuilder docIdAsString = new StringBuilder("DocIdBuffer  [ ");
     for (int i = 0; i < _numValues; i++) {
@@ -539,7 +543,7 @@ public final class RangeIndexCreator implements DictionaryBasedInvertedIndexCrea
 
     @Override
     public void put(int position, Number value) {
-      _dataBuffer.putFloat(position << 2, value.intValue());
+      _dataBuffer.putFloat(position << 2, value.floatValue());
     }
 
     @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
@@ -37,7 +37,7 @@ import org.apache.pinot.segment.local.segment.index.readers.OnHeapFloatDictionar
 import org.apache.pinot.segment.local.segment.index.readers.OnHeapIntDictionary;
 import org.apache.pinot.segment.local.segment.index.readers.OnHeapLongDictionary;
 import org.apache.pinot.segment.local.segment.index.readers.OnHeapStringDictionary;
-import org.apache.pinot.segment.local.segment.index.readers.RangeIndexReader;
+import org.apache.pinot.segment.local.segment.index.readers.RangeIndexReaderImpl;
 import org.apache.pinot.segment.local.segment.index.readers.StringDictionary;
 import org.apache.pinot.segment.local.segment.index.readers.bloom.BloomFilterReaderFactory;
 import org.apache.pinot.segment.local.segment.index.readers.forward.FixedBitMVForwardIndexReader;
@@ -56,6 +56,7 @@ import org.apache.pinot.segment.spi.index.reader.H3IndexReader;
 import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
 import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.apache.pinot.segment.spi.index.reader.RangeIndexReader;
 import org.apache.pinot.segment.spi.index.reader.SortedIndexReader;
 import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
@@ -73,7 +74,7 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
 
   private final ForwardIndexReader<?> _forwardIndex;
   private final InvertedIndexReader<?> _invertedIndex;
-  private final InvertedIndexReader<?> _rangeIndex;
+  private final RangeIndexReader<?> _rangeIndex;
   private final TextIndexReader _textIndex;
   private final TextIndexReader _fstIndex;
   private final JsonIndexReader _jsonIndex;
@@ -174,7 +175,7 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
       }
 
       if (loadRangeIndex) {
-        _rangeIndex = new RangeIndexReader(segmentReader.getIndexFor(columnName, ColumnIndexType.RANGE_INDEX));
+        _rangeIndex = new RangeIndexReaderImpl(segmentReader.getIndexFor(columnName, ColumnIndexType.RANGE_INDEX));
       } else {
         _rangeIndex = null;
       }
@@ -199,7 +200,7 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
   }
 
   @Override
-  public InvertedIndexReader<?> getRangeIndex() {
+  public RangeIndexReader<?> getRangeIndex() {
     return _rangeIndex;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/BaseDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/BaseDataSource.java
@@ -28,6 +28,7 @@ import org.apache.pinot.segment.spi.index.reader.H3IndexReader;
 import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
 import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.apache.pinot.segment.spi.index.reader.RangeIndexReader;
 import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
 
 
@@ -36,7 +37,7 @@ public abstract class BaseDataSource implements DataSource {
   private final ForwardIndexReader<?> _forwardIndex;
   private final Dictionary _dictionary;
   private final InvertedIndexReader<?> _invertedIndex;
-  private final InvertedIndexReader<?> _rangeIndex;
+  private final RangeIndexReader<?> _rangeIndex;
   private final TextIndexReader _textIndex;
   private final TextIndexReader _fstIndex;
   private final JsonIndexReader _jsonIndex;
@@ -46,7 +47,7 @@ public abstract class BaseDataSource implements DataSource {
 
   public BaseDataSource(DataSourceMetadata dataSourceMetadata, ForwardIndexReader<?> forwardIndex,
       @Nullable Dictionary dictionary, @Nullable InvertedIndexReader<?> invertedIndex,
-      @Nullable InvertedIndexReader<?> rangeIndex, @Nullable TextIndexReader textIndex,
+      @Nullable RangeIndexReader<?> rangeIndex, @Nullable TextIndexReader textIndex,
       @Nullable TextIndexReader fstIndex, @Nullable JsonIndexReader jsonIndex, @Nullable H3IndexReader h3Index,
       @Nullable BloomFilterReader bloomFilter, @Nullable NullValueVectorReader nullValueVector) {
     _dataSourceMetadata = dataSourceMetadata;
@@ -86,7 +87,7 @@ public abstract class BaseDataSource implements DataSource {
 
   @Nullable
   @Override
-  public InvertedIndexReader<?> getRangeIndex() {
+  public RangeIndexReader<?> getRangeIndex() {
     return _rangeIndex;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/MutableDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/MutableDataSource.java
@@ -28,6 +28,7 @@ import org.apache.pinot.segment.spi.index.reader.H3IndexReader;
 import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
 import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.apache.pinot.segment.spi.index.reader.RangeIndexReader;
 import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -43,7 +44,7 @@ public class MutableDataSource extends BaseDataSource {
   public MutableDataSource(FieldSpec fieldSpec, int numDocs, int numValues, int maxNumValuesPerMVEntry,
       @Nullable PartitionFunction partitionFunction, @Nullable Set<Integer> partitions, @Nullable Comparable minValue,
       @Nullable Comparable maxValue, ForwardIndexReader forwardIndex, @Nullable Dictionary dictionary,
-      @Nullable InvertedIndexReader invertedIndex, @Nullable InvertedIndexReader rangeIndex,
+      @Nullable InvertedIndexReader invertedIndex, @Nullable RangeIndexReader rangeIndex,
       @Nullable TextIndexReader textIndex, boolean enableFST, @Nullable JsonIndexReader jsonIndex,
       @Nullable H3IndexReader h3Index, @Nullable BloomFilterReader bloomFilter,
       @Nullable NullValueVectorReader nullValueVector) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/RangeIndexReaderImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/RangeIndexReaderImpl.java
@@ -28,6 +28,8 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.annotation.Nullable;
+
 import static org.apache.pinot.spi.data.FieldSpec.DataType;
 import static org.apache.pinot.spi.data.FieldSpec.DataType.valueOf;
 
@@ -107,6 +109,7 @@ public class RangeIndexReaderImpl implements RangeIndexReader<ImmutableRoaringBi
    * {@inheritDoc}
    */
   @Override
+  @Nullable
   public ImmutableRoaringBitmap getMatchingDocIds(long min, long max) {
     return getMatchesInRange(findRangeId(min), findRangeId(max));
   }
@@ -115,6 +118,7 @@ public class RangeIndexReaderImpl implements RangeIndexReader<ImmutableRoaringBi
    * {@inheritDoc}
    */
   @Override
+  @Nullable
   public ImmutableRoaringBitmap getMatchingDocIds(int min, int max) {
     return getMatchesInRange(findRangeId(min), findRangeId(max));
   }
@@ -123,6 +127,7 @@ public class RangeIndexReaderImpl implements RangeIndexReader<ImmutableRoaringBi
    * {@inheritDoc}
    */
   @Override
+  @Nullable
   public ImmutableRoaringBitmap getMatchingDocIds(double min, double max) {
     return getMatchesInRange(findRangeId(min), findRangeId(max));
   }
@@ -131,6 +136,7 @@ public class RangeIndexReaderImpl implements RangeIndexReader<ImmutableRoaringBi
    * {@inheritDoc}
    */
   @Override
+  @Nullable
   public ImmutableRoaringBitmap getMatchingDocIds(float min, float max) {
     return getMatchesInRange(findRangeId(min), findRangeId(max));
   }
@@ -139,6 +145,7 @@ public class RangeIndexReaderImpl implements RangeIndexReader<ImmutableRoaringBi
    * {@inheritDoc}
    */
   @Override
+  @Nullable
   public ImmutableRoaringBitmap getPartiallyMatchingDocIds(long min, long max) {
     return getPartialMatchesInRange(findRangeId(min), findRangeId(max));
   }
@@ -147,6 +154,7 @@ public class RangeIndexReaderImpl implements RangeIndexReader<ImmutableRoaringBi
    * {@inheritDoc}
    */
   @Override
+  @Nullable
   public ImmutableRoaringBitmap getPartiallyMatchingDocIds(int min, int max) {
     return getPartialMatchesInRange(findRangeId(min), findRangeId(max));
   }
@@ -155,6 +163,7 @@ public class RangeIndexReaderImpl implements RangeIndexReader<ImmutableRoaringBi
    * {@inheritDoc}
    */
   @Override
+  @Nullable
   public ImmutableRoaringBitmap getPartiallyMatchingDocIds(double min, double max) {
     return getPartialMatchesInRange(findRangeId(min), findRangeId(max));
   }
@@ -163,6 +172,7 @@ public class RangeIndexReaderImpl implements RangeIndexReader<ImmutableRoaringBi
    * {@inheritDoc}
    */
   @Override
+  @Nullable
   public ImmutableRoaringBitmap getPartiallyMatchingDocIds(float min, float max) {
     return getPartialMatchesInRange(findRangeId(min), findRangeId(max));
   }
@@ -267,7 +277,7 @@ public class RangeIndexReaderImpl implements RangeIndexReader<ImmutableRoaringBi
     // 1. if firstRangeId is -1, the query range covers the first bucket
     // 2. if lastRangeId is _rangeStartArray.length, the query range covers the last bucket
     // 3. the loop isn't entered if the range ids are equal
-    MutableRoaringBitmap matching = firstRangeId < lastRangeId ? new MutableRoaringBitmap() : null;
+    MutableRoaringBitmap matching = firstRangeId + 1 < lastRangeId ? new MutableRoaringBitmap() : null;
     for (int rangeId = firstRangeId + 1; rangeId < lastRangeId; rangeId++) {
       matching.or(getDocIds(rangeId));
     }
@@ -284,7 +294,7 @@ public class RangeIndexReaderImpl implements RangeIndexReader<ImmutableRoaringBi
     return ImmutableRoaringBitmap.or(getDocIds(firstRangeId), getDocIds(lastRangeId));
   }
 
-  private boolean isOutOfRange(int docId) {
-    return docId < 0 || docId >= _rangeStartArray.length;
+  private boolean isOutOfRange(int rangeId) {
+    return rangeId < 0 || rangeId >= _rangeStartArray.length;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/RangeIndexReaderImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/RangeIndexReaderImpl.java
@@ -21,14 +21,13 @@ package org.apache.pinot.segment.local.segment.index.readers;
 import com.google.common.base.Preconditions;
 import java.lang.ref.SoftReference;
 import java.nio.ByteBuffer;
+import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.index.reader.RangeIndexReader;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import javax.annotation.Nullable;
 
 import static org.apache.pinot.spi.data.FieldSpec.DataType;
 import static org.apache.pinot.spi.data.FieldSpec.DataType.valueOf;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/RangeIndexReaderImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/RangeIndexReaderImpl.java
@@ -286,8 +286,12 @@ public class RangeIndexReaderImpl implements RangeIndexReader<ImmutableRoaringBi
 
   private ImmutableRoaringBitmap getPartialMatchesInRange(int firstRangeId, int lastRangeId) {
     if (firstRangeId == lastRangeId) {
-      return getDocIds(firstRangeId);
+      return firstRangeId == -1 ? null : getDocIds(firstRangeId);
     }
-    return ImmutableRoaringBitmap.or(getDocIds(firstRangeId), getDocIds(lastRangeId));
+    return firstRangeId == -1
+        ? getDocIds(lastRangeId)
+        : lastRangeId == -1
+        ? getDocIds(firstRangeId)
+        : ImmutableRoaringBitmap.or(getDocIds(firstRangeId), getDocIds(lastRangeId));
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/virtualcolumn/VirtualColumnIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/virtualcolumn/VirtualColumnIndexContainer.java
@@ -27,6 +27,7 @@ import org.apache.pinot.segment.spi.index.reader.H3IndexReader;
 import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
 import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.apache.pinot.segment.spi.index.reader.RangeIndexReader;
 import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
 
 
@@ -56,7 +57,7 @@ public class VirtualColumnIndexContainer implements ColumnIndexContainer {
   }
 
   @Override
-  public InvertedIndexReader<?> getRangeIndex() {
+  public RangeIndexReader<?> getRangeIndex() {
     return null;
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/RangeIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/RangeIndexCreatorTest.java
@@ -275,6 +275,16 @@ public class RangeIndexCreatorTest {
         assertEquals(ImmutableRoaringBitmap.or(
             rangeIndexReader.getPartiallyMatchingDocIds(lowerPartialRange[0], lowerPartialRange[1]),
             rangeIndexReader.getPartiallyMatchingDocIds(upperPartialRange[0], upperPartialRange[1])), partialMatches);
+        // edge cases
+        assertEquals(((int[]) values).length, numValuesPerMVEntry
+            * rangeIndexReader.getMatchingDocIds(Integer.MIN_VALUE, Integer.MAX_VALUE).getCardinality());
+        assertNull(rangeIndexReader.getPartiallyMatchingDocIds(Integer.MIN_VALUE, Integer.MAX_VALUE));
+        assertNull(rangeIndexReader.getMatchingDocIds(Integer.MIN_VALUE, Integer.MIN_VALUE));
+        assertNull(rangeIndexReader.getPartiallyMatchingDocIds(Integer.MIN_VALUE, Integer.MIN_VALUE));
+        assertNull(rangeIndexReader.getMatchingDocIds(Integer.MAX_VALUE, Integer.MAX_VALUE));
+        assertNull(rangeIndexReader.getPartiallyMatchingDocIds(Integer.MAX_VALUE, Integer.MAX_VALUE));
+        assertEquals(rangeIndexReader.getPartiallyMatchingDocIds(lowerPartialRange[0], coveredRange[1]),
+            rangeIndexReader.getMatchingDocIds(Integer.MIN_VALUE, upperPartialRange[1]));
         break;
       }
       case LONG: {
@@ -307,6 +317,16 @@ public class RangeIndexCreatorTest {
         assertEquals(ImmutableRoaringBitmap.or(
             rangeIndexReader.getPartiallyMatchingDocIds(lowerPartialRange[0], lowerPartialRange[1]),
             rangeIndexReader.getPartiallyMatchingDocIds(upperPartialRange[0], upperPartialRange[1])), partialMatches);
+        // edge cases
+        assertEquals(((long[]) values).length, numValuesPerMVEntry
+            * rangeIndexReader.getMatchingDocIds(Long.MIN_VALUE, Long.MAX_VALUE).getCardinality());
+        assertNull(rangeIndexReader.getPartiallyMatchingDocIds(Long.MIN_VALUE, Long.MAX_VALUE));
+        assertNull(rangeIndexReader.getMatchingDocIds(Long.MIN_VALUE, Long.MIN_VALUE));
+        assertNull(rangeIndexReader.getPartiallyMatchingDocIds(Long.MIN_VALUE, Long.MIN_VALUE));
+        assertNull(rangeIndexReader.getMatchingDocIds(Long.MAX_VALUE, Long.MAX_VALUE));
+        assertNull(rangeIndexReader.getPartiallyMatchingDocIds(Long.MAX_VALUE, Long.MAX_VALUE));
+        assertEquals(rangeIndexReader.getPartiallyMatchingDocIds(lowerPartialRange[0], coveredRange[1]),
+            rangeIndexReader.getMatchingDocIds(Long.MIN_VALUE, upperPartialRange[1]));
         break;
       }
       case FLOAT: {
@@ -339,6 +359,16 @@ public class RangeIndexCreatorTest {
         assertEquals(ImmutableRoaringBitmap.or(
             rangeIndexReader.getPartiallyMatchingDocIds(lowerPartialRange[0], lowerPartialRange[1]),
             rangeIndexReader.getPartiallyMatchingDocIds(upperPartialRange[0], upperPartialRange[1])), partialMatches);
+        // edge cases
+        assertEquals(((float[]) values).length, numValuesPerMVEntry
+            * rangeIndexReader.getMatchingDocIds(Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY).getCardinality());
+        assertNull(rangeIndexReader.getPartiallyMatchingDocIds(Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY));
+        assertNull(rangeIndexReader.getMatchingDocIds(Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY));
+        assertNull(rangeIndexReader.getPartiallyMatchingDocIds(Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY));
+        assertNull(rangeIndexReader.getMatchingDocIds(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY));
+        assertNull(rangeIndexReader.getPartiallyMatchingDocIds(Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY));
+        assertEquals(rangeIndexReader.getPartiallyMatchingDocIds(lowerPartialRange[0], coveredRange[1]),
+            rangeIndexReader.getMatchingDocIds(Float.NEGATIVE_INFINITY, upperPartialRange[1]));
         break;
       }
       case DOUBLE: {
@@ -371,6 +401,16 @@ public class RangeIndexCreatorTest {
         assertEquals(ImmutableRoaringBitmap.or(
             rangeIndexReader.getPartiallyMatchingDocIds(lowerPartialRange[0], lowerPartialRange[1]),
             rangeIndexReader.getPartiallyMatchingDocIds(upperPartialRange[0], upperPartialRange[1])), partialMatches);
+        // edge cases
+        assertEquals(((double[]) values).length, numValuesPerMVEntry
+            * rangeIndexReader.getMatchingDocIds(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY).getCardinality());
+        assertNull(rangeIndexReader.getPartiallyMatchingDocIds(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY));
+        assertNull(rangeIndexReader.getMatchingDocIds(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY));
+        assertNull(rangeIndexReader.getPartiallyMatchingDocIds(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY));
+        assertNull(rangeIndexReader.getMatchingDocIds(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY));
+        assertNull(rangeIndexReader.getPartiallyMatchingDocIds(Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY));
+        assertEquals(rangeIndexReader.getPartiallyMatchingDocIds(lowerPartialRange[0], coveredRange[1]),
+            rangeIndexReader.getMatchingDocIds(Double.NEGATIVE_INFINITY, upperPartialRange[1]));
         break;
       }
       default:
@@ -498,44 +538,52 @@ public class RangeIndexCreatorTest {
         int[] ints = (int[]) values;
         int[] sorted = Arrays.copyOf(ints, ints.length);
         Arrays.sort(sorted);
-        int[][] split = new int[ints.length / numValuesPerRange][2];
-        for (int i = 0; i < split.length; ++i) {
+        int[][] split = new int[ints.length / numValuesPerRange + 1][2];
+        for (int i = 0; i < split.length - 1; ++i) {
           split[i][0] = sorted[i * numValuesPerRange];
           split[i][1] = sorted[(i + 1) * numValuesPerRange - 1];
         }
+        split[split.length - 1][0] = sorted[(split.length - 1) * numValuesPerRange];
+        split[split.length - 1][1] = sorted[sorted.length - 1];
         return split;
       }
       case LONG: {
         long[] longs = (long[]) values;
         long[] sorted = Arrays.copyOf(longs, longs.length);
         Arrays.sort(sorted);
-        long[][] split = new long[longs.length / numValuesPerRange][2];
-        for (int i = 0; i < split.length; ++i) {
+        long[][] split = new long[longs.length / numValuesPerRange + 1][2];
+        for (int i = 0; i < split.length - 1; ++i) {
           split[i][0] = sorted[i * numValuesPerRange];
           split[i][1] = sorted[(i + 1) * numValuesPerRange - 1];
         }
+        split[split.length - 1][0] = sorted[(split.length - 1) * numValuesPerRange];
+        split[split.length - 1][1] = sorted[sorted.length - 1];
         return split;
       }
       case FLOAT: {
         float[] floats = (float[]) values;
         float[] sorted = Arrays.copyOf(floats, floats.length);
         Arrays.sort(sorted);
-        float[][] split = new float[floats.length / numValuesPerRange][2];
-        for (int i = 0; i < split.length; ++i) {
+        float[][] split = new float[floats.length / numValuesPerRange + 1][2];
+        for (int i = 0; i < split.length - 1; ++i) {
           split[i][0] = sorted[i * numValuesPerRange];
           split[i][1] = sorted[(i + 1) * numValuesPerRange - 1];
         }
+        split[split.length - 1][0] = sorted[(split.length - 1) * numValuesPerRange];
+        split[split.length - 1][1] = sorted[sorted.length - 1];
         return split;
       }
       case DOUBLE: {
         double[] doubles = (double[]) values;
         double[] sorted = Arrays.copyOf(doubles, doubles.length);
         Arrays.sort(sorted);
-        double[][] split = new double[doubles.length / numValuesPerRange][2];
-        for (int i = 0; i < split.length; ++i) {
+        double[][] split = new double[doubles.length / numValuesPerRange + 1][2];
+        for (int i = 0; i < split.length - 1; ++i) {
           split[i][0] = sorted[i * numValuesPerRange];
           split[i][1] = sorted[(i + 1) * numValuesPerRange - 1];
         }
+        split[split.length - 1][0] = sorted[(split.length - 1) * numValuesPerRange];
+        split[split.length - 1][1] = sorted[sorted.length - 1];
         return split;
       }
       default:

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/RangeIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/RangeIndexCreatorTest.java
@@ -20,10 +20,12 @@ package org.apache.pinot.segment.local.segment.index.creator;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Random;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.segment.creator.impl.inv.RangeIndexCreator;
-import org.apache.pinot.segment.local.segment.index.readers.RangeIndexReader;
+import org.apache.pinot.segment.local.segment.index.readers.RangeIndexReaderImpl;
+import org.apache.pinot.segment.spi.index.reader.RangeIndexReader;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -35,11 +37,12 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.apache.pinot.segment.spi.V1Constants.Indexes.BITMAP_RANGE_INDEX_FILE_EXTENSION;
+import static org.testng.Assert.*;
 
 
 public class RangeIndexCreatorTest {
   private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "RangeIndexCreatorTest");
-  private static final Random RANDOM = new Random();
+  private static final Random RANDOM = new Random(42);
   private static final String COLUMN_NAME = "testColumn";
 
   @BeforeClass
@@ -106,23 +109,22 @@ public class RangeIndexCreatorTest {
       throws IOException {
     FieldSpec fieldSpec = new DimensionFieldSpec(COLUMN_NAME, dataType, true);
     int numDocs = 1000;
-    Number[] values = new Number[numDocs];
+    Object values = valuesArray(dataType, numDocs);
 
+    int numValuesPerRange;
     try (RangeIndexCreator creator = new RangeIndexCreator(INDEX_DIR, fieldSpec, dataType, -1, -1, numDocs, numDocs)) {
       addDataToIndexer(dataType, numDocs, 1, creator, values);
       creator.seal();
+      // account for off by one bug in v1 implementation
+      numValuesPerRange = creator.getNumValuesPerRange() + 1;
     }
 
     File rangeIndexFile = new File(INDEX_DIR, COLUMN_NAME + BITMAP_RANGE_INDEX_FILE_EXTENSION);
     try (PinotDataBuffer dataBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(rangeIndexFile)) {
-      RangeIndexReader rangeIndexReader = new RangeIndexReader(dataBuffer);
-      Number[] rangeStartArray = rangeIndexReader.getRangeStartArray();
-      for (int rangeId = 0; rangeId < rangeStartArray.length; rangeId++) {
-        ImmutableRoaringBitmap bitmap = rangeIndexReader.getDocIds(rangeId);
-        for (int docId : bitmap.toArray()) {
-          checkValueForDocId(dataType, values, rangeStartArray, rangeId, docId, 1);
-        }
-      }
+      RangeIndexReaderImpl rangeIndexReader = new RangeIndexReaderImpl(dataBuffer);
+      verifyRangesForDataType(dataType, values,
+          splitIntoRanges(dataType, values, numValuesPerRange),
+          1, rangeIndexReader);
     }
 
     FileUtils.forceDelete(rangeIndexFile);
@@ -134,38 +136,36 @@ public class RangeIndexCreatorTest {
     int numDocs = 1000;
     int numValuesPerMVEntry = 10;
     int numValues = numDocs * numValuesPerMVEntry;
-    Number[] values = new Number[numValues];
+    Object values = valuesArray(dataType, numValues);
 
+    int numValuesPerRange;
     try (
         RangeIndexCreator creator = new RangeIndexCreator(INDEX_DIR, fieldSpec, dataType, -1, -1, numDocs, numValues)) {
       addDataToIndexer(dataType, numDocs, numValuesPerMVEntry, creator, values);
       creator.seal();
+      // account for off by one bug in existing implementation
+      numValuesPerRange = creator.getNumValuesPerRange() + 1;
     }
 
     File rangeIndexFile = new File(INDEX_DIR, COLUMN_NAME + BITMAP_RANGE_INDEX_FILE_EXTENSION);
     try (PinotDataBuffer dataBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(rangeIndexFile)) {
-      RangeIndexReader rangeIndexReader = new RangeIndexReader(dataBuffer);
-      Number[] rangeStartArray = rangeIndexReader.getRangeStartArray();
-      int numRanges = rangeStartArray.length;
-      for (int rangeId = 0; rangeId < numRanges; rangeId++) {
-        ImmutableRoaringBitmap bitmap = rangeIndexReader.getDocIds(rangeId);
-        for (int docId : bitmap.toArray()) {
-          checkValueForDocId(dataType, values, rangeStartArray, rangeId, docId, numValuesPerMVEntry);
-        }
-      }
+      RangeIndexReaderImpl rangeIndexReader = new RangeIndexReaderImpl(dataBuffer);
+      verifyRangesForDataType(dataType, values,
+          splitIntoRanges(dataType, values, numValuesPerRange),
+          numValuesPerMVEntry, rangeIndexReader);
     }
 
     FileUtils.forceDelete(rangeIndexFile);
   }
 
   private void addDataToIndexer(DataType dataType, int numDocs, int numValuesPerEntry, RangeIndexCreator creator,
-      Number[] values) {
+      Object values) {
     switch (dataType) {
       case INT:
         if (numValuesPerEntry == 1) {
           for (int i = 0; i < numDocs; i++) {
             int value = RANDOM.nextInt();
-            values[i] = value;
+            ((int[]) values)[i] = value;
             creator.add(value);
           }
         } else {
@@ -174,7 +174,7 @@ public class RangeIndexCreatorTest {
             for (int j = 0; j < numValuesPerEntry; j++) {
               int value = RANDOM.nextInt();
               intValues[j] = value;
-              values[i * numValuesPerEntry + j] = value;
+              ((int[]) values)[i * numValuesPerEntry + j] = value;
             }
             creator.add(intValues, numValuesPerEntry);
           }
@@ -184,7 +184,7 @@ public class RangeIndexCreatorTest {
         if (numValuesPerEntry == 1) {
           for (int i = 0; i < numDocs; i++) {
             long value = RANDOM.nextLong();
-            values[i] = value;
+            ((long[]) values)[i] = value;
             creator.add(value);
           }
         } else {
@@ -193,7 +193,7 @@ public class RangeIndexCreatorTest {
             for (int j = 0; j < numValuesPerEntry; j++) {
               long value = RANDOM.nextLong();
               longValues[j] = value;
-              values[i * numValuesPerEntry + j] = value;
+              ((long[]) values)[i * numValuesPerEntry + j] = value;
             }
             creator.add(longValues, numValuesPerEntry);
           }
@@ -203,7 +203,7 @@ public class RangeIndexCreatorTest {
         if (numValuesPerEntry == 1) {
           for (int i = 0; i < numDocs; i++) {
             float value = RANDOM.nextFloat();
-            values[i] = value;
+            ((float[]) values)[i] = value;
             creator.add(value);
           }
         } else {
@@ -212,7 +212,7 @@ public class RangeIndexCreatorTest {
             for (int j = 0; j < numValuesPerEntry; j++) {
               float value = RANDOM.nextFloat();
               floatValues[j] = value;
-              values[i * numValuesPerEntry + j] = value;
+              ((float[]) values)[i * numValuesPerEntry + j] = value;
             }
             creator.add(floatValues, numValuesPerEntry);
           }
@@ -222,7 +222,7 @@ public class RangeIndexCreatorTest {
         if (numValuesPerEntry == 1) {
           for (int i = 0; i < numDocs; i++) {
             double value = RANDOM.nextDouble();
-            values[i] = value;
+            ((double[]) values)[i] = value;
             creator.add(value);
           }
         } else {
@@ -231,7 +231,7 @@ public class RangeIndexCreatorTest {
             for (int j = 0; j < numValuesPerEntry; j++) {
               double value = RANDOM.nextDouble();
               doubleValues[j] = value;
-              values[i * numValuesPerEntry + j] = value;
+              ((double[]) values)[i * numValuesPerEntry + j] = value;
             }
             creator.add(doubleValues, numValuesPerEntry);
           }
@@ -242,141 +242,304 @@ public class RangeIndexCreatorTest {
     }
   }
 
-  private void checkValueForDocId(DataType dataType, Number[] values, Number[] rangeStartArray, int rangeId, int docId,
-      int numValuesPerEntry) {
+  private void verifyRangesForDataType(DataType dataType, Object values, Object ranges, int numValuesPerMVEntry,
+                                       RangeIndexReader<ImmutableRoaringBitmap> rangeIndexReader) {
     switch (dataType) {
-      case INT:
-        if (numValuesPerEntry == 1) {
-          checkInt(rangeStartArray, rangeId, values[docId].intValue());
-        } else {
-          checkIntMV(rangeStartArray, rangeId, values, docId, numValuesPerEntry);
+      case INT: {
+        // single bucket ranges
+        int rangeId = 0;
+        for (int[] range : (int[][]) ranges) {
+          assertNull(rangeIndexReader.getMatchingDocIds(range[0], range[1]),
+              "range index can't guarantee match within a single range");
+          ImmutableRoaringBitmap partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(range[0], range[1]);
+          assertNotNull(partialMatches, "partial matches for single range must not be null");
+          for (int docId : partialMatches.toArray()) {
+            checkValueForDocId(dataType, values, ranges, rangeId, docId, numValuesPerMVEntry);
+          }
+          ++rangeId;
         }
-        break;
-      case LONG:
-        if (numValuesPerEntry == 1) {
-          checkLong(rangeStartArray, rangeId, values[docId].longValue());
-        } else {
-          checkLongMV(rangeStartArray, rangeId, values, docId, numValuesPerEntry);
+        // multi bucket ranges
+        int[] lowerPartialRange = ((int[][]) ranges)[0];
+        int[] coveredRange = ((int[][]) ranges)[1];
+        int[] upperPartialRange = ((int[][]) ranges)[2];
+        ImmutableRoaringBitmap matches = rangeIndexReader.getMatchingDocIds(lowerPartialRange[0], upperPartialRange[1]);
+        assertNotNull(matches,  "matches for covered range must not be null");
+        for (int docId : matches.toArray()) {
+          checkValueForDocId(dataType, values, ranges, 1, docId, numValuesPerMVEntry);
         }
+        assertEquals(matches, rangeIndexReader.getPartiallyMatchingDocIds(coveredRange[0], coveredRange[1]));
+        // partial matches must be the combination of the two edge buckets
+        ImmutableRoaringBitmap partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(
+            lowerPartialRange[0], upperPartialRange[1]);
+        assertNotNull(partialMatches, "partial matches for single range must not be null");
+        assertEquals(ImmutableRoaringBitmap.or(
+            rangeIndexReader.getPartiallyMatchingDocIds(lowerPartialRange[0], lowerPartialRange[1]),
+            rangeIndexReader.getPartiallyMatchingDocIds(upperPartialRange[0], upperPartialRange[1])), partialMatches);
         break;
-      case FLOAT:
-        if (numValuesPerEntry == 1) {
-          checkFloat(rangeStartArray, rangeId, values[docId].floatValue());
-        } else {
-          checkFloatMV(rangeStartArray, rangeId, values, docId, numValuesPerEntry);
+      }
+      case LONG: {
+        // single bucket ranges
+        int rangeId = 0;
+        for (long[] range : (long[][]) ranges) {
+          assertNull(rangeIndexReader.getMatchingDocIds(range[0], range[1]),
+              "range index can't guarantee match within a single range");
+          ImmutableRoaringBitmap partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(range[0], range[1]);
+          assertNotNull(partialMatches, "partial matches for single range must not be null");
+          for (int docId : partialMatches.toArray()) {
+            checkValueForDocId(dataType, values, ranges, rangeId, docId, numValuesPerMVEntry);
+          }
+          ++rangeId;
         }
-        break;
-      case DOUBLE:
-        if (numValuesPerEntry == 1) {
-          checkDouble(rangeStartArray, rangeId, values[docId].doubleValue());
-        } else {
-          checkDoubleMV(rangeStartArray, rangeId, values, docId, numValuesPerEntry);
+        // multi bucket ranges
+        long[] lowerPartialRange = ((long[][]) ranges)[0];
+        long[] coveredRange = ((long[][]) ranges)[1];
+        long[] upperPartialRange = ((long[][]) ranges)[2];
+        ImmutableRoaringBitmap matches = rangeIndexReader.getMatchingDocIds(lowerPartialRange[0], upperPartialRange[1]);
+        assertNotNull(matches,  "matches for covered range must not be null");
+        for (int docId : matches.toArray()) {
+          checkValueForDocId(dataType, values, ranges, 1, docId, numValuesPerMVEntry);
         }
+        assertEquals(matches, rangeIndexReader.getPartiallyMatchingDocIds(coveredRange[0], coveredRange[1]));
+        // partial matches must be the combination of the two edge buckets
+        ImmutableRoaringBitmap partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(
+            lowerPartialRange[0], upperPartialRange[1]);
+        assertNotNull(partialMatches, "partial matches for single range must not be null");
+        assertEquals(ImmutableRoaringBitmap.or(
+            rangeIndexReader.getPartiallyMatchingDocIds(lowerPartialRange[0], lowerPartialRange[1]),
+            rangeIndexReader.getPartiallyMatchingDocIds(upperPartialRange[0], upperPartialRange[1])), partialMatches);
         break;
+      }
+      case FLOAT: {
+        // single bucket ranges
+        int rangeId = 0;
+        for (float[] range : (float[][]) ranges) {
+          assertNull(rangeIndexReader.getMatchingDocIds(range[0], range[1]),
+              "range index can't guarantee match within a single range");
+          ImmutableRoaringBitmap partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(range[0], range[1]);
+          assertNotNull(partialMatches, "partial matches for single range must not be null");
+          for (int docId : partialMatches.toArray()) {
+            checkValueForDocId(dataType, values, ranges, rangeId, docId, numValuesPerMVEntry);
+          }
+          ++rangeId;
+        }
+        // multi bucket ranges
+        float[] lowerPartialRange = ((float[][]) ranges)[0];
+        float[] coveredRange = ((float[][]) ranges)[1];
+        float[] upperPartialRange = ((float[][]) ranges)[2];
+        ImmutableRoaringBitmap matches = rangeIndexReader.getMatchingDocIds(lowerPartialRange[0], upperPartialRange[1]);
+        assertNotNull(matches,  "matches for covered range must not be null");
+        for (int docId : matches.toArray()) {
+          checkValueForDocId(dataType, values, ranges, 1, docId, numValuesPerMVEntry);
+        }
+        assertEquals(matches, rangeIndexReader.getPartiallyMatchingDocIds(coveredRange[0], coveredRange[1]));
+        // partial matches must be the combination of the two edge buckets
+        ImmutableRoaringBitmap partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(
+            lowerPartialRange[0], upperPartialRange[1]);
+        assertNotNull(partialMatches, "partial matches for single range must not be null");
+        assertEquals(ImmutableRoaringBitmap.or(
+            rangeIndexReader.getPartiallyMatchingDocIds(lowerPartialRange[0], lowerPartialRange[1]),
+            rangeIndexReader.getPartiallyMatchingDocIds(upperPartialRange[0], upperPartialRange[1])), partialMatches);
+        break;
+      }
+      case DOUBLE: {
+        // single bucket ranges
+        int rangeId = 0;
+        for (double[] range : (double[][]) ranges) {
+          assertNull(rangeIndexReader.getMatchingDocIds(range[0], range[1]),
+              "range index can't guarantee match within a single range");
+          ImmutableRoaringBitmap partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(range[0], range[1]);
+          assertNotNull(partialMatches, "partial matches for single range must not be null");
+          for (int docId : partialMatches.toArray()) {
+            checkValueForDocId(dataType, values, ranges, rangeId, docId, numValuesPerMVEntry);
+          }
+          ++rangeId;
+        }
+        // multi bucket ranges
+        double[] lowerPartialRange = ((double[][]) ranges)[0];
+        double[] coveredRange = ((double[][]) ranges)[1];
+        double[] upperPartialRange = ((double[][]) ranges)[2];
+        ImmutableRoaringBitmap matches = rangeIndexReader.getMatchingDocIds(lowerPartialRange[0], upperPartialRange[1]);
+        assertNotNull(matches,  "matches for covered range must not be null");
+        for (int docId : matches.toArray()) {
+          checkValueForDocId(dataType, values, ranges, 1, docId, numValuesPerMVEntry);
+        }
+        assertEquals(matches, rangeIndexReader.getPartiallyMatchingDocIds(coveredRange[0], coveredRange[1]));
+        // partial matches must be the combination of the two edge buckets
+        ImmutableRoaringBitmap partialMatches = rangeIndexReader.getPartiallyMatchingDocIds(
+            lowerPartialRange[0], upperPartialRange[1]);
+        assertNotNull(partialMatches, "partial matches for single range must not be null");
+        assertEquals(ImmutableRoaringBitmap.or(
+            rangeIndexReader.getPartiallyMatchingDocIds(lowerPartialRange[0], lowerPartialRange[1]),
+            rangeIndexReader.getPartiallyMatchingDocIds(upperPartialRange[0], upperPartialRange[1])), partialMatches);
+        break;
+      }
       default:
         throw new IllegalStateException();
     }
   }
 
-  private void checkInt(Number[] rangeStartArray, int rangeId, int value) {
-    Assert.assertTrue(rangeStartArray[rangeId].intValue() <= value);
-    if (rangeId != rangeStartArray.length - 1) {
-      Assert.assertTrue(value < rangeStartArray[rangeId + 1].intValue());
+  private void checkValueForDocId(DataType dataType, Object values, Object ranges, int rangeId, int docId,
+      int numValuesPerEntry) {
+    switch (dataType) {
+      case INT:
+        if (numValuesPerEntry == 1) {
+          checkInt((int[][]) ranges, rangeId, ((int[]) values)[docId]);
+        } else {
+          checkIntMV((int[][]) ranges, rangeId, (int[]) values, docId, numValuesPerEntry);
+        }
+        break;
+      case LONG:
+        if (numValuesPerEntry == 1) {
+          checkLong((long[][]) ranges, rangeId, ((long[]) values)[docId]);
+        } else {
+          checkLongMV((long[][]) ranges, rangeId, (long[]) values, docId, numValuesPerEntry);
+        }
+        break;
+      case FLOAT:
+        if (numValuesPerEntry == 1) {
+          checkFloat((float[][]) ranges, rangeId, ((float[]) values)[docId]);
+        } else {
+          checkFloatMV((float[][]) ranges, rangeId, (float[]) values, docId, numValuesPerEntry);
+        }
+        break;
+      case DOUBLE:
+        if (numValuesPerEntry == 1) {
+          checkDouble((double[][]) ranges, rangeId, ((double[]) values)[docId]);
+        } else {
+          checkDoubleMV((double[][]) ranges, rangeId, (double[]) values, docId, numValuesPerEntry);
+        }
+        break;
+      default:
+        throw new IllegalStateException("unexpected type " + dataType);
     }
   }
 
-  private void checkIntMV(Number[] rangeStartArray, int rangeId, Number[] values, int docId, int numValuesPerMVEntry) {
-    if (rangeId != rangeStartArray.length - 1) {
-      for (int i = 0; i < numValuesPerMVEntry; i++) {
-        if (rangeStartArray[rangeId].intValue() <= values[docId * numValuesPerMVEntry + i].intValue()
-            && values[docId * numValuesPerMVEntry + i].intValue() < rangeStartArray[rangeId + 1].intValue()) {
-          return;
-        }
-      }
-    } else {
-      for (int i = 0; i < numValuesPerMVEntry; i++) {
-        if (rangeStartArray[rangeId].intValue() <= values[docId * numValuesPerMVEntry + i].intValue()) {
-          return;
-        }
+  private void checkInt(int[][] ranges, int rangeId, int value) {
+    Assert.assertTrue(ranges[rangeId][0] <= value);
+    Assert.assertTrue(value <= ranges[rangeId][1]);
+  }
+
+  private void checkIntMV(int[][] ranges, int rangeId, int[] values, int docId, int numValuesPerMVEntry) {
+    for (int i = 0; i < numValuesPerMVEntry; i++) {
+      if (ranges[rangeId][0] <= values[docId * numValuesPerMVEntry + i]
+          && values[docId * numValuesPerMVEntry + i] <= ranges[rangeId][1]) {
+        return;
       }
     }
     Assert.fail();
   }
 
-  private void checkLong(Number[] rangeStartArray, int rangeId, long value) {
-    Assert.assertTrue(rangeStartArray[rangeId].longValue() <= value);
-    if (rangeId != rangeStartArray.length - 1) {
-      Assert.assertTrue(value < rangeStartArray[rangeId + 1].longValue());
-    }
+  private void checkLong(long[][] ranges, int rangeId, long value) {
+    Assert.assertTrue(ranges[rangeId][0] <= value);
+    Assert.assertTrue(value <= ranges[rangeId][1]);
   }
 
-  private void checkLongMV(Number[] rangeStartArray, int rangeId, Number[] values, int docId, int numValuesPerMVEntry) {
-    if (rangeId != rangeStartArray.length - 1) {
-      for (int i = 0; i < numValuesPerMVEntry; i++) {
-        if (rangeStartArray[rangeId].longValue() <= values[docId * numValuesPerMVEntry + i].longValue()
-            && values[docId * numValuesPerMVEntry + i].longValue() < rangeStartArray[rangeId + 1].longValue()) {
-          return;
-        }
-      }
-    } else {
-      for (int i = 0; i < numValuesPerMVEntry; i++) {
-        if (rangeStartArray[rangeId].longValue() <= values[docId * numValuesPerMVEntry + i].longValue()) {
-          return;
-        }
+  private void checkLongMV(long[][] ranges, int rangeId, long[] values, int docId, int numValuesPerMVEntry) {
+    for (int i = 0; i < numValuesPerMVEntry; i++) {
+      if (ranges[rangeId][0] <= values[docId * numValuesPerMVEntry + i]
+          && values[docId * numValuesPerMVEntry + i] <= ranges[rangeId][1]) {
+        return;
       }
     }
     Assert.fail();
   }
 
-  private void checkFloat(Number[] rangeStartArray, int rangeId, float value) {
-    Assert.assertTrue(rangeStartArray[rangeId].floatValue() <= value);
-    if (rangeId != rangeStartArray.length - 1) {
-      Assert.assertTrue(value < rangeStartArray[rangeId + 1].floatValue());
-    }
+  private void checkFloat(float[][] ranges, int rangeId, float value) {
+    Assert.assertTrue(ranges[rangeId][0] <= value);
+    Assert.assertTrue(value <= ranges[rangeId][1]);
   }
 
-  private void checkFloatMV(Number[] rangeStartArray, int rangeId, Number[] values, int docId,
+  private void checkFloatMV(float[][] ranges, int rangeId, float[] values, int docId,
       int numValuesPerMVEntry) {
-    if (rangeId != rangeStartArray.length - 1) {
-      for (int i = 0; i < numValuesPerMVEntry; i++) {
-        if (rangeStartArray[rangeId].floatValue() <= values[docId * numValuesPerMVEntry + i].floatValue()
-            && values[docId * numValuesPerMVEntry + i].floatValue() < rangeStartArray[rangeId + 1].floatValue()) {
-          return;
-        }
-      }
-    } else {
-      for (int i = 0; i < numValuesPerMVEntry; i++) {
-        if (rangeStartArray[rangeId].floatValue() <= values[docId * numValuesPerMVEntry + i].floatValue()) {
-          return;
-        }
+    for (int i = 0; i < numValuesPerMVEntry; i++) {
+      if (ranges[rangeId][0] <= values[docId * numValuesPerMVEntry + i]
+          && values[docId * numValuesPerMVEntry + i] <= ranges[rangeId][1]) {
+        return;
       }
     }
     Assert.fail();
   }
 
-  private void checkDouble(Number[] rangeStartArray, int rangeId, double value) {
-    Assert.assertTrue(rangeStartArray[rangeId].doubleValue() <= value);
-    if (rangeId != rangeStartArray.length - 1) {
-      Assert.assertTrue(value < rangeStartArray[rangeId + 1].doubleValue());
-    }
+  private void checkDouble(double[][] ranges, int rangeId, double value) {
+    Assert.assertTrue(ranges[rangeId][0] <= value);
+    Assert.assertTrue(value <= ranges[rangeId][1]);
   }
 
-  private void checkDoubleMV(Number[] rangeStartArray, int rangeId, Number[] values, int docId,
+  private void checkDoubleMV(double[][] ranges, int rangeId, double[] values, int docId,
       int numValuesPerMVEntry) {
-    if (rangeId != rangeStartArray.length - 1) {
-      for (int i = 0; i < numValuesPerMVEntry; i++) {
-        if (rangeStartArray[rangeId].doubleValue() <= values[docId * numValuesPerMVEntry + i].doubleValue()
-            && values[docId * numValuesPerMVEntry + i].doubleValue() < rangeStartArray[rangeId + 1].doubleValue()) {
-          return;
-        }
-      }
-    } else {
-      for (int i = 0; i < numValuesPerMVEntry; i++) {
-        if (rangeStartArray[rangeId].doubleValue() <= values[docId * numValuesPerMVEntry + i].doubleValue()) {
-          return;
-        }
+    for (int i = 0; i < numValuesPerMVEntry; i++) {
+      if (ranges[rangeId][0] <= values[docId * numValuesPerMVEntry + i]
+          && values[docId * numValuesPerMVEntry + i] <= ranges[rangeId][1]) {
+        return;
       }
     }
     Assert.fail();
+  }
+
+
+  private static Object valuesArray(DataType dataType, int numValues) {
+    switch (dataType) {
+      case INT:
+        return new int[numValues];
+      case LONG:
+        return new long[numValues];
+      case FLOAT:
+        return new float[numValues];
+      case DOUBLE:
+        return new double[numValues];
+      default:
+        throw new IllegalArgumentException("unexpected type " + dataType);
+    }
+  }
+
+  private static Object splitIntoRanges(DataType dataType, Object values, int numValuesPerRange) {
+    switch (dataType) {
+      case INT: {
+        int[] ints = (int[]) values;
+        int[] sorted = Arrays.copyOf(ints, ints.length);
+        Arrays.sort(sorted);
+        int[][] split = new int[ints.length / numValuesPerRange][2];
+        for (int i = 0; i < split.length; ++i) {
+          split[i][0] = sorted[i * numValuesPerRange];
+          split[i][1] = sorted[(i + 1) * numValuesPerRange - 1];
+        }
+        return split;
+      }
+      case LONG: {
+        long[] longs = (long[]) values;
+        long[] sorted = Arrays.copyOf(longs, longs.length);
+        Arrays.sort(sorted);
+        long[][] split = new long[longs.length / numValuesPerRange][2];
+        for (int i = 0; i < split.length; ++i) {
+          split[i][0] = sorted[i * numValuesPerRange];
+          split[i][1] = sorted[(i + 1) * numValuesPerRange - 1];
+        }
+        return split;
+      }
+      case FLOAT: {
+        float[] floats = (float[]) values;
+        float[] sorted = Arrays.copyOf(floats, floats.length);
+        Arrays.sort(sorted);
+        float[][] split = new float[floats.length / numValuesPerRange][2];
+        for (int i = 0; i < split.length; ++i) {
+          split[i][0] = sorted[i * numValuesPerRange];
+          split[i][1] = sorted[(i + 1) * numValuesPerRange - 1];
+        }
+        return split;
+      }
+      case DOUBLE: {
+        double[] doubles = (double[]) values;
+        double[] sorted = Arrays.copyOf(doubles, doubles.length);
+        Arrays.sort(sorted);
+        double[][] split = new double[doubles.length / numValuesPerRange][2];
+        for (int i = 0; i < split.length; ++i) {
+          split[i][0] = sorted[i * numValuesPerRange];
+          split[i][1] = sorted[(i + 1) * numValuesPerRange - 1];
+        }
+        return split;
+      }
+      default:
+        throw new IllegalArgumentException("unexpected type " + dataType);
+    }
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/DataSource.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/DataSource.java
@@ -26,6 +26,7 @@ import org.apache.pinot.segment.spi.index.reader.H3IndexReader;
 import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
 import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.apache.pinot.segment.spi.index.reader.RangeIndexReader;
 import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
 
 
@@ -61,7 +62,7 @@ public interface DataSource {
    * <p>TODO: Have a separate interface for range index.
    */
   @Nullable
-  InvertedIndexReader<?> getRangeIndex();
+  RangeIndexReader<?> getRangeIndex();
 
   /**
    * Returns the text index for the column if exists, or {@code null} if not.

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/column/ColumnIndexContainer.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/column/ColumnIndexContainer.java
@@ -26,6 +26,7 @@ import org.apache.pinot.segment.spi.index.reader.H3IndexReader;
 import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
 import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.apache.pinot.segment.spi.index.reader.RangeIndexReader;
 import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
 
 
@@ -47,7 +48,7 @@ public interface ColumnIndexContainer extends Closeable {
   /**
    * Returns the range index for the column, or {@code null} if it does not exist.
    */
-  InvertedIndexReader<?> getRangeIndex();
+  RangeIndexReader<?> getRangeIndex();
 
   /**
    * Returns the text index for the column, or {@code null} if it does not exist.

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/RangeIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/RangeIndexReader.java
@@ -28,6 +28,8 @@ import javax.annotation.Nullable;
 public interface RangeIndexReader<T> extends Closeable {
   /**
    * Returns doc ids with a value between min and max, both inclusive.
+   * Doc ids returned by this method must correspond to values which
+   * satisfy the query.
    * @param min the inclusive lower bound.
    * @param max the inclusive upper bound.
    * @return the matching doc ids.
@@ -37,6 +39,8 @@ public interface RangeIndexReader<T> extends Closeable {
 
   /**
    * Returns doc ids with a value between min and max, both inclusive.
+   * Doc ids returned by this method must correspond to values which
+   * satisfy the query.
    * @param min the inclusive lower bound.
    * @param max the inclusive upper bound.
    * @return the matching doc ids.
@@ -46,6 +50,8 @@ public interface RangeIndexReader<T> extends Closeable {
 
   /**
    * Returns doc ids with a value between min and max, both inclusive.
+   * Doc ids returned by this method must correspond to values which
+   * satisfy the query.
    * @param min the inclusive lower bound.
    * @param max the inclusive upper bound.
    * @return the matching doc ids.
@@ -55,6 +61,8 @@ public interface RangeIndexReader<T> extends Closeable {
 
   /**
    * Returns doc ids with a value between min and max, both inclusive.
+   * Doc ids returned by this method must correspond to values which
+   * satisfy the query.
    * @param min the inclusive lower bound.
    * @param max the inclusive upper bound.
    * @return the matching doc ids.
@@ -64,6 +72,9 @@ public interface RangeIndexReader<T> extends Closeable {
 
   /**
    * Returns doc ids with a value between min and max, both inclusive.
+   * Doc ids returned by this method may correspond to values which
+   * satisfy the query, and require post filtering. If the implementation
+   * supports exact matches, this method will return null.
    * @param min the inclusive lower bound.
    * @param max the inclusive upper bound.
    * @return the matching doc ids.
@@ -73,6 +84,9 @@ public interface RangeIndexReader<T> extends Closeable {
 
   /**
    * Returns doc ids with a value between min and max, both inclusive.
+   * Doc ids returned by this method may correspond to values which
+   * satisfy the query, and require post filtering. If the implementation
+   * supports exact matches, this method will return null.
    * @param min the inclusive lower bound.
    * @param max the inclusive upper bound.
    * @return the matching doc ids.
@@ -82,6 +96,9 @@ public interface RangeIndexReader<T> extends Closeable {
 
   /**
    * Returns doc ids with a value between min and max, both inclusive.
+   * Doc ids returned by this method may correspond to values which
+   * satisfy the query, and require post filtering. If the implementation
+   * supports exact matches, this method will return null.
    * @param min the inclusive lower bound.
    * @param max the inclusive upper bound.
    * @return the matching doc ids.
@@ -91,6 +108,9 @@ public interface RangeIndexReader<T> extends Closeable {
 
   /**
    * Returns doc ids with a value between min and max, both inclusive.
+   * Doc ids returned by this method may correspond to values which
+   * satisfy the query, and require post filtering. If the implementation
+   * supports exact matches, this method will return null.
    * @param min the inclusive lower bound.
    * @param max the inclusive upper bound.
    * @return the matching doc ids.

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/RangeIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/RangeIndexReader.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index.reader;
+
+import java.io.Closeable;
+
+/**
+ * Interface for indexed range queries
+ * @param <T>
+ */
+public interface RangeIndexReader<T> extends Closeable {
+  /**
+   * Returns doc ids with a value between min and max, both inclusive.
+   * @param min the inclusive lower bound.
+   * @param max the inclusive upper bound.
+   * @return the matching doc ids.
+   */
+  T getMatchingDocIds(long min, long max);
+
+  /**
+   * Returns doc ids with a value between min and max, both inclusive.
+   * @param min the inclusive lower bound.
+   * @param max the inclusive upper bound.
+   * @return the matching doc ids.
+   */
+  T getMatchingDocIds(int min, int max);
+
+  /**
+   * Returns doc ids with a value between min and max, both inclusive.
+   * @param min the inclusive lower bound.
+   * @param max the inclusive upper bound.
+   * @return the matching doc ids.
+   */
+  T getMatchingDocIds(double min, double max);
+
+  /**
+   * Returns doc ids with a value between min and max, both inclusive.
+   * @param min the inclusive lower bound.
+   * @param max the inclusive upper bound.
+   * @return the matching doc ids.
+   */
+  T getMatchingDocIds(float min, float max);
+
+  /**
+   * Returns doc ids with a value between min and max, both inclusive.
+   * @param min the inclusive lower bound.
+   * @param max the inclusive upper bound.
+   * @return the matching doc ids.
+   */
+  T getPartiallyMatchingDocIds(long min, long max);
+
+  /**
+   * Returns doc ids with a value between min and max, both inclusive.
+   * @param min the inclusive lower bound.
+   * @param max the inclusive upper bound.
+   * @return the matching doc ids.
+   */
+  T getPartiallyMatchingDocIds(int min, int max);
+
+  /**
+   * Returns doc ids with a value between min and max, both inclusive.
+   * @param min the inclusive lower bound.
+   * @param max the inclusive upper bound.
+   * @return the matching doc ids.
+   */
+  T getPartiallyMatchingDocIds(double min, double max);
+
+  /**
+   * Returns doc ids with a value between min and max, both inclusive.
+   * @param min the inclusive lower bound.
+   * @param max the inclusive upper bound.
+   * @return the matching doc ids.
+   */
+  T getPartiallyMatchingDocIds(float min, float max);
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/RangeIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/RangeIndexReader.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.spi.index.reader;
 
 import java.io.Closeable;
+import javax.annotation.Nullable;
 
 /**
  * Interface for indexed range queries
@@ -31,14 +32,7 @@ public interface RangeIndexReader<T> extends Closeable {
    * @param max the inclusive upper bound.
    * @return the matching doc ids.
    */
-  T getMatchingDocIds(long min, long max);
-
-  /**
-   * Returns doc ids with a value between min and max, both inclusive.
-   * @param min the inclusive lower bound.
-   * @param max the inclusive upper bound.
-   * @return the matching doc ids.
-   */
+  @Nullable
   T getMatchingDocIds(int min, int max);
 
   /**
@@ -47,7 +41,8 @@ public interface RangeIndexReader<T> extends Closeable {
    * @param max the inclusive upper bound.
    * @return the matching doc ids.
    */
-  T getMatchingDocIds(double min, double max);
+  @Nullable
+  T getMatchingDocIds(long min, long max);
 
   /**
    * Returns doc ids with a value between min and max, both inclusive.
@@ -55,6 +50,7 @@ public interface RangeIndexReader<T> extends Closeable {
    * @param max the inclusive upper bound.
    * @return the matching doc ids.
    */
+  @Nullable
   T getMatchingDocIds(float min, float max);
 
   /**
@@ -63,7 +59,8 @@ public interface RangeIndexReader<T> extends Closeable {
    * @param max the inclusive upper bound.
    * @return the matching doc ids.
    */
-  T getPartiallyMatchingDocIds(long min, long max);
+  @Nullable
+  T getMatchingDocIds(double min, double max);
 
   /**
    * Returns doc ids with a value between min and max, both inclusive.
@@ -71,6 +68,7 @@ public interface RangeIndexReader<T> extends Closeable {
    * @param max the inclusive upper bound.
    * @return the matching doc ids.
    */
+  @Nullable
   T getPartiallyMatchingDocIds(int min, int max);
 
   /**
@@ -79,7 +77,8 @@ public interface RangeIndexReader<T> extends Closeable {
    * @param max the inclusive upper bound.
    * @return the matching doc ids.
    */
-  T getPartiallyMatchingDocIds(double min, double max);
+  @Nullable
+  T getPartiallyMatchingDocIds(long min, long max);
 
   /**
    * Returns doc ids with a value between min and max, both inclusive.
@@ -87,5 +86,15 @@ public interface RangeIndexReader<T> extends Closeable {
    * @param max the inclusive upper bound.
    * @return the matching doc ids.
    */
+  @Nullable
   T getPartiallyMatchingDocIds(float min, float max);
+
+  /**
+   * Returns doc ids with a value between min and max, both inclusive.
+   * @param min the inclusive lower bound.
+   * @param max the inclusive upper bound.
+   * @return the matching doc ids.
+   */
+  @Nullable
+  T getPartiallyMatchingDocIds(double min, double max);
 }


### PR DESCRIPTION
## Description
This PR refactors the interface between the `RangeIndexBasedFilterOperator` and `RangeIndexReader`, the latter of which I plan to submit a proposal to enhance. This work is being done in advance of submitting the enhancement proposal to limit the amount of change necessary. 

The pending proposal for a new range index will support fast exact matches without the need to scan, and this PR tries to make it possible to model both exact and inexact indexing with the same interface, allowing the `RangeIndexReaderImpl` to decide the implementation to use based on the version in the index header.

I actually found 2 bugs in the current implementation doing this:
* Off by one bug in the range sizing. For 1000 distinct values, there should be 50 values in each bucket, but 51 are assigned to the first 19 buckets and only 31 to the last bucket. I left this in place.
* `float` values were converted to `int` which interferes with bucketing, meaning in the test for float all 20 buckets were collapsed into one. I fixed this. This flaw could have been caught by clearly separating preconditions (i.e. ranges) from the system under test, but slipped through because the bucketing logic was assumed as a precondition of the test.

/cc @Jackie-Jiang @mayankshriv 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
