### PR TITLE
Expose resource manager via ClusterInfoAccessor for task generator to use

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
@@ -36,7 +36,6 @@ import org.apache.pinot.common.minion.MinionTaskMetadataUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
-import org.apache.pinot.controller.helix.core.PinotResourceManagerResponse;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
@@ -131,10 +130,6 @@ public class ClusterInfoAccessor {
         .persistTaskMetadata(_pinotHelixResourceManager.getPropertyStore(), taskType, taskMetadata, expectedVersion);
   }
 
-  public PinotResourceManagerResponse deleteSegments(String tableNameWithType, List<String> segmentNames) {
-    return _pinotHelixResourceManager.deleteSegments(tableNameWithType, segmentNames);
-  }
-
   /**
    * Get all tasks' state for the given task type.
    *
@@ -193,5 +188,25 @@ public class ClusterInfoAccessor {
    */
   public LeadControllerManager getLeaderControllerManager() {
     return _leadControllerManager;
+  }
+
+  /**
+   * Get the helix resource manager for minion task generator to
+   * access the info of tables, segments, instances, etc.
+   *
+   * @return helix resource manager
+   */
+  public PinotHelixResourceManager getPinotHelixResourceManager() {
+    return _pinotHelixResourceManager;
+  }
+
+  /**
+   * Get the helix task resource manager for minion task generator to
+   * access the info of minion tasks.
+   *
+   * @return helix task resource manager
+   */
+  public PinotHelixTaskResourceManager getPinotHelixTaskResourceManager() {
+    return _pinotHelixTaskResourceManager;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
@@ -36,6 +36,7 @@ import org.apache.pinot.common.minion.MinionTaskMetadataUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.PinotResourceManagerResponse;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
@@ -128,6 +129,10 @@ public class ClusterInfoAccessor {
   public void setMinionTaskMetadata(BaseTaskMetadata taskMetadata, String taskType, int expectedVersion) {
     MinionTaskMetadataUtils
         .persistTaskMetadata(_pinotHelixResourceManager.getPropertyStore(), taskType, taskMetadata, expectedVersion);
+  }
+
+  public PinotResourceManagerResponse deleteSegments(String tableNameWithType, List<String> segmentNames) {
+    return _pinotHelixResourceManager.deleteSegments(tableNameWithType, segmentNames);
   }
 
   /**


### PR DESCRIPTION
## Description
Expose `_pinotHelixResourceManager` and `_pinotHelixTaskResourceManager` via `ClusterInfoAccessor` for task generator to use

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
