### PR TITLE
optimise getUnpaddedString with SWAR padding search

### DIFF
--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkFixedByteValueReaderWriter.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkFixedByteValueReaderWriter.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import java.io.IOException;
+import java.nio.ByteOrder;
+import java.util.SplittableRandom;
+import org.apache.pinot.segment.local.io.util.FixedByteValueReaderWriter;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+
+@State(Scope.Benchmark)
+public class BenchmarkFixedByteValueReaderWriter {
+
+  @Param({"8", "32", "1024", "65536"})
+  int _length;
+
+  @Param("4096")
+  int _values;
+
+  @Param({"true", "false"})
+  boolean _nativeOrder;
+
+  @Param("42")
+  int _paddingByte;
+
+  private PinotDataBuffer _dataBuffer;
+  private FixedByteValueReaderWriter _writer;
+  byte[] _buffer;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    _dataBuffer = PinotDataBuffer.allocateDirect(_values * _length,
+        _nativeOrder ? ByteOrder.nativeOrder() : ByteOrder.BIG_ENDIAN, "");
+    _writer = new FixedByteValueReaderWriter(_dataBuffer);
+    SplittableRandom random = new SplittableRandom(42);
+    byte[] bytes = new byte[_length];
+    for (int i = 0; i < _values; i++) {
+      int index = random.nextInt(bytes.length);
+      bytes[index] = (byte) _paddingByte;
+      _writer.writeBytes(i, _length, bytes);
+      bytes[index] = 0;
+    }
+    _buffer = bytes;
+  }
+
+  @TearDown(Level.Trial)
+  public void cleanup()
+      throws IOException {
+    _dataBuffer.close();
+  }
+
+  @Benchmark
+  public void readStrings(Blackhole bh) {
+    for (int i = 0; i < _values; i++) {
+      bh.consume(_writer.getUnpaddedString(i, _length, (byte) _paddingByte, _buffer));
+    }
+  }
+}

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkFixedByteValueReaderWriter.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkFixedByteValueReaderWriter.java
@@ -54,7 +54,7 @@ public class BenchmarkFixedByteValueReaderWriter {
 
   @Setup(Level.Trial)
   public void setup() {
-    _dataBuffer = PinotDataBuffer.allocateDirect(_values * _length,
+    _dataBuffer = PinotDataBuffer.allocateDirect(_values * (long) _length,
         _nativeOrder ? ByteOrder.nativeOrder() : ByteOrder.BIG_ENDIAN, "");
     _writer = new FixedByteValueReaderWriter(_dataBuffer);
     SplittableRandom random = new SplittableRandom(42);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/FixedByteValueReaderWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/FixedByteValueReaderWriter.java
@@ -70,7 +70,7 @@ public final class FixedByteValueReaderWriter implements ValueReader {
       long tmp = (zeroed & 0x7F7F7F7F7F7F7F7FL) + 0x7F7F7F7F7F7F7F7FL;
       tmp = ~(tmp | zeroed | 0x7F7F7F7F7F7F7F7FL);
       if (tmp == 0) {
-       position += 8;
+        position += 8;
       } else {
         position += _dataBuffer.order() == ByteOrder.LITTLE_ENDIAN
             ? Long.numberOfTrailingZeros(tmp) >>> 3

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/readerwriter/FixedByteValueReaderWriterTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/readerwriter/FixedByteValueReaderWriterTest.java
@@ -49,7 +49,7 @@ public class FixedByteValueReaderWriterTest {
         {16, 16, ByteOrder.LITTLE_ENDIAN},
         {16, 16, ByteOrder.BIG_ENDIAN},
         {9, 16, ByteOrder.LITTLE_ENDIAN},
-        {9, 16, ByteOrder.BIG_ENDIAN},
+        {9, 16, ByteOrder.BIG_ENDIAN}
     };
   }
 
@@ -58,8 +58,8 @@ public class FixedByteValueReaderWriterTest {
       throws IOException {
     byte nt = 0;
     byte[] bytes = new byte[configuredMaxLength];
-    try (PinotDataBuffer buffer = PinotDataBuffer.allocateDirect(configuredMaxLength * 1000L,
-        byteOrder, "testFixedByteValueReaderWriter")) {
+    try (PinotDataBuffer buffer = PinotDataBuffer.allocateDirect(configuredMaxLength * 1000L, byteOrder,
+        "testFixedByteValueReaderWriter")) {
       FixedByteValueReaderWriter readerWriter = new FixedByteValueReaderWriter(buffer);
       List<String> inputs = new ArrayList<>(1000);
       for (int i = 0; i < 1000; i++) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/readerwriter/FixedByteValueReaderWriterTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/readerwriter/FixedByteValueReaderWriterTest.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.readerwriter;
+
+import java.io.IOException;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.pinot.segment.local.io.util.FixedByteValueReaderWriter;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class FixedByteValueReaderWriterTest {
+
+  @DataProvider
+  public static Object[][] params() {
+    return new Object[][] {
+        {10, 10, ByteOrder.LITTLE_ENDIAN},
+        {10, 10, ByteOrder.BIG_ENDIAN},
+        {10, 20, ByteOrder.LITTLE_ENDIAN},
+        {10, 20, ByteOrder.BIG_ENDIAN},
+        {19, 20, ByteOrder.LITTLE_ENDIAN},
+        {19, 20, ByteOrder.BIG_ENDIAN},
+        {8, 16, ByteOrder.LITTLE_ENDIAN},
+        {8, 16, ByteOrder.BIG_ENDIAN},
+        {16, 16, ByteOrder.LITTLE_ENDIAN},
+        {16, 16, ByteOrder.BIG_ENDIAN},
+        {9, 16, ByteOrder.LITTLE_ENDIAN},
+        {9, 16, ByteOrder.BIG_ENDIAN},
+    };
+  }
+
+  @Test(dataProvider = "params")
+  public void testFixedByteValueReaderWriter(int maxStringLength, int configuredMaxLength, ByteOrder byteOrder)
+      throws IOException {
+    byte nt = 0;
+    byte[] bytes = new byte[configuredMaxLength];
+    try (PinotDataBuffer buffer = PinotDataBuffer.allocateDirect(configuredMaxLength * 1000L,
+        byteOrder, "testFixedByteValueReaderWriter")) {
+      FixedByteValueReaderWriter readerWriter = new FixedByteValueReaderWriter(buffer);
+      List<String> inputs = new ArrayList<>(1000);
+      for (int i = 0; i < 1000; i++) {
+        int length = ThreadLocalRandom.current().nextInt(maxStringLength);
+        Arrays.fill(bytes, 0, length, (byte) 'a');
+        readerWriter.writeBytes(i, configuredMaxLength, bytes);
+        inputs.add(new String(bytes, 0, length, StandardCharsets.UTF_8));
+        Arrays.fill(bytes, nt);
+      }
+      for (int i = 0; i < 1000; i++) {
+        assertEquals(readerWriter.getUnpaddedString(i, configuredMaxLength, nt, bytes), inputs.get(i));
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description
This method was the hottest method on the pinot server in a string-heavy load test:

<img width="936" alt="Screenshot 2021-11-05 at 12 33 13" src="https://user-images.githubusercontent.com/16439049/140510773-506129fb-bbb2-4fd2-8435-4063b3030167.png">

This change performs the search for padding bytes 8 bytes at a time which accelerates the search.

Before
```
Benchmark                                        (_length)  (_nativeOrder)  (_paddingByte)  (_values)  Mode  Cnt       Score       Error  Units
BenchmarkFixedByteValueReaderWriter.readStrings          8            true              42       4096  avgt    5     144.520 ±     3.255  us/op
BenchmarkFixedByteValueReaderWriter.readStrings          8           false              42       4096  avgt    5     157.459 ±    43.499  us/op
BenchmarkFixedByteValueReaderWriter.readStrings         32            true              42       4096  avgt    5     274.456 ±     3.420  us/op
BenchmarkFixedByteValueReaderWriter.readStrings         32           false              42       4096  avgt    5     277.324 ±    11.429  us/op
BenchmarkFixedByteValueReaderWriter.readStrings       1024            true              42       4096  avgt    5    4987.751 ±   204.235  us/op
BenchmarkFixedByteValueReaderWriter.readStrings       1024           false              42       4096  avgt    5    4978.517 ±   306.599  us/op
BenchmarkFixedByteValueReaderWriter.readStrings      65536            true              42       4096  avgt    5  361066.397 ± 22635.672  us/op
BenchmarkFixedByteValueReaderWriter.readStrings      65536           false              42       4096  avgt    5  330063.036 ± 22979.931  us/op
```

After
```
Benchmark                                        (_length)  (_nativeOrder)  (_paddingByte)  (_values)  Mode  Cnt      Score      Error  Units
BenchmarkFixedByteValueReaderWriter.readStrings          8            true              42       4096  avgt    5    127.794 ±    2.571  us/op
BenchmarkFixedByteValueReaderWriter.readStrings          8           false              42       4096  avgt    5    130.723 ±   10.582  us/op
BenchmarkFixedByteValueReaderWriter.readStrings         32            true              42       4096  avgt    5    192.249 ±    3.020  us/op
BenchmarkFixedByteValueReaderWriter.readStrings         32           false              42       4096  avgt    5    192.169 ±   15.036  us/op
BenchmarkFixedByteValueReaderWriter.readStrings       1024            true              42       4096  avgt    5    982.148 ±   52.506  us/op
BenchmarkFixedByteValueReaderWriter.readStrings       1024           false              42       4096  avgt    5   1025.949 ±   59.918  us/op
BenchmarkFixedByteValueReaderWriter.readStrings      65536            true              42       4096  avgt    5  62129.454 ± 1744.739  us/op
BenchmarkFixedByteValueReaderWriter.readStrings      65536           false              42       4096  avgt    5  65727.304 ± 1073.443  us/op
```

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
