### PR TITLE
add SingleSpaceSeparator rule and fix recent violations

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -171,6 +171,7 @@
     </module>
     <module name="WhitespaceAfter"/>
     <module name="WhitespaceAround"/>
+    <module name="SingleSpaceSeparator"/>
 
     <!-- Allow Checkstyle warnings to be suppressed using trailing comments -->
     <module name="SuppressWithNearbyCommentFilter"/>

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/RangeIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/RangeIndexCreatorTest.java
@@ -263,7 +263,7 @@ public class RangeIndexCreatorTest {
         int[] coveredRange = ((int[][]) ranges)[1];
         int[] upperPartialRange = ((int[][]) ranges)[2];
         ImmutableRoaringBitmap matches = rangeIndexReader.getMatchingDocIds(lowerPartialRange[0], upperPartialRange[1]);
-        assertNotNull(matches,  "matches for covered range must not be null");
+        assertNotNull(matches, "matches for covered range must not be null");
         for (int docId : matches.toArray()) {
           checkValueForDocId(dataType, values, ranges, 1, docId, numValuesPerMVEntry);
         }
@@ -305,7 +305,7 @@ public class RangeIndexCreatorTest {
         long[] coveredRange = ((long[][]) ranges)[1];
         long[] upperPartialRange = ((long[][]) ranges)[2];
         ImmutableRoaringBitmap matches = rangeIndexReader.getMatchingDocIds(lowerPartialRange[0], upperPartialRange[1]);
-        assertNotNull(matches,  "matches for covered range must not be null");
+        assertNotNull(matches, "matches for covered range must not be null");
         for (int docId : matches.toArray()) {
           checkValueForDocId(dataType, values, ranges, 1, docId, numValuesPerMVEntry);
         }
@@ -347,7 +347,7 @@ public class RangeIndexCreatorTest {
         float[] coveredRange = ((float[][]) ranges)[1];
         float[] upperPartialRange = ((float[][]) ranges)[2];
         ImmutableRoaringBitmap matches = rangeIndexReader.getMatchingDocIds(lowerPartialRange[0], upperPartialRange[1]);
-        assertNotNull(matches,  "matches for covered range must not be null");
+        assertNotNull(matches, "matches for covered range must not be null");
         for (int docId : matches.toArray()) {
           checkValueForDocId(dataType, values, ranges, 1, docId, numValuesPerMVEntry);
         }
@@ -389,7 +389,7 @@ public class RangeIndexCreatorTest {
         double[] coveredRange = ((double[][]) ranges)[1];
         double[] upperPartialRange = ((double[][]) ranges)[2];
         ImmutableRoaringBitmap matches = rangeIndexReader.getMatchingDocIds(lowerPartialRange[0], upperPartialRange[1]);
-        assertNotNull(matches,  "matches for covered range must not be null");
+        assertNotNull(matches, "matches for covered range must not be null");
         for (int docId : matches.toArray()) {
           checkValueForDocId(dataType, values, ranges, 1, docId, numValuesPerMVEntry);
         }


### PR DESCRIPTION
## Description
I recently committed changes with double white spaces by mistake. This removes them and adds a checkstyle rule to prevent it from happening again.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
