### PR TITLE
add extra properties to the tuner, 

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -30,6 +30,7 @@ import it.unimi.dsi.fastutil.Swapper;
 import it.unimi.dsi.fastutil.ints.IntComparator;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
@@ -167,7 +168,7 @@ public class PinotTableRestletResource {
 
       Schema schema = _pinotHelixResourceManager.getSchemaForTableConfig(tableConfig);
 
-      TableConfigTunerUtils.applyTunerConfigs(_pinotHelixResourceManager, tableConfig, schema);
+      TableConfigTunerUtils.applyTunerConfigs(_pinotHelixResourceManager, tableConfig, schema, Collections.emptyMap());
 
       // TableConfigUtils.validate(...) is used across table create/update.
       TableConfigUtils.validate(tableConfig, schema);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -361,7 +361,7 @@ public class TableConfigsRestletResource {
   }
 
   private void tuneConfig(TableConfig tableConfig, Schema schema) {
-    TableConfigTunerUtils.applyTunerConfigs(_pinotHelixResourceManager, tableConfig, schema);
+    TableConfigTunerUtils.applyTunerConfigs(_pinotHelixResourceManager, tableConfig, schema, Collections.emptyMap());
     TableConfigUtils.ensureMinReplicas(tableConfig, _controllerConf.getDefaultTableMinReplicas());
     TableConfigUtils.ensureStorageQuotaConstraints(tableConfig, _controllerConf.getDimTableMaxSize());
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/NoOpTableTableConfigTuner.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/NoOpTableTableConfigTuner.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.tuner;
 
+import java.util.Map;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
@@ -28,7 +29,7 @@ public class NoOpTableTableConfigTuner implements TableConfigTuner {
 
   @Override
   public TableConfig apply(PinotHelixResourceManager pinotHelixResourceManager,
-      TableConfig initialConfig, Schema schema) {
+      TableConfig initialConfig, Schema schema, Map<String, String> extraProperties) {
     return initialConfig;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/RealTimeAutoIndexTuner.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/RealTimeAutoIndexTuner.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.tuner;
 
+import java.util.Map;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -35,7 +36,7 @@ public class RealTimeAutoIndexTuner implements TableConfigTuner {
 
   @Override
   public TableConfig apply(PinotHelixResourceManager pinotHelixResourceManager,
-      TableConfig tableConfig, Schema schema) {
+      TableConfig tableConfig, Schema schema, Map<String, String> extraProperties) {
     IndexingConfig initialIndexingConfig = tableConfig.getIndexingConfig();
     initialIndexingConfig.setInvertedIndexColumns(schema.getDimensionNames());
     initialIndexingConfig.setNoDictionaryColumns(schema.getMetricNames());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/TableConfigTuner.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/TableConfigTuner.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.tuner;
 
+import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -32,13 +33,13 @@ import org.apache.yetus.audience.InterfaceStability;
 public interface TableConfigTuner {
 
   /**
-   * Used to initialize underlying implementation with Schema
-   * and custom properties (eg: metrics end point)
+   * Apply tuner to a {@link TableConfig}.
    *
    * @param pinotHelixResourceManager Pinot Helix Resource Manager to access Helix resources
    * @param tableConfig tableConfig that needs to be tuned.
    * @param schema Table schema
+   * @param extraProperties extraProperties for the tuner implementation.
    */
   TableConfig apply(@Nullable PinotHelixResourceManager pinotHelixResourceManager,
-      TableConfig tableConfig, Schema schema);
+      TableConfig tableConfig, Schema schema, Map<String, String> extraProperties);
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/TableConfigTunerUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/TableConfigTunerUtils.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.controller.tuner;
 
 import java.util.List;
+import java.util.Map;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -38,11 +39,11 @@ public class TableConfigTunerUtils {
    * Apply the entire tunerConfig list inside the tableConfig.
    */
   public static void applyTunerConfigs(PinotHelixResourceManager pinotHelixResourceManager, TableConfig tableConfig,
-      Schema schema) {
+      Schema schema, Map<String, String> extraProperties) {
     List<TunerConfig> tunerConfigs = tableConfig.getTunerConfigsList();
     if (CollectionUtils.isNotEmpty(tunerConfigs)) {
       for (TunerConfig tunerConfig : tunerConfigs) {
-        applyTunerConfig(pinotHelixResourceManager, tunerConfig, tableConfig, schema);
+        applyTunerConfig(pinotHelixResourceManager, tunerConfig, tableConfig, schema, extraProperties);
       }
     }
   }
@@ -52,11 +53,11 @@ public class TableConfigTunerUtils {
    */
   public static void applyTunerConfig(
       PinotHelixResourceManager pinotHelixResourceManager, TunerConfig tunerConfig, TableConfig tableConfig,
-      Schema schema) {
+      Schema schema, Map<String, String> extraProperties) {
     if (tunerConfig != null && tunerConfig.getName() != null && !tunerConfig.getName().isEmpty()) {
       try {
         TableConfigTuner tuner = TableConfigTunerRegistry.getTuner(tunerConfig.getName());
-        tuner.apply(pinotHelixResourceManager, tableConfig, schema);
+        tuner.apply(pinotHelixResourceManager, tableConfig, schema, extraProperties);
       } catch (Exception e) {
         LOGGER.error(String.format("Exception occur when applying tuner: %s", tunerConfig.getName()), e);
       }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/tuner/RealTimeAutoIndexTunerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/tuner/RealTimeAutoIndexTunerTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.controller.tuner;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -62,7 +63,7 @@ public class RealTimeAutoIndexTunerTest {
         .setTableName("test").setTunerConfigList(Arrays.asList(_tunerConfig)).build();
     TableConfigTunerRegistry.init(Arrays.asList(DEFAULT_TABLE_CONFIG_TUNER_PACKAGES));
     TableConfigTuner tuner = TableConfigTunerRegistry.getTuner(TUNER_NAME);
-    TableConfig result = tuner.apply(null, tableConfig, _schema);
+    TableConfig result = tuner.apply(null, tableConfig, _schema, Collections.emptyMap());
 
     IndexingConfig newConfig = result.getIndexingConfig();
     List<String> invertedIndexColumns = newConfig.getInvertedIndexColumns();

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/tuner/TunerRegistryTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/tuner/TunerRegistryTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.controller.tuner;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -51,7 +52,7 @@ public class TunerRegistryTest {
         .setTableName("test").setTunerConfigList(Arrays.asList(_tunerConfig)).build();
     TableConfigTunerRegistry.init(Arrays.asList(DEFAULT_TABLE_CONFIG_TUNER_PACKAGES));
     TableConfigTuner tuner = TableConfigTunerRegistry.getTuner(TUNER_NAME);
-    TableConfig result = tuner.apply(null, tableConfig, schema);
+    TableConfig result = tuner.apply(null, tableConfig, schema, Collections.emptyMap());
     Assert.assertEquals(result, tableConfig);
   }
 }


### PR DESCRIPTION
We made tuner stateless a while ago so now it is requires some extra properties for run. for example some of the unused properties set by `TunerConfig`.

This adds additional map field at the end of the Tuner `apply` API. 