### PR TITLE
add persistence.extraVolumeMounts and persistence.extraVolumes to statefulsets

### DIFF
--- a/kubernetes/helm/pinot/templates/broker/statefulset.yml
+++ b/kubernetes/helm/pinot/templates/broker/statefulset.yml
@@ -80,6 +80,9 @@ spec:
         volumeMounts:
           - name: config
             mountPath: /var/pinot/broker/config
+          {{- if ne (len .Values.broker.persistence.extraVolumeMounts) 0 }}
+{{ toYaml .Values.broker.persistence.extraVolumeMounts | indent 10 }}
+          {{- end }}
         {{- if .Values.broker.probes.livenessEnabled }}
         livenessProbe:
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
@@ -103,3 +106,6 @@ spec:
         - name: config
           configMap:
             name: {{ include "pinot.broker.config" . }}
+      {{- if ne (len .Values.broker.persistence.extraVolumes) 0 }}
+{{ toYaml .Values.broker.persistence.extraVolumes | indent 8 }}
+      {{- end }}

--- a/kubernetes/helm/pinot/templates/controller/statefulset.yaml
+++ b/kubernetes/helm/pinot/templates/controller/statefulset.yaml
@@ -93,6 +93,9 @@ spec:
             mountPath: /var/pinot/controller/config
           - name: data
             mountPath: "{{ .Values.controller.persistence.mountPath }}"
+          {{- if ne (len .Values.controller.persistence.extraVolumeMounts) 0 }}
+{{ toYaml .Values.controller.persistence.extraVolumeMounts | indent 10 }}
+          {{- end }}
         resources:
 {{ toYaml .Values.controller.resources | indent 12 }}
       restartPolicy: Always
@@ -104,6 +107,9 @@ spec:
       - name: data
         emptyDir: {}
 {{- end }}
+      {{- if ne (len .Values.controller.persistence.extraVolumes) 0 }}
+{{ toYaml .Values.controller.persistence.extraVolumes | indent 6 }}
+      {{- end }}
 {{- if .Values.controller.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/kubernetes/helm/pinot/templates/minion/statefulset.yml
+++ b/kubernetes/helm/pinot/templates/minion/statefulset.yml
@@ -100,6 +100,9 @@ spec:
           - name: data
             mountPath: "{{ .Values.minion.persistence.mountPath }}"
           {{- end }}
+          {{- if ne (len .Values.minion.persistence.extraVolumeMounts) 0 }}
+{{ toYaml .Values.minion.persistence.extraVolumeMounts | indent 10 }}
+          {{- end }}
         resources:
 {{ toYaml .Values.minion.resources | indent 12 }}
       restartPolicy: Always
@@ -111,7 +114,9 @@ spec:
         - name: data
           emptyDir: {}
       {{- end }}
-
+      {{- if ne (len .Values.minion.persistence.extraVolumes) 0 }}
+{{ toYaml .Values.minion.persistence.extraVolumes | indent 8 }}
+      {{- end }}
   {{- if .Values.minion.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/kubernetes/helm/pinot/templates/server/statefulset.yml
+++ b/kubernetes/helm/pinot/templates/server/statefulset.yml
@@ -72,7 +72,7 @@ spec:
 {{ toYaml .Values.server.extraEnv | indent 10 }}
 {{- end}}
         envFrom:
-{{ toYaml .Values.server.envFrom | indent 10 }} 
+{{ toYaml .Values.server.envFrom | indent 10 }}
         ports:
           - containerPort: {{ .Values.server.service.nettyPort }}
             protocol: {{ .Values.server.service.protocol }}
@@ -101,6 +101,9 @@ spec:
             mountPath: /var/pinot/server/config
           - name: data
             mountPath: "{{ .Values.server.persistence.mountPath }}"
+          {{- if ne (len .Values.server.persistence.extraVolumeMounts) 0 }}
+{{ toYaml .Values.server.persistence.extraVolumeMounts | indent 10 }}
+          {{- end }}
         resources:
 {{ toYaml .Values.server.resources | indent 12 }}
       restartPolicy: Always
@@ -112,7 +115,9 @@ spec:
         - name: data
           emptyDir: {}
       {{- end }}
-
+      {{- if ne (len .Values.server.persistence.extraVolumes) 0 }}
+{{ toYaml .Values.server.persistence.extraVolumes | indent 8 }}
+      {{- end }}
   {{- if .Values.server.persistence.enabled }}
   volumeClaimTemplates:
     - metadata:

--- a/kubernetes/helm/pinot/values.yaml
+++ b/kubernetes/helm/pinot/values.yaml
@@ -74,6 +74,8 @@ controller:
     size: 1G
     mountPath: /var/pinot/controller/data
     storageClass: ""
+    extraVolumes: []
+    extraVolumeMounts: []
 
   data:
     dir: /var/pinot/controller/data
@@ -164,6 +166,10 @@ broker:
     livenessEnabled: true
     readinessEnabled: true
 
+  persistence:
+    extraVolumes: []
+    extraVolumeMounts: []
+
   service:
     annotations: {}
     clusterIP: "None"
@@ -242,6 +248,8 @@ server:
     mountPath: /var/pinot/server/data
     storageClass: ""
     #storageClass: "ssd"
+    extraVolumes: []
+    extraVolumeMounts: []
 
   jvmOpts: "-Xms512M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-server.log"
 
@@ -327,6 +335,8 @@ minion:
     mountPath: /var/pinot/minion/data
     storageClass: ""
     #storageClass: "ssd"
+    extraVolumes: []
+    extraVolumeMounts: []
 
   service:
     annotations: {}


### PR DESCRIPTION
Add options to allow users to define additional mounts in all the statefulsets, i.e. for mounting certificates from secrets for tls setups.