### PR TITLE
Refactor query rewriter to interfaces and implementations

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -67,6 +67,7 @@ import org.apache.pinot.spi.services.ServiceStartable;
 import org.apache.pinot.spi.utils.CommonConstants.Broker;
 import org.apache.pinot.spi.utils.CommonConstants.Helix;
 import org.apache.pinot.spi.utils.NetUtils;
+import org.apache.pinot.sql.parsers.rewriter.QueryRewriterFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -245,6 +246,9 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
     HelixExternalViewBasedQueryQuotaManager queryQuotaManager =
         new HelixExternalViewBasedQueryQuotaManager(_brokerMetrics, _instanceId);
     queryQuotaManager.init(_spectatorHelixManager);
+    // Initialize QueryRewriterFactory
+    LOGGER.info("Initializing QueryRewriterFactory");
+    QueryRewriterFactory.init(_brokerConf.getProperty(Broker.CONFIG_OF_BROKER_QUERY_REWRITER_CLASS_NAMES));
     // Initialize FunctionRegistry before starting the broker request handler
     FunctionRegistry.init();
     TableCache tableCache = new TableCache(_propertyStore, caseInsensitive);

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -20,7 +20,6 @@ package org.apache.pinot.sql.parsers;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -29,7 +28,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.annotation.Nullable;
 import org.apache.calcite.config.Lex;
 import org.apache.calcite.sql.SqlBasicCall;
 import org.apache.calcite.sql.SqlDataTypeSpec;
@@ -50,19 +48,15 @@ import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.function.FunctionDefinitionRegistry;
-import org.apache.pinot.common.function.FunctionInfo;
-import org.apache.pinot.common.function.FunctionInvoker;
-import org.apache.pinot.common.function.FunctionRegistry;
-import org.apache.pinot.common.function.TransformFunctionType;
 import org.apache.pinot.common.request.DataSource;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
 import org.apache.pinot.common.request.Function;
