### PR TITLE
Add revertSegmentReplacement API

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/lineage/LineageEntryState.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/lineage/LineageEntryState.java
@@ -22,5 +22,5 @@ package org.apache.pinot.common.lineage;
  * Enum for represent the state of lineage entry
  */
 public enum LineageEntryState {
-  IN_PROGRESS, COMPLETED
+  IN_PROGRESS, COMPLETED, REVERTED
 }


### PR DESCRIPTION
When all the segmentsFrom are 'ONLINE' state, this new API allows
to revert the segment replacement and use the original segments
when routing the query. This will be useful when the bad data
gets pushed and wants to go back to the previous state quickly.