### PR TITLE
ThriftMessageDecoder for reading arbitrary thrift data from Kafka

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-thrift/src/main/java/org/apache/pinot/plugin/inputformat/thrift/ThriftMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-thrift/src/main/java/org/apache/pinot/plugin/inputformat/thrift/ThriftMessageDecoder.java
@@ -1,0 +1,137 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at
+ *
+ * <p>http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * <p>Unless required by applicable law or agreed to in writing, software distributed under the
+ * License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.pinot.plugin.inputformat.thrift;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordExtractor;
+import org.apache.pinot.spi.plugin.PluginManager;
+import org.apache.pinot.spi.stream.StreamMessageDecoder;
+import org.apache.thrift.TBase;
+import org.apache.thrift.TDeserializer;
+import org.apache.thrift.protocol.TBinaryProtocol;
+import org.apache.thrift.protocol.TCompactProtocol;
+import org.apache.thrift.protocol.TJSONProtocol;
+import org.apache.thrift.protocol.TProtocolFactory;
+import org.apache.thrift.protocol.TProtocolUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
+
+/** An implementation of StreamMessageDecoder to read Thrift records from a stream. */
+public class ThriftMessageDecoder implements StreamMessageDecoder<byte[]> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ThriftMessageDecoder.class);
+  private static final ThreadLocal<TDeserializer> DESERIALIZER_COMPACT =
+      new ThreadLocal<TDeserializer>() {
+        @Override
+        protected TDeserializer initialValue() {
+          return new TDeserializer(new TCompactProtocol.Factory());
+        }
+      };
+
+  private static final ThreadLocal<TDeserializer> DESERIALIZER_BINARY =
+      new ThreadLocal<TDeserializer>() {
+        @Override
+        protected TDeserializer initialValue() {
+          return new TDeserializer(new TBinaryProtocol.Factory());
+        }
+      };
+
+  private static final ThreadLocal<TDeserializer> DESERIALIZER_JSON =
+      new ThreadLocal<TDeserializer>() {
+        @Override
+        protected TDeserializer initialValue() {
+          return new TDeserializer(new TJSONProtocol.Factory());
+        }
+      };
+
+  private static final Base64.Decoder BASE64_DECODER = Base64.getDecoder();
+  private static final byte[] EMPTY_BYTES = new byte[0];
+  private static final String THRIFT_CLASS_PROP_KEY = "thrift.class";
+  private static final String THRIFT_RECORD_EXTRACTOR_CLASS =
+      "org.apache.pinot.plugin.inputformat.thrift.ThriftRecordExtractor";
+
+  private RecordExtractor<TBase> _thriftRecordExtractor;
+  private Class<TBase> _thriftClass;
+
+  public Class<TBase> getThriftClass(String thriftClassName)
+      throws ClassNotFoundException, NoSuchMethodException, InstantiationException,
+          IllegalAccessException, InvocationTargetException {
+    return (Class<TBase>) Class.forName(thriftClassName).getConstructor().newInstance();
+  }
+
+  public static byte[] decodeB64IfNeeded(final byte[] src) {
+    checkNotNull(src, "src bytes cannot be null");
+    if (src.length <= 0) {
+      return EMPTY_BYTES;
+    }
+    final byte last = src[src.length - 1];
+    return (0 == last || '}' == last) ? src : BASE64_DECODER.decode(src);
+  }
+
+  @Override
+  public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName)
+      throws Exception {
+    checkState(
+        props.containsKey(THRIFT_CLASS_PROP_KEY),
+        "The " + THRIFT_CLASS_PROP_KEY + " must be provided for streaming thrift records");
+    _thriftClass = getThriftClass(props.get(THRIFT_CLASS_PROP_KEY));
+    String recordExtractorClass = null;
+    if (props != null) {
+      recordExtractorClass = props.get(RECORD_EXTRACTOR_CONFIG_KEY);
+    }
+    if (recordExtractorClass == null) {
+      recordExtractorClass = THRIFT_RECORD_EXTRACTOR_CLASS;
+    }
+    _thriftRecordExtractor = PluginManager.get().createInstance(recordExtractorClass);
+    _thriftRecordExtractor.init(fieldsToRead, null);
+  }
+
+  @Override
+  public GenericRow decode(byte[] payload, GenericRow destination) {
+    try {
+      final byte[] src = decodeB64IfNeeded(payload);
+      final TProtocolFactory protocolFactory = TProtocolUtil.guessProtocolFactory(src, null);
+      checkNotNull(protocolFactory);
+      final TBase from = _thriftClass.newInstance();
+      if (protocolFactory instanceof TCompactProtocol.Factory) {
+        DESERIALIZER_COMPACT.get().deserialize(from, src);
+      } else if (protocolFactory instanceof TBinaryProtocol.Factory) {
+        DESERIALIZER_BINARY.get().deserialize(from, src);
+      } else {
+        DESERIALIZER_JSON.get().deserialize(from, src);
+      }
+      _thriftRecordExtractor.extract(from, destination);
+      return destination;
+    } catch (Exception e) {
+      LOGGER.error(
+          "Caught exception while decoding row, discarding row. Payload is {}",
+          new String(payload),
+          e);
+      return null;
+    }
+  }
+
+  @Override
+  public GenericRow decode(byte[] payload, int offset, int length, GenericRow destination) {
+    return decode(Arrays.copyOfRange(payload, offset, offset + length), destination);
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-thrift/src/test/java/org/apache/pinot/plugin/inputformat/thrift/ThriftMessageDecoderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-thrift/src/test/java/org/apache/pinot/plugin/inputformat/thrift/ThriftMessageDecoderTest.java
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.thrift;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class ThriftMessageDecoderTest {
+
+  // private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+  // @Test
+  // public void testJsonDecoderWithoutOutgoingTimeSpec()
+  //     throws Exception {
+  //   Schema schema = Schema.fromFile(new File(
+  //       getClass().getClassLoader().getResource("data/test_sample_data_schema_without_outgoing_time_spec.json")
+  //           .getFile()));
+  //   Map<String, FieldSpec.DataType> sourceFields = new HashMap<>();
+  //   for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
+  //     sourceFields.put(fieldSpec.getName(), fieldSpec.getDataType());
+  //   }
+  //   testJsonDecoder(sourceFields);
+  // }
+
+  // @Test
+  // public void testJsonDecoderWithOutgoingTimeSpec()
+  //     throws Exception {
+  //   Schema schema = Schema.fromFile(new File(
+  //       getClass().getClassLoader().getResource("data/test_sample_data_schema_with_outgoing_time_spec.json")
+  //           .getFile()));
+  //   Map<String, FieldSpec.DataType> sourceFields = new HashMap<>();
+  //   for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
+  //     sourceFields.put(fieldSpec.getName(), fieldSpec.getDataType());
+  //   }
+  //   sourceFields.remove("secondsSinceEpoch");
+  //   sourceFields.put("time_day", FieldSpec.DataType.INT);
+  //   testJsonDecoder(sourceFields);
+  // }
+
+  // @Test
+  // public void testJsonDecoderNoTimeSpec()
+  //     throws Exception {
+  //   Schema schema = Schema.fromFile(
+  //       new File(getClass().getClassLoader().getResource("data/test_sample_data_schema_no_time_field.json").getFile()));
+  //   Map<String, FieldSpec.DataType> sourceFields = new HashMap<>();
+  //   for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
+  //     sourceFields.put(fieldSpec.getName(), fieldSpec.getDataType());
+  //   }
+  //   testJsonDecoder(sourceFields);
+  // }
+
+  // private void testJsonDecoder(Map<String, FieldSpec.DataType> sourceFields)
+  //     throws Exception {
+  //   try (BufferedReader reader = new BufferedReader(
+  //       new FileReader(getClass().getClassLoader().getResource("data/test_sample_data.json").getFile()))) {
+  //     KafkaJSONMessageDecoder decoder = new KafkaJSONMessageDecoder();
+  //     decoder.init(new HashMap<>(), sourceFields.keySet(), "testTopic");
+  //     GenericRow r = new GenericRow();
+  //     String line = reader.readLine();
+  //     while (line != null) {
+  //       JsonNode jsonNode = OBJECT_MAPPER.reader().readTree(line);
+  //       decoder.decode(line.getBytes(), r);
+  //       for (String field : sourceFields.keySet()) {
+  //         Object actualValue = r.getValue(field);
+  //         JsonNode expectedValue = jsonNode.get(field);
+  //         switch (sourceFields.get(field)) {
+  //           case STRING:
+  //             Assert.assertEquals(actualValue, expectedValue.asText());
+  //             break;
+  //           case INT:
+  //             Assert.assertEquals(actualValue, expectedValue.asInt());
+  //             break;
+  //           case LONG:
+  //             Assert.assertEquals(actualValue, expectedValue.asLong());
+  //             break;
+  //           case FLOAT:
+  //             Assert.assertEquals(actualValue, (float) expectedValue.asDouble());
+  //             break;
+  //           case DOUBLE:
+  //             Assert.assertEquals(actualValue, expectedValue.asDouble());
+  //             break;
+  //           default:
+  //             Assert.assertTrue(false, "Shouldn't arrive here.");
+  //             break;
+  //         }
+  //       }
+  //       line = reader.readLine();
+  //     }
+  //   }
+  // }
+}


### PR DESCRIPTION
## Description

This is a WIP for adding a Stream Decoder that can read Thrift. I used the [SimpleAvroMessageDecoder](https://github.com/apache/pinot/blob/9275a430049ff0d2888cb353fc7ef369d53a171c/pinot-plugins/pinot-input-format/pinot-avro/src/main/java/org/apache/pinot/plugin/inputformat/avro/SimpleAvroMessageDecoder.java), the [JSONMessageDecoder](https://github.com/apache/pinot/blob/7e9ca6a5a4afe0d4e283ac1307c45430e474cbf2/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONMessageDecoder.java), and the [ThriftDeserialization](https://github.com/apache/druid/blob/df4894afff5efb31264e98f39f4f14dd934ecc3d/extensions-contrib/thrift-extensions/src/main/java/org/apache/druid/data/input/thrift/ThriftDeserialization.java#L106) code from Apache Druid as a basis for getting this first pass together.

I am working on some tests, but it may be a few weeks until I get back to this PR, so if anyone has some time between now and then to give me some notes or to get this over the finish line, then please do so. 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
* [x] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
There is a new props configuration named `stream.kafka.decoder.prop.thrift.class`. One way in which you can include this class is by placing it in the `CLASSPATH` by adding it to the [plugins folder](https://github.com/apache/pinot/blob/0500c121a115b4412b7a5b08452359e76d93b095/pinot-tools/src/main/resources/appAssemblerScriptTemplate#L110-L141). In the default case, this will be at :`/opt/pinot/plugins`.

## Documentation
I have not adding this to the documentation yet. I will do it on my next pass.