### PR TITLE
Fix /version endpoint

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/Utils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/Utils.java
@@ -19,14 +19,14 @@
 package org.apache.pinot.common;
 
 import java.io.IOException;
-import java.net.JarURLConnection;
+import java.io.InputStream;
 import java.net.URL;
-import java.net.URLClassLoader;
-import java.net.URLConnection;
+import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.jar.Attributes;
+import java.util.jar.Manifest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -118,37 +118,28 @@ public class Utils {
   public static Map<String, String> getComponentVersions() {
     Map<String, String> componentVersions = new HashMap<>();
 
-    // Find the first URLClassLoader, walking up the chain of parent classloaders if necessary
+    // unless Utils was somehow loaded on the bootclasspath, this will not be null
+    // and will find all manifests
     ClassLoader classLoader = Utils.class.getClassLoader();
-    while (classLoader != null && !(classLoader instanceof URLClassLoader)) {
-      classLoader = classLoader.getParent();
-    }
-
     if (classLoader != null) {
-      URLClassLoader urlClassLoader = (URLClassLoader) classLoader;
-      URL[] urls = urlClassLoader.getURLs();
-      for (URL url : urls) {
-        try {
-          // Convert the URL to the JAR into a JAR URL: eg. jar:http://www.foo.com/bar/baz.jar!/ in order to load it
-          URL jarUrl = new URL("jar", "", url + "!/");
-          URLConnection connection = jarUrl.openConnection();
-          if (connection instanceof JarURLConnection) {
-            JarURLConnection jarURLConnection = (JarURLConnection) connection;
-
-            // Read JAR attributes and log the Implementation-Title and Implementation-Version manifestvalues for pinot
-            // components
-            Attributes attributes = jarURLConnection.getMainAttributes();
+      try {
+        Enumeration<URL> manifests = classLoader.getResources("META-INF/MANIFEST.MF");
+        while (manifests.hasMoreElements()) {
+          URL url = manifests.nextElement();
+          try (InputStream stream = url.openStream()) {
+            Manifest manifest = new Manifest(stream);
+            Attributes attributes = manifest.getMainAttributes();
             if (attributes != null) {
               String implementationTitle = attributes.getValue(Attributes.Name.IMPLEMENTATION_TITLE);
-              String implementationVersion = attributes.getValue(Attributes.Name.IMPLEMENTATION_VERSION);
               if (implementationTitle != null && implementationTitle.contains("pinot")) {
+                String implementationVersion = attributes.getValue(Attributes.Name.IMPLEMENTATION_VERSION);
                 componentVersions.put(implementationTitle, implementationVersion);
               }
             }
           }
-        } catch (IOException e) {
-          // Ignored
         }
+      } catch (IOException e) {
+        // ignore
       }
     }
 


### PR DESCRIPTION
## Description
This fixes the manifest scan which drives the /version endpoint which doesn't work on JDK11 (fixes #7449). The problem is that the application class loader is no longer a `URLClassLoader` so the existing approach wouldn't work on JDK9+. Since this logic depends on built jars, this is quite difficult to test, but I verified the fix works by running `HybridQuickstart` with an appropriate class path at the command line:
<img width="1301" alt="Screenshot 2021-09-21 at 16 06 49" src="https://user-images.githubusercontent.com/16439049/134197697-4ab358cd-54c3-4c33-9717-daade64c0a02.png">


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
