### PR TITLE
fix pinot-controller/broker recent fork timeout

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerTest.java
@@ -38,6 +38,7 @@ import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.utils.ZkStarter;
+import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.parsers.QueryCompiler;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
 import org.apache.pinot.segment.spi.partition.metadata.ColumnPartitionMetadata;
@@ -66,7 +67,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
 
-public class SegmentPrunerTest {
+public class SegmentPrunerTest extends ControllerTest {
   private static final String RAW_TABLE_NAME = "testTable";
   private static final String OFFLINE_TABLE_NAME = "testTable_OFFLINE";
   private static final String REALTIME_TABLE_NAME = "testTable_REALTIME";
@@ -101,9 +102,9 @@ public class SegmentPrunerTest {
 
   @BeforeClass
   public void setUp() {
-    _zkInstance = ZkStarter.startLocalZkServer();
+    startZk();
     _zkClient =
-        new ZkClient(_zkInstance.getZkUrl(), ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT,
+        new ZkClient(getZkUrl(), ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT,
             new ZNRecordSerializer());
     _propertyStore =
         new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(_zkClient), "/SegmentPrunerTest/PROPERTYSTORE", null);
@@ -112,7 +113,7 @@ public class SegmentPrunerTest {
   @AfterClass
   public void tearDown() {
     _zkClient.close();
-    ZkStarter.stopLocalZkServer(_zkInstance);
+    stopZk();
   }
 
   @Test

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerTest.java
@@ -37,7 +37,6 @@ import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.request.BrokerRequest;
-import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.parsers.QueryCompiler;
 import org.apache.pinot.pql.parsers.Pql2Compiler;
@@ -96,7 +95,6 @@ public class SegmentPrunerTest extends ControllerTest {
   private static final String SDF_QUERY_5 =
       "SELECT * FROM testTable where timeColumn in (20200101, 20200102) AND timeColumn >= 20200530";
 
-  private ZkStarter.ZookeeperInstance _zkInstance;
   private ZkClient _zkClient;
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManagerTest.java
@@ -32,7 +32,6 @@ import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
-import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -57,7 +56,6 @@ import static org.testng.Assert.assertNull;
 public class TimeBoundaryManagerTest extends ControllerTest {
   private static final String TIME_COLUMN = "time";
 
-  private ZkStarter.ZookeeperInstance _zkInstance;
   private ZkClient _zkClient;
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManagerTest.java
@@ -33,6 +33,7 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.utils.ZkStarter;
+import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -53,7 +54,7 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
 
-public class TimeBoundaryManagerTest {
+public class TimeBoundaryManagerTest extends ControllerTest {
   private static final String TIME_COLUMN = "time";
 
   private ZkStarter.ZookeeperInstance _zkInstance;
@@ -62,9 +63,9 @@ public class TimeBoundaryManagerTest {
 
   @BeforeClass
   public void setUp() {
-    _zkInstance = ZkStarter.startLocalZkServer();
+    startZk();
     _zkClient =
-        new ZkClient(_zkInstance.getZkUrl(), ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT,
+        new ZkClient(getZkUrl(), ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT,
             new ZNRecordSerializer());
     _propertyStore =
         new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(_zkClient), "/TimeBoundaryManagerTest/PROPERTYSTORE", null);
@@ -73,7 +74,7 @@ public class TimeBoundaryManagerTest {
   @AfterClass
   public void tearDown() {
     _zkClient.close();
-    ZkStarter.stopLocalZkServer(_zkInstance);
+    stopZk();
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderTest.java
@@ -41,7 +41,7 @@ import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.restlet.resources.SegmentConsumerInfo;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.ConsumingSegmentInfoReader;
-import org.apache.pinot.controller.utils.FakeHttpServerUtils;
+import org.apache.pinot.controller.utils.FakeHttpServer;
 import org.apache.pinot.spi.config.table.TableStatus;
 import org.apache.pinot.spi.utils.CommonConstants.ConsumerState;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -149,7 +149,7 @@ public class ConsumingSegmentInfoReaderTest {
   /**
    * Server to return fake consuming segment info
    */
-  private static class FakeConsumingInfoServer extends FakeHttpServerUtils.FakeHttpServer {
+  private static class FakeConsumingInfoServer extends FakeHttpServer {
     List<SegmentConsumerInfo> _consumerInfos;
 
     FakeConsumingInfoServer(List<SegmentConsumerInfo> consumerInfos) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderTest.java
@@ -23,10 +23,8 @@ import com.google.common.collect.HashBiMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.sun.net.httpserver.HttpHandler;
-import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -35,7 +33,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executor;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import org.apache.commons.httpclient.HttpConnectionManager;
@@ -44,6 +41,7 @@ import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.restlet.resources.SegmentConsumerInfo;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.ConsumingSegmentInfoReader;
+import org.apache.pinot.controller.utils.FakeHttpServerUtils;
 import org.apache.pinot.spi.config.table.TableStatus;
 import org.apache.pinot.spi.utils.CommonConstants.ConsumerState;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -153,29 +151,11 @@ public class ConsumingSegmentInfoReaderTest {
   /**
    * Server to return fake consuming segment info
    */
-  private static class FakeConsumingInfoServer {
-    String _endpoint;
-    InetSocketAddress _socket = new InetSocketAddress(0);
+  private static class FakeConsumingInfoServer extends FakeHttpServerUtils.FakeHttpServer {
     List<SegmentConsumerInfo> _consumerInfos;
-    ExecutorService _executorService;
-    HttpServer _httpServer;
 
     FakeConsumingInfoServer(List<SegmentConsumerInfo> consumerInfos) {
       _consumerInfos = consumerInfos;
-    }
-
-    private void start(String path, HttpHandler handler)
-        throws IOException {
-      _executorService = Executors.newCachedThreadPool();
-      _httpServer = HttpServer.create(_socket, 0);
-      _httpServer.setExecutor(_executorService);
-      _httpServer.createContext(path, handler);
-      new Thread(() -> _httpServer.start()).start();
-      _endpoint = "http://localhost:" + _httpServer.getAddress().getPort();
-    }
-
-    private void stop() {
-      _executorService.shutdown();
     }
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderTest.java
@@ -124,9 +124,7 @@ public class ConsumingSegmentInfoReaderTest {
   @AfterClass
   public void tearDown() {
     for (Map.Entry<String, FakeConsumingInfoServer> fakeServerEntry : _serverMap.entrySet()) {
-      FakeConsumingInfoServer server = fakeServerEntry.getValue();
-      server.stop();
-      server._httpServer.stop(0);
+      fakeServerEntry.getValue().stop();
     }
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentsMetadataTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentsMetadataTest.java
@@ -112,9 +112,7 @@ public class PinotSegmentsMetadataTest {
   @AfterClass
   public void tearDown() {
     for (Map.Entry<String, SegmentsServerMock> fakeServerEntry : _serverMap.entrySet()) {
-      SegmentsServerMock server = fakeServerEntry.getValue();
-      server.stop();
-      server._httpServer.stop(0);
+      fakeServerEntry.getValue().stop();
     }
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentsMetadataTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentsMetadataTest.java
@@ -36,7 +36,7 @@ import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.ServerSegmentMetadataReader;
-import org.apache.pinot.controller.utils.FakeHttpServerUtils;
+import org.apache.pinot.controller.utils.FakeHttpServer;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
@@ -178,7 +178,7 @@ public class PinotSegmentsMetadataTest {
     Assert.assertEquals(expectedNonResponsiveServers, totalResponses - metadata.size());
   }
 
-  public static class SegmentsServerMock extends FakeHttpServerUtils.FakeHttpServer {
+  public static class SegmentsServerMock extends FakeHttpServer {
     String _segment;
     String _segmentMetadata;
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentsMetadataTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentsMetadataTest.java
@@ -23,10 +23,8 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.sun.net.httpserver.HttpHandler;
-import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -38,6 +36,7 @@ import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.ServerSegmentMetadataReader;
+import org.apache.pinot.controller.utils.FakeHttpServerUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.mockito.stubbing.Answer;
 import org.slf4j.Logger;
@@ -113,7 +112,9 @@ public class PinotSegmentsMetadataTest {
   @AfterClass
   public void tearDown() {
     for (Map.Entry<String, SegmentsServerMock> fakeServerEntry : _serverMap.entrySet()) {
-      fakeServerEntry.getValue()._httpServer.stop(0);
+      SegmentsServerMock server = fakeServerEntry.getValue();
+      server.stop();
+      server._httpServer.stop(0);
     }
   }
 
@@ -179,12 +180,9 @@ public class PinotSegmentsMetadataTest {
     Assert.assertEquals(expectedNonResponsiveServers, totalResponses - metadata.size());
   }
 
-  public static class SegmentsServerMock {
+  public static class SegmentsServerMock extends FakeHttpServerUtils.FakeHttpServer {
     String _segment;
-    String _endpoint;
-    InetSocketAddress _socket = new InetSocketAddress(0);
     String _segmentMetadata;
-    HttpServer _httpServer;
 
     public SegmentsServerMock(String segment) {
       _segment = segment;
@@ -196,14 +194,6 @@ public class PinotSegmentsMetadataTest {
       ObjectNode objectNode = jsonNode.deepCopy();
       objectNode.put("segmentName", _segment);
       _segmentMetadata = JsonUtils.objectToString(objectNode);
-    }
-
-    private void start(String path, HttpHandler handler)
-        throws IOException {
-      _httpServer = HttpServer.create(_socket, 0);
-      _httpServer.createContext(path, handler);
-      new Thread(() -> _httpServer.start()).start();
-      _endpoint = "http://localhost:" + _httpServer.getAddress().getPort();
     }
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableSizeReaderTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableSizeReaderTest.java
@@ -135,9 +135,7 @@ public class TableSizeReaderTest {
   @AfterClass
   public void tearDown() {
     for (Map.Entry<String, FakeSizeServer> fakeServerEntry : _serverMap.entrySet()) {
-      FakeSizeServer server = fakeServerEntry.getValue();
-      server.stop();
-      server._httpServer.stop(0);
+      fakeServerEntry.getValue().stop();
     }
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableSizeReaderTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableSizeReaderTest.java
@@ -41,7 +41,7 @@ import org.apache.pinot.common.restlet.resources.SegmentSizeInfo;
 import org.apache.pinot.common.restlet.resources.TableSizeInfo;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.TableSizeReader;
-import org.apache.pinot.controller.utils.FakeHttpServerUtils;
+import org.apache.pinot.controller.utils.FakeHttpServer;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.mockito.ArgumentMatchers;
@@ -170,7 +170,7 @@ public class TableSizeReaderTest {
     return "server" + index;
   }
 
-  private static class FakeSizeServer extends FakeHttpServerUtils.FakeHttpServer {
+  private static class FakeSizeServer extends FakeHttpServer {
     List<String> _segments;
     List<SegmentSizeInfo> _sizes = new ArrayList<>();
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/utils/FakeHttpServer.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/utils/FakeHttpServer.java
@@ -29,33 +29,27 @@ import java.util.concurrent.Executors;
 /**
  * Fake HTTP Server that encapsulates one fake handler.
  */
-public class FakeHttpServerUtils {
+public class FakeHttpServer {
+  public String _endpoint;
+  public InetSocketAddress _socket = new InetSocketAddress(0);
+  public ExecutorService _executorService;
+  public HttpServer _httpServer;
 
-  private FakeHttpServerUtils() {
+  public FakeHttpServer() {
   }
 
-  public static class FakeHttpServer {
-    public String _endpoint;
-    public InetSocketAddress _socket = new InetSocketAddress(0);
-    public ExecutorService _executorService;
-    public HttpServer _httpServer;
+  public void start(String path, HttpHandler handler)
+      throws IOException {
+    _executorService = Executors.newCachedThreadPool();
+    _httpServer = HttpServer.create(_socket, 0);
+    _httpServer.setExecutor(_executorService);
+    _httpServer.createContext(path, handler);
+    new Thread(() -> _httpServer.start()).start();
+    _endpoint = "http://localhost:" + _httpServer.getAddress().getPort();
+  }
 
-    public FakeHttpServer() {
-    }
-
-    public void start(String path, HttpHandler handler)
-        throws IOException {
-      _executorService = Executors.newCachedThreadPool();
-      _httpServer = HttpServer.create(_socket, 0);
-      _httpServer.setExecutor(_executorService);
-      _httpServer.createContext(path, handler);
-      new Thread(() -> _httpServer.start()).start();
-      _endpoint = "http://localhost:" + _httpServer.getAddress().getPort();
-    }
-
-    public void stop() {
-      _executorService.shutdown();
-      _httpServer.stop(0);
-    }
+  public void stop() {
+    _executorService.shutdown();
+    _httpServer.stop(0);
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/utils/FakeHttpServerUtils.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/utils/FakeHttpServerUtils.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.utils;
+
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+
+/**
+ * Fake HTTP Server that encapsulates one fake handler.
+ */
+public class FakeHttpServerUtils {
+
+  private FakeHttpServerUtils() {
+  }
+
+  public static class FakeHttpServer {
+    public String _endpoint;
+    public InetSocketAddress _socket = new InetSocketAddress(0);
+    public ExecutorService _executorService;
+    public HttpServer _httpServer;
+
+    public FakeHttpServer() {
+    }
+
+    public void start(String path, HttpHandler handler)
+        throws IOException {
+      _executorService = Executors.newCachedThreadPool();
+      _httpServer = HttpServer.create(_socket, 0);
+      _httpServer.setExecutor(_executorService);
+      _httpServer.createContext(path, handler);
+      new Thread(() -> _httpServer.start()).start();
+      _endpoint = "http://localhost:" + _httpServer.getAddress().getPort();
+    }
+
+    public void stop() {
+      _executorService.shutdown();
+    }
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/utils/FakeHttpServerUtils.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/utils/FakeHttpServerUtils.java
@@ -55,6 +55,7 @@ public class FakeHttpServerUtils {
 
     public void stop() {
       _executorService.shutdown();
+      _httpServer.stop(0);
     }
   }
 }


### PR DESCRIPTION
several fork timeout were identified in #7474 . fixing them here.

This also shows that a test fork timeout usually means sth is wrong within the teardown logic of a test suite/class. FYI #7248. but still yet to figure out exactly which teardown were broken because surefire plugin doesn't print such info in logs. 