### PR TITLE
Upgrade localstack utils version to 0.2.15

### DIFF
--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -34,7 +34,7 @@
 
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
-    <localstack-utils.version>0.2.11</localstack-utils.version>
+    <localstack-utils.version>0.2.15</localstack-utils.version>
     <awaitility.version>3.0.0</awaitility.version>
     <aws.sdk.version>2.14.28</aws.sdk.version>
   </properties>


### PR DESCRIPTION
Localstack version 0.2.11 version is creating issues with Kinesis integration tests. Upgrading the version to solve this issue