### PR TITLE
make it possible to specify field config properties for columns with JSON and RANGE indexes

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigTest.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.AssertJUnit.assertTrue;
+
+
+public class TableConfigTest {
+
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  @DataProvider
+  public Object[][] configs()
+      throws IOException {
+    try (Stream<Path> configs = Files.list(Paths.get("src/test/resources/testConfigs"))) {
+      return configs.map(path -> {
+            try {
+              return Files.readAllBytes(path);
+            } catch (IOException e) {
+              throw new RuntimeException(e);
+            }
+          })
+          .map(config -> new Object[]{config})
+          .toArray(Object[][]::new);
+    }
+  }
+
+  @Test(dataProvider = "configs")
+  public void testConfigNotRejected(byte[] config)
+      throws IOException {
+    TableConfig tableConfig = OBJECT_MAPPER.readerFor(TableConfig.class).readValue(config);
+    assertTrue(StringUtils.isNotBlank(tableConfig.getTableName()));
+  }
+}

--- a/pinot-common/src/test/resources/testConfigs/jsonIndexConfig.json
+++ b/pinot-common/src/test/resources/testConfigs/jsonIndexConfig.json
@@ -1,0 +1,35 @@
+{
+  "tableName": "testTable",
+  "segmentsConfig": {
+    "replication": "1",
+    "schemaName": "testTable",
+    "timeColumnName": "time"
+  },
+  "fieldConfigList": [
+    {
+      "encodingType": "RAW",
+      "indexType": "JSON",
+      "name": "event_json",
+      "properties": {
+        "deriveNumDocsPerChunkForRawIndex": "true",
+        "rawIndexWriterVersion": "3"
+      }
+    }
+  ],
+  "tableIndexConfig": {
+    "invertedIndexColumns": [],
+    "jsonIndexColumns": [
+      "event_json",
+      "group_json",
+      "member_json",
+      "venue_json"
+    ],
+    "loadMode": "HEAP"
+  },
+  "tenants": {
+    "broker": "DefaultTenant",
+    "server": "DefaultTenant"
+  },
+  "tableType": "OFFLINE",
+  "metadata": {}
+}

--- a/pinot-common/src/test/resources/testConfigs/noIndexConfig.json
+++ b/pinot-common/src/test/resources/testConfigs/noIndexConfig.json
@@ -1,0 +1,28 @@
+{
+  "tableName": "testTable",
+  "segmentsConfig": {
+    "replication": "1",
+    "schemaName": "testTable",
+    "timeColumnName": "time"
+  },
+  "fieldConfigList": [
+    {
+      "encodingType": "RAW",
+      "name": "event_text",
+      "properties": {
+        "deriveNumDocsPerChunkForRawIndex": "true",
+        "rawIndexWriterVersion": "3"
+      }
+    }
+  ],
+  "tableIndexConfig": {
+    "invertedIndexColumns": [],
+    "loadMode": "HEAP"
+  },
+  "tenants": {
+    "broker": "DefaultTenant",
+    "server": "DefaultTenant"
+  },
+  "tableType": "OFFLINE",
+  "metadata": {}
+}

--- a/pinot-common/src/test/resources/testConfigs/rangeIndexConfig.json
+++ b/pinot-common/src/test/resources/testConfigs/rangeIndexConfig.json
@@ -1,0 +1,28 @@
+{
+  "tableName": "testTable",
+  "segmentsConfig": {
+    "replication": "1",
+    "schemaName": "testTable",
+    "timeColumnName": "time"
+  },
+  "fieldConfigList": [
+    {
+      "encodingType": "DICTIONARY",
+      "indexType": "RANGE",
+      "name": "hits"
+    }
+  ],
+  "tableIndexConfig": {
+    "invertedIndexColumns": [],
+    "rangeIndexColumns": [
+      "hits"
+    ],
+    "loadMode": "HEAP"
+  },
+  "tenants": {
+    "broker": "DefaultTenant",
+    "server": "DefaultTenant"
+  },
+  "tableType": "OFFLINE",
+  "metadata": {}
+}

--- a/pinot-common/src/test/resources/testConfigs/textIndexConfig.json
+++ b/pinot-common/src/test/resources/testConfigs/textIndexConfig.json
@@ -1,0 +1,35 @@
+{
+  "tableName": "testTable",
+  "segmentsConfig": {
+    "replication": "1",
+    "schemaName": "testTable",
+    "timeColumnName": "time"
+  },
+  "fieldConfigList": [
+    {
+      "encodingType": "RAW",
+      "indexType": "TEXT",
+      "name": "event_text",
+      "properties": {
+        "deriveNumDocsPerChunkForRawIndex": "true",
+        "rawIndexWriterVersion": "3"
+      }
+    }
+  ],
+  "tableIndexConfig": {
+    "invertedIndexColumns": [],
+    "jsonIndexColumns": [
+      "event_text",
+      "group_text",
+      "member_text",
+      "venue_text"
+    ],
+    "loadMode": "HEAP"
+  },
+  "tenants": {
+    "broker": "DefaultTenant",
+    "server": "DefaultTenant"
+  },
+  "tableType": "OFFLINE",
+  "metadata": {}
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -69,7 +69,7 @@ public class FieldConfig extends BaseJsonConfig {
 
   // If null, there won't be any index
   public enum IndexType {
-    INVERTED, SORTED, TEXT, FST, H3
+    INVERTED, SORTED, TEXT, FST, H3, JSON, RANGE
   }
 
   public enum CompressionCodec {


### PR DESCRIPTION
## Description
Previously deserialising tableConfig with field config e.g.

```json
  "fieldConfigList": [
    {
      "encodingType": "RAW",
      "indexType": "JSON",
      "name": "event_json",
      "properties": {
        "deriveNumDocsPerChunkForRawIndex": "true",
        "rawIndexWriterVersion": "3"
      }
    }
  ]
```

would fail because of the missing JSON index type in field config.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
