### PR TITLE
Add timezone as argument in toDateTime

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
@@ -28,6 +28,7 @@ import org.apache.pinot.spi.annotations.ScalarFunction;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeField;
 import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
 
 
 /**
@@ -254,6 +255,17 @@ public class DateTimeFunctions {
   @ScalarFunction
   public static String toDateTime(long millis, String pattern) {
     return DateTimePatternHandler.parseEpochMillisToDateTimeString(millis, pattern);
+  }
+
+  /**
+   * Converts epoch millis to DateTime string represented by pattern
+   * and the time zone id.
+   */
+  @ScalarFunction
+  public static String toDateTime(long millis, String pattern, String timezoneId) {
+    return DateTimeFormat
+            .forPattern(pattern)
+            .withZone(DateTimeZone.forID(timezoneId)).print(millis);
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
@@ -222,6 +222,13 @@ public class DateTimeFunctionsTest {
         "Mon Apr 10 20:31:30 UTC 2220"
     });
 
+    // toDateTime with timezone conversion
+    GenericRow row103 = new GenericRow();
+    row103.putValue("dateTime", 1633740369000L);
+    row103.putValue("tz", "America/Los_Angeles");
+    inputs.add(new Object[]{"toDateTime(dateTime, 'yyyy-MM-dd ZZZ', tz)",
+            Lists.newArrayList("dateTime", "tz"), row103, "2021-10-08 America/Los_Angeles"});
+
     // fromDateTime simple
     GenericRow row110 = new GenericRow();
     row110.putValue("dateTime", "19730216");


### PR DESCRIPTION
## Description
<code>ToDateTime()</code> scalar function do not have timezone conversion support, and the result is always in UTC. To support timezone conversion in <code>ToDateTime()</code>, add timezone id as the third argument.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
