### PR TITLE
accelerate `ByteArray.hashCode`

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/ByteArray.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/ByteArray.java
@@ -94,7 +94,23 @@ public class ByteArray implements Comparable<ByteArray>, Serializable {
 
   @Override
   public int hashCode() {
-    return Arrays.hashCode(_bytes);
+    int hash = 1;
+    int i = 0;
+    for (; i + 7 < _bytes.length; i += 8) {
+      hash = -1807454463 * hash
+          + 1742810335 * _bytes[i]
+          + 887503681 * _bytes[i + 1]
+          + 28629151 * _bytes[i + 2]
+          + 923521 * _bytes[i + 3]
+          + 29791 * _bytes[i + 4]
+          + 961 * _bytes[i + 5]
+          + 31 * _bytes[i + 6]
+          + _bytes[i + 7];
+    }
+    for (; i < _bytes.length; i++) {
+      hash = 31 * hash + _bytes[i];
+    }
+    return hash;
   }
 
   @Override

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/ByteArrayTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/ByteArrayTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.spi.utils;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -27,6 +28,19 @@ import static org.testng.Assert.assertTrue;
 
 
 public class ByteArrayTest {
+
+  @Test(description = "hash code may have been used for partitioning so must be stable")
+  public void testHashCode() {
+    // ensure to test below 8
+    byte[] bytes = new byte[ThreadLocalRandom.current().nextInt(8)];
+    ThreadLocalRandom.current().nextBytes(bytes);
+    assertEquals(Arrays.hashCode(bytes), new ByteArray(bytes).hashCode());
+    for (int i = 0; i < 10_000; i++) {
+      bytes = new byte[ThreadLocalRandom.current().nextInt(2048)];
+      ThreadLocalRandom.current().nextBytes(bytes);
+      assertEquals(Arrays.hashCode(bytes), new ByteArray(bytes).hashCode());
+    }
+  }
 
   @Test
   public void testCompare() {


### PR DESCRIPTION
## Description

Speed up `ByteArray.hashCode` which speeds up building column statistics. Unfortunately the algorithm needs to be maintained in case it has been used for partitioning, but it can be sped up easily by breaking a data dependency in the loop.

```java
@State(Scope.Benchmark)
public class BenchmarkByteArray {

  @Param({"7", "127", "1023"})
  int _size;

  ByteArray _bytes;

  @Setup(Level.Trial)
  public void init() {
    byte[] bytes = new byte[_size];
    ThreadLocalRandom.current().nextBytes(bytes);
    _bytes = new ByteArray(bytes);
  }

  @Benchmark
  public int byteArrayHashCode() {
    return _bytes.hashCode();
  }

  @Benchmark
  public int arraysHashCode() {
    return Arrays.hashCode(_bytes.getBytes());
  }
}
```

```
Benchmark                             (_size)  Mode  Cnt    Score   Error  Units
BenchmarkByteArray.arraysHashCode           7  avgt    5    6.823 ± 3.155  ns/op
BenchmarkByteArray.arraysHashCode         127  avgt    5   83.459 ± 5.859  ns/op
BenchmarkByteArray.arraysHashCode        1023  avgt    5  678.600 ± 4.842  ns/op
BenchmarkByteArray.byteArrayHashCode        7  avgt    5    6.294 ± 0.021  ns/op
BenchmarkByteArray.byteArrayHashCode      127  avgt    5   56.796 ± 1.975  ns/op
BenchmarkByteArray.byteArrayHashCode     1023  avgt    5  406.462 ± 3.246  ns/op
```


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
