### PR TITLE
add Metadata SPI interfaces and pinot-metadata module

### DIFF
--- a/pinot-plugins/pinot-system-metadata/pinot-system-metadata-common/pom.xml
+++ b/pinot-plugins/pinot-system-metadata/pinot-system-metadata-common/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>pinot-metadata</artifactId>
+    <groupId>org.apache.pinot</groupId>
+    <version>0.9.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <artifactId>pinot-system-metadata-common</artifactId>
+  <name>Pinot Local Metadata Store</name>
+  <url>https://pinot.apache.org/</url>
+  <properties>
+    <pinot.root>${basedir}/../../..</pinot.root>
+    <phase.prop>package</phase.prop>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-spi</artifactId>
+    </dependency>
+
+    <!-- Test Dependencies -->
+    <dependency>
+      <groupId>org.xerial</groupId>
+      <artifactId>sqlite-jdbc</artifactId>
+      <version>3.36.0.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/pinot-plugins/pinot-system-metadata/pinot-system-metadata-common/src/main/java/org/apache/pinot/plugin/system/ComponentSystemMetadataRegistry.java
+++ b/pinot-plugins/pinot-system-metadata/pinot-system-metadata-common/src/main/java/org/apache/pinot/plugin/system/ComponentSystemMetadataRegistry.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.system;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.system.SystemMetadata;
+import org.apache.pinot.spi.system.SystemMetadataRegistry;
+import org.apache.pinot.spi.system.SystemMetadataStore;
+import org.apache.pinot.spi.system.SystemMetadataStoreFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A system metadata registry that runs as a singleton on each component (broker/controller/minion/server).
+ */
+public class ComponentSystemMetadataRegistry implements SystemMetadataRegistry {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ComponentSystemMetadataRegistry.class);
+  private static SystemMetadataRegistry INSTANCE = new ComponentSystemMetadataRegistry();
+
+  private SystemMetadataStore _systemMetadataStore;
+  private Map<String, SystemMetadata> _systemMetadataMap;
+
+  private ComponentSystemMetadataRegistry() {
+    _systemMetadataStore = null;
+    _systemMetadataMap = new HashMap<>();
+  }
+
+  public static SystemMetadataRegistry getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public void init(PinotConfiguration pinotConfiguration) {
+    PinotConfiguration pinotConfig = pinotConfiguration.subset(SYSTEM_METADATA_CONFIG_PREFIX);
+    if (_systemMetadataStore == null) {
+      SystemMetadataStoreFactory systemMetadataStoreFactory = SystemMetadataStoreFactory.loadFactory(pinotConfig);
+      if (systemMetadataStoreFactory != null) {
+        _systemMetadataStore = systemMetadataStoreFactory.create();
+        try {
+          _systemMetadataStore.connect();
+        } catch (Exception e) {
+          LOGGER.error("Unable to connect to _systemMetadataStore!", e);
+          _systemMetadataStore = null;
+        }
+      }
+    }
+  }
+
+  @Override
+  public void registerSystemMetadata(SystemMetadata systemMetadata) {
+    if (_systemMetadataStore == null) {
+      throw new IllegalStateException("SystemMetadataStore not initialized..");
+    }
+    if (_systemMetadataStore.accepts(systemMetadata)) {
+      _systemMetadataMap.put(systemMetadata.getSystemMetadataName(), systemMetadata);
+    }
+  }
+
+  @Override
+  public SystemMetadataStore getSystemMetadataStore(String metadataName) {
+    return _systemMetadataMap.containsKey(metadataName) ? _systemMetadataStore : null;
+  }
+
+  @Override
+  public void removeSystemMetadata(String metadataName) {
+    _systemMetadataMap.remove(metadataName);
+  }
+
+  @Override
+  public void shutdown()
+      throws Exception {
+    if (_systemMetadataStore != null) {
+      _systemMetadataStore.shutdown();
+    }
+  }
+}

