### PR TITLE
inline binary comparison ops to prevent function call overhead

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
@@ -253,7 +253,7 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
     byte[][] leftBytesValues = _leftTransformFunction.transformToBytesValuesSV(projectionBlock);
     byte[][] rightBytesValues = _rightTransformFunction.transformToBytesValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult((new ByteArray(leftBytesValues[i])).compareTo(new ByteArray(rightBytesValues[i])));
+      _results[i] = getIntResult((ByteArray.compare(leftBytesValues[i], rightBytesValues[i])));
     }
   }
 
@@ -347,7 +347,7 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
   private void fillLongResultArray(ProjectionBlock projectionBlock, float[] leftValues, int length) {
     long[] rightValues = _rightTransformFunction.transformToLongValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(BigDecimal.valueOf(rightValues[i])));
+      _results[i] = getIntResult(Double.compare(leftValues[i], rightValues[i]));
     }
   }
 
@@ -387,7 +387,7 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
   private void fillLongResultArray(ProjectionBlock projectionBlock, double[] leftValues, int length) {
     long[] rightValues = _rightTransformFunction.transformToLongValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(BigDecimal.valueOf(rightValues[i])));
+      _results[i] = getIntResult(Double.compare(leftValues[i], rightValues[i]));
     }
   }
 
@@ -436,8 +436,7 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
       case NOT_EQUAL:
         return comparisonResult != 0;
       default:
-        assert false;
-        return false;
+        throw new IllegalStateException();
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
@@ -347,7 +347,7 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
   private void fillLongResultArray(ProjectionBlock projectionBlock, float[] leftValues, int length) {
     long[] rightValues = _rightTransformFunction.transformToLongValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(Double.compare(leftValues[i], rightValues[i]));
+      _results[i] = compare(leftValues[i], rightValues[i]);
     }
   }
 
@@ -387,7 +387,7 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
   private void fillLongResultArray(ProjectionBlock projectionBlock, double[] leftValues, int length) {
     long[] rightValues = _rightTransformFunction.transformToLongValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(Double.compare(leftValues[i], rightValues[i]));
+      _results[i] = compare(leftValues[i], rightValues[i]);
     }
   }
 
@@ -414,6 +414,14 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
       } catch (NumberFormatException e) {
         _results[i] = 0;
       }
+    }
+  }
+
+  private int compare(double left, long right) {
+    if (Math.abs(right) <= 1L << 53) {
+      return getIntResult(Double.compare(left, right));
+    } else {
+      return getIntResult(BigDecimal.valueOf(left).compareTo(BigDecimal.valueOf(right)));
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
@@ -86,8 +86,8 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
   @Override
   public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
     // Check that there are exact 2 arguments
-    Preconditions
-        .checkArgument(arguments.size() == 2, "Exact 2 arguments are required for binary operator transform function");
+    Preconditions.checkArgument(arguments.size() == 2,
+        "Exact 2 arguments are required for binary operator transform function");
     _leftTransformFunction = arguments.get(0);
     _rightTransformFunction = arguments.get(1);
     _leftStoredType = _leftTransformFunction.getResultMetadata().getDataType().getStoredType();
@@ -289,8 +289,7 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
     String[] rightStringValues = _rightTransformFunction.transformToStringValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
       try {
-        _results[i] =
-            getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
+        _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
       } catch (NumberFormatException e) {
         _results[i] = 0;
       }
@@ -314,14 +313,14 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
   private void fillFloatResultArray(ProjectionBlock projectionBlock, long[] leftValues, int length) {
     float[] rightFloatValues = _rightTransformFunction.transformToFloatValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(Double.compare(leftValues[i], rightFloatValues[i]));
+      _results[i] = getIntResult(compare(leftValues[i], rightFloatValues[i]));
     }
   }
 
   private void fillDoubleResultArray(ProjectionBlock projectionBlock, long[] leftValues, int length) {
     double[] rightDoubleValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(Double.compare(leftValues[i], rightDoubleValues[i]));
+      _results[i] = getIntResult(compare(leftValues[i], rightDoubleValues[i]));
     }
   }
 
@@ -329,8 +328,7 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
     String[] rightStringValues = _rightTransformFunction.transformToStringValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
       try {
-        _results[i] =
-            getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
+        _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
       } catch (NumberFormatException e) {
         _results[i] = 0;
       }
@@ -369,8 +367,7 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
     String[] rightStringValues = _rightTransformFunction.transformToStringValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
       try {
-        _results[i] =
-            getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
+        _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
       } catch (NumberFormatException e) {
         _results[i] = 0;
       }
