### PR TITLE
Relocate shaded parquet libs in pinot-distribution and plugins shaded jars

### DIFF
--- a/pinot-distribution/pom.xml
+++ b/pinot-distribution/pom.xml
@@ -183,6 +183,22 @@
                   <pattern>org.apache.http</pattern>
                   <shadedPattern>shaded.org.apache.http</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>software.amazon</pattern>
+                  <shadedPattern>shaded.software.amazon</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.reflections</pattern>
+                  <shadedPattern>shaded.org.reflections</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.netty</pattern>
+                  <shadedPattern>shaded.io.netty</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.apache.parquet</pattern>
+                  <shadedPattern>shaded.org.apache.parquet</shadedPattern>
+                </relocation>
               </relocations>
             </configuration>
           </execution>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -121,6 +121,10 @@
                       <pattern>io.netty</pattern>
                       <shadedPattern>shaded.io.netty</shadedPattern>
                     </relocation>
+                    <relocation>
+                      <pattern>org.apache.parquet</pattern>
+                      <shadedPattern>shaded.org.apache.parquet</shadedPattern>
+                    </relocation>
                   </relocations>
                 </configuration>
               </execution>


### PR DESCRIPTION
## Description

1. Shade parquet libs to resolve class not found issue:
Have been seeing issue around using ingestion job with spark/hdfs/parquet, sample exceptions like:
```
java.lang.NoSuchMethodError: org.apache.parquet.schema.Type.getLogicalTypeAnnotation()Lorg/apache/parquet/schema/LogicalTypeAnnotation;
	at org.apache.parquet.avro.AvroSchemaConverter.convertField(AvroSchemaConverter.java:280)
```

2. Also, relocate packages in pinot-distribution jar to on par with existing plugins shaded jars.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
