### PR TITLE
fix: Sorting tables by number of segments is broken

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -369,7 +369,17 @@ export default function CustomizedTables({
                     className={classes.head}
                     key={index}
                     onClick={() => {
-                      setFinalData(_.orderBy(finalData, column, order ? 'asc' : 'desc'));
+                      if(column === 'Number of Segments'){
+                        const data = finalData.sort((a,b)=>{
+                          const aSegmentInt = parseInt(a[column]);
+                          const bSegmentInt = parseInt(b[column]);
+                          const result = order ? (aSegmentInt > bSegmentInt) : (aSegmentInt < bSegmentInt);
+                          return result ? 1 : -1;
+                        });
+                        setFinalData(data);
+                      } else {
+                        setFinalData(_.orderBy(finalData, column, order ? 'asc' : 'desc'));
+                      }
                       setOrder(!order);
                       setColumnClicked(column);
                     }}


### PR DESCRIPTION
## Description
Fixed sorting of Number of Segments column.
![image](https://user-images.githubusercontent.com/6761317/136939972-a0c42968-56f7-4a2d-8e8a-b069f71b8a4a.png)
![image](https://user-images.githubusercontent.com/6761317/136939998-069da2c2-cbaf-42a0-8586-be3c140ea0ba.png)

This fixes https://github.com/apache/pinot/issues/7539