### PR TITLE
Fix TableCacheTest by using unique schema and table name

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/TableCacheTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/TableCacheTest.java
@@ -41,12 +41,12 @@ import static org.testng.Assert.assertNull;
 
 
 public class TableCacheTest {
-  private static final String SCHEMA_NAME = "testSchema";
-  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String SCHEMA_NAME = "cacheTestSchema";
+  private static final String RAW_TABLE_NAME = "cacheTestTable";
   private static final String OFFLINE_TABLE_NAME = TableNameBuilder.OFFLINE.tableNameWithType(RAW_TABLE_NAME);
   private static final String REALTIME_TABLE_NAME = TableNameBuilder.REALTIME.tableNameWithType(RAW_TABLE_NAME);
 
-  private static final String MANGLED_RAW_TABLE_NAME = "TeStTaBlE";
+  private static final String MANGLED_RAW_TABLE_NAME = "cAcHeTeStTaBlE";
   private static final String MANGLED_OFFLINE_TABLE_NAME = MANGLED_RAW_TABLE_NAME + "_oFfLiNe";
 
   @BeforeClass


### PR DESCRIPTION
The test is flaky because it shares the setup with other controller tests, and other tests have schema of the same name left over.