### PR TITLE
Follow up to improve restlet API package config key

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.controller;
 
 import com.google.common.base.Preconditions;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -28,7 +27,6 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.configuration.Configuration;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.common.utils.StringUtil;
@@ -840,12 +838,7 @@ public class ControllerConf extends PinotConfiguration {
   }
 
   public String getControllerResourcePackages() {
-    Object rawProperty = getRawProperty(CONTROLLER_RESOURCE_PACKAGES, DEFAULT_CONTROLLER_RESOURCE_PACKAGES);
-    if (rawProperty instanceof String) {
-      return (String) rawProperty;
-    } else {
-      return StringUtils.join(((ArrayList) rawProperty).toArray(), ',');
-    }
+    return getProperty(CONTROLLER_RESOURCE_PACKAGES, DEFAULT_CONTROLLER_RESOURCE_PACKAGES);
   }
 
   private long convertPeriodToUnit(String period, TimeUnit timeUnitToConvertTo) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.controller;
 
 import com.google.common.base.Preconditions;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -27,6 +28,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.configuration.Configuration;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.common.utils.StringUtil;
@@ -71,8 +73,8 @@ public class ControllerConf extends PinotConfiguration {
   public static final String DEFAULT_TABLE_CONFIG_TUNER_PACKAGES = "org.apache.pinot";
 
   // Comma separated list of packages that contains javax service resources.
-  private static final String CONTROLLER_RESOURCE_PACKAGES = "controller.restlet.api.resource.packages";
-  private static final String DEFAULT_CONTROLLER_RESOURCE_PACKAGES = "org.apache.pinot.controller.api.resources";
+  public static final String CONTROLLER_RESOURCE_PACKAGES = "controller.restlet.api.resource.packages";
+  public static final String DEFAULT_CONTROLLER_RESOURCE_PACKAGES = "org.apache.pinot.controller.api.resources";
 
   public enum ControllerMode {
     DUAL, PINOT_ONLY, HELIX_ONLY
@@ -838,7 +840,12 @@ public class ControllerConf extends PinotConfiguration {
   }
 
   public String getControllerResourcePackages() {
-    return getProperty(CONTROLLER_RESOURCE_PACKAGES, DEFAULT_CONTROLLER_RESOURCE_PACKAGES);
+    Object rawProperty = getRawProperty(CONTROLLER_RESOURCE_PACKAGES, DEFAULT_CONTROLLER_RESOURCE_PACKAGES);
+    if (rawProperty instanceof String) {
+      return (String) rawProperty;
+    } else {
+      return StringUtils.join(((ArrayList) rawProperty).toArray(), ',');
+    }
   }
 
   private long convertPeriodToUnit(String period, TimeUnit timeUnitToConvertTo) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerTestUtils.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerTestUtils.java
@@ -676,7 +676,7 @@ public abstract class ControllerTestUtils {
     return _controllerStarter;
   }
 
-  public static Map<String, Object> getSuiteControllerConfiguration(Map<String, Object> extraProperties) {
+  public static Map<String, Object> getSuiteControllerConfiguration() {
     Map<String, Object> properties = getDefaultControllerConfiguration();
 
     // Used in AccessControlTest
@@ -689,8 +689,6 @@ public abstract class ControllerTestUtils {
     properties.put("controller.segment.fetcher.auth.token", "*personal*");
     properties.put("controller.admin.access.control.principals.user.password", "*personal*");
 
-    properties.putAll(extraProperties);
-
     return properties;
   }
 
@@ -702,10 +700,13 @@ public abstract class ControllerTestUtils {
   /**
    * Initialize shared state for the TestNG suite.
    */
-  public static void startSuiteRun(Map<String, Object> properties)
+  public static void startSuiteRun(Map<String, Object> extraProperties)
       throws Exception {
     startZk();
-    startController(getSuiteControllerConfiguration(properties));
+
+    Map<String, Object> suiteControllerConfiguration = getSuiteControllerConfiguration();
+    suiteControllerConfiguration.putAll(extraProperties);
+    startController(suiteControllerConfiguration);
 
     addMoreFakeBrokerInstancesToAutoJoinHelixCluster(NUM_BROKER_INSTANCES, true);
     addMoreFakeServerInstancesToAutoJoinHelixCluster(NUM_SERVER_INSTANCES, true);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerTestUtils.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerTestUtils.java
@@ -676,7 +676,7 @@ public abstract class ControllerTestUtils {
     return _controllerStarter;
   }
 
-  public static Map<String, Object> getSuiteControllerConfiguration() {
+  public static Map<String, Object> getSuiteControllerConfiguration(Map<String, Object> extraProperties) {
     Map<String, Object> properties = getDefaultControllerConfiguration();
 
     // Used in AccessControlTest
@@ -689,16 +689,23 @@ public abstract class ControllerTestUtils {
     properties.put("controller.segment.fetcher.auth.token", "*personal*");
     properties.put("controller.admin.access.control.principals.user.password", "*personal*");
 
+    properties.putAll(extraProperties);
+
     return properties;
+  }
+
+  public static void startSuiteRun()
+      throws Exception {
+    startSuiteRun(Collections.emptyMap());
   }
 
   /**
    * Initialize shared state for the TestNG suite.
    */
-  public static void startSuiteRun()
+  public static void startSuiteRun(Map<String, Object> properties)
       throws Exception {
     startZk();
-    startController(getSuiteControllerConfiguration());
+    startController(getSuiteControllerConfiguration(properties));
 
     addMoreFakeBrokerInstancesToAutoJoinHelixCluster(NUM_BROKER_INSTANCES, true);
     addMoreFakeServerInstancesToAutoJoinHelixCluster(NUM_SERVER_INSTANCES, true);
@@ -723,11 +730,16 @@ public abstract class ControllerTestUtils {
    */
   public static void setupClusterAndValidate()
       throws Exception {
+    setupClusterAndValidate(Collections.emptyMap());
+  }
+
+  public static void setupClusterAndValidate(Map<String, Object> extraProperties)
+      throws Exception {
     if (_zookeeperInstance == null || _helixResourceManager == null) {
       // this is expected to happen only when running a single test case outside of testNG suite, i.e when test
       // cases are run one at a time within IntelliJ or through maven command line. When running under a testNG
       // suite, state will have already been setup by @BeforeSuite method in ControllerTestSetup.
-      startSuiteRun();
+      startSuiteRun(extraProperties);
     }
 
     // Check number of tenants

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotDummyExtraRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotDummyExtraRestletResourceTest.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.common.utils.StringUtil;
+import org.apache.pinot.controller.ControllerTestUtils;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.controller.ControllerConf.CONTROLLER_RESOURCE_PACKAGES;
+import static org.apache.pinot.controller.ControllerConf.DEFAULT_CONTROLLER_RESOURCE_PACKAGES;
+import static org.testng.Assert.assertEquals;
+
+
+/**
+ * Test for extra resource package registered with HTTP server
+ */
+public class PinotDummyExtraRestletResourceTest {
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    Map<String, Object> extraProperties = new HashMap<>();
+    extraProperties.put(CONTROLLER_RESOURCE_PACKAGES, String.format("%s,%s",
+        "org.apache.pinot.controller.api.resources.extrapackage", DEFAULT_CONTROLLER_RESOURCE_PACKAGES));
+    ControllerTestUtils.setupClusterAndValidate(extraProperties);
+  }
+
+  @Test
+  public void testExtraDummyResourcePackages()
+      throws Exception {
+    String baseUrl = ControllerTestUtils.getControllerBaseApiUrl();
+    String resp = ControllerTestUtils.sendGetRequest(StringUtil.join("/", baseUrl, "testExtra"));
+    assertEquals(resp, "DummyMsg");
+  }
+
+  @AfterClass
+  public void tearDown() {
+    ControllerTestUtils.cleanup();
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/extrapackage/PinotDummyExtraRestletResource.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/extrapackage/PinotDummyExtraRestletResource.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources.extrapackage;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+
+
+@Api(tags = "testExtra")
+@Path("/testExtra")
+public class PinotDummyExtraRestletResource {
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "dummy get API")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Success"),
+      @ApiResponse(code = 500, message = "Internal error")
+  })
+  public String getDummyMsg() {
+    return "DummyMsg";
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.spi.env;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -31,6 +32,7 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.MapConfiguration;
 import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
 import org.apache.pinot.spi.utils.Obfuscator;
 
@@ -354,7 +356,12 @@ public class PinotConfiguration {
    * @return the property String value. Fallback to default value if missing.
    */
   public String getProperty(String name, String defaultValue) {
-    return getRawProperty(name, defaultValue).toString();
+    Object rawProperty = getRawProperty(name, defaultValue);
+    if (rawProperty instanceof List) {
+      return StringUtils.join(((ArrayList) rawProperty).toArray(), ',');
+    } else {
+      return rawProperty.toString();
+    }
   }
 
   private <T> T getProperty(String name, T defaultValue, Class<T> returnType) {


### PR DESCRIPTION
Follow up with #7488

- common.configuration actually auto split comma-sep list. need to fix it.
- making the config key public so we can directly use.
- added test