### PR TITLE
Add table name with type to segment directory configs

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -112,7 +112,10 @@ public class ImmutableSegmentLoader {
 
     // Load the segment again for the configured tier backend. Default is 'local'.
     PinotConfiguration tierConfigs = indexLoadingConfig.getTierConfigs();
-    PinotConfiguration segDirConfigs = new PinotConfiguration(tierConfigs.toMap());
+    Map<String, Object> segDirConfigMap = tierConfigs.toMap();
+    segDirConfigMap.put(IndexLoadingConfig.TABLE_NAME_WITH_TYPE_KEY,
+        indexLoadingConfig.getTableConfig().getTableName());
+    PinotConfiguration segDirConfigs = new PinotConfiguration(segDirConfigMap);
     SegmentDirectory actualSegmentDirectory =
         SegmentDirectoryLoaderRegistry.getSegmentDirectoryLoader(indexLoadingConfig.getTierBackend())
             .load(indexDir.toURI(), segDirConfigs);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -116,7 +116,7 @@ public class ImmutableSegmentLoader {
     if (indexLoadingConfig.getTableNameWithType() != null) {
       segDirConfigMap.put(IndexLoadingConfig.TABLE_NAME_WITH_TYPE_KEY, indexLoadingConfig.getTableNameWithType());
     }
-    PinotConfiguration segDirConfigs = new PinotConfiguration(tierConfigs.toMap());
+    PinotConfiguration segDirConfigs = new PinotConfiguration(segDirConfigMap);
     SegmentDirectory actualSegmentDirectory =
         SegmentDirectoryLoaderRegistry.getSegmentDirectoryLoader(indexLoadingConfig.getTierBackend())
             .load(indexDir.toURI(), segDirConfigs);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -113,9 +113,10 @@ public class ImmutableSegmentLoader {
     // Load the segment again for the configured tier backend. Default is 'local'.
     PinotConfiguration tierConfigs = indexLoadingConfig.getTierConfigs();
     Map<String, Object> segDirConfigMap = tierConfigs.toMap();
-    segDirConfigMap.put(IndexLoadingConfig.TABLE_NAME_WITH_TYPE_KEY,
-        indexLoadingConfig.getTableConfig().getTableName());
-    PinotConfiguration segDirConfigs = new PinotConfiguration(segDirConfigMap);
+    if (indexLoadingConfig.getTableNameWithType() != null) {
+      segDirConfigMap.put(IndexLoadingConfig.TABLE_NAME_WITH_TYPE_KEY, indexLoadingConfig.getTableNameWithType());
+    }
+    PinotConfiguration segDirConfigs = new PinotConfiguration(tierConfigs.toMap());
     SegmentDirectory actualSegmentDirectory =
         SegmentDirectoryLoaderRegistry.getSegmentDirectoryLoader(indexLoadingConfig.getTierBackend())
             .load(indexDir.toURI(), segDirConfigs);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -49,6 +49,7 @@ import org.apache.pinot.spi.utils.ReadMode;
 public class IndexLoadingConfig {
   private static final int DEFAULT_REALTIME_AVG_MULTI_VALUE_COUNT = 2;
   public static final String DEFAULT_TIER_BACKEND = "local";
+  public static final String TABLE_NAME_WITH_TYPE_KEY = "tableNameWithType";
 
   private ReadMode _readMode = ReadMode.DEFAULT_MODE;
   private List<String> _sortedColumns = Collections.emptyList();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -51,6 +51,7 @@ public class IndexLoadingConfig {
   public static final String DEFAULT_TIER_BACKEND = "local";
   public static final String TABLE_NAME_WITH_TYPE_KEY = "tableNameWithType";
 
+  private String _tableNameWithType;
   private ReadMode _readMode = ReadMode.DEFAULT_MODE;
   private List<String> _sortedColumns = Collections.emptyList();
   private Set<String> _invertedIndexColumns = new HashSet<>();
@@ -92,6 +93,7 @@ public class IndexLoadingConfig {
   }
 
   private void extractFromTableConfig(TableConfig tableConfig) {
+    _tableNameWithType = tableConfig.getTableName();
     IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
     String tableReadMode = indexingConfig.getLoadMode();
     if (tableReadMode != null) {
@@ -255,6 +257,10 @@ public class IndexLoadingConfig {
    * For tests only.
    */
   public IndexLoadingConfig() {
+  }
+
+  public String getTableNameWithType() {
+    return _tableNameWithType;
   }
 
   public ReadMode getReadMode() {


### PR DESCRIPTION
The SegmentDirectoryLoader.load only gets the segment's indexDirURI and segmentDirectoryConfigs. The segment metadata from the segment is not sufficient to get the full table name (table name can be totally different in the metadata, and can be only rawTableName typically). Only way to know full table name there is by sending it in the segmentDirectoryConfigs.