### PR TITLE
Enhance MergeRangeFilterOptimizer to rewrite predicate A < 10 OR A = …

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/Range.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/Range.java
@@ -116,4 +116,28 @@ public class Range {
         stringUpperBound.equals(RangePredicate.UNBOUNDED) ? null : dataType.convertInternal(stringUpperBound);
     return new Range(lowerBound, lowerInclusive, upperBound, upperInclusive);
   }
+
+  public Comparable getLowerBound() {
+    return _lowerBound;
+  }
+
+  public boolean isLowerInclusive() {
+    return _lowerInclusive;
+  }
+
+  public void setLowerInclusive(boolean lowerInclusive) {
+    _lowerInclusive = lowerInclusive;
+  }
+
+  public Comparable getUpperBound() {
+    return _upperBound;
+  }
+
+  public boolean isUpperInclusive() {
+    return _upperInclusive;
+  }
+
+  public void setUpperInclusive(boolean upperInclusive) {
+    _upperInclusive = upperInclusive;
+  }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

MergeRangeFilterOptimizer now merges equality with range predicates in OR filters\.

```mermaid
flowchart TD
  N0["Entry optimize#40;Expression filterExpression#44; Schema schema#41; #40;F1#41;"]:::stModified
  N1["Check if operator is OR #40;F1#41;"]:::stModified
  N2["Initialize rangeMap#44; equalityExpressions#44; newChildren #40;F1#41;"]:::stModified
  N3["Iterate over OR children #40;F1#41;"]:::stModified
  N4["Classify child as range#47;equals or other #40;F1#41;"]:::stModified
  N5["Extract column#44; skip non#45;ID#47;multi#45;value #40;F1#41;"]:::stModified
  N6["Store equality in equalityExpressions #40;F1#41;"]:::stModified
  N7["Compute Range and add to rangeMap per column #40;F1#41;"]:::stModified
  N8["Recursively optimize other child and add to newChildren #40;F1#41;"]:::stModified
  N9["Process equality expressions#58; adjust range inclusivity or keep #40;F1#44; F2#41;"]:::stModified
  N10["Build new children from merged ranges #40;F1#41;"]:::stModified
  N11["Return single child or update operands and return #40;F1#41;"]:::stModified
  N0 -->|"next"| N1
  N1 -->|"if OR"| N2
  N2 -->|"after init"| N3
  N3 -->|"loop body"| N4
  N4 -->|"range#47;equals branch"| N5
  N4 -->|"other branch"| N8
  N5 -->|"if EQUALS"| N6
  N5 -->|"if range"| N7
  N6 -->|"continue loop"| N3
  N7 -->|"continue loop"| N3
  N8 -->|"continue loop"| N3
  N3 -->|"after loop"| N9
  N9 -->|"process equalities"| N10
  N10 -->|"build children"| N11
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/MergeRangeFilterOptimizer\.java — [before](https://github.com/apache/pinot/blob/1b4241d1adeb590b7d7c06e943f895b7bcd2242d/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/MergeRangeFilterOptimizer.java) · [after](https://github.com/apache/pinot/blob/566ac9d9dc73f63b82d35ccae46dd37240e67d63/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/MergeRangeFilterOptimizer.java)
- F2: pinot\-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/Range\.java — [before](https://github.com/apache/pinot/blob/1b4241d1adeb590b7d7c06e943f895b7bcd2242d/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/Range.java) · [after](https://github.com/apache/pinot/blob/566ac9d9dc73f63b82d35ccae46dd37240e67d63/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/Range.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjFiNDI0MWQxYWRlYjU5MGI3ZDdjMDZlOTQzZjg5NWI3YmNkMjI0MmQiLCJjb250ZXh0X2hhc2giOiJiYjJkYjRmN2JiYjNjOTEyZjdhODExMGQ0MjI0MGU0ZjBmYzI3M2JlM2QyZWRkNWRhODQ2ODc1MzVjOTc3OWYwIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MTMwMjcwLCJoZWFkX3NoYSI6IjU2NmFjOWQ5ZGM3M2Y2M2I4MmQzNWNjYWU0NmRkMzcyNDBlNjdkNjMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIxYjQyNDFkMWFkZWI1OTBiN2Q3YzA2ZTk0M2Y4OTViN2JjZDIyNDJkIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 1cec90eef6cb956926a340b9966c6fb06863627684685bab8a4b8ba65ecd2c61 -->
<!-- pinot-pr-flow:end -->

Currently, MergeRangeFilterOptimizer don't support operations to optimize query with filter patterns consisting of predicate A < 10 OR A = 10 as A<=10. this issue will track removal of that limitation and provide support for the same as part for optimizing query execution

Issue #7625 