### PR TITLE
Add additional override in SegmentWriter and SegmentUploader

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
@@ -135,7 +135,7 @@ public class FileIngestionHelper {
 
       // Get SegmentGeneratorConfig
       SegmentGeneratorConfig segmentGeneratorConfig =
-          IngestionUtils.generateSegmentGeneratorConfig(_tableConfig, _schema, batchIngestionConfigOverride);
+          IngestionUtils.generateSegmentGeneratorConfig(_tableConfig, _schema, batchConfigMapOverride);
 
       // Build segment
       String segmentName = IngestionUtils.buildSegment(segmentGeneratorConfig);

--- a/pinot-plugins/pinot-segment-uploader/pinot-segment-uploader-default/src/main/java/org/apache/pinot/plugin/segmentuploader/SegmentUploaderDefault.java
+++ b/pinot-plugins/pinot-segment-uploader/pinot-segment-uploader-default/src/main/java/org/apache/pinot/plugin/segmentuploader/SegmentUploaderDefault.java
@@ -22,7 +22,9 @@ import com.google.common.base.Preconditions;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -50,7 +52,12 @@ public class SegmentUploaderDefault implements SegmentUploader {
   private BatchConfig _batchConfig;
 
   @Override
-  public void init(TableConfig tableConfig)
+  public void init(TableConfig tableConfig) throws Exception {
+    init(tableConfig, Collections.emptyMap());
+  }
+
+  @Override
+  public void init(TableConfig tableConfig, Map<String, String> batchConfigOverride)
       throws Exception {
     _tableNameWithType = tableConfig.getTableName();
 
@@ -63,8 +70,13 @@ public class SegmentUploaderDefault implements SegmentUploader {
     Preconditions
         .checkState(tableConfig.getIngestionConfig().getBatchIngestionConfig().getBatchConfigMaps().size() == 1,
             "batchConfigMaps must contain only 1 BatchConfig for table: %s", _tableNameWithType);
-    _batchConfig = new BatchConfig(_tableNameWithType,
+
+    // apply config override provided by user.
+    Map<String, String> batchConfigMap = new HashMap<>(
         tableConfig.getIngestionConfig().getBatchIngestionConfig().getBatchConfigMaps().get(0));
+    batchConfigMap.putAll(batchConfigOverride);
+
+    _batchConfig = new BatchConfig(_tableNameWithType, batchConfigMap);
 
     Preconditions.checkState(StringUtils.isNotBlank(_batchConfig.getPushControllerURI()),
         "Must provide: %s in batchConfigs for table: %s", BatchConfigProperties.PUSH_CONTROLLER_URI,

--- a/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/src/main/java/org/apache/pinot/plugin/segmentwriter/filebased/FileBasedSegmentWriter.java
+++ b/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/src/main/java/org/apache/pinot/plugin/segmentwriter/filebased/FileBasedSegmentWriter.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.plugin.segmentwriter.filebased;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -183,12 +182,10 @@ public class FileBasedSegmentWriter implements SegmentWriter {
       batchConfigMapOverride.put(BatchConfigProperties.INPUT_DIR_URI, _bufferFile.getAbsolutePath());
       batchConfigMapOverride.put(BatchConfigProperties.OUTPUT_DIR_URI, segmentDir.getAbsolutePath());
       batchConfigMapOverride.put(BatchConfigProperties.INPUT_FORMAT, BUFFER_FILE_FORMAT.toString());
-      BatchIngestionConfig batchIngestionConfig = new BatchIngestionConfig(Lists.newArrayList(batchConfigMapOverride),
-          _batchIngestionConfig.getSegmentIngestionType(), _batchIngestionConfig.getSegmentIngestionFrequency());
 
       // Build segment
       SegmentGeneratorConfig segmentGeneratorConfig =
-          IngestionUtils.generateSegmentGeneratorConfig(_tableConfig, _schema, batchIngestionConfig);
+          IngestionUtils.generateSegmentGeneratorConfig(_tableConfig, _schema, batchConfigMapOverride);
       String segmentName = IngestionUtils.buildSegment(segmentGeneratorConfig);
       LOGGER.info("Successfully built segment: {} for table: {}", segmentName, _tableNameWithType);
 

--- a/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/src/main/java/org/apache/pinot/plugin/segmentwriter/filebased/FileBasedSegmentWriter.java
+++ b/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/src/main/java/org/apache/pinot/plugin/segmentwriter/filebased/FileBasedSegmentWriter.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -81,7 +82,12 @@ public class FileBasedSegmentWriter implements SegmentWriter {
   private GenericData.Record _reusableRecord;
 
   @Override
-  public void init(TableConfig tableConfig, Schema schema)
+  public void init(TableConfig tableConfig, Schema schema) throws Exception {
+    init(tableConfig, schema, Collections.emptyMap());
+  }
+
+  @Override
+  public void init(TableConfig tableConfig, Schema schema, Map<String, String> batchConfigOverride)
       throws Exception {
     _tableConfig = tableConfig;
     _tableNameWithType = _tableConfig.getTableName();
@@ -95,7 +101,11 @@ public class FileBasedSegmentWriter implements SegmentWriter {
     _batchIngestionConfig = _tableConfig.getIngestionConfig().getBatchIngestionConfig();
     Preconditions.checkState(_batchIngestionConfig.getBatchConfigMaps().size() == 1,
         "batchConfigMaps must contain only 1 BatchConfig for table: %s", _tableNameWithType);
-    _batchConfig = new BatchConfig(_tableNameWithType, _batchIngestionConfig.getBatchConfigMaps().get(0));
+
+    // apply config override provided by user.
+    Map<String, String> batchConfigMap = new HashMap<>(_batchIngestionConfig.getBatchConfigMaps().get(0));
+    batchConfigMap.putAll(batchConfigOverride);
+    _batchConfig = new BatchConfig(_tableNameWithType, batchConfigMap);
 
     Preconditions.checkState(StringUtils.isNotBlank(_batchConfig.getOutputDirURI()),
         "Must provide: %s in batchConfigs for table: %s", BatchConfigProperties.OUTPUT_DIR_URI, _tableNameWithType);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/segment/uploader/SegmentUploader.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/segment/uploader/SegmentUploader.java
@@ -19,10 +19,12 @@
 package org.apache.pinot.spi.ingestion.segment.uploader;
 
 import java.net.URI;
+import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.annotations.InterfaceStability;
 import org.apache.pinot.spi.auth.AuthContext;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
 
 
 /**
@@ -32,10 +34,17 @@ import org.apache.pinot.spi.config.table.TableConfig;
 public interface SegmentUploader {
 
   /**
-   * Initializes the {@link SegmentUploader}
-   * @param tableConfig The table config for the segment upload
+   * @see #init(TableConfig, Map)
    */
   void init(TableConfig tableConfig)
+      throws Exception;
+
+  /**
+   * Initializes the {@link SegmentUploader}
+   * @param tableConfig The table config for the segment upload
+   * @param batchConfigOverride The config override on top of tableConfig
+   */
+  void init(TableConfig tableConfig, Map<String, String> batchConfigOverride)
       throws Exception;
 
   /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/segment/uploader/SegmentUploader.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/segment/uploader/SegmentUploader.java
@@ -24,7 +24,6 @@ import javax.annotation.Nullable;
 import org.apache.pinot.spi.annotations.InterfaceStability;
 import org.apache.pinot.spi.auth.AuthContext;
 import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.data.Schema;
 
 
 /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/segment/writer/SegmentWriter.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/segment/writer/SegmentWriter.java
@@ -20,6 +20,7 @@ package org.apache.pinot.spi.ingestion.segment.writer;
 
 import java.io.Closeable;
 import java.net.URI;
+import java.util.Map;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
@@ -32,11 +33,18 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 public interface SegmentWriter extends Closeable {
 
   /**
+   * @see #init(TableConfig, Schema, Map)
+   */
+  void init(TableConfig tableConfig, Schema schema)
+      throws Exception;
+
+  /**
    * Initializes the {@link SegmentWriter} with provided tableConfig and Pinot schema.
    * @param tableConfig The table config for the segment
    * @param schema The Pinot schema for the table
+   * @param batchConfigOverride The config override on top of tableConfig
    */
-  void init(TableConfig tableConfig, Schema schema)
+  void init(TableConfig tableConfig, Schema schema, Map<String, String> batchConfigOverride)
       throws Exception;
 
   /**


### PR DESCRIPTION
## Description
Currently the `SegmentWriter` and `SegmentUploader` doesn't allow overrides on top of TableConfig.

However, it looks like the `BatchConfig` construct is exactly built to allow overrides on top of the `BatchIngestionConfig`. Making additional APIs in both interfaces to support an optional override Map.

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options - NO
- Deprecation of configurations - NO
- Signature changes to public methods/interfaces - NO (no changes, only additions)
- New plugins added or old plugins removed - NO

## Release Notes
- Adding optional `Map<String, String> batchConfigOverride` argument to `SegmentWriter` and `SegmentUploader`.

## Documentation
N/A

