### PR TITLE
Move HelixManager initialization to init

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -176,6 +176,11 @@ public abstract class BaseServerStarter implements ServiceStartable {
     // Set data table version send to broker.
     DataTableBuilder.setCurrentDataTableVersion(_serverConf
         .getProperty(Server.CONFIG_OF_CURRENT_DATA_TABLE_VERSION, Server.DEFAULT_CURRENT_DATA_TABLE_VERSION));
+
+    LOGGER.info("Initializing Helix manager with zkAddress: {}, clusterName: {}, instanceId: {}", _zkAddress,
+        _helixClusterName, _instanceId);
+    _helixManager =
+        HelixManagerFactory.getZKHelixManager(_helixClusterName, _instanceId, InstanceType.PARTICIPANT, _zkAddress);
   }
 
   /**
@@ -368,11 +373,6 @@ public abstract class BaseServerStarter implements ServiceStartable {
       LOGGER.info("Installing default SSL context for any client requests");
       TlsUtils.installDefaultSSLSocketFactory(tlsDefaults);
     }
-
-    LOGGER.info("Initializing Helix manager with zkAddress: {}, clusterName: {}, instanceId: {}", _zkAddress,
-        _helixClusterName, _instanceId);
-    _helixManager =
-        HelixManagerFactory.getZKHelixManager(_helixClusterName, _instanceId, InstanceType.PARTICIPANT, _zkAddress);
 
     LOGGER.info("Initializing server instance and registering state model factory");
     Utils.logVersions();


### PR DESCRIPTION
This gives the implementations of this class a reliable place between it being initialized and it being used