### PR TITLE
Fix pql double quote checker exception

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluatorTest.java
@@ -133,7 +133,7 @@ public class InbuiltFunctionEvaluatorTest {
       fail();
     } catch (Exception e) {
       // assert that exception contains the full function call signature
-      assertTrue(e.toString().contains("fromDateTime[reverse['2020-01-01T00:00:00Z'], invalid_identifier]"));
+      assertTrue(e.toString().contains("fromDateTime(reverse('2020-01-01T00:00:00Z'),invalid_identifier)"));
       // assert that FunctionInvoker ISE is captured correctly.
       assertTrue(e.getCause() instanceof IllegalStateException);
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluatorTest.java
@@ -26,7 +26,7 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
-import static org.testng.AssertJUnit.fail;
+import static org.testng.Assert.fail;
 
 
 public class InbuiltFunctionEvaluatorTest {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
@@ -122,8 +122,7 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
         return _functionInvoker.invoke(_arguments);
       } catch (Exception e) {
         throw new RuntimeException(
-            "Caught exception while execute function: " + _functionInvoker.getMethod().getName()
-                + " with argument nodes: " + Arrays.toString(_argumentNodes), e);
+            "Caught exception while executing function: " + this, e);
       }
     }
 
@@ -138,14 +137,13 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
         return _functionInvoker.invoke(_arguments);
       } catch (Exception e) {
         throw new RuntimeException(
-            "Caught exception while execute function: " + _functionInvoker.getMethod().getName()
-                + " with argument nodes: " + Arrays.toString(_argumentNodes), e);
+            "Caught exception while executing function: " + this, e);
       }
     }
 
     @Override
     public String toString() {
-      return String.format("[FunctionExecutionNode[functionName:%s]]", _functionInvoker.getMethod().getName());
+      return _functionInvoker.getMethod().getName() + Arrays.toString(_argumentNodes);
     }
   }
 
@@ -168,7 +166,7 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
 
     @Override
     public String toString() {
-      return String.format("[ConstantExecutionNode[const:%s]]", _value);
+      return String.format("\'%s\'", _value);
     }
   }
 
@@ -193,7 +191,7 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
 
     @Override
     public String toString() {
-      return String.format("[ColumnExecutionNode[columnName:%s,columnId:%d]]", _column, _id);
+      return _column;
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
@@ -121,20 +121,26 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
         _functionInvoker.convertTypes(_arguments);
         return _functionInvoker.invoke(_arguments);
       } catch (Exception e) {
-        throw new IllegalStateException(
-            "Caught exception while invoking method: " + _functionInvoker.getMethod().getName()
+        throw new RuntimeException(
+            "Caught exception while execute function: " + _functionInvoker.getMethod().getName()
                 + " with argument nodes: " + Arrays.toString(_argumentNodes), e);
       }
     }
 
     @Override
     public Object execute(Object[] values) {
-      int numArguments = _argumentNodes.length;
-      for (int i = 0; i < numArguments; i++) {
-        _arguments[i] = _argumentNodes[i].execute(values);
+      try {
+        int numArguments = _argumentNodes.length;
+        for (int i = 0; i < numArguments; i++) {
+          _arguments[i] = _argumentNodes[i].execute(values);
+        }
+        _functionInvoker.convertTypes(_arguments);
+        return _functionInvoker.invoke(_arguments);
+      } catch (Exception e) {
+        throw new RuntimeException(
+            "Caught exception while execute function: " + _functionInvoker.getMethod().getName()
+                + " with argument nodes: " + Arrays.toString(_argumentNodes), e);
       }
-      _functionInvoker.convertTypes(_arguments);
-      return _functionInvoker.invoke(_arguments);
     }
 
     @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
@@ -20,8 +20,8 @@ package org.apache.pinot.segment.local.function;
 
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.function.FunctionInfo;
 import org.apache.pinot.common.function.FunctionInvoker;
 import org.apache.pinot.common.function.FunctionRegistry;
@@ -121,8 +121,7 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
         _functionInvoker.convertTypes(_arguments);
         return _functionInvoker.invoke(_arguments);
       } catch (Exception e) {
-        throw new RuntimeException(
-            "Caught exception while executing function: " + this, e);
+        throw new RuntimeException("Caught exception while executing function: " + this, e);
       }
     }
 
@@ -136,14 +135,13 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
         _functionInvoker.convertTypes(_arguments);
         return _functionInvoker.invoke(_arguments);
       } catch (Exception e) {
-        throw new RuntimeException(
-            "Caught exception while executing function: " + this, e);
+        throw new RuntimeException("Caught exception while executing function: " + this, e);
       }
     }
 
     @Override
     public String toString() {
-      return _functionInvoker.getMethod().getName() + Arrays.toString(_argumentNodes);
+      return _functionInvoker.getMethod().getName() + '(' + StringUtils.join(_argumentNodes, ',') + ')';
     }
   }
 
@@ -166,7 +164,7 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
 
     @Override
     public String toString() {
-      return String.format("\'%s\'", _value);
+      return String.format("'%s'", _value);
     }
   }
 


### PR DESCRIPTION
Currently if there's a double quoted PQL syntax ingestion transform such as
```
  "ingestionConfig": {
    "transformConfigs": [
      {
        "columnName": "created_at_timestamp",
        "transformFunction": "fromDateTime(created_at, \"yyyy-MM-dd''T''HH:mm:ss''Z''\")"
      }
    ]
  },
```
It will fail because the double quoted literal is considered as quoted identifier in Calcite SQL parser. 
This is not a problem during SQL execution because the column will not be found. but during ingestion we dont have a proper schema validation thus exception will not be meaningful.

Propose to wrap exception in InbuiltFunctionEvaluator that executes any ScalarFuntion in FunctionRegistry and provide extra context information about the argument that passed in. 

Before:
```
java.lang.IllegalStateException: Caught exception while invoking method: public static long org.apache.pinot.common.function.scalar.DateTimeFunctions.fromDateTime(java.lang.String,java.lang.String) with arguments: [2021-04-20T16:41:00-0700, null]
	at org.apache.pinot.common.function.FunctionInvoker.invoke(FunctionInvoker.java:131)
	at 
...
Caused by: java.lang.reflect.InvocationTargetException
	at jdk.internal.reflect.GeneratedMethodAccessor33.invoke(Unknown Source)
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:566)
	at org.apache.pinot.common.function.FunctionInvoker.invoke(FunctionInvoker.java:128)
	... 8 more
Caused by: java.lang.IllegalArgumentException: Invalid pattern specification
	at org.joda.time.format.DateTimeFormat.createFormatterForPattern(DateTimeFormat.java:682)
	at org.joda.time.format.DateTimeFormat.forPattern(DateTimeFormat.java:177)
```

Now:
```
... [Extra wrapper exception with column info]
java.lang.RuntimeException: Caught exception while executing function: fromDateTime[reverse['2020-01-01T00:00:00Z'], invalid_identifier]
	at org.apache.pinot.segment.local.function.InbuiltFunctionEvaluator$FunctionExecutionNode.execute(InbuiltFunctionEvaluator.java:126)
	at org.apache.pinot.segment.local.function.InbuiltFunctionEvaluator.evaluate(InbuiltFunctionEvaluator.java:88)
... [Original Exception]
Caused by: java.lang.IllegalStateException: Caught exception while invoking method: public static long org.apache.pinot.common.function.scalar.DateTimeFunctions.fromDateTime(java.lang.String,java.lang.String) with arguments: [2018-01-01T11:00:00Z, null]
  	at org.apache....
...
```