### PR TITLE
Always enable the ThreadTimer

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableImplV3.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableImplV3.java
@@ -187,7 +187,6 @@ public class DataTableImplV3 extends BaseDataTable {
   public byte[] toBytes()
       throws IOException {
     ThreadTimer threadTimer = new ThreadTimer();
-    threadTimer.start();
 
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -91,7 +91,6 @@ public abstract class BaseCombineOperator extends BaseOperator<IntermediateResul
         @Override
         public void runJob() {
           ThreadTimer executionThreadTimer = new ThreadTimer();
-          executionThreadTimer.start();
 
           // Register the task to the phaser
           // NOTE: If the phaser is terminated (returning negative value) when trying to register the task, that means

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/ThreadTimer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/ThreadTimer.java
@@ -28,42 +28,34 @@ import org.slf4j.LoggerFactory;
  * The {@code ThreadTimer} class providing the functionality of measuring the CPU time for the current thread.
  */
 public class ThreadTimer {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ThreadTimer.class);
   private static final ThreadMXBean MX_BEAN = ManagementFactory.getThreadMXBean();
   private static final boolean IS_CURRENT_THREAD_CPU_TIME_SUPPORTED = MX_BEAN.isCurrentThreadCpuTimeSupported();
-  private static final Logger LOGGER = LoggerFactory.getLogger(ThreadTimer.class);
-  private static boolean _isThreadCpuTimeMeasurementEnabled = false;
-  private long _startTimeNs = -1;
-  private long _endTimeNs = -1;
 
-  public ThreadTimer() {
-  }
-
-  public static void setThreadCpuTimeMeasurementEnabled(boolean enable) {
-    _isThreadCpuTimeMeasurementEnabled = enable && IS_CURRENT_THREAD_CPU_TIME_SUPPORTED;
-  }
-
-  public void start() {
-    if (_isThreadCpuTimeMeasurementEnabled) {
-      _startTimeNs = MX_BEAN.getCurrentThreadCpuTime();
-    }
-  }
-
-  public void stop() {
-    if (_isThreadCpuTimeMeasurementEnabled) {
-      _endTimeNs = MX_BEAN.getCurrentThreadCpuTime();
-    }
-  }
-
-  public long getThreadTimeNs() {
-    return _endTimeNs - _startTimeNs;
-  }
-
-  public long stopAndGetThreadTimeNs() {
-    stop();
-    return getThreadTimeNs();
-  }
+  private final long _startTimeNs;
 
   static {
     LOGGER.info("Current thread cpu time measurement supported: {}", IS_CURRENT_THREAD_CPU_TIME_SUPPORTED);
+  }
+
+  /**
+   * Constructs and starts the thread timer.
+   */
+  public ThreadTimer() {
+    _startTimeNs = getCurrentThreadCpuTime();
+  }
+
+  /**
+   * Stops the thread timer and returns the thread CPU time in nanos.
+   */
+  public long stopAndGetThreadTimeNs() {
+    return getCurrentThreadCpuTime() - _startTimeNs;
+  }
+
+  /**
+   * Returns the current thread CPU time, or the system nano time if the current thread CPU time is not supported.
+   */
+  private static long getCurrentThreadCpuTime() {
+    return IS_CURRENT_THREAD_CPU_TIME_SUPPORTED ? MX_BEAN.getCurrentThreadCpuTime() : System.nanoTime();
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datatable/DataTableSerDeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datatable/DataTableSerDeTest.java
@@ -36,7 +36,6 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.common.utils.DataTable.MetadataKey;
 import org.apache.pinot.common.utils.StringUtil;
-import org.apache.pinot.core.query.request.context.ThreadTimer;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -253,16 +252,10 @@ public class DataTableSerDeTest {
     DataTableBuilder dataTableBuilder = new DataTableBuilder(dataSchema);
     fillDataTableWithRandomData(dataTableBuilder, columnDataTypes, numColumns);
 
+    // THREAD_CPU_TIME_NS should be set
     DataTable dataTable = dataTableBuilder.build();
     DataTable newDataTable = DataTableFactory.getDataTable(dataTable.toBytes());
-    // When ThreadCpuTimeMeasurement is disabled, value of threadCpuTimeNs is 0.
-    Assert.assertEquals(newDataTable.getMetadata().get(MetadataKey.THREAD_CPU_TIME_NS.getName()), String.valueOf(0));
-
-    // Enable ThreadCpuTimeMeasurement, serialize/de-serialize data table again.
-    ThreadTimer.setThreadCpuTimeMeasurementEnabled(true);
-    newDataTable = DataTableFactory.getDataTable(dataTable.toBytes());
-    // When ThreadCpuTimeMeasurement is enabled, value of threadCpuTimeNs is not 0.
-    Assert.assertNotEquals(newDataTable.getMetadata().get(MetadataKey.THREAD_CPU_TIME_NS.getName()), String.valueOf(0));
+    Assert.assertTrue(Long.parseLong(newDataTable.getMetadata().get(MetadataKey.THREAD_CPU_TIME_NS.getName())) > 0);
   }
 
   @Test

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -211,9 +211,6 @@ public abstract class ClusterTest extends ControllerTest {
             .setProperty(Server.CONFIG_OF_INSTANCE_SEGMENT_TAR_DIR, Server.DEFAULT_INSTANCE_SEGMENT_TAR_DIR + "-" + i);
         configuration.setProperty(Server.CONFIG_OF_ADMIN_API_PORT, baseAdminApiPort - i);
         configuration.setProperty(Server.CONFIG_OF_NETTY_PORT, baseNettyPort + i);
-        // Thread time measurement is disabled by default, enable it in integration tests.
-        // TODO: this can be removed when we eventually enable thread time measurement by default.
-        configuration.setProperty(Server.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT, true);
         HelixServerStarter helixServerStarter = new HelixServerStarter();
         helixServerStarter.init(configuration);
         helixServerStarter.start();

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -58,7 +58,6 @@ import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.core.common.datatable.DataTableBuilder;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
-import org.apache.pinot.core.query.request.context.ThreadTimer;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.transport.TlsConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
@@ -163,11 +162,6 @@ public abstract class BaseServerStarter implements ServiceStartable {
 
     // Initialize Pinot Environment Provider
     _pinotEnvironmentProvider = initializePinotEnvironmentProvider();
-
-    // Enable/disable thread CPU time measurement through instance config.
-    ThreadTimer.setThreadCpuTimeMeasurementEnabled(_serverConf
-        .getProperty(Server.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT,
-            Server.DEFAULT_ENABLE_THREAD_CPU_TIME_MEASUREMENT));
 
     // Set data table version send to broker.
     DataTableBuilder.setCurrentDataTableVersion(_serverConf

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -390,10 +390,6 @@ public class CommonConstants {
     public static final String DEFAULT_ACCESS_CONTROL_FACTORY_CLASS =
         "org.apache.pinot.server.api.access.AllowAllAccessFactory";
 
-    public static final String CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT =
-        "pinot.server.instance.enableThreadCpuTimeMeasurement";
-    public static final boolean DEFAULT_ENABLE_THREAD_CPU_TIME_MEASUREMENT = false;
-
     public static final String CONFIG_OF_CURRENT_DATA_TABLE_VERSION = "pinot.server.instance.currentDataTableVersion";
     public static final int DEFAULT_CURRENT_DATA_TABLE_VERSION = 3;
 


### PR DESCRIPTION
Currently the thread CPU time measurement is disabled by default, and we return the wall-clock time in the response which can be quite misleading.

In this PR:
- Always enable the ThreadTimer
- Use system nano time if current thread CPU time is unsupported
- Simplify the usage of ThreadTimer