### PR TITLE
Need to make TaskMetadata abstract methods public

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/BaseTaskMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/BaseTaskMetadata.java
@@ -34,12 +34,12 @@ public abstract class BaseTaskMetadata {
   /**
    * @return table name appended with its type. E.g. MyTable_OFFLINE
    */
-  abstract String getTableNameWithType();
+  public abstract String getTableNameWithType();
 
   /**
    * @return {@link ZNRecord} containing the task metadata
    */
-  abstract ZNRecord toZNRecord();
+  public abstract ZNRecord toZNRecord();
 
   /**
    * @return task metadata as a Json string


### PR DESCRIPTION
## Description
Need to make TaskMetadata abstract methods `public` since its going to be overriden and called from outside the package. Follow up change from previous [PR](https://github.com/apache/pinot/pull/7575).

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)