### PR TITLE
memoize literals in query context in order to deduplicate them

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/TransformPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/TransformPlanNode.java
@@ -68,7 +68,7 @@ public class TransformPlanNode implements PlanNode {
     ProjectionOperator projectionOperator =
         new ProjectionPlanNode(_indexSegment, _queryContext, projectionColumns, _maxDocsPerCall, _filterOperator).run();
     if (hasNonIdentifierExpression) {
-      return new TransformOperator(projectionOperator, _expressions);
+      return new TransformOperator(_queryContext, projectionOperator, _expressions);
     } else {
       return new PassThroughTransformOperator(projectionOperator, _expressions);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/MemoizedClassAssociation.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/MemoizedClassAssociation.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.util;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Creates a function which associates generic values with a class and memoizes this association atomically.
+ * @param <T>
+ */
+public class MemoizedClassAssociation<T> extends ClassValue<T> {
+
+  public static <T> Function<Class<?>, T> of(Supplier<T> supplier) {
+    return new MemoizedClassAssociation<>(supplier)::get;
+  }
+
+  private final Supplier<T> _supplier;
+
+  private MemoizedClassAssociation(Supplier<T> supplier) {
+    _supplier = supplier;
+  }
+
+  @Override
+  protected T computeValue(Class<?> type) {
+    return _supplier.get();
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/DefaultAggregationExecutorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/DefaultAggregationExecutorTest.java
@@ -130,7 +130,7 @@ public class DefaultAggregationExecutorTest {
     MatchAllFilterOperator matchAllFilterOperator = new MatchAllFilterOperator(totalDocs);
     DocIdSetOperator docIdSetOperator = new DocIdSetOperator(matchAllFilterOperator, DocIdSetPlanNode.MAX_DOC_PER_CALL);
     ProjectionOperator projectionOperator = new ProjectionOperator(dataSourceMap, docIdSetOperator);
-    TransformOperator transformOperator = new TransformOperator(projectionOperator, expressions);
+    TransformOperator transformOperator = new TransformOperator(_queryContext, projectionOperator, expressions);
     TransformBlock transformBlock = transformOperator.nextBlock();
     AggregationFunction[] aggregationFunctions = _queryContext.getAggregationFunctions();
     assert aggregationFunctions != null;


### PR DESCRIPTION
## Description
`LiteralTransformFunction` is allocated as many times as there are segments but they contain a large buffer, this change memoizes literals so each literal is shared.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
