### PR TITLE
Add getIndexSegment() to the Operator interface

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/Operator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/Operator.java
@@ -19,9 +19,12 @@
 package org.apache.pinot.core.common;
 
 import org.apache.pinot.core.operator.ExecutionStatistics;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.exception.EarlyTerminationException;
 
 
+@InterfaceAudience.Private
 public interface Operator<T extends Block> {
 
   /**
@@ -36,5 +39,25 @@ public interface Operator<T extends Block> {
    */
   T nextBlock();
 
-  ExecutionStatistics getExecutionStatistics();
+  /**
+   * Returns the name of the operator.
+   * NOTE: This method is called for tracing purpose. The sub-class should try to return a constant to avoid the
+   * unnecessary overhead.
+   */
+  String getOperatorName();
+
+  /**
+   * Returns the index segment associated with the operator.
+   */
+  default IndexSegment getIndexSegment() {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Returns the execution statistics associated with the operator. This method should be called after the operator has
+   * finished execution.
+   */
+  default ExecutionStatistics getExecutionStatistics() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/AcquireReleaseColumnsSegmentOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/AcquireReleaseColumnsSegmentOperator.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.core.operator;
 
-import org.apache.pinot.core.common.Block;
 import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.plan.PlanNode;
 import org.apache.pinot.segment.spi.FetchContext;
 import org.apache.pinot.segment.spi.IndexSegment;
@@ -35,13 +35,15 @@ import org.apache.pinot.segment.spi.IndexSegment;
  * The reason this is done is the planners access segment buffers,
  * and we need to acquire the segment before any access is made to the buffers.
  */
-public class AcquireReleaseColumnsSegmentOperator extends BaseOperator {
+@SuppressWarnings("unchecked")
+public class AcquireReleaseColumnsSegmentOperator extends BaseOperator<IntermediateResultsBlock> {
   private static final String OPERATOR_NAME = "AcquireReleaseColumnsSegmentOperator";
 
   private final PlanNode _planNode;
   private final IndexSegment _indexSegment;
   private final FetchContext _fetchContext;
-  private Operator _childOperator;
+
+  private Operator<IntermediateResultsBlock> _childOperator;
 
   public AcquireReleaseColumnsSegmentOperator(PlanNode planNode, IndexSegment indexSegment, FetchContext fetchContext) {
     _planNode = planNode;
@@ -53,8 +55,8 @@ public class AcquireReleaseColumnsSegmentOperator extends BaseOperator {
    * Runs the planNode to get the childOperator, and then proceeds with execution.
    */
   @Override
-  protected Block getNextBlock() {
-    _childOperator = _planNode.run();
+  protected IntermediateResultsBlock getNextBlock() {
+    _childOperator = (Operator<IntermediateResultsBlock>) _planNode.run();
     return _childOperator.nextBlock();
   }
 
@@ -75,6 +77,11 @@ public class AcquireReleaseColumnsSegmentOperator extends BaseOperator {
   @Override
   public String getOperatorName() {
     return OPERATOR_NAME;
+  }
+
+  @Override
+  public IndexSegment getIndexSegment() {
+    return _indexSegment;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/BaseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/BaseOperator.java
@@ -52,13 +52,4 @@ public abstract class BaseOperator<T extends Block> implements Operator<T> {
 
   // Make it protected because we should always call nextBlock()
   protected abstract T getNextBlock();
-
-  // Enforcing sub-class to implement the getOperatorName(), as they can just return a static final,
-  // as opposed to this super class calling getClass().getSimpleName().
-  public abstract String getOperatorName();
-
-  @Override
-  public ExecutionStatistics getExecutionStatistics() {
-    throw new UnsupportedOperationException();
-  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
@@ -34,7 +34,6 @@ import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
-import org.apache.pinot.core.operator.query.SelectionOrderByOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
@@ -82,8 +81,8 @@ public class MinMaxValueBasedSelectionOrderByCombineOperator extends BaseCombine
     String firstOrderByColumn = firstOrderByExpression.getExpression().getIdentifier();
 
     _minMaxValueContexts = new ArrayList<>(_numOperators);
-    for (Operator operator : _operators) {
-      _minMaxValueContexts.add(new MinMaxValueContext((SelectionOrderByOperator) operator, firstOrderByColumn));
+    for (Operator<IntermediateResultsBlock> operator : _operators) {
+      _minMaxValueContexts.add(new MinMaxValueContext(operator, firstOrderByColumn));
     }
     if (firstOrderByExpression.isAsc()) {
       // For ascending order, sort on column min value in ascending order
@@ -289,11 +288,11 @@ public class MinMaxValueBasedSelectionOrderByCombineOperator extends BaseCombine
   }
 
   private static class MinMaxValueContext {
-    final SelectionOrderByOperator _operator;
+    final Operator<IntermediateResultsBlock> _operator;
     final Comparable _minValue;
     final Comparable _maxValue;
 
-    MinMaxValueContext(SelectionOrderByOperator operator, String column) {
+    MinMaxValueContext(Operator<IntermediateResultsBlock> operator, String column) {
       _operator = operator;
       DataSourceMetadata dataSourceMetadata = operator.getIndexSegment().getDataSource(column).getDataSourceMetadata();
       _minValue = dataSourceMetadata.getMinValue();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DistinctOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DistinctOperator.java
@@ -74,6 +74,11 @@ public class DistinctOperator extends BaseOperator<IntermediateResultsBlock> {
   }
 
   @Override
+  public IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
   public ExecutionStatistics getExecutionStatistics() {
     long numEntriesScannedInFilter = _transformOperator.getExecutionStatistics().getNumEntriesScannedInFilter();
     long numEntriesScannedPostFilter = (long) _numDocsScanned * _transformOperator.getNumColumnsProjected();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOnlyOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOnlyOperator.java
@@ -100,6 +100,11 @@ public class SelectionOnlyOperator extends BaseOperator<IntermediateResultsBlock
   }
 
   @Override
+  public IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
   public ExecutionStatistics getExecutionStatistics() {
     long numEntriesScannedInFilter = _transformOperator.getExecutionStatistics().getNumEntriesScannedInFilter();
     long numEntriesScannedPostFilter = (long) _numDocsScanned * _transformOperator.getNumColumnsProjected();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
@@ -163,10 +163,6 @@ public class SelectionOrderByOperator extends BaseOperator<IntermediateResultsBl
     };
   }
 
-  public IndexSegment getIndexSegment() {
-    return _indexSegment;
-  }
-
   @Override
   protected IntermediateResultsBlock getNextBlock() {
     if (_expressions.size() == _orderByExpressions.size()) {
@@ -316,6 +312,11 @@ public class SelectionOrderByOperator extends BaseOperator<IntermediateResultsBl
   @Override
   public String getOperatorName() {
     return OPERATOR_NAME;
+  }
+
+  @Override
+  public IndexSegment getIndexSegment() {
+    return _indexSegment;
   }
 
   @Override


### PR DESCRIPTION
## Description
Add `getIndexSegment()` to the `Operator` interface, which can be implemented by the single-segment operators.
Make `MinMaxValueBasedSelectionOrderByCombineOperator` to use the interface api instead of casting the operator class so that the logic can be applied to different operators.