--- a/pinot-plugins/pinot-system-metadata/pinot-system-metadata-common/src/test/java/org/apache/pinot/plugin/system/SystemMetadataRegistryTest.java
+++ b/pinot-plugins/pinot-system-metadata/pinot-system-metadata-common/src/test/java/org/apache/pinot/plugin/system/SystemMetadataRegistryTest.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.system;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.MetricFieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.system.SystemMetadata;
+import org.apache.pinot.spi.system.SystemMetadataRegistry;
+import org.apache.pinot.spi.system.SystemMetadataStore;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class SystemMetadataRegistryTest {
+  private static final Map<String, Object> SYSTEM_METADATA_TEST_CONFIG = new HashMap<>();
+  static {
+    SYSTEM_METADATA_TEST_CONFIG.put("system.metadata.factory.class",
+        "org.apache.pinot.plugin.system.sqlite.SqliteMetadataStoreFactory");
+    SYSTEM_METADATA_TEST_CONFIG.put("system.metadata.sqlite.conn",
+        "jdbc:sqlite::memory:");
+  }
+
+  @Test
+  public void testSystemMetadataRegistry()
+      throws Exception {
+    PinotConfiguration pinotConfiguration = new PinotConfiguration(
+        SYSTEM_METADATA_TEST_CONFIG
+    );
+    // 1. initialize system metadata registry.
+    SystemMetadataRegistry systemMetadataRegistry = ComponentSystemMetadataRegistry.getInstance();
+    systemMetadataRegistry.init(pinotConfiguration);
+
+    // 2. register system metadata
+    TestSystemMetadata systemMetadata = new TestSystemMetadata();
+    systemMetadataRegistry.registerSystemMetadata(systemMetadata);
+
+    // 3. get the system metadata store for posting data.
+    SystemMetadataStore systemMetadataStore = systemMetadataRegistry.getSystemMetadataStore(
+        systemMetadata.getSystemMetadataName());
+
+    // 4. post data
+    Object[] data = new Object[]{1L, "2S", 3L};
+    systemMetadataStore.collect(systemMetadata, System.currentTimeMillis(), data);
+    List<Object[]> rows = systemMetadataStore.inspect(systemMetadata);
+    Assert.assertEquals(rows.size(), 1);
+    Assert.assertEquals(rows.get(0), data);
+  }
+
+  private static class TestSystemMetadata implements SystemMetadata {
+    private static final FieldSpec[] FIELD_SPECS = new FieldSpec[]{
+        new DimensionFieldSpec("d", FieldSpec.DataType.LONG, true),
+        new DimensionFieldSpec("s", FieldSpec.DataType.STRING, true),
+        new MetricFieldSpec("m", FieldSpec.DataType.LONG)};
+    private static final FieldSpec.DataType[] FIELD_TYPES = Arrays.stream(FIELD_SPECS)
+        .map(FieldSpec::getDataType).collect(Collectors.toList()).toArray(new FieldSpec.DataType[0]);
+    private static final String[] FIELD_NAMES = Arrays.stream(FIELD_SPECS)
+        .map(FieldSpec::getName).collect(Collectors.toList()).toArray(new String[0]);
+
+    @Override
+    public String[] getColumnName() {
+      return FIELD_NAMES;
+    }
+
+    @Override
+    public FieldSpec.DataType[] getColumnDataType() {
+      return FIELD_TYPES;
+    }
+
+    @Override
+    public String getSystemMetadataName() {
+      return "TestSystemMetadata";
+    }
+  }
+}