-import org.apache.pinot.common.request.Identifier;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.utils.request.RequestUtils;
-import org.apache.pinot.pql.parsers.pql2.ast.FilterKind;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.sql.parsers.rewriter.QueryRewriter;
+import org.apache.pinot.sql.parsers.rewriter.QueryRewriterFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,6 +79,8 @@ public class CalciteSqlParser {
   private static final SqlParser.Config PARSER_CONFIG =
       SqlParser.configBuilder().setLex(PINOT_LEX).setConformance(SqlConformanceEnum.BABEL)
           .setParserFactory(SqlBabelParserImpl.FACTORY).build();
+
+  public static final List<QueryRewriter> QUERY_REWRITERS = new ArrayList<>(QueryRewriterFactory.getQueryRewriters());
 
   // To Keep the backward compatibility with 'OPTION' Functionality in PQL, which is used to
   // provide more hints for query processing.
@@ -114,48 +110,10 @@ public class CalciteSqlParser {
     return pinotQuery;
   }
 
-  static void validate(Map<Identifier, Expression> aliasMap, PinotQuery pinotQuery)
+  static void validate(PinotQuery pinotQuery)
       throws SqlCompilationException {
-    validateSelectionClause(aliasMap, pinotQuery);
     validateGroupByClause(pinotQuery);
     validateDistinctQuery(pinotQuery);
-  }
-
-  private static void validateSelectionClause(Map<Identifier, Expression> aliasMap, PinotQuery pinotQuery)
-      throws SqlCompilationException {
-    // Sanity check on selection expression shouldn't use alias reference.
-    Set<String> aliasKeys = new HashSet<>();
-    for (Identifier identifier : aliasMap.keySet()) {
-      String aliasName = identifier.getName().toLowerCase();
-      if (!aliasKeys.add(aliasName)) {
-        throw new SqlCompilationException("Duplicated alias name found.");
-      }
-    }
-    for (Expression selectExpr : pinotQuery.getSelectList()) {
-      matchIdentifierInAliasMap(selectExpr, aliasKeys);
-    }
-  }
-
-  private static void matchIdentifierInAliasMap(Expression selectExpr, Set<String> aliasKeys)
-      throws SqlCompilationException {
-    Function functionCall = selectExpr.getFunctionCall();
-    if (functionCall != null) {
-      if (functionCall.getOperator().equalsIgnoreCase(SqlKind.AS.toString())) {
-        matchIdentifierInAliasMap(functionCall.getOperands().get(0), aliasKeys);
-      } else {
-        if (functionCall.getOperandsSize() > 0) {
-          for (Expression operand : functionCall.getOperands()) {
-            matchIdentifierInAliasMap(operand, aliasKeys);
-          }
-        }
-      }
-    }
-    if (selectExpr.getIdentifier() != null) {
-      if (aliasKeys.contains(selectExpr.getIdentifier().getName().toLowerCase())) {
-        throw new SqlCompilationException(
-            "Alias " + selectExpr.getIdentifier().getName() + " cannot be referred in SELECT Clause");
-      }
-    }
   }
 
   private static void validateGroupByClause(PinotQuery pinotQuery)
@@ -237,7 +195,7 @@ public class CalciteSqlParser {
     return true;
   }
 
-  private static boolean isAggregateExpression(Expression expression) {
+  public static boolean isAggregateExpression(Expression expression) {
     Function functionCall = expression.getFunctionCall();
     if (functionCall != null) {
       String operator = functionCall.getOperator();
@@ -257,6 +215,10 @@ public class CalciteSqlParser {
     return false;
   }
 
+  public static boolean isAsFunction(Expression expression) {
+    return expression.getFunctionCall() != null && expression.getFunctionCall().getOperator().equalsIgnoreCase("AS");
+  }
+
   /**
    * Extract all the identifiers from given expressions.
    *
@@ -271,8 +233,8 @@ public class CalciteSqlParser {
         identifiers.add(expression.getIdentifier().getName());
       } else if (expression.getFunctionCall() != null) {
         if (excludeAs && expression.getFunctionCall().getOperator().equalsIgnoreCase("AS")) {
-          identifiers
-              .addAll(extractIdentifiers(Arrays.asList(expression.getFunctionCall().getOperands().get(0)), true));
+          identifiers.addAll(
+              extractIdentifiers(Arrays.asList(expression.getFunctionCall().getOperands().get(0)), true));
           continue;
         } else {
           identifiers.addAll(extractIdentifiers(expression.getFunctionCall().getOperands(), excludeAs));
@@ -394,352 +356,11 @@ public class CalciteSqlParser {
   }
 
   private static void queryRewrite(PinotQuery pinotQuery) {
-    // Invoke compilation time functions
-    invokeCompileTimeFunctions(pinotQuery);
-
-    // Rewrite Selection list
-    rewriteSelections(pinotQuery.getSelectList());
-
-    // Update Predicate Comparison
-    Expression filterExpression = pinotQuery.getFilterExpression();
-    if (filterExpression != null) {
-      pinotQuery.setFilterExpression(updateComparisonPredicate(filterExpression));
+    for (QueryRewriter queryRewriter : QUERY_REWRITERS) {
+      pinotQuery = queryRewriter.rewrite(pinotQuery);
     }
-    Expression havingExpression = pinotQuery.getHavingExpression();
-    if (havingExpression != null) {
-      pinotQuery.setHavingExpression(updateComparisonPredicate(havingExpression));
-    }
-
-    // Update Ordinals
-    applyOrdinals(pinotQuery);
-
-    // Rewrite GroupBy to Distinct
-    rewriteNonAggregationGroupByToDistinct(pinotQuery);
-
-    // Update alias
-    Map<Identifier, Expression> aliasMap = extractAlias(pinotQuery.getSelectList());
-    applyAlias(aliasMap, pinotQuery);
-
     // Validate
-    validate(aliasMap, pinotQuery);
-  }
-
-  private static void applyOrdinals(PinotQuery pinotQuery) {
-    // handle GROUP BY clause
-    for (int i = 0; i < pinotQuery.getGroupByListSize(); i++) {
-      final Expression groupByExpr = pinotQuery.getGroupByList().get(i);
-      if (groupByExpr.isSetLiteral() && groupByExpr.getLiteral().isSetLongValue()) {
-        final int ordinal = (int) groupByExpr.getLiteral().getLongValue();
-        pinotQuery.getGroupByList().set(i, getExpressionFromOrdinal(pinotQuery.getSelectList(), ordinal));
-      }
-    }
-
-    // handle ORDER BY clause
-    for (int i = 0; i < pinotQuery.getOrderByListSize(); i++) {
-      final Expression orderByExpr = pinotQuery.getOrderByList().get(i).getFunctionCall().getOperands().get(0);
-      if (orderByExpr.isSetLiteral() && orderByExpr.getLiteral().isSetLongValue()) {
-        final int ordinal = (int) orderByExpr.getLiteral().getLongValue();
-        pinotQuery.getOrderByList().get(i).getFunctionCall()
-            .setOperands(Arrays.asList(getExpressionFromOrdinal(pinotQuery.getSelectList(), ordinal)));
-      }
-    }
-  }
-
-  private static Expression getExpressionFromOrdinal(List<Expression> selectList, int ordinal) {
-    if (ordinal > 0 && ordinal <= selectList.size()) {
-      final Expression expression = selectList.get(ordinal - 1);
-      // If the expression has AS, return the left operand.
-      if (expression.isSetFunctionCall() && expression.getFunctionCall().getOperator().equals(SqlKind.AS.name())) {
-        return expression.getFunctionCall().getOperands().get(0);
-      }
-      return expression;
-    } else {
-      throw new SqlCompilationException(
-          String.format("Expected Ordinal value to be between 1 and %d.", selectList.size()));
-    }
-  }
-
-  private static void rewriteSelections(List<Expression> selectList) {
-    for (Expression expression : selectList) {
-      // Rewrite aggregation
-      tryToRewriteArrayFunction(expression);
-    }
-  }
-
-  private static void tryToRewriteArrayFunction(Expression expression) {
-    if (!expression.isSetFunctionCall()) {
-      return;
-    }
-    Function functionCall = expression.getFunctionCall();
-    switch (canonicalize(functionCall.getOperator())) {
-      case "sum":
-        if (functionCall.getOperands().size() != 1) {
-          return;
-        }
-        if (functionCall.getOperands().get(0).isSetFunctionCall()) {
-          Function innerFunction = functionCall.getOperands().get(0).getFunctionCall();
-          if (isSameFunction(innerFunction.getOperator(), TransformFunctionType.ARRAYSUM.getName())) {
-            Function sumMvFunc = new Function(AggregationFunctionType.SUMMV.getName());
-            sumMvFunc.setOperands(innerFunction.getOperands());
-            expression.setFunctionCall(sumMvFunc);
-          }
-        }
-        return;
-      case "min":
-        if (functionCall.getOperands().size() != 1) {
-          return;
-        }
-        if (functionCall.getOperands().get(0).isSetFunctionCall()) {
-          Function innerFunction = functionCall.getOperands().get(0).getFunctionCall();
-          if (isSameFunction(innerFunction.getOperator(), TransformFunctionType.ARRAYMIN.getName())) {
-            Function sumMvFunc = new Function(AggregationFunctionType.MINMV.getName());
-            sumMvFunc.setOperands(innerFunction.getOperands());
-            expression.setFunctionCall(sumMvFunc);
-          }
-        }
-        return;
-      case "max":
-        if (functionCall.getOperands().size() != 1) {
-          return;
-        }
-        if (functionCall.getOperands().get(0).isSetFunctionCall()) {
-          Function innerFunction = functionCall.getOperands().get(0).getFunctionCall();
-          if (isSameFunction(innerFunction.getOperator(), TransformFunctionType.ARRAYMAX.getName())) {
-            Function sumMvFunc = new Function(AggregationFunctionType.MAXMV.getName());
-            sumMvFunc.setOperands(innerFunction.getOperands());
-            expression.setFunctionCall(sumMvFunc);
-          }
-        }
-        return;
-      default:
-        break;
-    }
-    for (Expression operand : functionCall.getOperands()) {
-      tryToRewriteArrayFunction(operand);
-    }
-  }
-
-  private static String canonicalize(String functionName) {
-    return StringUtils.remove(functionName, '_').toLowerCase();
-  }
-
-  private static boolean isSameFunction(String function1, String function2) {
-    return canonicalize(function1).equals(canonicalize(function2));
-  }
-
-  /**
-   * Rewrite non-aggregate group by query to distinct query.
-   * E.g.
-   * ```
-   *   SELECT col1+col2*5 FROM foo GROUP BY col1, col2 => SELECT distinct col1+col2*5 FROM foo
-   *   SELECT col1, col2 FROM foo GROUP BY col1, col2 => SELECT distinct col1, col2 FROM foo
-   * ```
-   * @param pinotQuery
-   */
-  private static void rewriteNonAggregationGroupByToDistinct(PinotQuery pinotQuery) {
-    boolean hasAggregation = false;
-    for (Expression select : pinotQuery.getSelectList()) {
-      if (isAggregateExpression(select)) {
-        hasAggregation = true;
-      }
-    }
-    if (pinotQuery.getOrderByList() != null) {
-      for (Expression orderBy : pinotQuery.getOrderByList()) {
-        if (isAggregateExpression(orderBy)) {
-          hasAggregation = true;
-        }
-      }
-    }
-    if (!hasAggregation && pinotQuery.getGroupByListSize() > 0) {
-      Set<String> selectIdentifiers = extractIdentifiers(pinotQuery.getSelectList(), true);
-      Set<String> groupByIdentifiers = extractIdentifiers(pinotQuery.getGroupByList(), true);
-      if (groupByIdentifiers.containsAll(selectIdentifiers)) {
-        Expression distinctExpression = RequestUtils.getFunctionExpression("DISTINCT");
-        for (Expression select : pinotQuery.getSelectList()) {
-          if (isAsFunction(select)) {
-            Function asFunc = select.getFunctionCall();
-            distinctExpression.getFunctionCall().addToOperands(asFunc.getOperands().get(0));
-          } else {
-            distinctExpression.getFunctionCall().addToOperands(select);
-          }
-        }
-        pinotQuery.setSelectList(Arrays.asList(distinctExpression));
-        pinotQuery.setGroupByList(Collections.emptyList());
-      } else {
-        selectIdentifiers.removeAll(groupByIdentifiers);
-        throw new SqlCompilationException(String.format(
-            "For non-aggregation group by query, all the identifiers in select clause should be in groupBys. Found "
-                + "identifier: %s", Arrays.toString(selectIdentifiers.toArray(new String[0]))));
-      }
-    }
-  }
-
-  private static boolean isAsFunction(Expression expression) {
-    return expression.getFunctionCall() != null && expression.getFunctionCall().getOperator().equalsIgnoreCase("AS");
-  }
-
-  private static void invokeCompileTimeFunctions(PinotQuery pinotQuery) {
-    for (int i = 0; i < pinotQuery.getSelectListSize(); i++) {
-      Expression expression = invokeCompileTimeFunctionExpression(pinotQuery.getSelectList().get(i));
-      pinotQuery.getSelectList().set(i, expression);
-    }
-    for (int i = 0; i < pinotQuery.getGroupByListSize(); i++) {
-      Expression expression = invokeCompileTimeFunctionExpression(pinotQuery.getGroupByList().get(i));
-      pinotQuery.getGroupByList().set(i, expression);
-    }
-    for (int i = 0; i < pinotQuery.getOrderByListSize(); i++) {
-      Expression expression = invokeCompileTimeFunctionExpression(pinotQuery.getOrderByList().get(i));
-      pinotQuery.getOrderByList().set(i, expression);
-    }
-    Expression filterExpression = invokeCompileTimeFunctionExpression(pinotQuery.getFilterExpression());
-    pinotQuery.setFilterExpression(filterExpression);
-    Expression havingExpression = invokeCompileTimeFunctionExpression(pinotQuery.getHavingExpression());
-    pinotQuery.setHavingExpression(havingExpression);
-  }
-
-  // This method converts a predicate expression to the what Pinot could evaluate.
-  // For comparison expression, left operand could be any expression, but right operand only
-  // supports literal.
-  // E.g. 'WHERE a > b' will be updated to 'WHERE a - b > 0'
-  private static Expression updateComparisonPredicate(Expression expression) {
-    Function function = expression.getFunctionCall();
-    if (function != null) {
-      String operator = function.getOperator().toUpperCase();
-      FilterKind filterKind;
-      try {
-        filterKind = FilterKind.valueOf(operator);
-      } catch (Exception e) {
-        throw new SqlCompilationException("Unsupported filter kind: " + operator);
-      }
-      List<Expression> operands = function.getOperands();
-      switch (filterKind) {
-        case AND:
-        case OR:
-          operands.replaceAll(CalciteSqlParser::updateComparisonPredicate);
-          break;
-        case EQUALS:
-        case NOT_EQUALS:
-        case GREATER_THAN:
-        case GREATER_THAN_OR_EQUAL:
-        case LESS_THAN:
-        case LESS_THAN_OR_EQUAL:
-          Expression firstOperand = operands.get(0);
-          Expression secondOperand = operands.get(1);
-
-          // Handle predicate like '10 = a' -> 'a = 10'
-          if (firstOperand.isSetLiteral()) {
-            if (!secondOperand.isSetLiteral()) {
-              function.setOperator(getOppositeOperator(filterKind).name());
-              operands.set(0, secondOperand);
-              operands.set(1, firstOperand);
-            }
-            break;
-          }
-
-          // Handle predicate like 'a > b' -> 'a - b > 0'
-          if (!secondOperand.isSetLiteral()) {
-            Expression minusExpression = RequestUtils.getFunctionExpression(SqlKind.MINUS.name());
-            minusExpression.getFunctionCall().setOperands(Arrays.asList(firstOperand, secondOperand));
-            operands.set(0, minusExpression);
-            operands.set(1, RequestUtils.getLiteralExpression(0));
-            break;
-          }
-          break;
-        default:
-          int numOperands = operands.size();
-          for (int i = 1; i < numOperands; i++) {
-            if (!operands.get(i).isSetLiteral()) {
-              throw new SqlCompilationException(String
-                  .format("For %s predicate, the operands except for the first one must be literal, got: %s",
-                      filterKind, expression));
-            }
-          }
-          break;
-      }
-    }
-    return expression;
-  }
-
-  /**
-   * The purpose of this method is to convert expression "0 < columnA" to "columnA > 0".
-   * The conversion would be:
-   *  from ">" to "<",
-   *  from "<" to ">",
-   *  from ">=" to "<=",
-   *  from "<=" to ">=".
-   */
-  private static FilterKind getOppositeOperator(FilterKind filterKind) {
-    switch (filterKind) {
-      case GREATER_THAN:
-        return FilterKind.LESS_THAN;
-      case GREATER_THAN_OR_EQUAL:
-        return FilterKind.LESS_THAN_OR_EQUAL;
-      case LESS_THAN:
-        return FilterKind.GREATER_THAN;
-      case LESS_THAN_OR_EQUAL:
-        return FilterKind.GREATER_THAN_OR_EQUAL;
-      default:
-        // Do nothing
-        return filterKind;
-    }
-  }
-
-  private static void applyAlias(Map<Identifier, Expression> aliasMap, PinotQuery pinotQuery) {
-    Expression filterExpression = pinotQuery.getFilterExpression();
-    if (filterExpression != null) {
-      applyAlias(aliasMap, filterExpression);
-    }
-    List<Expression> groupByList = pinotQuery.getGroupByList();
-    if (groupByList != null) {
-      for (Expression expression : groupByList) {
-        applyAlias(aliasMap, expression);
-      }
-    }
-    Expression havingExpression = pinotQuery.getHavingExpression();
-    if (havingExpression != null) {
-      applyAlias(aliasMap, havingExpression);
-    }
-    List<Expression> orderByList = pinotQuery.getOrderByList();
-    if (orderByList != null) {
-      for (Expression expression : orderByList) {
-        applyAlias(aliasMap, expression);
-      }
-    }
-  }
-
-  private static void applyAlias(Map<Identifier, Expression> aliasMap, Expression expression) {
-    Identifier identifierKey = expression.getIdentifier();
-    if (identifierKey != null) {
-      Expression aliasExpression = aliasMap.get(identifierKey);
-      if (aliasExpression != null) {
-        expression.setType(aliasExpression.getType());
-        expression.setIdentifier(aliasExpression.getIdentifier());
-        expression.setFunctionCall(aliasExpression.getFunctionCall());
-        expression.setLiteral(aliasExpression.getLiteral());
-      }
-      return;
-    }
-    Function function = expression.getFunctionCall();
-    if (function != null) {
-      for (Expression operand : function.getOperands()) {
-        applyAlias(aliasMap, operand);
-      }
-    }
-  }
-
-  private static Map<Identifier, Expression> extractAlias(List<Expression> expressions) {
-    Map<Identifier, Expression> aliasMap = new HashMap<>();
-    for (Expression expression : expressions) {
-      Function functionCall = expression.getFunctionCall();
-      if (functionCall == null) {
-        continue;
-      }
-      if (functionCall.getOperator().equalsIgnoreCase(SqlKind.AS.toString())) {
-        Expression identifierExpr = functionCall.getOperands().get(1);
-        aliasMap.put(identifierExpr.getIdentifier(), functionCall.getOperands().get(0));
-      }
-    }
-    return aliasMap;
+    validate(pinotQuery);
   }
 
   private static List<String> extractOptionsFromSql(String sql) {
@@ -991,7 +612,7 @@ public class CalciteSqlParser {
     // Compile first operand of the function (either an identifier or another DOT and/or ITEM function).
     SqlKind kind0 = operands[0].getKind();
     if (kind0 == SqlKind.IDENTIFIER) {
-      path.append(((SqlIdentifier) operands[0]).toString());
+      path.append(operands[0].toString());
     } else if (kind0 == SqlKind.DOT || kind0 == SqlKind.OTHER_FUNCTION) {
       SqlBasicCall function0 = (SqlBasicCall) operands[0];
       String name0 = function0.getOperator().getName();
@@ -1013,6 +634,15 @@ public class CalciteSqlParser {
     } else {
       throw new SqlCompilationException("SELECT list item has bad path expression.");
     }
+  }
+
+
+  public static String canonicalize(String functionName) {
+    return StringUtils.remove(functionName, '_').toLowerCase();
+  }
+
+  public static boolean isSameFunction(String function1, String function2) {
+    return canonicalize(function1).equals(canonicalize(function2));
   }
 
   private static void validateFunction(String functionName, List<Expression> operands) {
@@ -1092,44 +722,6 @@ public class CalciteSqlParser {
     Expression andExpression = RequestUtils.getFunctionExpression(SqlKind.OR.name());
     andExpression.getFunctionCall().setOperands(operands);
     return andExpression;
-  }
-
-  protected static Expression invokeCompileTimeFunctionExpression(@Nullable Expression expression) {
-    if (expression == null || expression.getFunctionCall() == null) {
-      return expression;
-    }
-    Function function = expression.getFunctionCall();
-    List<Expression> operands = function.getOperands();
-    int numOperands = operands.size();
-    boolean compilable = true;
-    for (int i = 0; i < numOperands; i++) {
-      Expression operand = invokeCompileTimeFunctionExpression(operands.get(i));
-      if (operand.getLiteral() == null) {
-        compilable = false;
-      }
-      operands.set(i, operand);
-    }
-    String functionName = function.getOperator();
-    if (compilable) {
-      FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, numOperands);
-      if (functionInfo != null) {
-        Object[] arguments = new Object[numOperands];
-        for (int i = 0; i < numOperands; i++) {
-          arguments[i] = function.getOperands().get(i).getLiteral().getFieldValue();
-        }
-        try {
-          FunctionInvoker invoker = new FunctionInvoker(functionInfo);
-          invoker.convertTypes(arguments);
-          Object result = invoker.invoke(arguments);
-          return RequestUtils.getLiteralExpression(result);
-        } catch (Exception e) {
-          throw new SqlCompilationException(
-              "Caught exception while invoking method: " + functionInfo.getMethod() + " with arguments: " + Arrays
-                  .toString(arguments), e);
-        }
-      }
-    }
-    return expression;
   }
 
   public static boolean isLiteralOnlyExpression(Expression e) {

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/AliasApplier.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/AliasApplier.java
@@ -1,0 +1,141 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.rewriter;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.Identifier;
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.sql.parsers.SqlCompilationException;
+
+
+public class AliasApplier implements QueryRewriter {
+  @Override
+  public PinotQuery rewrite(PinotQuery pinotQuery) {
+
+    // Update alias
+    Map<Identifier, Expression> aliasMap = extractAlias(pinotQuery.getSelectList());
+    applyAlias(aliasMap, pinotQuery);
+
+    // Validate
+    validateSelectionClause(aliasMap, pinotQuery);
+    return pinotQuery;
+  }
+
+  private static Map<Identifier, Expression> extractAlias(List<Expression> expressions) {
+    Map<Identifier, Expression> aliasMap = new HashMap<>();
+    for (Expression expression : expressions) {
+      Function functionCall = expression.getFunctionCall();
+      if (functionCall == null) {
+        continue;
+      }
+      if (functionCall.getOperator().equalsIgnoreCase(SqlKind.AS.toString())) {
+        Expression identifierExpr = functionCall.getOperands().get(1);
+        aliasMap.put(identifierExpr.getIdentifier(), functionCall.getOperands().get(0));
+      }
+    }
+    return aliasMap;
+  }
+
+  private static void applyAlias(Map<Identifier, Expression> aliasMap, PinotQuery pinotQuery) {
+    Expression filterExpression = pinotQuery.getFilterExpression();
+    if (filterExpression != null) {
+      applyAlias(aliasMap, filterExpression);
+    }
+    List<Expression> groupByList = pinotQuery.getGroupByList();
+    if (groupByList != null) {
+      for (Expression expression : groupByList) {
+        applyAlias(aliasMap, expression);
+      }
+    }
+    Expression havingExpression = pinotQuery.getHavingExpression();
+    if (havingExpression != null) {
+      applyAlias(aliasMap, havingExpression);
+    }
+    List<Expression> orderByList = pinotQuery.getOrderByList();
+    if (orderByList != null) {
+      for (Expression expression : orderByList) {
+        applyAlias(aliasMap, expression);
+      }
+    }
+  }
+
+  private static void applyAlias(Map<Identifier, Expression> aliasMap, Expression expression) {
+    Identifier identifierKey = expression.getIdentifier();
+    if (identifierKey != null) {
+      Expression aliasExpression = aliasMap.get(identifierKey);
+      if (aliasExpression != null) {
+        expression.setType(aliasExpression.getType());
+        expression.setIdentifier(aliasExpression.getIdentifier());
+        expression.setFunctionCall(aliasExpression.getFunctionCall());
+        expression.setLiteral(aliasExpression.getLiteral());
+      }
+      return;
+    }
+    Function function = expression.getFunctionCall();
+    if (function != null) {
+      for (Expression operand : function.getOperands()) {
+        applyAlias(aliasMap, operand);
+      }
+    }
+  }
+
+  private static void validateSelectionClause(Map<Identifier, Expression> aliasMap, PinotQuery pinotQuery)
+      throws SqlCompilationException {
+    // Sanity check on selection expression shouldn't use alias reference.
+    Set<String> aliasKeys = new HashSet<>();
+    for (Identifier identifier : aliasMap.keySet()) {
+      String aliasName = identifier.getName().toLowerCase();
+      if (!aliasKeys.add(aliasName)) {
+        throw new SqlCompilationException("Duplicated alias name found.");
+      }
+    }
+    for (Expression selectExpr : pinotQuery.getSelectList()) {
+      matchIdentifierInAliasMap(selectExpr, aliasKeys);
+    }
+  }
+
+  private static void matchIdentifierInAliasMap(Expression selectExpr, Set<String> aliasKeys)
+      throws SqlCompilationException {
+    Function functionCall = selectExpr.getFunctionCall();
+    if (functionCall != null) {
+      if (functionCall.getOperator().equalsIgnoreCase(SqlKind.AS.toString())) {
+        matchIdentifierInAliasMap(functionCall.getOperands().get(0), aliasKeys);
+      } else {
+        if (functionCall.getOperandsSize() > 0) {
+          for (Expression operand : functionCall.getOperands()) {
+            matchIdentifierInAliasMap(operand, aliasKeys);
+          }
+        }
+      }
+    }
+    if (selectExpr.getIdentifier() != null) {
+      if (aliasKeys.contains(selectExpr.getIdentifier().getName().toLowerCase())) {
+        throw new SqlCompilationException(
+            "Alias " + selectExpr.getIdentifier().getName() + " cannot be referred in SELECT Clause");
+      }
+    }
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/CompileTimeFunctionsInvoker.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/CompileTimeFunctionsInvoker.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.rewriter;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.function.FunctionInfo;
+import org.apache.pinot.common.function.FunctionInvoker;
+import org.apache.pinot.common.function.FunctionRegistry;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.common.utils.request.RequestUtils;
+import org.apache.pinot.sql.parsers.SqlCompilationException;
+
+
+public class CompileTimeFunctionsInvoker implements QueryRewriter {
+  @Override
+  public PinotQuery rewrite(PinotQuery pinotQuery) {
+    for (int i = 0; i < pinotQuery.getSelectListSize(); i++) {
+      Expression expression = invokeCompileTimeFunctionExpression(pinotQuery.getSelectList().get(i));
+      pinotQuery.getSelectList().set(i, expression);
+    }
+    for (int i = 0; i < pinotQuery.getGroupByListSize(); i++) {
+      Expression expression = invokeCompileTimeFunctionExpression(pinotQuery.getGroupByList().get(i));
+      pinotQuery.getGroupByList().set(i, expression);
+    }
+    for (int i = 0; i < pinotQuery.getOrderByListSize(); i++) {
+      Expression expression = invokeCompileTimeFunctionExpression(pinotQuery.getOrderByList().get(i));
+      pinotQuery.getOrderByList().set(i, expression);
+    }
+    Expression filterExpression = invokeCompileTimeFunctionExpression(pinotQuery.getFilterExpression());
+    pinotQuery.setFilterExpression(filterExpression);
+    Expression havingExpression = invokeCompileTimeFunctionExpression(pinotQuery.getHavingExpression());
+    pinotQuery.setHavingExpression(havingExpression);
+    return pinotQuery;
+  }
+
+  protected static Expression invokeCompileTimeFunctionExpression(@Nullable Expression expression) {
+    if (expression == null || expression.getFunctionCall() == null) {
+      return expression;
+    }
+    Function function = expression.getFunctionCall();
+    List<Expression> operands = function.getOperands();
+    int numOperands = operands.size();
+    boolean compilable = true;
+    for (int i = 0; i < numOperands; i++) {
+      Expression operand = invokeCompileTimeFunctionExpression(operands.get(i));
+      if (operand.getLiteral() == null) {
+        compilable = false;
+      }
+      operands.set(i, operand);
+    }
+    String functionName = function.getOperator();
+    if (compilable) {
+      FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, numOperands);
+      if (functionInfo != null) {
+        Object[] arguments = new Object[numOperands];
+        for (int i = 0; i < numOperands; i++) {
+          arguments[i] = function.getOperands().get(i).getLiteral().getFieldValue();
+        }
+        try {
+          FunctionInvoker invoker = new FunctionInvoker(functionInfo);
+          invoker.convertTypes(arguments);
+          Object result = invoker.invoke(arguments);
+          return RequestUtils.getLiteralExpression(result);
+        } catch (Exception e) {
+          throw new SqlCompilationException(
+              "Caught exception while invoking method: " + functionInfo.getMethod() + " with arguments: "
+                  + Arrays.toString(arguments), e);
+        }
+      }
+    }
+    return expression;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/NonAggregationGroupByToDistinctQueryRewriter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/NonAggregationGroupByToDistinctQueryRewriter.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.rewriter;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Set;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.common.utils.request.RequestUtils;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.apache.pinot.sql.parsers.SqlCompilationException;
+
+
+public class NonAggregationGroupByToDistinctQueryRewriter implements QueryRewriter {
+  /**
+   * Rewrite non-aggregate group by query to distinct query.
+   * E.g.
+   * ```
+   *   SELECT col1+col2*5 FROM foo GROUP BY col1, col2 => SELECT distinct col1+col2*5 FROM foo
+   *   SELECT col1, col2 FROM foo GROUP BY col1, col2 => SELECT distinct col1, col2 FROM foo
+   * ```
+   * @param pinotQuery
+   */
+  @Override
+  public PinotQuery rewrite(PinotQuery pinotQuery) {
+    boolean hasAggregation = false;
+    for (Expression select : pinotQuery.getSelectList()) {
+      if (CalciteSqlParser.isAggregateExpression(select)) {
+        hasAggregation = true;
+      }
+    }
+    if (pinotQuery.getOrderByList() != null) {
+      for (Expression orderBy : pinotQuery.getOrderByList()) {
+        if (CalciteSqlParser.isAggregateExpression(orderBy)) {
+          hasAggregation = true;
+        }
+      }
+    }
+    if (!hasAggregation && pinotQuery.getGroupByListSize() > 0) {
+      Set<String> selectIdentifiers = CalciteSqlParser.extractIdentifiers(pinotQuery.getSelectList(), true);
+      Set<String> groupByIdentifiers = CalciteSqlParser.extractIdentifiers(pinotQuery.getGroupByList(), true);
+      if (groupByIdentifiers.containsAll(selectIdentifiers)) {
+        Expression distinctExpression = RequestUtils.getFunctionExpression("DISTINCT");
+        for (Expression select : pinotQuery.getSelectList()) {
+          if (CalciteSqlParser.isAsFunction(select)) {
+            Function asFunc = select.getFunctionCall();
+            distinctExpression.getFunctionCall().addToOperands(asFunc.getOperands().get(0));
+          } else {
+            distinctExpression.getFunctionCall().addToOperands(select);
+          }
+        }
+        pinotQuery.setSelectList(Arrays.asList(distinctExpression));
+        pinotQuery.setGroupByList(Collections.emptyList());
+      } else {
+        selectIdentifiers.removeAll(groupByIdentifiers);
+        throw new SqlCompilationException(String.format(
+            "For non-aggregation group by query, all the identifiers in select clause should be in groupBys. Found "
+                + "identifier: %s", Arrays.toString(selectIdentifiers.toArray(new String[0]))));
+      }
+    }
+    return pinotQuery;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/OrdinalsUpdater.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/OrdinalsUpdater.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.rewriter;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.sql.parsers.SqlCompilationException;
+
+
+public class OrdinalsUpdater implements QueryRewriter {
+  @Override
+  public PinotQuery rewrite(PinotQuery pinotQuery) {
+    // handle GROUP BY clause
+    for (int i = 0; i < pinotQuery.getGroupByListSize(); i++) {
+      final Expression groupByExpr = pinotQuery.getGroupByList().get(i);
+      if (groupByExpr.isSetLiteral() && groupByExpr.getLiteral().isSetLongValue()) {
+        final int ordinal = (int) groupByExpr.getLiteral().getLongValue();
+        pinotQuery.getGroupByList().set(i, getExpressionFromOrdinal(pinotQuery.getSelectList(), ordinal));
+      }
+    }
+
+    // handle ORDER BY clause
+    for (int i = 0; i < pinotQuery.getOrderByListSize(); i++) {
+      final Expression orderByExpr = pinotQuery.getOrderByList().get(i).getFunctionCall().getOperands().get(0);
+      if (orderByExpr.isSetLiteral() && orderByExpr.getLiteral().isSetLongValue()) {
+        final int ordinal = (int) orderByExpr.getLiteral().getLongValue();
+        pinotQuery.getOrderByList().get(i).getFunctionCall()
+            .setOperands(Arrays.asList(getExpressionFromOrdinal(pinotQuery.getSelectList(), ordinal)));
+      }
+    }
+    return pinotQuery;
+  }
+
+  private static Expression getExpressionFromOrdinal(List<Expression> selectList, int ordinal) {
+    if (ordinal > 0 && ordinal <= selectList.size()) {
+      final Expression expression = selectList.get(ordinal - 1);
+      // If the expression has AS, return the left operand.
+      if (expression.isSetFunctionCall() && expression.getFunctionCall().getOperator().equals(SqlKind.AS.name())) {
+        return expression.getFunctionCall().getOperands().get(0);
+      }
+      return expression;
+    } else {
+      throw new SqlCompilationException(
+          String.format("Expected Ordinal value to be between 1 and %d.", selectList.size()));
+    }
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriter.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.rewriter;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.common.utils.request.RequestUtils;
+import org.apache.pinot.pql.parsers.pql2.ast.FilterKind;
+import org.apache.pinot.sql.parsers.SqlCompilationException;
+
+
+public class PredicateComparisonRewriter implements QueryRewriter {
+  @Override
+  public PinotQuery rewrite(PinotQuery pinotQuery) {
+    Expression filterExpression = pinotQuery.getFilterExpression();
+    if (filterExpression != null) {
+      pinotQuery.setFilterExpression(updateComparisonPredicate(filterExpression));
+    }
+    Expression havingExpression = pinotQuery.getHavingExpression();
+    if (havingExpression != null) {
+      pinotQuery.setHavingExpression(updateComparisonPredicate(havingExpression));
+    }
+    return pinotQuery;
+  }
+
+  // This method converts a predicate expression to the what Pinot could evaluate.
+  // For comparison expression, left operand could be any expression, but right operand only
+  // supports literal.
+  // E.g. 'WHERE a > b' will be updated to 'WHERE a - b > 0'
+  private static Expression updateComparisonPredicate(Expression expression) {
+    Function function = expression.getFunctionCall();
+    if (function != null) {
+      String operator = function.getOperator().toUpperCase();
+      FilterKind filterKind;
+      try {
+        filterKind = FilterKind.valueOf(operator);
+      } catch (Exception e) {
+        throw new SqlCompilationException("Unsupported filter kind: " + operator);
+      }
+      List<Expression> operands = function.getOperands();
+      switch (filterKind) {
+        case AND:
+        case OR:
+          operands.replaceAll(PredicateComparisonRewriter::updateComparisonPredicate);
+          break;
+        case EQUALS:
+        case NOT_EQUALS:
+        case GREATER_THAN:
+        case GREATER_THAN_OR_EQUAL:
+        case LESS_THAN:
+        case LESS_THAN_OR_EQUAL:
+          Expression firstOperand = operands.get(0);
+          Expression secondOperand = operands.get(1);
+
+          // Handle predicate like '10 = a' -> 'a = 10'
+          if (firstOperand.isSetLiteral()) {
+            if (!secondOperand.isSetLiteral()) {
+              function.setOperator(getOppositeOperator(filterKind).name());
+              operands.set(0, secondOperand);
+              operands.set(1, firstOperand);
+            }
+            break;
+          }
+
+          // Handle predicate like 'a > b' -> 'a - b > 0'
+          if (!secondOperand.isSetLiteral()) {
+            Expression minusExpression = RequestUtils.getFunctionExpression(SqlKind.MINUS.name());
+            minusExpression.getFunctionCall().setOperands(Arrays.asList(firstOperand, secondOperand));
+            operands.set(0, minusExpression);
+            operands.set(1, RequestUtils.getLiteralExpression(0));
+            break;
+          }
+          break;
+        default:
+          int numOperands = operands.size();
+          for (int i = 1; i < numOperands; i++) {
+            if (!operands.get(i).isSetLiteral()) {
+              throw new SqlCompilationException(
+                  String.format("For %s predicate, the operands except for the first one must be literal, got: %s",
+                      filterKind, expression));
+            }
+          }
+          break;
+      }
+    }
+    return expression;
+  }
+
+  /**
+   * The purpose of this method is to convert expression "0 < columnA" to "columnA > 0".
+   * The conversion would be:
+   *  from ">" to "<",
+   *  from "<" to ">",
+   *  from ">=" to "<=",
+   *  from "<=" to ">=".
+   */
+  private static FilterKind getOppositeOperator(FilterKind filterKind) {
+    switch (filterKind) {
+      case GREATER_THAN:
+        return FilterKind.LESS_THAN;
+      case GREATER_THAN_OR_EQUAL:
+        return FilterKind.LESS_THAN_OR_EQUAL;
+      case LESS_THAN:
+        return FilterKind.GREATER_THAN;
+      case LESS_THAN_OR_EQUAL:
+        return FilterKind.GREATER_THAN_OR_EQUAL;
+      default:
+        // Do nothing
+        return filterKind;
+    }
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/QueryRewriter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/QueryRewriter.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.rewriter;
+
+import org.apache.pinot.common.request.PinotQuery;
+
+
+/**
+ * QueryRewriter is the interface to rewrite PinotQuery.
+ * Rewrite is recommended to be in-place.
+ */
+public interface QueryRewriter {
+  PinotQuery rewrite(PinotQuery pinotQuery);
+}

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/QueryRewriterFactory.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/QueryRewriterFactory.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.rewriter;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class QueryRewriterFactory {
+
+  private QueryRewriterFactory() {
+  }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(QueryRewriterFactory.class);
+
+  static final List<String> DEFAULT_QUERY_REWRITERS_CLASS_NAMES =
+      ImmutableList.of(CompileTimeFunctionsInvoker.class.getName(), SelectionsRewriter.class.getName(),
+          PredicateComparisonRewriter.class.getName(), OrdinalsUpdater.class.getName(),
+          NonAggregationGroupByToDistinctQueryRewriter.class.getName(), AliasApplier.class.getName());
+
+  public static void init(String queryRewritersClassNamesStr) {
+    List<String> queryRewritersClassNames =
+        (queryRewritersClassNamesStr != null) ? Arrays.asList(queryRewritersClassNamesStr.split(","))
+            : DEFAULT_QUERY_REWRITERS_CLASS_NAMES;
+    final List<QueryRewriter> queryRewriters = getQueryRewriters(queryRewritersClassNames);
+    synchronized (CalciteSqlParser.class) {
+      CalciteSqlParser.QUERY_REWRITERS.clear();
+      CalciteSqlParser.QUERY_REWRITERS.addAll(queryRewriters);
+    }
+  }
+
+  public static List<QueryRewriter> getQueryRewriters() {
+    return getQueryRewriters(DEFAULT_QUERY_REWRITERS_CLASS_NAMES);
+  }
+
+  private static List<QueryRewriter> getQueryRewriters(List<String> queryRewriterClasses) {
+    final ImmutableList.Builder<QueryRewriter> builder = ImmutableList.builder();
+    for (String queryRewriterClassName : queryRewriterClasses) {
+      try {
+        builder.add(getQueryRewriter(queryRewriterClassName));
+      } catch (Exception e) {
+        LOGGER.error("Failed to load QueryRewriter: {}", queryRewriterClassName, e);
+      }
+    }
+    return builder.build();
+  }
+
+  private static QueryRewriter getQueryRewriter(String queryRewriterClassName)
+      throws Exception {
+    final Class<QueryRewriter> queryRewriterClass = (Class<QueryRewriter>) Class.forName(queryRewriterClassName);
+    return (QueryRewriter) queryRewriterClass.getDeclaredConstructors()[0].newInstance();
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/SelectionsRewriter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/SelectionsRewriter.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.rewriter;
+
+import org.apache.pinot.common.function.TransformFunctionType;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+
+
+public class SelectionsRewriter implements QueryRewriter {
+  @Override
+  public PinotQuery rewrite(PinotQuery pinotQuery) {
+    for (Expression expression : pinotQuery.getSelectList()) {
+      // Rewrite aggregation
+      tryToRewriteArrayFunction(expression);
+    }
+    return pinotQuery;
+  }
+
+  private static void tryToRewriteArrayFunction(Expression expression) {
+    if (!expression.isSetFunctionCall()) {
+      return;
+    }
+    Function functionCall = expression.getFunctionCall();
+    switch (CalciteSqlParser.canonicalize(functionCall.getOperator())) {
+      case "sum":
+        if (functionCall.getOperands().size() != 1) {
+          return;
+        }
+        if (functionCall.getOperands().get(0).isSetFunctionCall()) {
+          Function innerFunction = functionCall.getOperands().get(0).getFunctionCall();
+          if (CalciteSqlParser.isSameFunction(innerFunction.getOperator(), TransformFunctionType.ARRAYSUM.getName())) {
+            Function sumMvFunc = new Function(AggregationFunctionType.SUMMV.getName());
+            sumMvFunc.setOperands(innerFunction.getOperands());
+            expression.setFunctionCall(sumMvFunc);
+          }
+        }
+        return;
+      case "min":
+        if (functionCall.getOperands().size() != 1) {
+          return;
+        }
+        if (functionCall.getOperands().get(0).isSetFunctionCall()) {
+          Function innerFunction = functionCall.getOperands().get(0).getFunctionCall();
+          if (CalciteSqlParser.isSameFunction(innerFunction.getOperator(), TransformFunctionType.ARRAYMIN.getName())) {
+            Function sumMvFunc = new Function(AggregationFunctionType.MINMV.getName());
+            sumMvFunc.setOperands(innerFunction.getOperands());
+            expression.setFunctionCall(sumMvFunc);
+          }
+        }
+        return;
+      case "max":
+        if (functionCall.getOperands().size() != 1) {
+          return;
+        }
+        if (functionCall.getOperands().get(0).isSetFunctionCall()) {
+          Function innerFunction = functionCall.getOperands().get(0).getFunctionCall();
+          if (CalciteSqlParser.isSameFunction(innerFunction.getOperator(), TransformFunctionType.ARRAYMAX.getName())) {
+            Function sumMvFunc = new Function(AggregationFunctionType.MAXMV.getName());
+            sumMvFunc.setOperands(innerFunction.getOperands());
+            expression.setFunctionCall(sumMvFunc);
+          }
+        }
+        return;
+      default:
+        break;
+    }
+    for (Expression operand : functionCall.getOperands()) {
+      tryToRewriteArrayFunction(operand);
+    }
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/QueryRewriterFactoryTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/QueryRewriterFactoryTest.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.rewriter;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.sql.parsers.CalciteSqlParser.QUERY_REWRITERS;
+
+
+public class QueryRewriterFactoryTest {
+
+  @Test
+  public void testQueryRewriters()
+      throws ReflectiveOperationException {
+    // Default behavior
+    QueryRewriterFactory.init(null);
+    Assert.assertEquals(QUERY_REWRITERS.size(), 6);
+    Assert.assertTrue(QUERY_REWRITERS.get(0) instanceof CompileTimeFunctionsInvoker);
+    Assert.assertTrue(QUERY_REWRITERS.get(1) instanceof SelectionsRewriter);
+    Assert.assertTrue(QUERY_REWRITERS.get(2) instanceof PredicateComparisonRewriter);
+    Assert.assertTrue(QUERY_REWRITERS.get(3) instanceof OrdinalsUpdater);
+    Assert.assertTrue(QUERY_REWRITERS.get(4) instanceof NonAggregationGroupByToDistinctQueryRewriter);
+    Assert.assertTrue(QUERY_REWRITERS.get(5) instanceof AliasApplier);
+
+    // Check init with other configs
+    QueryRewriterFactory.init("org.apache.pinot.sql.parsers.rewriter.PredicateComparisonRewriter,"
+        + "org.apache.pinot.sql.parsers.rewriter.CompileTimeFunctionsInvoker,"
+        + "org.apache.pinot.sql.parsers.rewriter.SelectionsRewriter");
+    Assert.assertEquals(QUERY_REWRITERS.size(), 3);
+    Assert.assertTrue(QUERY_REWRITERS.get(0) instanceof PredicateComparisonRewriter);
+    Assert.assertTrue(QUERY_REWRITERS.get(1) instanceof CompileTimeFunctionsInvoker);
+    Assert.assertTrue(QUERY_REWRITERS.get(2) instanceof SelectionsRewriter);
+
+    // Revert back to default behavior
+    QueryRewriterFactory.init(null);
+    Assert.assertEquals(QUERY_REWRITERS.size(), 6);
+    Assert.assertTrue(QUERY_REWRITERS.get(0) instanceof CompileTimeFunctionsInvoker);
+    Assert.assertTrue(QUERY_REWRITERS.get(1) instanceof SelectionsRewriter);
+    Assert.assertTrue(QUERY_REWRITERS.get(2) instanceof PredicateComparisonRewriter);
+    Assert.assertTrue(QUERY_REWRITERS.get(3) instanceof OrdinalsUpdater);
+    Assert.assertTrue(QUERY_REWRITERS.get(4) instanceof NonAggregationGroupByToDistinctQueryRewriter);
+    Assert.assertTrue(QUERY_REWRITERS.get(5) instanceof AliasApplier);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -97,6 +97,7 @@ import org.apache.pinot.spi.services.ServiceRole;
 import org.apache.pinot.spi.services.ServiceStartable;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.NetUtils;
+import org.apache.pinot.sql.parsers.rewriter.QueryRewriterFactory;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -361,6 +362,10 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     initControllerFilePathProvider();
     initSegmentFetcherFactory();
     initPinotCrypterFactory();
+
+    LOGGER.info("Initializing QueryRewriterFactory");
+    QueryRewriterFactory.init(
+        _config.getProperty(CommonConstants.Controller.CONFIG_OF_CONTROLLER_QUERY_REWRITER_CLASS_NAMES));
 
     LOGGER.info("Initializing Helix participant manager");
     _helixParticipantManager = HelixManagerFactory

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
@@ -57,6 +57,7 @@ import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
 import org.apache.pinot.spi.services.ServiceRole;
 import org.apache.pinot.spi.services.ServiceStartable;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.sql.parsers.rewriter.QueryRewriterFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -193,6 +194,9 @@ public abstract class BaseMinionStarter implements ServiceStartable {
     LOGGER.info("Initializing PinotFSFactory");
     PinotConfiguration pinotFSConfig = _config.subset(CommonConstants.Minion.PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY);
     PinotFSFactory.init(pinotFSConfig);
+
+    LOGGER.info("Initializing QueryRewriterFactory");
+    QueryRewriterFactory.init(_config.getProperty(CommonConstants.Minion.CONFIG_OF_MINION_QUERY_REWRITER_CLASS_NAMES));
 
     LOGGER.info("Initializing segment fetchers for all protocols");
     PinotConfiguration segmentFetcherFactoryConfig =

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -87,6 +87,7 @@ import org.apache.pinot.spi.utils.CommonConstants.Server;
 import org.apache.pinot.spi.utils.CommonConstants.Server.SegmentCompletionProtocol;
 import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.sql.parsers.rewriter.QueryRewriterFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -449,6 +450,10 @@ public abstract class BaseServerStarter implements ServiceStartable {
     } else {
       _helixAdmin.removeConfig(_instanceConfigScope, Collections.singletonList(Instance.GRPC_PORT_KEY));
     }
+
+    // Init QueryRewriterFactory
+    LOGGER.info("Initializing QueryRewriterFactory");
+    QueryRewriterFactory.init(_serverConf.getProperty(Server.CONFIG_OF_SERVER_QUERY_REWRITER_CLASS_NAMES));
 
     // Register message handler factory
     SegmentMessageHandlerFactory messageHandlerFactory =

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -187,6 +187,7 @@ public class CommonConstants {
     public static final String CONFIG_OF_ALLOWED_TABLES_FOR_EMITTING_METRICS =
         "pinot.broker.allowedTablesForEmittingMetrics";
 
+    public static final String CONFIG_OF_BROKER_QUERY_REWRITER_CLASS_NAMES = "pinot.broker.query.rewriter.class.names";
     public static final String CONFIG_OF_BROKER_QUERY_RESPONSE_LIMIT = "pinot.broker.query.response.limit";
     public static final int DEFAULT_BROKER_QUERY_RESPONSE_LIMIT = Integer.MAX_VALUE;
     public static final String CONFIG_OF_BROKER_QUERY_LOG_LENGTH = "pinot.broker.query.log.length";
@@ -251,6 +252,7 @@ public class CommonConstants {
     public static final String CONFIG_OF_QUERY_EXECUTOR_PRUNER_CLASS = "pinot.server.query.executor.pruner.class";
     public static final String CONFIG_OF_QUERY_EXECUTOR_TIMEOUT = "pinot.server.query.executor.timeout";
     public static final String CONFIG_OF_QUERY_EXECUTOR_CLASS = "pinot.server.query.executor.class";
+    public static final String CONFIG_OF_SERVER_QUERY_REWRITER_CLASS_NAMES = "pinot.server.query.rewriter.class.names";
     public static final String CONFIG_OF_REQUEST_HANDLER_FACTORY_CLASS = "pinot.server.requestHandlerFactory.class";
     public static final String CONFIG_OF_NETTY_SERVER_ENABLED = "pinot.server.netty.enabled";
     public static final boolean DEFAULT_NETTY_SERVER_ENABLED = true;
@@ -424,6 +426,8 @@ public class CommonConstants {
     public static final String DEFAULT_METRICS_PREFIX = "pinot.controller.";
 
     public static final String CONFIG_OF_INSTANCE_ID = "pinot.controller.instance.id";
+    public static final String CONFIG_OF_CONTROLLER_QUERY_REWRITER_CLASS_NAMES =
+        "pinot.controller.query.rewriter.class.names";
   }
 
   public static class Minion {
@@ -453,6 +457,7 @@ public class CommonConstants {
     public static final String CONFIG_OF_ADMIN_API_PORT = "pinot.minion.adminapi.port";
     public static final String MINION_TLS_PREFIX = "pinot.minion.tls";
     public static final int DEFAULT_ADMIN_API_PORT = 6500;
+    public static final String CONFIG_OF_MINION_QUERY_REWRITER_CLASS_NAMES = "pinot.minion.query.rewriter.class.names";
   }
 
   public static class Segment {


### PR DESCRIPTION
## Description
- Refactor query rewriter to interfaces
- Move existing query rewriters to implementations
  - AliasApplier
  - CompileTimeFunctionsInvoker
  - NonAggregationGroupByToDistinctQueryRewriter
  - OrdinalsUpdater
  - PredicateComparisonRewriter
  - SelectionsRewriter
- QueryVisistors are constructed from a list of class names.
- Add an environment variable `queryVisitorsClassNames` to allow override the default query rewriter class names.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
