### PR TITLE
Allow Metadata and Dictionary Based Plans for No Op Filters

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByPlanNode.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.core.operator.filter.BaseFilterOperator;
 import org.apache.pinot.core.operator.query.AggregationGroupByOperator;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
@@ -58,6 +59,9 @@ public class AggregationGroupByPlanNode implements PlanNode {
     AggregationFunction[] aggregationFunctions = _queryContext.getAggregationFunctions();
     ExpressionContext[] groupByExpressions = _queryContext.getGroupByExpressions().toArray(new ExpressionContext[0]);
 
+    FilterPlanNode filterPlanNode = new FilterPlanNode(_indexSegment, _queryContext);
+    BaseFilterOperator filterOperator = filterPlanNode.run();
+
     // Use star-tree to solve the query if possible
     List<StarTreeV2> starTrees = _indexSegment.getStarTrees();
     if (starTrees != null && !StarTreeUtils.isStarTreeDisabled(_queryContext)) {
@@ -65,7 +69,8 @@ public class AggregationGroupByPlanNode implements PlanNode {
           StarTreeUtils.extractAggregationFunctionPairs(aggregationFunctions);
       if (aggregationFunctionColumnPairs != null) {
         Map<String, List<CompositePredicateEvaluator>> predicateEvaluatorsMap =
-            StarTreeUtils.extractPredicateEvaluatorsMap(_indexSegment, _queryContext.getFilter(), null);
+            StarTreeUtils.extractPredicateEvaluatorsMap(_indexSegment, _queryContext.getFilter(),
+                filterPlanNode.getPredicateEvaluatorMap());
         if (predicateEvaluatorsMap != null) {
           for (StarTreeV2 starTreeV2 : starTrees) {
             if (StarTreeUtils.isFitForStarTree(starTreeV2.getMetadata(), aggregationFunctionColumnPairs,
@@ -83,8 +88,9 @@ public class AggregationGroupByPlanNode implements PlanNode {
 
     Set<ExpressionContext> expressionsToTransform =
         AggregationFunctionUtils.collectExpressionsToTransform(aggregationFunctions, groupByExpressions);
-    TransformOperator transformPlanNode = new TransformPlanNode(_indexSegment, _queryContext, expressionsToTransform,
-        DocIdSetPlanNode.MAX_DOC_PER_CALL).run();
+    TransformOperator transformPlanNode =
+        new TransformPlanNode(_indexSegment, _queryContext, expressionsToTransform, DocIdSetPlanNode.MAX_DOC_PER_CALL,
+            filterOperator).run();
     return new AggregationGroupByOperator(_queryContext, groupByExpressions, transformPlanNode, numTotalDocs, false);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/DocIdSetPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/DocIdSetPlanNode.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.plan;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.core.operator.DocIdSetOperator;
 import org.apache.pinot.core.operator.filter.BaseFilterOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
@@ -30,27 +31,22 @@ public class DocIdSetPlanNode implements PlanNode {
   private final IndexSegment _indexSegment;
   private final QueryContext _queryContext;
   private final int _maxDocPerCall;
+  private final BaseFilterOperator _filterOperator;
 
-  private BaseFilterOperator _filterOperator;
-
-  public DocIdSetPlanNode(IndexSegment indexSegment, QueryContext queryContext, int maxDocPerCall) {
+  public DocIdSetPlanNode(IndexSegment indexSegment, QueryContext queryContext, int maxDocPerCall,
+      @Nullable BaseFilterOperator filterOperator) {
     assert maxDocPerCall > 0 && maxDocPerCall <= MAX_DOC_PER_CALL;
 
     _indexSegment = indexSegment;
     _queryContext = queryContext;
     _maxDocPerCall = maxDocPerCall;
-  }
-
-  public DocIdSetPlanNode(IndexSegment indexSegment, QueryContext queryContext, int maxDocPerCall,
-      BaseFilterOperator preComputedFilterOperator) {
-    this(indexSegment, queryContext, maxDocPerCall);
-
-    _filterOperator = preComputedFilterOperator;
+    _filterOperator = filterOperator;
   }
 
   @Override
   public DocIdSetOperator run() {
-    return new DocIdSetOperator(new FilterPlanNode(_indexSegment, _queryContext,
-        _filterOperator).run(), _maxDocPerCall);
+    return new DocIdSetOperator(
+        _filterOperator != null ? _filterOperator : new FilterPlanNode(_indexSegment, _queryContext).run(),
+        _maxDocPerCall);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectionPlanNode.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.plan;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.pinot.core.operator.DocIdSetOperator;
 import org.apache.pinot.core.operator.ProjectionOperator;
 import org.apache.pinot.core.operator.filter.BaseFilterOperator;
@@ -38,20 +39,15 @@ public class ProjectionPlanNode implements PlanNode {
   private final QueryContext _queryContext;
   private final Set<String> _projectionColumns;
   private final int _maxDocsPerCall;
-  private BaseFilterOperator _filterOperator;
+  private final BaseFilterOperator _filterOperator;
 
   public ProjectionPlanNode(IndexSegment indexSegment, QueryContext queryContext, Set<String> projectionColumns,
-      int maxDocsPerCall) {
+      int maxDocsPerCall, @Nullable BaseFilterOperator filterOperator) {
     _indexSegment = indexSegment;
     _queryContext = queryContext;
     _projectionColumns = projectionColumns;
     _maxDocsPerCall = maxDocsPerCall;
-  }
-
-  public ProjectionPlanNode(IndexSegment indexSegment, QueryContext queryContext, Set<String> projectionColumns,
-      int maxDocsPerCall, BaseFilterOperator preComputedFilterOperator) {
-    this(indexSegment, queryContext, projectionColumns, maxDocsPerCall);
-    _filterOperator = preComputedFilterOperator;
+    _filterOperator = filterOperator;
   }
 
   @Override
@@ -62,8 +58,8 @@ public class ProjectionPlanNode implements PlanNode {
     }
     // NOTE: Skip creating DocIdSetOperator when maxDocsPerCall is 0 (for selection query with LIMIT 0)
     DocIdSetOperator docIdSetOperator =
-        _maxDocsPerCall > 0 ? new DocIdSetPlanNode(_indexSegment, _queryContext, _maxDocsPerCall,
-            _filterOperator).run() : null;
+        _maxDocsPerCall > 0 ? new DocIdSetPlanNode(_indexSegment, _queryContext, _maxDocsPerCall, _filterOperator).run()
+            : null;
     return new ProjectionOperator(dataSourceMap, docIdSetOperator);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/TransformPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/TransformPlanNode.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.plan;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.operator.ProjectionOperator;
 import org.apache.pinot.core.operator.filter.BaseFilterOperator;
@@ -38,24 +39,20 @@ public class TransformPlanNode implements PlanNode {
   private final QueryContext _queryContext;
   private final Collection<ExpressionContext> _expressions;
   private final int _maxDocsPerCall;
-  private BaseFilterOperator _filterOperator;
+  private final BaseFilterOperator _filterOperator;
 
   public TransformPlanNode(IndexSegment indexSegment, QueryContext queryContext,
       Collection<ExpressionContext> expressions, int maxDocsPerCall) {
-    _indexSegment = indexSegment;
-    _queryContext = queryContext;
-    _expressions = expressions;
-    _maxDocsPerCall = maxDocsPerCall;
+    this(indexSegment, queryContext, expressions, maxDocsPerCall, null);
   }
 
   public TransformPlanNode(IndexSegment indexSegment, QueryContext queryContext,
-      Collection<ExpressionContext> expressions, int maxDocsPerCall,
-      BaseFilterOperator preComputedFilterOperator) {
+      Collection<ExpressionContext> expressions, int maxDocsPerCall, @Nullable BaseFilterOperator filterOperator) {
     _indexSegment = indexSegment;
     _queryContext = queryContext;
     _expressions = expressions;
     _maxDocsPerCall = maxDocsPerCall;
-    _filterOperator = preComputedFilterOperator;
+    _filterOperator = filterOperator;
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -151,54 +151,63 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
   @DataProvider(name = "testPlanMakerDataProvider")
   public Object[][] testPlanMakerDataProvider() {
     List<Object[]> entries = new ArrayList<>();
+    // Selection
     entries.add(new Object[]{
-        "select * from testTable", /*selection query*/
-        SelectionOnlyOperator.class, SelectionOnlyOperator.class
+        "select * from testTable", SelectionOnlyOperator.class, SelectionOnlyOperator.class
     });
+    // Selection
     entries.add(new Object[]{
-        "select column1,column5 from testTable", /*selection query*/
-        SelectionOnlyOperator.class, SelectionOnlyOperator.class
+        "select column1,column5 from testTable", SelectionOnlyOperator.class, SelectionOnlyOperator.class
     });
+    // Selection with filter
     entries.add(new Object[]{
-        "select * from testTable where daysSinceEpoch > 100", /*selection query with filters*/
-        SelectionOnlyOperator.class, SelectionOnlyOperator.class
+        "select * from testTable where daysSinceEpoch > 100", SelectionOnlyOperator.class, SelectionOnlyOperator.class
     });
+    // COUNT from metadata
     entries.add(new Object[]{
-        "select count(*) from testTable", /*count(*) from metadata*/
-        MetadataBasedAggregationOperator.class, AggregationOperator.class
+        "select count(*) from testTable", MetadataBasedAggregationOperator.class, AggregationOperator.class
     });
+    // COUNT from metadata with match all filter
     entries.add(new Object[]{
-        "select max(daysSinceEpoch),min(daysSinceEpoch) from testTable", /*min max from dictionary*/
+        "select count(*) from testTable where column1 > 10", MetadataBasedAggregationOperator.class,
+        AggregationOperator.class
+    });
+    // MIN/MAX from dictionary
+    entries.add(new Object[]{
+        "select max(daysSinceEpoch),min(daysSinceEpoch) from testTable", DictionaryBasedAggregationOperator.class,
+        AggregationOperator.class
+    });
+    // MIN/MAX from dictionary with match all filter
+    entries.add(new Object[]{
+        "select max(daysSinceEpoch),min(daysSinceEpoch) from testTable where column1 > 10",
         DictionaryBasedAggregationOperator.class, AggregationOperator.class
     });
+    // MINMAXRANGE from dictionary
     entries.add(new Object[]{
-        "select minmaxrange(daysSinceEpoch) from testTable", /*min max from dictionary*/
+        "select minmaxrange(daysSinceEpoch) from testTable", DictionaryBasedAggregationOperator.class,
+        AggregationOperator.class
+    });
+    // MINMAXRANGE from dictionary with match all filter
+    entries.add(new Object[]{
+        "select minmaxrange(daysSinceEpoch) from testTable where column1 > 10",
         DictionaryBasedAggregationOperator.class, AggregationOperator.class
     });
+    // Aggregation
     entries.add(new Object[]{
-        "select max(column17),min(column17) from testTable", /* minmax from dictionary*/
-        DictionaryBasedAggregationOperator.class, AggregationOperator.class
+        "select sum(column1) from testTable", AggregationOperator.class, AggregationOperator.class
     });
+    // Aggregation group-by
     entries.add(new Object[]{
-        "select minmaxrange(column17) from testTable", /*no minmax metadata, go to dictionary*/
-        DictionaryBasedAggregationOperator.class, AggregationOperator.class
+        "select sum(column1) from testTable group by daysSinceEpoch", AggregationGroupByOperator.class,
+        AggregationGroupByOperator.class
     });
+    // COUNT from metadata, MIN from dictionary
     entries.add(new Object[]{
-        "select sum(column1) from testTable", /*aggregation query*/
-        AggregationOperator.class, AggregationOperator.class
+        "select count(*),min(column17) from testTable", AggregationOperator.class, AggregationOperator.class
     });
-    entries.add(new Object[]{
-        "select sum(column1) from testTable group by daysSinceEpoch", /*aggregation with group by query*/
-        AggregationGroupByOperator.class, AggregationGroupByOperator.class
-    });
-    entries.add(new Object[]{
-        "select count(*),min(column17) from testTable",
-        /*multiple aggregations query, one from metadata, one from dictionary*/
-        AggregationOperator.class, AggregationOperator.class
-    });
+    // Aggregation group-by
     entries.add(new Object[]{
         "select count(*),min(daysSinceEpoch) from testTable group by daysSinceEpoch",
-        /*multiple aggregations with group by*/
         AggregationGroupByOperator.class, AggregationGroupByOperator.class
     });
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctCountQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctCountQueriesTest.java
@@ -36,6 +36,7 @@ import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.operator.query.AggregationGroupByOperator;
+import org.apache.pinot.core.operator.query.AggregationOperator;
 import org.apache.pinot.core.operator.query.DictionaryBasedAggregationOperator;
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
 import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
@@ -95,7 +96,7 @@ public class DistinctCountQueriesTest extends BaseQueriesTest {
 
   @Override
   protected String getFilter() {
-    // NOTE: Use a match all filter to switch between DictionaryBasedAggregationOperator and AggregationOperator
+    // NOTE: This is a match all filter
     return " WHERE intColumn >= 0";
   }
 
@@ -184,28 +185,23 @@ public class DistinctCountQueriesTest extends BaseQueriesTest {
 
   @Test
   public void testAggregationOnly() {
+    // Dictionary based
     String query =
         "SELECT DISTINCTCOUNT(intColumn), DISTINCTCOUNT(longColumn), DISTINCTCOUNT(floatColumn), DISTINCTCOUNT"
             + "(doubleColumn), DISTINCTCOUNT(stringColumn), DISTINCTCOUNT(bytesColumn) FROM testTable";
 
     // Inner segment
-    Operator operator = getOperatorForPqlQuery(query);
-    assertTrue(operator instanceof DictionaryBasedAggregationOperator);
-    IntermediateResultsBlock resultsBlock = ((DictionaryBasedAggregationOperator) operator).nextBlock();
-    QueriesTestUtils
-        .testInnerSegmentExecutionStatistics(operator.getExecutionStatistics(), NUM_RECORDS, 0, 0, NUM_RECORDS);
-    List<Object> aggregationResult = resultsBlock.getAggregationResult();
-
-    operator = getOperatorForPqlQueryWithFilter(query);
-    assertTrue(operator instanceof DictionaryBasedAggregationOperator);
-    IntermediateResultsBlock resultsBlockWithFilter = ((DictionaryBasedAggregationOperator) operator).nextBlock();
-    List<Object> aggregationResultWithFilter = resultsBlockWithFilter.getAggregationResult();
-
-    assertNotNull(aggregationResult);
-    assertNotNull(aggregationResultWithFilter);
-    assertEquals(aggregationResult, aggregationResultWithFilter);
-    for (int i = 0; i < 6; i++) {
-      assertEquals(((Set) aggregationResult.get(i)).size(), _values.size());
+    for (Object operator : Arrays.asList(getOperatorForSqlQuery(query), getOperatorForSqlQueryWithFilter(query))) {
+      assertTrue(operator instanceof DictionaryBasedAggregationOperator);
+      IntermediateResultsBlock resultsBlock = ((DictionaryBasedAggregationOperator) operator).nextBlock();
+      QueriesTestUtils.testInnerSegmentExecutionStatistics(((Operator) operator).getExecutionStatistics(), NUM_RECORDS,
+          0, 0, NUM_RECORDS);
+      List<Object> aggregationResult = resultsBlock.getAggregationResult();
+      assertNotNull(aggregationResult);
+      assertEquals(aggregationResult.size(), 6);
+      for (int i = 0; i < 6; i++) {
+        assertEquals(((Set) aggregationResult.get(i)).size(), _values.size());
+      }
     }
 
     // Inter segments
@@ -213,10 +209,39 @@ public class DistinctCountQueriesTest extends BaseQueriesTest {
     for (int i = 0; i < 6; i++) {
       expectedResults[i] = Integer.toString(_values.size());
     }
+    for (BrokerResponseNative brokerResponse : Arrays.asList(getBrokerResponseForPqlQuery(query),
+        getBrokerResponseForPqlQueryWithFilter(query))) {
+      QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 4 * NUM_RECORDS, 0, 0, 4 * NUM_RECORDS,
+          expectedResults);
+    }
+
+    // Regular aggregation
+    query = query + " WHERE intColumn >= 500";
+
+    // Inner segment
+    int expectedResult = 0;
+    for (Integer value : _values) {
+      if (value >= 500) {
+        expectedResult++;
+      }
+    }
+    Operator operator = getOperatorForSqlQuery(query);
+    assertTrue(operator instanceof AggregationOperator);
+    List<Object> aggregationResult = ((AggregationOperator) operator).nextBlock().getAggregationResult();
+    assertNotNull(aggregationResult);
+    assertEquals(aggregationResult.size(), 6);
+    for (int i = 0; i < 6; i++) {
+      assertEquals(((Set) aggregationResult.get(i)).size(), expectedResult);
+    }
+
+    // Inter segment
     BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
-    QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 4 * NUM_RECORDS, 0, 0, 4 * NUM_RECORDS, expectedResults);
-    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
+    List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
+    assertNotNull(aggregationResults);
+    assertEquals(aggregationResults.size(), 6);
+    for (int i = 0; i < 6; i++) {
+      assertEquals(aggregationResults.get(i).getValue(), Integer.toString(expectedResult));
+    }
   }
 
   @Test
@@ -230,9 +255,8 @@ public class DistinctCountQueriesTest extends BaseQueriesTest {
     Operator operator = getOperatorForPqlQuery(query);
     assertTrue(operator instanceof AggregationGroupByOperator);
     IntermediateResultsBlock resultsBlock = ((AggregationGroupByOperator) operator).nextBlock();
-    QueriesTestUtils
-        .testInnerSegmentExecutionStatistics(operator.getExecutionStatistics(), NUM_RECORDS, 0, 6 * NUM_RECORDS,
-            NUM_RECORDS);
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(operator.getExecutionStatistics(), NUM_RECORDS, 0,
+        6 * NUM_RECORDS, NUM_RECORDS);
     AggregationGroupByResult aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
     assertNotNull(aggregationGroupByResult);
     int numGroups = 0;

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationMultiValueQueriesTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.queries;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.operator.query.AggregationGroupByOperator;
 import org.apache.pinot.core.operator.query.AggregationOperator;
-import org.apache.pinot.core.operator.query.MetadataBasedAggregationOperator;
 import org.testng.annotations.Test;
 
 
@@ -186,16 +185,5 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     QueriesTestUtils.testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(),
         "949960647\000238753654\0002147483647\0002147483647\000674022574\000674022574\000674022574", 2L, 1899921294L,
         238753654, 674022574, 1348045148L, 2L);
-  }
-
-  @Test
-  public void testAlwaysTruePredicate() {
-    String query = "SELECT COUNT(*) FROM testTable" + " WHERE column1 > 10 AND column2 > 5";
-
-    MetadataBasedAggregationOperator aggregationOperator = getOperatorForPqlQuery(query);
-    IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();
-    QueriesTestUtils
-        .testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 100000L, 0L, 0L,
-            100000L);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/SegmentPartitionedDistinctCountQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/SegmentPartitionedDistinctCountQueriesTest.java
@@ -36,6 +36,7 @@ import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.operator.query.AggregationGroupByOperator;
+import org.apache.pinot.core.operator.query.AggregationOperator;
 import org.apache.pinot.core.operator.query.DictionaryBasedAggregationOperator;
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
 import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
@@ -91,13 +92,12 @@ public class SegmentPartitionedDistinctCountQueriesTest extends BaseQueriesTest 
       new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
 
   private Set<Integer> _values;
-  private long _expectedResult;
   private IndexSegment _indexSegment;
   private List<IndexSegment> _indexSegments;
 
   @Override
   protected String getFilter() {
-    // NOTE: Use a match all filter to switch between DictionaryBasedAggregationOperator and AggregationOperator
+    // NOTE: This is a match all filter
     return " WHERE intColumn >= 0";
   }
 
@@ -134,7 +134,6 @@ public class SegmentPartitionedDistinctCountQueriesTest extends BaseQueriesTest 
       record.putValue(BYTES_COLUMN, bytesValue);
       records.add(record);
     }
-    _expectedResult = _values.size();
 
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE_CONFIG, SCHEMA);
     segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
@@ -152,58 +151,79 @@ public class SegmentPartitionedDistinctCountQueriesTest extends BaseQueriesTest 
 
   @Test
   public void testAggregationOnly() {
-    String query =
-        "SELECT SEGMENTPARTITIONEDDISTINCTCOUNT(intColumn), SEGMENTPARTITIONEDDISTINCTCOUNT(longColumn), "
-            + "SEGMENTPARTITIONEDDISTINCTCOUNT(floatColumn), SEGMENTPARTITIONEDDISTINCTCOUNT(doubleColumn), "
-            + "SEGMENTPARTITIONEDDISTINCTCOUNT(stringColumn), SEGMENTPARTITIONEDDISTINCTCOUNT(bytesColumn) FROM "
-            + "testTable";
+    // Dictionary based
+    String query = "SELECT SEGMENTPARTITIONEDDISTINCTCOUNT(intColumn), SEGMENTPARTITIONEDDISTINCTCOUNT(longColumn), "
+        + "SEGMENTPARTITIONEDDISTINCTCOUNT(floatColumn), SEGMENTPARTITIONEDDISTINCTCOUNT(doubleColumn), "
+        + "SEGMENTPARTITIONEDDISTINCTCOUNT(stringColumn), SEGMENTPARTITIONEDDISTINCTCOUNT(bytesColumn) FROM "
+        + "testTable";
 
     // Inner segment
-    Operator operator = getOperatorForPqlQuery(query);
-    assertTrue(operator instanceof DictionaryBasedAggregationOperator);
-    IntermediateResultsBlock resultsBlock = ((DictionaryBasedAggregationOperator) operator).nextBlock();
-    QueriesTestUtils
-        .testInnerSegmentExecutionStatistics(operator.getExecutionStatistics(), NUM_RECORDS, 0, 0, NUM_RECORDS);
-    List<Object> aggregationResult = resultsBlock.getAggregationResult();
-
-    operator = getOperatorForPqlQueryWithFilter(query);
-    assertTrue(operator instanceof DictionaryBasedAggregationOperator);
-    IntermediateResultsBlock resultsBlockWithFilter = ((DictionaryBasedAggregationOperator) operator).nextBlock();
-    List<Object> aggregationResultWithFilter = resultsBlockWithFilter.getAggregationResult();
-
-    assertNotNull(aggregationResult);
-    assertNotNull(aggregationResultWithFilter);
-    assertEquals(aggregationResult, aggregationResultWithFilter);
-    for (int i = 0; i < 6; i++) {
-      assertEquals((long) aggregationResult.get(i), _expectedResult);
+    for (Object operator : Arrays.asList(getOperatorForSqlQuery(query), getOperatorForSqlQueryWithFilter(query))) {
+      assertTrue(operator instanceof DictionaryBasedAggregationOperator);
+      IntermediateResultsBlock resultsBlock = ((DictionaryBasedAggregationOperator) operator).nextBlock();
+      QueriesTestUtils.testInnerSegmentExecutionStatistics(((Operator) operator).getExecutionStatistics(), NUM_RECORDS,
+          0, 0, NUM_RECORDS);
+      List<Object> aggregationResult = resultsBlock.getAggregationResult();
+      assertNotNull(aggregationResult);
+      assertEquals(aggregationResult.size(), 6);
+      for (int i = 0; i < 6; i++) {
+        assertEquals(((Long) aggregationResult.get(i)).intValue(), _values.size());
+      }
     }
 
     // Inter segments (expect 4 * inner segment result)
     String[] expectedResults = new String[6];
     for (int i = 0; i < 6; i++) {
-      expectedResults[i] = Long.toString(4 * _expectedResult);
+      expectedResults[i] = Integer.toString(4 * _values.size());
     }
+    for (BrokerResponseNative brokerResponse : Arrays.asList(getBrokerResponseForPqlQuery(query),
+        getBrokerResponseForPqlQueryWithFilter(query))) {
+      QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 4 * NUM_RECORDS, 0, 0, 4 * NUM_RECORDS,
+          expectedResults);
+    }
+
+    // Regular aggregation
+    query = query + " WHERE intColumn >= 500";
+
+    // Inner segment
+    int expectedResult = 0;
+    for (Integer value : _values) {
+      if (value >= 500) {
+        expectedResult++;
+      }
+    }
+    Operator operator = getOperatorForSqlQuery(query);
+    assertTrue(operator instanceof AggregationOperator);
+    List<Object> aggregationResult = ((AggregationOperator) operator).nextBlock().getAggregationResult();
+    assertNotNull(aggregationResult);
+    assertEquals(aggregationResult.size(), 6);
+    for (int i = 0; i < 6; i++) {
+      assertEquals(((Long) aggregationResult.get(i)).intValue(), expectedResult);
+    }
+
+    // Inter segment (expect 4 * inner segment result)
     BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
-    QueriesTestUtils
-        .testInterSegmentAggregationResult(brokerResponse, 4 * NUM_RECORDS, 0, 0, 4 * NUM_RECORDS, expectedResults);
-    brokerResponse = getBrokerResponseForPqlQueryWithFilter(query);
+    List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
+    assertNotNull(aggregationResults);
+    assertEquals(aggregationResults.size(), 6);
+    for (int i = 0; i < 6; i++) {
+      assertEquals(aggregationResults.get(i).getValue(), Integer.toString(4 * expectedResult));
+    }
   }
 
   @Test
   public void testAggregationGroupBy() {
-    String query =
-        "SELECT SEGMENTPARTITIONEDDISTINCTCOUNT(intColumn), SEGMENTPARTITIONEDDISTINCTCOUNT(longColumn), "
-            + "SEGMENTPARTITIONEDDISTINCTCOUNT(floatColumn), SEGMENTPARTITIONEDDISTINCTCOUNT(doubleColumn), "
-            + "SEGMENTPARTITIONEDDISTINCTCOUNT(stringColumn), SEGMENTPARTITIONEDDISTINCTCOUNT(bytesColumn) FROM "
-            + "testTable GROUP BY intColumn";
+    String query = "SELECT SEGMENTPARTITIONEDDISTINCTCOUNT(intColumn), SEGMENTPARTITIONEDDISTINCTCOUNT(longColumn), "
+        + "SEGMENTPARTITIONEDDISTINCTCOUNT(floatColumn), SEGMENTPARTITIONEDDISTINCTCOUNT(doubleColumn), "
+        + "SEGMENTPARTITIONEDDISTINCTCOUNT(stringColumn), SEGMENTPARTITIONEDDISTINCTCOUNT(bytesColumn) FROM "
+        + "testTable GROUP BY intColumn";
 
     // Inner segment
     Operator operator = getOperatorForPqlQuery(query);
     assertTrue(operator instanceof AggregationGroupByOperator);
     IntermediateResultsBlock resultsBlock = ((AggregationGroupByOperator) operator).nextBlock();
-    QueriesTestUtils
-        .testInnerSegmentExecutionStatistics(operator.getExecutionStatistics(), NUM_RECORDS, 0, 6 * NUM_RECORDS,
-            NUM_RECORDS);
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(operator.getExecutionStatistics(), NUM_RECORDS, 0,
+        6 * NUM_RECORDS, NUM_RECORDS);
     AggregationGroupByResult aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
     assertNotNull(aggregationGroupByResult);
     int numGroups = 0;


### PR DESCRIPTION
When building aggregation plans, we ought to also consider the fact
that some filters might be no-ops on certain segments. For those segments,
we should consider using metadata or dictionary based plans.

Supersedes #7533 and fixes #7463