--- a/pinot-plugins/pinot-system-metadata/pinot-system-metadata-common/src/test/java/org/apache/pinot/plugin/system/sqlite/SqliteMetadataStore.java
+++ b/pinot-plugins/pinot-system-metadata/pinot-system-metadata-common/src/test/java/org/apache/pinot/plugin/system/sqlite/SqliteMetadataStore.java
@@ -1,0 +1,200 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.system.sqlite;
+
+import com.google.common.base.Preconditions;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.system.SystemMetadata;
+import org.apache.pinot.spi.system.SystemMetadataStore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A basic sqlite system metadata store that connects to a sqlite metadata store.
+ */
+public class SqliteMetadataStore implements SystemMetadataStore {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SqliteMetadataStore.class);
+  private static final String SQLITE_METADATA_STORE_CONN_URL = "sqlite.conn";
+
+  private final PinotConfiguration _pinotConfiguration;
+
+  private Connection _connection;
+
+  public SqliteMetadataStore(PinotConfiguration pinotConfiguration) {
+    _pinotConfiguration = pinotConfiguration;
+  }
+
+  @Override
+  public void connect()
+      throws Exception {
+    _connection = DriverManager.getConnection(_pinotConfiguration.getProperty(SQLITE_METADATA_STORE_CONN_URL));
+  }
+
+  @Override
+  public void shutdown()
+      throws Exception {
+    _connection.close();
+  }
+
+  @Override
+  public boolean accepts(SystemMetadata systemMetadata) {
+    try {
+      Statement stat = _connection.createStatement();
+      int status = stat.executeUpdate(String.format("CREATE TABLE %s(%s)", systemMetadata.getSystemMetadataName(),
+          getColumnList(systemMetadata.getColumnName())));
+      return status == 0;
+    } catch (Exception e) {
+      LOGGER.error(String.format("Unable to accept SystemMetadata %s", systemMetadata.getSystemMetadataName()), e);
+      return false;
+    }
+  }
+
+  @Override
+  public void collect(SystemMetadata systemMetadata, long timestamp, Object[] row)
+      throws Exception {
+    PreparedStatement stat = _connection.prepareStatement(String.format("INSERT INTO %s VALUES(%s)",
+        systemMetadata.getSystemMetadataName(), getPrepareStatementPlaceholders(systemMetadata.getColumnName())));
+    executeStatement(stat, systemMetadata.getColumnDataType(), row);
+  }
+
+  @Override
+  public List<Object[]> inspect(SystemMetadata systemMetadata)
+      throws Exception {
+    Statement stat = _connection.createStatement();
+    ResultSet rs = stat.executeQuery(String.format("SELECT * FROM %s", systemMetadata.getSystemMetadataName()));
+    List<Object[]> result = new ArrayList<>();
+    while (rs.next()) {
+      result.add(constructRow(rs, systemMetadata));
+    }
+    return result;
+  }
+
+  @Override
+  public void flush()
+      throws Exception {
+    // no-op
+  }
+
+  private String getColumnList(String[] columnNames) {
+    return StringUtils.join(columnNames, ", ");
+  }
+
+  private String getPrepareStatementPlaceholders(String[] columnNames) {
+    int placeholderLength = columnNames.length;
+    String[] placeHolders = new String[placeholderLength];
+    Arrays.fill(placeHolders, "?");
+    return StringUtils.join(placeHolders, ", ");
+  }
+
+  private void executeStatement(PreparedStatement stat, FieldSpec.DataType[] dataTypes, Object[] row)
+      throws Exception {
+    Preconditions.checkState(dataTypes.length == row.length,
+        "schema and data size much match!");
+    int index = 0;
+    for (FieldSpec.DataType dataType : dataTypes) {
+      switch (dataType) {
+        case INT:
+          stat.setInt(index + 1, (int) row[index]);
+          index++;
+          break;
+        case LONG:
+          stat.setLong(index + 1, (long) row[index]);
+          index++;
+          break;
+        case FLOAT:
+          stat.setFloat(index + 1, (float) row[index]);
+          index++;
+          break;
+        case DOUBLE:
+          stat.setDouble(index + 1, (double) row[index]);
+          index++;
+          break;
+        case BOOLEAN:
+          stat.setBoolean(index + 1, (boolean) row[index]);
+          index++;
+          break;
+        case TIMESTAMP:
+          stat.setTimestamp(index + 1, (Timestamp) row[index]);
+          index++;
+          break;
+        case STRING:
+          stat.setString(index + 1, (String) row[index]);
+          index++;
+          break;
+        default:
+          throw new UnsupportedOperationException("Unsupported schema type: " + dataType);
+      }
+    }
+    stat.executeUpdate();
+  }
+
+  private Object[] constructRow(ResultSet rs, SystemMetadata systemMetadata)
+      throws Exception {
+    FieldSpec.DataType[] columnDataType = systemMetadata.getColumnDataType();
+    String[] columnName = systemMetadata.getColumnName();
+    Object[] row = new Object[columnName.length];
+    for (int idx = 0; idx < columnName.length; idx++) {
+      switch (columnDataType[idx]) {
+        case INT:
+          row[idx] = rs.getInt(columnName[idx]);
+          break;
+        case LONG:
+          row[idx] = rs.getLong(columnName[idx]);
+          break;
+        case FLOAT:
+          row[idx] = rs.getFloat(columnName[idx]);
+          break;
+        case DOUBLE:
+          row[idx] = rs.getDouble(columnName[idx]);
+          break;
+        case BOOLEAN:
+          row[idx] = rs.getBoolean(columnName[idx]);
+          break;
+        case TIMESTAMP:
+          row[idx] = rs.getTimestamp(columnName[idx]);
+          break;
+        case STRING:
+          row[idx] = rs.getString(columnName[idx]);
+          break;
+        default:
+          throw new UnsupportedOperationException("Unsupported schema type: " + columnDataType[idx]);
+      }
+    }
+    return row;
+  }
+}

