### PR TITLE
Unify CombineOperator multi-threading logic

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOnlyCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOnlyCombineOperator.java
@@ -35,7 +35,6 @@ import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.operator.combine.BaseCombineOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
-import org.apache.pinot.spi.exception.EarlyTerminationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -71,30 +70,19 @@ public class StreamingSelectionOnlyCombineOperator extends BaseCombineOperator {
 
   @Override
   protected void processSegments(int threadIndex) {
-    for (int operatorIndex = threadIndex; operatorIndex < _numOperators; operatorIndex += _numTasks) {
+    for (int operatorIndex = threadIndex; operatorIndex < _numOperators; operatorIndex += _numThreads) {
       Operator<IntermediateResultsBlock> operator = _operators.get(operatorIndex);
-      try {
-        IntermediateResultsBlock resultsBlock;
-        while ((resultsBlock = operator.nextBlock()) != null) {
-          Collection<Object[]> rows = resultsBlock.getSelectionResult();
-          assert rows != null;
-          long numRowsCollected = _numRowsCollected.addAndGet(rows.size());
-          _blockingQueue.offer(resultsBlock);
-          if (numRowsCollected >= _limit) {
-            return;
-          }
+      IntermediateResultsBlock resultsBlock;
+      while ((resultsBlock = operator.nextBlock()) != null) {
+        Collection<Object[]> rows = resultsBlock.getSelectionResult();
+        assert rows != null;
+        long numRowsCollected = _numRowsCollected.addAndGet(rows.size());
+        _blockingQueue.offer(resultsBlock);
+        if (numRowsCollected >= _limit) {
+          return;
         }
-        _blockingQueue.offer(LAST_RESULTS_BLOCK);
-      } catch (EarlyTerminationException e) {
-        // Early-terminated by interruption (canceled by the main thread)
-        return;
-      } catch (Exception e) {
-        // Caught exception, skip processing the remaining operators
-        LOGGER.error("Caught exception while executing operator of index: {} (query: {})", operatorIndex, _queryContext,
-            e);
-        _blockingQueue.offer(new IntermediateResultsBlock(e));
-        return;
       }
+      _blockingQueue.offer(LAST_RESULTS_BLOCK);
     }
   }
 


### PR DESCRIPTION
Unify the logic of using multiple threads to process segments within the combine operators
- Make group-by combine operators follow the `numThreads` limit so that we can control it's thread usage
- Extract common logic in combine operators and simplify the actual implementation

NOTE: This PR doesn't limit the thread usage for group-by combine operator to keep the existing behavior, but only make it possible