### PR TITLE
to handle datetime column consistently

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -68,6 +68,7 @@ import org.apache.pinot.segment.spi.index.reader.H3IndexResolution;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
+import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.FieldSpec.FieldType;
@@ -76,7 +77,6 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
-import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -639,7 +639,10 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
 
             if (_config.getTimeColumnType() == SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE) {
               // For TimeColumnType.SIMPLE_DATE_FORMAT, convert time value into millis since epoch
-              DateTimeFormatter dateTimeFormatter = DateTimeFormat.forPattern(_config.getSimpleDateFormat());
+              // Use DateTimeFormatter from DateTimeFormatSpec to handle default time zone consistently.
+              DateTimeFormatSpec formatSpec = _config.getDateTimeFormatSpec();
+              Preconditions.checkNotNull(formatSpec, "DateTimeFormatSpec must exist for SimpleDate");
+              DateTimeFormatter dateTimeFormatter = formatSpec.getDateTimeFormatter();
               startTime = dateTimeFormatter.parseMillis(startTimeStr);
               endTime = dateTimeFormatter.parseMillis(endTimeStr);
               timeUnit = TimeUnit.MILLISECONDS;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -51,7 +51,6 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
-import org.joda.time.format.DateTimeFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -100,7 +100,7 @@ public class SegmentGeneratorConfig implements Serializable {
   private SegmentPartitionConfig _segmentPartitionConfig = null;
   private int _sequenceId = -1;
   private TimeColumnType _timeColumnType = TimeColumnType.EPOCH;
-  private String _simpleDateFormat = null;
+  private DateTimeFormatSpec _dateTimeFormatSpec = null;
   // Use on-heap or off-heap memory to generate index (currently only affect inverted index and star-tree v2)
   private boolean _onHeap = false;
   private boolean _skipTimeValueCheck = false;
@@ -213,7 +213,7 @@ public class SegmentGeneratorConfig implements Serializable {
         setTimeColumnName(dateTimeFieldSpec.getName());
         DateTimeFormatSpec formatSpec = new DateTimeFormatSpec(dateTimeFieldSpec.getFormat());
         if (formatSpec.getTimeFormat() == DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT) {
-          setSimpleDateFormat(formatSpec.getSDFPattern());
+          setSimpleDateFormat(formatSpec);
         } else {
           setSegmentTimeUnit(formatSpec.getColumnUnit());
         }
@@ -286,18 +286,13 @@ public class SegmentGeneratorConfig implements Serializable {
     _customProperties.putAll(properties);
   }
 
-  public void setSimpleDateFormat(String simpleDateFormat) {
+  private void setSimpleDateFormat(DateTimeFormatSpec formatSpec) {
     _timeColumnType = TimeColumnType.SIMPLE_DATE;
-    try {
-      DateTimeFormat.forPattern(simpleDateFormat);
-    } catch (Exception e) {
-      throw new RuntimeException("Illegal simple date format specification", e);
-    }
-    _simpleDateFormat = simpleDateFormat;
+    _dateTimeFormatSpec = formatSpec;
   }
 
-  public String getSimpleDateFormat() {
-    return _simpleDateFormat;
+  public DateTimeFormatSpec getDateTimeFormatSpec() {
+    return _dateTimeFormatSpec;
   }
 
   public TimeColumnType getTimeColumnType() {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -51,7 +51,6 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
-import org.joda.time.format.DateTimeFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,7 +99,6 @@ public class SegmentGeneratorConfig implements Serializable {
   private SegmentPartitionConfig _segmentPartitionConfig = null;
   private int _sequenceId = -1;
   private TimeColumnType _timeColumnType = TimeColumnType.EPOCH;
-  private String _simpleDateFormat = null;
   private DateTimeFormatSpec _dateTimeFormatSpec = null;
   // Use on-heap or off-heap memory to generate index (currently only affect inverted index and star-tree v2)
   private boolean _onHeap = false;
@@ -212,13 +210,7 @@ public class SegmentGeneratorConfig implements Serializable {
       DateTimeFieldSpec dateTimeFieldSpec = schema.getSpecForTimeColumn(timeColumnName);
       if (dateTimeFieldSpec != null) {
         setTimeColumnName(dateTimeFieldSpec.getName());
-        DateTimeFormatSpec formatSpec = new DateTimeFormatSpec(dateTimeFieldSpec.getFormat());
-        setDateTimeFormatSpec(formatSpec);
-        if (formatSpec.getTimeFormat() == DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT) {
-          setSimpleDateFormat(formatSpec.getSDFPattern());
-        } else {
-          setSegmentTimeUnit(formatSpec.getColumnUnit());
-        }
+        setDateTimeFormatSpec(new DateTimeFormatSpec(dateTimeFieldSpec.getFormat()));
       }
     }
   }
@@ -288,26 +280,19 @@ public class SegmentGeneratorConfig implements Serializable {
     _customProperties.putAll(properties);
   }
 
-  private void setDateTimeFormatSpec(DateTimeFormatSpec formatSpec) {
+  public void setDateTimeFormatSpec(DateTimeFormatSpec formatSpec) {
     _dateTimeFormatSpec = formatSpec;
+    if (formatSpec.getTimeFormat() == DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT) {
+      // timeUnit is only needed by EPOCH time format.
+      _timeColumnType = TimeColumnType.SIMPLE_DATE;
+    } else {
+      _segmentTimeUnit = formatSpec.getColumnUnit();
+      _timeColumnType = TimeColumnType.EPOCH;
+    }
   }
 
   public DateTimeFormatSpec getDateTimeFormatSpec() {
     return _dateTimeFormatSpec;
-  }
-
-  public void setSimpleDateFormat(String simpleDateFormat) {
-    _timeColumnType = TimeColumnType.SIMPLE_DATE;
-    try {
-      DateTimeFormat.forPattern(simpleDateFormat);
-    } catch (Exception e) {
-      throw new RuntimeException("Illegal simple date format specification", e);
-    }
-    _simpleDateFormat = simpleDateFormat;
-  }
-
-  public String getSimpleDateFormat() {
-    return _simpleDateFormat;
   }
 
   public TimeColumnType getTimeColumnType() {

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfigTest.java
@@ -28,6 +28,7 @@ import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
 
@@ -44,13 +45,15 @@ public class SegmentGeneratorConfigTest {
     assertEquals(segmentGeneratorConfig.getTimeColumnName(), "daysSinceEpoch");
     assertEquals(segmentGeneratorConfig.getTimeColumnType(), SegmentGeneratorConfig.TimeColumnType.EPOCH);
     assertEquals(segmentGeneratorConfig.getSegmentTimeUnit(), TimeUnit.DAYS);
-    assertNull(segmentGeneratorConfig.getDateTimeFormatSpec());
+    assertNull(segmentGeneratorConfig.getSimpleDateFormat());
+    assertNotNull(segmentGeneratorConfig.getDateTimeFormatSpec());
 
     // MUST provide valid tableConfig with time column if time details are wanted
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("test").build();
     segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     assertNull(segmentGeneratorConfig.getTimeColumnName());
     assertNull(segmentGeneratorConfig.getSegmentTimeUnit());
+    assertNull(segmentGeneratorConfig.getSimpleDateFormat());
     assertNull(segmentGeneratorConfig.getDateTimeFormatSpec());
 
     schema = new Schema.SchemaBuilder().addDateTime("daysSinceEpoch", FieldSpec.DataType.INT, "1:DAYS:EPOCH", "1:DAYS")
@@ -61,7 +64,8 @@ public class SegmentGeneratorConfigTest {
     assertEquals(segmentGeneratorConfig.getTimeColumnName(), "daysSinceEpoch");
     assertEquals(segmentGeneratorConfig.getTimeColumnType(), SegmentGeneratorConfig.TimeColumnType.EPOCH);
     assertEquals(segmentGeneratorConfig.getSegmentTimeUnit(), TimeUnit.DAYS);
-    assertNull(segmentGeneratorConfig.getDateTimeFormatSpec());
+    assertNull(segmentGeneratorConfig.getSimpleDateFormat());
+    assertNotNull(segmentGeneratorConfig.getDateTimeFormatSpec());
   }
 
   @Test
@@ -75,6 +79,8 @@ public class SegmentGeneratorConfigTest {
     assertEquals(segmentGeneratorConfig.getTimeColumnName(), "Date");
     assertEquals(segmentGeneratorConfig.getTimeColumnType(), SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE);
     assertNull(segmentGeneratorConfig.getSegmentTimeUnit());
+    assertEquals(segmentGeneratorConfig.getSimpleDateFormat(), "yyyyMMdd");
+    assertNotNull(segmentGeneratorConfig.getDateTimeFormatSpec());
     assertEquals(segmentGeneratorConfig.getDateTimeFormatSpec().getSDFPattern(), "yyyyMMdd");
 
     // MUST provide valid tableConfig with time column if time details are wanted
@@ -82,6 +88,7 @@ public class SegmentGeneratorConfigTest {
     segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     assertNull(segmentGeneratorConfig.getTimeColumnName());
     assertNull(segmentGeneratorConfig.getSegmentTimeUnit());
+    assertNull(segmentGeneratorConfig.getSimpleDateFormat());
     assertNull(segmentGeneratorConfig.getDateTimeFormatSpec());
 
     schema = new Schema.SchemaBuilder()
@@ -91,6 +98,8 @@ public class SegmentGeneratorConfigTest {
     assertEquals(segmentGeneratorConfig.getTimeColumnName(), "Date");
     assertEquals(segmentGeneratorConfig.getTimeColumnType(), SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE);
     assertNull(segmentGeneratorConfig.getSegmentTimeUnit());
+    assertEquals(segmentGeneratorConfig.getSimpleDateFormat(), "yyyyMMdd");
+    assertNotNull(segmentGeneratorConfig.getDateTimeFormatSpec());
     assertEquals(segmentGeneratorConfig.getDateTimeFormatSpec().getSDFPattern(), "yyyyMMdd");
   }
 }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfigTest.java
@@ -44,14 +44,14 @@ public class SegmentGeneratorConfigTest {
     assertEquals(segmentGeneratorConfig.getTimeColumnName(), "daysSinceEpoch");
     assertEquals(segmentGeneratorConfig.getTimeColumnType(), SegmentGeneratorConfig.TimeColumnType.EPOCH);
     assertEquals(segmentGeneratorConfig.getSegmentTimeUnit(), TimeUnit.DAYS);
-    assertNull(segmentGeneratorConfig.getSimpleDateFormat());
+    assertNull(segmentGeneratorConfig.getDateTimeFormatSpec());
 
     // MUST provide valid tableConfig with time column if time details are wanted
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("test").build();
     segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     assertNull(segmentGeneratorConfig.getTimeColumnName());
     assertNull(segmentGeneratorConfig.getSegmentTimeUnit());
-    assertNull(segmentGeneratorConfig.getSimpleDateFormat());
+    assertNull(segmentGeneratorConfig.getDateTimeFormatSpec());
 
     schema = new Schema.SchemaBuilder().addDateTime("daysSinceEpoch", FieldSpec.DataType.INT, "1:DAYS:EPOCH", "1:DAYS")
         .build();
@@ -61,7 +61,7 @@ public class SegmentGeneratorConfigTest {
     assertEquals(segmentGeneratorConfig.getTimeColumnName(), "daysSinceEpoch");
     assertEquals(segmentGeneratorConfig.getTimeColumnType(), SegmentGeneratorConfig.TimeColumnType.EPOCH);
     assertEquals(segmentGeneratorConfig.getSegmentTimeUnit(), TimeUnit.DAYS);
-    assertNull(segmentGeneratorConfig.getSimpleDateFormat());
+    assertNull(segmentGeneratorConfig.getDateTimeFormatSpec());
   }
 
   @Test
@@ -75,14 +75,14 @@ public class SegmentGeneratorConfigTest {
     assertEquals(segmentGeneratorConfig.getTimeColumnName(), "Date");
     assertEquals(segmentGeneratorConfig.getTimeColumnType(), SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE);
     assertNull(segmentGeneratorConfig.getSegmentTimeUnit());
-    assertEquals(segmentGeneratorConfig.getSimpleDateFormat(), "yyyyMMdd");
+    assertEquals(segmentGeneratorConfig.getDateTimeFormatSpec().getSDFPattern(), "yyyyMMdd");
 
     // MUST provide valid tableConfig with time column if time details are wanted
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("test").build();
     segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     assertNull(segmentGeneratorConfig.getTimeColumnName());
     assertNull(segmentGeneratorConfig.getSegmentTimeUnit());
-    assertNull(segmentGeneratorConfig.getSimpleDateFormat());
+    assertNull(segmentGeneratorConfig.getDateTimeFormatSpec());
 
     schema = new Schema.SchemaBuilder()
         .addDateTime("Date", FieldSpec.DataType.STRING, "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", "1:DAYS").build();
@@ -91,6 +91,6 @@ public class SegmentGeneratorConfigTest {
     assertEquals(segmentGeneratorConfig.getTimeColumnName(), "Date");
     assertEquals(segmentGeneratorConfig.getTimeColumnType(), SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE);
     assertNull(segmentGeneratorConfig.getSegmentTimeUnit());
-    assertEquals(segmentGeneratorConfig.getSimpleDateFormat(), "yyyyMMdd");
+    assertEquals(segmentGeneratorConfig.getDateTimeFormatSpec().getSDFPattern(), "yyyyMMdd");
   }
 }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfigTest.java
@@ -45,7 +45,6 @@ public class SegmentGeneratorConfigTest {
     assertEquals(segmentGeneratorConfig.getTimeColumnName(), "daysSinceEpoch");
     assertEquals(segmentGeneratorConfig.getTimeColumnType(), SegmentGeneratorConfig.TimeColumnType.EPOCH);
     assertEquals(segmentGeneratorConfig.getSegmentTimeUnit(), TimeUnit.DAYS);
-    assertNull(segmentGeneratorConfig.getSimpleDateFormat());
     assertNotNull(segmentGeneratorConfig.getDateTimeFormatSpec());
 
     // MUST provide valid tableConfig with time column if time details are wanted
@@ -53,7 +52,6 @@ public class SegmentGeneratorConfigTest {
     segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     assertNull(segmentGeneratorConfig.getTimeColumnName());
     assertNull(segmentGeneratorConfig.getSegmentTimeUnit());
-    assertNull(segmentGeneratorConfig.getSimpleDateFormat());
     assertNull(segmentGeneratorConfig.getDateTimeFormatSpec());
 
     schema = new Schema.SchemaBuilder().addDateTime("daysSinceEpoch", FieldSpec.DataType.INT, "1:DAYS:EPOCH", "1:DAYS")
@@ -64,7 +62,6 @@ public class SegmentGeneratorConfigTest {
     assertEquals(segmentGeneratorConfig.getTimeColumnName(), "daysSinceEpoch");
     assertEquals(segmentGeneratorConfig.getTimeColumnType(), SegmentGeneratorConfig.TimeColumnType.EPOCH);
     assertEquals(segmentGeneratorConfig.getSegmentTimeUnit(), TimeUnit.DAYS);
-    assertNull(segmentGeneratorConfig.getSimpleDateFormat());
     assertNotNull(segmentGeneratorConfig.getDateTimeFormatSpec());
   }
 
@@ -79,7 +76,6 @@ public class SegmentGeneratorConfigTest {
     assertEquals(segmentGeneratorConfig.getTimeColumnName(), "Date");
     assertEquals(segmentGeneratorConfig.getTimeColumnType(), SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE);
     assertNull(segmentGeneratorConfig.getSegmentTimeUnit());
-    assertEquals(segmentGeneratorConfig.getSimpleDateFormat(), "yyyyMMdd");
     assertNotNull(segmentGeneratorConfig.getDateTimeFormatSpec());
     assertEquals(segmentGeneratorConfig.getDateTimeFormatSpec().getSDFPattern(), "yyyyMMdd");
 
@@ -88,7 +84,6 @@ public class SegmentGeneratorConfigTest {
     segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     assertNull(segmentGeneratorConfig.getTimeColumnName());
     assertNull(segmentGeneratorConfig.getSegmentTimeUnit());
-    assertNull(segmentGeneratorConfig.getSimpleDateFormat());
     assertNull(segmentGeneratorConfig.getDateTimeFormatSpec());
 
     schema = new Schema.SchemaBuilder()
@@ -98,7 +93,6 @@ public class SegmentGeneratorConfigTest {
     assertEquals(segmentGeneratorConfig.getTimeColumnName(), "Date");
     assertEquals(segmentGeneratorConfig.getTimeColumnType(), SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE);
     assertNull(segmentGeneratorConfig.getSegmentTimeUnit());
-    assertEquals(segmentGeneratorConfig.getSimpleDateFormat(), "yyyyMMdd");
     assertNotNull(segmentGeneratorConfig.getDateTimeFormatSpec());
     assertEquals(segmentGeneratorConfig.getDateTimeFormatSpec().getSDFPattern(), "yyyyMMdd");
   }


### PR DESCRIPTION
## Description
SegmentColumnarIndexCreator uses local time zone while converting datetime w/o time zone to timestamp. This is inconsistent with DateTimeFormatSpec.fromFormatToMillis() which uses UTC by default. This PR reuses DateTimeFormatSpec to handle timecolumn in SegmentColumnarIndexCreator.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

This bugfix is <code>backward-incompat</code>. Without the fix, if the segment timeColumn uses SimpleDate format and its values don't have time zones, the start/end times in SegmentMetadata (segment.start.time and segment.end.time) are converted to timestamp based on `local time zone`. 

But DateTimeFormatPatternSpec initialized with the same SimpleDate format converts those time values to timestamp with UTC. DateTimeFormatPatternSpec is used many other places, e.g. DateTimeFormatSpec.fromMillisToFormat(), except for the conversion for start/end time in SegmentMetadata. So this fix in PR reuses DateTimeFormatPatternSpec there too.

Does this PR fix a zero-downtime upgrade introduced earlier?
* [x] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

This PR may change the the start/end times in SegmentMetadata (segment.start.time and segment.end.time), when timeColumn uses SimpleDate format and the time values don't have time zones.

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
