### PR TITLE
Fix the flaky SimpleMinionClusterIntegrationTest

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
@@ -86,11 +86,14 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
   }
 
   private void verifyTaskCount(String task, int errors, int waiting, int running, int total) {
-    PinotHelixTaskResourceManager.TaskCount taskCount = _helixTaskResourceManager.getTaskCount(task);
-    assertEquals(taskCount.getError(), errors);
-    assertEquals(taskCount.getWaiting(), waiting);
-    assertEquals(taskCount.getRunning(), running);
-    assertEquals(taskCount.getTotal(), total);
+    // Wait for at most 10 seconds for Helix to generate the tasks
+    TestUtils.waitForCondition((aVoid) -> {
+      PinotHelixTaskResourceManager.TaskCount taskCount = _helixTaskResourceManager.getTaskCount(task);
+      return taskCount.getError() == errors
+          && taskCount.getWaiting() == waiting
+          && taskCount.getRunning() == running
+          && taskCount.getTotal() == total;
+    }, 10_000L, "Failed to reach expected task count");
   }
 
   @Test


### PR DESCRIPTION
When submitting a minion task, the actual task scheduling is generated async, and might not be reflected immediately. Added a 10s wait for verifying the task count.

Sample failure: https://github.com/apache/pinot/runs/4112960198?check_suite_focus=true