--- a/pinot-plugins/pinot-system-metadata/pinot-system-metadata-common/src/test/java/org/apache/pinot/plugin/system/sqlite/SqliteMetadataStoreFactory.java
+++ b/pinot-plugins/pinot-system-metadata/pinot-system-metadata-common/src/test/java/org/apache/pinot/plugin/system/sqlite/SqliteMetadataStoreFactory.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.system.sqlite;
+
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.system.SystemMetadataStore;
+import org.apache.pinot.spi.system.SystemMetadataStoreFactory;
+
+
+/**
+ * A basic sqlite system metadata store that connects to a sqlite metadata store.
+ */
+public class SqliteMetadataStoreFactory extends SystemMetadataStoreFactory {
+  private PinotConfiguration _configuration;
+
+  @Override
+  protected void init(PinotConfiguration configuration) {
+    _configuration = configuration;
+  }
+
+  @Override
+  public SystemMetadataStore create() {
+    return new SqliteMetadataStore(_configuration);
+  }
+}

--- a/pinot-plugins/pinot-system-metadata/pinot-system-metadata-common/src/test/resources/resources/META-INF/services/org.apache.pinot.spi.system.SystemMetadataStoreFactory
+++ b/pinot-plugins/pinot-system-metadata/pinot-system-metadata-common/src/test/resources/resources/META-INF/services/org.apache.pinot.spi.system.SystemMetadataStoreFactory
@@ -1,0 +1,1 @@
+org.apache.pinot.plugin.system.sqlite.SqliteMetadataStoreFactory

--- a/pinot-plugins/pinot-system-metadata/pom.xml
+++ b/pinot-plugins/pinot-system-metadata/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>pinot-plugins</artifactId>
+    <groupId>org.apache.pinot</groupId>
+    <version>0.9.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+  <artifactId>pinot-metadata</artifactId>
+  <packaging>pom</packaging>
+  <name>Pinot Metrics</name>
+  <url>https://pinot.apache.org/</url>
+  <properties>
+    <pinot.root>${basedir}/../..</pinot.root>
+    <plugin.type>pinot-metadata</plugin.type>
+  </properties>
+  <modules>
+    <module>pinot-system-metadata-common</module>
+  </modules>
+
+  <dependencies>
+    <!-- Test -->
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -45,6 +45,7 @@
     <module>pinot-batch-ingestion</module>
     <module>pinot-stream-ingestion</module>
     <module>pinot-minion-tasks</module>
