### PR TITLE
adding instance method initialization

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionInvoker.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionInvoker.java
@@ -64,6 +64,13 @@ public class FunctionInvoker {
   /**
    * Returns the underlying java method.
    */
+  public Object getInstance() {
+    return _instance;
+  }
+
+  /**
+   * Returns the underlying java method.
+   */
   public Method getMethod() {
     return _method;
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/InitializableScalarFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/InitializableScalarFunction.java
@@ -1,0 +1,19 @@
+package org.apache.pinot.common.function.scalar;
+
+/**
+ * Interface that defines {@link org.apache.pinot.spi.annotations.ScalarFunction}
+ * annotated Function that supports preprocess literal arguments.
+ */
+public interface InitializableScalarFunction {
+
+  /**
+   * Initialize internal state. This will be called by the query expression parser
+   * during expression parsing and called with argument.
+   *
+   * Each concrete implementation should check and validate the desired positional
+   * arguments and ensure that it is of literal type.
+   *
+   * @param arguments positional argument expressions.
+   */
+  void init(Object... arguments);
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/InitializableScalarFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/InitializableScalarFunction.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.common.function.scalar;
 
 /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.function.scalar;
 
+import com.google.common.base.Preconditions;
 import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
 import java.util.regex.Pattern;
@@ -326,16 +327,23 @@ public class StringFunctions {
     return Normalizer.normalize(input, Normalizer.Form.NFC);
   }
 
-  /**
-   * see Normalizer#normalize(String, Form)
-   * @param input
-   * @param form
-   * @return transforms string with the specified normalization form
-   */
-  @ScalarFunction
-  public static String normalize(String input, String form) {
-    Normalizer.Form targetForm = Normalizer.Form.valueOf(form);
-    return Normalizer.normalize(input, targetForm);
+  public static class NormalizeFunction {
+    private Normalizer.Form _form;
+
+    public void init(String input, String form) {
+      _form = Normalizer.Form.valueOf(form);
+    }
+
+    /**
+     * see Normalizer#normalize(String, Form)
+     * @param input
+     * @param form
+     * @return transforms string with the specified normalization form
+     */
+    @ScalarFunction
+    String normalize(String input, String form) {
+      return Normalizer.normalize(input, _form);
+    }
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -327,11 +327,17 @@ public class StringFunctions {
     return Normalizer.normalize(input, Normalizer.Form.NFC);
   }
 
-  public static class NormalizeFunction {
+  /**
+   * see Normalizer#normalize(String, Form)
+   */
+  public static class NormalizeFunction implements InitializableScalarFunction {
     private Normalizer.Form _form;
 
-    public void init(String input, String form) {
-      _form = Normalizer.Form.valueOf(form);
+    @Override
+    public void init(Object... arguments) {
+      Preconditions.checkState(arguments.length == 2
+          && arguments[1] instanceof String);
+      _form = Normalizer.Form.valueOf((String) arguments[1]);
     }
 
     /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapper.java
@@ -117,7 +117,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
 
     // if FunctionInvoker contains an instance function. initialize it.
     Object instance = _functionInvoker.getInstance();
-    if (instance != null && instance instanceof InitializableScalarFunction) {
+    if (instance instanceof InitializableScalarFunction) {
       ((InitializableScalarFunction) instance).init(_arguments);
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapper.java
@@ -19,9 +19,12 @@
 package org.apache.pinot.core.operator.transform.function;
 
 import com.google.common.base.Preconditions;
+import java.lang.reflect.Method;
 import java.sql.Timestamp;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.pinot.common.function.FunctionInfo;
 import org.apache.pinot.common.function.FunctionInvoker;
@@ -113,6 +116,22 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
       }
     }
     _nonLiteralValues = new Object[_numNonLiteralArguments][];
+
+    // if FunctionInvoker contains an instance function. initialize it.
+    if (_functionInvoker.getInstance() != null) {
+      Object instance = _functionInvoker.getInstance();
+      Method[] methods = Arrays.stream(instance.getClass().getDeclaredMethods())
+          .filter(m -> "init".equals(m.getName()))
+          .toArray(Method[]::new);
+      if (methods.length == 1) {
+        try {
+          methods[0].invoke(instance, _arguments);
+        } catch (Exception e) {
+          throw new IllegalStateException(
+              "Caught exception while invoking method: " + methods[0] + " with arguments: " + Arrays.toString(_arguments), e);
+        }
+      }
+    }
   }
 
   @Override


### PR DESCRIPTION
Currently ScalarTransformFunctionWrapper doesn't actually take advantage of Literal arguments passed in. 

Creating a framework (very basic) to showcase how to invoke initialization to reduce overhead during each scalarFunction invoke.
This is using a very basic example of string normalize function to reduce the overhead of each match of ENUM extract, not much but it will come really handy in other more heavy use cases like regex Pattern compilation (which is per row)

TODO
- [ ] create a interface for the init method (or making it accept variable-length arguments like `Object... `?)
- [ ] sanitize the APIs so that there's less if checkers