@@ -409,11 +406,18 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
     String[] rightStringValues = _rightTransformFunction.transformToStringValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
       try {
-        _results[i] =
-            getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
+        _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
       } catch (NumberFormatException e) {
         _results[i] = 0;
       }
+    }
+  }
+
+  private int compare(long left, double right) {
+    if (Math.abs(left) <= 1L << 53) {
+      return getIntResult(Double.compare(left, right));
+    } else {
+      return getIntResult(BigDecimal.valueOf(left).compareTo(BigDecimal.valueOf(right)));
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/EqualsTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/EqualsTransformFunction.java
@@ -40,13 +40,7 @@ import org.apache.pinot.common.function.TransformFunctionType;
  */
 public class EqualsTransformFunction extends BinaryOperatorTransformFunction {
 
-  @Override
-  public String getName() {
-    return TransformFunctionType.EQUALS.getName();
-  }
-
-  @Override
-  protected boolean getBinaryFuncResult(int comparisonResult) {
-    return comparisonResult == 0;
+  public EqualsTransformFunction() {
+    super(TransformFunctionType.EQUALS);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GreaterThanOrEqualTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GreaterThanOrEqualTransformFunction.java
@@ -40,13 +40,7 @@ import org.apache.pinot.common.function.TransformFunctionType;
  */
 public class GreaterThanOrEqualTransformFunction extends BinaryOperatorTransformFunction {
 
-  @Override
-  public String getName() {
-    return TransformFunctionType.GREATER_THAN_OR_EQUAL.getName();
-  }
-
-  @Override
-  protected boolean getBinaryFuncResult(int comparisonResult) {
-    return comparisonResult >= 0;
+  public GreaterThanOrEqualTransformFunction() {
+    super(TransformFunctionType.GREATER_THAN_OR_EQUAL);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GreaterThanTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GreaterThanTransformFunction.java
@@ -40,13 +40,7 @@ import org.apache.pinot.common.function.TransformFunctionType;
  */
 public class GreaterThanTransformFunction extends BinaryOperatorTransformFunction {
 
-  @Override
-  public String getName() {
-    return TransformFunctionType.GREATER_THAN.getName();
-  }
-
-  @Override
-  protected boolean getBinaryFuncResult(int comparisonResult) {
-    return comparisonResult > 0;
+  public GreaterThanTransformFunction() {
+    super(TransformFunctionType.GREATER_THAN);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LessThanOrEqualTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LessThanOrEqualTransformFunction.java
@@ -40,13 +40,7 @@ import org.apache.pinot.common.function.TransformFunctionType;
  */
 public class LessThanOrEqualTransformFunction extends BinaryOperatorTransformFunction {
 
-  @Override
-  public String getName() {
-    return TransformFunctionType.LESS_THAN_OR_EQUAL.getName();
-  }
-
-  @Override
-  protected boolean getBinaryFuncResult(int comparisonResult) {
-    return comparisonResult <= 0;
+  public LessThanOrEqualTransformFunction() {
+    super(TransformFunctionType.LESS_THAN_OR_EQUAL);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LessThanTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LessThanTransformFunction.java
@@ -40,13 +40,7 @@ import org.apache.pinot.common.function.TransformFunctionType;
  */
 public class LessThanTransformFunction extends BinaryOperatorTransformFunction {
 
-  @Override
-  public String getName() {
-    return TransformFunctionType.LESS_THAN.getName();
-  }
-
-  @Override
-  protected boolean getBinaryFuncResult(int comparisonResult) {
-    return comparisonResult < 0;
+  public LessThanTransformFunction() {
+    super(TransformFunctionType.LESS_THAN);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/NotEqualsTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/NotEqualsTransformFunction.java
@@ -40,13 +40,7 @@ import org.apache.pinot.common.function.TransformFunctionType;
  */
 public class NotEqualsTransformFunction extends BinaryOperatorTransformFunction {
 
-  @Override
-  public String getName() {
-    return TransformFunctionType.NOT_EQUALS.getName();
-  }
-
-  @Override
-  protected boolean getBinaryFuncResult(int comparisonResult) {
-    return comparisonResult != 0;
+  public NotEqualsTransformFunction() {
+    super(TransformFunctionType.NOT_EQUALS);
   }
 }


### PR DESCRIPTION
## Description

In a CPU bound load test where there are at least 3 binary operations in play, nearly 10% of the time on the server is spent evaluating `BinaryOperatorTransformFunction.getIntResult`. 

<img width="1148" alt="Screenshot 2021-11-05 at 13 08 48" src="https://user-images.githubusercontent.com/16439049/140515238-e487b5c5-45d2-41bc-b01c-66a1ad46c2c7.png">

This moves the very simple overrides into the base class, and leaves the individual classes in place for the sake of the registration mechanism alone. 


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
