### PR TITLE
follow up with picocli migration

### DIFF
--- a/pinot-perf/src/main/java/org/apache/pinot/perf/RawIndexBenchmark.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/RawIndexBenchmark.java
@@ -50,8 +50,7 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
-import org.kohsuke.args4j.CmdLineParser;
-import org.kohsuke.args4j.Option;
+import picocli.CommandLine;
 
 
 /**
@@ -60,6 +59,7 @@ import org.kohsuke.args4j.Option;
  * given input file containing strings (one string per line).
  */
 @SuppressWarnings({"FieldCanBeLocal", "unused"})
+@CommandLine.Command
 public class RawIndexBenchmark {
   private static final String SEGMENT_DIR_NAME = System.getProperty("java.io.tmpdir") + File.separator + "rawIndexPerf";
   private static final String SEGMENT_NAME = "perfTestSegment";
@@ -70,29 +70,34 @@ public class RawIndexBenchmark {
   private static final int DEFAULT_NUM_LOOKUP = 100_000;
   private static final int DEFAULT_NUM_CONSECUTIVE_LOOKUP = 50;
 
-  @Option(name = "-segmentDir", required = false, forbids = {"-dataFile"}, usage = "Untarred segment")
+  @CommandLine.Option(names = {"-segmentDir"}, required = false, description = "Untarred segment")
   private String _segmentDir = null;
 
-  @Option(name = "-fwdIndexColumn", required = false, usage = "Name of column with dictionary encoded index")
+  @CommandLine.Option(names = {"-fwdIndexColumn"}, required = false,
+      description = "Name of column with dictionary encoded index")
   private String _fwdIndexColumn = DEFAULT_FWD_INDEX_COLUMN;
 
-  @Option(name = "-rawIndexColumn", required = false, usage = "Name of column with raw index (no-dictionary")
+  @CommandLine.Option(names = {"-rawIndexColumn"}, required = false,
+      description = "Name of column with raw index (no-dictionary")
   private String _rawIndexColumn = DEFAULT_RAW_INDEX_COLUMN;
 
-  @Option(name = "-dataFile", required = false, forbids = {"-segmentDir"},
-      usage = "File containing input data (one string per line)")
+  @CommandLine.Option(names = {"-dataFile"}, required = false,
+      description = "File containing input data (one string per line)")
   private String _dataFile = null;
 
-  @Option(name = "-loadMode", required = false, usage = "Load mode for data (mmap|heap")
+  @CommandLine.Option(names = {"-loadMode"}, required = false, description = "Load mode for data (mmap|heap")
   private String _loadMode = "heap";
 
-  @Option(name = "-numLookups", required = false, usage = "Number of lookups to be performed for benchmark")
+  @CommandLine.Option(names = {"-numLookups"}, required = false,
+      description = "Number of lookups to be performed for benchmark")
   private int _numLookups = DEFAULT_NUM_LOOKUP;
 
-  @Option(name = "-numConsecutiveLookups", required = false, usage = "Number of consecutive docIds to lookup")
+  @CommandLine.Option(names = {"-numConsecutiveLookups"}, required = false,
+      description = "Number of consecutive docIds to lookup")
   private int _numConsecutiveLookups = DEFAULT_NUM_CONSECUTIVE_LOOKUP;
 
-  @Option(name = "-help", required = false, help = true, aliases = {"-h"}, usage = "print this message")
+  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
+      description = "print this message")
   private boolean _help = false;
 
   private int _numRows = 0;
@@ -296,8 +301,8 @@ public class RawIndexBenchmark {
   public static void main(String[] args)
       throws Exception {
     RawIndexBenchmark benchmark = new RawIndexBenchmark();
-    CmdLineParser parser = new CmdLineParser(benchmark);
-    parser.parseArgument(args);
+    CommandLine commandLine = new CommandLine(benchmark);
+    commandLine.parseArgs(args);
     benchmark.run();
   }
 }

--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -210,10 +210,6 @@
       <artifactId>commons-cli</artifactId>
     </dependency>
     <dependency>
-      <groupId>args4j</groupId>
-      <artifactId>args4j</artifactId>
-    </dependency>
-    <dependency>
       <groupId>info.picocli</groupId>
       <artifactId>picocli</artifactId>
     </dependency>

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/AbstractBaseCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/AbstractBaseCommand.java
@@ -18,9 +18,6 @@
  */
 package org.apache.pinot.tools;
 
-import java.lang.reflect.Field;
-import org.kohsuke.args4j.Option;
-
 
 public class AbstractBaseCommand {
   public static final String DEFAULT_ZK_ADDRESS = "localhost:2181";
@@ -47,16 +44,6 @@ public class AbstractBaseCommand {
 
   public void printUsage() {
     System.out.println("Usage: " + this.getName());
-
-    for (Field f : this.getClass().getDeclaredFields()) {
-      if (f.isAnnotationPresent(Option.class)) {
-        Option option = f.getAnnotation(Option.class);
-
-        System.out.println(String
-            .format("\t%-25s %-30s: %s (required=%s)", option.name(), option.metaVar(), option.usage(),
-                option.required()));
-      }
-    }
     printExamples();
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/AutoAddInvertedIndexTool.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/AutoAddInvertedIndexTool.java
@@ -19,54 +19,55 @@
 package org.apache.pinot.tools;
 
 import org.apache.pinot.controller.util.AutoAddInvertedIndex;
-import org.kohsuke.args4j.Option;
+import picocli.CommandLine;
 
 
 @SuppressWarnings("FieldCanBeLocal")
+@CommandLine.Command
 public class AutoAddInvertedIndexTool extends AbstractBaseCommand implements Command {
-  @Option(name = "-zkAddress", required = true, metaVar = "<string>", usage = "Address of the Zookeeper (host:port)")
+  @CommandLine.Option(names = {"-zkAddress"}, required = true, description = "Address of the Zookeeper (host:port)")
   private String _zkAddress;
 
-  @Option(name = "-clusterName", required = true, metaVar = "<string>", usage = "Pinot cluster name")
+  @CommandLine.Option(names = {"-clusterName"}, required = true, description = "Pinot cluster name")
   private String _clusterName;
 
-  @Option(name = "-controllerAddress", required = true, metaVar = "<string>",
-      usage = "Address of the Pinot controller (host:port)")
+  @CommandLine.Option(names = {"-controllerAddress"}, required = true, 
+      description = "Address of the Pinot controller (host:port)")
   private String _controllerAddress;
 
-  @Option(name = "-brokerAddress", required = true, metaVar = "<string>",
-      usage = "Address of the Pinot broker (host:port)")
+  @CommandLine.Option(names = {"-brokerAddress"}, required = true, 
+      description = "Address of the Pinot broker (host:port)")
   private String _brokerAddress;
 
-  @Option(name = "-strategy", required = false, metaVar = "<Strategy>",
-      usage = "Strategy to add inverted index (QUERY), default: QUERY")
+  @CommandLine.Option(names = {"-strategy"}, required = false, 
+      description = "Strategy to add inverted index (QUERY), default: QUERY")
   private AutoAddInvertedIndex.Strategy _strategy = AutoAddInvertedIndex.Strategy.QUERY;
 
-  @Option(name = "-mode", required = false, metaVar = "<Mode>",
-      usage = "Mode to add inverted index (NEW|REMOVE|REFRESH|APPEND), default: NEW")
+  @CommandLine.Option(names = {"-mode"}, required = false, 
+      description = "Mode to add inverted index (NEW|REMOVE|REFRESH|APPEND), default: NEW")
   private AutoAddInvertedIndex.Mode _mode = AutoAddInvertedIndex.Mode.NEW;
 
-  @Option(name = "-tableNamePattern", required = false, metaVar = "<string>",
-      usage = "Optional table name pattern to trigger adding inverted index, default: null (match any table name)")
+  @CommandLine.Option(names = {"-tableNamePattern"}, required = false, 
+      description = "Optional table name pattern trigger to add inverted index, default: null (match any table name)")
   private String _tableNamePattern = null;
 
-  @Option(name = "-tableSizeThreshold", required = false, metaVar = "<long>",
-      usage = "Optional table size threshold to trigger adding inverted index, default: "
+  @CommandLine.Option(names = {"-tableSizeThreshold"}, required = false, 
+      description = "Optional table size threshold to trigger adding inverted index, default: "
           + AutoAddInvertedIndex.DEFAULT_TABLE_SIZE_THRESHOLD)
   private long _tableSizeThreshold = AutoAddInvertedIndex.DEFAULT_TABLE_SIZE_THRESHOLD;
 
-  @Option(name = "-cardinalityThreshold", required = false, metaVar = "<long>",
-      usage = "Optional cardinality threshold to trigger adding inverted index, default: "
+  @CommandLine.Option(names = {"-cardinalityThreshold"}, required = false, 
+      description = "Optional cardinality threshold to trigger adding inverted index, default: "
           + AutoAddInvertedIndex.DEFAULT_CARDINALITY_THRESHOLD)
   private long _cardinalityThreshold = AutoAddInvertedIndex.DEFAULT_CARDINALITY_THRESHOLD;
 
-  @Option(name = "-maxNumInvertedIndex", required = false, metaVar = "<int>",
-      usage = "Optional max number of inverted index added, default: "
+  @CommandLine.Option(names = {"-maxNumInvertedIndex"}, required = false, 
+      description = "Optional max number of inverted index added, default: "
           + AutoAddInvertedIndex.DEFAULT_MAX_NUM_INVERTED_INDEX_ADDED)
   private int _maxNumInvertedIndex = AutoAddInvertedIndex.DEFAULT_MAX_NUM_INVERTED_INDEX_ADDED;
 
-  @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"},
-      usage = "Print this message.")
+  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
+      description = "Print this message.")
   private boolean _help = false;
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/SegmentDumpTool.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/SegmentDumpTool.java
@@ -53,7 +53,7 @@ public class SegmentDumpTool extends AbstractBaseCommand implements Command {
   public void doMain(String[] args)
       throws Exception {
     CommandLine commandLine = new CommandLine(this);
-    CommandLine.ParseResult parseResult = commandLine.parseArgs(args);
+    commandLine.parseArgs(args);
     dump();
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/SegmentDumpTool.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/SegmentDumpTool.java
@@ -35,29 +35,25 @@ import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.ReadMode;
-import org.kohsuke.args4j.Argument;
-import org.kohsuke.args4j.CmdLineParser;
-import org.kohsuke.args4j.Option;
-import org.kohsuke.args4j.spi.StringArrayOptionHandler;
+import picocli.CommandLine;
 
 
+@CommandLine.Command
 public class SegmentDumpTool extends AbstractBaseCommand implements Command {
-  @Argument
-  @Option(name = "-path", required = true, metaVar = "<string>",
-      usage = "Path of the folder containing the segment" + " file")
+  @CommandLine.Option(names = {"-path"}, required = true,
+      description = "Path of the folder containing the segment" + " file")
   private String _segmentDir = null;
 
-  @Argument(index = 1, multiValued = true)
-  @Option(name = "-columns", handler = StringArrayOptionHandler.class, usage = "Columns to dump")
+  @CommandLine.Option(names = {"-columns"}, arity = "1..*", description = "Columns to dump")
   private List<String> _columnNames;
 
-  @Option(name = "-dumpStarTree")
+  @CommandLine.Option(names = {"-dumpStarTree"})
   private boolean _dumpStarTree = false;
 
   public void doMain(String[] args)
       throws Exception {
-    CmdLineParser parser = new CmdLineParser(this);
-    parser.parseArgument(args);
+    CommandLine commandLine = new CommandLine(this);
+    CommandLine.ParseResult parseResult = commandLine.parseArgs(args);
     dump();
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/UpdateSegmentState.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/UpdateSegmentState.java
@@ -31,11 +31,12 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.utils.config.TableConfigUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.utils.CommonConstants;
-import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
 
 
+@CommandLine.Command
 public class UpdateSegmentState extends AbstractBaseCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(UpdateSegmentState.class);
   private static final String CMD_NAME = "UpdateSegmentState";
@@ -44,24 +45,24 @@ public class UpdateSegmentState extends AbstractBaseCommand implements Command {
   static final String DEFAULT_ZK_ADDRESS = "localhost:2181";
   static final String DEFAULT_CLUSTER_NAME = "PinotCluster";
 
-  @Option(name = "-zkAddress", required = false, metaVar = "<http>", usage = "Http address of Zookeeper.")
+  @CommandLine.Option(names = {"-zkAddress"}, required = false, description = "Http address of Zookeeper.")
   private String _zkAddress = DEFAULT_ZK_ADDRESS;
 
-  @Option(name = "-clusterName", required = false, metaVar = "<String>", usage = "Pinot cluster name.")
+  @CommandLine.Option(names = {"-clusterName"}, required = false, description = "Pinot cluster name.")
   private String _clusterName = DEFAULT_CLUSTER_NAME;
 
-  @Option(name = "-tenantName", required = false, metaVar = "<string>", usage = "Name of tenant.")
+  @CommandLine.Option(names = {"-tenantName"}, required = false, description = "Name of tenant.")
   private String _tenantName;
 
-  @Option(name = "-tableName", required = false, metaVar = "<string>",
-      usage = "Name of the table (e.g. foo_table_OFFLINE).")
+  @CommandLine.Option(names = {"-tableName"}, required = false, 
+      description = "Name of the table (e.g. foo_table_OFFLINE).")
   private String _tableName;
 
-  @Option(name = "-fix", required = false, metaVar = "<boolean>", usage = "Update IDEALSTATE values (OFFLINE->ONLINE).")
+  @CommandLine.Option(names = {"-fix"}, required = false, description = "Update IDEALSTATE values (OFFLINE->ONLINE).")
   private boolean _fix = false;
 
-  @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"},
-      usage = "Print this message.")
+  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
+      description = "Print this message.")
   private boolean _help = false;
 
   public UpdateSegmentState() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/ValidateTableRetention.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/ValidateTableRetention.java
@@ -19,28 +19,29 @@
 package org.apache.pinot.tools;
 
 import org.apache.pinot.controller.util.TableRetentionValidator;
-import org.kohsuke.args4j.Option;
+import picocli.CommandLine;
 
 
 @SuppressWarnings("FieldCanBeLocal")
+@CommandLine.Command
 public class ValidateTableRetention extends AbstractBaseCommand implements Command {
-  @Option(name = "-zkAddress", required = true, metaVar = "<string>", usage = "Address of the Zookeeper (host:port)")
+  @CommandLine.Option(names = {"-zkAddress"}, required = true, description = "Address of the Zookeeper (host:port)")
   private String _zkAddress;
 
-  @Option(name = "-clusterName", required = true, metaVar = "<string>", usage = "Pinot cluster name")
+  @CommandLine.Option(names = {"-clusterName"}, required = true, description = "Pinot cluster name")
   private String _clusterName;
 
-  @Option(name = "-tableNamePattern", required = false, metaVar = "<string>",
-      usage = "Optional table name pattern to trigger adding inverted index, default: null (match any table name)")
+  @CommandLine.Option(names = {"-tableNamePattern"}, required = false, 
+      description = "Optional table name pattern trigger to add inverted index, default: null (match any table name)")
   private String _tableNamePattern = null;
 
-  @Option(name = "-durationInDaysThreshold", required = false, metaVar = "<long>",
-      usage = "Optional duration in days threshold to log a warning for table with too large retention time, default: "
-          + TableRetentionValidator.DEFAULT_DURATION_IN_DAYS_THRESHOLD)
+  @CommandLine.Option(names = {"-durationInDaysThreshold"}, required = false, 
+      description = "Optional duration in days threshold to log a warning for table with too large retention time,"
+          + " default: " + TableRetentionValidator.DEFAULT_DURATION_IN_DAYS_THRESHOLD)
   private long _durationInDaysThreshold = TableRetentionValidator.DEFAULT_DURATION_IN_DAYS_THRESHOLD;
 
-  @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"},
-      usage = "Print this message.")
+  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
+      description = "Print this message.")
   private boolean _help = false;
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/filesystem/PinotFSBenchmarkRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/filesystem/PinotFSBenchmarkRunner.java
@@ -20,44 +20,45 @@ package org.apache.pinot.tools.filesystem;
 
 import org.apache.pinot.tools.AbstractBaseCommand;
 import org.apache.pinot.tools.Command;
-import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
 
 
+@CommandLine.Command
 public class PinotFSBenchmarkRunner extends AbstractBaseCommand implements Command {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotFSBenchmarkRunner.class);
 
-  @Option(name = "-mode", required = true, metaVar = "<String>",
-      usage = "Test mode. (ALL|LISTFILES|READWRITE|DELETE|RENAME)")
+  @CommandLine.Option(names = {"-mode"}, required = true,
+      description = "Test mode. (ALL|LISTFILES|READWRITE|DELETE|RENAME)")
   private String _mode;
 
-  @Option(name = "-pinotFSConfigFile", required = true, metaVar = "<String>",
-      usage = "Path for PinotFS configuration file")
+  @CommandLine.Option(names = {"-pinotFSConfigFile"}, required = true, 
+      description = "Path for PinotFS configuration file")
   private String _pinotFSConfigFile;
 
-  @Option(name = "-baseDirectoryUri", required = true, metaVar = "<String>",
-      usage = "Temp directory path for running benchmark against. e.g. file:///path/to/test, abfss://host/path...")
+  @CommandLine.Option(names = {"-baseDirectoryUri"}, required = true, 
+      description = "Temp dir path for running benchmark against. e.g. file:///path/to/test, abfss://host/path...")
   private String _baseDirectoryUri;
 
-  @Option(name = "-localTempDir", required = false, metaVar = "<String>", usage = "Local temp directory for benchmark.")
+  @CommandLine.Option(names = {"-localTempDir"}, required = false, description = "Local temp directory for benchmark.")
   private String _localTempDir;
 
-  @Option(name = "-numSegmentsForListTest", required = false, metaVar = "<Integer>",
-      usage = "The number of segments to create before running listFiles test.")
+  @CommandLine.Option(names = {"-numSegmentsForListTest"}, required = false, 
+      description = "The number of segments to create before running listFiles test.")
   private Integer _numSegmentsForListTest;
 
-  @Option(name = "-dataSizeInMBsForCopyTest", required = false, metaVar = "<Integer>",
-      usage = "Data size in MB for copy test. (e.g. 1024 = 1GB)")
+  @CommandLine.Option(names = {"-dataSizeInMBsForCopyTest"}, required = false, 
+      description = "Data size in MB for copy test. (e.g. 1024 = 1GB)")
   private Integer _dataSizeInMBsForCopyTest;
 
-  @Option(name = "-numOps", required = false, metaVar = "<Integer>",
-      usage = "The number of trials of operations when running a benchmark.")
+  @CommandLine.Option(names = {"-numOps"}, required = false, 
+      description = "The number of trials of operations when running a benchmark.")
   private Integer _numOps;
 
-  @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"},
-      usage = "Print this message.")
+  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
+      description = "Print this message.")
   private boolean _help = false;
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
@@ -28,60 +28,60 @@ import java.util.concurrent.TimeUnit;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.tools.AbstractBaseCommand;
 import org.apache.pinot.tools.Command;
-import org.kohsuke.args4j.CmdLineParser;
-import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
 
 
 @SuppressWarnings("FieldCanBeLocal")
+@CommandLine.Command
 public class PerfBenchmarkRunner extends AbstractBaseCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(PerfBenchmarkRunner.class);
 
-  @Option(name = "-mode", required = true, metaVar = "<String>",
-      usage = "Mode of the PerfBenchmarkRunner (startAll|startAllButServer|startServerWithPreLoadedSegments).")
+  @CommandLine.Option(names = {"-mode"}, required = true,
+      description = "Mode of the PerfBenchmarkRunner (startAll|startAllButServer|startServerWithPreLoadedSegments).")
   private String _mode;
 
-  @Option(name = "-dataDir", required = false, metaVar = "<String>",
-      usage = "Path to directory containing un-tarred segments.")
+  @CommandLine.Option(names = {"-dataDir"}, required = false, 
+      description = "Path to directory containing un-tarred segments.")
   private String _dataDir;
 
-  @Option(name = "-tempDir", required = false, metaVar = "<String>",
-      usage = "Path to temporary directory to start the cluster")
+  @CommandLine.Option(names = {"-tempDir"}, required = false, 
+      description = "Path to temporary directory to start the cluster")
   private String _tempDir = "/tmp/";
 
-  @Option(name = "-loadMode", required = false, metaVar = "<String>", usage = "Load mode of the segments (HEAP|MMAP).")
+  @CommandLine.Option(names = {"-loadMode"}, required = false, description = "Load mode of the segments (HEAP|MMAP).")
   private String _loadMode = "HEAP";
 
-  @Option(name = "-segmentFormatVersion", required = false, metaVar = "<String>",
-      usage = "Segment format version to be loaded (v1|v3).")
+  @CommandLine.Option(names = {"-segmentFormatVersion"}, required = false, 
+      description = "Segment format version to be loaded (v1|v3).")
   private String _segmentFormatVersion;
 
-  @Option(name = "-batchLoad", required = false, metaVar = "<boolean>", usage = "Batch load multiple tables.")
+  @CommandLine.Option(names = {"-batchLoad"}, required = false, description = "Batch load multiple tables.")
   private boolean _isBatchLoad;
 
-  @Option(name = "-numThreads", required = false, metaVar = "<int>",
-      usage = "Number of threads for batch load (default 10).")
+  @CommandLine.Option(names = {"-numThreads"}, required = false, 
+      description = "Number of threads for batch load (default 10).")
   private int _numThreads = 10;
 
-  @Option(name = "-timeoutInSeconds", required = false, metaVar = "<int>",
-      usage = "Timeout in seconds for batch load (default 60).")
+  @CommandLine.Option(names = {"-timeoutInSeconds"}, required = false, 
+      description = "Timeout in seconds for batch load (default 60).")
   private int _timeoutInSeconds = 60;
 
-  @Option(name = "-tableNames", required = false, metaVar = "<String>",
-      usage = "Comma separated table names with types to be loaded (non-batch load).")
+  @CommandLine.Option(names = {"-tableNames"}, required = false, 
+      description = "Comma separated table names with types to be loaded (non-batch load).")
   private String _tableNames;
 
-  @Option(name = "-invertedIndexColumns", required = false, metaVar = "<String>",
-      usage = "Comma separated inverted index columns to be created (non-batch load).")
+  @CommandLine.Option(names = {"-invertedIndexColumns"}, required = false, 
+      description = "Comma separated inverted index columns to be created (non-batch load).")
   private String _invertedIndexColumns;
 
-  @Option(name = "-bloomFilterColumns", required = false, metaVar = "<String>",
-      usage = "Comma separated bloom filter columns to be created (non-batch load).")
+  @CommandLine.Option(names = {"-bloomFilterColumns"}, required = false, 
+      description = "Comma separated bloom filter columns to be created (non-batch load).")
   private String _bloomFilterColumns;
 
-  @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"},
-      usage = "Print this message.")
+  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
+      description = "Print this message.")
   private boolean _help = false;
 
   @Override
@@ -191,8 +191,8 @@ public class PerfBenchmarkRunner extends AbstractBaseCommand implements Command 
   public static void main(String[] args)
       throws Exception {
     PerfBenchmarkRunner perfBenchmarkRunner = new PerfBenchmarkRunner();
-    CmdLineParser parser = new CmdLineParser(perfBenchmarkRunner);
-    parser.parseArgument(args);
+    CommandLine commandLine = new CommandLine(perfBenchmarkRunner);
+    CommandLine.ParseResult parseResult = commandLine.parseArgs(args);
 
     if (perfBenchmarkRunner._help) {
       perfBenchmarkRunner.printUsage();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
@@ -192,7 +192,7 @@ public class PerfBenchmarkRunner extends AbstractBaseCommand implements Command 
       throws Exception {
     PerfBenchmarkRunner perfBenchmarkRunner = new PerfBenchmarkRunner();
     CommandLine commandLine = new CommandLine(perfBenchmarkRunner);
-    CommandLine.ParseResult parseResult = commandLine.parseArgs(args);
+    commandLine.parseArgs(args);
 
     if (perfBenchmarkRunner._help) {
       perfBenchmarkRunner.printUsage();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/QueryRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/QueryRunner.java
@@ -914,7 +914,7 @@ public class QueryRunner extends AbstractBaseCommand implements Command {
       throws Exception {
     QueryRunner queryRunner = new QueryRunner();
     CommandLine commandLine = new CommandLine(queryRunner);
-    CommandLine.ParseResult parseResult = commandLine.parseArgs(args);
+    commandLine.parseArgs(args);
     if (queryRunner._help) {
       queryRunner.printUsage();
     } else {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/QueryRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/QueryRunner.java
@@ -39,67 +39,69 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.math.stat.descriptive.DescriptiveStatistics;
 import org.apache.pinot.tools.AbstractBaseCommand;
 import org.apache.pinot.tools.Command;
-import org.kohsuke.args4j.CmdLineParser;
-import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
 
 
 @SuppressWarnings("FieldCanBeLocal")
+@CommandLine.Command
 public class QueryRunner extends AbstractBaseCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(QueryRunner.class);
   private static final int MILLIS_PER_SECOND = 1000;
   private static final long NANO_DELTA = (long) 5E5;
   private static final String CLIENT_TIME_STATISTICS = "CLIENT TIME STATISTICS";
 
-  @Option(name = "-mode", required = true, metaVar = "<String>",
-      usage = "Mode of query runner (singleThread|multiThreads|targetQPS|increasingQPS).")
+  @CommandLine.Option(names = {"-mode"}, required = true, 
+      description = "Mode of query runner (singleThread|multiThreads|targetQPS|increasingQPS).")
   private String _mode;
-  @Option(name = "-queryFile", required = true, metaVar = "<String>", usage = "Path to query file.")
+  @CommandLine.Option(names = {"-queryFile"}, required = true, description = "Path to query file.")
   private String _queryFile;
-  @Option(name = "-queryMode", required = false, metaVar = "<String>",
-      usage = "Mode of query generator (full|resample).")
+  @CommandLine.Option(names = {"-queryMode"}, required = false,
+      description = "Mode of query generator (full|resample).")
   private String _queryMode = QueryMode.FULL.toString();
-  @Option(name = "-queryCount", required = false, metaVar = "<int>",
-      usage = "Number of queries to run (default 0 = all).")
+  @CommandLine.Option(names = {"-queryCount"}, required = false,
+      description = "Number of queries to run (default 0 = all).")
   private int _queryCount = 0;
-  @Option(name = "-numTimesToRunQueries", required = false, metaVar = "<int>",
-      usage = "Number of times to run all queries in the query file, 0 means infinite times (default 1).")
+  @CommandLine.Option(names = {"-numTimesToRunQueries"}, required = false, 
+      description = "Number of times to run all queries in the query file, 0 means infinite times (default 1).")
   private int _numTimesToRunQueries = 1;
-  @Option(name = "-reportIntervalMs", required = false, metaVar = "<int>",
-      usage = "Interval in milliseconds to report simple statistics (default 3000).")
+  @CommandLine.Option(names = {"-reportIntervalMs"}, required = false, 
+      description = "Interval in milliseconds to report simple statistics (default 3000).")
   private int _reportIntervalMs = 3000;
-  @Option(name = "-numIntervalsToReportAndClearStatistics", required = false, metaVar = "<int>",
-      usage = "Number of report intervals to report detailed statistics and clear them, 0 means never (default 10).")
+  @CommandLine.Option(names = {"-numIntervalsToReportAndClearStatistics"}, required = false, 
+      description = "Number of report intervals to report detailed statistics and clear them,"
+          + " 0 means never (default 10).")
   private int _numIntervalsToReportAndClearStatistics = 10;
-  @Option(name = "-numThreads", required = false, metaVar = "<int>",
-      usage = "Number of threads sending queries for multiThreads, targetQPS and increasingQPS mode (default 5). "
+  @CommandLine.Option(names = {"-numThreads"}, required = false, 
+      description = "Number of threads sending queries for multiThreads, targetQPS and increasingQPS mode (default 5). "
           + "This can be used to simulate multiple clients sending queries concurrently.")
   private int _numThreads = 5;
-  @Option(name = "-startQPS", required = false, metaVar = "<int>",
-      usage = "Start QPS for targetQPS and increasingQPS mode")
+  @CommandLine.Option(names = {"-startQPS"}, required = false, 
+      description = "Start QPS for targetQPS and increasingQPS mode")
   private double _startQPS;
-  @Option(name = "-deltaQPS", required = false, metaVar = "<int>", usage = "Delta QPS for increasingQPS mode.")
+  @CommandLine.Option(names = {"-deltaQPS"}, required = false, description = "Delta QPS for increasingQPS mode.")
   private double _deltaQPS;
-  @Option(name = "-numIntervalsToIncreaseQPS", required = false, metaVar = "<int>",
-      usage = "Number of report intervals to increase QPS for increasingQPS mode (default 10).")
+  @CommandLine.Option(names = {"-numIntervalsToIncreaseQPS"}, required = false, 
+      description = "Number of report intervals to increase QPS for increasingQPS mode (default 10).")
   private int _numIntervalsToIncreaseQPS = 10;
-  @Option(name = "-brokerHost", required = false, metaVar = "<String>", usage = "Broker host name (default localhost).")
+  @CommandLine.Option(names = {"-brokerHost"}, required = false, description = "Broker host name (default localhost).")
   private String _brokerHost = "localhost";
-  @Option(name = "-brokerPort", required = false, metaVar = "<int>", usage = "Broker port number (default 8099).")
+  @CommandLine.Option(names = {"-brokerPort"}, required = false, description = "Broker port number (default 8099).")
   private int _brokerPort = 8099;
-  @Option(name = "-queueDepth", required = false, metaVar = "<int>",
-      usage = "Queue size limit for multi-threaded execution (default 64).")
+  @CommandLine.Option(names = {"-queueDepth"}, required = false,
+      description = "Queue size limit for multi-threaded execution (default 64).")
   private int _queueDepth = 64;
-  @Option(name = "-timeout", required = false, metaVar = "<long>",
-      usage = "Timeout in milliseconds for completing all queries (default: unlimited).")
+  @CommandLine.Option(names = {"-timeout"}, required = false,
+      description = "Timeout in milliseconds for completing all queries (default: unlimited).")
   private long _timeout = 0;
-  @Option(name = "-verbose", required = false, usage = "Enable verbose query logging (default: false).")
+  @CommandLine.Option(names = {"-verbose"}, required = false,
+      description = "Enable verbose query logging (default: false).")
   private boolean _verbose = false;
-  @Option(name = "-dialect", required = false, metaVar = "<String>", usage = "Query dialect to use (pql|sql).")
+  @CommandLine.Option(names = {"-dialect"}, required = false, description = "Query dialect to use (pql|sql).")
   private String _dialect = "pql";
-  @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"},
-      usage = "Print this message.")
+  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
+      description = "Print this message.")
   private boolean _help;
 
   private enum QueryMode {
@@ -911,9 +913,8 @@ public class QueryRunner extends AbstractBaseCommand implements Command {
   public static void main(String[] args)
       throws Exception {
     QueryRunner queryRunner = new QueryRunner();
-    CmdLineParser parser = new CmdLineParser(queryRunner);
-    parser.parseArgument(args);
-
+    CommandLine commandLine = new CommandLine(queryRunner);
+    CommandLine.ParseResult parseResult = commandLine.parseArgs(args);
     if (queryRunner._help) {
       queryRunner.printUsage();
     } else {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/DictionaryToRawIndexConverter.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/DictionaryToRawIndexConverter.java
@@ -409,7 +409,7 @@ public class DictionaryToRawIndexConverter implements Command {
       throws Exception {
     DictionaryToRawIndexConverter converter = new DictionaryToRawIndexConverter();
     CommandLine commandLine = new CommandLine(converter);
-    CommandLine.ParseResult parseResult = commandLine.parseArgs(args);
+    commandLine.parseArgs(args);
     converter.convert();
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/DictionaryToRawIndexConverter.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/DictionaryToRawIndexConverter.java
@@ -20,7 +20,6 @@ package org.apache.pinot.tools.segment.converter;
 
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Field;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -43,10 +42,10 @@ import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
-import org.kohsuke.args4j.CmdLineParser;
-import org.kohsuke.args4j.Option;
+import org.apache.pinot.tools.Command;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -55,34 +54,41 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * Class to convert segment with dictionary encoded column to raw index (without dictionary).
  */
 @SuppressWarnings({"FieldCanBeLocal", "unused", "rawtypes", "unchecked"})
-public class DictionaryToRawIndexConverter {
+@CommandLine.Command
+public class DictionaryToRawIndexConverter implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(DictionaryToRawIndexConverter.class);
 
-  @Option(name = "-dataDir", required = true, usage = "Directory containing uncompressed segments")
+  @CommandLine.Option(names = {"-dataDir"}, required = true,
+      description = "Directory containing uncompressed segments")
   private String _dataDir = null;
 
-  @Option(name = "-columns", required = true, usage = "Comma separated list of column names to convert")
+  @CommandLine.Option(names = {"-columns"}, required = true,
+      description = "Comma separated list of column names to convert")
   private String _columns = null;
 
-  @Option(name = "-tableName", required = false, usage = "New table name, if different from original")
+  @CommandLine.Option(names = {"-tableName"}, required = false,
+      description = "New table name, if different from original")
   private String _tableName = null;
 
-  @Option(name = "-outputDir", required = true, usage = "Output directory for writing results")
+  @CommandLine.Option(names = {"-outputDir"}, required = true, description = "Output directory for writing results")
   private String _outputDir = null;
 
-  @Option(name = "-overwrite", required = false, usage = "Overwrite output directory")
+  @CommandLine.Option(names = {"-overwrite"}, required = false, description = "Overwrite output directory")
   private boolean _overwrite = false;
 
-  @Option(name = "-numThreads", required = false, usage = "Number of threads to launch for conversion")
+  @CommandLine.Option(names = {"-numThreads"}, required = false,
+      description = "Number of threads to launch for conversion")
   private int _numThreads = 4;
 
-  @Option(name = "-compressOutput", required = false, usage = "Compress (tar + gzip) output segment")
+  @CommandLine.Option(names = {"-compressOutput"}, required = false,
+      description = "Compress (tar + gzip) output segment")
   private boolean _compressOutput = false;
 
-  @Option(name = "-compressionType", required = false, usage = "Compression Type")
+  @CommandLine.Option(names = {"-compressionType"}, required = false, description = "Compression Type")
   private String _compressionType = "Snappy";
 
-  @Option(name = "-help", required = false, help = true, aliases = {"-h"}, usage = "print this message")
+  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
+      description = "print this message")
   private boolean _help = false;
 
   /**
@@ -262,20 +268,28 @@ public class DictionaryToRawIndexConverter {
     properties.save();
   }
 
+  @Override
+  public boolean execute()
+      throws Exception {
+    return false;
+  }
+
   /**
    * Helper method to print usage at the command line interface.
    */
-  private static void printUsage() {
-    System.out.println("Usage: DictionaryTORawIndexConverter");
-    for (Field field : DictionaryToRawIndexConverter.class.getDeclaredFields()) {
+  @Override
+  public void printUsage() {
+    //
+  }
 
-      if (field.isAnnotationPresent(Option.class)) {
-        Option option = field.getAnnotation(Option.class);
+  @Override
+  public String description() {
+    return null;
+  }
 
-        System.out
-            .println(String.format("\t%-15s: %s (required=%s)", option.name(), option.usage(), option.required()));
-      }
-    }
+  @Override
+  public boolean getHelp() {
+    return _help;
   }
 
   /**
@@ -394,8 +408,8 @@ public class DictionaryToRawIndexConverter {
   public static void main(String[] args)
       throws Exception {
     DictionaryToRawIndexConverter converter = new DictionaryToRawIndexConverter();
-    CmdLineParser parser = new CmdLineParser(converter);
-    parser.parseArgument(args);
+    CommandLine commandLine = new CommandLine(converter);
+    CommandLine.ParseResult parseResult = commandLine.parseArgs(args);
     converter.convert();
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/DictionaryToRawIndexConverter.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/DictionaryToRawIndexConverter.java
@@ -20,6 +20,8 @@ package org.apache.pinot.tools.segment.converter;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -42,7 +44,6 @@ import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
-import org.apache.pinot.tools.Command;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -55,7 +56,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 @SuppressWarnings({"FieldCanBeLocal", "unused", "rawtypes", "unchecked"})
 @CommandLine.Command
-public class DictionaryToRawIndexConverter implements Command {
+public class DictionaryToRawIndexConverter {
   private static final Logger LOGGER = LoggerFactory.getLogger(DictionaryToRawIndexConverter.class);
 
   @CommandLine.Option(names = {"-dataDir"}, required = true,
@@ -268,28 +269,19 @@ public class DictionaryToRawIndexConverter implements Command {
     properties.save();
   }
 
-  @Override
-  public boolean execute()
-      throws Exception {
-    return false;
-  }
-
   /**
    * Helper method to print usage at the command line interface.
    */
-  @Override
   public void printUsage() {
-    //
-  }
-
-  @Override
-  public String description() {
-    return null;
-  }
-
-  @Override
-  public boolean getHelp() {
-    return _help;
+    System.out.println("Usage: DictionaryTORawIndexConverter");
+    for (Field field : DictionaryToRawIndexConverter.class.getDeclaredFields()) {
+      if (field.isAnnotationPresent(CommandLine.Option.class)) {
+        CommandLine.Option option = field.getAnnotation(CommandLine.Option.class);
+        System.out
+            .println(String.format("\t%-15s: %s (required=%s)",
+                Arrays.toString(option.names()), Arrays.toString(option.description()), option.required()));
+      }
+    }
   }
 
   /**

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/PinotSegmentConvertCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/PinotSegmentConvertCommand.java
@@ -26,7 +26,6 @@ import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.tools.AbstractBaseCommand;
 import org.apache.pinot.tools.Command;
-import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -47,33 +46,33 @@ public class PinotSegmentConvertCommand extends AbstractBaseCommand implements C
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotSegmentConvertCommand.class);
   private static final String TEMP_DIR_NAME = "temp";
 
-  @Option(name = "-dataDir", required = true, metaVar = "<String>",
-      usage = "Path to data directory containing Pinot segments.")
+  @CommandLine.Option(names = {"-dataDir"}, required = true,
+      description = "Path to data directory containing Pinot segments.")
   private String _dataDir;
 
-  @Option(name = "-outputDir", required = true, metaVar = "<String>", usage = "Path to output directory.")
+  @CommandLine.Option(names = {"-outputDir"}, required = true, description = "Path to output directory.")
   private String _outputDir;
 
-  @Option(name = "-outputFormat", required = true, metaVar = "<String>",
-      usage = "Format to convert to (AVRO/CSV/JSON).")
+  @CommandLine.Option(names = {"-outputFormat"}, required = true, 
+      description = "Format to convert to (AVRO/CSV/JSON).")
   private String _outputFormat;
 
-  @Option(name = "-csvDelimiter", required = false, metaVar = "<char>", usage = "CSV delimiter (default ',').")
+  @CommandLine.Option(names = {"-csvDelimiter"}, required = false, description = "CSV delimiter (default ',').")
   private char _csvDelimiter = ',';
 
-  @Option(name = "-csvListDelimiter", required = false, metaVar = "<char>",
-      usage = "CSV List delimiter for multi-value columns (default ';').")
+  @CommandLine.Option(names = {"-csvListDelimiter"}, required = false, 
+      description = "CSV List delimiter for multi-value columns (default ';').")
   private char _csvListDelimiter = ';';
 
-  @Option(name = "-csvWithHeader", required = false, metaVar = "<boolean>", usage = "Print CSV Header (default false).")
+  @CommandLine.Option(names = {"-csvWithHeader"}, required = false, description = "Print CSV Header (default false).")
   private boolean _csvWithHeader;
 
-  @Option(name = "-overwrite", required = false, metaVar = "<boolean>",
-      usage = "Overwrite the existing file (default false).")
+  @CommandLine.Option(names = {"-overwrite"}, required = false, 
+      description = "Overwrite the existing file (default false).")
   private boolean _overwrite;
 
-  @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"},
-      usage = "Print this message.")
+  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
+      description = "Print this message.")
   private boolean _help;
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/SegmentMergeCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/SegmentMergeCommand.java
@@ -44,7 +44,6 @@ import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.tools.Command;
 import org.apache.pinot.tools.admin.command.AbstractBaseAdminCommand;
-import org.kohsuke.args4j.Option;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -63,39 +62,39 @@ public class SegmentMergeCommand extends AbstractBaseAdminCommand implements Com
   private static final String DEFAULT_MERGE_TYPE = "CONCATENATE";
   private static final int DEFAULT_SEQUENCE_ID = 0;
 
-  @Option(name = "-inputPaths", required = true, metaVar = "<String>",
-      usage = "Comma separated input segment files or directories that contains input segments to be merged")
+  @CommandLine.Option(names = {"-inputPaths"}, required = true, 
+      description = "Comma separated input segment files or directories that contains input segments to be merged")
   private String _inputSegmentPaths;
 
-  @Option(name = "-outputPath", required = true, metaVar = "<String>",
-      usage = "Output segment path. This should be different from working directory.")
+  @CommandLine.Option(names = {"-outputPath"}, required = true, 
+      description = "Output segment path. This should be different from working directory.")
   private String _outputPath;
 
-  @Option(name = "-tableConfigFilePath", required = true, metaVar = "<String>", usage = "Table config file path.")
+  @CommandLine.Option(names = {"-tableConfigFilePath"}, required = true, description = "Table config file path.")
   private String _tableConfigFilePath;
 
-  @Option(name = "-schemaFilePath", required = true, metaVar = "<String>", usage = "Schema file path")
+  @CommandLine.Option(names = {"-schemaFilePath"}, required = true, description = "Schema file path")
   private String _schemaFilePath;
 
-  @Option(name = "-tarOutputSegment", required = true, metaVar = "<String>",
-      usage = "Indicate whether to tar output segment (true, false)")
+  @CommandLine.Option(names = {"-tarOutputSegment"}, required = true, 
+      description = "Indicate whether to tar output segment (true, false)")
   private String _tarOutputSegment;
 
-  @Option(name = "-outputSegmentName", required = false, metaVar = "<String>",
-      usage = "The name of output segment file")
+  @CommandLine.Option(names = {"-outputSegmentName"}, required = false, 
+      description = "The name of output segment file")
   private String _outputSegmentName;
 
   // TODO: once rollup mode is supported, make this field required
-  @Option(name = "-mergeType", required = false, metaVar = "<String>",
-      usage = "Merge type (\"CONCATENATE\" or \"ROLLUP\"). Currently, only \"CONCATENATE\" type is supported.")
+  @CommandLine.Option(names = {"-mergeType"}, required = false, 
+      description = "Merge type (\"CONCATENATE\" or \"ROLLUP\"). Currently, only \"CONCATENATE\" type is supported.")
   private String _mergeType = DEFAULT_MERGE_TYPE;
 
-  @Option(name = "-workingDirectory", required = false, metaVar = "<String>",
-      usage = "Path for working directory. This directory gets cleaned up after the job")
+  @CommandLine.Option(names = {"-workingDirectory"}, required = false, 
+      description = "Path for working directory. This directory gets cleaned up after the job")
   private String _workingDirectory;
 
-  @Option(name = "-help", required = false, help = true, aliases = {"-h", "--h", "--help"},
-      usage = "Print this message.")
+  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
+      description = "Print this message.")
   private boolean _help = false;
 
   public boolean getHelp() {

--- a/pom.xml
+++ b/pom.xml
@@ -1277,11 +1277,6 @@
         <version>3.0.12</version>
       </dependency>
       <dependency>
-        <groupId>args4j</groupId>
-        <artifactId>args4j</artifactId>
-        <version>2.32</version>
-      </dependency>
-      <dependency>
         <groupId>info.picocli</groupId>
         <artifactId>picocli</artifactId>
         <version>4.6.1</version>


### PR DESCRIPTION
This is a follow up of #7665

This PR completely removed args4j dependency and migrate all CLI utilities to use picocli. This should close: #7673 
Afterwards #7710 outlines all the remaining TODOs that can be address later.