### PR TITLE
test xmls are not updated with latest test classes

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerStarterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerStarterStatelessTest.java
@@ -34,7 +34,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.fail;
 
 
-public class ControllerStarterTest extends ControllerTest {
+public class ControllerStarterStatelessTest extends ControllerTest {
   private final Map<String, Object> _configOverride = new HashMap<>();
 
   @Override

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderStatelessTest.java
@@ -61,8 +61,8 @@ import static org.mockito.Mockito.when;
 /**
  * Tests the {@link ConsumingSegmentInfoReader}
  */
-public class ConsumingSegmentInfoReaderTest {
-  private static final Logger LOGGER = LoggerFactory.getLogger(ConsumingSegmentInfoReaderTest.class);
+public class ConsumingSegmentInfoReaderStatelessTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConsumingSegmentInfoReaderStatelessTest.class);
 
   private static final String TABLE_NAME = "myTable_REALTIME";
   private static final String SEGMENT_NAME_PARTITION_0 = "table__0__29__12345";

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotIngestionRestletResourceStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotIngestionRestletResourceStatelessTest.java
@@ -50,7 +50,7 @@ import org.testng.annotations.Test;
  * Tests for the ingestion restlet
  *
  */
-public class PinotIngestionRestletResourceTest extends ControllerTest {
+public class PinotIngestionRestletResourceStatelessTest extends ControllerTest {
   private static final String TABLE_NAME = "testTable";
   private static final String TABLE_NAME_WITH_TYPE = "testTable_OFFLINE";
   private File _inputFile;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/MinionInstancesCleanupTaskStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/MinionInstancesCleanupTaskStatelessTest.java
@@ -27,7 +27,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 
-public class MinionInstancesCleanupTaskTest extends ControllerTest {
+public class MinionInstancesCleanupTaskStatelessTest extends ControllerTest {
   @BeforeClass
   public void setup()
       throws Exception {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/MinionInstancesCleanupTaskStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/MinionInstancesCleanupTaskStatelessTest.java
@@ -18,8 +18,10 @@
  */
 package org.apache.pinot.controller.helix.core.minion;
 
+import java.util.Map;
 import java.util.Properties;
 import org.apache.pinot.common.metrics.ControllerGauge;
+import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -46,17 +48,29 @@ public class MinionInstancesCleanupTaskStatelessTest extends ControllerTest {
     Assert.assertEquals(
         _controllerStarter.getControllerMetrics().getValueOfGlobalGauge(ControllerGauge.DROPPED_MINION_INSTANCES), 0);
     stopFakeInstance("Minion_localhost_0");
+    Thread.sleep(1000);
     minionInstancesCleanupTask.runTask(new Properties());
     Assert.assertEquals(
         _controllerStarter.getControllerMetrics().getValueOfGlobalGauge(ControllerGauge.DROPPED_MINION_INSTANCES), 1);
     stopFakeInstance("Minion_localhost_1");
+    Thread.sleep(1000);
     minionInstancesCleanupTask.runTask(new Properties());
     Assert.assertEquals(
         _controllerStarter.getControllerMetrics().getValueOfGlobalGauge(ControllerGauge.DROPPED_MINION_INSTANCES), 2);
     stopFakeInstance("Minion_localhost_2");
+    Thread.sleep(1000);
     minionInstancesCleanupTask.runTask(new Properties());
     Assert.assertEquals(
         _controllerStarter.getControllerMetrics().getValueOfGlobalGauge(ControllerGauge.DROPPED_MINION_INSTANCES), 3);
+  }
+
+  @Override
+  public Map<String, Object> getDefaultControllerConfiguration() {
+    Map<String, Object> properties = super.getDefaultControllerConfiguration();
+    // Override the cleanup before deletion period so that test can avoid stuck failure
+    properties.put(ControllerConf.ControllerPeriodicTasksConf.
+        MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_PERIOD, "1s");
+    return properties;
   }
 
   @AfterClass

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
@@ -46,7 +46,7 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 
-public class PinotTaskManagerTest extends ControllerTest {
+public class PinotTaskManagerStatelessTest extends ControllerTest {
   private static final String RAW_TABLE_NAME = "myTable";
   private static final String OFFLINE_TABLE_NAME = TableNameBuilder.OFFLINE.tableNameWithType(RAW_TABLE_NAME);
 

--- a/pinot-controller/testng-statefull.xml
+++ b/pinot-controller/testng-statefull.xml
@@ -28,57 +28,64 @@
   -->
   <test name="testng.suite.controller.statefull">
     <packages>
-      <package name="org.apache.pinot.controller.api.resources.*"/>
-      <package name="org.apache.pinot.controller.api.upload.*"/>
-      <package name="org.apache.pinot.controller.helix.core.assignment.*"/>
-      <package name="org.apache.pinot.controller.helix.core.minion.generator.*"/>
-      <package name="org.apache.pinot.controller.helix.core.periodictask.*"/>
-      <package name="org.apache.pinot.controller.helix.core.realtime.*"/>
-      <package name="org.apache.pinot.controller.helix.core.retention.*"/>
-      <package name="org.apache.pinot.controller.helix.core.util.*"/>
-      <package name="org.apache.pinot.controller.recommender.*"/>
-      <package name="org.apache.pinot.controller.util.*"/>
-      <package name="org.apache.pinot.controller.utils.*"/>
+      <package name="org.apache.pinot.controller.*"/>
     </packages>
     <classes>
-      <class name="org.apache.pinot.controller.ControllerTestSetup"/>
-      <class name="org.apache.pinot.controller.LeadControllerManagerTest"/>
-      <!-- org.apache.pinot.controller.api package files -->
-      <class name="org.apache.pinot.controller.api.PinotSegmentsMetadataTest"/>
-      <class name="org.apache.pinot.controller.api.PinotTenantRestletResourceTest"/>
-      <class name="org.apache.pinot.controller.api.PinotSegmentRestletResourceTest"/>
-      <class name="org.apache.pinot.controller.api.PinotInstanceRestletResourceTest"/>
-      <class name="org.apache.pinot.controller.api.PinotSchemaRestletResourceTest"/>
-      <class name="org.apache.pinot.controller.api.SegmentCompletionUtilsTest"/>
-      <class name="org.apache.pinot.controller.api.TableViewsTest"/>
-      <class name="org.apache.pinot.controller.api.PinotFileUploadTest"/>
-      <class name="org.apache.pinot.controller.api.PinotTableRestletResourceTest"/>
-      <class name="org.apache.pinot.controller.api.ControllerFilePathProviderTest"/>
-      <class name="org.apache.pinot.controller.api.SegmentCompletionProtocolDeserTest"/>
-      <class name="org.apache.pinot.controller.api.PinotInstanceAssignmentRestletResourceTest"/>
-      <class name="org.apache.pinot.controller.api.TableSizeReaderTest"/>
-      <class name="org.apache.pinot.controller.api.ServerTableSizeReaderTest"/>
-      <class name="org.apache.pinot.controller.api.AccessControlTest"/>
-
-      <!-- org.apache.pinot.controller.helix package files -->
-      <class name="org.apache.pinot.controller.helix.HelixHelperTest"/>
-      <class name="org.apache.pinot.controller.helix.ControllerInstanceToggleTest"/>
-      <class name="org.apache.pinot.controller.helix.ControllerTest"/>
-      <class name="org.apache.pinot.controller.helix.ControllerSentinelTestV2"/>
-      <class name="org.apache.pinot.controller.helix.PinotResourceManagerTest"/>
-      <class name="org.apache.pinot.controller.helix.TableCacheTest"/>
-      <class name="org.apache.pinot.controller.helix.SegmentStatusCheckerTest"/>
-
-      <!-- org.apache.pinot.controller.validation package files -->
-      <class name="org.apache.pinot.controller.validation.StorageQuotaCheckerTest"/>
-      <class name="org.apache.pinot.controller.validation.ValidationManagerTest"/>
-
-      <!-- org.apache.pinot.controller.helix.core package files -->
-      <class name="org.apache.pinot.controller.helix.core.PinotHelixResourceManagerTest"/>
-
-      <!-- org.apache.pinot.controller.helix.core.rebalance package files -->
-      <class name="org.apache.pinot.controller.helix.core.rebalance.TableRebalancerTest"/>
-
+      <class name="org.apache.pinot.controller.ControllerStarterStatelessTest">
+        <methods>
+          <exclude name=".*" />
+        </methods>
+      </class>
+      <class name="org.apache.pinot.controller.api.PinotBrokerRestletResourceStatelessTest">
+        <methods>
+          <exclude name=".*" />
+        </methods>
+      </class>
+      <class name="org.apache.pinot.controller.api.PinotIngestionRestletResourceStatelessTest">
+        <methods>
+          <exclude name=".*" />
+        </methods>
+      </class>
+      <class name="org.apache.pinot.controller.helix.ControllerTenantStatelessTest">
+        <methods>
+          <exclude name=".*" />
+        </methods>
+      </class>
+      <class name="org.apache.pinot.controller.helix.PinotControllerModeStatelessTest">
+        <methods>
+          <exclude name=".*" />
+        </methods>
+      </class>
+      <class name="org.apache.pinot.controller.helix.ControllerPeriodicTaskStarterStatelessTest">
+        <methods>
+          <exclude name=".*" />
+        </methods>
+      </class>
+      <class name="org.apache.pinot.controller.helix.core.PinotHelixResourceManagerStatelessTest">
+        <methods>
+          <exclude name=".*" />
+        </methods>
+      </class>
+      <class name="org.apache.pinot.controller.helix.core.minion.MinionInstancesCleanupTaskStatelessTest">
+        <methods>
+          <exclude name=".*" />
+        </methods>
+      </class>
+      <class name="org.apache.pinot.controller.helix.core.minion.PinotTaskManagerStatelessTest">
+        <methods>
+          <exclude name=".*" />
+        </methods>
+      </class>
+      <class name="org.apache.pinot.controller.helix.core.rebalance.TableRebalancerClusterStatelessTest">
+        <methods>
+          <exclude name=".*" />
+        </methods>
+      </class>
+      <class name="org.apache.pinot.controller.validation.ValidationManagerStatelessTest">
+        <methods>
+          <exclude name=".*" />
+        </methods>
+      </class>
     </classes>
   </test>
 </suite>

--- a/pinot-controller/testng-statefull.xml
+++ b/pinot-controller/testng-statefull.xml
@@ -20,7 +20,7 @@
     under the License.
 
 -->
-<suite name="testng.suite.controller.statefull" parallel="false">
+<suite name="testng.suite.controller.statefull">
   <!--
       Test cases listed here share state with each other (see ControllerTestSetup.java). This allows
       the test suite to run faster becuase individual test cases don't have to waste time setting up

--- a/pinot-controller/testng-statefull.xml
+++ b/pinot-controller/testng-statefull.xml
@@ -20,7 +20,7 @@
     under the License.
 
 -->
-<suite name="testng.suite.controller.statefull">
+<suite name="testng.suite.controller.statefull" parallel="false">
   <!--
       Test cases listed here share state with each other (see ControllerTestSetup.java). This allows
       the test suite to run faster becuase individual test cases don't have to waste time setting up
@@ -32,6 +32,11 @@
     </packages>
     <classes>
       <class name="org.apache.pinot.controller.ControllerStarterStatelessTest">
+        <methods>
+          <exclude name=".*" />
+        </methods>
+      </class>
+      <class name="org.apache.pinot.controller.api.ConsumingSegmentInfoReaderStatelessTest">
         <methods>
           <exclude name=".*" />
         </methods>

--- a/pinot-controller/testng-stateless.xml
+++ b/pinot-controller/testng-stateless.xml
@@ -20,7 +20,7 @@
     under the License.
 
 -->
-<suite name="testng.suite.controller.stateless">
+<suite name="testng.suite.controller.stateless" parallel="false">
   <!--
       These test cases take extra time to run because they have to spend time setting up and destroying
       their individual state. When possible add new test cases to the testng-stateful.xml suite, so that
@@ -31,6 +31,7 @@
   <test name="testng.suite.controller.stateless">
     <classes>
       <class name="org.apache.pinot.controller.ControllerStarterStatelessTest"/>
+      <class name="org.apache.pinot.controller.api.ConsumingSegmentInfoReaderStatelessTest"/>
       <class name="org.apache.pinot.controller.api.PinotBrokerRestletResourceStatelessTest"/>
       <class name="org.apache.pinot.controller.api.PinotIngestionRestletResourceStatelessTest"/>
       <class name="org.apache.pinot.controller.helix.ControllerTenantStatelessTest"/>

--- a/pinot-controller/testng-stateless.xml
+++ b/pinot-controller/testng-stateless.xml
@@ -30,13 +30,17 @@
   -->
   <test name="testng.suite.controller.stateless">
     <classes>
+      <class name="org.apache.pinot.controller.ControllerStarterStatelessTest"/>
       <class name="org.apache.pinot.controller.api.PinotBrokerRestletResourceStatelessTest"/>
+      <class name="org.apache.pinot.controller.api.PinotIngestionRestletResourceStatelessTest"/>
       <class name="org.apache.pinot.controller.helix.ControllerTenantStatelessTest"/>
       <class name="org.apache.pinot.controller.helix.PinotControllerModeStatelessTest"/>
       <class name="org.apache.pinot.controller.helix.ControllerPeriodicTaskStarterStatelessTest"/>
-      <class name="org.apache.pinot.controller.validation.ValidationManagerStatelessTest"/>
       <class name="org.apache.pinot.controller.helix.core.PinotHelixResourceManagerStatelessTest"/>
+      <class name="org.apache.pinot.controller.helix.core.minion.MinionInstancesCleanupTaskStatelessTest"/>
+      <class name="org.apache.pinot.controller.helix.core.minion.PinotTaskManagerStatelessTest"/>
       <class name="org.apache.pinot.controller.helix.core.rebalance.TableRebalancerClusterStatelessTest"/>
+      <class name="org.apache.pinot.controller.validation.ValidationManagerStatelessTest"/>
     </classes>
   </test>
 </suite>

--- a/pinot-controller/testng-stateless.xml
+++ b/pinot-controller/testng-stateless.xml
@@ -20,7 +20,7 @@
     under the License.
 
 -->
-<suite name="testng.suite.controller.stateless" parallel="false">
+<suite name="testng.suite.controller.stateless">
   <!--
       These test cases take extra time to run because they have to spend time setting up and destroying
       their individual state. When possible add new test cases to the testng-stateful.xml suite, so that


### PR DESCRIPTION
Apparently testng xmls have not include the entire set of test files in controller test. 
- 2 tests, which were not run previously, were fixed
- 2 tests were fixed individually in #7490.