### PR TITLE
Add option to limit thread usage per query

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/AggregationOnlyCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/AggregationOnlyCombineOperator.java
@@ -34,8 +34,8 @@ public class AggregationOnlyCombineOperator extends BaseCombineOperator {
   private static final String OPERATOR_NAME = "AggregationOnlyCombineOperator";
 
   public AggregationOnlyCombineOperator(List<Operator> operators, QueryContext queryContext,
-      ExecutorService executorService, long endTimeMs) {
-    super(operators, queryContext, executorService, endTimeMs);
+      ExecutorService executorService, long endTimeMs, int maxExecutionThreads) {
+    super(operators, queryContext, executorService, endTimeMs, maxExecutionThreads);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/CombineOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/CombineOperatorUtils.java
@@ -38,10 +38,14 @@ public class CombineOperatorUtils {
       Math.max(1, Math.min(10, Runtime.getRuntime().availableProcessors() / 2));
 
   /**
-   * Returns the number of threads used to execute the query in parallel.
+   * Returns the number of tasks used to execute the query in parallel.
    */
-  public static int getNumThreadsForQuery(int numOperators) {
-    return Math.min(numOperators, MAX_NUM_THREADS_PER_QUERY);
+  public static int getNumTasksForQuery(int numOperators, int maxExecutionThreads) {
+    if (maxExecutionThreads > 0) {
+      return Math.min(numOperators, maxExecutionThreads);
+    } else {
+      return Math.min(numOperators, MAX_NUM_THREADS_PER_QUERY);
+    }
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/DistinctCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/DistinctCombineOperator.java
@@ -37,8 +37,8 @@ public class DistinctCombineOperator extends BaseCombineOperator {
   private final boolean _hasOrderBy;
 
   public DistinctCombineOperator(List<Operator> operators, QueryContext queryContext, ExecutorService executorService,
-      long endTimeMs) {
-    super(operators, queryContext, executorService, endTimeMs);
+      long endTimeMs, int maxExecutionThreads) {
+    super(operators, queryContext, executorService, endTimeMs, maxExecutionThreads);
     _hasOrderBy = queryContext.getOrderByExpressions() != null;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOnlyCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOnlyCombineOperator.java
@@ -45,8 +45,8 @@ public class SelectionOnlyCombineOperator extends BaseCombineOperator {
   private final int _numRowsToKeep;
 
   public SelectionOnlyCombineOperator(List<Operator> operators, QueryContext queryContext,
-      ExecutorService executorService, long endTimeMs) {
-    super(operators, queryContext, executorService, endTimeMs);
+      ExecutorService executorService, long endTimeMs, int maxExecutionThreads) {
+    super(operators, queryContext, executorService, endTimeMs, maxExecutionThreads);
     _numRowsToKeep = queryContext.getLimit();
   }
 
@@ -80,13 +80,13 @@ public class SelectionOnlyCombineOperator extends BaseCombineOperator {
     DataSchema dataSchemaToMerge = blockToMerge.getDataSchema();
     assert mergedDataSchema != null && dataSchemaToMerge != null;
     if (!mergedDataSchema.equals(dataSchemaToMerge)) {
-      String errorMessage = String
-          .format("Data schema mismatch between merged block: %s and block to merge: %s, drop block to merge",
+      String errorMessage =
+          String.format("Data schema mismatch between merged block: %s and block to merge: %s, drop block to merge",
               mergedDataSchema, dataSchemaToMerge);
       // NOTE: This is segment level log, so log at debug level to prevent flooding the log.
       LOGGER.debug(errorMessage);
-      mergedBlock
-          .addToProcessingExceptions(QueryException.getException(QueryException.MERGE_RESPONSE_ERROR, errorMessage));
+      mergedBlock.addToProcessingExceptions(
+          QueryException.getException(QueryException.MERGE_RESPONSE_ERROR, errorMessage));
       return;
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOrderByCombineOperator.java
@@ -49,8 +49,8 @@ public class SelectionOrderByCombineOperator extends BaseCombineOperator {
   private final int _numRowsToKeep;
 
   public SelectionOrderByCombineOperator(List<Operator> operators, QueryContext queryContext,
-      ExecutorService executorService, long endTimeMs) {
-    super(operators, queryContext, executorService, endTimeMs);
+      ExecutorService executorService, long endTimeMs, int maxExecutionThreads) {
+    super(operators, queryContext, executorService, endTimeMs, maxExecutionThreads);
     _numRowsToKeep = queryContext.getLimit() + queryContext.getOffset();
   }
 
@@ -75,7 +75,7 @@ public class SelectionOrderByCombineOperator extends BaseCombineOperator {
     if (orderByExpressions.get(0).getExpression().getType() == ExpressionContext.Type.IDENTIFIER) {
       try {
         return new MinMaxValueBasedSelectionOrderByCombineOperator(_operators, _queryContext, _executorService,
-            _endTimeMs).getNextBlock();
+            _endTimeMs, _numTasks).getNextBlock();
       } catch (Exception e) {
         LOGGER.warn("Caught exception while using min/max value based combine, using the default combine", e);
       }
@@ -89,13 +89,13 @@ public class SelectionOrderByCombineOperator extends BaseCombineOperator {
     DataSchema dataSchemaToMerge = blockToMerge.getDataSchema();
     assert mergedDataSchema != null && dataSchemaToMerge != null;
     if (!mergedDataSchema.equals(dataSchemaToMerge)) {
-      String errorMessage = String
-          .format("Data schema mismatch between merged block: %s and block to merge: %s, drop block to merge",
+      String errorMessage =
+          String.format("Data schema mismatch between merged block: %s and block to merge: %s, drop block to merge",
               mergedDataSchema, dataSchemaToMerge);
       // NOTE: This is segment level log, so log at debug level to prevent flooding the log.
       LOGGER.debug(errorMessage);
-      mergedBlock
-          .addToProcessingExceptions(QueryException.getException(QueryException.MERGE_RESPONSE_ERROR, errorMessage));
+      mergedBlock.addToProcessingExceptions(
+          QueryException.getException(QueryException.MERGE_RESPONSE_ERROR, errorMessage));
       return;
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOnlyCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOnlyCombineOperator.java
@@ -57,8 +57,9 @@ public class StreamingSelectionOnlyCombineOperator extends BaseCombineOperator {
   private final AtomicLong _numRowsCollected = new AtomicLong();
 
   public StreamingSelectionOnlyCombineOperator(List<Operator> operators, QueryContext queryContext,
-      ExecutorService executorService, long endTimeMs, StreamObserver<Server.ServerResponse> streamObserver) {
-    super(operators, queryContext, executorService, endTimeMs);
+      ExecutorService executorService, long endTimeMs, int maxExecutionThreads,
+      StreamObserver<Server.ServerResponse> streamObserver) {
+    super(operators, queryContext, executorService, endTimeMs, maxExecutionThreads);
     _streamObserver = streamObserver;
     _limit = queryContext.getLimit();
   }
@@ -69,8 +70,8 @@ public class StreamingSelectionOnlyCombineOperator extends BaseCombineOperator {
   }
 
   @Override
-  protected void processSegments(int threadIndex) {
-    for (int operatorIndex = threadIndex; operatorIndex < _numOperators; operatorIndex += _numThreads) {
+  protected void processSegments(int taskIndex) {
+    for (int operatorIndex = taskIndex; operatorIndex < _numOperators; operatorIndex += _numTasks) {
       Operator<IntermediateResultsBlock> operator = _operators.get(operatorIndex);
       IntermediateResultsBlock resultsBlock;
       while ((resultsBlock = operator.nextBlock()) != null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
@@ -32,6 +32,7 @@ import org.apache.pinot.common.proto.Server;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.operator.combine.AggregationOnlyCombineOperator;
+import org.apache.pinot.core.operator.combine.CombineOperatorUtils;
 import org.apache.pinot.core.operator.combine.DistinctCombineOperator;
 import org.apache.pinot.core.operator.combine.GroupByCombineOperator;
 import org.apache.pinot.core.operator.combine.GroupByOrderByCombineOperator;
@@ -49,11 +50,6 @@ import org.apache.pinot.spi.exception.BadQueryRequestException;
  * The <code>CombinePlanNode</code> class provides the execution plan for combining results from multiple segments.
  */
 public class CombinePlanNode implements PlanNode {
-  // Use at most 10 or half of the processors threads for each query.
-  // If there are less than 2 processors, use 1 thread.
-  // Runtime.getRuntime().availableProcessors() may return value < 2 in container based environment, e.g. Kubernetes.
-  private static final int MAX_NUM_THREADS_PER_QUERY =
-      Math.max(1, Math.min(10, Runtime.getRuntime().availableProcessors() / 2));
   // Try to schedule 10 plans for each thread, or evenly distribute plans to all MAX_NUM_THREADS_PER_QUERY threads
   private static final int TARGET_NUM_PLANS_PER_THREAD = 10;
 
@@ -61,6 +57,7 @@ public class CombinePlanNode implements PlanNode {
   private final QueryContext _queryContext;
   private final ExecutorService _executorService;
   private final long _endTimeMs;
+  private final int _maxExecutionThreads;
   private final int _numGroupsLimit;
 
   // Used for SQL GROUP BY during server combine
@@ -76,18 +73,20 @@ public class CombinePlanNode implements PlanNode {
    * @param queryContext Query context
    * @param executorService Executor service
    * @param endTimeMs End time in milliseconds for the query
+   * @param maxExecutionThreads Maximum number of threads used to execute the query
    * @param numGroupsLimit Limit of number of groups stored in each segment
    * @param minGroupTrimSize Minimum number of groups to keep when trimming groups for SQL GROUP BY
    * @param groupTrimThreshold Trim threshold to use for server combine for SQL GROUP BY
    * @param streamObserver Optional stream observer for streaming query
    */
   public CombinePlanNode(List<PlanNode> planNodes, QueryContext queryContext, ExecutorService executorService,
-      long endTimeMs, int numGroupsLimit, int minGroupTrimSize, int groupTrimThreshold,
+      long endTimeMs, int maxExecutionThreads, int numGroupsLimit, int minGroupTrimSize, int groupTrimThreshold,
       @Nullable StreamObserver<Server.ServerResponse> streamObserver) {
     _planNodes = planNodes;
     _queryContext = queryContext;
     _executorService = executorService;
     _endTimeMs = endTimeMs;
+    _maxExecutionThreads = maxExecutionThreads;
     _numGroupsLimit = numGroupsLimit;
     _minGroupTrimSize = minGroupTrimSize;
     _groupTrimThreshold = groupTrimThreshold;
@@ -108,8 +107,10 @@ public class CombinePlanNode implements PlanNode {
     } else {
       // Large number of plan nodes, run them in parallel
 
-      int numThreads = Math.min((numPlanNodes + TARGET_NUM_PLANS_PER_THREAD - 1) / TARGET_NUM_PLANS_PER_THREAD,
-          MAX_NUM_THREADS_PER_QUERY);
+      int maxExecutionThreads =
+          _maxExecutionThreads > 0 ? _maxExecutionThreads : CombineOperatorUtils.MAX_NUM_THREADS_PER_QUERY;
+      int numThreads =
+          Math.min((numPlanNodes + TARGET_NUM_PLANS_PER_THREAD - 1) / TARGET_NUM_PLANS_PER_THREAD, maxExecutionThreads);
 
       // Use a Phaser to ensure all the Futures are done (not scheduled, finished or interrupted) before the main thread
       // returns. We need to ensure no execution left before the main thread returning because the main thread holds the
@@ -177,32 +178,36 @@ public class CombinePlanNode implements PlanNode {
     if (_streamObserver != null) {
       // Streaming query (only support selection only)
       return new StreamingSelectionOnlyCombineOperator(operators, _queryContext, _executorService, _endTimeMs,
-          _streamObserver);
+          _maxExecutionThreads, _streamObserver);
     }
     if (QueryContextUtils.isAggregationQuery(_queryContext)) {
       if (_queryContext.getGroupByExpressions() == null) {
         // Aggregation only
-        return new AggregationOnlyCombineOperator(operators, _queryContext, _executorService, _endTimeMs);
+        return new AggregationOnlyCombineOperator(operators, _queryContext, _executorService, _endTimeMs,
+            _maxExecutionThreads);
       } else {
         // Aggregation group-by
         Map<String, String> queryOptions = _queryContext.getQueryOptions();
         if (queryOptions != null && QueryOptions.isGroupByModeSQL(queryOptions)) {
           return new GroupByOrderByCombineOperator(operators, _queryContext, _executorService, _endTimeMs,
-              _minGroupTrimSize, _groupTrimThreshold);
+              _maxExecutionThreads, _minGroupTrimSize, _groupTrimThreshold);
         }
-        return new GroupByCombineOperator(operators, _queryContext, _executorService, _endTimeMs, _numGroupsLimit);
+        return new GroupByCombineOperator(operators, _queryContext, _executorService, _endTimeMs, _maxExecutionThreads,
+            _numGroupsLimit);
       }
     } else if (QueryContextUtils.isSelectionQuery(_queryContext)) {
       if (_queryContext.getLimit() == 0 || _queryContext.getOrderByExpressions() == null) {
         // Selection only
-        return new SelectionOnlyCombineOperator(operators, _queryContext, _executorService, _endTimeMs);
+        return new SelectionOnlyCombineOperator(operators, _queryContext, _executorService, _endTimeMs,
+            _maxExecutionThreads);
       } else {
         // Selection order-by
-        return new SelectionOrderByCombineOperator(operators, _queryContext, _executorService, _endTimeMs);
+        return new SelectionOrderByCombineOperator(operators, _queryContext, _executorService, _endTimeMs,
+            _maxExecutionThreads);
       }
     } else {
       assert QueryContextUtils.isDistinctQuery(_queryContext);
-      return new DistinctCombineOperator(operators, _queryContext, _executorService, _endTimeMs);
+      return new DistinctCombineOperator(operators, _queryContext, _executorService, _endTimeMs, _maxExecutionThreads);
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptions.java
@@ -88,6 +88,12 @@ public class QueryOptions {
   }
 
   @Nullable
+  public static Integer getMaxExecutionThreads(Map<String, String> queryOptions) {
+    String maxExecutionThreadsString = queryOptions.get(Request.QueryOptionKey.MAX_EXECUTION_THREADS);
+    return maxExecutionThreadsString != null ? Integer.parseInt(maxExecutionThreadsString) : null;
+  }
+
+  @Nullable
   public static Integer getMinSegmentGroupTrimSize(Map<String, String> queryOptions) {
     String minSegmentGroupTrimSizeString = queryOptions.get(Request.QueryOptionKey.MIN_SEGMENT_GROUP_TRIM_SIZE);
     return minSegmentGroupTrimSizeString != null ? Integer.parseInt(minSegmentGroupTrimSizeString) : null;

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineSlowOperatorsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineSlowOperatorsTest.java
@@ -65,7 +65,8 @@ public class CombineSlowOperatorsTest {
   public void testSelectionOnlyCombineOperator() {
     List<Operator> operators = getOperators();
     SelectionOnlyCombineOperator combineOperator = new SelectionOnlyCombineOperator(operators,
-        QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable"), _executorService, TIMEOUT_MS);
+        QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable"), _executorService, TIMEOUT_MS,
+        InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS);
     testCombineOperator(operators, combineOperator);
   }
 
@@ -77,7 +78,7 @@ public class CombineSlowOperatorsTest {
     List<Operator> operators = getOperators();
     AggregationOnlyCombineOperator combineOperator = new AggregationOnlyCombineOperator(operators,
         QueryContextConverterUtils.getQueryContextFromSQL("SELECT COUNT(*) FROM testTable"), _executorService,
-        TIMEOUT_MS);
+        TIMEOUT_MS, InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS);
     testCombineOperator(operators, combineOperator);
   }
 
@@ -86,7 +87,8 @@ public class CombineSlowOperatorsTest {
     List<Operator> operators = getOperators();
     GroupByCombineOperator combineOperator = new GroupByCombineOperator(operators,
         QueryContextConverterUtils.getQueryContextFromSQL("SELECT COUNT(*) FROM testTable GROUP BY column"),
-        _executorService, TIMEOUT_MS, InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT);
+        _executorService, TIMEOUT_MS, InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT,
+        InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS);
     testCombineOperator(operators, combineOperator);
   }
 
@@ -96,7 +98,7 @@ public class CombineSlowOperatorsTest {
     GroupByOrderByCombineOperator combineOperator = new GroupByOrderByCombineOperator(operators,
         QueryContextConverterUtils.getQueryContextFromSQL("SELECT COUNT(*) FROM testTable GROUP BY column"),
         _executorService, TIMEOUT_MS, InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
-        InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
+        InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD, InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS);
     testCombineOperator(operators, combineOperator);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/SelectionCombineOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/SelectionCombineOperatorTest.java
@@ -230,7 +230,8 @@ public class SelectionCombineOperatorTest {
     }
     CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, queryContext, EXECUTOR,
         System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS,
-        InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
+        InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS, InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT,
+        InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
         InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD, null);
     return combinePlanNode.run().nextBlock();
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/CombinePlanNodeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/CombinePlanNodeTest.java
@@ -59,7 +59,8 @@ public class CombinePlanNodeTest {
       }
       CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, _queryContext, _executorService,
           System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS,
-          InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
+          InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS, InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT,
+          InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
           InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD, null);
       combinePlanNode.run();
       Assert.assertEquals(numPlans, count.get());
@@ -85,7 +86,7 @@ public class CombinePlanNodeTest {
     }
     CombinePlanNode combinePlanNode =
         new CombinePlanNode(planNodes, _queryContext, _executorService, System.currentTimeMillis() + 100,
-            InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT,
+            InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS, InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT,
             InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
             InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD, null);
     try {
@@ -109,7 +110,8 @@ public class CombinePlanNodeTest {
     }
     CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, _queryContext, _executorService,
         System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS,
-        InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
+        InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS, InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT,
+        InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
         InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD, null);
     try {
       combinePlanNode.run();

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/GroupByTrimTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/GroupByTrimTest.java
@@ -122,7 +122,8 @@ public class GroupByTrimTest {
     GroupByOrderByCombineOperator combineOperator =
         new GroupByOrderByCombineOperator(Collections.singletonList(groupByOperator), queryContext, _executorService,
             System.currentTimeMillis() + CommonConstants.Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS,
-            minServerGroupTrimSize, InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
+            InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS, minServerGroupTrimSize,
+            InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
 
     // Execute the query
     IntermediateResultsBlock resultsBlock = combineOperator.nextBlock();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -228,6 +228,7 @@ public class CommonConstants {
         public static final String RESPONSE_FORMAT = "responseFormat";
         public static final String GROUP_BY_MODE = "groupByMode";
         public static final String SKIP_UPSERT = "skipUpsert";
+        public static final String MAX_EXECUTION_THREADS = "maxExecutionThreads";
         public static final String MIN_SEGMENT_GROUP_TRIM_SIZE = "minSegmentGroupTrimSize";
         public static final String MIN_SERVER_GROUP_TRIM_SIZE = "minServerGroupTrimSize";
       }


### PR DESCRIPTION
## Description
Add instance config and query option to limit the maximum execution threads used for a query.
By default (same as existing behavior), pinot will use up to 10 threads (or half of the CPU cores is it is smaller than 10) for non-group-by queries; and all threads for group-by queries.
This option can be used to:
- Limit the thread usage for very expensive queries such as large group-by or full table scan
- Fully utilize all the threads for non-group-by queries to get the smallest latency

Example run of large group-by queries (10 segments, each with 10M records, grouping on a column of cardinality 10M):

Without thread limit:
- Latency: 4103ms
- Total thread time: 38353324527ns

With thread limit 1 (single thread):
- Latency: 10495ms
- Total thread time: 10487257767ns

Profile of CPU usage (run without limit 3 times, then single thread 3 times)
![Screen Shot 2021-09-28 at 5 06 56 PM](https://user-images.githubusercontent.com/17555551/135182486-111f1a83-5c5c-41ee-b009-564917df3d7a.png)

## Release Notes
Added server instance config `pinot.server.query.executor.max.execution.threads` to configure the instance level thread limit
Added query option `maxExecutionThreads` to configure the query level thread limit, which can be used to override the instance level limit if both exist