### PR TITLE
add `BOOLEAN_ARRAY` and `TIMESTAMP_ARRAY` types

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/DataSchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/DataSchemaTest.java
@@ -29,15 +29,18 @@ import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.*;
 public class DataSchemaTest {
   private static final String[] COLUMN_NAMES = {
       "int", "long", "float", "double", "string", "object", "int_array", "long_array", "float_array", "double_array",
-      "string_array"
+      "string_array", "boolean_array", "timestamp_array"
   };
   private static final int NUM_COLUMNS = COLUMN_NAMES.length;
   private static final DataSchema.ColumnDataType[] COLUMN_DATA_TYPES =
-      {INT, LONG, FLOAT, DOUBLE, STRING, OBJECT, INT_ARRAY, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY, STRING_ARRAY};
+      {INT, LONG, FLOAT, DOUBLE, STRING, OBJECT, INT_ARRAY, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY, STRING_ARRAY,
+      BOOLEAN_ARRAY, TIMESTAMP_ARRAY};
   private static final DataSchema.ColumnDataType[] COMPATIBLE_COLUMN_DATA_TYPES =
-      {LONG, FLOAT, DOUBLE, INT, STRING, OBJECT, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY, INT_ARRAY, STRING_ARRAY};
+      {LONG, FLOAT, DOUBLE, INT, STRING, OBJECT, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY, INT_ARRAY, STRING_ARRAY,
+       BOOLEAN_ARRAY, TIMESTAMP_ARRAY};
   private static final DataSchema.ColumnDataType[] UPGRADED_COLUMN_DATA_TYPES = {
-      LONG, DOUBLE, DOUBLE, DOUBLE, STRING, OBJECT, LONG_ARRAY, DOUBLE_ARRAY, DOUBLE_ARRAY, DOUBLE_ARRAY, STRING_ARRAY
+      LONG, DOUBLE, DOUBLE, DOUBLE, STRING, OBJECT, LONG_ARRAY, DOUBLE_ARRAY, DOUBLE_ARRAY, DOUBLE_ARRAY, STRING_ARRAY,
+      BOOLEAN_ARRAY, TIMESTAMP_ARRAY
   };
 
   @Test
@@ -88,7 +91,8 @@ public class DataSchemaTest {
     DataSchema dataSchema = new DataSchema(COLUMN_NAMES, COLUMN_DATA_TYPES);
     Assert.assertEquals(dataSchema.toString(),
         "[int(INT),long(LONG),float(FLOAT),double(DOUBLE),string(STRING),object(OBJECT),int_array(INT_ARRAY),"
-            + "long_array(LONG_ARRAY),float_array(FLOAT_ARRAY),double_array(DOUBLE_ARRAY),string_array(STRING_ARRAY)]");
+            + "long_array(LONG_ARRAY),float_array(FLOAT_ARRAY),double_array(DOUBLE_ARRAY),string_array(STRING_ARRAY),"
+            + "boolean_array(BOOLEAN_ARRAY),timestamp_array(TIMESTAMP_ARRAY)]");
   }
 
   @Test
@@ -162,15 +166,19 @@ public class DataSchemaTest {
       Assert.assertFalse(columnDataType.isCompatible(STRING_ARRAY));
     }
 
-    Assert.assertFalse(STRING_ARRAY.isNumber());
-    Assert.assertFalse(STRING_ARRAY.isWholeNumber());
-    Assert.assertTrue(STRING_ARRAY.isArray());
-    Assert.assertFalse(STRING_ARRAY.isNumberArray());
-    Assert.assertFalse(STRING_ARRAY.isWholeNumberArray());
-    Assert.assertFalse(STRING_ARRAY.isCompatible(DOUBLE));
-    Assert.assertFalse(STRING_ARRAY.isCompatible(STRING));
-    Assert.assertFalse(STRING_ARRAY.isCompatible(DOUBLE_ARRAY));
-    Assert.assertTrue(STRING_ARRAY.isCompatible(STRING_ARRAY));
+    for (DataSchema.ColumnDataType columnDataType : new DataSchema.ColumnDataType[]{STRING_ARRAY, BOOLEAN_ARRAY,
+        TIMESTAMP_ARRAY}) {
+      Assert.assertFalse(columnDataType.isNumber());
+      Assert.assertFalse(columnDataType.isWholeNumber());
+      Assert.assertTrue(columnDataType.isArray());
+      Assert.assertFalse(columnDataType.isNumberArray());
+      Assert.assertFalse(columnDataType.isWholeNumberArray());
+      Assert.assertFalse(columnDataType.isCompatible(DOUBLE));
+      Assert.assertFalse(columnDataType.isCompatible(STRING));
+      Assert.assertFalse(columnDataType.isCompatible(DOUBLE_ARRAY));
+      Assert.assertFalse(columnDataType.isCompatible(INT_ARRAY));
+      Assert.assertTrue(columnDataType.isCompatible(columnDataType));
+    }
 
     Assert.assertEquals(fromDataType(FieldSpec.DataType.INT, true), INT);
     Assert.assertEquals(fromDataType(FieldSpec.DataType.INT, false), INT_ARRAY);
@@ -182,5 +190,7 @@ public class DataSchemaTest {
     Assert.assertEquals(fromDataType(FieldSpec.DataType.DOUBLE, false), DOUBLE_ARRAY);
     Assert.assertEquals(fromDataType(FieldSpec.DataType.STRING, true), STRING);
     Assert.assertEquals(fromDataType(FieldSpec.DataType.STRING, false), STRING_ARRAY);
+    Assert.assertEquals(fromDataType(FieldSpec.DataType.BOOLEAN, false), BOOLEAN_ARRAY);
+    Assert.assertEquals(fromDataType(FieldSpec.DataType.TIMESTAMP, false), TIMESTAMP_ARRAY);
   }
 }


### PR DESCRIPTION
## Description
This adds MV support for `BOOLEAN` and `TIMESTAMP` fields which makes type inference from JSON safer.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
