### PR TITLE
Adding generic util method for persisting task metadata in a ZNode

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/BaseTaskMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/BaseTaskMetadata.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.minion;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.helix.ZNRecord;
+import org.apache.pinot.spi.utils.JsonUtils;
+
+
+/**
+ * Base abstract class for minion task metadata.
+ *
+ * This metadata gets serialized and stored in zookeeper under the path:
+ * MINION_TASK_METADATA/${taskName}/${tableNameWithType}
+ */
+public abstract class BaseTaskMetadata {
+
+  /**
+   * @return table name appended with its type. E.g. MyTable_OFFLINE
+   */
+  abstract String getTableNameWithType();
+
+  /**
+   * @return {@link ZNRecord} containing the task metadata
+   */
+  abstract ZNRecord toZNRecord();
+
+  /**
+   * @return task metadata as a Json string
+   */
+  public String toJsonString() {
+    try {
+      return JsonUtils.objectToString(this);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return toJsonString();
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/MergeRollupTaskMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/MergeRollupTaskMetadata.java
@@ -18,11 +18,9 @@
  */
 package org.apache.pinot.common.minion;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.helix.ZNRecord;
-import org.apache.pinot.spi.utils.JsonUtils;
 
 
 /**
@@ -32,7 +30,7 @@ import org.apache.pinot.spi.utils.JsonUtils;
  *
  * This gets serialized and stored in zookeeper under the path MINION_TASK_METADATA/MergeRollupTask/tableNameWithType
  */
-public class MergeRollupTaskMetadata {
+public class MergeRollupTaskMetadata extends BaseTaskMetadata {
 
   private static final String WATERMARK_KEY_PREFIX = "watermarkMs_";
   private static final int WATERMARK_KEY_PREFIX_LENGTH = WATERMARK_KEY_PREFIX.length();
@@ -74,18 +72,5 @@ public class MergeRollupTaskMetadata {
       znRecord.setLongField(WATERMARK_KEY_PREFIX + entry.getKey(), entry.getValue());
     }
     return znRecord;
-  }
-
-  public String toJsonString() {
-    try {
-      return JsonUtils.objectToString(this);
-    } catch (JsonProcessingException e) {
-      throw new IllegalStateException(e);
-    }
-  }
-
-  @Override
-  public String toString() {
-    return toJsonString();
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
@@ -63,34 +63,20 @@ public final class MinionTaskMetadataUtils {
   }
 
   /**
-   * Persists the provided {@link MergeRollupTaskMetadata} to MINION_TASK_METADATA/MergeRollupTask/tableNameWthType.
+   * Generic method for persisting {@link BaseTaskMetadata} to MINION_TASK_METADATA. The metadata will be saved in the
+   * ZNode under the path: /MINION_TASK_METADATA/${taskType}/${tableNameWithType}
+   *
    * Will fail if expectedVersion does not match.
    * Set expectedVersion -1 to override version check.
    */
-  public static void persistMergeRollupTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore, String taskType,
-      MergeRollupTaskMetadata mergeRollupTaskMetadata, int expectedVersion) {
-    String path = ZKMetadataProvider
-        .constructPropertyStorePathForMinionTaskMetadata(taskType, mergeRollupTaskMetadata.getTableNameWithType());
-    if (!propertyStore.set(path, mergeRollupTaskMetadata.toZNRecord(), expectedVersion, AccessOption.PERSISTENT)) {
-      throw new ZkException("Failed to persist minion MergeRollupTask metadata: " + mergeRollupTaskMetadata);
-    }
-  }
-
-  /**
-   * Persists the provided {@link RealtimeToOfflineSegmentsTaskMetadata} to MINION_TASK_METADATA
-   * /RealtimeToOfflineSegmentsTask/tableNameWthType.
-   * Will fail if expectedVersion does not match.
-   * Set expectedVersion -1 to override version check.
-   */
-  public static void persistRealtimeToOfflineSegmentsTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore,
-      String taskType, RealtimeToOfflineSegmentsTaskMetadata realtimeToOfflineSegmentsTaskMetadata,
-      int expectedVersion) {
+  public static void persistTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore, String taskType,
+      BaseTaskMetadata taskMetadata, int expectedVersion) {
     String path = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(taskType,
-        realtimeToOfflineSegmentsTaskMetadata.getTableNameWithType());
+        taskMetadata.getTableNameWithType());
     if (!propertyStore
-        .set(path, realtimeToOfflineSegmentsTaskMetadata.toZNRecord(), expectedVersion, AccessOption.PERSISTENT)) {
+        .set(path, taskMetadata.toZNRecord(), expectedVersion, AccessOption.PERSISTENT)) {
       throw new ZkException(
-          "Failed to persist minion RealtimeToOfflineSegmentsTask metadata: " + realtimeToOfflineSegmentsTaskMetadata);
+          "Failed to persist minion metadata for task: " + taskType + " and metadata: " + taskMetadata);
     }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/RealtimeToOfflineSegmentsTaskMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/RealtimeToOfflineSegmentsTaskMetadata.java
@@ -18,9 +18,7 @@
  */
 package org.apache.pinot.common.minion;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.helix.ZNRecord;
-import org.apache.pinot.spi.utils.JsonUtils;
 
 
 /**
@@ -40,7 +38,7 @@ import org.apache.pinot.spi.utils.JsonUtils;
  * - Verify that is is running the latest task scheduled by the task generator
  * - Update the watermark as the end of the window that it executed for
  */
-public class RealtimeToOfflineSegmentsTaskMetadata {
+public class RealtimeToOfflineSegmentsTaskMetadata extends BaseTaskMetadata {
 
   private static final String WATERMARK_KEY = "watermarkMs";
 
@@ -72,18 +70,5 @@ public class RealtimeToOfflineSegmentsTaskMetadata {
     ZNRecord znRecord = new ZNRecord(_tableNameWithType);
     znRecord.setLongField(WATERMARK_KEY, _watermarkMs);
     return znRecord;
-  }
-
-  public String toJsonString() {
-    try {
-      return JsonUtils.objectToString(this);
-    } catch (JsonProcessingException e) {
-      throw new IllegalStateException(e);
-    }
-  }
-
-  @Override
-  public String toString() {
-    return toJsonString();
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.minion;
+
+import org.I0Itec.zkclient.exception.ZkException;
+import org.apache.helix.AccessOption;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.HelixPropertyStore;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+
+/**
+ * Tests for {@link MinionTaskMetadataUtils}
+ */
+public class MinionTaskMetadataUtilsTest {
+
+  @Test
+  public void testPersistTaskMetadata() {
+    DummyTaskMetadata taskMetadata = new DummyTaskMetadata("TestTable_OFFLINE", 1000);
+    HelixPropertyStore<ZNRecord> mockPropertyStore = Mockito.mock(HelixPropertyStore.class);
+    String expectedPath = "/MINION_TASK_METADATA/TestTaskType/TestTable_OFFLINE";
+    int expectedVersion = -1;
+
+    // Test happy path. No exceptions thrown.
+    when(mockPropertyStore.set(expectedPath, taskMetadata.toZNRecord(), expectedVersion,
+        AccessOption.PERSISTENT)).thenReturn(true);
+    MinionTaskMetadataUtils.persistTaskMetadata(mockPropertyStore, "TestTaskType", taskMetadata, expectedVersion);
+    verify(mockPropertyStore, times(1)).set(expectedPath, taskMetadata.toZNRecord(), expectedVersion,
+        AccessOption.PERSISTENT);
+
+    // Test exception thrown
+    when(mockPropertyStore.set(expectedPath, taskMetadata.toZNRecord(), -1, AccessOption.PERSISTENT))
+        .thenReturn(false);
+    try {
+      MinionTaskMetadataUtils.persistTaskMetadata(mockPropertyStore, "TestTaskType", taskMetadata, expectedVersion);
+      fail("ZkException should have been thrown");
+    } catch (ZkException e) {
+      verify(mockPropertyStore, times(2)).set(expectedPath, taskMetadata.toZNRecord(), expectedVersion,
+          AccessOption.PERSISTENT);
+      assertEquals(e.getMessage(), "Failed to persist minion metadata for task: TestTaskType and metadata:"
+          + " {\"tableNameWithType\":\"TestTable_OFFLINE\"}");
+    }
+  }
+
+  public class DummyTaskMetadata extends BaseTaskMetadata {
+
+    private final String _tableNameWithType;
+    private final long _metadataVal;
+
+    public DummyTaskMetadata(String tableNameWithType, long metadataVal) {
+      _tableNameWithType = tableNameWithType;
+      _metadataVal = metadataVal;
+    }
+
+    public String getTableNameWithType() {
+      return _tableNameWithType;
+    }
+
+    public ZNRecord toZNRecord() {
+      ZNRecord znRecord = new ZNRecord(_tableNameWithType);
+      znRecord.setLongField("metadataVal", _metadataVal);
+      return znRecord;
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
@@ -122,7 +122,7 @@ public class ClusterInfoAccessor {
    * This call will override any previous metadata node
    */
   public void setMergeRollupTaskMetadata(MergeRollupTaskMetadata mergeRollupTaskMetadata, int expectedVersion) {
-    MinionTaskMetadataUtils.persistMergeRollupTaskMetadata(_pinotHelixResourceManager.getPropertyStore(),
+    MinionTaskMetadataUtils.persistTaskMetadata(_pinotHelixResourceManager.getPropertyStore(),
         MinionConstants.MergeRollupTask.TASK_TYPE, mergeRollupTaskMetadata, expectedVersion);
   }
 
@@ -143,7 +143,7 @@ public class ClusterInfoAccessor {
    */
   public void setRealtimeToOfflineSegmentsTaskMetadata(
       RealtimeToOfflineSegmentsTaskMetadata realtimeToOfflineSegmentsTaskMetadata) {
-    MinionTaskMetadataUtils.persistRealtimeToOfflineSegmentsTaskMetadata(_pinotHelixResourceManager.getPropertyStore(),
+    MinionTaskMetadataUtils.persistTaskMetadata(_pinotHelixResourceManager.getPropertyStore(),
         MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE, realtimeToOfflineSegmentsTaskMetadata, -1);
   }
 

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/MinionTaskZkMetadataManager.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/MinionTaskZkMetadataManager.java
@@ -53,7 +53,7 @@ public class MinionTaskZkMetadataManager {
    */
   public void setRealtimeToOfflineSegmentsTaskMetadata(
       RealtimeToOfflineSegmentsTaskMetadata realtimeToOfflineSegmentsTaskMetadata, int expectedVersion) {
-    MinionTaskMetadataUtils.persistRealtimeToOfflineSegmentsTaskMetadata(_helixManager.getHelixPropertyStore(),
+    MinionTaskMetadataUtils.persistTaskMetadata(_helixManager.getHelixPropertyStore(),
         RealtimeToOfflineSegmentsTask.TASK_TYPE, realtimeToOfflineSegmentsTaskMetadata, expectedVersion);
   }
 }


### PR DESCRIPTION
## Description
Adding a generic util method and abstract class for persisting task metadata in a ZNode.

I noticed that all the persist methods in `MinionTaskMetadataUtils` were doing the same thing. I deleted the existing `persistMergeRollupTaskMetadata` and `persistRealtimeToOfflineSegmentsTaskMetadata` util methods and migrated the callers to use the new generic method.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)
