### PR TITLE
allow queries to missing columns to fill in default value

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/DataSchemaSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/DataSchemaSegmentPruner.java
@@ -35,7 +35,13 @@ public class DataSchemaSegmentPruner implements SegmentPruner {
 
   @Override
   public boolean prune(IndexSegment segment, QueryContext query) {
-    return !segment.getColumnNames().containsAll(query.getColumns());
+    for (String column : query.getColumns()) {
+      if (segment.getColumnNames().contains(column)) {
+        return false;
+      }
+    }
+    // don't prune unless the segment has none of the relevant columns
+    return !query.getColumns().isEmpty();
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/EmptyIndexSegment.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/EmptyIndexSegment.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.segment.local.indexsegment.immutable;
 
-import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -27,11 +26,14 @@ import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.ThreadSafeMutableRoaringBitmap;
+import org.apache.pinot.segment.spi.index.metadata.ColumnMetadataImpl;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 
 
@@ -59,8 +61,10 @@ public class EmptyIndexSegment implements ImmutableSegment {
   @Override
   public DataSource getDataSource(String column) {
     ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
-    Preconditions.checkNotNull(columnMetadata,
-        "ColumnMetadata for " + column + " should not be null. " + "Potentially invalid column name specified.");
+    if (columnMetadata == null) {
+      columnMetadata = new ColumnMetadataImpl.Builder()
+          .setFieldSpec(new DimensionFieldSpec(column, FieldSpec.DataType.STRING, true)).build();
+    }
     return new EmptyDataSource(columnMetadata);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -18,13 +18,13 @@
  */
 package org.apache.pinot.segment.local.indexsegment.immutable;
 
-import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.segment.local.segment.index.datasource.ImmutableDataSource;
+import org.apache.pinot.segment.local.segment.index.datasource.MissingColumnDataSource;
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
 import org.apache.pinot.segment.local.startree.v2.store.StarTreeIndexContainer;
 import org.apache.pinot.segment.local.upsert.PartitionUpsertMetadataManager;
@@ -40,6 +40,7 @@ import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -113,8 +114,9 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
   @Override
   public DataSource getDataSource(String column) {
     ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
-    Preconditions.checkNotNull(columnMetadata,
-        "ColumnMetadata for " + column + " should not be null. " + "Potentially invalid column name specified.");
+    if (columnMetadata == null) {
+      return new MissingColumnDataSource(this, column, FieldSpec.DataType.STRING);
+    }
     return new ImmutableDataSource(columnMetadata, _indexContainerMap.get(column));
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/IntermediateSegment.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/IntermediateSegment.java
@@ -37,6 +37,7 @@ import org.apache.pinot.segment.local.realtime.impl.forward.FixedByteMVMutableFo
 import org.apache.pinot.segment.local.realtime.impl.forward.FixedByteSVMutableForwardIndex;
 import org.apache.pinot.segment.local.segment.index.column.IntermediateIndexContainer;
 import org.apache.pinot.segment.local.segment.index.column.NumValuesInfo;
+import org.apache.pinot.segment.local.segment.index.datasource.MissingColumnDataSource;
 import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.segment.spi.V1Constants;
@@ -210,7 +211,11 @@ public class IntermediateSegment implements MutableSegment {
 
   @Override
   public DataSource getDataSource(String columnName) {
-    return _indexContainerMap.get(columnName).toDataSource(_numDocsIndexed);
+    IntermediateIndexContainer indexContainer = _indexContainerMap.get(columnName);
+    if (indexContainer == null) {
+      return new MissingColumnDataSource(this, columnName, FieldSpec.DataType.STRING);
+    }
+    return indexContainer.toDataSource(_numDocsIndexed);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -52,6 +52,7 @@ import org.apache.pinot.segment.local.realtime.impl.invertedindex.RealtimeLucene
 import org.apache.pinot.segment.local.realtime.impl.json.MutableJsonIndex;
 import org.apache.pinot.segment.local.realtime.impl.nullvalue.MutableNullValueVector;
 import org.apache.pinot.segment.local.segment.index.datasource.ImmutableDataSource;
+import org.apache.pinot.segment.local.segment.index.datasource.MissingColumnDataSource;
 import org.apache.pinot.segment.local.segment.index.datasource.MutableDataSource;
 import org.apache.pinot.segment.local.segment.virtualcolumn.VirtualColumnContext;
 import org.apache.pinot.segment.local.segment.virtualcolumn.VirtualColumnProvider;
@@ -743,8 +744,9 @@ public class MutableSegmentImpl implements MutableSegment {
         // If the column was added during ingestion, we will construct the column provider based on its fieldSpec to
         // provide values
         fieldSpec = _newlyAddedColumnsFieldMap.get(column);
-        Preconditions.checkNotNull(fieldSpec,
-            "FieldSpec for " + column + " should not be null. " + "Potentially invalid column name specified.");
+        if (fieldSpec == null) {
+          return new MissingColumnDataSource(this, column, STRING);
+        }
       }
       // TODO: Refactor virtual column provider to directly generate data source
       VirtualColumnContext virtualColumnContext = new VirtualColumnContext(fieldSpec, _numDocsIndexed);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/MissingColumnDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/MissingColumnDataSource.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.datasource;
+
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.local.segment.missing.MissingColumnReaderFactory;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+
+
+public class MissingColumnDataSource extends BaseDataSource {
+
+  public MissingColumnDataSource(IndexSegment indexSegment, String column) {
+    this(indexSegment, createMissingFieldSpec(column, FieldSpec.DataType.STRING));
+  }
+
+  public MissingColumnDataSource(IndexSegment indexSegment, String column, FieldSpec.DataType dataType) {
+    this(indexSegment, createMissingFieldSpec(column, dataType));
+  }
+
+  public MissingColumnDataSource(IndexSegment indexSegment, FieldSpec fieldSpec) {
+    super(new MissingColumnDataSourceMetadata(indexSegment.getSegmentMetadata().getTotalDocs(), fieldSpec),
+        MissingColumnReaderFactory.createMissingColumnReader(fieldSpec),
+        null, null, null, null, null, null, null,
+        null, null);
+  }
+
+  private static FieldSpec createMissingFieldSpec(String column, FieldSpec.DataType dataType) {
+    return new DimensionFieldSpec(column, dataType, true);
+  }
+
+  private static final class MissingColumnDataSourceMetadata implements DataSourceMetadata {
+
+    private final int _numDocs;
+    private final FieldSpec _fieldSpec;
+
+    private MissingColumnDataSourceMetadata(int numDocs, FieldSpec fieldSpec) {
+      _numDocs = numDocs;
+      _fieldSpec = fieldSpec;
+    }
+
+    @Override
+    public FieldSpec getFieldSpec() {
+      return _fieldSpec;
+    }
+
+    @Override
+    public boolean isSorted() {
+      return false;
+    }
+
+    @Override
+    public int getNumDocs() {
+      return _numDocs;
+    }
+
+    @Override
+    public int getNumValues() {
+      return _numDocs;
+    }
+
+    @Override
+    public int getMaxNumValuesPerMVEntry() {
+      return 0;
+    }
+
+    @Nullable
+    @Override
+    public Comparable getMinValue() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Comparable getMaxValue() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public PartitionFunction getPartitionFunction() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Set<Integer> getPartitions() {
+      return null;
+    }
+  }
+
+
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/missing/MissingColumnReaderFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/missing/MissingColumnReaderFactory.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.missing;
+
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.spi.data.FieldSpec;
+
+
+public class MissingColumnReaderFactory {
+
+  private MissingColumnReaderFactory() {
+
+  }
+
+  public static ForwardIndexReader<?> createMissingColumnReader(FieldSpec fieldSpec) {
+    // TODO make it possible to configure a replacement
+    return new MissingColumnValueReader(fieldSpec);
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/missing/MissingColumnValueReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/missing/MissingColumnValueReader.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.missing;
+
+import java.io.IOException;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
+import org.apache.pinot.spi.data.FieldSpec;
+
+
+final class MissingColumnValueReader implements ForwardIndexReader<ForwardIndexReaderContext> {
+
+  private static final byte[] MISSING_BYTES = new byte[0];
+  private static final int MISSING_INT = 0;
+  private static final long MISSING_LONG = 0;
+  private static final float MISSING_FLOAT = Float.NaN;
+  private static final double MISSING_DOUBLE = Double.NaN;
+  private static final String MISSING_STRING = "";
+
+  private final FieldSpec _fieldSpec;
+
+  MissingColumnValueReader(FieldSpec fieldSpec) {
+    _fieldSpec = fieldSpec;
+  }
+
+  @Override
+  public boolean isDictionaryEncoded() {
+    return false;
+  }
+
+  @Override
+  public boolean isSingleValue() {
+    return _fieldSpec.isSingleValueField();
+  }
+
+  @Override
+  public FieldSpec.DataType getValueType() {
+    return _fieldSpec.getDataType();
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+
+  }
+
+  @Override
+  public int getInt(int docId, ForwardIndexReaderContext context) {
+    return MISSING_INT;
+  }
+
+  @Override
+  public long getLong(int docId, ForwardIndexReaderContext context) {
+    return MISSING_LONG;
+  }
+
+  @Override
+  public float getFloat(int docId, ForwardIndexReaderContext context) {
+    return MISSING_FLOAT;
+  }
+
+  @Override
+  public double getDouble(int docId, ForwardIndexReaderContext context) {
+    return MISSING_DOUBLE;
+  }
+
+  @Override
+  public String getString(int docId, ForwardIndexReaderContext context) {
+    return MISSING_STRING;
+  }
+
+  @Override
+  public byte[] getBytes(int docId, ForwardIndexReaderContext context) {
+    return MISSING_BYTES;
+  }
+}


### PR DESCRIPTION
## Description

Segments are pruned when any of the columns are missing from the schema for the segment, so when querying, no records are returned

<img width="969" alt="Screenshot 2021-10-12 at 11 43 05" src="https://user-images.githubusercontent.com/16439049/136941540-37b288da-5018-47f9-8544-90ea6dc9c751.png">

This has a drawback which means that default values need to be backfilled when there are schema changes, but it also prevents use cases like querying entity-attribute-value columns by attribute. 

With this change, segments are only pruned if none of the columns are known in the schema for that segment (and this lenience could be configurable and off by default), and when the column is unknown at the segment level, a `MissingColumnDataSource` is created, which results in default values being populated in the query output. The `ForwardIndexReader` is intended to be overridden so that plugins can change missing column resolution, to e.g. filter a special EAV column by the name of the attribute missing in the schema.

This works, but has some drawbacks, notably that the column's type is hardcoded to string. This draft PR is here for feedback about the approach.

<img width="1200" alt="Screenshot 2021-10-12 at 11 29 37" src="https://user-images.githubusercontent.com/16439049/136942555-e6694b40-4f1b-42d6-8f59-a7b8302ef121.png">

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
