### PR TITLE
Enhance BloomFilter rule to include IN predicate(#7444)

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/BloomFilterRule.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/BloomFilterRule.java
@@ -109,7 +109,8 @@ public class BloomFilterRule extends AbstractRule {
       String colName = lhs.toString();
       if (lhs.getType() == ExpressionContext.Type.FUNCTION) {
         LOGGER.trace("Skipping the function {}", colName);
-      } else if (filterContext.getPredicate().getType() == Predicate.Type.EQ) {
+      } else if (filterContext.getPredicate().getType() == Predicate.Type.EQ
+          || filterContext.getPredicate().getType() == Predicate.Type.IN) {
         ret.add(_input.colNameToInt(colName));
       }
     }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/recommender/TestConfigEngine.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/recommender/TestConfigEngine.java
@@ -240,7 +240,7 @@ public class TestConfigEngine {
     AbstractRule abstractRule =
         RulesToExecute.RuleFactory.getRule(RulesToExecute.Rule.BloomFilterRule, _input, output);
     abstractRule.run();
-    assertEquals(output.getIndexConfig().getBloomFilterColumns().toString(), "[c]");
+    assertEquals(output.getIndexConfig().getBloomFilterColumns().toString(), "[b, c, e]");
   }
 
   @Test


### PR DESCRIPTION
Support in the execution engine was added for bloom filter (#7005) based pruning using IN predicate. The index recommendation rule isn't yet updated to support IN predicate. The current implementation of BloomFilterRule ignores IN predicate, this issue will track removal of that limitation

Issue #7444 