### PR TITLE
Change FetchContext to have list of index per column to fetch

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/FetchContext.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/FetchContext.java
@@ -18,8 +18,12 @@
  */
 package org.apache.pinot.segment.spi;
 
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import org.apache.pinot.segment.spi.store.ColumnIndexType;
 
 
 /**
@@ -28,12 +32,33 @@ import java.util.UUID;
 public class FetchContext {
   private final UUID _fetchId;
   private final String _segmentName;
-  private final Set<String> _columns;
+  private final Map<String, List<ColumnIndexType>> _columnToIndexList;
 
+  /**
+   * Create a new FetchRequest for this segment, to fetch all buffers of the given columns
+   * @param fetchId unique fetch id
+   * @param segmentName segment name
+   * @param columns set of columns to fetch
+   */
   public FetchContext(UUID fetchId, String segmentName, Set<String> columns) {
     _fetchId = fetchId;
     _segmentName = segmentName;
-    _columns = columns;
+    _columnToIndexList = new HashMap<>();
+    for (String column : columns) {
+      _columnToIndexList.put(column, null);
+    }
+  }
+
+  /**
+   * Create a new FetchRequest for this segment, to fetch those indexes as mentioned in the column to indexes list map
+   * @param fetchId unique fetch id
+   * @param segmentName segment name
+   * @param columnToIndexList map of column names as key, and list of indexes to fetch as values
+   */
+  public FetchContext(UUID fetchId, String segmentName, Map<String, List<ColumnIndexType>> columnToIndexList) {
+    _fetchId = fetchId;
+    _segmentName = segmentName;
+    _columnToIndexList = columnToIndexList;
   }
 
   /**
@@ -52,9 +77,10 @@ public class FetchContext {
   }
 
   /**
-   * Columns to be fetched as part of this request
+   * Map of columns to fetch as key, and the list of indexes to fetch for the column as value
+   * The list of indexes can be null, which indicates that every index for this column should be fetched
    */
-  public Set<String> getColumns() {
-    return _columns;
+  public Map<String, List<ColumnIndexType>> getColumnToIndexList() {
+    return _columnToIndexList;
   }
 }


### PR DESCRIPTION
This will help fetch only the indexes we need instead of every buffer for every column.