### PR TITLE
set ZK stat version when fetching segment ZK metadata

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadata.java
@@ -123,6 +123,14 @@ public class SegmentZKMetadata implements ZKMetadata {
     setValue(Segment.INDEX_VERSION, indexVersion);
   }
 
+  public int getZkStatVersion() {
+    return _znRecord.getVersion();
+  }
+
+  public void setZkStatVersion(int zkStatVersion) {
+    _znRecord.setVersion(zkStatVersion);
+  }
+
   public long getTotalDocs() {
     return _znRecord.getLongField(Segment.TOTAL_DOCS, -1);
   }

--- a/pinot-common/src/test/java/org/apache/pinot/common/metadata/SegmentZKMetadataTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metadata/SegmentZKMetadataTest.java
@@ -48,6 +48,7 @@ public class SegmentZKMetadataTest {
 
     SegmentZKMetadata inProgressSegmentMetadata = getTestInProgressRealtimeSegmentZKMetadata();
     SegmentZKMetadata doneSegmentMetadata = getTestDoneRealtimeSegmentZKMetadata();
+    doneSegmentMetadata.setZkStatVersion(6);
 
     Assert.assertTrue(MetadataUtils.comparisonZNRecords(inProgressZnRecord, inProgressSegmentMetadata.toZNRecord()));
     Assert.assertTrue(MetadataUtils.comparisonZNRecords(doneZnRecord, doneSegmentMetadata.toZNRecord()));
@@ -56,6 +57,7 @@ public class SegmentZKMetadataTest {
     assertEquals(inProgressSegmentMetadata.hashCode(), new SegmentZKMetadata(inProgressZnRecord).hashCode());
     assertEquals(doneSegmentMetadata, new SegmentZKMetadata(doneZnRecord));
     assertEquals(doneSegmentMetadata.hashCode(), new SegmentZKMetadata(doneZnRecord).hashCode());
+    assertEquals(6, doneSegmentMetadata.getZkStatVersion());
 
     Assert.assertTrue(
         MetadataUtils.comparisonZNRecords(inProgressZnRecord, new SegmentZKMetadata(inProgressZnRecord).toZNRecord()));


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds ZK stat version to each segment metadata when fetching from ZK\.

```mermaid
flowchart TD
  N0["Initialize stats list #40;F1#41;"]:::stAdded
  N1["Fetch children with stats #40;F1#41;"]:::stModified
  N2["Loop over znRecords #40;F1#41;"]:::stModified
  N3["Create SegmentZKMetadata #40;F1#41;"]:::stAdded
  N4["Set ZK stat version #40;F1#44; F2#41;"]:::stAdded
  N5["Add to result list #40;F1#41;"]:::stAdded
  N6["Return list #40;F1#41;"]:::stUnchanged
  N0 --> N1
  N1 --> N2
  N2 --> N3
  N3 --> N4
  N4 --> N5
  N5 --> N2
  N2 --> N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider\.java — [before](https://github.com/apache/pinot/blob/69a91acbead90b110800bbf98424415630f78527/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java) · [after](https://github.com/apache/pinot/blob/058bca2ca64cea95549f7c55feb0adc8e64f4655/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java)
- F2: pinot\-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadata\.java — [before](https://github.com/apache/pinot/blob/69a91acbead90b110800bbf98424415630f78527/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadata.java) · [after](https://github.com/apache/pinot/blob/058bca2ca64cea95549f7c55feb0adc8e64f4655/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadata.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjY5YTkxYWNiZWFkOTBiMTEwODAwYmJmOTg0MjQ0MTU2MzBmNzg1MjciLCJjb250ZXh0X2hhc2giOiI2NTc5MTMzYTZmOWMyMTBkYjZjMTVmYjgyYmZhOTg4YWNhMGY4MjJmN2ZkZTk4YWViNzJiZDQ2ZGJkMzgxY2JlIiwiZ2VuZXJhdGVkX2F0IjoxNzg4OTE1NjExLCJoZWFkX3NoYSI6IjA1OGJjYTJjYTY0Y2VhOTU1NDlmN2M1NWZlYjBhZGM4ZTY0ZjQ2NTUiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI2OWE5MWFjYmVhZDkwYjExMDgwMGJiZjk4NDI0NDE1NjMwZjc4NTI3IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 13b3ef3e5b217c11811d20c53c5262fbfbf3f3f96a96d661468be7c555f4b6ca -->
<!-- pinot-pr-flow:end -->

## Description
Set Zk stat version to SegmentZKMetadata when fetching segment metadata from ZK.

