### PR TITLE
TableConfigBuilder init from TableConfig

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -345,6 +345,20 @@ public class TableConfigSerDeTest {
       checkNullTimeValueHandling(JsonUtils.stringToObject(tableConfig.toJsonString(), TableConfig.class), true);
       checkNullTimeValueHandling(TableConfigUtils.fromZNRecord(TableConfigUtils.toZNRecord(tableConfig)), true);
     }
+    {
+      // test tableConfigBuilder can accept copy
+      TableConfig tableConfig = tableConfigBuilder.build();
+      TableConfig newConfig = new TableConfigBuilder(tableConfig).build();
+
+      // assert that configs are different objects.
+      assertNotSame(newConfig, tableConfig);
+      assertNotSame(newConfig.getIndexingConfig(), tableConfig.getIndexingConfig());
+      assertNotSame(newConfig.getValidationConfig(), tableConfig.getValidationConfig());
+      assertNotSame(newConfig.getTenantConfig(), tableConfig.getTenantConfig());
+
+      // assert that deep-copy values are identical.
+      assertEquals(newConfig, tableConfig);
+    }
   }
 
   private void checkSegmentsValidationAndRetentionConfig(TableConfig tableConfig) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/BaseJsonConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/BaseJsonConfig.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;


### PR DESCRIPTION
## Description
This allows TableConfigBuilder init from TableConfig.

## Goal
Goal of this PR is having an easy way to clone a tableConfig, modify some subfields and construct a new one tableConfig. 
Currently there's no easy way to do so. 

## Alternative solutions
solution 1 is to go with the TableConfigBuilder path (this PR)
- Pro: it explicitly ask the user to copy the tableConfig because it doesn't expose setter directly.
- Con: there's deep-copy overhead; there's maintenance cost in TableConfigBuilder when adding/changing configs


solution 2 is to directly add field setter to TableConfig
- Pro: easy and straightforward
- Con: doesn't prevent accident change to tableConfig without a copy;

Since config change usually doesn't affect performance-critical path I prefer solution1 because of its auto safety against accidental config changes. but open to solution2 or other suggestions.