### PR TITLE
Move acquire/release to right before/after execution call

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/AcquireReleaseColumnsSegmentOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/AcquireReleaseColumnsSegmentOperator.java
@@ -30,8 +30,10 @@ import org.apache.pinot.segment.spi.IndexSegment;
  * NOTE: This is only used if <code>pinot.server.query.executor.enable.prefetch</code> is true
  * This creates a mechanism to acquire and release column buffers before reading data.
  * This Operator is different from others in the following way:
- * It expects the PlanNode of the execution, instead of the Operator. It runs the plan to get the operator, before it begins execution.
- * The reason this is done is the planners access segment buffers, and we need to acquire the segment before any access is made to the buffers.
+ * It expects the PlanNode of the execution, instead of the Operator.
+ * It runs the plan to get the operator, before it begins execution.
+ * The reason this is done is the planners access segment buffers,
+ * and we need to acquire the segment before any access is made to the buffers.
  */
 public class AcquireReleaseColumnsSegmentOperator extends BaseOperator {
   private static final String OPERATOR_NAME = "AcquireReleaseColumnsSegmentOperator";

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AcquireReleaseColumnsSegmentPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AcquireReleaseColumnsSegmentPlanNode.java
@@ -25,6 +25,12 @@ import org.apache.pinot.segment.spi.IndexSegment;
 
 /**
  * A common wrapper for the segment-level plan node.
+ * NOTE: This is only used if <code>pinot.server.query.executor.enable.prefetch</code> is true
+ * This PlanNode differs from the other PlanNodes in the following way:
+ * This PlanNode does not invoke a <code>run</code> on the childOperator in its run method.
+ * Instead, it passes the childPlanNode as is, to the {@link AcquireReleaseColumnsSegmentOperator},
+ * and it is that operator's responsibility to run the childPlanNode and get the childOperator before execution.
+ * The reason this is done is the planners access segment buffers, and we need to acquire the segment before any access is made to the buffers.
  */
 public class AcquireReleaseColumnsSegmentPlanNode implements PlanNode {
 
@@ -39,8 +45,11 @@ public class AcquireReleaseColumnsSegmentPlanNode implements PlanNode {
     _fetchContext = fetchContext;
   }
 
+  /**
+   * Doesn't run the childPlan, but instead just creates a {@link AcquireReleaseColumnsSegmentOperator} and passes the plan to it
+   */
   @Override
   public AcquireReleaseColumnsSegmentOperator run() {
-    return new AcquireReleaseColumnsSegmentOperator(_childPlanNode.run(), _indexSegment, _fetchContext);
+    return new AcquireReleaseColumnsSegmentOperator(_childPlanNode, _indexSegment, _fetchContext);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AcquireReleaseColumnsSegmentPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AcquireReleaseColumnsSegmentPlanNode.java
@@ -30,7 +30,8 @@ import org.apache.pinot.segment.spi.IndexSegment;
  * This PlanNode does not invoke a <code>run</code> on the childOperator in its run method.
  * Instead, it passes the childPlanNode as is, to the {@link AcquireReleaseColumnsSegmentOperator},
  * and it is that operator's responsibility to run the childPlanNode and get the childOperator before execution.
- * The reason this is done is the planners access segment buffers, and we need to acquire the segment before any access is made to the buffers.
+ * The reason this is done is the planners access segment buffers,
+ * and we need to acquire the segment before any access is made to the buffers.
  */
 public class AcquireReleaseColumnsSegmentPlanNode implements PlanNode {
 
@@ -46,7 +47,8 @@ public class AcquireReleaseColumnsSegmentPlanNode implements PlanNode {
   }
 
   /**
-   * Doesn't run the childPlan, but instead just creates a {@link AcquireReleaseColumnsSegmentOperator} and passes the plan to it
+   * Doesn't run the childPlan,
+   * but instead just creates a {@link AcquireReleaseColumnsSegmentOperator} and passes the plan to it
    */
   @Override
   public AcquireReleaseColumnsSegmentOperator run() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -175,7 +175,7 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
         } else {
           columns = queryContext.getColumns();
         }
-        FetchContext fetchContext = new FetchContext(UUID.randomUUID(), columns);
+        FetchContext fetchContext = new FetchContext(UUID.randomUUID(), indexSegment.getSegmentName(), columns);
         fetchContexts.add(fetchContext);
         planNodes.add(
             new AcquireReleaseColumnsSegmentPlanNode(makeSegmentPlanNode(indexSegment, queryContext), indexSegment,

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkRoaringBitmapCreation.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkRoaringBitmapCreation.java
@@ -1,0 +1,217 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.ref.SoftReference;
+import java.nio.ByteOrder;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.math.RandomUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pinot.segment.local.segment.creator.impl.inv.BitmapInvertedIndexWriter;
+import org.apache.pinot.segment.spi.memory.PinotByteBuffer;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.profile.GCProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+import org.roaringbitmap.RoaringBitmap;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+
+
+/**
+ * Benchmark created to test the impact of removing the SoftReference array cache for ImmutableRoaringBitmap
+ */
+@State(Scope.Benchmark)
+@Fork(1)
+public class BenchmarkRoaringBitmapCreation {
+
+  private static final int NUM_DOCS = 1_000_000;
+  private static final int CARDINALITY = 100_000;
+  private static final File TEMP_DIR =
+      new File(FileUtils.getTempDirectory(), "bitmap_creation_benchmark_" + System.currentTimeMillis());
+
+  @Param({"100", "10000", "99999"}) // higher this is, lesser the cache access
+  public int _dictIdsToRead;
+
+  private int _numBitmaps;
+  private BitmapInvertedIndexWriter _bitmapInvertedIndexWriter;
+  private SoftReference<SoftReference<ImmutableRoaringBitmap>[]> _bitmapsArrayReference = null;
+  private SoftReference<SoftReference<Pair<Integer, Integer>>[]> _offsetLengthPairsArrayReference = null;
+  private PinotDataBuffer _offsetLengthBuffer;
+  private PinotDataBuffer _bitmapBuffer;
+  private int _firstOffset;
+
+  @Setup
+  public void setup()
+      throws IllegalAccessException, InstantiationException, IOException {
+    _numBitmaps = CARDINALITY;
+
+    File bufferDir = new File(TEMP_DIR, "cardinality_" + CARDINALITY);
+    FileUtils.forceMkdir(bufferDir);
+    File bufferFile = new File(bufferDir, "buffer");
+    _bitmapInvertedIndexWriter = new BitmapInvertedIndexWriter(bufferFile, _numBitmaps);
+    // Insert between 10-1000 values per bitmap
+    for (int i = 0; i < _numBitmaps; i++) {
+      int size = 10 + RandomUtils.nextInt(990);
+      int[] data = new int[size];
+      for (int j = 0; j < size; j++) {
+        data[j] = RandomUtils
+            .nextInt(NUM_DOCS); // docIds will repeat across bitmaps, but doesn't matter for purpose of this benchmark
+      }
+      RoaringBitmap bitmap = RoaringBitmap.bitmapOf(data);
+      _bitmapInvertedIndexWriter.add(bitmap);
+    }
+
+    PinotDataBuffer dataBuffer = PinotByteBuffer.mapReadOnlyBigEndianFile(bufferFile);
+    long offsetBufferEndOffset = (long) (_numBitmaps + 1) * Integer.BYTES;
+    _offsetLengthBuffer = dataBuffer.view(0, offsetBufferEndOffset, ByteOrder.BIG_ENDIAN);
+    _bitmapBuffer = dataBuffer.view(offsetBufferEndOffset, dataBuffer.size());
+    _firstOffset = _offsetLengthBuffer.getInt(0);
+  }
+
+  @TearDown
+  public void teardown()
+      throws IOException {
+    _bitmapInvertedIndexWriter.close();
+    FileUtils.deleteQuietly(TEMP_DIR);
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public boolean cacheReferences() {
+    int dictId = RandomUtils.nextInt(_dictIdsToRead);
+    ImmutableRoaringBitmap roaringBitmapFromCache = getRoaringBitmapFromCache(dictId);
+    return roaringBitmapFromCache.isEmpty();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public boolean alwaysBuild() {
+    int dictId = RandomUtils.nextInt(_dictIdsToRead);
+    ImmutableRoaringBitmap immutableRoaringBitmap = buildRoaringBitmap(dictId);
+    return immutableRoaringBitmap.isEmpty();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MICROSECONDS)
+  public boolean alwaysBuildCachedOffsetAndLength() {
+    int dictId = RandomUtils.nextInt(_dictIdsToRead);
+    ImmutableRoaringBitmap immutableRoaringBitmap = buildRoaringBitmapUsingOffsetPairFromCache(dictId);
+    return immutableRoaringBitmap.isEmpty();
+  }
+
+  /**
+   * Code as of before this commit, using an array of SoftReference for the ImmutableRoaringBitmap
+   */
+  private ImmutableRoaringBitmap getRoaringBitmapFromCache(int dictId) {
+    SoftReference<ImmutableRoaringBitmap>[] bitmapArrayReference =
+        (_bitmapsArrayReference != null) ? _bitmapsArrayReference.get() : null;
+    if (bitmapArrayReference != null) {
+      SoftReference<ImmutableRoaringBitmap> bitmapReference = bitmapArrayReference[dictId];
+      ImmutableRoaringBitmap bitmap = (bitmapReference != null) ? bitmapReference.get() : null;
+      if (bitmap != null) {
+        return bitmap;
+      }
+    } else {
+      bitmapArrayReference = new SoftReference[_numBitmaps];
+      _bitmapsArrayReference = new SoftReference<>(bitmapArrayReference);
+    }
+    synchronized (this) {
+      SoftReference<ImmutableRoaringBitmap> bitmapReference = bitmapArrayReference[dictId];
+      ImmutableRoaringBitmap bitmap = (bitmapReference != null) ? bitmapReference.get() : null;
+      if (bitmap == null) {
+        bitmap = buildRoaringBitmap(dictId);
+        bitmapArrayReference[dictId] = new SoftReference<>(bitmap);
+      }
+      return bitmap;
+    }
+  }
+
+  private ImmutableRoaringBitmap buildRoaringBitmap(int dictId) {
+    Pair<Integer, Integer> offsetLengthPair = buildOffsetLengthPair(dictId);
+    return buildRoaringBitmap(offsetLengthPair);
+  }
+
+  private Pair<Integer, Integer> buildOffsetLengthPair(int dictId) {
+    int offset = _offsetLengthBuffer.getInt(dictId * Integer.BYTES);
+    int length = _offsetLengthBuffer.getInt((dictId + 1) * Integer.BYTES) - offset;
+    return Pair.of(offset, length);
+  }
+
+  private ImmutableRoaringBitmap buildRoaringBitmap(Pair<Integer, Integer> offsetLengthPair) {
+    return new ImmutableRoaringBitmap(
+        _bitmapBuffer.toDirectByteBuffer(offsetLengthPair.getLeft() - _firstOffset, offsetLengthPair.getRight()));
+  }
+
+  private ImmutableRoaringBitmap buildRoaringBitmapUsingOffsetPairFromCache(int dictId) {
+    return buildRoaringBitmap(getOffsetLengthPairFromCache(dictId));
+  }
+
+  private Pair<Integer, Integer> getOffsetLengthPairFromCache(int dictId) {
+
+    SoftReference<Pair<Integer, Integer>>[] offsetLengthPairArrayReference =
+        (_offsetLengthPairsArrayReference != null) ? _offsetLengthPairsArrayReference.get() : null;
+    if (offsetLengthPairArrayReference != null) {
+      SoftReference<Pair<Integer, Integer>> offsetLengthPairReference = offsetLengthPairArrayReference[dictId];
+      Pair<Integer, Integer> offsetLengthPair =
+          (offsetLengthPairReference != null) ? offsetLengthPairReference.get() : null;
+      if (offsetLengthPair != null) {
+        return offsetLengthPair;
+      }
+    } else {
+      offsetLengthPairArrayReference = new SoftReference[_numBitmaps];
+      _offsetLengthPairsArrayReference = new SoftReference<>(offsetLengthPairArrayReference);
+    }
+    synchronized (this) {
+      SoftReference<Pair<Integer, Integer>> offsetLengthPairReference = offsetLengthPairArrayReference[dictId];
+      Pair<Integer, Integer> offsetLengthPair =
+          (offsetLengthPairReference != null) ? offsetLengthPairReference.get() : null;
+      if (offsetLengthPair == null) {
+        offsetLengthPair = buildOffsetLengthPair(dictId);
+        offsetLengthPairArrayReference[dictId] = new SoftReference<>(offsetLengthPair);
+      }
+      return offsetLengthPair;
+    }
+  }
+
+  public static void main(String[] args)
+      throws Exception {
+    ChainedOptionsBuilder opt = new OptionsBuilder().include(BenchmarkRoaringBitmapCreation.class.getSimpleName())
+        .warmupTime(TimeValue.seconds(10)).warmupIterations(1).measurementTime(TimeValue.seconds(60))
+        .measurementIterations(1).forks(1).addProfiler(GCProfiler.class);
+    new Runner(opt.build()).run();
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BitmapInvertedIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BitmapInvertedIndexReader.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.segment.local.segment.index.readers;
 
-import java.lang.ref.SoftReference;
 import java.nio.ByteOrder;
 import org.apache.pinot.segment.local.segment.creator.impl.inv.BitmapInvertedIndexWriter;
 import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
@@ -35,7 +34,6 @@ import org.slf4j.LoggerFactory;
 public class BitmapInvertedIndexReader implements InvertedIndexReader<ImmutableRoaringBitmap> {
   public static final Logger LOGGER = LoggerFactory.getLogger(BitmapInvertedIndexReader.class);
 
-  private final int _numBitmaps;
   private final PinotDataBuffer _offsetBuffer;
   private final PinotDataBuffer _bitmapBuffer;
 
@@ -44,11 +42,7 @@ public class BitmapInvertedIndexReader implements InvertedIndexReader<ImmutableR
   //   2. Offset buffer stores the offsets within the bitmap buffer
   private final int _firstOffset;
 
-  private volatile SoftReference<SoftReference<ImmutableRoaringBitmap>[]> _bitmaps;
-
   public BitmapInvertedIndexReader(PinotDataBuffer dataBuffer, int numBitmaps) {
-    _numBitmaps = numBitmaps;
-
     long offsetBufferEndOffset = (long) (numBitmaps + 1) * Integer.BYTES;
     _offsetBuffer = dataBuffer.view(0, offsetBufferEndOffset, ByteOrder.BIG_ENDIAN);
     _bitmapBuffer = dataBuffer.view(offsetBufferEndOffset, dataBuffer.size());
@@ -59,29 +53,6 @@ public class BitmapInvertedIndexReader implements InvertedIndexReader<ImmutableR
   @SuppressWarnings("unchecked")
   @Override
   public ImmutableRoaringBitmap getDocIds(int dictId) {
-    SoftReference<ImmutableRoaringBitmap>[] bitmapArrayReference = (_bitmaps != null) ? _bitmaps.get() : null;
-    if (bitmapArrayReference != null) {
-      SoftReference<ImmutableRoaringBitmap> bitmapReference = bitmapArrayReference[dictId];
-      ImmutableRoaringBitmap bitmap = (bitmapReference != null) ? bitmapReference.get() : null;
-      if (bitmap != null) {
-        return bitmap;
-      }
-    } else {
-      bitmapArrayReference = new SoftReference[_numBitmaps];
-      _bitmaps = new SoftReference<>(bitmapArrayReference);
-    }
-    synchronized (this) {
-      SoftReference<ImmutableRoaringBitmap> bitmapReference = bitmapArrayReference[dictId];
-      ImmutableRoaringBitmap bitmap = (bitmapReference != null) ? bitmapReference.get() : null;
-      if (bitmap == null) {
-        bitmap = buildRoaringBitmap(dictId);
-        bitmapArrayReference[dictId] = new SoftReference<>(bitmap);
-      }
-      return bitmap;
-    }
-  }
-
-  private ImmutableRoaringBitmap buildRoaringBitmap(int dictId) {
     int offset = _offsetBuffer.getInt(dictId * Integer.BYTES);
     int length = _offsetBuffer.getInt((dictId + 1) * Integer.BYTES) - offset;
     return new ImmutableRoaringBitmap(_bitmapBuffer.toDirectByteBuffer(offset - _firstOffset, length));

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/NullValueVectorReaderImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/NullValueVectorReaderImpl.java
@@ -32,12 +32,13 @@ public class NullValueVectorReaderImpl implements NullValueVectorReader {
   }
 
   public boolean isNull(int docId) {
-    ImmutableRoaringBitmap nullBitmap = new ImmutableRoaringBitmap(_dataBuffer.toDirectByteBuffer(0, (int) _dataBuffer.size()));
+    ImmutableRoaringBitmap nullBitmap =
+        new ImmutableRoaringBitmap(_dataBuffer.toDirectByteBuffer(0, (int) _dataBuffer.size()));
     return nullBitmap.contains(docId);
   }
 
   @Override
   public ImmutableRoaringBitmap getNullBitmap() {
-    return  new ImmutableRoaringBitmap(_dataBuffer.toDirectByteBuffer(0, (int) _dataBuffer.size()));
+    return new ImmutableRoaringBitmap(_dataBuffer.toDirectByteBuffer(0, (int) _dataBuffer.size()));
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/NullValueVectorReaderImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/NullValueVectorReaderImpl.java
@@ -25,18 +25,19 @@ import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 
 public class NullValueVectorReaderImpl implements NullValueVectorReader {
 
-  private final ImmutableRoaringBitmap _nullBitmap;
+  private final PinotDataBuffer _dataBuffer;
 
   public NullValueVectorReaderImpl(PinotDataBuffer dataBuffer) {
-    _nullBitmap = new ImmutableRoaringBitmap(dataBuffer.toDirectByteBuffer(0, (int) dataBuffer.size()));
+    _dataBuffer = dataBuffer;
   }
 
   public boolean isNull(int docId) {
-    return _nullBitmap.contains(docId);
+    ImmutableRoaringBitmap nullBitmap = new ImmutableRoaringBitmap(_dataBuffer.toDirectByteBuffer(0, (int) _dataBuffer.size()));
+    return nullBitmap.contains(docId);
   }
 
   @Override
   public ImmutableRoaringBitmap getNullBitmap() {
-    return _nullBitmap;
+    return  new ImmutableRoaringBitmap(_dataBuffer.toDirectByteBuffer(0, (int) _dataBuffer.size()));
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/NullValueVectorReaderImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/NullValueVectorReaderImpl.java
@@ -32,9 +32,7 @@ public class NullValueVectorReaderImpl implements NullValueVectorReader {
   }
 
   public boolean isNull(int docId) {
-    ImmutableRoaringBitmap nullBitmap =
-        new ImmutableRoaringBitmap(_dataBuffer.toDirectByteBuffer(0, (int) _dataBuffer.size()));
-    return nullBitmap.contains(docId);
+    return getNullBitmap().contains(docId);
   }
 
   @Override

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/FetchContext.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/FetchContext.java
@@ -27,10 +27,12 @@ import java.util.UUID;
  */
 public class FetchContext {
   private final UUID _fetchId;
+  private final String _segmentName;
   private final Set<String> _columns;
 
-  public FetchContext(UUID fetchId, Set<String> columns) {
+  public FetchContext(UUID fetchId, String segmentName, Set<String> columns) {
     _fetchId = fetchId;
+    _segmentName = segmentName;
     _columns = columns;
   }
 
@@ -40,6 +42,13 @@ public class FetchContext {
    */
   public UUID getFetchId() {
     return _fetchId;
+  }
+
+  /**
+   * Segment name associated with this fetch context
+   */
+  public String getSegmentName() {
+    return _segmentName;
   }
 
   /**


### PR DESCRIPTION
1) Add more info to FetchContext 
2) Make AcquireReleaseOperator take the plan instead of the operator for the child, to ensure acquire can happen before buffers accessed in planning
3) Move acquire release to BaseCombineOperator level, to better ensure release only happens after buffer access are done

To ensure clean acquire/release semantics, dataBuffers can no longer cache DirectByteBuffers. Removing it from BitmapInvertedIndexReader, RangeInvertedIndexReader and NullValueVectorReaderImpl.
Included jmh benchmarks in the change, which shows
1. while cached bitmaps outperform in a setup with large heap and high repeatability, it performs significantly worse in a setup with tight heap and low repeatability, compared to always building the bitmap.
2. in the case where alwaysBuild performed slower, the overhead we're talking about here is <1 microseconds per read. In the case where alwaysBuild performed better, it outdid by 4.6 microseconds per read.
3. These results remain consistent regardless of low/high cardinality
