### PR TITLE
Add aws sts dependency to enable auth using web identity token

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
@@ -117,6 +117,30 @@
     </dependency>
 
     <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>sts</artifactId>
+      <version>${aws.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-codec</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-buffer</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-common</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
       <groupId>org.reactivestreams</groupId>
       <artifactId>reactive-streams</artifactId>
     </dependency>
@@ -183,9 +207,11 @@
                   <goal>shade</goal>
                 </goals>
                 <configuration>
-                  <transformers>
+                  <transformers combine.self="override">
                     <transformer
                         implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                    <transformer
+                        implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                   </transformers>
                   <!--
                   Usually in hadoop environment, there are multiple jars with different versions.

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
@@ -207,6 +207,15 @@
                   <goal>shade</goal>
                 </goals>
                 <configuration>
+                  <!-- combine.self="override" needs to be specified as without this attribute child pom appears to merge
+                   shade plugin configurations in its parents pom.Notably the shade plugin configuration in the root pom declares a mainClass which 
+                   causes the build to fail - https://github.com/apache/pinot/blob/master/pom.xml#L1880
+                   The build will fail with the message "Unable to parse configuration of mojo org.apache.maven.plugins:maven-shade-plugin:3.2.1:shade 
+                   for parameter mainClass: Cannot find 'mainClass' in class org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" error
+                   Adding "combine.self" attribute in the child pom's configuration will allow maven to execute the shade plugin independently from the
+                   parent pom. For more details please see https://github.com/stevenschlansker/maven-configure-transformer-bug & 
+                   https://mail-archives.apache.org/mod_mbox/maven-issues/201605.mbox/%3CJIRA.12964833.1462316804000.103574.1462316952817@Atlassian.JIRA%3E
+                   -->
                   <transformers combine.self="override">
                     <transformer
                         implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>


### PR DESCRIPTION
Based on https://github.com/apache/pinot/commit/69a91acbead90b110800bbf98424415630f78527 changes done by @singalravi 
But due to the shaded relocation of software.amazon packages ServicesResourceTransformer needs to be included.If software.amazon can be excluded then the change will mirror exactly as pinot-s3 changes

## Description
WebIdentityTokenFileCredentialsProvider needs sts dependency in its classpath
See https://github.com/aws/aws-sdk-java-v2/blob/2.13.46/core/auth/src/main/java/software/amazon/awssdk/auth/credentials/WebIdentityTokenFileCredentialsProvider.java#L29-L34

