### PR TITLE
Support JSON queries with top-level array path expression.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/statement/JsonStatementOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/statement/JsonStatementOptimizer.java
@@ -390,7 +390,23 @@ public class JsonStatementOptimizer implements StatementOptimizer {
    *  two parts when joined together (name.first) represent a JSON path expression.
    */
   private static String[] getIdentifierParts(Identifier identifier) {
-    return StringUtils.split(identifier.getName(), '.');
+    String name = identifier.getName();
+
+    // If identifier represents a top level json object then there must be a '.' in the identifier name.
+    if (name.indexOf('.') != -1) {
+      return StringUtils.split(name, '.');
+    }
+
+    // If identifier represents a top level array object then there must be a '[' in identifier name.
+    int index = name.indexOf('[');
+    if (index != -1) {
+      // split the identifier into two parts where the first part is the column name and the second part is array
+      // subscript.
+      return new String[]{name.substring(0, index), name.substring(index)};
+    }
+
+    // Identifier must be a column name.
+    return new String[]{name};
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/statement/JsonStatementOptimizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/statement/JsonStatementOptimizerTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.query.optimizer.statement;
 
-import java.util.Arrays;
 import org.apache.pinot.core.query.optimizer.QueryOptimizer;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -26,7 +25,10 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
+
 import org.testng.annotations.Test;
+
+import java.util.Arrays;
 
 
 /**
@@ -64,10 +66,16 @@ public class JsonStatementOptimizerTest {
         "SELECT JSON_EXTRACT_SCALAR(jsonColumn, '$.data[0][1].a.b[0]', 'STRING', 'null') AS \"jsonColumn.data[0][1].a"
             + ".b[0]\" FROM testTable", TABLE_CONFIG_WITH_INDEX, SCHEMA);
 
+    // SELECT using json path expression with top-level array addressing.
+    TestHelper.assertEqualsQuery("SELECT jsonColumn[0] FROM testTable",
+        "SELECT JSON_EXTRACT_SCALAR(jsonColumn, '$.[0]', 'STRING', 'null') AS \"jsonColumn[0]\" FROM testTable",
+        TABLE_CONFIG_WITH_INDEX, SCHEMA);
+
     // SELECT using json path expressions within double quotes.
     TestHelper.assertEqualsQuery("SELECT \"jsonColumn.a.b.c[0][1][2][3].d.e.f[0].g\" FROM testTable",
         "SELECT JSON_EXTRACT_SCALAR(jsonColumn, '$.a.b.c[0][1][2][3].d.e.f[0].g', 'STRING', 'null') AS \"jsonColumn.a"
             + ".b.c[0][1][2][3].d.e.f[0].g\" FROM testTable", TABLE_CONFIG_WITH_INDEX, SCHEMA);
+
   }
 
   /** Test that a predicate comparing a json path expression with literal is properly converted into a JSON_MATCH
@@ -100,6 +108,16 @@ public class JsonStatementOptimizerTest {
         "SELECT * FROM testTable WHERE JSON_EXTRACT_SCALAR(jsonColumn, '$.id', 'JSON', 'null') IS NOT NULL AND "
             + "JSON_EXTRACT_SCALAR(jsonColumn, '$.id', 'LONG', -9223372036854775808) = 101", TABLE_CONFIG_WITHOUT_INDEX,
         SCHEMA);
+
+    // Use top-level array addressing in json path expression in filter
+    TestHelper.assertEqualsQuery("SELECT * FROM testTable WHERE jsonColumn[2] IS NOT NULL and jsonColumn[2] = 'test'",
+        "SELECT * FROM testTable WHERE JSON_EXTRACT_SCALAR(jsonColumn, '$.[2]', 'JSON', 'null') IS NOT NULL AND JSON_EXTRACT_SCALAR(jsonColumn, '$.[2]', 'STRING', 'null') = 'test'",
+        TABLE_CONFIG_WITHOUT_INDEX, SCHEMA);
+
+    // Use top-level array addressing in json path expression in filter
+    TestHelper.assertEqualsQuery("SELECT * FROM testTable WHERE jsonColumn[2] IS NOT NULL and jsonColumn[2] = 'test'",
+        "SELECT * FROM testTable WHERE JSON_MATCH(jsonColumn, '\"$.[2]\" IS NOT NULL') AND JSON_MATCH(jsonColumn, '\"$.[2]\" = ''test''')",
+        TABLE_CONFIG_WITH_INDEX, SCHEMA);
   }
 
   /** Test that a json path expression in GROUP BY clause is properly converted into a JSON_EXTRACT_SCALAR function. */
@@ -114,6 +132,11 @@ public class JsonStatementOptimizerTest {
         "SELECT JSON_EXTRACT_SCALAR(jsonColumn, '$.id', 'STRING', 'null') AS \"jsonColumn.id\", count(*) FROM "
             + "testTable GROUP BY JSON_EXTRACT_SCALAR(jsonColumn, '$.id', 'STRING', 'null')",
         TABLE_CONFIG_WITHOUT_INDEX, SCHEMA);
+
+    // Use top-level array addressing in json path expression in GROUP BY clause.
+    TestHelper.assertEqualsQuery("SELECT jsonColumn[0], count(*) FROM testTable GROUP BY jsonColumn[0]",
+        "SELECT JSON_EXTRACT_SCALAR(jsonColumn, '$.[0]', 'STRING', 'null') AS \"jsonColumn[0]\", count(*) FROM testTable GROUP BY JSON_EXTRACT_SCALAR(jsonColumn, '$.[0]', 'STRING', 'null')",
+        TABLE_CONFIG_WITH_INDEX, SCHEMA);
   }
 
   /** Test that a json path expression in HAVING clause is properly converted into a JSON_EXTRACT_SCALAR function. */


### PR DESCRIPTION
## Description
This PR allows for supporting top-level array path expressions (`jsonColumn[1]` in the query below) in JSON queries.

`SELECT jsonColumn[1] FROM testTable WHERE intColumn=14`

**Note:**
Ideally top-level path expressions should be specified as `jsonColumn.[1]`(dot between column name and array subscript). However, Calcite parser will throw error with this path expressions and hence as a workaround this PR is adding support for specifying top-level path expressions as `jsonColumn[1]` (without any dot). This latter path expression should be treated as a shortcut to the former path expression (and is not expected to cause any compatibility issues if and when we add support for full json path expressions in Calcite grammar).

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
