### PR TITLE
Make dim tables creation bypass tenant validation

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TagNameUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TagNameUtils.java
@@ -125,6 +125,13 @@ public class TagNameUtils {
   }
 
   /**
+   * Extracts the REALTIME server tag name from the given tenant config.
+   */
+  public static String extractRealtimeServerTag(TenantConfig tenantConfig) {
+    return getRealtimeTagForTenant(tenantConfig.getServer());
+  }
+
+  /**
    * Extracts the REALTIME consuming server tag name from the given tenant config.
    */
   public static String extractConsumingServerTag(TenantConfig tenantConfig) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1277,7 +1277,18 @@ public class PinotHelixResourceManager {
     // Check if tenant exists before creating the table
     Set<String> tagsToCheck = new TreeSet<>();
     tagsToCheck.add(TagNameUtils.extractBrokerTag(tenantConfig));
-    if (tableConfig.getTableType() == TableType.OFFLINE) {
+
+    // The dimension table is an OFFLINE table but it will be deployed to the same tenant as the fact table.
+    // Thus, check if any REALTIME or OFFLINE tagged servers exists before creating dimension table.
+    if (tableConfig.isDimTable()) {
+      String offlineTag = TagNameUtils.extractOfflineServerTag(tenantConfig);
+      String realtimeTag = TagNameUtils.extractRealtimeServerTag(tenantConfig);
+
+      if (getInstancesWithTag(offlineTag).isEmpty() && getInstancesWithTag(realtimeTag).isEmpty()) {
+        throw new InvalidTableConfigException(
+            "Failed to find instances for dimension table: " + tableNameWithType);
+      }
+    } else if (tableConfig.getTableType() == TableType.OFFLINE) {
       tagsToCheck.add(TagNameUtils.extractOfflineServerTag(tenantConfig));
     } else {
       String consumingServerTag = TagNameUtils.extractConsumingServerTag(tenantConfig);
@@ -1294,7 +1305,7 @@ public class PinotHelixResourceManager {
       tagsToCheck.add(completedServerTag);
     }
     for (String tag : tagsToCheck) {
-      if (!tableConfig.isDimTable() && getInstancesWithTag(tag).isEmpty()) {
+      if (getInstancesWithTag(tag).isEmpty()) {
         throw new InvalidTableConfigException(
             "Failed to find instances with tag: " + tag + " for table: " + tableNameWithType);
       }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -76,6 +76,29 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
   }
 
   @Test
+  public void testValidateDimTableTenantConfig() {
+    // Create broker tenant on 3 Brokers
+    Tenant brokerTenant = new Tenant(TenantRole.BROKER, BROKER_TENANT_NAME, 3, 0, 0);
+    _helixResourceManager.createBrokerTenant(brokerTenant);
+
+    String rawTableName = "testTable";
+
+    // Dim table missing broker
+    TableConfig dimTableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName).build();
+    dimTableConfig.setTenantConfig(new TenantConfig(null, SERVER_TENANT_NAME, null));
+    try {
+      _helixResourceManager.validateTableTenantConfig(dimTableConfig);
+      Assert.fail("Expected InvalidTableConfigException");
+    } catch (InvalidTableConfigException e) {
+      // expected
+    }
+
+    // Dim table (offline) deployed to realtime tenant
+    dimTableConfig.setTenantConfig(new TenantConfig(BROKER_TENANT_NAME, SERVER_TENANT_NAME, null));
+    _helixResourceManager.validateTableTenantConfig(dimTableConfig);
+  }
+
+  @Test
   public void testValidateTenantConfig() {
     // Create broker tenant on 3 Brokers
     Tenant brokerTenant = new Tenant(TenantRole.BROKER, BROKER_TENANT_NAME, 3, 0, 0);


### PR DESCRIPTION
issue #7549

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->

For Pinot lookup join feature, we need to create dim table in the same tenant of the fact time, and the dim table need to be created in all the hosts.

The current behavior is that,
-  the dim table is a offline table 
-  the validation validate if there is a offline tagged host in the tenant
-  if the fact table is a realtime table, the dim table need to be deployed to the realtime tenant with at least one offline host. 

This PR updated the validation to bypass the above tag validation for dim table.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
