### PR TITLE
do not allow qualification of member variables with this

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -203,6 +203,10 @@
     <property name="format" value="\*[\s]*@(params|throw|returns)[\s]+"/>
     <property name="message" value="Correct misspelled Javadoc tag"/>
   </module>
+  <module name="RegexpSingleline">
+    <property name="format" value="this\._"/>
+    <property name="message" value="Do not qualify member variables with this"/>
+  </module>
 
   <!-- Read checker suppressions from a file -->
   <module name="SuppressionFilter">

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/io/params/InvertedSortedIndexJointRuleParams.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/io/params/InvertedSortedIndexJointRuleParams.java
@@ -80,7 +80,7 @@ public class InvertedSortedIndexJointRuleParams {
   @JsonSetter(value = "THRESHOLD_RATIO_MIN_GAIN_DIFF_BETWEEN_ITERATION", nulls = Nulls.SKIP)
   public void setThresholdRatioMinGainDiffBetweenIteration(
       Double thresholdRatioMinGainDiffBetweenIteration) {
-    this._thresholdRatioMinGainDiffBetweenIteration = thresholdRatioMinGainDiffBetweenIteration;
+    _thresholdRatioMinGainDiffBetweenIteration = thresholdRatioMinGainDiffBetweenIteration;
   }
 
   public Integer getMaxNumIterationWithoutGain() {
@@ -108,7 +108,7 @@ public class InvertedSortedIndexJointRuleParams {
   @JsonSetter(value = "THRESHOLD_RATIO_MIN_AND_PREDICATE_TOP_CANDIDATES", nulls = Nulls.SKIP)
   public void setThresholdRatioMinAndPredicateTopCandidates(
       Double thresholdRatioMinAndPredicateTopCandidates) {
-    this._thresholdRatioMinAndPredicateTopCandidates = thresholdRatioMinAndPredicateTopCandidates;
+    _thresholdRatioMinAndPredicateTopCandidates = thresholdRatioMinAndPredicateTopCandidates;
   }
 
   public Double getPercentSelectForFunction() {


### PR DESCRIPTION
## Description
Code like `this.foo = foo` is common elsewhere in the Java ecosystem, but pinot prefixes member variables with an underscore. Style violations like `this._foo = foo` frequently come up in code review, and this PR automates enforcement of this style. 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
