### PR TITLE
ban prefix increment

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -99,6 +99,10 @@
     <module name="StringLiteralEquality"/>
     <!-- Use 'L' with long literals -->
     <module name="UpperEll"/>
+    <!-- ban prefix increment, decrement -->
+    <module name="IllegalToken">
+      <property name="tokens" value="INC,DEC"/>
+    </module>
 
     <!-- IMPORTS -->
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/MaxHitRateTracker.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/queryquota/MaxHitRateTracker.java
@@ -70,7 +70,7 @@ public class MaxHitRateTracker extends HitCounter {
 
     int maxCount = 0;
     // Skipping the end index here as its bucket hasn't fully gathered all the hits yet.
-    for (int i = startIndex; i != endIndex; i = (++i % _bucketCount)) {
+    for (int i = startIndex; i != endIndex; i = ((i + 1) % _bucketCount)) {
       if (numTimeUnits - _bucketStartTime.get(i) < _bucketCount) {
         maxCount = Math.max(_bucketHitCount.get(i), maxCount);
       }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/BaseAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/BaseAstNode.java
@@ -97,7 +97,7 @@ public abstract class BaseAstNode implements AstNode {
   @Override
   public String toString(int indent) {
     String str = "";
-    for (int i = 0; i < indent; ++i) {
+    for (int i = 0; i < indent; i++) {
       str += " ";
     }
     str += toString();

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/BooleanOperatorAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/BooleanOperatorAstNode.java
@@ -84,7 +84,7 @@ public enum BooleanOperatorAstNode implements AstNode {
   @Override
   public String toString(int indent) {
     String str = "";
-    for (int i = 0; i < indent; ++i) {
+    for (int i = 0; i < indent; i++) {
       str += " ";
     }
     str += toString();

--- a/pinot-common/src/test/java/org/apache/pinot/common/http/MultiGetRequestTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/http/MultiGetRequestTest.java
@@ -125,25 +125,25 @@ public class MultiGetRequestTest {
       try {
         getMethod = completionService.take().get();
         if (getMethod.getStatusCode() >= 300) {
-          ++errors;
+          errors++;
           Assert.assertEquals(getMethod.getResponseBodyAsString(), ERROR_MSG);
         } else {
-          ++success;
+          success++;
           Assert.assertEquals(getMethod.getResponseBodyAsString(), SUCCESS_MSG);
         }
       } catch (InterruptedException e) {
         LOGGER.error("Interrupted", e);
-        ++errors;
+        errors++;
       } catch (ExecutionException e) {
         if (Throwables.getRootCause(e) instanceof SocketTimeoutException) {
           LOGGER.debug("Timeout");
-          ++timeouts;
+          timeouts++;
         } else {
           LOGGER.error("Error", e);
-          ++errors;
+          errors++;
         }
       } catch (IOException e) {
-        ++errors;
+        errors++;
       } finally {
         if (getMethod != null) {
           getMethod.releaseConnection();

--- a/pinot-common/src/test/java/org/apache/pinot/common/metadata/InstanceZKMetadataTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metadata/InstanceZKMetadataTest.java
@@ -48,7 +48,7 @@ public class InstanceZKMetadataTest {
     Map<String, String> groupIdMap = new HashMap<>();
     Map<String, String> partitionMap = new HashMap<>();
 
-    for (int i = 0; i < 10; ++i) {
+    for (int i = 0; i < 10; i++) {
       groupIdMap.put("testRes" + i + "_REALTIME", "groupId" + i);
       partitionMap.put("testRes" + i + "_REALTIME", "part" + i);
     }
@@ -62,7 +62,7 @@ public class InstanceZKMetadataTest {
     instanceMetadata.setInstanceType("Server");
     instanceMetadata.setInstanceName("localhost");
     instanceMetadata.setInstancePort(1234);
-    for (int i = 0; i < 10; ++i) {
+    for (int i = 0; i < 10; i++) {
       instanceMetadata.setGroupId("testRes" + i, "groupId" + i);
       instanceMetadata.setPartition("testRes" + i, "part" + i);
     }

--- a/pinot-common/src/test/java/org/apache/pinot/common/metadata/MetadataUtils.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metadata/MetadataUtils.java
@@ -68,7 +68,7 @@ public class MetadataUtils {
             Arrays.sort(list1Array);
             String[] list2Array = list2.toArray(new String[0]);
             Arrays.sort(list2Array);
-            for (int i = 0; i < list1.size(); ++i) {
+            for (int i = 0; i < list1.size(); i++) {
               if (list1Array[i] == null && list2Array[i] == null) {
                 continue;
               }

--- a/pinot-connectors/presto-pinot-driver/src/main/java/org/apache/pinot/connector/presto/PinotScatterGatherQueryClient.java
+++ b/pinot-connectors/presto-pinot-driver/src/main/java/org/apache/pinot/connector/presto/PinotScatterGatherQueryClient.java
@@ -212,7 +212,7 @@ public class PinotScatterGatherQueryClient {
 
   private static <T> T doWithRetries(int retries, Function<Integer, T> caller) {
     PinotException firstError = null;
-    for (int i = 0; i < retries; ++i) {
+    for (int i = 0; i < retries; i++) {
       try {
         return caller.apply(i);
       } catch (PinotException e) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -658,7 +658,7 @@ public class PinotHelixResourceManager {
       LOGGER.error(message);
       return PinotResourceManagerResponse.failure(message);
     }
-    for (int i = 0; i < numberOfInstancesToAdd; ++i) {
+    for (int i = 0; i < numberOfInstancesToAdd; i++) {
       String instanceName = unTaggedInstanceList.get(i);
       retagInstance(instanceName, Helix.UNTAGGED_BROKER_INSTANCE, brokerTenantTag);
       // Update idealState by adding new instance to table mapping.
@@ -732,7 +732,7 @@ public class PinotHelixResourceManager {
   private PinotResourceManagerResponse scaleDownBroker(Tenant tenant, String brokerTenantTag,
       List<String> instancesInClusterWithTag) {
     int numberBrokersToUntag = instancesInClusterWithTag.size() - tenant.getNumberOfInstances();
-    for (int i = 0; i < numberBrokersToUntag; ++i) {
+    for (int i = 0; i < numberBrokersToUntag; i++) {
       retagInstance(instancesInClusterWithTag.get(i), brokerTenantTag, Helix.UNTAGGED_BROKER_INSTANCE);
     }
     return PinotResourceManagerResponse.SUCCESS;
@@ -795,10 +795,10 @@ public class PinotHelixResourceManager {
       List<String> unTaggedInstanceList) {
     int incOffline = serverTenant.getOfflineInstances() - taggedOfflineServers.size();
     int incRealtime = serverTenant.getRealtimeInstances() - taggedRealtimeServers.size();
-    for (int i = 0; i < incOffline; ++i) {
+    for (int i = 0; i < incOffline; i++) {
       retagInstance(unTaggedInstanceList.get(i), Helix.UNTAGGED_SERVER_INSTANCE, offlineServerTag);
     }
-    for (int i = incOffline; i < incOffline + incRealtime; ++i) {
+    for (int i = incOffline; i < incOffline + incRealtime; i++) {
       String instanceName = unTaggedInstanceList.get(i);
       retagInstance(instanceName, Helix.UNTAGGED_SERVER_INSTANCE, realtimeServerTag);
       // TODO: update idealStates & instanceZkMetadata
@@ -813,14 +813,14 @@ public class PinotHelixResourceManager {
     int incRealtime = serverTenant.getRealtimeInstances() - taggedRealtimeServers.size();
     taggedRealtimeServers.removeAll(taggedOfflineServers);
     taggedOfflineServers.removeAll(taggedRealtimeServers);
-    for (int i = 0; i < incOffline; ++i) {
+    for (int i = 0; i < incOffline; i++) {
       if (i < incInstances) {
         retagInstance(unTaggedInstanceList.get(i), Helix.UNTAGGED_SERVER_INSTANCE, offlineServerTag);
       } else {
         _helixAdmin.addInstanceTag(_helixClusterName, taggedRealtimeServers.get(i - incInstances), offlineServerTag);
       }
     }
-    for (int i = incOffline; i < incOffline + incRealtime; ++i) {
+    for (int i = incOffline; i < incOffline + incRealtime; i++) {
       if (i < incInstances) {
         retagInstance(unTaggedInstanceList.get(i), Helix.UNTAGGED_SERVER_INSTANCE, realtimeServerTag);
         // TODO: update idealStates & instanceZkMetadata
@@ -969,7 +969,7 @@ public class PinotHelixResourceManager {
       return PinotResourceManagerResponse.failure(message);
     }
     String brokerTag = TagNameUtils.getBrokerTagForTenant(brokerTenant.getTenantName());
-    for (int i = 0; i < brokerTenant.getNumberOfInstances(); ++i) {
+    for (int i = 0; i < brokerTenant.getNumberOfInstances(); i++) {
       retagInstance(unTaggedInstanceList.get(i), Helix.UNTAGGED_BROKER_INSTANCE, brokerTag);
     }
     return PinotResourceManagerResponse.SUCCESS;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -194,7 +194,7 @@ public class PinotTableIdealStateBuilder {
     int replicaId = 0;
 
     String groupId = getGroupIdFromRealtimeDataTable(realtimeTableName, streamConfig);
-    for (int i = 0; i < numInstancesPerReplica * numDataReplicas; ++i) {
+    for (int i = 0; i < numInstancesPerReplica * numDataReplicas; i++) {
       String instance = instanceList.get(i);
       InstanceZKMetadata instanceZKMetadata = ZKMetadataProvider.getInstanceZKMetadata(zkHelixPropertyStore, instance);
       if (instanceZKMetadata == null) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -646,7 +646,8 @@ public class TableRebalancer {
         String instanceName = entry.getKey();
         if (!nextInstanceStateMap.containsKey(instanceName)) {
           nextInstanceStateMap.put(instanceName, entry.getValue());
-          if (--instancesToKeep == 0) {
+          instancesToKeep--;
+          if (instancesToKeep == 0) {
             break;
           }
         }
@@ -661,7 +662,8 @@ public class TableRebalancer {
         String instanceName = entry.getKey();
         if (!nextInstanceStateMap.containsKey(instanceName)) {
           nextInstanceStateMap.put(instanceName, entry.getValue());
-          if (--instancesToAdd == 0) {
+          instancesToAdd--;
+          if (instancesToAdd == 0) {
             break;
           }
         }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
@@ -71,7 +71,7 @@ public class PinotInstanceRestletResourceTest {
           counts[0] = instances.size();
           for (int i = 0; i < counts[0]; i++) {
             if (instances.get(i).asText().startsWith(Helix.PREFIX_OF_CONTROLLER_INSTANCE)) {
-              ++counts[1];
+              counts[1]++;
             }
           }
         }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentRestletResourceTest.java
@@ -61,7 +61,7 @@ public class PinotSegmentRestletResourceTest {
     checkCrcRequest(segmentMetadataTable, 0);
 
     // Upload Segments
-    for (int i = 0; i < 5; ++i) {
+    for (int i = 0; i < 5; i++) {
       SegmentMetadata segmentMetadata = SegmentMetadataMockUtils.mockSegmentMetadata(TABLE_NAME);
       ControllerTestUtils.getHelixResourceManager()
           .addNewSegment(TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME), segmentMetadata, "downloadUrl");
@@ -72,7 +72,7 @@ public class PinotSegmentRestletResourceTest {
     checkCrcRequest(segmentMetadataTable, 5);
 
     // Add more segments
-    for (int i = 0; i < 5; ++i) {
+    for (int i = 0; i < 5; i++) {
       SegmentMetadata segmentMetadata = SegmentMetadataMockUtils.mockSegmentMetadata(TABLE_NAME);
       ControllerTestUtils.getHelixResourceManager()
           .addNewSegment(TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME), segmentMetadata, "downloadUrl");

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentsMetadataTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentsMetadataTest.java
@@ -89,21 +89,21 @@ public class PinotSegmentsMetadataTest {
     s.updateMetadataMock();
     s.start(URI_PATH, createSegmentMetadataHandler(200, s._segmentMetadata, 0));
     _serverMap.put(serverName(counter), s);
-    ++counter;
+    counter++;
 
     // server1
     s = new SegmentsServerMock("s2");
     s.updateMetadataMock();
     s.start(URI_PATH, createSegmentMetadataHandler(200, s._segmentMetadata, 0));
     _serverMap.put(serverName(counter), s);
-    ++counter;
+    counter++;
 
     // server2
     s = new SegmentsServerMock("s3");
     s.updateMetadataMock();
     s.start(URI_PATH, createSegmentMetadataHandler(404, s._segmentMetadata, 0));
     _serverMap.put(serverName(counter), s);
-    ++counter;
+    counter++;
   }
 
   private String serverName(int counter) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableSizeReaderTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableSizeReaderTest.java
@@ -99,37 +99,37 @@ public class TableSizeReaderTest {
     FakeSizeServer s = new FakeSizeServer(Arrays.asList("s2", "s3", "s6"));
     s.start(URI_PATH, createHandler(200, s._sizes, 0));
     _serverMap.put(serverName(counter), s);
-    ++counter;
+    counter++;
 
     // server1
     s = new FakeSizeServer(Arrays.asList("s2", "s5"));
     s.start(URI_PATH, createHandler(200, s._sizes, 0));
     _serverMap.put(serverName(counter), s);
-    ++counter;
+    counter++;
 
     // server2
     s = new FakeSizeServer(Arrays.asList("s3", "s6"));
     s.start(URI_PATH, createHandler(404, s._sizes, 0));
     _serverMap.put(serverName(counter), s);
-    ++counter;
+    counter++;
 
     // server3
     s = new FakeSizeServer(Arrays.asList("r1", "r2"));
     s.start(URI_PATH, createHandler(200, s._sizes, 0));
     _serverMap.put(serverName(counter), s);
-    ++counter;
+    counter++;
 
     // server4
     s = new FakeSizeServer(Arrays.asList("r2"));
     s.start(URI_PATH, createHandler(200, s._sizes, 0));
     _serverMap.put(serverName(counter), s);
-    ++counter;
+    counter++;
 
     // server5 ... timing out server
     s = new FakeSizeServer(Arrays.asList("s1", "s3"));
     s.start(URI_PATH, createHandler(200, s._sizes, TIMEOUT_MSEC * 100));
     _serverMap.put(serverName(counter), s);
-    ++counter;
+    counter++;
   }
 
   @AfterClass
@@ -293,7 +293,7 @@ public class TableSizeReaderTest {
         Assert.assertTrue(segmentDetails._serverInfo.containsKey(expectedServer));
         if (expectedServer.equals("server2") || expectedServer.equals("server5")) {
           hasErrors = true;
-          --numResponses;
+          numResponses--;
         }
       }
       if (numResponses != 0) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerInstanceToggleTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerInstanceToggleTest.java
@@ -88,28 +88,32 @@ public class ControllerInstanceToggleTest {
     for (String instanceName : ControllerTestUtils
         .getHelixAdmin().getInstancesInClusterWithTag(ControllerTestUtils.getHelixClusterName(), SERVER_TAG_NAME)) {
       toggleInstanceState(instanceName, "disable");
-      checkNumOnlineInstancesFromExternalView(OFFLINE_TABLE_NAME, --numEnabledInstances);
+      numEnabledInstances--;
+      checkNumOnlineInstancesFromExternalView(OFFLINE_TABLE_NAME, numEnabledInstances);
     }
 
     // Enable server instances
     for (String instanceName : ControllerTestUtils
         .getHelixAdmin().getInstancesInClusterWithTag(ControllerTestUtils.getHelixClusterName(), SERVER_TAG_NAME)) {
       toggleInstanceState(instanceName, "ENABLE");
-      checkNumOnlineInstancesFromExternalView(OFFLINE_TABLE_NAME, ++numEnabledInstances);
+      numEnabledInstances++;
+      checkNumOnlineInstancesFromExternalView(OFFLINE_TABLE_NAME, numEnabledInstances);
     }
 
     // Disable broker instances
     for (String instanceName : ControllerTestUtils
         .getHelixAdmin().getInstancesInClusterWithTag(ControllerTestUtils.getHelixClusterName(), BROKER_TAG_NAME)) {
       toggleInstanceState(instanceName, "Disable");
-      checkNumOnlineInstancesFromExternalView(CommonConstants.Helix.BROKER_RESOURCE_INSTANCE, --numEnabledInstances);
+      numEnabledInstances--;
+      checkNumOnlineInstancesFromExternalView(CommonConstants.Helix.BROKER_RESOURCE_INSTANCE, numEnabledInstances);
     }
 
     // Enable broker instances
     for (String instanceName : ControllerTestUtils
         .getHelixAdmin().getInstancesInClusterWithTag(ControllerTestUtils.getHelixClusterName(), BROKER_TAG_NAME)) {
       toggleInstanceState(instanceName, "Enable");
-      checkNumOnlineInstancesFromExternalView(CommonConstants.Helix.BROKER_RESOURCE_INSTANCE, ++numEnabledInstances);
+      numEnabledInstances++;
+      checkNumOnlineInstancesFromExternalView(CommonConstants.Helix.BROKER_RESOURCE_INSTANCE, numEnabledInstances);
     }
 
     // Delete table

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerSentinelTestV2.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerSentinelTestV2.java
@@ -66,7 +66,7 @@ public class ControllerSentinelTestV2 {
             .size(), ControllerTestUtils.NUM_BROKER_INSTANCES);
 
     // Adding segments
-    for (int i = 0; i < 10; ++i) {
+    for (int i = 0; i < 10; i++) {
       Assert.assertEquals(
           ControllerTestUtils
               .getHelixAdmin().getResourceIdealState(ControllerTestUtils.getHelixClusterName(), TABLE_NAME + "_OFFLINE")

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotResourceManagerTest.java
@@ -128,7 +128,7 @@ public class PinotResourceManagerTest {
 
     // Concurrent segment deletion
     ExecutorService addSegmentExecutor = Executors.newFixedThreadPool(3);
-    for (int i = 0; i < 3; ++i) {
+    for (int i = 0; i < 3; i++) {
       addSegmentExecutor.execute(new Runnable() {
         @Override
         public void run() {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -66,7 +66,7 @@ public class RetentionManagerTest {
     // Create metadata for 10 segments really old, that will be removed by the retention manager.
     final int numOlderSegments = 10;
     List<String> removedSegments = new ArrayList<>();
-    for (int i = 0; i < numOlderSegments; ++i) {
+    for (int i = 0; i < numOlderSegments; i++) {
       SegmentMetadata segmentMetadata = mockSegmentMetadata(pastTimeStamp, pastTimeStamp, timeUnit);
       SegmentZKMetadata segmentZKMetadata = new SegmentZKMetadata(segmentMetadata.getName());
       ZKMetadataUtils
@@ -75,7 +75,7 @@ public class RetentionManagerTest {
       removedSegments.add(segmentZKMetadata.getSegmentName());
     }
     // Create metadata for 5 segments that will not be removed.
-    for (int i = 0; i < 5; ++i) {
+    for (int i = 0; i < 5; i++) {
       SegmentMetadata segmentMetadata =
           mockSegmentMetadata(dayAfterTomorrowTimeStamp, dayAfterTomorrowTimeStamp, timeUnit);
       SegmentZKMetadata segmentZKMetadata = new SegmentZKMetadata(segmentMetadata.getName());

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/SegmentLineageCleanupTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/SegmentLineageCleanupTest.java
@@ -104,13 +104,13 @@ public class SegmentLineageCleanupTest {
   public void testSegmentLineageCleanup()
       throws IOException, InterruptedException {
     // Create metadata for original segments
-    for (int i = 0; i < 5; ++i) {
+    for (int i = 0; i < 5; i++) {
       ControllerTestUtils.getHelixResourceManager().addNewSegment(OFFLINE_TABLE_NAME,
           SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "segment_" + i), "downloadUrl");
     }
 
     // Create metadata for merged segments.
-    for (int i = 0; i < 2; ++i) {
+    for (int i = 0; i < 2; i++) {
       ControllerTestUtils.getHelixResourceManager().addNewSegment(OFFLINE_TABLE_NAME,
           SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "merged_" + i), "downloadUrl");
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -430,7 +430,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
         // We did not consume any rows. Update the partition-consuming metric only if we have been idling for a long
         // time.
         // Create a new stream consumer wrapper, in case we are stuck on something.
-        if (++consecutiveIdleCount > maxIdleCountBeforeStatUpdate) {
+        consecutiveIdleCount++;
+        if (consecutiveIdleCount > maxIdleCountBeforeStatUpdate) {
           _serverMetrics.setValueOfTableGauge(_metricKeyName, ServerGauge.LLC_PARTITION_CONSUMING, 1);
           consecutiveIdleCount = 0;
           makeStreamConsumer("Idle for too long");

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
@@ -249,7 +249,7 @@ public class TableResizer {
       Comparator<IntermediateRecord> comparator = _intermediateRecordComparator.reversed();
       IntermediateRecord[] topRecordsHeap = getTopRecordsHeap(recordsMap, size, comparator);
       Record[] sortedTopRecords = new Record[size];
-      while (--size >= 0) {
+      while (size-- > 0) {
         sortedTopRecords[size] = topRecordsHeap[0]._record;
         topRecordsHeap[0] = topRecordsHeap[size];
         downHeap(topRecordsHeap, size, 0, comparator);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/statement/JsonStatementOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/statement/JsonStatementOptimizer.java
@@ -232,7 +232,7 @@ public class JsonStatementOptimizer implements StatementOptimizer {
           // appears.
           outputDataType = getJsonExtractOutputDataType(function);
 
-          for (int i = 0; i < operands.size(); ++i) {
+          for (int i = 0; i < operands.size(); i++) {
             // recursively check to see if there is a <json-column>.<json-path> identifier in this expression.
             Pair<String, Boolean> operandResult = optimizeJsonIdentifier(operands.get(i), schema, outputDataType);
             hasJsonPathExpression |= operandResult.getSecond();

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/SortedRangeIntersection.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/SortedRangeIntersection.java
@@ -63,7 +63,7 @@ public class SortedRangeIntersection {
       }
       // move all pointers forward such that range they point to contain maxHead
       int j = -1;
-      while (++j < sortedRangeSetList.size()) {
+      while (j++ < sortedRangeSetList.size() - 1) {
         if (j == maxHeadIndex) {
           continue;
         }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/TableResizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/TableResizerTest.java
@@ -100,7 +100,7 @@ public class TableResizerTest {
     _groupByResultHolders[1] = new DoubleGroupByResultHolder(numRecords, numRecords, 0.0);
     _groupByResultHolders[2] = new ObjectGroupByResultHolder(numRecords, numRecords);
     _groupByResultHolders[3] = new ObjectGroupByResultHolder(numRecords, numRecords);
-    for (int i = 0; i < numRecords; ++i) {
+    for (int i = 0; i < numRecords; i++) {
       Record record = _records.get(i);
       _groupByResultHolders[0].setValueForKey(i, (double) record.getValues()[3]);
       _groupByResultHolders[1].setValueForKey(i, (double) record.getValues()[4]);

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/CombinePlanNodeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/CombinePlanNodeTest.java
@@ -47,7 +47,7 @@ public class CombinePlanNodeTest {
     AtomicInteger count = new AtomicInteger(0);
 
     Random rand = new Random();
-    for (int i = 0; i < 5; ++i) {
+    for (int i = 0; i < 5; i++) {
       count.set(0);
       int numPlans = rand.nextInt(5000);
       List<PlanNode> planNodes = new ArrayList<>();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionSingleValueQueriesTest.java
@@ -400,7 +400,7 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
 
   private int getVirtualColumns(DataSchema selectionDataSchema) {
     int virtualCols = 0;
-    for (int i = 0; i < selectionDataSchema.size(); ++i) {
+    for (int i = 0; i < selectionDataSchema.size(); i++) {
       if (selectionDataSchema.getColumnName(i).startsWith("$")) {
         virtualCols++;
       }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeToOfflineSegmentsMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeToOfflineSegmentsMinionClusterIntegrationTest.java
@@ -112,7 +112,8 @@ public class RealtimeToOfflineSegmentsMinionClusterIntegrationTest extends Realt
       waitForTaskToComplete(expectedWatermark);
       // check segment is in offline
       segmentsZKMetadata = _pinotHelixResourceManager.getSegmentsZKMetadata(_offlineTableName);
-      Assert.assertEquals(segmentsZKMetadata.size(), ++numOfflineSegments);
+      numOfflineSegments++;
+      Assert.assertEquals(segmentsZKMetadata.size(), numOfflineSegments);
       long expectedOfflineSegmentTimeMs = expectedWatermark - 86400000;
       Assert.assertEquals(segmentsZKMetadata.get(i).getStartTimeMs(), expectedOfflineSegmentTimeMs);
       Assert.assertEquals(segmentsZKMetadata.get(i).getEndTimeMs(), expectedOfflineSegmentTimeMs);

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkOffheapBitmapInvertedIndexCreator.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkOffheapBitmapInvertedIndexCreator.java
@@ -46,15 +46,15 @@ public class BenchmarkOffheapBitmapInvertedIndexCreator {
     ROUND_ROBIN {
       @Override
       void assign(OffHeapBitmapInvertedIndexCreator creator, int docs, int cardinality) {
-        for (int i = 0; i < docs; ++i) {
+        for (int i = 0; i < docs; i++) {
           creator.add(i % cardinality);
         }
       }
     }, SORTED_UNIFORM {
       @Override
       void assign(OffHeapBitmapInvertedIndexCreator creator, int docs, int cardinality) {
-        for (int i = 0; i < cardinality; ++i) {
-          for (int j = 0; j < docs / cardinality; ++j) {
+        for (int i = 0; i < cardinality; i++) {
+          for (int j = 0; j < docs / cardinality; j++) {
             creator.add(i);
           }
         }

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/RawIndexBenchmark.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/RawIndexBenchmark.java
@@ -281,7 +281,7 @@ public class RawIndexBenchmark {
     }
 
     int docId = random.nextInt(maxDocId);
-    for (; j < _numLookups; ++j) {
+    for (; j < _numLookups; j++) {
       docIdSet[j] = docId++;
     }
     return docIdSet;

--- a/pinot-plugins/pinot-input-format/pinot-orc/src/main/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-orc/src/main/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReader.java
@@ -191,9 +191,11 @@ public class ORCRecordReader implements RecordReader {
       reuse.putValue(field, extractValue(field, _rowBatch.cols[i], fieldType, _nextRowId));
     }
 
-    if (++_nextRowId == _rowBatch.size) {
+    if (_nextRowId == _rowBatch.size - 1) {
       _hasNext = _orcRecordReader.nextBatch(_rowBatch);
       _nextRowId = 0;
+    } else {
+      _nextRowId++;
     }
     return reuse;
   }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/src/main/java/org/apache/pinot/plugin/stream/kafka09/KafkaStreamLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/src/main/java/org/apache/pinot/plugin/stream/kafka09/KafkaStreamLevelConsumer.java
@@ -78,7 +78,7 @@ public class KafkaStreamLevelConsumer implements StreamLevelConsumer {
     if (_kafkaIterator.hasNext()) {
       try {
         destination = _messageDecoder.decode(_kafkaIterator.next().message(), destination);
-        ++_currentCount;
+        _currentCount++;
 
         final long now = System.currentTimeMillis();
         // Log every minute or 100k events

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamLevelConsumer.java
@@ -104,7 +104,7 @@ public class KafkaStreamLevelConsumer implements StreamLevelConsumer {
         updateOffsets(record.partition(), record.offset());
         destination = _messageDecoder.decode(record.value().get(), destination);
 
-        ++_currentCount;
+        _currentCount++;
 
         final long now = System.currentTimeMillis();
         // Log every minute or 100k events

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamLevelConsumer.java
@@ -75,7 +75,7 @@ public class PulsarStreamLevelConsumer implements StreamLevelConsumer {
         final Message<byte[]> record = _reader.readNext();
         destination = _messageDecoder.decode(record.getData(), destination);
 
-        ++_currentCount;
+        _currentCount++;
 
         final long now = System.currentTimeMillis();
         // Log every minute or 100k events

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/QuantileDigest.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/QuantileDigest.java
@@ -422,7 +422,7 @@ public class QuantileDigest {
 
   @VisibleForTesting
   void compress() {
-    ++_compressions;
+    _compressions++;
 
     final int compressionFactor = calculateCompressionFactor();
 
@@ -464,7 +464,7 @@ public class QuantileDigest {
         }
 
         if (oldNodeWeight < ZERO_WEIGHT_THRESHOLD && node._weightedCount >= ZERO_WEIGHT_THRESHOLD) {
-          ++_nonZeroNodeCount;
+          _nonZeroNodeCount++;
         }
 
         return true;
@@ -495,7 +495,7 @@ public class QuantileDigest {
         node._weightedCount *= factor;
 
         if (oldWeight >= ZERO_WEIGHT_THRESHOLD && node._weightedCount < ZERO_WEIGHT_THRESHOLD) {
-          --_nonZeroNodeCount;
+          _nonZeroNodeCount--;
         }
 
         return true;
@@ -535,7 +535,7 @@ public class QuantileDigest {
         current._weightedCount += weight;
 
         if (current._weightedCount >= ZERO_WEIGHT_THRESHOLD && oldWeight < ZERO_WEIGHT_THRESHOLD) {
-          ++_nonZeroNodeCount;
+          _nonZeroNodeCount++;
         }
 
         _weightedCount += weight;
@@ -591,7 +591,7 @@ public class QuantileDigest {
 
   private Node createNode(long bits, int level, double weight) {
     _weightedCount += weight;
-    ++_totalNodeCount;
+    _totalNodeCount++;
     if (weight >= ZERO_WEIGHT_THRESHOLD) {
       _nonZeroNodeCount++;
     }
@@ -670,17 +670,17 @@ public class QuantileDigest {
     }
 
     if (node._weightedCount >= ZERO_WEIGHT_THRESHOLD) {
-      --_nonZeroNodeCount;
+      _nonZeroNodeCount--;
     }
 
     _weightedCount -= node._weightedCount;
 
     Node result = null;
     if (node.isLeaf()) {
-      --_totalNodeCount;
+      _totalNodeCount--;
     } else if (node.hasSingleChild()) {
       result = node.getSingleChild();
-      --_totalNodeCount;
+      _totalNodeCount--;
     } else {
       node._weightedCount = 0;
       result = node;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/PinotDataBitSet.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/PinotDataBitSet.java
@@ -90,7 +90,8 @@ public final class PinotDataBitSet implements Closeable {
     } else {
       // The value is in multiple bytes
       while (numBitsLeft > Byte.SIZE) {
-        currentValue = (currentValue << Byte.SIZE) | (_dataBuffer.getByte(++byteOffset) & BYTE_MASK);
+        byteOffset++;
+        currentValue = (currentValue << Byte.SIZE) | (_dataBuffer.getByte(byteOffset) & BYTE_MASK);
         numBitsLeft -= Byte.SIZE;
       }
       return (currentValue << numBitsLeft) | ((_dataBuffer.getByte(byteOffset + 1) & BYTE_MASK) >>> (Byte.SIZE
@@ -109,7 +110,8 @@ public final class PinotDataBitSet implements Closeable {
     for (int i = 0; i < length; i++) {
       if (bitOffsetInFirstByte == Byte.SIZE) {
         bitOffsetInFirstByte = 0;
-        currentValue = _dataBuffer.getByte(++byteOffset) & BYTE_MASK;
+        byteOffset++;
+        currentValue = _dataBuffer.getByte(byteOffset) & BYTE_MASK;
       }
       int numBitsLeft = numBitsPerValue - (Byte.SIZE - bitOffsetInFirstByte);
       if (numBitsLeft <= 0) {
@@ -120,10 +122,12 @@ public final class PinotDataBitSet implements Closeable {
       } else {
         // The value is in multiple bytes
         while (numBitsLeft > Byte.SIZE) {
-          currentValue = (currentValue << Byte.SIZE) | (_dataBuffer.getByte(++byteOffset) & BYTE_MASK);
+          byteOffset++;
+          currentValue = (currentValue << Byte.SIZE) | (_dataBuffer.getByte(byteOffset) & BYTE_MASK);
           numBitsLeft -= Byte.SIZE;
         }
-        int nextByte = _dataBuffer.getByte(++byteOffset) & BYTE_MASK;
+        byteOffset++;
+        int nextByte = _dataBuffer.getByte(byteOffset) & BYTE_MASK;
         buffer[i] = (currentValue << numBitsLeft) | (nextByte >>> (Byte.SIZE - numBitsLeft));
         bitOffsetInFirstByte = numBitsLeft;
         currentValue = nextByte & (BYTE_MASK >>> bitOffsetInFirstByte);
@@ -150,9 +154,11 @@ public final class PinotDataBitSet implements Closeable {
           .putByte(byteOffset, (byte) ((firstByte & ~firstByteMask) | ((value >>> numBitsLeft) & firstByteMask)));
       while (numBitsLeft > Byte.SIZE) {
         numBitsLeft -= Byte.SIZE;
-        _dataBuffer.putByte(++byteOffset, (byte) (value >> numBitsLeft));
+        byteOffset++;
+        _dataBuffer.putByte(byteOffset, (byte) (value >> numBitsLeft));
       }
-      int lastByte = _dataBuffer.getByte(++byteOffset);
+      byteOffset++;
+      int lastByte = _dataBuffer.getByte(byteOffset);
       _dataBuffer.putByte(byteOffset,
           (byte) ((lastByte & (BYTE_MASK >>> numBitsLeft)) | (value << (Byte.SIZE - numBitsLeft))));
     }
@@ -169,7 +175,8 @@ public final class PinotDataBitSet implements Closeable {
       int value = values[i];
       if (bitOffsetInFirstByte == Byte.SIZE) {
         bitOffsetInFirstByte = 0;
-        firstByte = _dataBuffer.getByte(++byteOffset);
+        byteOffset++;
+        firstByte = _dataBuffer.getByte(byteOffset);
       }
       int firstByteMask = BYTE_MASK >>> bitOffsetInFirstByte;
       int numBitsLeft = numBitsPerValue - (Byte.SIZE - bitOffsetInFirstByte);
@@ -185,9 +192,11 @@ public final class PinotDataBitSet implements Closeable {
             .putByte(byteOffset, (byte) ((firstByte & ~firstByteMask) | ((value >>> numBitsLeft) & firstByteMask)));
         while (numBitsLeft > Byte.SIZE) {
           numBitsLeft -= Byte.SIZE;
-          _dataBuffer.putByte(++byteOffset, (byte) (value >> numBitsLeft));
+          byteOffset++;
+          _dataBuffer.putByte(byteOffset, (byte) (value >> numBitsLeft));
         }
-        int lastByte = _dataBuffer.getByte(++byteOffset);
+        byteOffset++;
+        int lastByte = _dataBuffer.getByte(byteOffset);
         firstByte = (lastByte & (0xFF >>> numBitsLeft)) | (value << (Byte.SIZE - numBitsLeft));
         _dataBuffer.putByte(byteOffset, (byte) firstByte);
         bitOffsetInFirstByte = numBitsLeft;
@@ -215,7 +224,8 @@ public final class PinotDataBitSet implements Closeable {
       return bitOffset + FIRST_BIT_SET[firstByte];
     }
     while (true) {
-      int currentByte = _dataBuffer.getByte(++byteOffset) & BYTE_MASK;
+      byteOffset++;
+      int currentByte = _dataBuffer.getByte(byteOffset) & BYTE_MASK;
       if (currentByte != 0) {
         return (byteOffset * Byte.SIZE) | FIRST_BIT_SET[currentByte];
       }
@@ -232,7 +242,8 @@ public final class PinotDataBitSet implements Closeable {
     }
     while (true) {
       n -= numBitsSet;
-      int currentByte = _dataBuffer.getByte(++byteOffset) & BYTE_MASK;
+      byteOffset++;
+      int currentByte = _dataBuffer.getByte(byteOffset) & BYTE_MASK;
       numBitsSet = NUM_BITS_SET[currentByte];
       if (numBitsSet >= n) {
         return (byteOffset * Byte.SIZE) | NTH_BIT_SET[n - 1][currentByte];

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/PinotDataBitSetV2.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/PinotDataBitSetV2.java
@@ -676,9 +676,11 @@ public abstract class PinotDataBitSetV2 implements Closeable {
           .putByte(byteOffset, (byte) ((firstByte & ~firstByteMask) | ((value >>> numBitsLeft) & firstByteMask)));
       while (numBitsLeft > Byte.SIZE) {
         numBitsLeft -= Byte.SIZE;
-        _dataBuffer.putByte(++byteOffset, (byte) (value >> numBitsLeft));
+        byteOffset++;
+        _dataBuffer.putByte(byteOffset, (byte) (value >> numBitsLeft));
       }
-      int lastByte = _dataBuffer.getByte(++byteOffset);
+      byteOffset++;
+      int lastByte = _dataBuffer.getByte(byteOffset);
       _dataBuffer.putByte(byteOffset,
           (byte) ((lastByte & (BYTE_MASK >>> numBitsLeft)) | (value << (Byte.SIZE - numBitsLeft))));
     }
@@ -695,7 +697,8 @@ public abstract class PinotDataBitSetV2 implements Closeable {
       int value = values[i];
       if (bitOffsetInFirstByte == Byte.SIZE) {
         bitOffsetInFirstByte = 0;
-        firstByte = _dataBuffer.getByte(++byteOffset);
+        byteOffset++;
+        firstByte = _dataBuffer.getByte(byteOffset);
       }
       int firstByteMask = BYTE_MASK >>> bitOffsetInFirstByte;
       int numBitsLeft = _numBitsPerValue - (Byte.SIZE - bitOffsetInFirstByte);
@@ -711,9 +714,11 @@ public abstract class PinotDataBitSetV2 implements Closeable {
             .putByte(byteOffset, (byte) ((firstByte & ~firstByteMask) | ((value >>> numBitsLeft) & firstByteMask)));
         while (numBitsLeft > Byte.SIZE) {
           numBitsLeft -= Byte.SIZE;
-          _dataBuffer.putByte(++byteOffset, (byte) (value >> numBitsLeft));
+          byteOffset++;
+          _dataBuffer.putByte(byteOffset, (byte) (value >> numBitsLeft));
         }
-        int lastByte = _dataBuffer.getByte(++byteOffset);
+        byteOffset++;
+        int lastByte = _dataBuffer.getByte(byteOffset);
         firstByte = (lastByte & (0xFF >>> numBitsLeft)) | (value << (Byte.SIZE - numBitsLeft));
         _dataBuffer.putByte(byteOffset, (byte) firstByte);
         bitOffsetInFirstByte = numBitsLeft;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/SegmentPreIndexStatsCollectorImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/SegmentPreIndexStatsCollectorImpl.java
@@ -101,7 +101,7 @@ public class SegmentPreIndexStatsCollectorImpl implements SegmentPreIndexStatsCo
       }
     }
 
-    ++_totalDocCount;
+    _totalDocCount++;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
@@ -393,7 +393,7 @@ public class SegmentLocalFSDirectory extends SegmentDirectory {
       if (_writers > 0) {
         return false;
       }
-      ++_readers;
+      _readers++;
       return true;
     }
 
@@ -401,15 +401,15 @@ public class SegmentLocalFSDirectory extends SegmentDirectory {
       if (_readers > 0 || _writers > 0) {
         return false;
       }
-      ++_writers;
+      _writers++;
       return true;
     }
 
     synchronized void unlock() {
       if (_writers > 0) {
-        --_writers;
+        _writers--;
       } else if (_readers > 0) {
-        --_readers;
+        _readers--;
       }
     }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/ColumnIndexDirectoryTestHelper.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/ColumnIndexDirectoryTestHelper.java
@@ -65,7 +65,7 @@ public class ColumnIndexDirectoryTestHelper {
       // NOTE: PinotDataBuffer is tracked in the ColumnIndexDirectory. No need to close it here.
       PinotDataBuffer buf = ColumnIndexDirectoryTestHelper.getIndexBuffer(columnDirectory, column, i);
       int numValues = (int) (buf.size() / 4);
-      for (int j = 0; j < numValues; ++j) {
+      for (int j = 0; j < numValues; j++) {
         Assert.assertEquals(buf.getInt(j * 4), j, "Inconsistent value at index: " + j);
       }
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectoryTest.java
@@ -88,7 +88,7 @@ public class SegmentLocalFSDirectoryTest {
 
   private void loadData(PinotDataBuffer buffer) {
     int limit = (int) (buffer.size() / 4);
-    for (int i = 0; i < limit; ++i) {
+    for (int i = 0; i < limit; i++) {
       buffer.putInt(i * 4, 10000 + i);
     }
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/MoveReplicaGroup.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/MoveReplicaGroup.java
@@ -228,7 +228,7 @@ public class MoveReplicaGroup extends AbstractBaseAdminCommand implements Comman
 
     Map<String, Map<String, String>> newIdealState = copyIdealState(idealStateMap);
 
-    for (int remapCount = 0; remapCount < _maxSegmentsToMove && !segmentsToMove.isEmpty(); ++remapCount) {
+    for (int remapCount = 0; remapCount < _maxSegmentsToMove && !segmentsToMove.isEmpty(); remapCount++) {
       String segment = segmentsToMove.poll()._segment;
       Map<String, String> existingMapping = newIdealState.get(segment);
       String destinationServer = getDestinationServer(destinationServers, existingMapping);
@@ -265,7 +265,7 @@ public class MoveReplicaGroup extends AbstractBaseAdminCommand implements Comman
       removedServers.add(si);
       if (!existingSegmentMapping.containsKey(si._server)) {
         selectedServer = si._server;
-        ++si._segments;
+        si._segments++;
         break;
       }
     }
@@ -328,7 +328,7 @@ public class MoveReplicaGroup extends AbstractBaseAdminCommand implements Comman
         String server = instanceEntry.getKey();
         ServerInstance instance = serverMap.get(server);
         if (instance != null) {
-          ++instance._segments;
+          instance._segments++;
         }
       }
     }
@@ -382,7 +382,7 @@ public class MoveReplicaGroup extends AbstractBaseAdminCommand implements Comman
       SourceSegments srcSegment = new SourceSegments(segmentEntry.getKey(), 0);
       for (Map.Entry<String, String> instanceEntry : segmentEntry.getValue().entrySet()) {
         if (srcHosts.contains(instanceEntry.getKey())) {
-          ++srcSegment._replicaCount;
+          srcSegment._replicaCount++;
         }
       }
       if (srcSegment._replicaCount > 0) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/anonymizer/PinotDataAndQueryAnonymizer.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/anonymizer/PinotDataAndQueryAnonymizer.java
@@ -584,7 +584,7 @@ public class PinotDataAndQueryAnonymizer {
 
       String newColumnName = prefix + "_COL_" + col;
       _origToDerivedColumnsMap.put(columnName, newColumnName);
-      ++col;
+      col++;
     }
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/query/comparison/QueryComparison.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/query/comparison/QueryComparison.java
@@ -281,12 +281,12 @@ public class QueryComparison {
   private static boolean compareAggregationArrays(JsonNode actualAggregation, JsonNode expectedAggregation) {
     Map<String, Double> map = new HashMap<>();
 
-    for (int i = 0; i < expectedAggregation.size(); ++i) {
+    for (int i = 0; i < expectedAggregation.size(); i++) {
       JsonNode object = expectedAggregation.get(i);
       map.put(object.get(FUNCTION).asText().toLowerCase(), object.get(VALUE).asDouble());
     }
 
-    for (int i = 0; i < actualAggregation.size(); ++i) {
+    for (int i = 0; i < actualAggregation.size(); i++) {
       JsonNode object = actualAggregation.get(i);
       String function = object.get(FUNCTION).asText().toLowerCase();
       String valueString = object.get(VALUE).asText();
@@ -322,13 +322,13 @@ public class QueryComparison {
 
     // Build map based on function (function_column name) to match individual entries.
     Map<String, Integer> functionMap = new HashMap<>();
-    for (int i = 0; i < numExpectedGroupBy; ++i) {
+    for (int i = 0; i < numExpectedGroupBy; i++) {
       JsonNode expectedAggr = expectedGroupByResults.get(i);
       String expectedFunction = expectedAggr.get(FUNCTION).asText().toLowerCase();
       functionMap.put(expectedFunction, i);
     }
 
-    for (int i = 0; i < numActualGroupBy; ++i) {
+    for (int i = 0; i < numActualGroupBy; i++) {
       JsonNode actualAggr = actualGroupByResults.get(i);
       String actualFunction = actualAggr.get(FUNCTION).asText().toLowerCase();
 
@@ -351,7 +351,7 @@ public class QueryComparison {
 
   private static List<Object> jsonArrayToList(JsonNode jsonArray) {
     List<Object> list = new ArrayList<>();
-    for (int i = 0; i < jsonArray.size(); ++i) {
+    for (int i = 0; i < jsonArray.size(); i++) {
       list.add(jsonArray.get(i));
     }
     return list;
@@ -362,13 +362,13 @@ public class QueryComparison {
     JsonNode expectedResult = expectedAggr.get(GROUP_BY_RESULT);
 
     Map<GroupByOperator, Double> expectedMap = new HashMap<>();
-    for (int i = 0; i < expectedResult.size(); ++i) {
+    for (int i = 0; i < expectedResult.size(); i++) {
       List<Object> group = jsonArrayToList(expectedResult.get(i).get(GROUP));
       GroupByOperator groupByOperator = new GroupByOperator(group);
       expectedMap.put(groupByOperator, expectedResult.get(i).get(VALUE).asDouble());
     }
 
-    for (int i = 0; i < actualResult.size(); ++i) {
+    for (int i = 0; i < actualResult.size(); i++) {
       List<Object> group = jsonArrayToList(actualResult.get(i).get(GROUP));
       GroupByOperator groupByOperator = new GroupByOperator(group);
 
@@ -492,7 +492,7 @@ public class QueryComparison {
     }
 
     if (expectedToActualColMap == null) {
-      for (int i = 0; i < expectedList.size(); ++i) {
+      for (int i = 0; i < expectedList.size(); i++) {
         String actualColumn = actualList.get(i).asText();
         String expectedColumn = expectedList.get(i).asText();
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/query/comparison/StatsGenerator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/query/comparison/StatsGenerator.java
@@ -46,7 +46,7 @@ public class StatsGenerator {
     String[] columns = dataReader.readLine().split("\\s+");
     int numColumns = columns.length;
 
-    for (int i = 0; i < numColumns; ++i) {
+    for (int i = 0; i < numColumns; i++) {
       statisticsList.add(new DescriptiveStatistics());
     }
 
@@ -58,7 +58,7 @@ public class StatsGenerator {
             "Row has missing columns: " + Arrays.toString(dataArray) + " Expected: " + numColumns + " columns.");
       }
 
-      for (int i = 0; i < dataArray.length; ++i) {
+      for (int i = 0; i < dataArray.length; i++) {
         double data = Double.valueOf(dataArray[i]);
         statisticsList.get(i).addValue(data);
       }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/AvgFunction.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/AvgFunction.java
@@ -42,7 +42,7 @@ public class AvgFunction extends AggregationFunc {
         numEntries += valArray[1];
       } else {
         sum += new Double(row.get(_column, NAME).toString());
-        ++numEntries;
+        numEntries++;
       }
     }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/EqualsPredicateFilter.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/EqualsPredicateFilter.java
@@ -36,7 +36,7 @@ public class EqualsPredicateFilter implements PredicateFilter {
   @Override
   public boolean apply(int[] dictIds, int length) {
     // length <= dictIds.length
-    for (int i = 0; i < length; ++i) {
+    for (int i = 0; i < length; i++) {
       if (dictIds[i] == _equalsDictId) {
         return true;
       }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/InPredicateFilter.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/InPredicateFilter.java
@@ -42,7 +42,7 @@ public class InPredicateFilter implements PredicateFilter {
   @Override
   public boolean apply(int[] dictIds, int length) {
     // length <= dictIds.length
-    for (int i = 0; i < length; ++i) {
+    for (int i = 0; i < length; i++) {
       if (_inSet.contains(dictIds[i])) {
         return true;
       }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/NotInPredicateFilter.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/NotInPredicateFilter.java
@@ -42,7 +42,7 @@ public class NotInPredicateFilter implements PredicateFilter {
   @Override
   public boolean apply(int[] dictIds, int length) {
     // length <= dictIds.length
-    for (int i = 0; i < length; ++i) {
+    for (int i = 0; i < length; i++) {
       if (_notInSet.contains(dictIds[i])) {
         return false;
       }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/NotPredicateFilter.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/NotPredicateFilter.java
@@ -36,7 +36,7 @@ public class NotPredicateFilter implements PredicateFilter {
   @Override
   public boolean apply(int[] dictIds, int length) {
     // length <= dictIds.length
-    for (int i = 0; i < length; ++i) {
+    for (int i = 0; i < length; i++) {
       if (dictIds[i] == _notEqualsDictId) {
         return false;
       }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/Projection.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/Projection.java
@@ -116,7 +116,7 @@ public class Projection {
         if (object instanceof int[]) {
           int[] dictIds = (int[]) object;
           Object[] values = new Object[dictIds.length];
-          for (int i = 0; i < dictIds.length; ++i) {
+          for (int i = 0; i < dictIds.length; i++) {
             values[i] = dictionary.get(dictIds[i]);
           }
           row.set(colId, values);
@@ -124,7 +124,7 @@ public class Projection {
           int dictId = (int) object;
           row.set(colId, dictionary.get(dictId));
         }
-        ++colId;
+        colId++;
       }
     }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/QueryResponse.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/QueryResponse.java
@@ -89,7 +89,7 @@ public class QueryResponse {
         AggregationResult aggregationResult =
             new AggregationResult(resultTable.getFunction(columnId), value.toString());
         _aggregationResults.add(aggregationResult);
-        ++columnId;
+        columnId++;
       }
     }
   }
@@ -125,12 +125,12 @@ public class QueryResponse {
         } else {
           group.add(value.toString());
         }
-        ++colId;
+        colId++;
       }
       groupValueStrings.add(group);
     }
 
-    for (int colId = numGroupByColumns; colId < columnList.size(); ++colId) {
+    for (int colId = numGroupByColumns; colId < columnList.size(); colId++) {
       String function = resultTable.getFunction(colId);
       if (function.equalsIgnoreCase("count_*")) {
         function = "count_star";
@@ -142,7 +142,7 @@ public class QueryResponse {
         String value = row.get(colId).toString();
         GroupValue groupValue = new GroupValue(value, groupValueStrings.get(rowId));
         groupValues.add(groupValue);
-        ++rowId;
+        rowId++;
       }
 
       AggregationResult aggregationResult = new AggregationResult(groupValues, groupByColumns, function);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/RangePredicateFilter.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/RangePredicateFilter.java
@@ -57,7 +57,7 @@ public class RangePredicateFilter implements PredicateFilter {
     if (_endIndex < 0) {
       _endIndex = -(_endIndex + 1) - 1;
     } else if (!includeEnd) {
-      --_endIndex;
+      _endIndex--;
     }
   }
 
@@ -69,7 +69,7 @@ public class RangePredicateFilter implements PredicateFilter {
   @Override
   public boolean apply(int[] dictIds, int length) {
     // length <= dictIds.length
-    for (int i = 0; i < length; ++i) {
+    for (int i = 0; i < length; i++) {
       if (apply(dictIds[i])) {
         return true;
       }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/ResultTable.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/ResultTable.java
@@ -47,7 +47,7 @@ public class ResultTable implements Iterable<ResultTable.Row> {
       if (function != null && function.equalsIgnoreCase(AVERAGE)) {
         averageColumns.add(i);
       }
-      ++i;
+      i++;
     }
     // No average columns found.
     if (averageColumns.isEmpty()) {
@@ -75,7 +75,7 @@ public class ResultTable implements Iterable<ResultTable.Row> {
       if (function != null && function.equalsIgnoreCase(DISTINCT_COUNT)) {
         distinctCountColumns.add(i);
       }
-      ++i;
+      i++;
     }
 
     // No distinctCount columns found.
@@ -122,10 +122,10 @@ public class ResultTable implements Iterable<ResultTable.Row> {
     for (Pair pair : columns) {
       String key = (String) pair.getFirst() + "_" + (String) pair.getSecond();
       _columnMap.put(key, index);
-      ++index;
+      index++;
     }
 
-    for (int i = 0; i < numRows; ++i) {
+    for (int i = 0; i < numRows; i++) {
       _rows.add(i, new Row(_columnMap));
     }
   }
@@ -259,7 +259,7 @@ public class ResultTable implements Iterable<ResultTable.Row> {
     @Override
     public String toString() {
       StringBuilder sb = new StringBuilder();
-      for (int i = 0; i < _cols.size(); ++i) {
+      for (int i = 0; i < _cols.size(); i++) {
         sb.append(_cols.get(i).toString());
       }
       return sb.toString();
@@ -270,7 +270,7 @@ public class ResultTable implements Iterable<ResultTable.Row> {
     }
 
     public void print() {
-      for (int i = 0; i < _cols.size(); ++i) {
+      for (int i = 0; i < _cols.size(); i++) {
         Object object = _cols.get(i);
         String value = (object instanceof Object[]) ? Arrays.toString((Object[]) object) : object.toString();
         LOGGER.info(_columnList.get(i) + " " + value);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/ScanBasedQueryProcessor.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/ScanBasedQueryProcessor.java
@@ -87,7 +87,7 @@ public class ScanBasedQueryProcessor implements Cloneable {
     for (ResultTable segmentResults : resultTables) {
       numDocsScanned += segmentResults.getNumDocsScanned();
       totalDocs += segmentResults.getTotalDocs();
-      ++numSegments;
+      numSegments++;
       results = (results == null) ? segmentResults : results.append(segmentResults);
     }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/SegmentQueryProcessor.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/scan/query/SegmentQueryProcessor.java
@@ -178,7 +178,7 @@ class SegmentQueryProcessor {
     // If no filter predicate, return the input without filtering.
     if (filterQueryTree == null) {
       List<Integer> allDocs = new ArrayList<>(_totalDocs);
-      for (int i = 0; i < _totalDocs; ++i) {
+      for (int i = 0; i < _totalDocs; i++) {
         allDocs.add(i);
       }
       return allDocs;
@@ -196,7 +196,7 @@ class SegmentQueryProcessor {
 
     List<Integer> result = filterDocIds(childFilters.get(0), inputDocIds);
     final FilterOperator operator = filterQueryTree.getOperator();
-    for (int i = 1; i < childFilters.size(); ++i) {
+    for (int i = 1; i < childFilters.size(); i++) {
 //      List<Integer> childResult = operator.equals(FilterOperator.AND) ? filterDocIds(childFilters.get(i), result)
 //          : filterDocIds(childFilters.get(i), inputDocIds);
       List<Integer> childResult = filterDocIds(childFilters.get(i), inputDocIds);


### PR DESCRIPTION
## Description
This enforces a code style request made in review recently (don't use prefix increment in loop induction variable) but isn't context sensitive enough to only apply to loop induction variables.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
