### PR TITLE
Replace emptiness checks with `isEmpty()`

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerResponse.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerResponse.java
@@ -43,7 +43,7 @@ class BrokerResponse {
   }
 
   boolean hasExceptions() {
-    return _exceptions != null && _exceptions.size() != 0;
+    return _exceptions != null && !_exceptions.isEmpty();
   }
 
   JsonNode getExceptions() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadataCustomMapModifier.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadataCustomMapModifier.java
@@ -59,7 +59,7 @@ public class SegmentZKMetadataCustomMapModifier {
     JsonNode jsonNode = JsonUtils.stringToJsonNode(jsonString);
     _modifyMode = ModifyMode.valueOf(jsonNode.get(MAP_MODIFY_MODE_KEY).asText());
     JsonNode jsonMap = jsonNode.get(MAP_KEY);
-    if (jsonMap == null || jsonMap.size() == 0) {
+    if (jsonMap == null || jsonMap.isEmpty()) {
       _map = null;
     } else {
       _map = new HashMap<>();

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/NamedThreadFactory.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/NamedThreadFactory.java
@@ -67,7 +67,7 @@ public class NamedThreadFactory implements ThreadFactory {
   }
 
   private static String checkPrefix(String prefix) {
-    return prefix == null || prefix.length() == 0 ? "Pinot" : prefix;
+    return prefix == null || prefix.isEmpty() ? "Pinot" : prefix;
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
@@ -106,7 +106,7 @@ public class PinotQuery2BrokerRequestConverter {
 
   private void convertGroupBy(PinotQuery pinotQuery, BrokerRequest brokerRequest) {
     List<Expression> groupByList = pinotQuery.getGroupByList();
-    if (groupByList != null && groupByList.size() > 0) {
+    if (groupByList != null && !groupByList.isEmpty()) {
       GroupBy groupBy = new GroupBy();
       for (Expression expression : groupByList) {
         String expressionStr = ParserUtils.standardizeExpression(expression, true);
@@ -164,7 +164,7 @@ public class PinotQuery2BrokerRequestConverter {
       }
     }
 
-    if (aggregationInfoList != null && aggregationInfoList.size() > 0) {
+    if (aggregationInfoList != null && !aggregationInfoList.isEmpty()) {
       brokerRequest.setAggregationsInfo(aggregationInfoList);
     } else if (selection != null) {
       if (pinotQuery.isSetOffset()) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -284,7 +284,7 @@ public class PinotQueryResource {
       conn.setRequestProperty("http.keepAlive", String.valueOf(true));
       conn.setRequestProperty("default", String.valueOf(true));
 
-      if (headers != null && headers.size() > 0) {
+      if (headers != null && !headers.isEmpty()) {
         final Set<Entry<String, String>> entries = headers.entrySet();
         for (final Entry<String, String> entry : entries) {
           conn.setRequestProperty(entry.getKey(), entry.getValue());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableDebugResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableDebugResource.java
@@ -347,7 +347,7 @@ public class TableDebugResource {
       PropertyKey.Builder keyBuilder = accessor.keyBuilder();
       List<String> sessionIds = accessor.getChildNames(keyBuilder.errors(instanceName));
 
-      if (sessionIds == null || sessionIds.size() == 0) {
+      if (sessionIds == null || sessionIds.isEmpty()) {
         return serverDebugInfos;
       }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -155,7 +155,7 @@ public class SegmentDeletionManager {
     LOGGER.info("Deleted {} segments from table {}:{}", segmentsToDelete.size(), tableName,
         segmentsToDelete.size() <= 5 ? segmentsToDelete : "");
 
-    if (segmentsToRetryLater.size() > 0) {
+    if (!segmentsToRetryLater.isEmpty()) {
       long effectiveDeletionDelay = Math.min(deletionDelay * 2, MAX_DELETION_DELAY_SECONDS);
       LOGGER.info("Postponing deletion of {} segments from table {}", segmentsToRetryLater.size(), tableName);
       deleteSegmentsWithDelay(tableName, segmentsToRetryLater, effectiveDeletionDelay);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotRealtimeSegmentManager.java
@@ -148,7 +148,7 @@ public class PinotRealtimeSegmentManager implements HelixPropertyListener, IZkCh
         IdealState state = idealStateMap.get(realtimeTableName);
 
         // Are there any partitions?
-        if (state.getPartitionSet().size() == 0) {
+        if (state.getPartitionSet().isEmpty()) {
           // No, this is a brand new ideal state, so we will add one new segment to every partition and replica
           List<String> instancesInResource = new ArrayList<>();
           try {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/utils/QueryInvertedSortedIndexRecommender.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/utils/QueryInvertedSortedIndexRecommender.java
@@ -246,7 +246,7 @@ public class QueryInvertedSortedIndexRecommender {
         double nESIWithIdx = previousPair.getRight().getnESIWithIdx();
         FixedLenBitset candidateDims = mutableEmptySet().union(previousPair.getRight().getCandidateDims());
 
-        while (totalNESIWithIdxSorted.size() > 0) {
+        while (!totalNESIWithIdxSorted.isEmpty()) {
           previousPair = totalNESIWithIdxSorted.remove(0);
           childResults.remove(previousPair.getRight());
           candidateDims.union(previousPair.getRight().getCandidateDims());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/AutoAddInvertedIndex.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/AutoAddInvertedIndex.java
@@ -224,7 +224,7 @@ public class AutoAddInvertedIndex {
 
       // Skip tables without dimensions
       List<String> dimensionNames = tableSchema.getDimensionNames();
-      if (dimensionNames.size() == 0) {
+      if (dimensionNames.isEmpty()) {
         LOGGER.info("Table: {}, skip adding inverted index because it does not have any dimension column",
             tableNameWithType);
         continue;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableIngestionStatusHelper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableIngestionStatusHelper.java
@@ -85,7 +85,7 @@ public class TableIngestionStatusHelper {
           continue;
       }
     }
-    if (failedTasks.size() > 0) {
+    if (!failedTasks.isEmpty()) {
       ingestionState = TableStatus.IngestionState.UNHEALTHY;
       errorMessage = "Follow ingestion tasks have failed: " + failedTasks.toString();
     }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
@@ -66,7 +66,7 @@ public class PinotInstanceRestletResourceTest {
         String getResponse = ControllerTestUtils.sendGetRequest(listInstancesUrl);
         JsonNode jsonNode = JsonUtils.stringToJsonNode(getResponse);
 
-        if (jsonNode != null && jsonNode.get("instances") != null && jsonNode.get("instances").size() > 0) {
+        if (jsonNode != null && jsonNode.get("instances") != null && !jsonNode.get("instances").isEmpty()) {
           JsonNode instances = jsonNode.get("instances");
           counts[0] = instances.size();
           for (int i = 0; i < counts[0]; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
@@ -131,7 +131,7 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
     try {
       _lookupTable.clear();
       List<SegmentDataManager> segmentManagers = acquireAllSegments();
-      if (segmentManagers.size() == 0) {
+      if (segmentManagers.isEmpty()) {
         return;
       }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentConverter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentConverter.java
@@ -126,7 +126,7 @@ public class SegmentConverter {
       File outputSegment = new File(mapperOutputPath + File.separator + outputSegmentName);
 
       // Sorting on group-by columns & Reduce stage
-      if (_recordAggregator != null && _groupByColumns != null && _groupByColumns.size() > 0) {
+      if (_recordAggregator != null && _groupByColumns != null && !_groupByColumns.isEmpty()) {
         String reducerOutputPath = _workingDir.getPath() + File.separator + REDUCER_PREFIX + currentPartition;
         try (ReducerRecordReader reducerRecordReader = new ReducerRecordReader(outputSegment, _recordAggregator,
             _groupByColumns)) {
@@ -244,7 +244,7 @@ public class SegmentConverter {
 
     public SegmentConverter build() {
       // Check that the group-by columns and record aggregator are configured together
-      if (_groupByColumns != null && _groupByColumns.size() > 0) {
+      if (_groupByColumns != null && !_groupByColumns.isEmpty()) {
         Preconditions
             .checkNotNull(_recordAggregator, "If group-by columns are given, the record aggregator is required.");
       } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/IntermediateResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/IntermediateResultsBlock.java
@@ -470,7 +470,7 @@ public class IntermediateResultsBlock implements Block {
     if (_numGroupsLimitReached) {
       dataTable.getMetadata().put(MetadataKey.NUM_GROUPS_LIMIT_REACHED.getName(), "true");
     }
-    if (_processingExceptions != null && _processingExceptions.size() > 0) {
+    if (_processingExceptions != null && !_processingExceptions.isEmpty()) {
       for (ProcessingException exception : _processingExceptions) {
         dataTable.addException(exception);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
@@ -73,7 +73,7 @@ public class CountAggregationFunction implements AggregationFunction<Long, Long>
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    if (blockValSetMap.size() == 0) {
+    if (blockValSetMap.isEmpty()) {
       aggregationResultHolder.setValue(aggregationResultHolder.getDoubleResult() + length);
     } else {
       // Star-tree pre-aggregated values
@@ -89,7 +89,7 @@ public class CountAggregationFunction implements AggregationFunction<Long, Long>
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    if (blockValSetMap.size() == 0) {
+    if (blockValSetMap.isEmpty()) {
       for (int i = 0; i < length; i++) {
         int groupKey = groupKeyArray[i];
         groupByResultHolder.setValueForKey(groupKey, groupByResultHolder.getDoubleResult(groupKey) + 1);
@@ -107,7 +107,7 @@ public class CountAggregationFunction implements AggregationFunction<Long, Long>
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    if (blockValSetMap.size() == 0) {
+    if (blockValSetMap.isEmpty()) {
       for (int i = 0; i < length; i++) {
         for (int groupKey : groupKeysArray[i]) {
           groupByResultHolder.setValueForKey(groupKey, groupByResultHolder.getDoubleResult(groupKey) + 1);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/DistinctTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/DistinctTable.java
@@ -143,6 +143,13 @@ public class DistinctTable {
     return _records.size();
   }
 
+  /**
+   * Returns true if the DistinctTable is empty.
+   */
+  public boolean isEmpty() {
+    return _records.isEmpty();
+  }
+
   @VisibleForTesting
   public Collection<Record> getRecords() {
     return _records;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizer.java
@@ -138,7 +138,7 @@ public class NumericalFilterOptimizer implements FilterOptimizer {
 
       // Remove all Literal operands that are TRUE.
       operands.removeIf(x -> x.equals(TRUE));
-      if (operands.size() == 0) {
+      if (operands.isEmpty()) {
         return setExpressionToBoolean(expression, true);
       }
     } else if (function.getOperator().equals(FilterKind.OR.name())) {
@@ -151,7 +151,7 @@ public class NumericalFilterOptimizer implements FilterOptimizer {
 
       // Remove all Literal operands that are FALSE.
       operands.removeIf(x -> x.equals(FALSE));
-      if (operands.size() == 0) {
+      if (operands.isEmpty()) {
         return setExpressionToBoolean(expression, false);
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -113,7 +113,7 @@ public class BrokerReduceService {
 
   public BrokerResponseNative reduceOnDataTable(BrokerRequest brokerRequest,
       Map<ServerRoutingInstance, DataTable> dataTableMap, long reduceTimeOutMs, @Nullable BrokerMetrics brokerMetrics) {
-    if (dataTableMap.size() == 0) {
+    if (dataTableMap.isEmpty()) {
       // Empty response.
       return BrokerResponseNative.empty();
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
@@ -73,7 +73,7 @@ public class DistinctDataTableReducer implements DataTableReducer {
     List<DistinctTable> nonEmptyDistinctTables = new ArrayList<>(dataTableMap.size());
     for (DataTable dataTable : dataTableMap.values()) {
       DistinctTable distinctTable = dataTable.getObject(0, 0);
-      if (distinctTable.size() > 0) {
+      if (!distinctTable.isEmpty()) {
         nonEmptyDistinctTables.add(distinctTable);
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/PeerServerSegmentFinder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/PeerServerSegmentFinder.java
@@ -77,7 +77,7 @@ public class PeerServerSegmentFinder {
           .attempt(() -> {
             getOnlineServersFromExternalView(segmentName, downloadScheme, tableNameWithType, helixAdmin, clusterName,
                 onlineServerURIs);
-            return onlineServerURIs.size() > 0;
+            return !onlineServerURIs.isEmpty();
           });
     } catch (Exception e) {
       _logger.error("Failure in getting online servers for segment {}", segmentName, e);

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/SortedRangeIntersection.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/SortedRangeIntersection.java
@@ -34,7 +34,7 @@ public class SortedRangeIntersection {
   }
 
   public static List<IntPair> intersectSortedRangeSets(List<List<IntPair>> sortedRangeSetList) {
-    if (sortedRangeSetList == null || sortedRangeSetList.size() == 0) {
+    if (sortedRangeSetList == null || sortedRangeSetList.isEmpty()) {
       return Collections.emptyList();
     }
     if (sortedRangeSetList.size() == 1) {
@@ -42,7 +42,7 @@ public class SortedRangeIntersection {
     }
     // if any list is empty return empty
     for (List<IntPair> rangeSet : sortedRangeSetList) {
-      if (rangeSet.size() == 0) {
+      if (rangeSet.isEmpty()) {
         return Collections.emptyList();
       }
     }
@@ -105,7 +105,7 @@ public class SortedRangeIntersection {
         intersection.setLeft(start);
         intersection.setRight(end);
       }
-      if (result.size() > 0) {
+      if (!result.isEmpty()) {
         // if new range is contiguous merge it
         IntPair prevIntersection = result.get(result.size() - 1);
         if (intersection.getLeft() == prevIntersection.getRight() + 1) {

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
@@ -808,13 +808,13 @@ public class ClusterIntegrationTestUtils {
 
     List<String> orderByColumns = new ArrayList<>();
     if (isSelectionQuery(brokerRequest) && brokerRequest.getOrderBy() != null
-        && brokerRequest.getOrderBy().size() > 0) {
+        && !brokerRequest.getOrderBy().isEmpty()) {
       orderByColumns.addAll(CalciteSqlParser.extractIdentifiers(brokerRequest.getPinotQuery().getOrderByList(), false));
     }
 
     // broker response
     JsonNode pinotResponse = ClusterTest.postSqlQuery(pinotQuery, brokerUrl, headers);
-    if (pinotResponse.get("exceptions").size() > 0) {
+    if (!pinotResponse.get("exceptions").isEmpty()) {
       throw new RuntimeException("Got Exceptions from Query Response: " + pinotResponse);
     }
     JsonNode brokerResponseRows = pinotResponse.get("resultTable").get("rows");
@@ -879,7 +879,7 @@ public class ClusterIntegrationTestUtils {
         // TODO: compare results for aggregation group by queries w/o order by
 
         // Compare results for aggregation group by queries with order by
-        if (brokerRequest.getOrderBy() != null && brokerRequest.getOrderBy().size() > 0) {
+        if (brokerRequest.getOrderBy() != null && !brokerRequest.getOrderBy().isEmpty()) {
           // don't compare query with multi-value column.
           if (sqlQuery.contains("_MV")) {
             return;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/compat/tests/SqlResultComparator.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/compat/tests/SqlResultComparator.java
@@ -276,7 +276,7 @@ public class SqlResultComparator {
   }
 
   public static boolean hasExceptions(JsonNode actual) {
-    if (actual.get(FIELD_EXCEPTIONS).size() != 0) {
+    if (!actual.get(FIELD_EXCEPTIONS).isEmpty()) {
       LOGGER.error("Got exception: {} when querying!", actual.get(FIELD_EXCEPTIONS));
       return true;
     }
@@ -414,7 +414,7 @@ public class SqlResultComparator {
   public static boolean isEmpty(JsonNode response) {
     int numDocsScanned = response.get(FIELD_NUM_DOCS_SCANNED).asInt();
     return numDocsScanned == 0 || !response.has(FIELD_RESULT_TABLE)
-        || response.get(FIELD_RESULT_TABLE).get(FIELD_ROWS).size() == 0;
+        || response.get(FIELD_RESULT_TABLE).get(FIELD_ROWS).isEmpty();
   }
 
   private static boolean areLengthsEqual(JsonNode actual, JsonNode expected) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/compat/tests/StreamOp.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/compat/tests/StreamOp.java
@@ -276,7 +276,7 @@ public class StreamOp extends BaseOp {
       throw new RuntimeException(errorMsg);
     }
 
-    if (response.has(EXCEPTIONS) && response.get(EXCEPTIONS).size() > 0) {
+    if (response.has(EXCEPTIONS) && !response.get(EXCEPTIONS).isEmpty()) {
       String errorMsg =
           String.format("Failed when running query: '%s'; got exceptions:\n%s\n", query, response.toPrettyString());
       JsonNode exceptions = response.get(EXCEPTIONS);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -438,7 +438,7 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
         String sqlQuery = query.get("sql").asText();
         JsonNode hsqls = query.get("hsqls");
         List<String> sqlQueries = new ArrayList<>();
-        if (hsqls == null || hsqls.size() == 0) {
+        if (hsqls == null || hsqls.isEmpty()) {
           sqlQueries.add(sqlQuery);
         } else {
           for (int i = 0; i < hsqls.size(); i++) {
@@ -596,7 +596,7 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
       try {
         JsonNode routingTables = getDebugInfo("debug/routingTable/" + getTableName());
         for (JsonNode routingTable : routingTables) {
-          if ((routingTable.size() == 0) != shouldBeEmpty) {
+          if ((routingTable.isEmpty()) != shouldBeEmpty) {
             return false;
           }
         }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/JsonPathClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/JsonPathClusterIntegrationTest.java
@@ -147,7 +147,7 @@ public class JsonPathClusterIntegrationTest extends BaseClusterIntegrationTest {
     JsonNode pinotResponse = postQuery(pqlQuery);
     ArrayNode selectionResults = (ArrayNode) pinotResponse.get("selectionResults").get("results");
     Assert.assertNotNull(selectionResults);
-    Assert.assertTrue(selectionResults.size() > 0);
+    Assert.assertFalse(selectionResults.isEmpty());
     for (int i = 0; i < selectionResults.size(); i++) {
       String value = selectionResults.get(i).get(0).textValue();
       Assert.assertTrue(value.indexOf("-k1-") > 0);
@@ -159,7 +159,7 @@ public class JsonPathClusterIntegrationTest extends BaseClusterIntegrationTest {
     pinotResponse = postQuery(pqlQuery);
     selectionResults = (ArrayNode) pinotResponse.get("selectionResults").get("results");
     Assert.assertNotNull(selectionResults);
-    Assert.assertTrue(selectionResults.size() > 0);
+    Assert.assertFalse(selectionResults.isEmpty());
     for (int i = 0; i < selectionResults.size(); i++) {
       String value = selectionResults.get(i).get(0).textValue();
       Assert.assertEquals(value, "value-k1-0");
@@ -170,7 +170,7 @@ public class JsonPathClusterIntegrationTest extends BaseClusterIntegrationTest {
     pinotResponse = postQuery(pqlQuery);
     selectionResults = (ArrayNode) pinotResponse.get("selectionResults").get("results");
     Assert.assertNotNull(selectionResults);
-    Assert.assertTrue(selectionResults.size() > 0);
+    Assert.assertFalse(selectionResults.isEmpty());
     for (int i = 0; i < selectionResults.size(); i++) {
       String value = selectionResults.get(i).get(0).textValue();
       Assert.assertEquals(value, "value-k1-0");
@@ -182,7 +182,7 @@ public class JsonPathClusterIntegrationTest extends BaseClusterIntegrationTest {
     pinotResponse = postQuery(pqlQuery);
     selectionResults = (ArrayNode) pinotResponse.get("selectionResults").get("results");
     Assert.assertNotNull(selectionResults);
-    Assert.assertTrue(selectionResults.size() > 0);
+    Assert.assertFalse(selectionResults.isEmpty());
     for (int i = 0; i < selectionResults.size(); i++) {
       String value = selectionResults.get(i).get(0).textValue();
       Assert.assertTrue(value.indexOf("-k1-") > 0);
@@ -192,7 +192,7 @@ public class JsonPathClusterIntegrationTest extends BaseClusterIntegrationTest {
     pinotResponse = postQuery(pqlQuery);
     selectionResults = (ArrayNode) pinotResponse.get("selectionResults").get("results");
     Assert.assertNotNull(selectionResults);
-    Assert.assertTrue(selectionResults.size() > 0);
+    Assert.assertFalse(selectionResults.isEmpty());
     for (int i = 0; i < selectionResults.size(); i++) {
       String value = selectionResults.get(i).get(0).textValue();
       Assert.assertTrue(value.indexOf("-k1-") > 0);
@@ -205,7 +205,7 @@ public class JsonPathClusterIntegrationTest extends BaseClusterIntegrationTest {
     JsonNode groupByResult = pinotResponse.get("aggregationResults").get(0).get("groupByResult");
     Assert.assertNotNull(groupByResult);
     Assert.assertTrue(groupByResult.isArray());
-    Assert.assertTrue(groupByResult.size() > 0);
+    Assert.assertFalse(groupByResult.isEmpty());
 
     pqlQuery = "Select count(*) from " + DEFAULT_TABLE_NAME + " group by " + MY_MAP_STR_K1_FIELD_NAME;
     pinotResponse = postQuery(pqlQuery);
@@ -213,7 +213,7 @@ public class JsonPathClusterIntegrationTest extends BaseClusterIntegrationTest {
     groupByResult = pinotResponse.get("aggregationResults").get(0).get("groupByResult");
     Assert.assertNotNull(groupByResult);
     Assert.assertTrue(groupByResult.isArray());
-    Assert.assertTrue(groupByResult.size() > 0);
+    Assert.assertFalse(groupByResult.isEmpty());
   }
 
   @Test
@@ -224,7 +224,7 @@ public class JsonPathClusterIntegrationTest extends BaseClusterIntegrationTest {
     JsonNode pinotResponse = postSqlQuery(sqlQuery);
     ArrayNode rows = (ArrayNode) pinotResponse.get("resultTable").get("rows");
     Assert.assertNotNull(rows);
-    Assert.assertTrue(rows.size() > 0);
+    Assert.assertFalse(rows.isEmpty());
     for (int i = 0; i < rows.size(); i++) {
       String value = rows.get(i).get(0).textValue();
       Assert.assertTrue(value.indexOf("-k1-") > 0);
@@ -236,7 +236,7 @@ public class JsonPathClusterIntegrationTest extends BaseClusterIntegrationTest {
     pinotResponse = postSqlQuery(sqlQuery);
     rows = (ArrayNode) pinotResponse.get("resultTable").get("rows");
     Assert.assertNotNull(rows);
-    Assert.assertTrue(rows.size() > 0);
+    Assert.assertFalse(rows.isEmpty());
     for (int i = 0; i < rows.size(); i++) {
       String value = rows.get(i).get(0).textValue();
       Assert.assertEquals(value, "value-k1-0");
@@ -248,7 +248,7 @@ public class JsonPathClusterIntegrationTest extends BaseClusterIntegrationTest {
     pinotResponse = postSqlQuery(sqlQuery);
     rows = (ArrayNode) pinotResponse.get("resultTable").get("rows");
     Assert.assertNotNull(rows);
-    Assert.assertTrue(rows.size() > 0);
+    Assert.assertFalse(rows.isEmpty());
     for (int i = 0; i < rows.size(); i++) {
       String value = rows.get(i).get(0).textValue();
       Assert.assertTrue(value.indexOf("-k1-") > 0);
@@ -275,7 +275,7 @@ public class JsonPathClusterIntegrationTest extends BaseClusterIntegrationTest {
     ArrayNode selectionResults = (ArrayNode) pinotResponse.get("selectionResults").get("results");
 
     Assert.assertNotNull(selectionResults);
-    Assert.assertTrue(selectionResults.size() > 0);
+    Assert.assertFalse(selectionResults.isEmpty());
     for (int i = 0; i < selectionResults.size(); i++) {
       String value = selectionResults.get(i).get(0).textValue();
       Map results = JsonUtils.stringToObject(value, Map.class);
@@ -301,7 +301,7 @@ public class JsonPathClusterIntegrationTest extends BaseClusterIntegrationTest {
     System.out.println("selectionResults = " + selectionResults);
 
     Assert.assertNotNull(selectionResults);
-    Assert.assertTrue(selectionResults.size() > 0);
+    Assert.assertFalse(selectionResults.isEmpty());
     for (int i = 0; i < selectionResults.size(); i++) {
       JsonNode k3 = selectionResults.get(i).get(0);
       Assert.assertEquals(k3.size(), 3);
@@ -329,7 +329,7 @@ public class JsonPathClusterIntegrationTest extends BaseClusterIntegrationTest {
     pinotResponse = postQuery(pqlQuery);
     selectionResults = (ArrayNode) pinotResponse.get("selectionResults").get("results");
     Assert.assertNotNull(selectionResults);
-    Assert.assertTrue(selectionResults.size() > 0);
+    Assert.assertFalse(selectionResults.isEmpty());
     for (int i = 0; i < selectionResults.size(); i++) {
       String value = selectionResults.get(i).get(0).textValue();
       Assert.assertTrue(value.indexOf("-k1-") > 0);
@@ -356,7 +356,7 @@ public class JsonPathClusterIntegrationTest extends BaseClusterIntegrationTest {
     JsonNode groupByResult = pinotResponse.get("aggregationResults").get(0).get("groupByResult");
     Assert.assertNotNull(groupByResult);
     Assert.assertTrue(groupByResult.isArray());
-    Assert.assertTrue(groupByResult.size() > 0);
+    Assert.assertFalse(groupByResult.isEmpty());
     for (int i = 0; i < groupByResult.size(); i++) {
       String seqId = _sortedSequenceIds.get(NUM_TOTAL_DOCS - 1 - i);
       final JsonNode groupbyRes = groupByResult.get(i);
@@ -374,7 +374,7 @@ public class JsonPathClusterIntegrationTest extends BaseClusterIntegrationTest {
     ArrayNode rows = (ArrayNode) pinotResponse.get("resultTable").get("rows");
 
     Assert.assertNotNull(rows);
-    Assert.assertTrue(rows.size() > 0);
+    Assert.assertFalse(rows.isEmpty());
     for (int i = 0; i < rows.size(); i++) {
       String value = rows.get(i).get(0).textValue();
       Map results = JsonUtils.stringToObject(value, Map.class);
@@ -413,7 +413,7 @@ public class JsonPathClusterIntegrationTest extends BaseClusterIntegrationTest {
     pinotResponse = postSqlQuery(sqlQuery);
     rows = (ArrayNode) pinotResponse.get("resultTable").get("rows");
     Assert.assertNotNull(rows);
-    Assert.assertTrue(rows.size() > 0);
+    Assert.assertFalse(rows.isEmpty());
     for (int i = 0; i < rows.size(); i++) {
       String value = rows.get(i).get(0).textValue();
       Assert.assertTrue(value.indexOf("-k1-") > 0);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -257,7 +257,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       try {
         JsonNode queryResponse = postQuery(TEST_TIMEOUT_QUERY);
         JsonNode exceptions = queryResponse.get("exceptions");
-        if (exceptions.size() != 0) {
+        if (!exceptions.isEmpty()) {
           // Timed out on broker side
           return exceptions.get(0).get("errorCode").asInt() == QueryException.BROKER_TIMEOUT_ERROR_CODE;
         } else {
@@ -281,7 +281,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       try {
         JsonNode queryResponse = postQuery(TEST_TIMEOUT_QUERY);
         JsonNode exceptions = queryResponse.get("exceptions");
-        if (exceptions.size() != 0) {
+        if (!exceptions.isEmpty()) {
           return false;
         }
         int numServersQueried = queryResponse.get("numServersQueried").asInt();
@@ -1093,7 +1093,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     JsonNode response = postQuery(pqlQuery);
     ArrayNode selectionResults = (ArrayNode) response.get("selectionResults").get("results");
     assertNotNull(selectionResults);
-    assertTrue(selectionResults.size() > 0);
+    assertFalse(selectionResults.isEmpty());
     for (int i = 0; i < selectionResults.size(); i++) {
       long daysSinceEpoch = selectionResults.get(i).get(0).asLong();
       long secondsSinceEpoch = selectionResults.get(i).get(1).asLong();
@@ -1106,7 +1106,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     response = postQuery(pqlQuery);
     selectionResults = (ArrayNode) response.get("selectionResults").get("results");
     assertNotNull(selectionResults);
-    assertTrue(selectionResults.size() > 0);
+    assertFalse(selectionResults.isEmpty());
     long prevValue = -1;
     for (int i = 0; i < selectionResults.size(); i++) {
       long daysSinceEpoch = selectionResults.get(i).get(0).asLong();
@@ -1122,7 +1122,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     response = postQuery(pqlQuery);
     selectionResults = (ArrayNode) response.get("selectionResults").get("results");
     assertNotNull(selectionResults);
-    assertTrue(selectionResults.size() > 0);
+    assertFalse(selectionResults.isEmpty());
     prevValue = Long.MAX_VALUE;
     for (int i = 0; i < selectionResults.size(); i++) {
       long daysSinceEpoch = selectionResults.get(i).get(0).asLong();

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -152,7 +152,7 @@ public class S3PinotFS extends PinotFS {
   }
 
   boolean isNullOrEmpty(String target) {
-    return target == null || "".equals(target);
+    return target == null || target.isEmpty();
   }
 
   private HeadObjectResponse getS3ObjectMetadata(URI uri)

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
@@ -130,7 +130,7 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
         GetRecordsRequest getRecordsRequest = GetRecordsRequest.builder().shardIterator(shardIterator).build();
         GetRecordsResponse getRecordsResponse = _kinesisClient.getRecords(getRecordsRequest);
 
-        if (getRecordsResponse.records().size() > 0) {
+        if (!getRecordsResponse.records().isEmpty()) {
           recordList.addAll(getRecordsResponse.records());
           nextStartSequenceNumber = recordList.get(recordList.size() - 1).sequenceNumber();
 
@@ -187,7 +187,7 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
   private KinesisRecordsBatch handleException(KinesisPartitionGroupOffset start, List<Record> recordList) {
     String shardId = start.getShardToStartSequenceMap().entrySet().iterator().next().getKey();
 
-    if (recordList.size() > 0) {
+    if (!recordList.isEmpty()) {
       String nextStartSequenceNumber = recordList.get(recordList.size() - 1).sequenceNumber();
       Map<String, String> newCheckpoint = new HashMap<>(start.getShardToStartSequenceMap());
       newCheckpoint.put(newCheckpoint.keySet().iterator().next(), nextStartSequenceNumber);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/OffHeapH3IndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/OffHeapH3IndexCreator.java
@@ -101,7 +101,7 @@ public class OffHeapH3IndexCreator extends BaseH3IndexCreator {
   public void seal()
       throws IOException {
     // If all posting lists are on-heap, directly generate the index file from the on-heap posting list map
-    if (_postingListChunkEndOffsets.size() == 0) {
+    if (_postingListChunkEndOffsets.isEmpty()) {
       _postingListOutputStream.close();
       for (Map.Entry<Long, RoaringBitmapWriter<RoaringBitmap>> entry : _postingListMap.entrySet()) {
         add(entry.getKey(), entry.getValue().get());

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/MultiplePinotSegmentRecordReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/MultiplePinotSegmentRecordReader.java
@@ -97,7 +97,7 @@ public class MultiplePinotSegmentRecordReader implements RecordReader {
   @Override
   public boolean hasNext() {
     if (_sortOrder != null) {
-      return _priorityQueue.size() > 0;
+      return !_priorityQueue.isEmpty();
     } else {
       for (PinotSegmentRecordReader recordReader : _recordReaders) {
         if (recordReader.hasNext()) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -181,7 +181,7 @@ public final class TableConfigUtils {
       Preconditions.checkState(tableConfig.getTableType() == TableType.OFFLINE,
           "Dimension table must be of OFFLINE table type.");
       Preconditions.checkState(schema != null, "Dimension table must have an associated schema");
-      Preconditions.checkState(schema.getPrimaryKeyColumns().size() > 0, "Dimension table must have primary key[s]");
+      Preconditions.checkState(!schema.getPrimaryKeyColumns().isEmpty(), "Dimension table must have primary key[s]");
     }
 
     String peerSegmentDownloadScheme = validationConfig.getPeerSegmentDownloadScheme();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/fst/RegexpMatcher.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/fst/RegexpMatcher.java
@@ -97,7 +97,7 @@ public class RegexpMatcher {
     final FST.BytesReader fstReader = _fst.getBytesReader();
 
     Transition t = new Transition();
-    while (queue.size() != 0) {
+    while (!queue.isEmpty()) {
       final Path<Long> path = queue.remove(queue.size() - 1);
 
       // If automaton is in accept state and the fstNode is final (i.e. end node) then add the entry to endNodes which

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/ConfigUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/ConfigUtils.java
@@ -60,7 +60,7 @@ public class ConfigUtils {
     final JsonNodeType nodeType = jsonNode.getNodeType();
     switch (nodeType) {
       case OBJECT:
-        if (jsonNode.size() > 0) {
+        if (!jsonNode.isEmpty()) {
           Iterator<Map.Entry<String, JsonNode>> iterator = jsonNode.fields();
           while (iterator.hasNext()) {
             final Map.Entry<String, JsonNode> next = iterator.next();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/UpdateSegmentState.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/UpdateSegmentState.java
@@ -204,7 +204,7 @@ public class UpdateSegmentState extends AbstractBaseCommand implements Command {
       LOGGER.info("Working on all tables for tenant " + _tenantName);
       List<String> tableNames = getAllTenantTables();
       LOGGER.info("Found " + tableNames.size() + " tables for tenant " + _tenantName);
-      if (tableNames.size() > 0) {
+      if (!tableNames.isEmpty()) {
         for (String tableName : tableNames) {
           fixTableIdealState(tableName);
         }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ValidateConfigCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ValidateConfigCommand.java
@@ -165,7 +165,7 @@ public class ValidateConfigCommand extends AbstractBaseCommand implements Comman
           tableNames.add(tableName);
         }
       }
-      if (tableNames.size() == 0) {
+      if (tableNames.isEmpty()) {
         throw new RuntimeException("No table name specified.");
       }
       return new ArrayList<>(tableNames);
@@ -185,7 +185,7 @@ public class ValidateConfigCommand extends AbstractBaseCommand implements Comman
           schemaNames.add(schemaName);
         }
       }
-      if (schemaNames.size() == 0) {
+      if (schemaNames.isEmpty()) {
         throw new RuntimeException("No schema name specified.");
       }
       return new ArrayList<>(schemaNames);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/QueryRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/QueryRunner.java
@@ -299,7 +299,7 @@ public class QueryRunner extends AbstractBaseCommand implements Command {
         totalBrokerTime += brokerTime;
         long clientTime = response.get("totalTime").asLong();
         totalClientTime += clientTime;
-        boolean hasException = response.get("exceptions").size() > 0;
+        boolean hasException = !response.get("exceptions").isEmpty();
         numExceptions += hasException ? 1 : 0;
         statisticsList.get(0).addValue(clientTime);
 
@@ -763,7 +763,7 @@ public class QueryRunner extends AbstractBaseCommand implements Command {
     totalBrokerTime.getAndAdd(brokerTime);
     long clientTime = response.get("totalTime").asLong();
     totalClientTime.getAndAdd(clientTime);
-    boolean hasException = response.get("exceptions").size() > 0;
+    boolean hasException = !response.get("exceptions").isEmpty();
     numExceptions.getAndAdd(hasException ? 1 : 0);
 
     statisticsList.get(0).addValue(clientTime);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/query/comparison/QueryComparison.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/query/comparison/QueryComparison.java
@@ -214,7 +214,7 @@ public class QueryComparison {
   }
 
   public static ComparisonStatus compareWithEmpty(JsonNode actualJson, JsonNode expectedJson) {
-    if (actualJson.get(EXCEPTIONS).size() != 0) {
+    if (!actualJson.get(EXCEPTIONS).isEmpty()) {
       return ComparisonStatus.FAILED;
     }
 
@@ -262,7 +262,7 @@ public class QueryComparison {
       return true;
     }
     JsonNode actualAggregation = actualJson.get(AGGREGATION_RESULTS);
-    if (actualAggregation.size() == 0) {
+    if (actualAggregation.isEmpty()) {
       return !expectedJson.has(AGGREGATION_RESULTS);
     }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/streams/githubevents/PullRequestMergedEvent.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/streams/githubevents/PullRequestMergedEvent.java
@@ -136,7 +136,7 @@ public class PullRequestMergedEvent {
    */
   private Set<String> extractReviewers() {
     Set<String> reviewers;
-    if (_reviewCommentsArray != null && _reviewCommentsArray.size() > 0) {
+    if (_reviewCommentsArray != null && !_reviewCommentsArray.isEmpty()) {
       reviewers = new HashSet<>();
       for (JsonNode reviewComment : _reviewCommentsArray) {
         reviewers.add(reviewComment.get("user").get("login").asText());
@@ -152,7 +152,7 @@ public class PullRequestMergedEvent {
    */
   private Set<String> extractCommenters() {
     Set<String> commenters;
-    if (_commentsArray != null && _commentsArray.size() > 0) {
+    if (_commentsArray != null && !_commentsArray.isEmpty()) {
       commenters = new HashSet<>();
       for (JsonNode comment : _commentsArray) {
         commenters.add(comment.get("user").get("login").asText());
@@ -168,12 +168,12 @@ public class PullRequestMergedEvent {
    */
   private Set<String> extractCommitters() {
     Set<String> committers;
-    if (_commitsArray != null && _commitsArray.size() > 0) {
+    if (_commitsArray != null && !_commitsArray.isEmpty()) {
       committers = new HashSet<>();
       for (JsonNode commit : _commitsArray) {
         JsonNode commitAsJsonNode = commit;
         JsonNode committer = commitAsJsonNode.get("committer");
-        if (committer.size() == 0) {
+        if (committer.isEmpty()) {
           committers.add(commitAsJsonNode.get("commit").get("committer").get("name").asText());
         } else {
           committers.add(committer.get("login").asText());
@@ -190,12 +190,12 @@ public class PullRequestMergedEvent {
    */
   private Set<String> extractAuthors() {
     Set<String> authors;
-    if (_commitsArray != null && _commitsArray.size() > 0) {
+    if (_commitsArray != null && !_commitsArray.isEmpty()) {
       authors = new HashSet<>();
       for (JsonNode commit : _commitsArray) {
         JsonNode commitAsJsonNode = commit;
         JsonNode author = commitAsJsonNode.get("author");
-        if (author.size() == 0) {
+        if (author.isEmpty()) {
           authors.add(commitAsJsonNode.get("commit").get("author").get("name").asText());
         } else {
           authors.add(author.get("login").asText());


### PR DESCRIPTION
## Description
The vast majority if not all of these will be benign, but this change set prevents emptiness checks from becoming bottlenecks if collection implementation is changed. Applies similar changes to manual emptiness checks performed on `String`s.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
