### PR TITLE
use StandardCharsets.UTF_8 

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/StringUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/StringUtils.java
@@ -18,36 +18,22 @@
  */
 package org.apache.pinot.spi.utils;
 
-import java.io.UnsupportedEncodingException;
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 
 public class StringUtils {
   private StringUtils() {
   }
 
-  private static final String UTF_8 = "UTF-8";
-
   public static byte[] encodeUtf8(String s) {
-    try {
-      // NOTE: Intentionally use charset name to reuse the string encoder
-      //noinspection CharsetObjectCanBeUsed
-      return s.getBytes(UTF_8);
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException(e);
-    }
+    return s.getBytes(UTF_8);
   }
 
   public static String decodeUtf8(byte[] bytes) {
-    return decodeUtf8(bytes, 0, bytes.length);
+    return new String(bytes, UTF_8);
   }
 
   public static String decodeUtf8(byte[] bytes, int offset, int length) {
-    try {
-      // NOTE: Intentionally use charset name to reuse the string encoder
-      //noinspection CharsetObjectCanBeUsed
-      return new String(bytes, offset, length, UTF_8);
-    } catch (UnsupportedEncodingException e) {
-      throw new RuntimeException(e);
-    }
+    return new String(bytes, offset, length, UTF_8);
   }
 }


### PR DESCRIPTION
## Description
Modernise `StringUtils` - use `StandardCharsets` which is faster (I can demonstrate this if necessary).

For context, this same change has been made within the JDK for performance reasons:

- https://github.com/openjdk/jdk/pull/5210
- https://github.com/openjdk/jdk/pull/5063

The problem this code was working around is still [present](https://github.com/openjdk/jdk8/blob/master/jdk/src/share/classes/java/lang/StringCoding.java#L348) in the latest JDK8 builds but this is a tradeoff - optimise for JDK8 or optimise for JDK11+.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
