### PR TITLE
Mask credentials in debug endpoint /appconfigs

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotAppConfigs.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotAppConfigs.java
@@ -38,6 +38,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.Obfuscator;
 
 
 /**
@@ -341,7 +342,7 @@ public class PinotAppConfigs {
 
   public String toJSONString() {
     try {
-      return OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(this);
+      return OBJECT_MAPPER.writerWithDefaultPrettyPrinter().writeValueAsString(new Obfuscator().toJson(this));
     } catch (JsonProcessingException e) {
       return e.getMessage();
     }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerTestUtils.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerTestUtils.java
@@ -233,9 +233,8 @@ public abstract class ControllerTestUtils {
 
   public static void addFakeBrokerInstanceToAutoJoinHelixCluster(String instanceId, boolean isSingleTenant)
       throws Exception {
-    HelixManager helixManager =
-        HelixManagerFactory.getZKHelixManager(getHelixClusterName(), instanceId, InstanceType.PARTICIPANT,
-            _zookeeperInstance.getZkUrl());
+    HelixManager helixManager = HelixManagerFactory
+        .getZKHelixManager(getHelixClusterName(), instanceId, InstanceType.PARTICIPANT, _zookeeperInstance.getZkUrl());
     helixManager.getStateMachineEngine()
         .registerStateModelFactory(FakeBrokerResourceOnlineOfflineStateModelFactory.STATE_MODEL_DEF,
             FakeBrokerResourceOnlineOfflineStateModelFactory.FACTORY_INSTANCE);
@@ -334,9 +333,8 @@ public abstract class ControllerTestUtils {
   protected static void addFakeServerInstanceToAutoJoinHelixCluster(String instanceId, boolean isSingleTenant,
       int adminPort)
       throws Exception {
-    HelixManager helixManager =
-        HelixManagerFactory.getZKHelixManager(getHelixClusterName(), instanceId, InstanceType.PARTICIPANT,
-            _zookeeperInstance.getZkUrl());
+    HelixManager helixManager = HelixManagerFactory
+        .getZKHelixManager(getHelixClusterName(), instanceId, InstanceType.PARTICIPANT, _zookeeperInstance.getZkUrl());
     helixManager.getStateMachineEngine()
         .registerStateModelFactory(FakeSegmentOnlineOfflineStateModelFactory.STATE_MODEL_DEF,
             FakeSegmentOnlineOfflineStateModelFactory.FACTORY_INSTANCE);
@@ -348,8 +346,9 @@ public abstract class ControllerTestUtils {
     } else {
       helixAdmin.addInstanceTag(getHelixClusterName(), instanceId, UNTAGGED_SERVER_INSTANCE);
     }
-    HelixConfigScope configScope = new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.PARTICIPANT,
-        getHelixClusterName()).forParticipant(instanceId).build();
+    HelixConfigScope configScope =
+        new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.PARTICIPANT, getHelixClusterName())
+            .forParticipant(instanceId).build();
     helixAdmin.setConfig(configScope, Collections.singletonMap(ADMIN_PORT_KEY, Integer.toString(adminPort)));
     FAKE_INSTANCE_HELIX_MANAGERS.add(helixManager);
   }
@@ -685,6 +684,10 @@ public abstract class ControllerTestUtils {
 
     // Used in PinotTableRestletResourceTest
     properties.put(ControllerConf.TABLE_MIN_REPLICAS, MIN_NUM_REPLICAS);
+
+    // Used in PinotControllerAppConfigsTest to test obfuscation
+    properties.put("controller.segment.fetcher.auth.token", "*personal*");
+    properties.put("controller.admin.access.control.principals.user.password", "*personal*");
 
     return properties;
   }


### PR DESCRIPTION
## Description

Mask credentials in debug endpoint /appconfigs using the Obfuscator class

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