+    <module>pinot-system-metadata</module>
     <module>pinot-metrics</module>
     <module>pinot-segment-writer</module>
     <module>pinot-segment-uploader</module>

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/system/SystemMetadata.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/system/SystemMetadata.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.system;
+
+import org.apache.pinot.spi.data.FieldSpec;
+
+
+/**
+ * Metadata interface that defines the schema of the metadata, e.g. the dimensions and metrics.
+ */
+public interface SystemMetadata {
+
+  /**
+   * get column name of the system metadata.
+   * @return the schema of the system metadata.
+   */
+  String[] getColumnName();
+
+  /**
+   * get column data type of the system metadata.
+   * @return the schema of the system metadata.
+   */
+  FieldSpec.DataType[] getColumnDataType();
+
+  /**
+   * name of the system metadata, used to identify the type of metadata contents.
+   *
+   * @return system metadata name.
+   */
+  String getSystemMetadataName();
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/system/SystemMetadataRegistry.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/system/SystemMetadataRegistry.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.system;
+
+import org.apache.pinot.spi.env.PinotConfiguration;
+
+
+/**
+ * Registry for metadata.
+ *
+ * It is used to keep track of the metadata reporting, such as:
+ *   1. what metadata is being reported by Pinot and which connector is used to store the
+ * metadata
+ *   2. validate if metadata schema is compatible with the connector/table requirements.
+ *   3. registers connector handler callback for each metadata report.
+ */
+public interface SystemMetadataRegistry {
+  String SYSTEM_METADATA_CONFIG_PREFIX = "system.metadata";
+
+  /**
+   * Initialize metadata store with configurations.
+   *
+   * @param pinotConfiguration
+   * @return system metadata store object.
+   */
+  void init(PinotConfiguration pinotConfiguration);
+
+  /**
+   * Register system metadata.
+   * @param systemMetadata
+   */
+  void registerSystemMetadata(SystemMetadata systemMetadata);
+
+  /**
+   * Acquire the system metadata store that this system metadata type is registered under.
+   *
+   * @param metadataName the name of the metadata.
+   * @return the system metadata store instance use to store this metadata type.
+   */
+  SystemMetadataStore getSystemMetadataStore(String metadataName);
+
+  /**
+   * Remove metadata by its name.
+   */
+  void removeSystemMetadata(String metadataName);
+
+  /**
+   * shutdown metadata
+   */
+  void shutdown() throws Exception;
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/system/SystemMetadataStore.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/system/SystemMetadataStore.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.system;
+
+import java.util.List;
+
+
+/**
+ * System metadata store interface used to connect to a metadata store.
+ */
+public interface SystemMetadataStore {
+
+  /**
+   * Connect to a system metadata store.
+   */
+  void connect() throws Exception;
+
+  /**
+   * Shutdown system metadata store connection.
+   */
+  void shutdown()
+      throws Exception;
+
+  /**
+   * Validate if this system metadata store accepts a particular {@link SystemMetadata} type.
+   *
+   * @param systemMetadata candidate system metadata.
+   * @return true if accepts system metadata.
+   */
+  boolean accepts(SystemMetadata systemMetadata);
+
+  /**
+   *
+   * collect a row to upload to system metadata store.
+   *
+   * @param systemMetadata system metadata type.
+   * @param timestamp system metadata creation timestamp.
+   * @param row metadata content, must match the schema provided in systemMetadata field.
+   * @throws Exception
+   */
+  void collect(
+      SystemMetadata systemMetadata,
+      long timestamp,
+      Object[] row) throws Exception;
+
+  /**
+   * collect multiple rows to upload to system metadata store.
+   *
+   * @see SystemMetadataStore#collect(SystemMetadata, long, Object[]).
+   */
+  default void collect(
+      SystemMetadata systemMetadata,
+      long timestamp,
+      List<Object[]> rows) throws Exception {
+    for (Object[] row : rows) {
+      collect(systemMetadata, timestamp, row);
+    }
+  }
+
+  /**
+   * Acquire system metadata contents.
+   * @param systemMetadata the system metadata type.
+   * @return list of rows of the system metadata type.
+   */
+  List<Object[]> inspect(SystemMetadata systemMetadata)
+      throws Exception;
+
+  /**
+   * Flush collected system metadata to the external store.
+   *
+   * @throws Exception
+   */
+  void flush() throws Exception;
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/system/SystemMetadataStoreFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/system/SystemMetadataStoreFactory.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.system;
+
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * This factory class handles the search and creation of the {@link SystemMetadataStore} class.
+ *
+ * It detects all registered implementation of the SystemMetadataStore class and reflectively create
+ * based on the requested configuration.
+ */
+public abstract class SystemMetadataStoreFactory {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SystemMetadataStoreFactory.class);
+
+  public static final String SYSTEM_METADATA_STORE_FACTORY_CLASS_CONFIG = "factory.class";
+
+  protected abstract void init(PinotConfiguration configuration);
+
+  public abstract SystemMetadataStore create();
+
+  public static SystemMetadataStoreFactory loadFactory(PinotConfiguration configuration) {
+    SystemMetadataStoreFactory systemMetadataStoreFactory;
+    String systemMetadataStoreFactoryClassName = configuration.getProperty(SYSTEM_METADATA_STORE_FACTORY_CLASS_CONFIG);
+    if (systemMetadataStoreFactoryClassName == null) {
+      return null;
+    }
+    try {
+      LOGGER.info("Instantiating system metadata store factory class {}", systemMetadataStoreFactoryClassName);
+      systemMetadataStoreFactory = (SystemMetadataStoreFactory) Class.forName(systemMetadataStoreFactoryClassName)
+          .getDeclaredConstructor().newInstance();
+      LOGGER.info("Initializing system metadata store factory class {}", systemMetadataStoreFactoryClassName);
+      systemMetadataStoreFactory.init(configuration);
+      return systemMetadataStoreFactory;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
initial commit for the skeleton of system metadata SPI and plugin modules
see more details in #7652.

This PR adds a system metadata SPI interface to pinot-spi that allows plug-n-play different kind of system metadata registry handlers to write system metadata to an external data store (can be RDBMS / FS / etc).

This PR is mostly focus on creating a suitable SPI for future extension so please kindly review the SPI based on the in-memory SQLite example.
