### PR TITLE
implement size balanced V4 raw chunk format

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkSVForwardIndexWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkSVForwardIndexWriter.java
@@ -53,7 +53,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * Only sequential writes are supported.
  */
 @NotThreadSafe
-public class VarByteChunkSVForwardIndexWriter extends BaseChunkSVForwardIndexWriter {
+public class VarByteChunkSVForwardIndexWriter extends BaseChunkSVForwardIndexWriter implements VarByteChunkWriter {
 
   public static final int CHUNK_HEADER_ENTRY_ROW_OFFSET_SIZE = Integer.BYTES;
 
@@ -87,10 +87,12 @@ public class VarByteChunkSVForwardIndexWriter extends BaseChunkSVForwardIndexWri
     _chunkDataOffSet = _chunkHeaderSize;
   }
 
+  @Override
   public void putString(String value) {
     putBytes(value.getBytes(UTF_8));
   }
 
+  @Override
   public void putBytes(byte[] value) {
     _chunkBuffer.putInt(_chunkHeaderOffset, _chunkDataOffSet);
     _chunkHeaderOffset += CHUNK_HEADER_ENTRY_ROW_OFFSET_SIZE;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkSVForwardIndexWriterV4.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkSVForwardIndexWriterV4.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.segment.local.io.writer.impl;
 
-import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -43,7 +42,7 @@ import org.slf4j.LoggerFactory;
  * Only sequential writes are supported.
  */
 @NotThreadSafe
-public class VarByteChunkSVForwardIndexWriterV4 implements Closeable {
+public class VarByteChunkSVForwardIndexWriterV4 implements VarByteChunkWriter {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(VarByteChunkSVForwardIndexWriterV4.class);
 
@@ -86,13 +85,13 @@ public class VarByteChunkSVForwardIndexWriterV4 implements Closeable {
     _metadataSize += 4 * Integer.BYTES;
   }
 
-  public void writeString(String string)
-      throws IOException {
-    writeBytes(string.getBytes(StandardCharsets.UTF_8));
+  @Override
+  public void putString(String string) {
+    putBytes(string.getBytes(StandardCharsets.UTF_8));
   }
 
-  public void writeBytes(byte[] bytes)
-      throws IOException {
+  @Override
+  public void putBytes(byte[] bytes) {
     int sizeRequired = Integer.BYTES + bytes.length;
     if (_chunkBuffer.position() >= _chunkBuffer.capacity() - sizeRequired) {
       writeChunk();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkSVForwardIndexWriterV4.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkSVForwardIndexWriterV4.java
@@ -1,0 +1,223 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.io.writer.impl;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.charset.StandardCharsets;
+import javax.annotation.concurrent.NotThreadSafe;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.io.compression.ChunkCompressorFactory;
+import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
+import org.apache.pinot.segment.spi.compression.ChunkCompressor;
+import org.apache.pinot.segment.spi.memory.CleanerUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Class to write out variable length bytes into a single column.
+ *
+ *
+ * Only sequential writes are supported.
+ */
+@NotThreadSafe
+public class VarByteChunkSVForwardIndexWriterV4 implements Closeable {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(VarByteChunkSVForwardIndexWriterV4.class);
+
+  public static final int VERSION = 4;
+
+  private static final String DATA_BUFFER_SUFFIX = ".buf";
+
+  private final File _dataBuffer;
+  private final RandomAccessFile _output;
+  private final FileChannel _dataChannel;
+  private final ByteBuffer _chunkBuffer;
+  private final ChunkCompressor _chunkCompressor;
+
+  private int _docIdOffset = 0;
+  private int _nextDocId = 0;
+  private int _metadataSize = 0;
+  private long _chunkOffset = 0;
+
+  public VarByteChunkSVForwardIndexWriterV4(File file, ChunkCompressionType compressionType, int chunkSize)
+      throws IOException {
+    _dataBuffer = new File(file.getName() + DATA_BUFFER_SUFFIX);
+    _output = new RandomAccessFile(file, "rw");
+    _dataChannel = new RandomAccessFile(_dataBuffer, "rw").getChannel();
+    _chunkCompressor = ChunkCompressorFactory.getCompressor(compressionType, true);
+    _chunkBuffer = ByteBuffer.allocateDirect(chunkSize).order(ByteOrder.LITTLE_ENDIAN);
+    // reserve space for numDocs
+    _chunkBuffer.position(Integer.BYTES);
+    writeHeader(_chunkCompressor.compressionType(), chunkSize);
+  }
+
+  private void writeHeader(ChunkCompressionType compressionType, int targetDecompressedChunkSize)
+      throws IOException {
+    // keep metadata BE for backwards compatibility
+    // (e.g. the version needs to be read by a factory which assumes BE)
+    _output.writeInt(VERSION);
+    _output.writeInt(targetDecompressedChunkSize);
+    _output.writeInt(compressionType.getValue());
+    // reserve a slot to write the data offset into
+    _output.writeInt(0);
+    _metadataSize += 4 * Integer.BYTES;
+  }
+
+  public void writeString(String string)
+      throws IOException {
+    writeBytes(string.getBytes(StandardCharsets.UTF_8));
+  }
+
+  public void writeBytes(byte[] bytes)
+      throws IOException {
+    int sizeRequired = Integer.BYTES + bytes.length;
+    if (_chunkBuffer.position() >= _chunkBuffer.capacity() - sizeRequired) {
+      writeChunk();
+      if (sizeRequired >= _chunkBuffer.capacity() - Integer.BYTES) {
+        writeHugeChunk(bytes);
+        return;
+      }
+    }
+    _chunkBuffer.putInt(bytes.length);
+    _chunkBuffer.put(bytes);
+    _nextDocId++;
+  }
+
+  private void writeHugeChunk(byte[] bytes) {
+    // huge values where the bytes and their length prefix don't fit in to the remainder of the buffer after the prefix
+    // for the number of documents in a regular chunk are written as a single value without metadata, and these chunks
+    // are detected by marking the MSB in the doc id offset
+    final ByteBuffer buffer;
+    if (_chunkCompressor.compressionType() == ChunkCompressionType.SNAPPY
+        || _chunkCompressor.compressionType() == ChunkCompressionType.ZSTANDARD) {
+      buffer = ByteBuffer.allocateDirect(bytes.length);
+      buffer.put(bytes);
+      buffer.flip();
+    } else {
+      // cast for JDK8 javac compatibility
+      buffer = (ByteBuffer) ByteBuffer.wrap(bytes);
+    }
+    try {
+      _nextDocId++;
+      write(buffer, true);
+    } finally {
+      CleanerUtil.cleanQuietly(buffer);
+    }
+  }
+
+  private void writeChunk() {
+    if (_nextDocId > _docIdOffset) {
+      int numDocs = _nextDocId - _docIdOffset;
+      // collect lengths
+      int[] valueLengths = new int[numDocs];
+      int[] offsets = new int[numDocs];
+      int offset = Integer.BYTES;
+      for (int i = 0; i < numDocs; i++) {
+        offsets[i] = offset;
+        int size = _chunkBuffer.getInt(offset);
+        valueLengths[i] = size;
+        offset += size + Integer.BYTES;
+      }
+      _chunkBuffer.putInt(0, numDocs);
+      // now iterate backwards shifting variable length content backwards to make space for prefixes at the start
+      // this pays for itself by allowing random access to readers
+      int limit = _chunkBuffer.position();
+      int accumulatedOffset = Integer.BYTES;
+      for (int i = numDocs - 2; i >= 0; i--) {
+        ByteBuffer source = _chunkBuffer.duplicate();
+        int copyFrom = offsets[i] + Integer.BYTES;
+        source.position(offsets[i]).limit(copyFrom + valueLengths[i]);
+        _chunkBuffer.position(offsets[i] + accumulatedOffset);
+        _chunkBuffer.put(source.slice());
+        accumulatedOffset += Integer.BYTES;
+      }
+      // compute byte offsets of each string from lengths
+      int metadataOffset = Integer.BYTES * (numDocs + 1);
+      offsets[0] = metadataOffset;
+      int cumulativeLength = valueLengths[0];
+      for (int i = 1; i < offsets.length; i++) {
+        offsets[i] = metadataOffset + cumulativeLength;
+        cumulativeLength += valueLengths[i];
+      }
+      // write the lengths into the space created at the front
+      for (int i = 0; i < offsets.length; i++) {
+        _chunkBuffer.putInt(Integer.BYTES * (i + 1), offsets[i]);
+      }
+      _chunkBuffer.position(0);
+      _chunkBuffer.limit(limit);
+      write(_chunkBuffer, false);
+      clearChunkBuffer();
+    }
+  }
+
+  private void write(ByteBuffer buffer, boolean huge) {
+    int maxCompressedSize = _chunkCompressor.maxCompressedSize(buffer.limit());
+    ByteBuffer target = null;
+    try {
+      target = _dataChannel.map(FileChannel.MapMode.READ_WRITE, _chunkOffset, maxCompressedSize)
+          .order(ByteOrder.LITTLE_ENDIAN);
+      int compressedSize = _chunkCompressor.compress(buffer, target);
+      // reverse bytes here because the file writes BE and we want to read the metadata LE
+      _output.writeInt(Integer.reverseBytes(_docIdOffset | (huge ? 0x80000000 : 0)));
+      _output.writeInt(Integer.reverseBytes((int) (_chunkOffset & 0xFFFFFFFFL)));
+      _metadataSize += 8;
+      _chunkOffset += compressedSize;
+      _docIdOffset = _nextDocId;
+    } catch (IOException e) {
+      LOGGER.error("Exception caught while compressing/writing data chunk", e);
+      throw new RuntimeException(e);
+    } finally {
+      CleanerUtil.cleanQuietly(target);
+    }
+  }
+
+  private void clearChunkBuffer() {
+    _chunkBuffer.clear();
+    _chunkBuffer.position(Integer.BYTES);
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    writeChunk();
+    // write out where the chunks start into slot reserved at offset 12
+    _output.seek(3 * Integer.BYTES);
+    _output.writeInt(_metadataSize);
+    _output.seek(_metadataSize);
+    _dataChannel.truncate(_chunkOffset);
+    _output.setLength(_metadataSize + _chunkOffset);
+    long total = _chunkOffset;
+    long position = 0;
+    while (total > 0) {
+      long transferred = _dataChannel.transferTo(position, total, _output.getChannel());
+      total -= transferred;
+      position += transferred;
+    }
+    _dataChannel.close();
+    _output.close();
+    FileUtils.deleteQuietly(_dataBuffer);
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkWriter.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.io.writer.impl;
+
+import java.io.Closeable;
+
+
+public interface VarByteChunkWriter extends Closeable {
+  void putString(String value);
+
+  void putBytes(byte[] value);
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueFixedByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueFixedByteRawIndexCreator.java
@@ -23,6 +23,8 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.apache.pinot.segment.local.io.writer.impl.BaseChunkSVForwardIndexWriter;
 import org.apache.pinot.segment.local.io.writer.impl.VarByteChunkSVForwardIndexWriter;
+import org.apache.pinot.segment.local.io.writer.impl.VarByteChunkSVForwardIndexWriterV4;
+import org.apache.pinot.segment.local.io.writer.impl.VarByteChunkWriter;
 import org.apache.pinot.segment.spi.V1Constants.Indexes;
 import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
 import org.apache.pinot.segment.spi.index.creator.ForwardIndexCreator;
@@ -39,7 +41,7 @@ public class MultiValueFixedByteRawIndexCreator implements ForwardIndexCreator {
   private static final int DEFAULT_NUM_DOCS_PER_CHUNK = 1000;
   private static final int TARGET_MAX_CHUNK_SIZE = 1024 * 1024;
 
-  private final VarByteChunkSVForwardIndexWriter _indexWriter;
+  private final VarByteChunkWriter _indexWriter;
   private final DataType _valueType;
 
   /**
@@ -79,8 +81,10 @@ public class MultiValueFixedByteRawIndexCreator implements ForwardIndexCreator {
     int numDocsPerChunk =
         deriveNumDocsPerChunk ? Math.max(TARGET_MAX_CHUNK_SIZE / (totalMaxLength
             + VarByteChunkSVForwardIndexWriter.CHUNK_HEADER_ENTRY_ROW_OFFSET_SIZE), 1) : DEFAULT_NUM_DOCS_PER_CHUNK;
-    _indexWriter = new VarByteChunkSVForwardIndexWriter(file, compressionType, totalDocs,
-        numDocsPerChunk, totalMaxLength, writerVersion);
+    _indexWriter = writerVersion < VarByteChunkSVForwardIndexWriterV4.VERSION
+        ? new VarByteChunkSVForwardIndexWriter(file, compressionType, totalDocs, numDocsPerChunk, totalMaxLength,
+        writerVersion)
+        : new VarByteChunkSVForwardIndexWriterV4(file, compressionType, TARGET_MAX_CHUNK_SIZE);
     _valueType = valueType;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/SingleValueVarByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/SingleValueVarByteRawIndexCreator.java
@@ -23,6 +23,8 @@ import java.io.File;
 import java.io.IOException;
 import org.apache.pinot.segment.local.io.writer.impl.BaseChunkSVForwardIndexWriter;
 import org.apache.pinot.segment.local.io.writer.impl.VarByteChunkSVForwardIndexWriter;
+import org.apache.pinot.segment.local.io.writer.impl.VarByteChunkSVForwardIndexWriterV4;
+import org.apache.pinot.segment.local.io.writer.impl.VarByteChunkWriter;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
 import org.apache.pinot.segment.spi.index.creator.ForwardIndexCreator;
@@ -37,7 +39,7 @@ public class SingleValueVarByteRawIndexCreator implements ForwardIndexCreator {
   private static final int DEFAULT_NUM_DOCS_PER_CHUNK = 1000;
   private static final int TARGET_MAX_CHUNK_SIZE = 1024 * 1024;
 
-  private final VarByteChunkSVForwardIndexWriter _indexWriter;
+  private final VarByteChunkWriter _indexWriter;
   private final DataType _valueType;
 
   /**
@@ -74,8 +76,10 @@ public class SingleValueVarByteRawIndexCreator implements ForwardIndexCreator {
       throws IOException {
     File file = new File(baseIndexDir, column + V1Constants.Indexes.RAW_SV_FORWARD_INDEX_FILE_EXTENSION);
     int numDocsPerChunk = deriveNumDocsPerChunk ? getNumDocsPerChunk(maxLength) : DEFAULT_NUM_DOCS_PER_CHUNK;
-    _indexWriter = new VarByteChunkSVForwardIndexWriter(file, compressionType, totalDocs, numDocsPerChunk, maxLength,
-        writerVersion);
+    _indexWriter = writerVersion < VarByteChunkSVForwardIndexWriterV4.VERSION
+        ? new VarByteChunkSVForwardIndexWriter(file, compressionType, totalDocs, numDocsPerChunk, maxLength,
+        writerVersion)
+        : new VarByteChunkSVForwardIndexWriterV4(file, compressionType, TARGET_MAX_CHUNK_SIZE);
     _valueType = valueType;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/BaseChunkSVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/BaseChunkSVForwardIndexReader.java
@@ -77,7 +77,7 @@ public abstract class BaseChunkSVForwardIndexReader
       _dataBuffer.getInt(headerOffset); // Total docs
       headerOffset += Integer.BYTES;
 
-      ChunkCompressionType compressionType = ChunkCompressionType.values()[_dataBuffer.getInt(headerOffset)];
+      ChunkCompressionType compressionType = ChunkCompressionType.valueOf(_dataBuffer.getInt(headerOffset));
       _chunkDecompressor = ChunkCompressorFactory.getDecompressor(compressionType);
       _isCompressed = !compressionType.equals(ChunkCompressionType.PASS_THROUGH);
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkSVForwardIndexReaderV4.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkSVForwardIndexReaderV4.java
@@ -1,0 +1,299 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.readers.forward;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.local.io.compression.ChunkCompressorFactory;
+import org.apache.pinot.segment.local.io.writer.impl.VarByteChunkSVForwardIndexWriterV4;
+import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
+import org.apache.pinot.segment.spi.compression.ChunkDecompressor;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
+import org.apache.pinot.segment.spi.memory.CleanerUtil;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class VarByteChunkSVForwardIndexReaderV4
+    implements ForwardIndexReader<VarByteChunkSVForwardIndexReaderV4.ReaderContext> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(VarByteChunkSVForwardIndexReaderV4.class);
+
+  private static final int METADATA_ENTRY_SIZE = 8;
+
+  private final FieldSpec.DataType _valueType;
+  private final int _targetDecompressedChunkSize;
+  private final ChunkDecompressor _chunkDecompressor;
+  private final ChunkCompressionType _chunkCompressionType;
+
+  private final PinotDataBuffer _metadata;
+  private final PinotDataBuffer _chunks;
+
+  public VarByteChunkSVForwardIndexReaderV4(PinotDataBuffer dataBuffer, FieldSpec.DataType valueType) {
+    if (dataBuffer.getInt(0) < VarByteChunkSVForwardIndexWriterV4.VERSION) {
+      throw new IllegalStateException("version " + dataBuffer.getInt(0) + " < "
+          + VarByteChunkSVForwardIndexWriterV4.VERSION);
+    }
+    _valueType = valueType;
+    _targetDecompressedChunkSize = dataBuffer.getInt(4);
+    _chunkCompressionType = ChunkCompressionType.valueOf(dataBuffer.getInt(8));
+    _chunkDecompressor = ChunkCompressorFactory.getDecompressor(_chunkCompressionType);
+    int chunksOffset = dataBuffer.getInt(12);
+    // the file has a BE header for compatability reasons (version selection) but the content is LE
+    _metadata = dataBuffer.view(16, chunksOffset, ByteOrder.LITTLE_ENDIAN);
+    _chunks = dataBuffer.view(chunksOffset, dataBuffer.size(), ByteOrder.LITTLE_ENDIAN);
+  }
+
+  @Override
+  public boolean isDictionaryEncoded() {
+    return false;
+  }
+
+  @Override
+  public boolean isSingleValue() {
+    return true;
+  }
+
+  @Override
+  public FieldSpec.DataType getValueType() {
+    return _valueType;
+  }
+
+  @Override
+  public String getString(int docId, ReaderContext context) {
+    return new String(context.getValue(docId), StandardCharsets.UTF_8);
+  }
+
+  @Override
+  public byte[] getBytes(int docId, ReaderContext context) {
+    return context.getValue(docId);
+  }
+
+  @Nullable
+  @Override
+  public ReaderContext createContext() {
+    return _chunkCompressionType == ChunkCompressionType.PASS_THROUGH
+        ? new UncompressedReaderContext(_chunks, _metadata)
+        : new CompressedReaderContext(_metadata, _chunks, _chunkDecompressor, _chunkCompressionType,
+            _targetDecompressedChunkSize);
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+  }
+
+  public static abstract class ReaderContext implements ForwardIndexReaderContext {
+
+    protected final PinotDataBuffer _chunks;
+    protected final PinotDataBuffer _metadata;
+    protected int _docIdOffset;
+    protected int _nextDocIdOffset;
+    protected boolean _regularChunk;
+    protected int _numDocsInCurrentChunk;
+
+    protected ReaderContext(PinotDataBuffer metadata, PinotDataBuffer chunks) {
+      _chunks = chunks;
+      _metadata = metadata;
+    }
+
+    public byte[] getValue(int docId) {
+      if (docId >= _docIdOffset && docId < _nextDocIdOffset) {
+        return readSmallUncompressedValue(docId);
+      } else {
+        try {
+          return decompressAndRead(docId);
+        } catch (IOException e) {
+          LOGGER.error("Exception caught while decompressing data chunk", e);
+          throw new RuntimeException(e);
+        }
+      }
+    }
+
+    protected long chunkIndexFor(int docId) {
+      long low = 0;
+      long high = (_metadata.size() / METADATA_ENTRY_SIZE) - 1;
+      while (low <= high) {
+        long mid = (low + high) >>> 1;
+        long position = mid * METADATA_ENTRY_SIZE;
+        int midDocId = _metadata.getInt(position) & 0x7FFFFFFF;
+        if (midDocId < docId) {
+          low = mid + 1;
+        } else if (midDocId > docId) {
+          high = mid - 1;
+        } else {
+          return position;
+        }
+      }
+      return (low - 1) * METADATA_ENTRY_SIZE;
+    }
+
+    protected abstract byte[] processChunkAndReadFirstValue(int docId, long offset, long limit)
+        throws IOException;
+
+    protected abstract byte[] readSmallUncompressedValue(int docId);
+
+    private byte[] decompressAndRead(int docId)
+        throws IOException {
+      long metadataEntry = chunkIndexFor(docId);
+      int info = _metadata.getInt(metadataEntry);
+      _docIdOffset = info & 0x7FFFFFFF;
+      _regularChunk = _docIdOffset == info;
+      long offset = _metadata.getInt(metadataEntry + Integer.BYTES) & 0xFFFFFFFFL;
+      long limit;
+      if (_metadata.size() - METADATA_ENTRY_SIZE > metadataEntry) {
+        _nextDocIdOffset = _metadata.getInt(metadataEntry + METADATA_ENTRY_SIZE) & 0x7FFFFFFF;
+        limit = _metadata.getInt(metadataEntry + METADATA_ENTRY_SIZE + Integer.BYTES) & 0xFFFFFFFFL;
+      } else {
+        _nextDocIdOffset = Integer.MAX_VALUE;
+        limit = _chunks.size();
+      }
+      return processChunkAndReadFirstValue(docId, offset, limit);
+    }
+  }
+
+  private static final class UncompressedReaderContext extends ReaderContext {
+
+    private ByteBuffer _chunk;
+
+    UncompressedReaderContext(PinotDataBuffer metadata, PinotDataBuffer chunks) {
+      super(chunks, metadata);
+    }
+
+    @Override
+    protected byte[] processChunkAndReadFirstValue(int docId, long offset, long limit) {
+      _chunk = _chunks.toDirectByteBuffer(offset, (int) (limit - offset));
+      if (!_regularChunk) {
+        return readHugeValue();
+      }
+      _numDocsInCurrentChunk = _chunk.getInt(0);
+      return readSmallUncompressedValue(docId);
+    }
+
+    private byte[] readHugeValue() {
+      byte[] value = new byte[_chunk.capacity()];
+      _chunk.get(value);
+      return value;
+    }
+
+    @Override
+    protected byte[] readSmallUncompressedValue(int docId) {
+      int index = docId - _docIdOffset;
+      int offset = _chunk.getInt((index + 1) * Integer.BYTES);
+      int nextOffset = index == _numDocsInCurrentChunk - 1
+          ? _chunk.limit()
+          : _chunk.getInt((index + 2) * Integer.BYTES);
+      ByteBuffer view = _chunk.duplicate();
+      view.position(offset);
+      view.order(ByteOrder.LITTLE_ENDIAN);
+      byte[] bytes = new byte[nextOffset - offset];
+      view.get(bytes);
+      return bytes;
+    }
+
+    @Override
+    public void close()
+        throws IOException {
+    }
+  }
+
+  private static final class CompressedReaderContext extends ReaderContext {
+
+    private final ByteBuffer _decompressedBuffer;
+    private final ChunkDecompressor _chunkDecompressor;
+    private final ChunkCompressionType _chunkCompressionType;
+
+    CompressedReaderContext(PinotDataBuffer metadata, PinotDataBuffer chunks, ChunkDecompressor chunkDecompressor,
+        ChunkCompressionType chunkCompressionType, int targetChunkSize) {
+      super(metadata, chunks);
+      _chunkDecompressor = chunkDecompressor;
+      _chunkCompressionType = chunkCompressionType;
+      _decompressedBuffer = ByteBuffer.allocateDirect(targetChunkSize).order(ByteOrder.LITTLE_ENDIAN);
+    }
+
+    @Override
+    protected byte[] processChunkAndReadFirstValue(int docId, long offset, long limit)
+        throws IOException {
+      _decompressedBuffer.clear();
+      ByteBuffer compressed = _chunks.toDirectByteBuffer(offset, (int) (limit - offset));
+      int decompressedLength = _chunkDecompressor.decompressedLength(compressed);
+      if (_regularChunk) {
+        _chunkDecompressor.decompress(compressed, _decompressedBuffer);
+        _numDocsInCurrentChunk = _decompressedBuffer.getInt(0);
+        return readSmallUncompressedValue(docId);
+      }
+      // huge value, no benefit from buffering, return the whole thing
+      return readHugeCompressedValue(compressed, decompressedLength);
+    }
+
+    @Override
+    protected byte[] readSmallUncompressedValue(int docId) {
+      int index = docId - _docIdOffset;
+      int offset = _decompressedBuffer.getInt((index + 1) * Integer.BYTES);
+      int nextOffset = index == _numDocsInCurrentChunk - 1
+          ? _decompressedBuffer.limit()
+          : _decompressedBuffer.getInt((index + 2) * Integer.BYTES);
+      ByteBuffer view = _decompressedBuffer.duplicate();
+      view.position(offset);
+      view.order(ByteOrder.LITTLE_ENDIAN);
+      byte[] bytes = new byte[nextOffset - offset];
+      view.get(bytes);
+      return bytes;
+    }
+
+    private byte[] readHugeCompressedValue(ByteBuffer compressed, int decompressedLength)
+        throws IOException {
+      // huge values don't have length prefixes; they occupy the entire chunk so are unambiguous
+      byte[] value = new byte[decompressedLength];
+      if (_chunkCompressionType == ChunkCompressionType.SNAPPY
+          || _chunkCompressionType == ChunkCompressionType.ZSTANDARD) {
+        // snappy and zstandard don't work without direct buffers
+        decompressViaDirectBuffer(compressed, value);
+      } else {
+        _chunkDecompressor.decompress(compressed, ByteBuffer.wrap(value).order(ByteOrder.LITTLE_ENDIAN));
+      }
+      return value;
+    }
+
+    private void decompressViaDirectBuffer(ByteBuffer compressed, byte[] target)
+        throws IOException {
+      ByteBuffer buffer = ByteBuffer.allocateDirect(target.length).order(ByteOrder.LITTLE_ENDIAN);
+      try {
+        _chunkDecompressor.decompress(compressed, buffer);
+        buffer.get(target);
+      } finally {
+        if (CleanerUtil.UNMAP_SUPPORTED) {
+          CleanerUtil.getCleaner().freeBuffer(buffer);
+        }
+      }
+    }
+
+    @Override
+    public void close()
+        throws IOException {
+      CleanerUtil.cleanQuietly(_decompressedBuffer);
+    }
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/VarByteChunkV4Test.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/VarByteChunkV4Test.java
@@ -46,8 +46,7 @@ import static org.testng.Assert.assertEquals;
 
 public class VarByteChunkV4Test {
 
-  private static final String DIR_NAME = System.getProperty("java.io.tmpdir") + File.separator
-      + "VarByteChunkV4Test";
+  private static final File TEST_DIR = new File(FileUtils.getTempDirectory(), "VarByteChunkV4Test");
 
   private File _file;
 
@@ -70,12 +69,12 @@ public class VarByteChunkV4Test {
   @BeforeClass
   public void forceMkDir()
       throws IOException {
-    FileUtils.forceMkdir(new File(DIR_NAME));
+    FileUtils.forceMkdir(TEST_DIR);
   }
 
   @AfterClass
   public void deleteDir() {
-    FileUtils.deleteQuietly(new File(DIR_NAME));
+    FileUtils.deleteQuietly(TEST_DIR);
   }
 
   @AfterMethod
@@ -88,7 +87,7 @@ public class VarByteChunkV4Test {
   @Test(dataProvider = "params")
   public void testStringSV(ChunkCompressionType compressionType, int longestEntry, int chunkSize)
       throws IOException {
-    _file = new File(DIR_NAME, "testStringSV");
+    _file = new File(TEST_DIR, "testStringSV");
     testSV(compressionType, longestEntry, chunkSize, FieldSpec.DataType.STRING, x -> x,
         VarByteChunkSVForwardIndexWriterV4::putString, (reader, context, docId) -> reader.getString(docId, context));
   }
@@ -96,7 +95,7 @@ public class VarByteChunkV4Test {
   @Test(dataProvider = "params")
   public void testBytesSV(ChunkCompressionType compressionType, int longestEntry, int chunkSize)
       throws IOException {
-    _file = new File(DIR_NAME, "testBytesSV");
+    _file = new File(TEST_DIR, "testBytesSV");
     testSV(compressionType, longestEntry, chunkSize, FieldSpec.DataType.BYTES, x -> x.getBytes(StandardCharsets.UTF_8),
         VarByteChunkSVForwardIndexWriterV4::putBytes, (reader, context, docId) -> reader.getBytes(docId, context));
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/VarByteChunkV4Test.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/VarByteChunkV4Test.java
@@ -1,0 +1,182 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.creator;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.io.writer.impl.VarByteChunkSVForwardIndexWriterV4;
+import org.apache.pinot.segment.local.segment.index.readers.forward.VarByteChunkSVForwardIndexReaderV4;
+import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+
+public class VarByteChunkV4Test {
+
+  private static final String DIR_NAME = System.getProperty("java.io.tmpdir") + File.separator
+      + "VarByteChunkV4Test";
+
+  private File _file;
+
+  @DataProvider
+  public Object[][] params() {
+    return new Object[][]{
+        {ChunkCompressionType.LZ4, 20, 1024},
+        {ChunkCompressionType.LZ4_LENGTH_PREFIXED, 20, 1024},
+        {ChunkCompressionType.PASS_THROUGH, 20, 1024},
+        {ChunkCompressionType.SNAPPY, 20, 1024},
+        {ChunkCompressionType.ZSTANDARD, 20, 1024},
+        {ChunkCompressionType.LZ4, 2048, 1024},
+        {ChunkCompressionType.LZ4_LENGTH_PREFIXED, 2048, 1024},
+        {ChunkCompressionType.PASS_THROUGH, 2048, 1024},
+        {ChunkCompressionType.SNAPPY, 2048, 1024},
+        {ChunkCompressionType.ZSTANDARD, 2048, 1024}
+    };
+  }
+
+  @BeforeClass
+  public void forceMkDir()
+      throws IOException {
+    FileUtils.forceMkdir(new File(DIR_NAME));
+  }
+
+  @AfterClass
+  public void deleteDir() {
+    FileUtils.deleteQuietly(new File(DIR_NAME));
+  }
+
+  @AfterMethod
+  public void after() {
+    if (_file != null) {
+      FileUtils.deleteQuietly(_file);
+    }
+  }
+
+  @Test(dataProvider = "params")
+  public void testStringSV(ChunkCompressionType compressionType, int longestEntry, int chunkSize)
+      throws IOException {
+    _file = new File(DIR_NAME, "testStringSV");
+    testSV(compressionType, longestEntry, chunkSize, FieldSpec.DataType.STRING, x -> x,
+        (writer, value) -> {
+          try {
+            writer.writeString(value);
+          } catch (IOException e) {
+            fail("write failed", e);
+          }
+        }, (reader, context, docId) -> reader.getString(docId, context));
+  }
+
+  @Test(dataProvider = "params")
+  public void testBytesSV(ChunkCompressionType compressionType, int longestEntry, int chunkSize)
+      throws IOException {
+    _file = new File(DIR_NAME, "testBytesSV");
+    testSV(compressionType, longestEntry, chunkSize, FieldSpec.DataType.BYTES, x -> x.getBytes(StandardCharsets.UTF_8),
+        (writer, value) -> {
+          try {
+            writer.writeBytes(value);
+          } catch (IOException e) {
+            fail("write failed", e);
+          }
+        }, (reader, context, docId) -> reader.getBytes(docId, context));
+  }
+
+  private <T> void testSV(ChunkCompressionType compressionType, int longestEntry, int chunkSize,
+      FieldSpec.DataType dataType, Function<String, T> forwardMapper,
+      BiConsumer<VarByteChunkSVForwardIndexWriterV4, T> write,
+      Read<T> read)
+      throws IOException {
+    List<T> values = randomStrings(1000, longestEntry).map(forwardMapper).collect(Collectors.toList());
+    try (VarByteChunkSVForwardIndexWriterV4 writer = new VarByteChunkSVForwardIndexWriterV4(_file, compressionType,
+        chunkSize)) {
+      for (T value : values) {
+        write.accept(writer, value);
+      }
+    }
+    try (PinotDataBuffer buffer = PinotDataBuffer.mapReadOnlyBigEndianFile(_file)) {
+      try (VarByteChunkSVForwardIndexReaderV4 reader = new VarByteChunkSVForwardIndexReaderV4(buffer, dataType);
+          VarByteChunkSVForwardIndexReaderV4.ReaderContext context = reader.createContext()) {
+        for (int i = 0; i < values.size(); i++) {
+          assertEquals(read.read(reader, context, i), values.get(i));
+        }
+        for (int i = 0; i < values.size(); i += 2) {
+          assertEquals(read.read(reader, context, i), values.get(i));
+        }
+        for (int i = 1; i < values.size(); i += 2) {
+          assertEquals(read.read(reader, context, i), values.get(i));
+        }
+        for (int i = 1; i < values.size(); i += 100) {
+          assertEquals(read.read(reader, context, i), values.get(i));
+        }
+        for (int i = values.size() - 1; i >= 0; i--) {
+          assertEquals(read.read(reader, context, i), values.get(i));
+        }
+        for (int i = values.size() - 1; i >= 0; i -= 2) {
+          assertEquals(read.read(reader, context, i), values.get(i));
+        }
+        for (int i = values.size() - 2; i >= 0; i -= 2) {
+          assertEquals(read.read(reader, context, i), values.get(i));
+        }
+        for (int i = values.size() - 1; i >= 0; i -= 100) {
+          assertEquals(read.read(reader, context, i), values.get(i));
+        }
+      }
+    }
+  }
+
+  private Stream<String> randomStrings(int count, int lengthOfLongestEntry) {
+    Random r = new Random(42);
+    return IntStream.range(0, count)
+        .mapToObj(i -> {
+          int length = r.nextInt(lengthOfLongestEntry);
+          byte[] bytes = new byte[length];
+          if (length != 0) {
+            bytes[bytes.length - 1] = 'c';
+            if (length > 2) {
+              Arrays.fill(bytes, 1, bytes.length - 1, (byte) 'b');
+            }
+            bytes[0] = 'a';
+          }
+          return new String(bytes, StandardCharsets.UTF_8);
+        });
+  }
+
+  @FunctionalInterface
+  interface Read<T> {
+    T read(VarByteChunkSVForwardIndexReaderV4 reader, VarByteChunkSVForwardIndexReaderV4.ReaderContext context,
+        int docId);
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/compression/ChunkCompressionType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/compression/ChunkCompressionType.java
@@ -21,6 +21,8 @@ package org.apache.pinot.segment.spi.compression;
 public enum ChunkCompressionType {
   PASS_THROUGH(0), SNAPPY(1), ZSTANDARD(2), LZ4(3), LZ4_LENGTH_PREFIXED(4);
 
+  private static final ChunkCompressionType[] VALUES = values();
+
   private final int _value;
 
   ChunkCompressionType(int value) {
@@ -29,5 +31,12 @@ public enum ChunkCompressionType {
 
   public int getValue() {
     return _value;
+  }
+
+  public static ChunkCompressionType valueOf(int ordinal) {
+    if (ordinal < 0 || ordinal >= VALUES.length) {
+      throw new IllegalArgumentException("invalid ordinal " + ordinal);
+    }
+    return VALUES[ordinal];
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/CleanerUtil.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/CleanerUtil.java
@@ -175,6 +175,16 @@ public final class CleanerUtil {
     };
   }
 
+  public static void cleanQuietly(ByteBuffer buffer) {
+    if (UNMAP_SUPPORTED && buffer != null && buffer.isDirect()) {
+      try {
+        getCleaner().freeBuffer(buffer);
+      } catch (IOException e) {
+        LOGGER.debug("failed to clean buffer", e);
+      }
+    }
+  }
+
   /**
    * Pass in an implementation of this interface to cleanup ByteBuffers.
    * CleanerUtil implements this to allow unmapping of bytebuffers


### PR DESCRIPTION
## Description

Implements #7616.

This PR aims to handle variable length data better than the existing raw index chunk format. It does this by allowing the user to choose a chunk size (default = 1MB) but allows a variable number of values per chunk. The file consists of:

* A 16 byte header, which is big endian for backwards compatibility
    * the version
    * the target chunk size (which allows the reader to size a buffer for the common case)
    * the compression type
    * the offset to the start of the chunks
* 8 bytes of metadata for each chunk
    * the first docId in the chunk (sorted). The MSB of the docId offset is used to mark huge chunks.
    * the byte offset of the chunk. This is an unsigned 32 bit integer supporting up to 4GB of compressed data
* The chunks. There are two kinds of chunk:
    * regular chunks have the same format as chunks in older versions: integer length prefix, followed by N offsets for each of the N values in the chunk
    * huge chunks just have a raw value, and can be identified by the MSB of the doc offset.

The docId resolution algorithm on the reader side is as follows:

1. Perform binary search for docId in docId offsets to locate chunk. 
    * If docId in range of current chunk in reader context, go to 5
2. Check if chunk is huge or regular
3. If huge, just allocate space for the value, decompress the value if necessary, and return it
4. If regular, decompress the chunk into a preallocated buffer
5. If regular, find value in constant time by subtracting docIdOffset from docId and reading Nth value (the length is determined by the next offset or the limit of the buffer as usual)

The format supports entirely incremental construction (does not require segment level statistics) so can be used for real time, and requires bounded, sublinear memory for buffering.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
