### PR TITLE
add a linter checker

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -38,6 +38,19 @@ on:
       - "**.md"
 
 jobs:
+  linter-test:
+    runs-on: ubuntu-latest
+    name: Pinot Unit Test Set ${{ matrix.testset }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Linter Test
+        env:
+          MAVEN_OPTS: -Xmx2G -DskipShade -DfailIfNoTests=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false
+        run: .github/workflows/scripts/.pinot_linter.sh
   unit-test:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -40,7 +40,7 @@ on:
 jobs:
   linter-test:
     runs-on: ubuntu-latest
-    name: Pinot Unit Test Set ${{ matrix.testset }}
+    name: Pinot Linter Test Set
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK 11

--- a/.github/workflows/scripts/.pinot_linter.sh
+++ b/.github/workflows/scripts/.pinot_linter.sh
@@ -25,11 +25,9 @@ java -version
 ifconfig
 netstat -i
 
-# mvn clean install -DskipTests -T 16 || exit 1
 
 mvn rat:check
 mvn checkstyle:check
 mvn spotless:check
 mvn enforcer:enforce
 
-mvn clean > /dev/null

--- a/.github/workflows/scripts/.pinot_linter.sh
+++ b/.github/workflows/scripts/.pinot_linter.sh
@@ -1,0 +1,35 @@
+#!/bin/bash -x
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Java version
+java -version
+
+# Check network
+ifconfig
+netstat -i
+
+# mvn clean install -DskipTests -T 16 || exit 1
+
+mvn rat:check
+mvn checkstyle:check
+mvn spotless:check
+mvn enforcer:enforce
+
+mvn clean > /dev/null


### PR DESCRIPTION
Create a linter-test.

This would help CI to fail-fast when checkstyle/linter/spotless/rat is broken.

Testing in: https://github.com/apache/pinot/pull/7469. 
https://github.com/apache/pinot/actions/runs/1263459692 shows that linter issue will cancel all other tests within 4 minutes