### PR TITLE
Support FST Index using Native FST Library

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -291,8 +291,8 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
           RealtimeSegmentConverter converter =
               new RealtimeSegmentConverter(_realtimeSegment, tempSegmentFolder.getAbsolutePath(), schema,
                   _tableNameWithType, tableConfig, segmentZKMetadata.getSegmentName(), _sortedColumn,
-                  _invertedIndexColumns, Collections.emptyList(), Collections.emptyList(), _noDictionaryColumns,
-                  _varLengthDictionaryColumns, indexingConfig.isNullHandlingEnabled());
+                  _invertedIndexColumns, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
+                  _noDictionaryColumns, _varLengthDictionaryColumns, indexingConfig.isNullHandlingEnabled());
 
           _segmentLogger.info("Trying to build segment");
           final long buildStartTime = System.nanoTime();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -267,6 +267,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   private final List<String> _invertedIndexColumns;
   private final List<String> _textIndexColumns;
   private final List<String> _fstIndexColumns;
+  private final List<String> _nativeFSTIndexColumns;
   private final List<String> _noDictionaryColumns;
   private final List<String> _varLengthDictionaryColumns;
   private final String _sortedColumn;
@@ -808,8 +809,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(_realtimeSegment, tempSegmentFolder.getAbsolutePath(), _schema,
               _tableNameWithType, _tableConfig, _segmentZKMetadata.getSegmentName(), _sortedColumn,
-              _invertedIndexColumns, _textIndexColumns, _fstIndexColumns, _noDictionaryColumns,
-              _varLengthDictionaryColumns, _nullHandlingEnabled);
+              _invertedIndexColumns, _textIndexColumns, _fstIndexColumns, _nativeFSTIndexColumns,
+              _noDictionaryColumns, _varLengthDictionaryColumns, _nullHandlingEnabled);
       _segmentLogger.info("Trying to build segment");
       try {
         converter.build(_segmentVersion, _serverMetrics);
@@ -1270,6 +1271,9 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
     Set<String> fstIndexColumns = indexLoadingConfig.getFSTIndexColumns();
     _fstIndexColumns = new ArrayList<>(fstIndexColumns);
+
+    Set<String> nativeFSTIndexColumns = indexLoadingConfig.getNativeFSTIndexColumns();
+    _nativeFSTIndexColumns = new ArrayList<>(nativeFSTIndexColumns);
 
     // Start new realtime segment
     String consumerDir = realtimeTableDataManager.getConsumerDir();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
@@ -63,10 +63,10 @@ public class FilterOperatorUtils {
       }
       return new ScanBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
     } else if (predicateType == Predicate.Type.REGEXP_LIKE) {
-      if (dataSource.getFSTIndex() != null && dataSource.getDataSourceMetadata().isSorted()) {
+      if (isFSTIndexPresent(dataSource) && dataSource.getDataSourceMetadata().isSorted()) {
         return new SortedIndexBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
       }
-      if (dataSource.getFSTIndex() != null && dataSource.getInvertedIndex() != null) {
+      if (isFSTIndexPresent(dataSource) && dataSource.getInvertedIndex() != null) {
         return new BitmapBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
       }
       return new ScanBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
@@ -200,5 +200,14 @@ public class FilterOperatorUtils {
       // Lower priority for multi-value column
       return basePriority + 1;
     }
+  }
+
+  /**
+   * Perform a composite check to see if there is a FST index present
+   * @param dataSource Datasource to be checked
+   * @return
+   */
+  private static boolean isFSTIndexPresent(DataSource dataSource) {
+    return (dataSource.getFSTIndex() != null || dataSource.getNativeFSTIndex() != null);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -204,7 +204,8 @@ public class FilterPlanNode implements PlanNode {
                         dataSource.getDictionary(), RegexpPatternConverterUtils.regexpLikeToLuceneRegExp(
                             ((RegexpLikePredicate) predicate).getValue()));
               } else if (dataSource.getNativeFSTIndex() != null) {
-                FSTBasedRegexpPredicateEvaluatorFactory.newFSTBasedEvaluator(dataSource.getNativeFSTIndex(),
+                predicateEvaluator =
+                    FSTBasedRegexpPredicateEvaluatorFactory.newFSTBasedEvaluator(dataSource.getNativeFSTIndex(),
                     dataSource.getDictionary(), RegexpPatternConverterUtils.regexpLikeToLuceneRegExp(
                         ((RegexpLikePredicate) predicate).getValue()));
               } else if (dataSource instanceof MutableDataSource &&

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -208,8 +208,9 @@ public class FilterPlanNode implements PlanNode {
                     FSTBasedRegexpPredicateEvaluatorFactory.newFSTBasedEvaluator(dataSource.getNativeFSTIndex(),
                     dataSource.getDictionary(), RegexpPatternConverterUtils.regexpLikeToLuceneRegExp(
                         ((RegexpLikePredicate) predicate).getValue()));
-              } else if (dataSource instanceof MutableDataSource &&
-                  (((MutableDataSource) dataSource).isFSTEnabled() || ((MutableDataSource) dataSource).isNativeFSTEnabled())) {
+              } else if (dataSource instanceof MutableDataSource
+                  && (((MutableDataSource) dataSource).isFSTEnabled()
+                  || ((MutableDataSource) dataSource).isNativeFSTEnabled())) {
                 predicateEvaluator =
                     FSTBasedRegexpPredicateEvaluatorFactory.newAutomatonBasedEvaluator(dataSource.getDictionary(),
                         RegexpPatternConverterUtils.regexpLikeToLuceneRegExp(

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -203,7 +203,12 @@ public class FilterPlanNode implements PlanNode {
                     FSTBasedRegexpPredicateEvaluatorFactory.newFSTBasedEvaluator(dataSource.getFSTIndex(),
                         dataSource.getDictionary(), RegexpPatternConverterUtils.regexpLikeToLuceneRegExp(
                             ((RegexpLikePredicate) predicate).getValue()));
-              } else if (dataSource instanceof MutableDataSource && ((MutableDataSource) dataSource).isFSTEnabled()) {
+              } else if (dataSource.getNativeFSTIndex() != null) {
+                FSTBasedRegexpPredicateEvaluatorFactory.newFSTBasedEvaluator(dataSource.getNativeFSTIndex(),
+                    dataSource.getDictionary(), RegexpPatternConverterUtils.regexpLikeToLuceneRegExp(
+                        ((RegexpLikePredicate) predicate).getValue()));
+              } else if (dataSource instanceof MutableDataSource &&
+                  (((MutableDataSource) dataSource).isFSTEnabled() || ((MutableDataSource) dataSource).isNativeFSTEnabled())) {
                 predicateEvaluator =
                     FSTBasedRegexpPredicateEvaluatorFactory.newAutomatonBasedEvaluator(dataSource.getDictionary(),
                         RegexpPatternConverterUtils.regexpLikeToLuceneRegExp(

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
@@ -63,6 +63,7 @@ public class FSTBasedRegexpLikeQueriesTest extends BaseQueriesTest {
   private static final String TABLE_NAME = "MyTable";
   private static final String SEGMENT_NAME = "testSegment";
   private static final String DOMAIN_NAMES_COL = "DOMAIN_NAMES";
+  private static final String NATIVE_INDEX_DOMAIN_NAMES_COL = "NATIVE_DOMAIN_NAMES";
   private static final String URL_COL = "URL_COL";
   private static final String INT_COL_NAME = "INT_COL";
   private static final String NO_INDEX_STRING_COL_NAME = "NO_INDEX_COL";
@@ -100,8 +101,13 @@ public class FSTBasedRegexpLikeQueriesTest extends BaseQueriesTest {
     fstIndexCols.add(DOMAIN_NAMES_COL);
     indexLoadingConfig.setFSTIndexColumns(fstIndexCols);
 
+    Set<String> nativeFSTIndexCols = new HashSet<>();
+    nativeFSTIndexCols.add(NATIVE_INDEX_DOMAIN_NAMES_COL);
+    indexLoadingConfig.setNativeFSTIndexColumns(nativeFSTIndexCols);
+
     Set<String> invertedIndexCols = new HashSet<>();
     invertedIndexCols.add(DOMAIN_NAMES_COL);
+    invertedIndexCols.add(NATIVE_INDEX_DOMAIN_NAMES_COL);
     indexLoadingConfig.setInvertedIndexColumns(invertedIndexCols);
     ImmutableSegment immutableSegment =
         ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), indexLoadingConfig);
@@ -145,6 +151,7 @@ public class FSTBasedRegexpLikeQueriesTest extends BaseQueriesTest {
       row.putField(INT_COL_NAME, INT_BASE_VALUE + i);
       row.putField(NO_INDEX_STRING_COL_NAME, noIndexData.get(i % noIndexData.size()));
       row.putField(DOMAIN_NAMES_COL, domain);
+      row.putField(NATIVE_INDEX_DOMAIN_NAMES_COL, domain);
       row.putField(URL_COL, url);
       rows.add(row);
     }
@@ -159,11 +166,16 @@ public class FSTBasedRegexpLikeQueriesTest extends BaseQueriesTest {
         new FieldConfig(DOMAIN_NAMES_COL, FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null));
     fieldConfigs
         .add(new FieldConfig(URL_COL, FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null));
+    fieldConfigs.add(
+        new FieldConfig(NATIVE_INDEX_DOMAIN_NAMES_COL, FieldConfig.EncodingType.DICTIONARY,
+            FieldConfig.IndexType.NATIVE_FST,null, null));
 
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setInvertedIndexColumns(Arrays.asList(DOMAIN_NAMES_COL)).setFieldConfigList(fieldConfigs).build();
+        .setInvertedIndexColumns(Arrays.asList(DOMAIN_NAMES_COL, NATIVE_INDEX_DOMAIN_NAMES_COL))
+        .setFieldConfigList(fieldConfigs).build();
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
         .addSingleValueDimension(DOMAIN_NAMES_COL, FieldSpec.DataType.STRING)
+        .addSingleValueDimension(NATIVE_INDEX_DOMAIN_NAMES_COL, FieldSpec.DataType.STRING)
         .addSingleValueDimension(URL_COL, FieldSpec.DataType.STRING)
         .addSingleValueDimension(NO_INDEX_STRING_COL_NAME, FieldSpec.DataType.STRING)
         .addMetric(INT_COL_NAME, FieldSpec.DataType.INT).build();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
@@ -168,7 +168,7 @@ public class FSTBasedRegexpLikeQueriesTest extends BaseQueriesTest {
         .add(new FieldConfig(URL_COL, FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null));
     fieldConfigs.add(
         new FieldConfig(NATIVE_INDEX_DOMAIN_NAMES_COL, FieldConfig.EncodingType.DICTIONARY,
-            FieldConfig.IndexType.NATIVE_FST,null, null));
+            FieldConfig.IndexType.NATIVE_FST, null, null));
 
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setInvertedIndexColumns(Arrays.asList(DOMAIN_NAMES_COL, NATIVE_INDEX_DOMAIN_NAMES_COL))
@@ -406,10 +406,12 @@ public class FSTBasedRegexpLikeQueriesTest extends BaseQueriesTest {
   @Test
   public void testFSTBasedRegexLikeWithNativeFSTIndex()
       throws Exception {
-    String query = "SELECT INT_COL, URL_COL FROM MyTable WHERE REGEXP_LIKE(NATIVE_DOMAIN_NAMES, 'www.domain1.*') LIMIT 50000";
+    String query = "SELECT INT_COL, URL_COL FROM MyTable WHERE "
+        + "REGEXP_LIKE(NATIVE_DOMAIN_NAMES, 'www.domain1.*') LIMIT 50000";
     testSelectionResults(query, 256, null);
 
-    query = "SELECT INT_COL, URL_COL FROM MyTable WHERE REGEXP_LIKE(NATIVE_DOMAIN_NAMES, 'www.sd.domain1.*') LIMIT 50000";
+    query = "SELECT INT_COL, URL_COL FROM MyTable WHERE REGEXP_LIKE(NATIVE_DOMAIN_NAMES,"
+        + "'www.sd.domain1.*') LIMIT 50000";
     testSelectionResults(query, 256, null);
 
     query = "SELECT INT_COL, URL_COL FROM MyTable WHERE REGEXP_LIKE(NATIVE_DOMAIN_NAMES, '.*domain1.*') LIMIT 50000";

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
@@ -381,6 +381,60 @@ public class FSTBasedRegexpLikeQueriesTest extends BaseQueriesTest {
   }
 
   @Test
+  public void testLikeOperatorWithNativeFSTIndex()
+      throws Exception {
+
+    String query = "SELECT INT_COL, URL_COL FROM MyTable WHERE NATIVE_DOMAIN_NAMES LIKE 'www.dom_in1.com' LIMIT 50000";
+    testSelectionResults(query, 64, null);
+
+    query = "SELECT INT_COL, URL_COL FROM MyTable WHERE NATIVE_DOMAIN_NAMES LIKE 'www.do_ai%' LIMIT 50000";
+    testSelectionResults(query, 512, null);
+
+    query = "SELECT INT_COL, URL_COL FROM MyTable WHERE NATIVE_DOMAIN_NAMES LIKE 'www.domain1%' LIMIT 50000";
+    testSelectionResults(query, 256, null);
+
+    query = "SELECT INT_COL, URL_COL FROM MyTable WHERE NATIVE_DOMAIN_NAMES LIKE 'www.sd.domain1%' LIMIT 50000";
+    testSelectionResults(query, 256, null);
+
+    query = "SELECT INT_COL, URL_COL FROM MyTable WHERE NATIVE_DOMAIN_NAMES LIKE '%domain1%' LIMIT 50000";
+    testSelectionResults(query, 512, null);
+
+    query = "SELECT INT_COL, URL_COL FROM MyTable WHERE NATIVE_DOMAIN_NAMES LIKE '%com' LIMIT 50000";
+    testSelectionResults(query, 256, null);
+  }
+
+  @Test
+  public void testFSTBasedRegexLikeWithNativeFSTIndex()
+      throws Exception {
+    String query = "SELECT INT_COL, URL_COL FROM MyTable WHERE REGEXP_LIKE(NATIVE_DOMAIN_NAMES, 'www.domain1.*') LIMIT 50000";
+    testSelectionResults(query, 256, null);
+
+    query = "SELECT INT_COL, URL_COL FROM MyTable WHERE REGEXP_LIKE(NATIVE_DOMAIN_NAMES, 'www.sd.domain1.*') LIMIT 50000";
+    testSelectionResults(query, 256, null);
+
+    query = "SELECT INT_COL, URL_COL FROM MyTable WHERE REGEXP_LIKE(NATIVE_DOMAIN_NAMES, '.*domain1.*') LIMIT 50000";
+    testSelectionResults(query, 512, null);
+
+    query = "SELECT INT_COL, URL_COL FROM MyTable WHERE REGEXP_LIKE(NATIVE_DOMAIN_NAMES, '.*domain.*') LIMIT 50000";
+    testSelectionResults(query, 1024, null);
+
+    query = "SELECT INT_COL, URL_COL FROM MyTable WHERE REGEXP_LIKE(NATIVE_DOMAIN_NAMES, '.*com') LIMIT 50000";
+    testSelectionResults(query, 256, null);
+
+    query = "SELECT INT_COL, URL_COL FROM MyTable WHERE REGEXP_LIKE(NATIVE_DOMAIN_NAMES, 'www.domain1.*') LIMIT 50000";
+    testSelectionResults(query, 256, null);
+
+    query = "SELECT INT_COL, URL_COL FROM MyTable WHERE REGEXP_LIKE(NATIVE_DOMAIN_NAMES, 'www.domain1.*') LIMIT 5";
+    List<Serializable[]> expected = new ArrayList<>();
+    expected.add(new Serializable[]{1000, "www.domain1.com/a"});
+    expected.add(new Serializable[]{1001, "www.domain1.co.ab/b"});
+    expected.add(new Serializable[]{1002, "www.domain1.co.bc/c"});
+    expected.add(new Serializable[]{1003, "www.domain1.co.cd/d"});
+    expected.add(new Serializable[]{1016, "www.domain1.com/a"});
+    testSelectionResults(query, 5, expected);
+  }
+
+  @Test
   public void testFSTBasedRegexpLikeWithOtherFilters()
       throws Exception {
     String query;

--- a/pinot-core/src/test/java/org/apache/pinot/realtime/converter/RealtimeSegmentConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/realtime/converter/RealtimeSegmentConverterTest.java
@@ -120,7 +120,8 @@ public class RealtimeSegmentConverterTest {
     RealtimeSegmentConverter converter =
         new RealtimeSegmentConverter(mutableSegmentImpl, outputDir.getAbsolutePath(), schema, tableNameWithType,
             tableConfig, segmentName, indexingConfig.getSortedColumn().get(0), indexingConfig.getInvertedIndexColumns(),
-            null, null, indexingConfig.getNoDictionaryColumns(), indexingConfig.getVarLengthDictionaryColumns(), false);
+            null, null, null, indexingConfig.getNoDictionaryColumns(),
+            indexingConfig.getVarLengthDictionaryColumns(), false);
 
     converter.build(SegmentVersion.v3, null);
     SegmentMetadataImpl metadata = new SegmentMetadataImpl(new File(outputDir, segmentName));

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -231,6 +231,7 @@ public class MutableSegmentImpl implements MutableSegment {
     Set<String> invertedIndexColumns = config.getInvertedIndexColumns();
     Set<String> textIndexColumns = config.getTextIndexColumns();
     Set<String> fstIndexColumns = config.getFSTIndexColumns();
+    Set<String> nativeFSTIndexColumns = config.getNativeFSTIndexColumns();
     Set<String> jsonIndexColumns = config.getJsonIndexColumns();
     Map<String, H3IndexConfig> h3IndexConfigs = config.getH3IndexConfigs();
 
@@ -354,8 +355,8 @@ public class MutableSegmentImpl implements MutableSegment {
       // TODO: Support range index and bloom filter for mutable segment
       _indexContainerMap.put(column,
           new IndexContainer(fieldSpec, partitionFunction, partitions, new NumValuesInfo(), forwardIndex, dictionary,
-              invertedIndexReader, null, textIndex, fstIndexColumns.contains(column), jsonIndex, h3Index, null,
-              nullValueVector));
+              invertedIndexReader, null, textIndex, fstIndexColumns.contains(column),
+              nativeFSTIndexColumns.contains(column), jsonIndex, h3Index, null, nullValueVector));
     }
 
     if (_realtimeLuceneReaders != null) {
@@ -1091,6 +1092,7 @@ public class MutableSegmentImpl implements MutableSegment {
     final MutableH3Index _h3Index;
     final RealtimeLuceneTextIndexReader _textIndex;
     final boolean _enableFST;
+    final boolean _enableNativeFST;
     final MutableJsonIndex _jsonIndex;
     final BloomFilterReader _bloomFilter;
     final MutableNullValueVector _nullValueVector;
@@ -1106,8 +1108,8 @@ public class MutableSegmentImpl implements MutableSegment {
         @Nullable Set<Integer> partitions, NumValuesInfo numValuesInfo, MutableForwardIndex forwardIndex,
         @Nullable MutableDictionary dictionary, @Nullable RealtimeInvertedIndexReader invertedIndex,
         @Nullable RangeIndexReader rangeIndex, @Nullable RealtimeLuceneTextIndexReader textIndex, boolean enableFST,
-        @Nullable MutableJsonIndex jsonIndex, @Nullable MutableH3Index h3Index, @Nullable BloomFilterReader bloomFilter,
-        @Nullable MutableNullValueVector nullValueVector) {
+        boolean enableNativeFST, @Nullable MutableJsonIndex jsonIndex, @Nullable MutableH3Index h3Index,
+        @Nullable BloomFilterReader bloomFilter, @Nullable MutableNullValueVector nullValueVector) {
       _fieldSpec = fieldSpec;
       _partitionFunction = partitionFunction;
       _partitions = partitions;
@@ -1120,6 +1122,7 @@ public class MutableSegmentImpl implements MutableSegment {
 
       _textIndex = textIndex;
       _enableFST = enableFST;
+      _enableNativeFST = enableNativeFST;
       _jsonIndex = jsonIndex;
       _bloomFilter = bloomFilter;
       _nullValueVector = nullValueVector;
@@ -1128,8 +1131,8 @@ public class MutableSegmentImpl implements MutableSegment {
     DataSource toDataSource() {
       return new MutableDataSource(_fieldSpec, _numDocsIndexed, _numValuesInfo._numValues,
           _numValuesInfo._maxNumValuesPerMVEntry, _partitionFunction, _partitions, _minValue, _maxValue, _forwardIndex,
-          _dictionary, _invertedIndex, _rangeIndex, _textIndex, _enableFST, _jsonIndex, _h3Index, _bloomFilter,
-          _nullValueVector);
+          _dictionary, _invertedIndex, _rangeIndex, _textIndex, _enableFST, _enableNativeFST, _jsonIndex, _h3Index,
+          _bloomFilter, _nullValueVector);
     }
 
     @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
@@ -119,6 +119,7 @@ public class RealtimeSegmentConverter {
     genConfig.setSegmentName(_segmentName);
     genConfig.setTextIndexCreationColumns(_textIndexColumns);
     genConfig.setFSTIndexCreationColumns(_fstIndexColumns);
+    genConfig.setNativeFSTIndexCreationColumns(_nativeFSTIndexColumns);
     SegmentPartitionConfig segmentPartitionConfig = _realtimeSegmentImpl.getSegmentPartitionConfig();
     genConfig.setSegmentPartitionConfig(segmentPartitionConfig);
     genConfig.setNullHandlingEnabled(_nullHandlingEnabled);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
@@ -52,6 +52,7 @@ public class RealtimeSegmentConverter {
   private final List<String> _invertedIndexColumns;
   private final List<String> _textIndexColumns;
   private final List<String> _fstIndexColumns;
+  private final List<String> _nativeFSTIndexColumns;
   private final List<String> _noDictionaryColumns;
   private final List<String> _varLengthDictionaryColumns;
   private final boolean _nullHandlingEnabled;
@@ -59,7 +60,8 @@ public class RealtimeSegmentConverter {
   public RealtimeSegmentConverter(MutableSegmentImpl realtimeSegment, String outputPath, Schema schema,
       String tableName, TableConfig tableConfig, String segmentName, String sortedColumn,
       List<String> invertedIndexColumns, List<String> textIndexColumns, List<String> fstIndexColumns,
-      List<String> noDictionaryColumns, List<String> varLengthDictionaryColumns, boolean nullHandlingEnabled) {
+      List<String> nativeFSTIndexColumns, List<String> noDictionaryColumns,
+      List<String> varLengthDictionaryColumns, boolean nullHandlingEnabled) {
     _realtimeSegmentImpl = realtimeSegment;
     _outputPath = outputPath;
     _invertedIndexColumns = new ArrayList<>(invertedIndexColumns);
@@ -76,6 +78,7 @@ public class RealtimeSegmentConverter {
     _nullHandlingEnabled = nullHandlingEnabled;
     _textIndexColumns = textIndexColumns;
     _fstIndexColumns = fstIndexColumns;
+    _nativeFSTIndexColumns = nativeFSTIndexColumns;
   }
 
   public void build(@Nullable SegmentVersion segmentVersion, ServerMetrics serverMetrics)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentConfig.java
@@ -45,6 +45,7 @@ public class RealtimeSegmentConfig {
   private final Set<String> _invertedIndexColumns;
   private final Set<String> _textIndexColumns;
   private final Set<String> _fstIndexColumns;
+  private final Set<String> _nativeFSTIndexColumns;
   private final Set<String> _jsonIndexColumns;
   private final Map<String, H3IndexConfig> _h3IndexConfigs;
   private final SegmentZKMetadata _segmentZKMetadata;
@@ -66,7 +67,8 @@ public class RealtimeSegmentConfig {
   private RealtimeSegmentConfig(String tableNameWithType, String segmentName, String streamName, Schema schema,
       String timeColumnName, int capacity, int avgNumMultiValues, Set<String> noDictionaryColumns,
       Set<String> varLengthDictionaryColumns, Set<String> invertedIndexColumns, Set<String> textIndexColumns,
-      Set<String> fstIndexColumns, Set<String> jsonIndexColumns, Map<String, H3IndexConfig> h3IndexConfigs,
+      Set<String> fstIndexColumns, Set<String> nativeFSTIndexColumns, Set<String> jsonIndexColumns,
+      Map<String, H3IndexConfig> h3IndexConfigs,
       SegmentZKMetadata segmentZKMetadata, boolean offHeap, PinotDataBufferMemoryManager memoryManager,
       RealtimeSegmentStatsHistory statsHistory, String partitionColumn, PartitionFunction partitionFunction,
       int partitionId, boolean aggregateMetrics, boolean nullHandlingEnabled, String consumerDir,
@@ -84,6 +86,7 @@ public class RealtimeSegmentConfig {
     _invertedIndexColumns = invertedIndexColumns;
     _textIndexColumns = textIndexColumns;
     _fstIndexColumns = fstIndexColumns;
+    _nativeFSTIndexColumns = nativeFSTIndexColumns;
     _jsonIndexColumns = jsonIndexColumns;
     _h3IndexConfigs = h3IndexConfigs;
     _segmentZKMetadata = segmentZKMetadata;
@@ -153,6 +156,10 @@ public class RealtimeSegmentConfig {
 
   public Set<String> getFSTIndexColumns() {
     return _fstIndexColumns;
+  }
+
+  public Set<String> getNativeFSTIndexColumns() {
+    return _nativeFSTIndexColumns;
   }
 
   public Set<String> getJsonIndexColumns() {
@@ -232,6 +239,7 @@ public class RealtimeSegmentConfig {
     private Set<String> _invertedIndexColumns;
     private Set<String> _textIndexColumns = new HashSet<>();
     private Set<String> _fstIndexColumns = new HashSet<>();
+    private Set<String> _nativeFSTIndexColumns = new HashSet<>();
     private Set<String> _jsonIndexColumns = new HashSet<>();
     private Map<String, H3IndexConfig> _h3IndexConfigs = new HashMap<>();
     private SegmentZKMetadata _segmentZKMetadata;
@@ -320,6 +328,11 @@ public class RealtimeSegmentConfig {
       return this;
     }
 
+    public Builder setNativeFSTIndexColumns(Set<String> nativeFSTIndexColumns) {
+      _nativeFSTIndexColumns = nativeFSTIndexColumns;
+      return this;
+    }
+
     public Builder setJsonIndexColumns(Set<String> jsonIndexColumns) {
       _jsonIndexColumns = jsonIndexColumns;
       return this;
@@ -403,10 +416,10 @@ public class RealtimeSegmentConfig {
     public RealtimeSegmentConfig build() {
       return new RealtimeSegmentConfig(_tableNameWithType, _segmentName, _streamName, _schema, _timeColumnName,
           _capacity, _avgNumMultiValues, _noDictionaryColumns, _varLengthDictionaryColumns, _invertedIndexColumns,
-          _textIndexColumns, _fstIndexColumns, _jsonIndexColumns, _h3IndexConfigs, _segmentZKMetadata, _offHeap,
-          _memoryManager, _statsHistory, _partitionColumn, _partitionFunction, _partitionId, _aggregateMetrics,
-          _nullHandlingEnabled, _consumerDir, _upsertMode, _upsertComparisonColumn, _hashFunction,
-          _partitionUpsertMetadataManager);
+          _textIndexColumns, _fstIndexColumns, _nativeFSTIndexColumns, _jsonIndexColumns, _h3IndexConfigs,
+          _segmentZKMetadata, _offHeap, _memoryManager, _statsHistory, _partitionColumn, _partitionFunction,
+          _partitionId, _aggregateMetrics, _nullHandlingEnabled, _consumerDir, _upsertMode,
+          _upsertComparisonColumn, _hashFunction, _partitionUpsertMetadataManager);
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/IntermediateIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/IntermediateIndexContainer.java
@@ -63,7 +63,8 @@ public class IntermediateIndexContainer implements Closeable {
   public DataSource toDataSource(int numDocsIndexed) {
     return new MutableDataSource(_fieldSpec, numDocsIndexed, _numValuesInfo._numValues,
         _numValuesInfo._maxNumValuesPerMVEntry, _partitionFunction, _partitions, _minValue, _maxValue, _forwardIndex,
-        _dictionary, null, null, null, false, null, null, null, null);
+        _dictionary, null, null, null, false, false, null,
+        null, null, null);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
@@ -184,7 +184,8 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
       }
 
       if (loadNativeFSTIndex) {
-        _nativeFSTIndex = new NativeFSTIndexReader(segmentReader.getIndexFor(columnName, ColumnIndexType.NATIVE_FST_INDEX));
+        _nativeFSTIndex = new NativeFSTIndexReader(segmentReader.
+            getIndexFor(columnName, ColumnIndexType.NATIVE_FST_INDEX));
       } else {
         _nativeFSTIndex = null;
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
@@ -160,6 +160,7 @@ public class SegmentV1V2ToV3FormatConverter implements SegmentFormatConverter {
           copyIndexIfExists(v2DataReader, v3DataWriter, column, ColumnIndexType.INVERTED_INDEX);
           copyIndexIfExists(v2DataReader, v3DataWriter, column, ColumnIndexType.FST_INDEX);
           copyIndexIfExists(v2DataReader, v3DataWriter, column, ColumnIndexType.JSON_INDEX);
+          copyIndexIfExists(v2DataReader, v3DataWriter, column, ColumnIndexType.NATIVE_FST_INDEX);
         }
 
         v3DataWriter.save();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/BaseDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/BaseDataSource.java
@@ -40,6 +40,7 @@ public abstract class BaseDataSource implements DataSource {
   private final RangeIndexReader<?> _rangeIndex;
   private final TextIndexReader _textIndex;
   private final TextIndexReader _fstIndex;
+  private final TextIndexReader _nativeFSTIndex;
   private final JsonIndexReader _jsonIndex;
   private final H3IndexReader _h3Index;
   private final BloomFilterReader _bloomFilter;
@@ -48,7 +49,8 @@ public abstract class BaseDataSource implements DataSource {
   public BaseDataSource(DataSourceMetadata dataSourceMetadata, ForwardIndexReader<?> forwardIndex,
       @Nullable Dictionary dictionary, @Nullable InvertedIndexReader<?> invertedIndex,
       @Nullable RangeIndexReader<?> rangeIndex, @Nullable TextIndexReader textIndex,
-      @Nullable TextIndexReader fstIndex, @Nullable JsonIndexReader jsonIndex, @Nullable H3IndexReader h3Index,
+      @Nullable TextIndexReader fstIndex, @Nullable TextIndexReader nativeFSTIndex,
+      @Nullable JsonIndexReader jsonIndex, @Nullable H3IndexReader h3Index,
       @Nullable BloomFilterReader bloomFilter, @Nullable NullValueVectorReader nullValueVector) {
     _dataSourceMetadata = dataSourceMetadata;
     _forwardIndex = forwardIndex;
@@ -57,6 +59,7 @@ public abstract class BaseDataSource implements DataSource {
     _rangeIndex = rangeIndex;
     _textIndex = textIndex;
     _fstIndex = fstIndex;
+    _nativeFSTIndex = nativeFSTIndex;
     _jsonIndex = jsonIndex;
     _h3Index = h3Index;
     _bloomFilter = bloomFilter;
@@ -101,6 +104,12 @@ public abstract class BaseDataSource implements DataSource {
   @Override
   public TextIndexReader getFSTIndex() {
     return _fstIndex;
+  }
+
+  @Nullable
+  @Override
+  public TextIndexReader getNativeFSTIndex() {
+    return _nativeFSTIndex;
   }
 
   @Nullable

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/EmptyDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/EmptyDataSource.java
@@ -32,7 +32,8 @@ import org.apache.pinot.spi.data.FieldSpec;
 public class EmptyDataSource extends BaseDataSource {
 
   public EmptyDataSource(ColumnMetadata columnMetadata) {
-    super(new EmptyDataSourceMetadata(columnMetadata), null, null, null, null, null, null, null, null, null, null);
+    super(new EmptyDataSourceMetadata(columnMetadata), null, null, null, null, null, null, null, null,
+        null, null, null);
   }
 
   private static class EmptyDataSourceMetadata implements DataSourceMetadata {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/ImmutableDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/ImmutableDataSource.java
@@ -36,7 +36,8 @@ public class ImmutableDataSource extends BaseDataSource {
     super(new ImmutableDataSourceMetadata(columnMetadata), columnIndexContainer.getForwardIndex(),
         columnIndexContainer.getDictionary(), columnIndexContainer.getInvertedIndex(),
         columnIndexContainer.getRangeIndex(), columnIndexContainer.getTextIndex(), columnIndexContainer.getFSTIndex(),
-        columnIndexContainer.getJsonIndex(), columnIndexContainer.getH3Index(), columnIndexContainer.getBloomFilter(),
+        columnIndexContainer.getNativeFSTIndex(), columnIndexContainer.getJsonIndex(),
+        columnIndexContainer.getH3Index(), columnIndexContainer.getBloomFilter(),
         columnIndexContainer.getNullValueVector());
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/MutableDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/MutableDataSource.java
@@ -40,22 +40,29 @@ import org.apache.pinot.spi.data.FieldSpec;
 @SuppressWarnings("rawtypes")
 public class MutableDataSource extends BaseDataSource {
   private final boolean _enableFST;
+  private final boolean _enableNativeFST;
 
   public MutableDataSource(FieldSpec fieldSpec, int numDocs, int numValues, int maxNumValuesPerMVEntry,
       @Nullable PartitionFunction partitionFunction, @Nullable Set<Integer> partitions, @Nullable Comparable minValue,
       @Nullable Comparable maxValue, ForwardIndexReader forwardIndex, @Nullable Dictionary dictionary,
       @Nullable InvertedIndexReader invertedIndex, @Nullable RangeIndexReader rangeIndex,
-      @Nullable TextIndexReader textIndex, boolean enableFST, @Nullable JsonIndexReader jsonIndex,
+      @Nullable TextIndexReader textIndex, boolean enableFST, boolean enableNativeFST,
+      @Nullable JsonIndexReader jsonIndex,
       @Nullable H3IndexReader h3Index, @Nullable BloomFilterReader bloomFilter,
       @Nullable NullValueVectorReader nullValueVector) {
     super(new MutableDataSourceMetadata(fieldSpec, numDocs, numValues, maxNumValuesPerMVEntry, partitionFunction,
             partitions, minValue, maxValue), forwardIndex, dictionary, invertedIndex, rangeIndex, textIndex, null,
-        jsonIndex, h3Index, bloomFilter, nullValueVector);
+        null, jsonIndex, h3Index, bloomFilter, nullValueVector);
     _enableFST = enableFST;
+    _enableNativeFST = enableNativeFST;
   }
 
   public boolean isFSTEnabled() {
     return _enableFST;
+  }
+
+  public boolean isNativeFSTEnabled() {
+    return _enableNativeFST;
   }
 
   private static class MutableDataSourceMetadata implements DataSourceMetadata {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexHandlerFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexHandlerFactory.java
@@ -50,6 +50,8 @@ public class IndexHandlerFactory {
         return new TextIndexHandler(indexDir, segmentMetadata, indexLoadingConfig, segmentWriter);
       case FST_INDEX:
         return new LuceneFSTIndexHandler(indexDir, segmentMetadata, indexLoadingConfig, segmentWriter);
+      case NATIVE_FST_INDEX:
+        return new NativeFSTIndexHandler(indexDir, segmentMetadata, indexLoadingConfig, segmentWriter);
       case JSON_INDEX:
         return new JsonIndexHandler(indexDir, segmentMetadata, indexLoadingConfig, segmentWriter);
       case H3_INDEX:

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexHandlerFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexHandlerFactory.java
@@ -24,6 +24,7 @@ import org.apache.pinot.segment.local.segment.index.loader.invertedindex.H3Index
 import org.apache.pinot.segment.local.segment.index.loader.invertedindex.InvertedIndexHandler;
 import org.apache.pinot.segment.local.segment.index.loader.invertedindex.JsonIndexHandler;
 import org.apache.pinot.segment.local.segment.index.loader.invertedindex.LuceneFSTIndexHandler;
+import org.apache.pinot.segment.local.segment.index.loader.invertedindex.NativeFSTIndexHandler;
 import org.apache.pinot.segment.local.segment.index.loader.invertedindex.RangeIndexHandler;
 import org.apache.pinot.segment.local.segment.index.loader.invertedindex.TextIndexHandler;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -59,6 +59,7 @@ public class IndexLoadingConfig {
   private int _rangeIndexVersion = IndexingConfig.DEFAULT_RANGE_INDEX_VERSION;
   private Set<String> _textIndexColumns = new HashSet<>();
   private Set<String> _fstIndexColumns = new HashSet<>();
+  private Set<String> _nativeFSTIndexColumns = new HashSet<>();
   private Set<String> _jsonIndexColumns = new HashSet<>();
   private Map<String, H3IndexConfig> _h3IndexConfigs = new HashMap<>();
   private Set<String> _noDictionaryColumns = new HashSet<>(); // TODO: replace this by _noDictionaryConfig.
@@ -206,6 +207,8 @@ public class IndexLoadingConfig {
         String column = fieldConfig.getName();
         if (fieldConfig.getIndexType() == FieldConfig.IndexType.FST) {
           _fstIndexColumns.add(column);
+        } else if (fieldConfig.getIndexType() == FieldConfig.IndexType.NATIVE_FST) {
+          _nativeFSTIndexColumns.add(column);
         }
       }
     }
@@ -306,6 +309,10 @@ public class IndexLoadingConfig {
     return _fstIndexColumns;
   }
 
+  public Set<String> getNativeFSTIndexColumns() {
+    return _nativeFSTIndexColumns;
+  }
+
   public Set<String> getJsonIndexColumns() {
     return _jsonIndexColumns;
   }
@@ -352,6 +359,11 @@ public class IndexLoadingConfig {
   @VisibleForTesting
   public void setFSTIndexColumns(Set<String> fstIndexColumns) {
     _fstIndexColumns = fstIndexColumns;
+  }
+
+  @VisibleForTesting
+  public void setNativeFSTIndexColumns(Set<String> nativeFSTIndexColumns) {
+    _nativeFSTIndexColumns = nativeFSTIndexColumns;
   }
 
   @VisibleForTesting

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/LuceneFSTIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/LuceneFSTIndexHandler.java
@@ -98,7 +98,7 @@ public class LuceneFSTIndexHandler implements IndexHandler {
     }
   }
 
-  private void checkUnsupportedOperationsForFSTIndex(ColumnMetadata columnMetadata) {
+  public static void checkUnsupportedOperationsForFSTIndex(ColumnMetadata columnMetadata) {
     String column = columnMetadata.getColumnName();
     if (columnMetadata.getDataType() != FieldSpec.DataType.STRING) {
       throw new UnsupportedOperationException("FST index is currently only supported on STRING columns: " + column);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/NativeFSTIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/NativeFSTIndexHandler.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.loader.invertedindex;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
+
+import org.apache.pinot.segment.local.segment.index.loader.IndexHandler;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.segment.local.segment.index.loader.LoaderUtils;
+import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.apache.pinot.segment.spi.creator.SegmentVersion;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.segment.spi.store.ColumnIndexType;
+import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.pinot.segment.spi.V1Constants.Indexes.FST_INDEX_FILE_EXTENSION;
+
+
+public class NativeFSTIndexHandler implements IndexHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LuceneFSTIndexHandler.class);
+
+  private final File _indexDir;
+  private final SegmentMetadata _segmentMetadata;
+  private final SegmentDirectory.Writer _segmentWriter;
+  private final Set<String> _columnsToAddIdx;
+
+  public NativeFSTIndexHandler(File indexDir, SegmentMetadata segmentMetadata, IndexLoadingConfig indexLoadingConfig,
+      SegmentDirectory.Writer segmentWriter) {
+    _indexDir = indexDir;
+    _segmentMetadata = segmentMetadata;
+    _segmentWriter = segmentWriter;
+    _columnsToAddIdx = new HashSet<>(indexLoadingConfig.getNativeFSTIndexColumns());
+  }
+
+  @Override
+  public void updateIndices()
+      throws Exception {
+    // Remove indices not set in table config any more
+    String segmentName = _segmentMetadata.getName();
+    Set<String> existingColumns = _segmentWriter.toSegmentDirectory().getColumnsWithIndex(ColumnIndexType.FST_INDEX);
+    for (String column : existingColumns) {
+      if (!_columnsToAddIdx.remove(column)) {
+        LOGGER.info("Removing existing FST index from segment: {}, column: {}", segmentName, column);
+        _segmentWriter.removeIndex(column, ColumnIndexType.FST_INDEX);
+        LOGGER.info("Removed existing FST index from segment: {}, column: {}", segmentName, column);
+      }
+    }
+    for (String column : _columnsToAddIdx) {
+      ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
+      if (columnMetadata != null) {
+        checkUnsupportedOperationsForFSTIndex(columnMetadata);
+        createFSTIndexForColumn(columnMetadata);
+      }
+    }
+  }
+
+  private void checkUnsupportedOperationsForFSTIndex(ColumnMetadata columnMetadata) {
+    String column = columnMetadata.getColumnName();
+    if (columnMetadata.getDataType() != FieldSpec.DataType.STRING) {
+      throw new UnsupportedOperationException("FST index is currently only supported on STRING columns: " + column);
+    }
+
+    if (!columnMetadata.hasDictionary()) {
+      throw new UnsupportedOperationException(
+          "FST index is currently only supported on dictionary encoded columns: " + column);
+    }
+
+    if (!columnMetadata.isSingleValue()) {
+      throw new UnsupportedOperationException("FST index is currently not supported on multi-value columns: " + column);
+    }
+  }
+
+  private void createFSTIndexForColumn(ColumnMetadata columnMetadata)
+      throws IOException {
+    String segmentName = _segmentMetadata.getName();
+    String column = columnMetadata.getColumnName();
+    File inProgress = new File(_indexDir, column + ".fst.inprogress");
+    File fstIndexFile = new File(_indexDir, column + FST_INDEX_FILE_EXTENSION);
+
+    if (!inProgress.exists()) {
+      // Create a marker file.
+      FileUtils.touch(inProgress);
+    } else {
+      FileUtils.deleteQuietly(fstIndexFile);
+    }
+
+    LOGGER.info("Creating new FST index for column: {} in segment: {}, cardinality: {}", column, segmentName,
+        columnMetadata.getCardinality());
+    LuceneFSTIndexCreator luceneFSTIndexCreator = new LuceneFSTIndexCreator(_indexDir, column, null);
+    try (Dictionary dictionary = LoaderUtils.getDictionary(_segmentWriter, columnMetadata)) {
+      for (int dictId = 0; dictId < dictionary.length(); dictId++) {
+        luceneFSTIndexCreator.add(dictionary.getStringValue(dictId));
+      }
+    }
+    luceneFSTIndexCreator.seal();
+
+    // For v3, write the generated range index file into the single file and remove it.
+    if (_segmentMetadata.getVersion() == SegmentVersion.v3) {
+      LoaderUtils.writeIndexToV3Format(_segmentWriter, column, fstIndexFile, ColumnIndexType.FST_INDEX);
+    }
+
+    // Delete the marker file.
+    FileUtils.deleteQuietly(inProgress);
+    LOGGER.info("Created FST index for segment: {}, column: {}", segmentName, column);
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/NativeFSTIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/NativeFSTIndexHandler.java
@@ -37,7 +37,6 @@ import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.pinot.segment.local.segment.index.loader.invertedindex.LuceneFSTIndexHandler.checkUnsupportedOperationsForFSTIndex;
 import static org.apache.pinot.segment.spi.V1Constants.Indexes.NATIVE_FST_INDEX_FILE_EXTENSION;
 
 /**
@@ -64,7 +63,8 @@ public class NativeFSTIndexHandler implements IndexHandler {
       throws Exception {
     // Remove indices not set in table config any more
     String segmentName = _segmentMetadata.getName();
-    Set<String> existingColumns = _segmentWriter.toSegmentDirectory().getColumnsWithIndex(ColumnIndexType.NATIVE_FST_INDEX);
+    Set<String> existingColumns = _segmentWriter.toSegmentDirectory().
+        getColumnsWithIndex(ColumnIndexType.NATIVE_FST_INDEX);
     for (String column : existingColumns) {
       if (!_columnsToAddIdx.remove(column)) {
         LOGGER.info("Removing existing Native FST index from segment: {}, column: {}", segmentName, column);
@@ -75,7 +75,8 @@ public class NativeFSTIndexHandler implements IndexHandler {
     for (String column : _columnsToAddIdx) {
       ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
       if (columnMetadata != null) {
-        checkUnsupportedOperationsForFSTIndex(columnMetadata);
+        org.apache.pinot.segment.local.segment.index.loader.invertedindex.
+            LuceneFSTIndexHandler.checkUnsupportedOperationsForFSTIndex(columnMetadata);
         createFSTIndexForColumn(columnMetadata);
       }
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/NativeFSTIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/NativeFSTIndexHandler.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
-
 import org.apache.pinot.segment.local.segment.index.loader.IndexHandler;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.index.loader.LoaderUtils;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/NativeFSTIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/NativeFSTIndexHandler.java
@@ -27,6 +27,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.segment.index.loader.IndexHandler;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.index.loader.LoaderUtils;
+import org.apache.pinot.segment.local.utils.nativefst.NativeFSTIndexCreator;
 import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
@@ -110,13 +111,13 @@ public class NativeFSTIndexHandler implements IndexHandler {
 
     LOGGER.info("Creating new FST index for column: {} in segment: {}, cardinality: {}", column, segmentName,
         columnMetadata.getCardinality());
-    LuceneFSTIndexCreator luceneFSTIndexCreator = new LuceneFSTIndexCreator(_indexDir, column, null);
+    NativeFSTIndexCreator nativeFSTIndexCreator = new NativeFSTIndexCreator(_indexDir, column, null);
     try (Dictionary dictionary = LoaderUtils.getDictionary(_segmentWriter, columnMetadata)) {
       for (int dictId = 0; dictId < dictionary.length(); dictId++) {
-        luceneFSTIndexCreator.add(dictionary.getStringValue(dictId));
+        nativeFSTIndexCreator.add(dictionary.getStringValue(dictId));
       }
     }
-    luceneFSTIndexCreator.seal();
+    nativeFSTIndexCreator.seal();
 
     // For v3, write the generated range index file into the single file and remove it.
     if (_segmentMetadata.getVersion() == SegmentVersion.v3) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
@@ -192,6 +192,9 @@ class FilePerIndexDirectory extends ColumnIndexDirectory {
       case FST_INDEX:
         fileExtension = V1Constants.Indexes.FST_INDEX_FILE_EXTENSION;
         break;
+      case NATIVE_FST_INDEX:
+        fileExtension = V1Constants.Indexes.NATIVE_FST_INDEX_FILE_EXTENSION;
+        break;
       case JSON_INDEX:
         fileExtension = V1Constants.Indexes.JSON_INDEX_FILE_EXTENSION;
         break;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/virtualcolumn/VirtualColumnIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/virtualcolumn/VirtualColumnIndexContainer.java
@@ -72,6 +72,11 @@ public class VirtualColumnIndexContainer implements ColumnIndexContainer {
   }
 
   @Override
+  public TextIndexReader getNativeFSTIndex() {
+    return null;
+  }
+
+  @Override
   public JsonIndexReader getJsonIndex() {
     return null;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeDataSource.java
@@ -33,7 +33,7 @@ public class StarTreeDataSource extends BaseDataSource {
   public StarTreeDataSource(FieldSpec fieldSpec, int numDocs, ForwardIndexReader<?> forwardIndex,
       @Nullable Dictionary dictionary) {
     super(new StarTreeDataSourceMetadata(fieldSpec, numDocs), forwardIndex, dictionary, null, null, null, null, null,
-        null, null, null);
+        null, null, null, null);
   }
 
   private static final class StarTreeDataSourceMetadata implements DataSourceMetadata {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -675,6 +675,7 @@ public final class TableConfigUtils {
         for (FieldConfig.IndexType indexType : fieldConfig.getIndexTypes()) {
           switch (indexType) {
             case FST:
+            case NATIVE_FST:
               Preconditions.checkArgument(fieldConfig.getEncodingType() == FieldConfig.EncodingType.DICTIONARY,
                   "FST Index is only enabled on dictionary encoded columns");
               Preconditions.checkState(fieldConfigColSpec.isSingleValueField()

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/NativeFSTIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/NativeFSTIndexCreatorTest.java
@@ -1,0 +1,55 @@
+package org.apache.pinot.segment.local.segment.index.creator;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteOrder;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.utils.nativefst.NativeFSTIndexCreator;
+import org.apache.pinot.segment.local.utils.nativefst.NativeFSTIndexReader;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.segment.spi.V1Constants.Indexes.NATIVE_FST_INDEX_FILE_EXTENSION;
+
+
+public class NativeFSTIndexCreatorTest {
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "NativeFSTIndex");
+
+  @BeforeClass
+  public void setUp()
+      throws IOException {
+    FileUtils.forceMkdir(INDEX_DIR);
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    FileUtils.deleteDirectory(INDEX_DIR);
+  }
+
+  @Test
+  public void testIndexWriterReader()
+      throws IOException {
+    String[] uniqueValues = new String[3];
+    uniqueValues[0] = "hello-world";
+    uniqueValues[1] = "hello-world123";
+    uniqueValues[2] = "still";
+
+    NativeFSTIndexCreator creator = new NativeFSTIndexCreator(INDEX_DIR, "testFSTColumn", uniqueValues);
+    creator.seal();
+    File fstFile = new File(INDEX_DIR, "testFSTColumn" + NATIVE_FST_INDEX_FILE_EXTENSION);
+    PinotDataBuffer pinotDataBuffer =
+        PinotDataBuffer.mapFile(fstFile, true, 0, fstFile.length(), ByteOrder.BIG_ENDIAN, "fstIndexFile");
+    NativeFSTIndexReader reader = new NativeFSTIndexReader(pinotDataBuffer);
+    int[] matchedDictIds = reader.getDictIds("hello.*").toArray();
+    Assert.assertEquals(2, matchedDictIds.length);
+    Assert.assertEquals(0, matchedDictIds[0]);
+    Assert.assertEquals(1, matchedDictIds[1]);
+
+    matchedDictIds = reader.getDictIds(".*llo").toArray();
+    Assert.assertEquals(0, matchedDictIds.length);
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/NativeFSTIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/NativeFSTIndexCreatorTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.segment.local.segment.index.creator;
 
 import java.io.File;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/LoaderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/LoaderTest.java
@@ -317,6 +317,7 @@ public class LoaderTest {
 
     IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
     indexLoadingConfig.setFSTIndexColumns(new HashSet<>(Arrays.asList(FST_INDEX_COL_NAME)));
+    indexLoadingConfig.setNativeFSTIndexColumns(new HashSet<>(Arrays.asList(FST_INDEX_COL_NAME)));
     indexLoadingConfig.setReadMode(ReadMode.mmap);
     IndexSegment indexSegment = ImmutableSegmentLoader.load(_indexDir, indexLoadingConfig);
     // check that loaded segment version is v3

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/LoaderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/LoaderTest.java
@@ -297,6 +297,7 @@ public class LoaderTest {
     SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     List<String> fstIndexCreationColumns = Lists.newArrayList(FST_INDEX_COL_NAME);
     segmentGeneratorConfig.setFSTIndexCreationColumns(fstIndexCreationColumns);
+    segmentGeneratorConfig.setNativeFSTIndexCreationColumns(fstIndexCreationColumns);
     segmentGeneratorConfig.setSegmentVersion(segmentVersion);
     driver.init(segmentGeneratorConfig);
     driver.build();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
@@ -246,6 +246,7 @@ public class SegmentPreProcessorTest {
     Set<String> fstColumns = new HashSet<>();
     fstColumns.add(EXISTING_STRING_COL_RAW);
     _indexLoadingConfig.setFSTIndexColumns(fstColumns);
+    _indexLoadingConfig.setNativeFSTIndexColumns(fstColumns);
     _indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_STRING_COL_RAW);
     constructV3Segment();
     SegmentDirectory segmentDirectory =
@@ -268,6 +269,7 @@ public class SegmentPreProcessorTest {
     Set<String> fstColumns = new HashSet<>();
     fstColumns.add(NEWLY_ADDED_FST_COL_DICT);
     _indexLoadingConfig.setFSTIndexColumns(fstColumns);
+    _indexLoadingConfig.setNativeFSTIndexColumns(fstColumns);
 
     constructV3Segment();
     checkFSTIndexCreation(NEWLY_ADDED_FST_COL_DICT, 1, 1, _newColumnsSchemaWithFST, true, true, 4);
@@ -282,6 +284,7 @@ public class SegmentPreProcessorTest {
     Set<String> fstColumns = new HashSet<>();
     fstColumns.add(EXISTING_STRING_COL_DICT);
     _indexLoadingConfig.setFSTIndexColumns(fstColumns);
+    _indexLoadingConfig.setNativeFSTIndexColumns(fstColumns);
 
     constructV3Segment();
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
@@ -873,6 +876,7 @@ public class SegmentPreProcessorTest {
     _indexLoadingConfig.setRangeIndexColumns(new HashSet<>(Collections.singletonList(strColumn)));
     _indexLoadingConfig.setTextIndexColumns(new HashSet<>(Collections.singletonList(strColumn)));
     _indexLoadingConfig.setFSTIndexColumns(new HashSet<>(Collections.singletonList(strColumn)));
+    _indexLoadingConfig.setNativeFSTIndexColumns(new HashSet<>(Collections.singletonList(strColumn)));
     _indexLoadingConfig.setBloomFilterConfigs(ImmutableMap.of(strColumn, new BloomFilterConfig(0.1, 1024, true)));
 
     // V1 use separate file for each column index.
@@ -942,6 +946,7 @@ public class SegmentPreProcessorTest {
     _indexLoadingConfig.setRangeIndexColumns(new HashSet<>(Collections.singletonList(strColumn)));
     _indexLoadingConfig.setTextIndexColumns(new HashSet<>(Collections.singletonList(strColumn)));
     _indexLoadingConfig.setFSTIndexColumns(new HashSet<>(Collections.singletonList(strColumn)));
+    _indexLoadingConfig.setNativeFSTIndexColumns(new HashSet<>(Collections.singletonList(strColumn)));
     _indexLoadingConfig.setBloomFilterConfigs(ImmutableMap.of(strColumn, new BloomFilterConfig(0.1, 1024, true)));
 
     // Create all kinds of indices.
@@ -957,6 +962,7 @@ public class SegmentPreProcessorTest {
       addedLength += reader.getIndexFor(strColumn, ColumnIndexType.INVERTED_INDEX).size() + 8;
       addedLength += reader.getIndexFor(strColumn, ColumnIndexType.RANGE_INDEX).size() + 8;
       addedLength += reader.getIndexFor(strColumn, ColumnIndexType.FST_INDEX).size() + 8;
+      addedLength += reader.getIndexFor(strColumn, ColumnIndexType.NATIVE_FST_INDEX).size() + 8;
       addedLength += reader.getIndexFor(strColumn, ColumnIndexType.BLOOM_FILTER).size() + 8;
       assertTrue(reader.hasIndexFor(strColumn, ColumnIndexType.TEXT_INDEX));
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -674,6 +674,17 @@ public class TableConfigUtilsTest {
           "FieldConfig encoding type is different from indexingConfig for column: myCol1");
     }
 
+    try {
+      FieldConfig fieldConfig =
+          new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.NATIVE_FST, null, null);
+      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should fail for with conflicting encoding type of myCol1");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getMessage(),
+          "FieldConfig encoding type is different from indexingConfig for column: myCol1");
+    }
+
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
     try {
@@ -682,6 +693,18 @@ public class TableConfigUtilsTest {
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail since FST index is enabled on RAW encoding type");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getMessage(), "FST Index is only enabled on dictionary encoded columns");
+    }
+
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
+    try {
+      FieldConfig fieldConfig =
+          new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.NATIVE_FST, null, null);
+      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should fail since Native FST index is enabled on RAW encoding type");
     } catch (Exception e) {
       Assert.assertEquals(e.getMessage(), "FST Index is only enabled on dictionary encoded columns");
     }
@@ -700,10 +723,32 @@ public class TableConfigUtilsTest {
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     try {
       FieldConfig fieldConfig =
+          new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.NATIVE_FST, null, null);
+      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should fail since Native FST index is enabled on multi value column");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getMessage(), "FST Index is only supported for single value string columns");
+    }
+
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+    try {
+      FieldConfig fieldConfig =
           new FieldConfig("intCol", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail since FST index is enabled on non String column");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getMessage(), "FST Index is only supported for single value string columns");
+    }
+
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+    try {
+      FieldConfig fieldConfig =
+          new FieldConfig("intCol", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.NATIVE_FST, null, null);
+      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should fail since Native FST index is enabled on non String column");
     } catch (Exception e) {
       Assert.assertEquals(e.getMessage(), "FST Index is only supported for single value string columns");
     }
@@ -725,6 +770,19 @@ public class TableConfigUtilsTest {
     try {
       FieldConfig fieldConfig =
           new FieldConfig("myCol21", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.FST, null, null);
+      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should fail since field name is not present in schema");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getMessage(),
+          "Column Name myCol21 defined in field config list must be a valid column defined in the schema");
+    }
+
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
+    try {
+      FieldConfig fieldConfig =
+          new FieldConfig("myCol21", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.NATIVE_FST, null, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail since field name is not present in schema");

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -73,6 +73,7 @@ public class SegmentGeneratorConfig implements Serializable {
   private final List<String> _invertedIndexCreationColumns = new ArrayList<>();
   private final List<String> _textIndexCreationColumns = new ArrayList<>();
   private final List<String> _fstIndexCreationColumns = new ArrayList<>();
+  private final List<String> _nativeFSTIndexCreationColumns = new ArrayList<>();
   private final List<String> _jsonIndexCreationColumns = new ArrayList<>();
   private final Map<String, H3IndexConfig> _h3IndexConfigs = new HashMap<>();
   private final List<String> _columnSortOrder = new ArrayList<>();
@@ -246,6 +247,8 @@ public class SegmentGeneratorConfig implements Serializable {
       for (FieldConfig fieldConfig : fieldConfigList) {
         if (fieldConfig.getIndexType() == FieldConfig.IndexType.FST) {
           _fstIndexCreationColumns.add(fieldConfig.getName());
+        } else if (fieldConfig.getIndexType() == FieldConfig.IndexType.NATIVE_FST) {
+          _nativeFSTIndexCreationColumns.add(fieldConfig.getName());
         }
       }
     }
@@ -330,6 +333,10 @@ public class SegmentGeneratorConfig implements Serializable {
     return _fstIndexCreationColumns;
   }
 
+  public List<String> getNativeFSTIndexCreationColumns() {
+    return _nativeFSTIndexCreationColumns;
+  }
+
   public List<String> getJsonIndexCreationColumns() {
     return _jsonIndexCreationColumns;
   }
@@ -373,6 +380,12 @@ public class SegmentGeneratorConfig implements Serializable {
   public void setFSTIndexCreationColumns(List<String> fstIndexCreationColumns) {
     if (fstIndexCreationColumns != null) {
       _fstIndexCreationColumns.addAll(fstIndexCreationColumns);
+    }
+  }
+
+  public void setNativeFSTIndexCreationColumns(List<String> nativeFSTIndexCreationColumns) {
+    if (nativeFSTIndexCreationColumns != null) {
+      _nativeFSTIndexCreationColumns.addAll(nativeFSTIndexCreationColumns);
     }
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/DataSource.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/DataSource.java
@@ -77,6 +77,12 @@ public interface DataSource {
   TextIndexReader getFSTIndex();
 
   /**
+   * Returns the Native FST index for the column if exists, or {@code null} if not.
+   */
+  @Nullable
+  TextIndexReader getNativeFSTIndex();
+
+  /**
    * Returns the json index for the column if exists, or {@code null} if not.
    */
   @Nullable

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/column/ColumnIndexContainer.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/column/ColumnIndexContainer.java
@@ -60,6 +60,12 @@ public interface ColumnIndexContainer extends Closeable {
    */
   TextIndexReader getFSTIndex();
 
+
+  /**
+   * Returns the Native FST index for the column, or {@code null} if it does not exist.
+   */
+  TextIndexReader getNativeFSTIndex();
+
   /**
    * Returns the json index for the column, or {@code null} if it does not exist.
    */

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/ColumnIndexType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/ColumnIndexType.java
@@ -26,6 +26,7 @@ public enum ColumnIndexType {
   NULLVALUE_VECTOR("nullvalue_vector"),
   TEXT_INDEX("text_index"),
   FST_INDEX("fst_index"),
+  NATIVE_FST_INDEX("native_fst_index"),
   JSON_INDEX("json_index"),
   RANGE_INDEX("range_index"),
   H3_INDEX("h3_index");

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -85,7 +85,7 @@ public class FieldConfig extends BaseJsonConfig {
 
   // If null, there won't be any index
   public enum IndexType {
-    INVERTED, SORTED, TEXT, FST, H3, JSON, RANGE
+    INVERTED, SORTED, TEXT, FST, NATIVE_FST, H3, JSON, RANGE
   }
 
   public enum CompressionCodec {


### PR DESCRIPTION
This PR introduces a new index type which is built using the native FST library. The new index is used for serving regexp queries (using REGEXP_LIKE) and LIKE operator.