### PR TITLE
Remove the AutomatonBasedRegexpPredicateEvaluator and use regular RegexpLikePredicateEvaluator

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/FSTBasedRegexpPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/FSTBasedRegexpPredicateEvaluatorFactory.java
@@ -18,10 +18,7 @@
  */
 package org.apache.pinot.core.operator.filter.predicate;
 
-import it.unimi.dsi.fastutil.ints.IntArrayList;
-import it.unimi.dsi.fastutil.ints.IntList;
 import org.apache.pinot.common.request.context.predicate.Predicate;
-import org.apache.pinot.segment.local.utils.fst.RegexpMatcher;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
@@ -53,75 +50,15 @@ public class FSTBasedRegexpPredicateEvaluatorFactory {
   }
 
   /**
-   * Creates a predicate evaluator which uses regex matching logic which is similar to
-   * FSTBasedRegexpPredicateEvaluator. This predicate evaluator is used for consuming
-   * segments and is there to make sure results are consistent between consuming and
-   * rolled out segments when FST index is enabled.
-   *
-   * @param dictionary Dictionary for the column
-   * @param regexpQuery input query to match
-   * @return Predicate evaluator
-   */
-  public static BaseDictionaryBasedPredicateEvaluator newAutomatonBasedEvaluator(Dictionary dictionary,
-      String regexpQuery) {
-    return new FSTBasedRegexpPredicateEvaluatorFactory.AutomatonBasedRegexpPredicateEvaluator(regexpQuery, dictionary);
-  }
-
-  /**
-   * This predicate evaluator is created to be used for consuming segments. This evaluator
-   * creates automaton following very similar logic to that of FSTBasedRegexpPredicateEvaluator,
-   * so the results stay consistent across consuming and rolled out segments.
-   */
-  private static class AutomatonBasedRegexpPredicateEvaluator extends BaseDictionaryBasedPredicateEvaluator {
-    private final RegexpMatcher _regexpMatcher;
-    private final Dictionary _dictionary;
-    int[] _matchingDictIds;
-
-    public AutomatonBasedRegexpPredicateEvaluator(String searchQuery, Dictionary dictionary) {
-      _regexpMatcher = new RegexpMatcher(searchQuery, null);
-      _dictionary = dictionary;
-    }
-
-    @Override
-    public Predicate.Type getPredicateType() {
-      return REGEXP_LIKE;
-    }
-
-    @Override
-    public boolean applySV(int dictId) {
-      return _regexpMatcher.match(_dictionary.getStringValue(dictId));
-    }
-
-    @Override
-    public int[] getMatchingDictIds() {
-      if (_matchingDictIds == null) {
-        IntList matchingDictIds = new IntArrayList();
-        int dictionarySize = _dictionary.length();
-        for (int dictId = 0; dictId < dictionarySize; dictId++) {
-          if (applySV(dictId)) {
-            matchingDictIds.add(dictId);
-          }
-        }
-        _matchingDictIds = matchingDictIds.toIntArray();
-      }
-      return _matchingDictIds;
-    }
-  }
-
-  /**
    * Matches regexp query using FSTIndexReader.
    */
   private static class FSTBasedRegexpPredicateEvaluator extends BaseDictionaryBasedPredicateEvaluator {
-    private final TextIndexReader _fstIndexReader;
-    private final String _searchQuery;
-    private final ImmutableRoaringBitmap _dictIds;
     private final Dictionary _dictionary;
+    private final ImmutableRoaringBitmap _dictIds;
 
     public FSTBasedRegexpPredicateEvaluator(TextIndexReader fstIndexReader, Dictionary dictionary, String searchQuery) {
       _dictionary = dictionary;
-      _fstIndexReader = fstIndexReader;
-      _searchQuery = searchQuery;
-      _dictIds = _fstIndexReader.getDictIds(_searchQuery);
+      _dictIds = fstIndexReader.getDictIds(searchQuery);
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -47,7 +47,6 @@ import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluatorProvider;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.util.QueryOptionsUtils;
-import org.apache.pinot.segment.local.segment.index.datasource.MutableDataSource;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.ThreadSafeMutableRoaringBitmap;
@@ -202,11 +201,6 @@ public class FilterPlanNode implements PlanNode {
                 predicateEvaluator =
                     FSTBasedRegexpPredicateEvaluatorFactory.newFSTBasedEvaluator(dataSource.getFSTIndex(),
                         dataSource.getDictionary(), RegexpPatternConverterUtils.regexpLikeToLuceneRegExp(
-                            ((RegexpLikePredicate) predicate).getValue()));
-              } else if (dataSource instanceof MutableDataSource && ((MutableDataSource) dataSource).isFSTEnabled()) {
-                predicateEvaluator =
-                    FSTBasedRegexpPredicateEvaluatorFactory.newAutomatonBasedEvaluator(dataSource.getDictionary(),
-                        RegexpPatternConverterUtils.regexpLikeToLuceneRegExp(
                             ((RegexpLikePredicate) predicate).getValue()));
               } else {
                 predicateEvaluator =

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -230,6 +230,7 @@ public class MutableSegmentImpl implements MutableSegment {
     Set<String> noDictionaryColumns = config.getNoDictionaryColumns();
     Set<String> invertedIndexColumns = config.getInvertedIndexColumns();
     Set<String> textIndexColumns = config.getTextIndexColumns();
+    // TODO: Add mutable FST and wire it up
     Set<String> fstIndexColumns = config.getFSTIndexColumns();
     Set<String> jsonIndexColumns = config.getJsonIndexColumns();
     Map<String, H3IndexConfig> h3IndexConfigs = config.getH3IndexConfigs();
@@ -296,8 +297,8 @@ public class MutableSegmentImpl implements MutableSegment {
         int estimatedCardinality = (int) (_statsHistory.getEstimatedCardinality(column) * 1.1);
         String dictionaryAllocationContext =
             buildAllocationContext(_segmentName, column, V1Constants.Dict.FILE_EXTENSION);
-        dictionary = MutableDictionaryFactory
-            .getMutableDictionary(storedType, _offHeap, _memoryManager, dictionaryColumnSize,
+        dictionary =
+            MutableDictionaryFactory.getMutableDictionary(storedType, _offHeap, _memoryManager, dictionaryColumnSize,
                 Math.min(estimatedCardinality, _capacity), dictionaryAllocationContext);
 
         if (fieldSpec.isSingleValueField()) {
@@ -354,8 +355,7 @@ public class MutableSegmentImpl implements MutableSegment {
       // TODO: Support range index and bloom filter for mutable segment
       _indexContainerMap.put(column,
           new IndexContainer(fieldSpec, partitionFunction, partitions, new NumValuesInfo(), forwardIndex, dictionary,
-              invertedIndexReader, null, textIndex, fstIndexColumns.contains(column), jsonIndex, h3Index, null,
-              nullValueVector));
+              invertedIndexReader, null, textIndex, jsonIndex, h3Index, null, nullValueVector));
     }
 
     if (_realtimeLuceneReaders != null) {
@@ -406,9 +406,9 @@ public class MutableSegmentImpl implements MutableSegment {
       // So to continue aggregating metrics for such cases, we will create dictionary even
       // if the column is part of noDictionary set from table config
       if (fieldSpec instanceof DimensionFieldSpec && _aggregateMetrics && (dataType == STRING || dataType == BYTES)) {
-        _logger
-            .info("Aggregate metrics is enabled. Will create dictionary in consuming segment for column {} of type {}",
-                column, dataType.toString());
+        _logger.info(
+            "Aggregate metrics is enabled. Will create dictionary in consuming segment for column {} of type {}",
+            column, dataType.toString());
         return false;
       }
       // So don't create dictionary if the column is member of noDictionary, is single-value
@@ -514,9 +514,8 @@ public class MutableSegmentImpl implements MutableSegment {
   private GenericRow handleUpsert(GenericRow row, int docId) {
     PrimaryKey primaryKey = row.getPrimaryKey(_schema.getPrimaryKeyColumns());
     Object upsertComparisonValue = row.getValue(_upsertComparisonColumn);
-    Preconditions
-        .checkState(upsertComparisonValue instanceof Comparable, "Upsert comparison column: %s must be comparable",
-            _upsertComparisonColumn);
+    Preconditions.checkState(upsertComparisonValue instanceof Comparable,
+        "Upsert comparison column: %s must be comparable", _upsertComparisonColumn);
     return _partitionUpsertMetadataManager.updateRecord(this,
         new PartitionUpsertMetadataManager.RecordInfo(primaryKey, docId, (Comparable) upsertComparisonValue), row);
   }
@@ -833,9 +832,8 @@ public class MutableSegmentImpl implements MutableSegment {
       if (_numDocsIndexed > 0) {
         int numSeconds = (int) ((System.currentTimeMillis() - _startTimeMillis) / 1000);
         long totalMemBytes = _memoryManager.getTotalAllocatedBytes();
-        _logger
-            .info("Segment used {} bytes of memory for {} rows consumed in {} seconds", totalMemBytes, _numDocsIndexed,
-                numSeconds);
+        _logger.info("Segment used {} bytes of memory for {} rows consumed in {} seconds", totalMemBytes,
+            _numDocsIndexed, numSeconds);
 
         RealtimeSegmentStatsHistory.SegmentStats segmentStats = new RealtimeSegmentStatsHistory.SegmentStats();
         for (Map.Entry<String, IndexContainer> entry : _indexContainerMap.entrySet()) {
@@ -996,15 +994,15 @@ public class MutableSegmentImpl implements MutableSegment {
     for (FieldSpec fieldSpec : _physicalMetricFieldSpecs) {
       String metric = fieldSpec.getName();
       if (!noDictionaryColumns.contains(metric)) {
-        _logger
-            .warn("Metrics aggregation cannot be turned ON in presence of dictionary encoded metrics, eg: {}", metric);
+        _logger.warn("Metrics aggregation cannot be turned ON in presence of dictionary encoded metrics, eg: {}",
+            metric);
         _aggregateMetrics = false;
         break;
       }
 
       if (!fieldSpec.isSingleValueField()) {
-        _logger
-            .warn("Metrics aggregation cannot be turned ON in presence of multi-value metric columns, eg: {}", metric);
+        _logger.warn("Metrics aggregation cannot be turned ON in presence of multi-value metric columns, eg: {}",
+            metric);
         _aggregateMetrics = false;
         break;
       }
@@ -1015,8 +1013,8 @@ public class MutableSegmentImpl implements MutableSegment {
     for (FieldSpec fieldSpec : _physicalDimensionFieldSpecs) {
       String dimension = fieldSpec.getName();
       if (noDictionaryColumns.contains(dimension)) {
-        _logger
-            .warn("Metrics aggregation cannot be turned ON in presence of no-dictionary dimensions, eg: {}", dimension);
+        _logger.warn("Metrics aggregation cannot be turned ON in presence of no-dictionary dimensions, eg: {}",
+            dimension);
         _aggregateMetrics = false;
         break;
       }
@@ -1032,9 +1030,9 @@ public class MutableSegmentImpl implements MutableSegment {
     // Time columns should be dictionary encoded.
     for (String timeColumnName : _physicalTimeColumnNames) {
       if (noDictionaryColumns.contains(timeColumnName)) {
-        _logger
-            .warn("Metrics aggregation cannot be turned ON in presence of no-dictionary datetime/time columns, eg: {}",
-                timeColumnName);
+        _logger.warn(
+            "Metrics aggregation cannot be turned ON in presence of no-dictionary datetime/time columns, eg: {}",
+            timeColumnName);
         _aggregateMetrics = false;
         break;
       }
@@ -1090,7 +1088,6 @@ public class MutableSegmentImpl implements MutableSegment {
     final RangeIndexReader _rangeIndex;
     final MutableH3Index _h3Index;
     final RealtimeLuceneTextIndexReader _textIndex;
-    final boolean _enableFST;
     final MutableJsonIndex _jsonIndex;
     final BloomFilterReader _bloomFilter;
     final MutableNullValueVector _nullValueVector;
@@ -1105,7 +1102,7 @@ public class MutableSegmentImpl implements MutableSegment {
     IndexContainer(FieldSpec fieldSpec, @Nullable PartitionFunction partitionFunction,
         @Nullable Set<Integer> partitions, NumValuesInfo numValuesInfo, MutableForwardIndex forwardIndex,
         @Nullable MutableDictionary dictionary, @Nullable RealtimeInvertedIndexReader invertedIndex,
-        @Nullable RangeIndexReader rangeIndex, @Nullable RealtimeLuceneTextIndexReader textIndex, boolean enableFST,
+        @Nullable RangeIndexReader rangeIndex, @Nullable RealtimeLuceneTextIndexReader textIndex,
         @Nullable MutableJsonIndex jsonIndex, @Nullable MutableH3Index h3Index, @Nullable BloomFilterReader bloomFilter,
         @Nullable MutableNullValueVector nullValueVector) {
       _fieldSpec = fieldSpec;
@@ -1119,7 +1116,6 @@ public class MutableSegmentImpl implements MutableSegment {
       _h3Index = h3Index;
 
       _textIndex = textIndex;
-      _enableFST = enableFST;
       _jsonIndex = jsonIndex;
       _bloomFilter = bloomFilter;
       _nullValueVector = nullValueVector;
@@ -1128,8 +1124,7 @@ public class MutableSegmentImpl implements MutableSegment {
     DataSource toDataSource() {
       return new MutableDataSource(_fieldSpec, _numDocsIndexed, _numValuesInfo._numValues,
           _numValuesInfo._maxNumValuesPerMVEntry, _partitionFunction, _partitions, _minValue, _maxValue, _forwardIndex,
-          _dictionary, _invertedIndex, _rangeIndex, _textIndex, _enableFST, _jsonIndex, _h3Index, _bloomFilter,
-          _nullValueVector);
+          _dictionary, _invertedIndex, _rangeIndex, _textIndex, _jsonIndex, _h3Index, _bloomFilter, _nullValueVector);
     }
 
     @Override
@@ -1151,8 +1146,8 @@ public class MutableSegmentImpl implements MutableSegment {
         try {
           _invertedIndex.close();
         } catch (Exception e) {
-          _logger
-              .error("Caught exception while closing inverted index for column: {}, continuing with error", column, e);
+          _logger.error("Caught exception while closing inverted index for column: {}, continuing with error", column,
+              e);
         }
       }
       if (_rangeIndex != null) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/IntermediateIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/IntermediateIndexContainer.java
@@ -63,7 +63,7 @@ public class IntermediateIndexContainer implements Closeable {
   public DataSource toDataSource(int numDocsIndexed) {
     return new MutableDataSource(_fieldSpec, numDocsIndexed, _numValuesInfo._numValues,
         _numValuesInfo._maxNumValuesPerMVEntry, _partitionFunction, _partitions, _minValue, _maxValue, _forwardIndex,
-        _dictionary, null, null, null, false, null, null, null, null);
+        _dictionary, null, null, null, null, null, null, null);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/MutableDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/MutableDataSource.java
@@ -39,23 +39,16 @@ import org.apache.pinot.spi.data.FieldSpec;
  */
 @SuppressWarnings("rawtypes")
 public class MutableDataSource extends BaseDataSource {
-  private final boolean _enableFST;
 
   public MutableDataSource(FieldSpec fieldSpec, int numDocs, int numValues, int maxNumValuesPerMVEntry,
       @Nullable PartitionFunction partitionFunction, @Nullable Set<Integer> partitions, @Nullable Comparable minValue,
       @Nullable Comparable maxValue, ForwardIndexReader forwardIndex, @Nullable Dictionary dictionary,
       @Nullable InvertedIndexReader invertedIndex, @Nullable RangeIndexReader rangeIndex,
-      @Nullable TextIndexReader textIndex, boolean enableFST, @Nullable JsonIndexReader jsonIndex,
-      @Nullable H3IndexReader h3Index, @Nullable BloomFilterReader bloomFilter,
-      @Nullable NullValueVectorReader nullValueVector) {
+      @Nullable TextIndexReader textIndex, @Nullable JsonIndexReader jsonIndex, @Nullable H3IndexReader h3Index,
+      @Nullable BloomFilterReader bloomFilter, @Nullable NullValueVectorReader nullValueVector) {
     super(new MutableDataSourceMetadata(fieldSpec, numDocs, numValues, maxNumValuesPerMVEntry, partitionFunction,
             partitions, minValue, maxValue), forwardIndex, dictionary, invertedIndex, rangeIndex, textIndex, null,
         jsonIndex, h3Index, bloomFilter, nullValueVector);
-    _enableFST = enableFST;
-  }
-
-  public boolean isFSTEnabled() {
-    return _enableFST;
   }
 
   private static class MutableDataSourceMetadata implements DataSourceMetadata {


### PR DESCRIPTION
Currently mutable FST is not supported yet, and there is no benefit using `AutomatonBasedRegexpPredicateEvaluator` over the regular `RegexpLikePredicateEvaluator`. When we add the mutable FST index, we can wire it with the `FSTBasedRegexpPredicateEvaluator`.