### PR TITLE
reinstate _numDocs bounds checks

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
@@ -85,10 +85,12 @@ public final class MVScanDocIdIterator implements ScanBasedDocIdIterator {
       int limit = docIdIterator.nextBatch(buffer);
       for (int i = 0; i < limit; i++) {
         int nextDocId = buffer[i];
-        int length = _reader.getDictIdMV(nextDocId, _dictIdBuffer, _readerContext);
-        _numEntriesScanned += length;
-        if (_predicateEvaluator.applyMV(_dictIdBuffer, length)) {
-          result.add(nextDocId);
+        if (nextDocId < _numDocs) {
+          int length = _reader.getDictIdMV(nextDocId, _dictIdBuffer, _readerContext);
+          _numEntriesScanned += length;
+          if (_predicateEvaluator.applyMV(_dictIdBuffer, length)) {
+            result.add(nextDocId);
+          }
         }
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
@@ -84,9 +84,11 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
       int limit = docIdIterator.nextBatch(buffer);
       for (int i = 0; i < limit; i++) {
         int nextDocId = buffer[i];
-        _numEntriesScanned++;
-        if (_valueMatcher.doesValueMatch(nextDocId)) {
-          result.add(nextDocId);
+        if (nextDocId < _numDocs) {
+          _numEntriesScanned++;
+          if (_valueMatcher.doesValueMatch(nextDocId)) {
+            result.add(nextDocId);
+          }
         }
       }
     }


### PR DESCRIPTION
## Description
#7530 removed pre-existing bounds checks which may be more important than was [thought at the time](https://github.com/apache/pinot/pull/7530#discussion_r723601745). I will try to add a test case to trigger an out of bounds error without this check before recommending for merging. 
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
