### PR TITLE
[Cleanup] Precompute and cache query properties in QueryContext

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/AggregationOnlyCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/AggregationOnlyCombineOperator.java
@@ -34,8 +34,8 @@ public class AggregationOnlyCombineOperator extends BaseCombineOperator {
   private static final String OPERATOR_NAME = "AggregationOnlyCombineOperator";
 
   public AggregationOnlyCombineOperator(List<Operator> operators, QueryContext queryContext,
-      ExecutorService executorService, long endTimeMs, int maxExecutionThreads) {
-    super(operators, queryContext, executorService, endTimeMs, maxExecutionThreads);
+      ExecutorService executorService) {
+    super(operators, queryContext, executorService);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/DistinctCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/DistinctCombineOperator.java
@@ -36,9 +36,8 @@ public class DistinctCombineOperator extends BaseCombineOperator {
 
   private final boolean _hasOrderBy;
 
-  public DistinctCombineOperator(List<Operator> operators, QueryContext queryContext, ExecutorService executorService,
-      long endTimeMs, int maxExecutionThreads) {
-    super(operators, queryContext, executorService, endTimeMs, maxExecutionThreads);
+  public DistinctCombineOperator(List<Operator> operators, QueryContext queryContext, ExecutorService executorService) {
+    super(operators, queryContext, executorService);
     _hasOrderBy = queryContext.getOrderByExpressions() != null;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
@@ -70,20 +70,28 @@ public class GroupByCombineOperator extends BaseCombineOperator {
   // _futures (try to interrupt the execution if it already started).
   private final CountDownLatch _operatorLatch;
 
-  public GroupByCombineOperator(List<Operator> operators, QueryContext queryContext, ExecutorService executorService,
-      long endTimeMs, int maxExecutionThreads, int innerSegmentNumGroupsLimit) {
-    // NOTE: For group-by queries, when maxExecutionThreads is not explicitly configured, create one thread per operator
-    super(operators, queryContext, executorService, endTimeMs,
-        maxExecutionThreads > 0 ? maxExecutionThreads : operators.size());
+  public GroupByCombineOperator(List<Operator> operators, QueryContext queryContext, ExecutorService executorService) {
+    super(operators, overrideMaxExecutionThreads(queryContext, operators.size()), executorService);
 
-    _innerSegmentNumGroupsLimit = innerSegmentNumGroupsLimit;
+    _innerSegmentNumGroupsLimit = queryContext.getNumGroupsLimit();
     _interSegmentNumGroupsLimit =
-        (int) Math.min((long) innerSegmentNumGroupsLimit * INTER_SEGMENT_NUM_GROUPS_LIMIT_FACTOR, Integer.MAX_VALUE);
+        (int) Math.min((long) _innerSegmentNumGroupsLimit * INTER_SEGMENT_NUM_GROUPS_LIMIT_FACTOR, Integer.MAX_VALUE);
 
     _aggregationFunctions = _queryContext.getAggregationFunctions();
     assert _aggregationFunctions != null;
     _numAggregationFunctions = _aggregationFunctions.length;
     _operatorLatch = new CountDownLatch(_numTasks);
+  }
+
+  /**
+   * For group-by queries, when maxExecutionThreads is not explicitly configured, create one task per operator.
+   */
+  private static QueryContext overrideMaxExecutionThreads(QueryContext queryContext, int numOperators) {
+    int maxExecutionThreads = queryContext.getMaxExecutionThreads();
+    if (maxExecutionThreads <= 0) {
+      queryContext.setMaxExecutionThreads(numOperators);
+    }
+    return queryContext;
   }
 
   @Override
@@ -166,7 +174,7 @@ public class GroupByCombineOperator extends BaseCombineOperator {
   @Override
   protected IntermediateResultsBlock mergeResults()
       throws Exception {
-    long timeoutMs = _endTimeMs - System.currentTimeMillis();
+    long timeoutMs = _queryContext.getEndTimeMs() - System.currentTimeMillis();
     boolean opCompleted = _operatorLatch.await(timeoutMs, TimeUnit.MILLISECONDS);
     if (!opCompleted) {
       // If this happens, the broker side should already timed out, just log the error and return

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
@@ -69,8 +69,8 @@ public class MinMaxValueBasedSelectionOrderByCombineOperator extends BaseCombine
   private final List<MinMaxValueContext> _minMaxValueContexts;
 
   MinMaxValueBasedSelectionOrderByCombineOperator(List<Operator> operators, QueryContext queryContext,
-      ExecutorService executorService, long endTimeMs, int maxExecutionThreads) {
-    super(operators, queryContext, executorService, endTimeMs, maxExecutionThreads);
+      ExecutorService executorService) {
+    super(operators, queryContext, executorService);
     _numRowsToKeep = queryContext.getLimit() + queryContext.getOffset();
 
     List<OrderByExpressionContext> orderByExpressions = _queryContext.getOrderByExpressions();
@@ -231,9 +231,10 @@ public class MinMaxValueBasedSelectionOrderByCombineOperator extends BaseCombine
       throws Exception {
     IntermediateResultsBlock mergedBlock = null;
     int numBlocksMerged = 0;
+    long endTimeMs = _queryContext.getEndTimeMs();
     while (numBlocksMerged + _numOperatorsSkipped.get() < _numOperators) {
       IntermediateResultsBlock blockToMerge =
-          _blockingQueue.poll(_endTimeMs - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+          _blockingQueue.poll(endTimeMs - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
       if (blockToMerge == null) {
         // Query times out, skip merging the remaining results blocks
         LOGGER.error("Timed out while polling results block, numBlocksMerged: {} (query: {})", numBlocksMerged,

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOnlyCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOnlyCombineOperator.java
@@ -45,8 +45,8 @@ public class SelectionOnlyCombineOperator extends BaseCombineOperator {
   private final int _numRowsToKeep;
 
   public SelectionOnlyCombineOperator(List<Operator> operators, QueryContext queryContext,
-      ExecutorService executorService, long endTimeMs, int maxExecutionThreads) {
-    super(operators, queryContext, executorService, endTimeMs, maxExecutionThreads);
+      ExecutorService executorService) {
+    super(operators, queryContext, executorService);
     _numRowsToKeep = queryContext.getLimit();
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOrderByCombineOperator.java
@@ -49,8 +49,8 @@ public class SelectionOrderByCombineOperator extends BaseCombineOperator {
   private final int _numRowsToKeep;
 
   public SelectionOrderByCombineOperator(List<Operator> operators, QueryContext queryContext,
-      ExecutorService executorService, long endTimeMs, int maxExecutionThreads) {
-    super(operators, queryContext, executorService, endTimeMs, maxExecutionThreads);
+      ExecutorService executorService) {
+    super(operators, queryContext, executorService);
     _numRowsToKeep = queryContext.getLimit() + queryContext.getOffset();
   }
 
@@ -74,8 +74,8 @@ public class SelectionOrderByCombineOperator extends BaseCombineOperator {
     assert orderByExpressions != null;
     if (orderByExpressions.get(0).getExpression().getType() == ExpressionContext.Type.IDENTIFIER) {
       try {
-        return new MinMaxValueBasedSelectionOrderByCombineOperator(_operators, _queryContext, _executorService,
-            _endTimeMs, _numTasks).getNextBlock();
+        return new MinMaxValueBasedSelectionOrderByCombineOperator(_operators, _queryContext,
+            _executorService).getNextBlock();
       } catch (Exception e) {
         LOGGER.warn("Caught exception while using min/max value based combine, using the default combine", e);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationGroupByOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationGroupByOrderByOperator.java
@@ -46,9 +46,6 @@ public class AggregationGroupByOrderByOperator extends BaseOperator<Intermediate
 
   private final AggregationFunction[] _aggregationFunctions;
   private final ExpressionContext[] _groupByExpressions;
-  private final int _maxInitialResultHolderCapacity;
-  private final int _numGroupsLimit;
-  private final int _minGroupTrimSize;
   private final TransformOperator _transformOperator;
   private final long _numTotalDocs;
   private final boolean _useStarTree;
@@ -58,14 +55,10 @@ public class AggregationGroupByOrderByOperator extends BaseOperator<Intermediate
   private int _numDocsScanned = 0;
 
   public AggregationGroupByOrderByOperator(AggregationFunction[] aggregationFunctions,
-      ExpressionContext[] groupByExpressions, int maxInitialResultHolderCapacity, int numGroupsLimit,
-      int minGroupTrimSize, TransformOperator transformOperator, long numTotalDocs, QueryContext queryContext,
-      boolean useStarTree) {
+      ExpressionContext[] groupByExpressions, TransformOperator transformOperator, long numTotalDocs,
+      QueryContext queryContext, boolean useStarTree) {
     _aggregationFunctions = aggregationFunctions;
     _groupByExpressions = groupByExpressions;
-    _maxInitialResultHolderCapacity = maxInitialResultHolderCapacity;
-    _numGroupsLimit = numGroupsLimit;
-    _minGroupTrimSize = minGroupTrimSize;
     _transformOperator = transformOperator;
     _numTotalDocs = numTotalDocs;
     _useStarTree = useStarTree;
@@ -82,8 +75,8 @@ public class AggregationGroupByOrderByOperator extends BaseOperator<Intermediate
     for (int i = 0; i < numGroupByExpressions; i++) {
       ExpressionContext groupByExpression = groupByExpressions[i];
       columnNames[i] = groupByExpression.toString();
-      columnDataTypes[i] = DataSchema.ColumnDataType
-          .fromDataTypeSV(_transformOperator.getResultMetadata(groupByExpression).getDataType());
+      columnDataTypes[i] = DataSchema.ColumnDataType.fromDataTypeSV(
+          _transformOperator.getResultMetadata(groupByExpression).getDataType());
     }
 
     // Extract column names and data types for aggregation functions
@@ -102,13 +95,9 @@ public class AggregationGroupByOrderByOperator extends BaseOperator<Intermediate
     // Perform aggregation group-by on all the blocks
     GroupByExecutor groupByExecutor;
     if (_useStarTree) {
-      groupByExecutor =
-          new StarTreeGroupByExecutor(_aggregationFunctions, _groupByExpressions, _maxInitialResultHolderCapacity,
-              _numGroupsLimit, _transformOperator);
+      groupByExecutor = new StarTreeGroupByExecutor(_queryContext, _groupByExpressions, _transformOperator);
     } else {
-      groupByExecutor =
-          new DefaultGroupByExecutor(_aggregationFunctions, _groupByExpressions, _maxInitialResultHolderCapacity,
-              _numGroupsLimit, _transformOperator);
+      groupByExecutor = new DefaultGroupByExecutor(_queryContext, _groupByExpressions, _transformOperator);
     }
     TransformBlock transformBlock;
     while ((transformBlock = _transformOperator.nextBlock()) != null) {
@@ -122,8 +111,9 @@ public class AggregationGroupByOrderByOperator extends BaseOperator<Intermediate
     // - There are more groups than the trim size
     // TODO: Currently the groups are not trimmed if there is no ordering specified. Consider ordering on group-by
     //       columns if no ordering is specified.
-    if (_queryContext.getOrderByExpressions() != null && _minGroupTrimSize > 0) {
-      int trimSize = GroupByUtils.getTableCapacity(_queryContext.getLimit(), _minGroupTrimSize);
+    int minGroupTrimSize = _queryContext.getMinSegmentGroupTrimSize();
+    if (_queryContext.getOrderByExpressions() != null && minGroupTrimSize > 0) {
+      int trimSize = GroupByUtils.getTableCapacity(_queryContext.getLimit(), minGroupTrimSize);
       if (groupByExecutor.getNumGroups() > trimSize) {
         TableResizer tableResizer = new TableResizer(_dataSchema, _queryContext);
         Collection<IntermediateRecord> intermediateRecords = groupByExecutor.trimGroupByResult(trimSize, tableResizer);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOnlyCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOnlyCombineOperator.java
@@ -57,9 +57,8 @@ public class StreamingSelectionOnlyCombineOperator extends BaseCombineOperator {
   private final AtomicLong _numRowsCollected = new AtomicLong();
 
   public StreamingSelectionOnlyCombineOperator(List<Operator> operators, QueryContext queryContext,
-      ExecutorService executorService, long endTimeMs, int maxExecutionThreads,
-      StreamObserver<Server.ServerResponse> streamObserver) {
-    super(operators, queryContext, executorService, endTimeMs, maxExecutionThreads);
+      ExecutorService executorService, StreamObserver<Server.ServerResponse> streamObserver) {
+    super(operators, queryContext, executorService);
     _streamObserver = streamObserver;
     _limit = queryContext.getLimit();
   }
@@ -92,9 +91,10 @@ public class StreamingSelectionOnlyCombineOperator extends BaseCombineOperator {
       throws Exception {
     long numRowsCollected = 0;
     int numOperatorsFinished = 0;
+    long endTimeMs = _queryContext.getEndTimeMs();
     while (numRowsCollected < _limit && numOperatorsFinished < _numOperators) {
       IntermediateResultsBlock resultsBlock =
-          _blockingQueue.poll(_endTimeMs - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+          _blockingQueue.poll(endTimeMs - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
       if (resultsBlock == null) {
         // Query times out, skip streaming the remaining results blocks
         LOGGER.error("Timed out while polling results block (query: {})", _queryContext);

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByPlanNode.java
@@ -43,15 +43,10 @@ import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 public class AggregationGroupByPlanNode implements PlanNode {
   private final IndexSegment _indexSegment;
   private final QueryContext _queryContext;
-  private final int _maxInitialResultHolderCapacity;
-  private final int _numGroupsLimit;
 
-  public AggregationGroupByPlanNode(IndexSegment indexSegment, QueryContext queryContext,
-      int maxInitialResultHolderCapacity, int numGroupsLimit) {
+  public AggregationGroupByPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
     _indexSegment = indexSegment;
     _queryContext = queryContext;
-    _maxInitialResultHolderCapacity = maxInitialResultHolderCapacity;
-    _numGroupsLimit = numGroupsLimit;
   }
 
   @Override
@@ -78,8 +73,8 @@ public class AggregationGroupByPlanNode implements PlanNode {
               TransformOperator transformOperator =
                   new StarTreeTransformPlanNode(starTreeV2, aggregationFunctionColumnPairs, groupByExpressions,
                       predicateEvaluatorsMap, _queryContext.getDebugOptions()).run();
-              return new AggregationGroupByOperator(aggregationFunctions, groupByExpressions,
-                  _maxInitialResultHolderCapacity, _numGroupsLimit, transformOperator, numTotalDocs, true);
+              return new AggregationGroupByOperator(_queryContext, groupByExpressions, transformOperator, numTotalDocs,
+                  true);
             }
           }
         }
@@ -90,7 +85,6 @@ public class AggregationGroupByPlanNode implements PlanNode {
         AggregationFunctionUtils.collectExpressionsToTransform(aggregationFunctions, groupByExpressions);
     TransformOperator transformPlanNode = new TransformPlanNode(_indexSegment, _queryContext, expressionsToTransform,
         DocIdSetPlanNode.MAX_DOC_PER_CALL).run();
-    return new AggregationGroupByOperator(aggregationFunctions, groupByExpressions, _maxInitialResultHolderCapacity,
-        _numGroupsLimit, transformPlanNode, numTotalDocs, false);
+    return new AggregationGroupByOperator(_queryContext, groupByExpressions, transformPlanNode, numTotalDocs, false);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
@@ -55,14 +55,6 @@ public class CombinePlanNode implements PlanNode {
   private final List<PlanNode> _planNodes;
   private final QueryContext _queryContext;
   private final ExecutorService _executorService;
-  private final long _endTimeMs;
-  private final int _maxExecutionThreads;
-  private final int _numGroupsLimit;
-
-  // Used for SQL GROUP BY during server combine
-  private final int _minGroupTrimSize;
-  private final int _groupTrimThreshold;
-
   private final StreamObserver<Server.ServerResponse> _streamObserver;
 
   /**
@@ -71,24 +63,13 @@ public class CombinePlanNode implements PlanNode {
    * @param planNodes List of underlying plan nodes
    * @param queryContext Query context
    * @param executorService Executor service
-   * @param endTimeMs End time in milliseconds for the query
-   * @param maxExecutionThreads Maximum number of threads used to execute the query
-   * @param numGroupsLimit Limit of number of groups stored in each segment
-   * @param minGroupTrimSize Minimum number of groups to keep when trimming groups for SQL GROUP BY
-   * @param groupTrimThreshold Trim threshold to use for server combine for SQL GROUP BY
    * @param streamObserver Optional stream observer for streaming query
    */
   public CombinePlanNode(List<PlanNode> planNodes, QueryContext queryContext, ExecutorService executorService,
-      long endTimeMs, int maxExecutionThreads, int numGroupsLimit, int minGroupTrimSize, int groupTrimThreshold,
       @Nullable StreamObserver<Server.ServerResponse> streamObserver) {
     _planNodes = planNodes;
     _queryContext = queryContext;
     _executorService = executorService;
-    _endTimeMs = endTimeMs;
-    _maxExecutionThreads = maxExecutionThreads;
-    _numGroupsLimit = numGroupsLimit;
-    _minGroupTrimSize = minGroupTrimSize;
-    _groupTrimThreshold = groupTrimThreshold;
     _streamObserver = streamObserver;
   }
 
@@ -106,9 +87,11 @@ public class CombinePlanNode implements PlanNode {
     } else {
       // Large number of plan nodes, run them in parallel
 
-      int maxExecutionThreads =
-          _maxExecutionThreads > 0 ? _maxExecutionThreads : CombineOperatorUtils.MAX_NUM_THREADS_PER_QUERY;
-      int numThreads =
+      int maxExecutionThreads = _queryContext.getMaxExecutionThreads();
+      if (maxExecutionThreads <= 0) {
+        maxExecutionThreads = CombineOperatorUtils.MAX_NUM_THREADS_PER_QUERY;
+      }
+      int numTasks =
           Math.min((numPlanNodes + TARGET_NUM_PLANS_PER_THREAD - 1) / TARGET_NUM_PLANS_PER_THREAD, maxExecutionThreads);
 
       // Use a Phaser to ensure all the Futures are done (not scheduled, finished or interrupted) before the main thread
@@ -119,8 +102,8 @@ public class CombinePlanNode implements PlanNode {
       Phaser phaser = new Phaser(1);
 
       // Submit all jobs
-      Future[] futures = new Future[numThreads];
-      for (int i = 0; i < numThreads; i++) {
+      Future[] futures = new Future[numTasks];
+      for (int i = 0; i < numTasks; i++) {
         int index = i;
         futures[i] = _executorService.submit(new TraceCallable<List<Operator>>() {
           @Override
@@ -135,7 +118,7 @@ public class CombinePlanNode implements PlanNode {
               }
 
               List<Operator> operators = new ArrayList<>();
-              for (int i = index; i < numPlanNodes; i += numThreads) {
+              for (int i = index; i < numPlanNodes; i += numTasks) {
                 operators.add(_planNodes.get(i).run());
               }
               return operators;
@@ -149,8 +132,8 @@ public class CombinePlanNode implements PlanNode {
       // Get all results
       try {
         for (Future future : futures) {
-          List<Operator> ops =
-              (List<Operator>) future.get(_endTimeMs - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+          List<Operator> ops = (List<Operator>) future.get(_queryContext.getEndTimeMs() - System.currentTimeMillis(),
+              TimeUnit.MILLISECONDS);
           operators.addAll(ops);
         }
       } catch (Exception e) {
@@ -176,36 +159,30 @@ public class CombinePlanNode implements PlanNode {
 
     if (_streamObserver != null) {
       // Streaming query (only support selection only)
-      return new StreamingSelectionOnlyCombineOperator(operators, _queryContext, _executorService, _endTimeMs,
-          _maxExecutionThreads, _streamObserver);
+      return new StreamingSelectionOnlyCombineOperator(operators, _queryContext, _executorService, _streamObserver);
     }
     if (QueryContextUtils.isAggregationQuery(_queryContext)) {
       if (_queryContext.getGroupByExpressions() == null) {
         // Aggregation only
-        return new AggregationOnlyCombineOperator(operators, _queryContext, _executorService, _endTimeMs,
-            _maxExecutionThreads);
+        return new AggregationOnlyCombineOperator(operators, _queryContext, _executorService);
       } else {
         // Aggregation group-by
         if (QueryOptionsUtils.isGroupByModeSQL(_queryContext.getQueryOptions())) {
-          return new GroupByOrderByCombineOperator(operators, _queryContext, _executorService, _endTimeMs,
-              _maxExecutionThreads, _minGroupTrimSize, _groupTrimThreshold);
+          return new GroupByOrderByCombineOperator(operators, _queryContext, _executorService);
         }
-        return new GroupByCombineOperator(operators, _queryContext, _executorService, _endTimeMs, _maxExecutionThreads,
-            _numGroupsLimit);
+        return new GroupByCombineOperator(operators, _queryContext, _executorService);
       }
     } else if (QueryContextUtils.isSelectionQuery(_queryContext)) {
       if (_queryContext.getLimit() == 0 || _queryContext.getOrderByExpressions() == null) {
         // Selection only
-        return new SelectionOnlyCombineOperator(operators, _queryContext, _executorService, _endTimeMs,
-            _maxExecutionThreads);
+        return new SelectionOnlyCombineOperator(operators, _queryContext, _executorService);
       } else {
         // Selection order-by
-        return new SelectionOrderByCombineOperator(operators, _queryContext, _executorService, _endTimeMs,
-            _maxExecutionThreads);
+        return new SelectionOrderByCombineOperator(operators, _queryContext, _executorService);
       }
     } else {
       assert QueryContextUtils.isDistinctQuery(_queryContext);
-      return new DistinctCombineOperator(operators, _queryContext, _executorService, _endTimeMs, _maxExecutionThreads);
+      return new DistinctCombineOperator(operators, _queryContext, _executorService);
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -24,6 +24,7 @@ import io.grpc.stub.StreamObserver;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
@@ -80,8 +81,6 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
   // set as pinot.server.query.executor.groupby.trim.threshold
   public static final String GROUPBY_TRIM_THRESHOLD_KEY = "groupby.trim.threshold";
   public static final int DEFAULT_GROUPBY_TRIM_THRESHOLD = 1_000_000;
-  public static final String ENABLE_PREFETCH = "enable.prefetch";
-  public static final boolean DEFAULT_ENABLE_PREFETCH = false;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(InstancePlanMakerImplV2.class);
 
@@ -93,7 +92,6 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
   private final int _minSegmentGroupTrimSize;
   private final int _minServerGroupTrimSize;
   private final int _groupByTrimThreshold;
-  private final boolean _enablePrefetch;
 
   @VisibleForTesting
   public InstancePlanMakerImplV2() {
@@ -103,7 +101,6 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     _minSegmentGroupTrimSize = DEFAULT_MIN_SEGMENT_GROUP_TRIM_SIZE;
     _minServerGroupTrimSize = DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE;
     _groupByTrimThreshold = DEFAULT_GROUPBY_TRIM_THRESHOLD;
-    _enablePrefetch = DEFAULT_ENABLE_PREFETCH;
   }
 
   @VisibleForTesting
@@ -115,7 +112,6 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     _minSegmentGroupTrimSize = minSegmentGroupTrimSize;
     _minServerGroupTrimSize = minServerGroupTrimSize;
     _groupByTrimThreshold = groupByTrimThreshold;
-    _enablePrefetch = DEFAULT_ENABLE_PREFETCH;
   }
 
   /**
@@ -141,21 +137,22 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     _groupByTrimThreshold = config.getProperty(GROUPBY_TRIM_THRESHOLD_KEY, DEFAULT_GROUPBY_TRIM_THRESHOLD);
     Preconditions.checkState(_groupByTrimThreshold > 0,
         "Invalid configurable: groupByTrimThreshold: %d must be positive", _groupByTrimThreshold);
-    _enablePrefetch = Boolean.parseBoolean(config.getProperty(ENABLE_PREFETCH));
     LOGGER.info("Initializing plan maker with maxInitialResultHolderCapacity: {}, numGroupsLimit: {}, "
-            + "minSegmentGroupTrimSize: {}, minServerGroupTrimSize: {}, enablePrefetch: {}",
-        _maxInitialResultHolderCapacity, _numGroupsLimit, _minSegmentGroupTrimSize, _minServerGroupTrimSize,
-        _enablePrefetch);
+            + "minSegmentGroupTrimSize: {}, minServerGroupTrimSize: {}", _maxInitialResultHolderCapacity,
+        _numGroupsLimit, _minSegmentGroupTrimSize, _minServerGroupTrimSize);
   }
 
   @Override
   public Plan makeInstancePlan(List<IndexSegment> indexSegments, QueryContext queryContext,
-      ExecutorService executorService, long endTimeMs) {
-    List<PlanNode> planNodes = new ArrayList<>(indexSegments.size());
+      ExecutorService executorService) {
+    applyQueryOptions(queryContext);
+
+    int numSegments = indexSegments.size();
+    List<PlanNode> planNodes = new ArrayList<>(numSegments);
     List<FetchContext> fetchContexts;
 
-    if (_enablePrefetch) {
-      fetchContexts = new ArrayList<>(indexSegments.size());
+    if (queryContext.isEnablePrefetch()) {
+      fetchContexts = new ArrayList<>(numSegments);
       List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
       for (IndexSegment indexSegment : indexSegments) {
         Set<String> columns;
@@ -177,23 +174,52 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
       }
     }
 
-    CombinePlanNode combinePlanNode =
-        new CombinePlanNode(planNodes, queryContext, executorService, endTimeMs, getMaxExecutionThreads(queryContext),
-            _numGroupsLimit, _minServerGroupTrimSize, _groupByTrimThreshold, null);
+    CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, queryContext, executorService, null);
     return new GlobalPlanImplV0(new InstanceResponsePlanNode(combinePlanNode, indexSegments, fetchContexts));
   }
 
-  private int getMaxExecutionThreads(QueryContext queryContext) {
-    Integer maxExecutionThreadsFromQuery = QueryOptionsUtils.getMaxExecutionThreads(queryContext.getQueryOptions());
+  private void applyQueryOptions(QueryContext queryContext) {
+    Map<String, String> queryOptions = queryContext.getQueryOptions();
+
+    // Set maxExecutionThreads
+    int maxExecutionThreads;
+    Integer maxExecutionThreadsFromQuery = QueryOptionsUtils.getMaxExecutionThreads(queryOptions);
     if (maxExecutionThreadsFromQuery != null && maxExecutionThreadsFromQuery > 0) {
       // Do not allow query to override the execution threads over the instance-level limit
       if (_maxExecutionThreads > 0) {
-        return Math.min(_maxExecutionThreads, maxExecutionThreadsFromQuery);
+        maxExecutionThreads = Math.min(_maxExecutionThreads, maxExecutionThreadsFromQuery);
       } else {
-        return maxExecutionThreadsFromQuery;
+        maxExecutionThreads = maxExecutionThreadsFromQuery;
       }
+    } else {
+      maxExecutionThreads = _maxExecutionThreads;
     }
-    return _maxExecutionThreads;
+    queryContext.setMaxExecutionThreads(maxExecutionThreads);
+
+    // Set group-by query options
+    if (QueryContextUtils.isAggregationQuery(queryContext) && queryContext.getGroupByExpressions() != null) {
+
+      // Set maxInitialResultHolderCapacity
+      queryContext.setMaxInitialResultHolderCapacity(_maxInitialResultHolderCapacity);
+
+      // Set numGroupsLimit
+      queryContext.setNumGroupsLimit(_numGroupsLimit);
+
+      // Set minSegmentGroupTrimSize
+      Integer minSegmentGroupTrimSizeFromQuery = QueryOptionsUtils.getMinSegmentGroupTrimSize(queryOptions);
+      int minSegmentGroupTrimSize =
+          minSegmentGroupTrimSizeFromQuery != null ? minSegmentGroupTrimSizeFromQuery : _minSegmentGroupTrimSize;
+      queryContext.setMinSegmentGroupTrimSize(minSegmentGroupTrimSize);
+
+      // Set minServerGroupTrimSize
+      Integer minServerGroupTrimSizeFromQuery = QueryOptionsUtils.getMinServerGroupTrimSize(queryOptions);
+      int minServerGroupTrimSize =
+          minServerGroupTrimSizeFromQuery != null ? minServerGroupTrimSizeFromQuery : _minServerGroupTrimSize;
+      queryContext.setMinServerGroupTrimSize(minServerGroupTrimSize);
+
+      // Set groupTrimThreshold
+      queryContext.setGroupTrimThreshold(_groupByTrimThreshold);
+    }
   }
 
   @Override
@@ -203,11 +229,9 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
       if (groupByExpressions != null) {
         // Aggregation group-by query
         if (QueryOptionsUtils.isGroupByModeSQL(queryContext.getQueryOptions())) {
-          return new AggregationGroupByOrderByPlanNode(indexSegment, queryContext, _maxInitialResultHolderCapacity,
-              _numGroupsLimit, _minSegmentGroupTrimSize);
+          return new AggregationGroupByOrderByPlanNode(indexSegment, queryContext);
         }
-        return new AggregationGroupByPlanNode(indexSegment, queryContext, _maxInitialResultHolderCapacity,
-            _numGroupsLimit);
+        return new AggregationGroupByPlanNode(indexSegment, queryContext);
       } else {
         // Aggregation only query
         return new AggregationPlanNode(indexSegment, queryContext);
@@ -222,14 +246,14 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
 
   @Override
   public Plan makeStreamingInstancePlan(List<IndexSegment> indexSegments, QueryContext queryContext,
-      ExecutorService executorService, StreamObserver<Server.ServerResponse> streamObserver, long endTimeMs) {
+      ExecutorService executorService, StreamObserver<Server.ServerResponse> streamObserver) {
+    applyQueryOptions(queryContext);
+
     List<PlanNode> planNodes = new ArrayList<>(indexSegments.size());
     for (IndexSegment indexSegment : indexSegments) {
       planNodes.add(makeStreamingSegmentPlanNode(indexSegment, queryContext));
     }
-    CombinePlanNode combinePlanNode =
-        new CombinePlanNode(planNodes, queryContext, executorService, endTimeMs, getMaxExecutionThreads(queryContext),
-            _numGroupsLimit, _minServerGroupTrimSize, _groupByTrimThreshold, streamObserver);
+    CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, queryContext, executorService, streamObserver);
     return new GlobalPlanImplV0(new InstanceResponsePlanNode(combinePlanNode, indexSegments, Collections.emptyList()));
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/PlanMaker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/PlanMaker.java
@@ -38,8 +38,7 @@ public interface PlanMaker {
   /**
    * Returns an instance level {@link Plan} which contains the logical execution plan for multiple segments.
    */
-  Plan makeInstancePlan(List<IndexSegment> indexSegments, QueryContext queryContext, ExecutorService executorService,
-      long endTimeMs);
+  Plan makeInstancePlan(List<IndexSegment> indexSegments, QueryContext queryContext, ExecutorService executorService);
 
   /**
    * Returns a segment level {@link PlanNode} which contains the logical execution plan for one segment.
@@ -51,7 +50,7 @@ public interface PlanMaker {
    * segments.
    */
   Plan makeStreamingInstancePlan(List<IndexSegment> indexSegments, QueryContext queryContext,
-      ExecutorService executorService, StreamObserver<Server.ServerResponse> streamObserver, long endTimeMs);
+      ExecutorService executorService, StreamObserver<Server.ServerResponse> streamObserver);
 
   /**
    * Returns a segment level {@link PlanNode} for a streaming query which contains the logical execution plan for one

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -31,6 +31,7 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FilterContext;
 import org.apache.pinot.common.request.context.FunctionContext;
 import org.apache.pinot.common.request.context.OrderByExpressionContext;
+import org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionFactory;
 
@@ -79,10 +80,29 @@ public class QueryContext {
   // TODO: Remove it once the whole query engine is using the QueryContext
   private final BrokerRequest _brokerRequest;
 
-  // Pre-calculate the aggregation functions and columns for the query so that it can be shared among all the segments
+  // Pre-calculate the aggregation functions and columns for the query so that it can be shared across all the segments
   private AggregationFunction[] _aggregationFunctions;
   private Map<FunctionContext, Integer> _aggregationFunctionIndexMap;
   private Set<String> _columns;
+
+  // Other properties to be shared across all the segments
+  // End time in milliseconds for the query
+  private long _endTimeMs;
+  // Whether to enable prefetch for the query
+  private boolean _enablePrefetch;
+  // Maximum number of threads used to execute the query
+  private int _maxExecutionThreads = InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS;
+  // The following properties apply to group-by queries
+  // Maximum initial capacity of the group-by result holder
+  private int _maxInitialResultHolderCapacity = InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY;
+  // Limit of number of groups stored in each segment
+  private int _numGroupsLimit = InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT;
+  // Minimum number of groups to keep per segment when trimming groups for SQL GROUP BY
+  private int _minSegmentGroupTrimSize = InstancePlanMakerImplV2.DEFAULT_MIN_SEGMENT_GROUP_TRIM_SIZE;
+  // Minimum number of groups to keep across segments when trimming groups for SQL GROUP BY
+  private int _minServerGroupTrimSize = InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE;
+  // Trim threshold to use for server combine for SQL GROUP BY
+  private int _groupTrimThreshold = InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD;
 
   private QueryContext(String tableName, List<ExpressionContext> selectExpressions, List<String> aliasList,
       @Nullable FilterContext filter, @Nullable List<ExpressionContext> groupByExpressions,
@@ -214,6 +234,70 @@ public class QueryContext {
    */
   public Set<String> getColumns() {
     return _columns;
+  }
+
+  public long getEndTimeMs() {
+    return _endTimeMs;
+  }
+
+  public void setEndTimeMs(long endTimeMs) {
+    _endTimeMs = endTimeMs;
+  }
+
+  public boolean isEnablePrefetch() {
+    return _enablePrefetch;
+  }
+
+  public void setEnablePrefetch(boolean enablePrefetch) {
+    _enablePrefetch = enablePrefetch;
+  }
+
+  public int getMaxExecutionThreads() {
+    return _maxExecutionThreads;
+  }
+
+  public void setMaxExecutionThreads(int maxExecutionThreads) {
+    _maxExecutionThreads = maxExecutionThreads;
+  }
+
+  public int getMaxInitialResultHolderCapacity() {
+    return _maxInitialResultHolderCapacity;
+  }
+
+  public void setMaxInitialResultHolderCapacity(int maxInitialResultHolderCapacity) {
+    _maxInitialResultHolderCapacity = maxInitialResultHolderCapacity;
+  }
+
+  public int getNumGroupsLimit() {
+    return _numGroupsLimit;
+  }
+
+  public void setNumGroupsLimit(int numGroupsLimit) {
+    _numGroupsLimit = numGroupsLimit;
+  }
+
+  public int getMinSegmentGroupTrimSize() {
+    return _minSegmentGroupTrimSize;
+  }
+
+  public void setMinSegmentGroupTrimSize(int minSegmentGroupTrimSize) {
+    _minSegmentGroupTrimSize = minSegmentGroupTrimSize;
+  }
+
+  public int getMinServerGroupTrimSize() {
+    return _minServerGroupTrimSize;
+  }
+
+  public void setMinServerGroupTrimSize(int minServerGroupTrimSize) {
+    _minServerGroupTrimSize = minServerGroupTrimSize;
+  }
+
+  public int getGroupTrimThreshold() {
+    return _groupTrimThreshold;
+  }
+
+  public void setGroupTrimThreshold(int groupTrimThreshold) {
+    _groupTrimThreshold = groupTrimThreshold;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/executor/StarTreeGroupByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/executor/StarTreeGroupByExecutor.java
@@ -27,6 +27,7 @@ import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.aggregation.groupby.DefaultGroupByExecutor;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair;
 
 
@@ -38,13 +39,16 @@ import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair
  *   <li>For <code>COUNT</code> aggregation function, we need to aggregate on the pre-aggregated column</li>
  * </ul>
  */
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class StarTreeGroupByExecutor extends DefaultGroupByExecutor {
   private final AggregationFunctionColumnPair[] _aggregationFunctionColumnPairs;
 
-  public StarTreeGroupByExecutor(AggregationFunction[] aggregationFunctions, ExpressionContext[] groupByExpressions,
-      int maxInitialResultHolderCapacity, int numGroupsLimit, TransformOperator transformOperator) {
-    super(aggregationFunctions, groupByExpressions, maxInitialResultHolderCapacity, numGroupsLimit, transformOperator);
+  public StarTreeGroupByExecutor(QueryContext queryContext, ExpressionContext[] groupByExpressions,
+      TransformOperator transformOperator) {
+    super(queryContext, groupByExpressions, transformOperator);
 
+    AggregationFunction[] aggregationFunctions = queryContext.getAggregationFunctions();
+    assert aggregationFunctions != null;
     int numAggregationFunctions = aggregationFunctions.length;
     _aggregationFunctionColumnPairs = new AggregationFunctionColumnPair[numAggregationFunctions];
     for (int i = 0; i < numAggregationFunctions; i++) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineSlowOperatorsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineSlowOperatorsTest.java
@@ -30,7 +30,7 @@ import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.ExecutionStatistics;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
-import org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.spi.exception.EarlyTerminationException;
 import org.testng.annotations.AfterClass;
@@ -64,9 +64,10 @@ public class CombineSlowOperatorsTest {
   @Test
   public void testSelectionOnlyCombineOperator() {
     List<Operator> operators = getOperators();
-    SelectionOnlyCombineOperator combineOperator = new SelectionOnlyCombineOperator(operators,
-        QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable"), _executorService, TIMEOUT_MS,
-        InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS);
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable");
+    queryContext.setEndTimeMs(System.currentTimeMillis() + TIMEOUT_MS);
+    SelectionOnlyCombineOperator combineOperator =
+        new SelectionOnlyCombineOperator(operators, queryContext, _executorService);
     testCombineOperator(operators, combineOperator);
   }
 
@@ -76,29 +77,31 @@ public class CombineSlowOperatorsTest {
   @Test
   public void testAggregationOnlyCombineOperator() {
     List<Operator> operators = getOperators();
-    AggregationOnlyCombineOperator combineOperator = new AggregationOnlyCombineOperator(operators,
-        QueryContextConverterUtils.getQueryContextFromSQL("SELECT COUNT(*) FROM testTable"), _executorService,
-        TIMEOUT_MS, InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS);
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContextFromSQL("SELECT COUNT(*) FROM testTable");
+    queryContext.setEndTimeMs(System.currentTimeMillis() + TIMEOUT_MS);
+    AggregationOnlyCombineOperator combineOperator =
+        new AggregationOnlyCombineOperator(operators, queryContext, _executorService);
     testCombineOperator(operators, combineOperator);
   }
 
   @Test
   public void testGroupByCombineOperator() {
     List<Operator> operators = getOperators();
-    GroupByCombineOperator combineOperator = new GroupByCombineOperator(operators,
-        QueryContextConverterUtils.getQueryContextFromSQL("SELECT COUNT(*) FROM testTable GROUP BY column"),
-        _executorService, TIMEOUT_MS, InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT,
-        InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS);
+    QueryContext queryContext =
+        QueryContextConverterUtils.getQueryContextFromSQL("SELECT COUNT(*) FROM testTable GROUP BY column");
+    queryContext.setEndTimeMs(System.currentTimeMillis() + TIMEOUT_MS);
+    GroupByCombineOperator combineOperator = new GroupByCombineOperator(operators, queryContext, _executorService);
     testCombineOperator(operators, combineOperator);
   }
 
   @Test
   public void testGroupByOrderByCombineOperator() {
     List<Operator> operators = getOperators();
-    GroupByOrderByCombineOperator combineOperator = new GroupByOrderByCombineOperator(operators,
-        QueryContextConverterUtils.getQueryContextFromSQL("SELECT COUNT(*) FROM testTable GROUP BY column"),
-        _executorService, TIMEOUT_MS, InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
-        InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD, InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS);
+    QueryContext queryContext =
+        QueryContextConverterUtils.getQueryContextFromSQL("SELECT COUNT(*) FROM testTable GROUP BY column");
+    queryContext.setEndTimeMs(System.currentTimeMillis() + TIMEOUT_MS);
+    GroupByOrderByCombineOperator combineOperator =
+        new GroupByOrderByCombineOperator(operators, queryContext, _executorService);
     testCombineOperator(operators, combineOperator);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/SelectionCombineOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/SelectionCombineOperatorTest.java
@@ -228,11 +228,8 @@ public class SelectionCombineOperatorTest {
     for (IndexSegment indexSegment : _indexSegments) {
       planNodes.add(PLAN_MAKER.makeSegmentPlanNode(indexSegment, queryContext));
     }
-    CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, queryContext, EXECUTOR,
-        System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS,
-        InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS, InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT,
-        InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
-        InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD, null);
+    queryContext.setEndTimeMs(System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS);
+    CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, queryContext, EXECUTOR, null);
     return combinePlanNode.run().nextBlock();
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/CombinePlanNodeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/CombinePlanNodeTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
@@ -57,11 +56,8 @@ public class CombinePlanNodeTest {
           return null;
         });
       }
-      CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, _queryContext, _executorService,
-          System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS,
-          InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS, InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT,
-          InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
-          InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD, null);
+      _queryContext.setEndTimeMs(System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS);
+      CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, _queryContext, _executorService, null);
       combinePlanNode.run();
       Assert.assertEquals(numPlans, count.get());
     }
@@ -84,11 +80,8 @@ public class CombinePlanNodeTest {
         return null;
       });
     }
-    CombinePlanNode combinePlanNode =
-        new CombinePlanNode(planNodes, _queryContext, _executorService, System.currentTimeMillis() + 100,
-            InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS, InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT,
-            InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
-            InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD, null);
+    _queryContext.setEndTimeMs(System.currentTimeMillis() + 100);
+    CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, _queryContext, _executorService, null);
     try {
       combinePlanNode.run();
     } catch (RuntimeException e) {
@@ -108,11 +101,8 @@ public class CombinePlanNodeTest {
         throw new RuntimeException("Inner exception message.");
       });
     }
-    CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, _queryContext, _executorService,
-        System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS,
-        InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS, InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT,
-        InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
-        InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD, null);
+    _queryContext.setEndTimeMs(System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS);
+    CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, _queryContext, _executorService, null);
     try {
       combinePlanNode.run();
     } catch (RuntimeException e) {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
@@ -207,8 +207,8 @@ public abstract class BaseQueriesTest {
    */
   private BrokerResponseNative getBrokerResponse(QueryContext queryContext, PlanMaker planMaker) {
     // Server side.
-    Plan plan = planMaker.makeInstancePlan(getIndexSegments(), queryContext, EXECUTOR_SERVICE,
-        System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS);
+    queryContext.setEndTimeMs(System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS);
+    Plan plan = planMaker.makeInstancePlan(getIndexSegments(), queryContext, EXECUTOR_SERVICE);
     DataTable instanceResponse = plan.execute();
 
     // Broker side.
@@ -229,8 +229,8 @@ public abstract class BaseQueriesTest {
       Utils.rethrowException(e);
     }
 
-    BrokerResponseNative brokerResponse = brokerReduceService
-        .reduceOnDataTable(queryContext.getBrokerRequest(), dataTableMap,
+    BrokerResponseNative brokerResponse =
+        brokerReduceService.reduceOnDataTable(queryContext.getBrokerRequest(), dataTableMap,
             CommonConstants.Broker.DEFAULT_BROKER_TIMEOUT_MS, null);
     brokerReduceService.shutDown();
     return brokerResponse;

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
@@ -1041,12 +1041,11 @@ public class DistinctQueriesTest extends BaseQueriesTest {
     IndexSegment segment1 = _indexSegments.get(1);
 
     // Server side
-    DataTable instanceResponse0 = PLAN_MAKER
-        .makeInstancePlan(Arrays.asList(segment0, segment0), queryContext, EXECUTOR_SERVICE,
-            System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS).execute();
-    DataTable instanceResponse1 = PLAN_MAKER
-        .makeInstancePlan(Arrays.asList(segment1, segment1), queryContext, EXECUTOR_SERVICE,
-            System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS).execute();
+    queryContext.setEndTimeMs(System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS);
+    DataTable instanceResponse0 =
+        PLAN_MAKER.makeInstancePlan(Arrays.asList(segment0, segment0), queryContext, EXECUTOR_SERVICE).execute();
+    DataTable instanceResponse1 =
+        PLAN_MAKER.makeInstancePlan(Arrays.asList(segment1, segment1), queryContext, EXECUTOR_SERVICE).execute();
 
     // Broker side
     Map<String, Object> properties = new HashMap<>();


### PR DESCRIPTION
For #7494

Precompute the query properties based on the instance config and the query options, and cache them into the `QueryContext` to reduce the arguments passed around