### PR TITLE
Fix verifyHostname issue in FileUploadDownloadClient

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ClientSSLContextGenerator.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ClientSSLContextGenerator.java
@@ -83,6 +83,7 @@ public class ClientSSLContextGenerator {
       sslContext = SSLContext.getInstance(SECURITY_ALGORITHM);
       sslContext.init(keyManagers, trustManagers, null);
     } catch (Exception e) {
+      LOGGER.error("Exception when generating SSLContext", e);
       Utils.rethrowException(e);
     }
     return sslContext;


### PR DESCRIPTION
## Description
Because of the changes in this PR https://github.com/apache/pinot/pull/7585, the endpoint has been converted to an IP address, which leads to the exception like below:
```
2021/11/04 04:04:29.913 WARN [HttpsSegmentFetcher] [HelixTaskExecutor-message_handle_thread] [pinot-server] [] Caught exception while downloading segment from: https://192.168.0.7:10611/segments/testTableName/testTableName_2021-11-04-04_2021-11-04-04_2 to: ...
javax.net.ssl.SSLPeerUnverifiedException: Certificate for <192.168.0.7> doesn't match any of the subject alternative names: [...]
        at org.apache.http.conn.ssl.SSLConnectionSocketFactory.verifyHostname(SSLConnectionSocketFactory.java:507) ~[httpclient-4.5.11.jar:4.5.11]
        at org.apache.http.conn.ssl.SSLConnectionSocketFactory.createLayeredSocket(SSLConnectionSocketFactory.java:437) ~[httpclient-4.5.11.jar:4.5.11]
        at org.apache.http.conn.ssl.SSLConnectionSocketFactory.connectSocket(SSLConnectionSocketFactory.java:384) ~[httpclient-4.5.11.jar:4.5.11]
        at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:142) ~[httpclient-4.5.11.jar:4.5.11]
        at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:376) ~[httpclient-4.5.11.jar:4.5.11]
        at org.apache.http.impl.execchain.MainClientExec.establishRoute(MainClientExec.java:393) ~[httpclient-4.5.11.jar:4.5.11]
        at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:236) ~[httpclient-4.5.11.jar:4.5.11]
        at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:186) ~[httpclient-4.5.11.jar:4.5.11]
        at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:89) ~[httpclient-4.5.11.jar:4.5.11]
        at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110) ~[httpclient-4.5.11.jar:4.5.11]
        at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185) ~[httpclient-4.5.11.jar:4.5.11]
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83) ~[httpclient-4.5.11.jar:4.5.11]
        at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:108) ~[httpclient-4.5.11.jar:4.5.11]
        at org.apache.pinot.common.utils.FileUploadDownloadClient.downloadFile(FileUploadDownloadClient.java:1015) ~[pinot-common-0.9.0-dev-322.jar:0.9.0-dev-322-421645d32f08e1fca2e33af2c20093841ca77098]
        at org.apache.pinot.common.utils.FileUploadDownloadClient.downloadFile(FileUploadDownloadClient.java:1088) ~[pinot-common-0.9.0-dev-322.jar:0.9.0-dev-322-421645d32f08e1fca2e33af2c20093841ca77098]
        at org.apache.pinot.common.utils.fetcher.HttpSegmentFetcher.lambda$fetchSegmentToLocal$0(HttpSegmentFetcher.java:66) ~[pinot-common-0.9.0-dev-322.jar:0.9.0-dev-322-421645d32f08e1fca2e33af2c20093841ca77098]
        at org.apache.pinot.spi.utils.retry.BaseRetryPolicy.attempt(BaseRetryPolicy.java:50) [pinot-spi-0.9.0-dev-322.jar:0.9.0-dev-322-421645d32f08e1fca2e33af2c20093841ca77098]
        at org.apache.pinot.common.utils.fetcher.HttpSegmentFetcher.fetchSegmentToLocal(HttpSegmentFetcher.java:54) [pinot-common-0.9.0-dev-322.jar:0.9.0-dev-322-421645d32f08e1fca2e33af2c20093841ca77098]
        at org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory.fetchSegmentToLocalInternal(SegmentFetcherFactory.java:147) [pinot-common-0.9.0-dev-322.jar:0.9.0-dev-322-421645d32f08e1fca2e33af2c20093841ca77098]
        at org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory.fetchSegmentToLocal(SegmentFetcherFactory.java:142) [pinot-common-0.9.0-dev-322.jar:0.9.0-dev-322-421645d32f08e1fca2e33af2c20093841ca77098]
        at org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory.fetchAndDecryptSegmentToLocalInternal(SegmentFetcherFactory.java:163) [pinot-common-0.9.0-dev-322.jar:0.9.0-dev-322-421645d32f08e1fca2e33af2c20093841ca77098]
        at org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory.fetchAndDecryptSegmentToLocal(SegmentFetcherFactory.java:157) [pinot-common-0.9.0-dev-322.jar:0.9.0-dev-322-421645d32f08e1fca2e33af2c20093841ca77098]
        at org.apache.pinot.core.data.manager.BaseTableDataManager.downloadAndDecrypt(BaseTableDataManager.java:442) [pinot-core-0.9.0-dev-322.jar:0.9.0-dev-322-421645d32f08e1fca2e33af2c20093841ca77098]
        at org.apache.pinot.core.data.manager.BaseTableDataManager.downloadSegmentFromDeepStore(BaseTableDataManager.java:429) [pinot-core-0.9.0-dev-322.jar:0.9.0-dev-322-421645d32f08e1fca2e33af2c20093841ca77098]
        at org.apache.pinot.core.data.manager.BaseTableDataManager.downloadSegment(BaseTableDataManager.java:384) [pinot-core-0.9.0-dev-322.jar:0.9.0-dev-322-421645d32f08e1fca2e33af2c20093841ca77098]
        at org.apache.pinot.core.data.manager.BaseTableDataManager.addOrReplaceSegment(BaseTableDataManager.java:371) [pinot-core-0.9.0-dev-322.jar:0.9.0-dev-322-421645d32f08e1fca2e33af2c20093841ca77098]
        at org.apache.pinot.server.starter.helix.HelixInstanceDataManager.addOrReplaceSegment(HelixInstanceDataManager.java:318) [pinot-server-0.9.0-dev-322.jar:0.9.0-dev-322-421645d32f08e1fca2e33af2c20093841ca77098]
        at org.apache.pinot.server.starter.helix.SegmentOnlineOfflineStateModelFactory$SegmentOnlineOfflineStateModel.onBecomeOnlineFromOffline(SegmentOnlineOfflineStateModelFactory.java:162) [pinot-server-0.9.0-dev-322.jar:0.9.0-dev-322-421645d32f08e1fca2e33af2c20093841ca77098]
        at jdk.internal.reflect.GeneratedMethodAccessor32.invoke(Unknown Source) ~[?:?]
```

This PR fixes the verifyHostname issue in FileUploadDownloadClient by setting NoopHostnameVerifier to skip validating hostname when uploading/downloading segments.

When sslContext is null, the previous HttpClients builder will internally initialize a new object by calling `SSLContexts.createDefault()`. So the behavior remains unchanged, we should be good here.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
