### PR TITLE
Support Native FST As An Index Subtype for FST Indices

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
@@ -103,7 +103,7 @@ public class FSTBasedRegexpLikeQueriesTest extends BaseQueriesTest {
       Set<String> fstIndexCols = new HashSet<>();
       fstIndexCols.add(DOMAIN_NAMES_COL);
       indexLoadingConfig.setFSTIndexColumns(fstIndexCols);
-      indexLoadingConfig.setFstIndexType(fstType);
+      indexLoadingConfig.setFSTIndexType(fstType);
 
       Set<String> invertedIndexCols = new HashSet<>();
       invertedIndexCols.add(DOMAIN_NAMES_COL);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
@@ -96,9 +96,7 @@ public class FSTBasedRegexpLikeQueriesTest extends BaseQueriesTest {
     FileUtils.deleteQuietly(INDEX_DIR);
 
     List<IndexSegment> segments = new ArrayList<>();
-
-    for (int i = 0; i < 2; i++) {
-      FSTType fstType = i == 1 ? FSTType.NATIVE : FSTType.LUCENE;
+    for (FSTType fstType : Arrays.asList(FSTType.LUCENE, FSTType.NATIVE)) {
 
       buildSegment(fstType);
       IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
@@ -44,6 +44,7 @@ import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.table.FSTIndexType;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -94,19 +95,30 @@ public class FSTBasedRegexpLikeQueriesTest extends BaseQueriesTest {
       throws Exception {
     FileUtils.deleteQuietly(INDEX_DIR);
 
-    buildSegment();
-    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
-    Set<String> fstIndexCols = new HashSet<>();
-    fstIndexCols.add(DOMAIN_NAMES_COL);
-    indexLoadingConfig.setFSTIndexColumns(fstIndexCols);
+    List<IndexSegment> segments = new ArrayList<>();
 
-    Set<String> invertedIndexCols = new HashSet<>();
-    invertedIndexCols.add(DOMAIN_NAMES_COL);
-    indexLoadingConfig.setInvertedIndexColumns(invertedIndexCols);
-    ImmutableSegment immutableSegment =
-        ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), indexLoadingConfig);
-    _indexSegment = immutableSegment;
-    _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
+    for (int i = 0; i < 2; i++) {
+      buildSegment();
+      IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
+      Set<String> fstIndexCols = new HashSet<>();
+      fstIndexCols.add(DOMAIN_NAMES_COL);
+      indexLoadingConfig.setFSTIndexColumns(fstIndexCols);
+
+      if (i == 1) {
+        indexLoadingConfig.setFstIndexType(FSTIndexType.NATIVE);
+      }
+
+      Set<String> invertedIndexCols = new HashSet<>();
+      invertedIndexCols.add(DOMAIN_NAMES_COL);
+      indexLoadingConfig.setInvertedIndexColumns(invertedIndexCols);
+      ImmutableSegment immutableSegment =
+          ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), indexLoadingConfig);
+
+      segments.add(immutableSegment);
+    }
+
+    _indexSegment = segments.get(0);
+    _indexSegments = segments;
   }
 
   @AfterClass

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
@@ -44,7 +44,7 @@ import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
-import org.apache.pinot.spi.config.table.FSTIndexType;
+import org.apache.pinot.spi.config.table.FSTType;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -98,14 +98,14 @@ public class FSTBasedRegexpLikeQueriesTest extends BaseQueriesTest {
     List<IndexSegment> segments = new ArrayList<>();
 
     for (int i = 0; i < 2; i++) {
-      FSTIndexType fstIndexType = i == 1 ? FSTIndexType.NATIVE : FSTIndexType.LUCENE;
+      FSTType fstType = i == 1 ? FSTType.NATIVE : FSTType.LUCENE;
 
-      buildSegment(fstIndexType);
+      buildSegment(fstType);
       IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
       Set<String> fstIndexCols = new HashSet<>();
       fstIndexCols.add(DOMAIN_NAMES_COL);
       indexLoadingConfig.setFSTIndexColumns(fstIndexCols);
-      indexLoadingConfig.setFstIndexType(fstIndexType);
+      indexLoadingConfig.setFstIndexType(fstType);
 
       Set<String> invertedIndexCols = new HashSet<>();
       invertedIndexCols.add(DOMAIN_NAMES_COL);
@@ -162,7 +162,7 @@ public class FSTBasedRegexpLikeQueriesTest extends BaseQueriesTest {
     return rows;
   }
 
-  private void buildSegment(FSTIndexType fstIndexType)
+  private void buildSegment(FSTType fstType)
       throws Exception {
     List<GenericRow> rows = createTestData(NUM_ROWS);
     List<FieldConfig> fieldConfigs = new ArrayList<>();
@@ -182,7 +182,7 @@ public class FSTBasedRegexpLikeQueriesTest extends BaseQueriesTest {
     config.setOutDir(INDEX_DIR.getPath());
     config.setTableName(TABLE_NAME);
     config.setSegmentName(SEGMENT_NAME);
-    config.setFstIndexType(fstIndexType);
+    config.setFstIndexType(fstType);
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
     try (RecordReader recordReader = new GenericRowRecordReader(rows)) {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
@@ -98,15 +98,14 @@ public class FSTBasedRegexpLikeQueriesTest extends BaseQueriesTest {
     List<IndexSegment> segments = new ArrayList<>();
 
     for (int i = 0; i < 2; i++) {
-      buildSegment();
+      FSTIndexType fstIndexType = i == 1 ? FSTIndexType.NATIVE : FSTIndexType.LUCENE;
+
+      buildSegment(fstIndexType);
       IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
       Set<String> fstIndexCols = new HashSet<>();
       fstIndexCols.add(DOMAIN_NAMES_COL);
       indexLoadingConfig.setFSTIndexColumns(fstIndexCols);
-
-      if (i == 1) {
-        indexLoadingConfig.setFstIndexType(FSTIndexType.NATIVE);
-      }
+      indexLoadingConfig.setFstIndexType(fstIndexType);
 
       Set<String> invertedIndexCols = new HashSet<>();
       invertedIndexCols.add(DOMAIN_NAMES_COL);
@@ -163,7 +162,7 @@ public class FSTBasedRegexpLikeQueriesTest extends BaseQueriesTest {
     return rows;
   }
 
-  private void buildSegment()
+  private void buildSegment(FSTIndexType fstIndexType)
       throws Exception {
     List<GenericRow> rows = createTestData(NUM_ROWS);
     List<FieldConfig> fieldConfigs = new ArrayList<>();
@@ -183,6 +182,7 @@ public class FSTBasedRegexpLikeQueriesTest extends BaseQueriesTest {
     config.setOutDir(INDEX_DIR.getPath());
     config.setTableName(TABLE_NAME);
     config.setSegmentName(SEGMENT_NAME);
+    config.setFstIndexType(fstIndexType);
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
     try (RecordReader recordReader = new GenericRowRecordReader(rows)) {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
@@ -180,7 +180,7 @@ public class FSTBasedRegexpLikeQueriesTest extends BaseQueriesTest {
     config.setOutDir(INDEX_DIR.getPath());
     config.setTableName(TABLE_NAME);
     config.setSegmentName(SEGMENT_NAME);
-    config.setFstIndexType(fstType);
+    config.setFSTIndexType(fstType);
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
     try (RecordReader recordReader = new GenericRowRecordReader(rows)) {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FSTBasedRegexpLikeQueriesTest.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.response.broker.AggregationResult;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
@@ -70,8 +71,6 @@ public class FSTBasedRegexpLikeQueriesTest extends BaseQueriesTest {
   private static final Integer INT_BASE_VALUE = 1000;
   private static final Integer NUM_ROWS = 1024;
 
-  private final List<GenericRow> _rows = new ArrayList<>();
-
   private IndexSegment _indexSegment;
   private List<IndexSegment> _indexSegments;
 
@@ -97,24 +96,22 @@ public class FSTBasedRegexpLikeQueriesTest extends BaseQueriesTest {
 
     List<IndexSegment> segments = new ArrayList<>();
     for (FSTType fstType : Arrays.asList(FSTType.LUCENE, FSTType.NATIVE)) {
-
       buildSegment(fstType);
+
       IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
       Set<String> fstIndexCols = new HashSet<>();
       fstIndexCols.add(DOMAIN_NAMES_COL);
       indexLoadingConfig.setFSTIndexColumns(fstIndexCols);
       indexLoadingConfig.setFSTIndexType(fstType);
-
       Set<String> invertedIndexCols = new HashSet<>();
       invertedIndexCols.add(DOMAIN_NAMES_COL);
       indexLoadingConfig.setInvertedIndexColumns(invertedIndexCols);
-      ImmutableSegment immutableSegment =
-          ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), indexLoadingConfig);
+      ImmutableSegment segment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), indexLoadingConfig);
 
-      segments.add(immutableSegment);
+      segments.add(segment);
     }
 
-    _indexSegment = segments.get(0);
+    _indexSegment = segments.get(ThreadLocalRandom.current().nextInt(2));
     _indexSegments = segments;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -270,11 +270,13 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
             "FST index is currently only supported on dictionary-encoded columns");
         TextIndexCreator textIndexCreator;
 
-        if (_config.getFstIndexType() == FSTIndexType.LUCENE) {
-          textIndexCreator = new LuceneFSTIndexCreator(_indexDir, columnName,
+        if (_config.getFstIndexType() != null
+            && _config.getFstIndexType() == FSTIndexType.NATIVE) {
+
+          textIndexCreator = new NativeFSTIndexCreator(_indexDir, columnName,
               (String[]) indexCreationInfo.getSortedUniqueElementsArray());
         } else {
-          textIndexCreator = new NativeFSTIndexCreator(_indexDir, columnName,
+          textIndexCreator = new LuceneFSTIndexCreator(_indexDir, columnName,
               (String[]) indexCreationInfo.getSortedUniqueElementsArray());
         }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -268,13 +268,12 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
             "FST index is currently only supported on STRING type columns");
         Preconditions.checkState(dictEnabledColumn,
             "FST index is currently only supported on dictionary-encoded columns");
+        String[] sortedValues = (String[]) indexCreationInfo.getSortedUniqueElementsArray();
         TextIndexCreator textIndexCreator;
         if (_config.getFSTIndexType() == FSTType.NATIVE) {
-          textIndexCreator = new NativeFSTIndexCreator(_indexDir, columnName,
-              (String[]) indexCreationInfo.getSortedUniqueElementsArray());
+          textIndexCreator = new NativeFSTIndexCreator(_indexDir, columnName, sortedValues);
         } else {
-          textIndexCreator = new LuceneFSTIndexCreator(_indexDir, columnName,
-              (String[]) indexCreationInfo.getSortedUniqueElementsArray());
+          textIndexCreator = new LuceneFSTIndexCreator(_indexDir, columnName, sortedValues);
         }
 
         _fstIndexCreatorMap.put(columnName, textIndexCreator);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -269,8 +269,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
         Preconditions.checkState(dictEnabledColumn,
             "FST index is currently only supported on dictionary-encoded columns");
         TextIndexCreator textIndexCreator;
-        if (_config.getFSTIndexType() != null
-            && _config.getFSTIndexType() == FSTType.NATIVE) {
+        if (_config.getFSTIndexType() == FSTType.NATIVE) {
           textIndexCreator = new NativeFSTIndexCreator(_indexDir, columnName,
               (String[]) indexCreationInfo.getSortedUniqueElementsArray());
         } else {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -67,7 +67,7 @@ import org.apache.pinot.segment.spi.index.creator.TextIndexCreator;
 import org.apache.pinot.segment.spi.index.creator.TextIndexType;
 import org.apache.pinot.segment.spi.index.reader.H3IndexResolution;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
-import org.apache.pinot.spi.config.table.FSTIndexType;
+import org.apache.pinot.spi.config.table.FSTType;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
@@ -271,7 +271,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
         TextIndexCreator textIndexCreator;
 
         if (_config.getFstIndexType() != null
-            && _config.getFstIndexType() == FSTIndexType.NATIVE) {
+            && _config.getFstIndexType() == FSTType.NATIVE) {
 
           textIndexCreator = new NativeFSTIndexCreator(_indexDir, columnName,
               (String[]) indexCreationInfo.getSortedUniqueElementsArray());

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -269,10 +269,8 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
         Preconditions.checkState(dictEnabledColumn,
             "FST index is currently only supported on dictionary-encoded columns");
         TextIndexCreator textIndexCreator;
-
-        if (_config.getFstIndexType() != null
-            && _config.getFstIndexType() == FSTType.NATIVE) {
-
+        if (_config.getFSTIndexType() != null
+            && _config.getFSTIndexType() == FSTType.NATIVE) {
           textIndexCreator = new NativeFSTIndexCreator(_indexDir, columnName,
               (String[]) indexCreationInfo.getSortedUniqueElementsArray());
         } else {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -277,7 +277,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
           textIndexCreator = new NativeFSTIndexCreator(_indexDir, columnName,
               (String[]) indexCreationInfo.getSortedUniqueElementsArray());
         }
-        
+
         _fstIndexCreatorMap.put(columnName, textIndexCreator);
       }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
@@ -53,6 +53,8 @@ import org.apache.pinot.segment.local.segment.index.readers.geospatial.Immutable
 import org.apache.pinot.segment.local.segment.index.readers.json.ImmutableJsonIndexReader;
 import org.apache.pinot.segment.local.segment.index.readers.sorted.SortedIndexReaderImpl;
 import org.apache.pinot.segment.local.segment.index.readers.text.LuceneTextIndexReader;
+import org.apache.pinot.segment.local.utils.nativefst.ImmutableFST;
+import org.apache.pinot.segment.local.utils.nativefst.NativeFSTIndexReader;
 import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.index.column.ColumnIndexContainer;
 import org.apache.pinot.segment.spi.index.reader.BloomFilterReader;
@@ -174,7 +176,13 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
       }
 
       if (loadFSTIndex) {
-        _fstIndex = new LuceneFSTIndexReader(segmentReader.getIndexFor(columnName, ColumnIndexType.FST_INDEX));
+        PinotDataBuffer buffer = segmentReader.getIndexFor(columnName, ColumnIndexType.FST_INDEX);
+        int version = buffer.getInt(0);
+        if (version == ImmutableFST.VERSION) {
+          _fstIndex = new NativeFSTIndexReader(buffer);
+        } else {
+          _fstIndex = new LuceneFSTIndexReader(buffer);
+        }
       } else {
         _fstIndex = null;
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
@@ -177,8 +177,8 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
 
       if (loadFSTIndex) {
         PinotDataBuffer buffer = segmentReader.getIndexFor(columnName, ColumnIndexType.FST_INDEX);
-
-        if (FSTHeader.isValidFST(buffer.toDirectByteBuffer(0, (int) buffer.size()))) {
+        int magicHeader = buffer.getInt(0);
+        if (magicHeader == FSTHeader.FST_MAGIC) {
           _fstIndex = new NativeFSTIndexReader(buffer);
         } else {
           _fstIndex = new LuceneFSTIndexReader(buffer);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
@@ -69,7 +69,7 @@ import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.ColumnIndexType;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.spi.config.table.BloomFilterConfig;
-import org.apache.pinot.spi.config.table.FSTIndexType;
+import org.apache.pinot.spi.config.table.FSTType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -177,7 +177,7 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
 
       if (loadFSTIndex) {
         PinotDataBuffer buffer = segmentReader.getIndexFor(columnName, ColumnIndexType.FST_INDEX);
-        if (indexLoadingConfig.getFstIndexType() == FSTIndexType.NATIVE) {
+        if (indexLoadingConfig.getFstIndexType() == FSTType.NATIVE) {
           _fstIndex = new NativeFSTIndexReader(buffer);
         } else {
           _fstIndex = new LuceneFSTIndexReader(buffer);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
@@ -21,6 +21,7 @@ package org.apache.pinot.segment.local.segment.index.column;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Map;
 import org.apache.pinot.segment.local.segment.creator.impl.inv.BitSlicedRangeIndexCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.inv.RangeIndexCreator;
@@ -177,7 +178,9 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
 
       if (loadFSTIndex) {
         PinotDataBuffer buffer = segmentReader.getIndexFor(columnName, ColumnIndexType.FST_INDEX);
-        if (indexLoadingConfig.getFstIndexType() == FSTType.NATIVE) {
+
+        if (org.apache.pinot.segment.local.utils.nativefst.FSTHeader
+            .isValidFST(buffer.toDirectByteBuffer(0, (int) buffer.size()))) {
           _fstIndex = new NativeFSTIndexReader(buffer);
         } else {
           _fstIndex = new LuceneFSTIndexReader(buffer);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
@@ -54,6 +54,7 @@ import org.apache.pinot.segment.local.segment.index.readers.json.ImmutableJsonIn
 import org.apache.pinot.segment.local.segment.index.readers.sorted.SortedIndexReaderImpl;
 import org.apache.pinot.segment.local.segment.index.readers.text.LuceneTextIndexReader;
 import org.apache.pinot.segment.local.utils.nativefst.NativeFSTIndexReader;
+import org.apache.pinot.segment.local.utils.nativefst.FSTHeader;
 import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.index.column.ColumnIndexContainer;
 import org.apache.pinot.segment.spi.index.reader.BloomFilterReader;
@@ -177,8 +178,7 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
       if (loadFSTIndex) {
         PinotDataBuffer buffer = segmentReader.getIndexFor(columnName, ColumnIndexType.FST_INDEX);
 
-        if (org.apache.pinot.segment.local.utils.nativefst.FSTHeader
-            .isValidFST(buffer.toDirectByteBuffer(0, (int) buffer.size()))) {
+        if (FSTHeader.isValidFST(buffer.toDirectByteBuffer(0, (int) buffer.size()))) {
           _fstIndex = new NativeFSTIndexReader(buffer);
         } else {
           _fstIndex = new LuceneFSTIndexReader(buffer);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
@@ -53,8 +53,8 @@ import org.apache.pinot.segment.local.segment.index.readers.geospatial.Immutable
 import org.apache.pinot.segment.local.segment.index.readers.json.ImmutableJsonIndexReader;
 import org.apache.pinot.segment.local.segment.index.readers.sorted.SortedIndexReaderImpl;
 import org.apache.pinot.segment.local.segment.index.readers.text.LuceneTextIndexReader;
-import org.apache.pinot.segment.local.utils.nativefst.NativeFSTIndexReader;
 import org.apache.pinot.segment.local.utils.nativefst.FSTHeader;
+import org.apache.pinot.segment.local.utils.nativefst.NativeFSTIndexReader;
 import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.index.column.ColumnIndexContainer;
 import org.apache.pinot.segment.spi.index.reader.BloomFilterReader;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
@@ -53,7 +53,6 @@ import org.apache.pinot.segment.local.segment.index.readers.geospatial.Immutable
 import org.apache.pinot.segment.local.segment.index.readers.json.ImmutableJsonIndexReader;
 import org.apache.pinot.segment.local.segment.index.readers.sorted.SortedIndexReaderImpl;
 import org.apache.pinot.segment.local.segment.index.readers.text.LuceneTextIndexReader;
-import org.apache.pinot.segment.local.utils.nativefst.ImmutableFST;
 import org.apache.pinot.segment.local.utils.nativefst.NativeFSTIndexReader;
 import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.index.column.ColumnIndexContainer;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
@@ -70,6 +70,7 @@ import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.ColumnIndexType;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.spi.config.table.BloomFilterConfig;
+import org.apache.pinot.spi.config.table.FSTIndexType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -177,8 +178,7 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
 
       if (loadFSTIndex) {
         PinotDataBuffer buffer = segmentReader.getIndexFor(columnName, ColumnIndexType.FST_INDEX);
-        int version = buffer.getInt(0);
-        if (version == ImmutableFST.VERSION) {
+        if (indexLoadingConfig.getFstIndexType() == FSTIndexType.NATIVE) {
           _fstIndex = new NativeFSTIndexReader(buffer);
         } else {
           _fstIndex = new LuceneFSTIndexReader(buffer);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
@@ -21,7 +21,6 @@ package org.apache.pinot.segment.local.segment.index.column;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.Map;
 import org.apache.pinot.segment.local.segment.creator.impl.inv.BitSlicedRangeIndexCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.inv.RangeIndexCreator;
@@ -70,7 +69,6 @@ import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.ColumnIndexType;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.spi.config.table.BloomFilterConfig;
-import org.apache.pinot.spi.config.table.FSTType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexHandlerFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexHandlerFactory.java
@@ -23,7 +23,7 @@ import org.apache.pinot.segment.local.segment.index.loader.bloomfilter.BloomFilt
 import org.apache.pinot.segment.local.segment.index.loader.invertedindex.H3IndexHandler;
 import org.apache.pinot.segment.local.segment.index.loader.invertedindex.InvertedIndexHandler;
 import org.apache.pinot.segment.local.segment.index.loader.invertedindex.JsonIndexHandler;
-import org.apache.pinot.segment.local.segment.index.loader.invertedindex.LuceneFSTIndexHandler;
+import org.apache.pinot.segment.local.segment.index.loader.invertedindex.FSTIndexHandler;
 import org.apache.pinot.segment.local.segment.index.loader.invertedindex.RangeIndexHandler;
 import org.apache.pinot.segment.local.segment.index.loader.invertedindex.TextIndexHandler;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
@@ -48,7 +48,8 @@ public class IndexHandlerFactory {
       case TEXT_INDEX:
         return new TextIndexHandler(indexDir, segmentMetadata, indexLoadingConfig, segmentWriter);
       case FST_INDEX:
-        return new LuceneFSTIndexHandler(indexDir, segmentMetadata, indexLoadingConfig, segmentWriter);
+        return new FSTIndexHandler(indexDir, segmentMetadata, indexLoadingConfig, segmentWriter,
+            indexLoadingConfig.getFstIndexType());
       case JSON_INDEX:
         return new JsonIndexHandler(indexDir, segmentMetadata, indexLoadingConfig, segmentWriter);
       case H3_INDEX:

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexHandlerFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexHandlerFactory.java
@@ -20,10 +20,10 @@ package org.apache.pinot.segment.local.segment.index.loader;
 
 import java.io.File;
 import org.apache.pinot.segment.local.segment.index.loader.bloomfilter.BloomFilterHandler;
+import org.apache.pinot.segment.local.segment.index.loader.invertedindex.FSTIndexHandler;
 import org.apache.pinot.segment.local.segment.index.loader.invertedindex.H3IndexHandler;
 import org.apache.pinot.segment.local.segment.index.loader.invertedindex.InvertedIndexHandler;
 import org.apache.pinot.segment.local.segment.index.loader.invertedindex.JsonIndexHandler;
-import org.apache.pinot.segment.local.segment.index.loader.invertedindex.FSTIndexHandler;
 import org.apache.pinot.segment.local.segment.index.loader.invertedindex.RangeIndexHandler;
 import org.apache.pinot.segment.local.segment.index.loader.invertedindex.TextIndexHandler;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexHandlerFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexHandlerFactory.java
@@ -49,7 +49,7 @@ public class IndexHandlerFactory {
         return new TextIndexHandler(indexDir, segmentMetadata, indexLoadingConfig, segmentWriter);
       case FST_INDEX:
         return new FSTIndexHandler(indexDir, segmentMetadata, indexLoadingConfig, segmentWriter,
-            indexLoadingConfig.getFstIndexType());
+            indexLoadingConfig.getFSTIndexType());
       case JSON_INDEX:
         return new JsonIndexHandler(indexDir, segmentMetadata, indexLoadingConfig, segmentWriter);
       case H3_INDEX:

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -34,6 +34,7 @@ import org.apache.pinot.segment.spi.creator.SegmentVersion;
 import org.apache.pinot.segment.spi.index.creator.H3IndexConfig;
 import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.BloomFilterConfig;
+import org.apache.pinot.spi.config.table.FSTIndexType;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
@@ -56,6 +57,7 @@ public class IndexLoadingConfig {
   private Set<String> _invertedIndexColumns = new HashSet<>();
   private Set<String> _rangeIndexColumns = new HashSet<>();
   private int _rangeIndexVersion = IndexingConfig.DEFAULT_RANGE_INDEX_VERSION;
+  private FSTIndexType _fstIndexType = FSTIndexType.LUCENE;
   private Set<String> _textIndexColumns = new HashSet<>();
   private Set<String> _fstIndexColumns = new HashSet<>();
   private Set<String> _jsonIndexColumns = new HashSet<>();
@@ -111,6 +113,8 @@ public class IndexLoadingConfig {
       _invertedIndexColumns.addAll(invertedIndexColumns);
     }
     _rangeIndexVersion = indexingConfig.getRangeIndexVersion();
+
+    _fstIndexType = indexingConfig.getFstIndexType();
 
     List<String> jsonIndexColumns = indexingConfig.getJsonIndexColumns();
     if (jsonIndexColumns != null) {
@@ -287,6 +291,10 @@ public class IndexLoadingConfig {
 
   public int getRangeIndexVersion() {
     return _rangeIndexVersion;
+  }
+
+  public FSTIndexType getFstIndexType() {
+    return _fstIndexType;
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -34,7 +34,7 @@ import org.apache.pinot.segment.spi.creator.SegmentVersion;
 import org.apache.pinot.segment.spi.index.creator.H3IndexConfig;
 import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.BloomFilterConfig;
-import org.apache.pinot.spi.config.table.FSTIndexType;
+import org.apache.pinot.spi.config.table.FSTType;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
@@ -57,7 +57,7 @@ public class IndexLoadingConfig {
   private Set<String> _invertedIndexColumns = new HashSet<>();
   private Set<String> _rangeIndexColumns = new HashSet<>();
   private int _rangeIndexVersion = IndexingConfig.DEFAULT_RANGE_INDEX_VERSION;
-  private FSTIndexType _fstIndexType = FSTIndexType.LUCENE;
+  private FSTType _fstTypeForFSTIndex = FSTType.LUCENE;
   private Set<String> _textIndexColumns = new HashSet<>();
   private Set<String> _fstIndexColumns = new HashSet<>();
   private Set<String> _jsonIndexColumns = new HashSet<>();
@@ -114,7 +114,7 @@ public class IndexLoadingConfig {
     }
     _rangeIndexVersion = indexingConfig.getRangeIndexVersion();
 
-    _fstIndexType = indexingConfig.getFstIndexType();
+    _fstTypeForFSTIndex = indexingConfig.getFstIndexType();
 
     List<String> jsonIndexColumns = indexingConfig.getJsonIndexColumns();
     if (jsonIndexColumns != null) {
@@ -293,8 +293,8 @@ public class IndexLoadingConfig {
     return _rangeIndexVersion;
   }
 
-  public FSTIndexType getFstIndexType() {
-    return _fstIndexType;
+  public FSTType getFstIndexType() {
+    return _fstTypeForFSTIndex;
   }
 
   /**
@@ -341,8 +341,8 @@ public class IndexLoadingConfig {
    * For tests only
    */
   @VisibleForTesting
-  public void setFstIndexType(FSTIndexType fstIndexType) {
-    _fstIndexType = fstIndexType;
+  public void setFstIndexType(FSTType fstType) {
+    _fstTypeForFSTIndex = fstType;
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -114,7 +114,7 @@ public class IndexLoadingConfig {
     }
     _rangeIndexVersion = indexingConfig.getRangeIndexVersion();
 
-    _fstTypeForFSTIndex = indexingConfig.getFstIndexType();
+    _fstTypeForFSTIndex = indexingConfig.getFSTIndexType();
 
     List<String> jsonIndexColumns = indexingConfig.getJsonIndexColumns();
     if (jsonIndexColumns != null) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -57,9 +57,9 @@ public class IndexLoadingConfig {
   private Set<String> _invertedIndexColumns = new HashSet<>();
   private Set<String> _rangeIndexColumns = new HashSet<>();
   private int _rangeIndexVersion = IndexingConfig.DEFAULT_RANGE_INDEX_VERSION;
-  private FSTType _fstIndexType = FSTType.LUCENE;
   private Set<String> _textIndexColumns = new HashSet<>();
   private Set<String> _fstIndexColumns = new HashSet<>();
+  private FSTType _fstIndexType = FSTType.LUCENE;
   private Set<String> _jsonIndexColumns = new HashSet<>();
   private Map<String, H3IndexConfig> _h3IndexConfigs = new HashMap<>();
   private Set<String> _noDictionaryColumns = new HashSet<>(); // TODO: replace this by _noDictionaryConfig.
@@ -112,9 +112,6 @@ public class IndexLoadingConfig {
     if (invertedIndexColumns != null) {
       _invertedIndexColumns.addAll(invertedIndexColumns);
     }
-    _rangeIndexVersion = indexingConfig.getRangeIndexVersion();
-
-    _fstIndexType = indexingConfig.getFSTIndexType();
 
     List<String> jsonIndexColumns = indexingConfig.getJsonIndexColumns();
     if (jsonIndexColumns != null) {
@@ -125,6 +122,10 @@ public class IndexLoadingConfig {
     if (rangeIndexColumns != null) {
       _rangeIndexColumns.addAll(rangeIndexColumns);
     }
+
+    _rangeIndexVersion = indexingConfig.getRangeIndexVersion();
+
+    _fstIndexType = indexingConfig.getFSTIndexType();
 
     List<String> bloomFilterColumns = indexingConfig.getBloomFilterColumns();
     if (bloomFilterColumns != null) {
@@ -338,14 +339,6 @@ public class IndexLoadingConfig {
   }
 
   /**
-   * For tests only
-   */
-  @VisibleForTesting
-  public void setFSTIndexType(FSTType fstType) {
-    _fstIndexType = fstType;
-  }
-
-  /**
    * For tests only.
    */
   @VisibleForTesting
@@ -367,6 +360,11 @@ public class IndexLoadingConfig {
   @VisibleForTesting
   public void setFSTIndexColumns(Set<String> fstIndexColumns) {
     _fstIndexColumns = fstIndexColumns;
+  }
+
+  @VisibleForTesting
+  public void setFSTIndexType(FSTType fstType) {
+    _fstIndexType = fstType;
   }
 
   @VisibleForTesting

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -338,6 +338,14 @@ public class IndexLoadingConfig {
   }
 
   /**
+   * For tests only
+   */
+  @VisibleForTesting
+  public void setFstIndexType(FSTIndexType fstIndexType) {
+    _fstIndexType = fstIndexType;
+  }
+
+  /**
    * For tests only.
    */
   @VisibleForTesting

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -57,7 +57,7 @@ public class IndexLoadingConfig {
   private Set<String> _invertedIndexColumns = new HashSet<>();
   private Set<String> _rangeIndexColumns = new HashSet<>();
   private int _rangeIndexVersion = IndexingConfig.DEFAULT_RANGE_INDEX_VERSION;
-  private FSTType _fstTypeForFSTIndex = FSTType.LUCENE;
+  private FSTType _fstIndexType = FSTType.LUCENE;
   private Set<String> _textIndexColumns = new HashSet<>();
   private Set<String> _fstIndexColumns = new HashSet<>();
   private Set<String> _jsonIndexColumns = new HashSet<>();
@@ -114,7 +114,7 @@ public class IndexLoadingConfig {
     }
     _rangeIndexVersion = indexingConfig.getRangeIndexVersion();
 
-    _fstTypeForFSTIndex = indexingConfig.getFSTIndexType();
+    _fstIndexType = indexingConfig.getFSTIndexType();
 
     List<String> jsonIndexColumns = indexingConfig.getJsonIndexColumns();
     if (jsonIndexColumns != null) {
@@ -293,8 +293,8 @@ public class IndexLoadingConfig {
     return _rangeIndexVersion;
   }
 
-  public FSTType getFstIndexType() {
-    return _fstTypeForFSTIndex;
+  public FSTType getFSTIndexType() {
+    return _fstIndexType;
   }
 
   /**
@@ -341,8 +341,8 @@ public class IndexLoadingConfig {
    * For tests only
    */
   @VisibleForTesting
-  public void setFstIndexType(FSTType fstType) {
-    _fstTypeForFSTIndex = fstType;
+  public void setFSTIndexType(FSTType fstType) {
+    _fstIndexType = fstType;
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/FSTIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/FSTIndexHandler.java
@@ -135,8 +135,8 @@ public class FSTIndexHandler implements IndexHandler {
 
     LOGGER.info("Creating new FST index for column: {} in segment: {}, cardinality: {}", column, segmentName,
         columnMetadata.getCardinality());
-    TextIndexCreator fstIndexCreator;
 
+    TextIndexCreator fstIndexCreator;
     if (_fstType == FSTType.LUCENE) {
       fstIndexCreator = new LuceneFSTIndexCreator(_indexDir, column, null);
     } else {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/FSTIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/FSTIndexHandler.java
@@ -124,8 +124,7 @@ public class FSTIndexHandler implements IndexHandler {
     String segmentName = _segmentMetadata.getName();
     String column = columnMetadata.getColumnName();
     File inProgress = new File(_indexDir, column + ".fst.inprogress");
-    String fileExtension = FST_INDEX_FILE_EXTENSION;
-    File fstIndexFile = new File(_indexDir, column + fileExtension);
+    File fstIndexFile = new File(_indexDir, column + FST_INDEX_FILE_EXTENSION);
 
     if (!inProgress.exists()) {
       // Create a marker file.

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/FSTIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/FSTIndexHandler.java
@@ -37,7 +37,7 @@ import org.apache.pinot.segment.spi.index.creator.TextIndexCreator;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.store.ColumnIndexType;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
-import org.apache.pinot.spi.config.table.FSTIndexType;
+import org.apache.pinot.spi.config.table.FSTType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -71,15 +71,15 @@ public class FSTIndexHandler implements IndexHandler {
   private final SegmentMetadata _segmentMetadata;
   private final SegmentDirectory.Writer _segmentWriter;
   private final Set<String> _columnsToAddIdx;
-  private final FSTIndexType _fstIndexType;
+  private final FSTType _fstType;
 
   public FSTIndexHandler(File indexDir, SegmentMetadata segmentMetadata, IndexLoadingConfig indexLoadingConfig,
-      SegmentDirectory.Writer segmentWriter, FSTIndexType fstIndexType) {
+      SegmentDirectory.Writer segmentWriter, FSTType fstType) {
     _indexDir = indexDir;
     _segmentMetadata = segmentMetadata;
     _segmentWriter = segmentWriter;
     _columnsToAddIdx = new HashSet<>(indexLoadingConfig.getFSTIndexColumns());
-    _fstIndexType = fstIndexType;
+    _fstType = fstType;
   }
 
   @Override
@@ -125,7 +125,7 @@ public class FSTIndexHandler implements IndexHandler {
     String segmentName = _segmentMetadata.getName();
     String column = columnMetadata.getColumnName();
     File inProgress = new File(_indexDir, column + ".fst.inprogress");
-    String fileExtension = _fstIndexType == FSTIndexType.LUCENE ? FST_INDEX_FILE_EXTENSION
+    String fileExtension = _fstType == FSTType.LUCENE ? FST_INDEX_FILE_EXTENSION
         : NATIVE_FST_INDEX_FILE_EXTENSION;
     File fstIndexFile = new File(_indexDir, column + fileExtension);
 
@@ -140,7 +140,7 @@ public class FSTIndexHandler implements IndexHandler {
         columnMetadata.getCardinality());
     TextIndexCreator textIndexCreator;
 
-    if (_fstIndexType == FSTIndexType.LUCENE) {
+    if (_fstType == FSTType.LUCENE) {
       textIndexCreator = new LuceneFSTIndexCreator(_indexDir, column, null);
     } else {
       textIndexCreator = new NativeFSTIndexCreator(_indexDir, column, null);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/nativefst/FSTHeader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/nativefst/FSTHeader.java
@@ -21,9 +21,6 @@ package org.apache.pinot.segment.local.utils.nativefst;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.nio.ByteBuffer;
-import java.util.Collections;
-import org.apache.avro.util.ByteBufferInputStream;
 
 
 /**
@@ -34,7 +31,7 @@ public final class FSTHeader {
   /**
    * FST magic (4 bytes).
    */
-  final static int FST_MAGIC = ('\\' << 24) | ('f' << 16) | ('s' << 8) | ('a');
+  public static final int FST_MAGIC = ('\\' << 24) | ('f' << 16) | ('s' << 8) | 'a';
 
   /** FST version number. */
   final byte _version;
@@ -79,20 +76,5 @@ public final class FSTHeader {
     os.write(FST_MAGIC >> 8);
     os.write(FST_MAGIC);
     os.write(version);
-  }
-
-  /**
-   * Check if the passed in byte is a valid FST header
-   */
-  public static boolean isValidFST(ByteBuffer data)
-      throws IOException {
-    InputStream inputStream = new ByteBufferInputStream(Collections.singletonList(data));
-
-    if (inputStream.read() != ((FST_MAGIC >>> 24)) || inputStream.read() != ((FST_MAGIC >>> 16) & 0xff)
-        || inputStream.read() != ((FST_MAGIC >>> 8) & 0xff) || inputStream.read() != ((FST_MAGIC) & 0xff)) {
-      return false;
-    }
-
-    return true;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/nativefst/FSTHeader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/nativefst/FSTHeader.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.segment.local.utils.nativefst;
 
-import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/nativefst/FSTHeader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/nativefst/FSTHeader.java
@@ -18,9 +18,14 @@
  */
 package org.apache.pinot.segment.local.utils.nativefst;
 
+import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.Collections;
+import org.apache.avro.util.ByteBufferInputStream;
 
 
 /**
@@ -76,5 +81,20 @@ public final class FSTHeader {
     os.write(FST_MAGIC >> 8);
     os.write(FST_MAGIC);
     os.write(version);
+  }
+
+  /**
+   * Check if the passed in byte is a valid FST header
+   */
+  public static boolean isValidFST(ByteBuffer data)
+      throws IOException {
+    InputStream inputStream = new ByteBufferInputStream(Collections.singletonList(data));
+
+    if (inputStream.read() != ((FST_MAGIC >>> 24)) || inputStream.read() != ((FST_MAGIC >>> 16) & 0xff)
+        || inputStream.read() != ((FST_MAGIC >>> 8) & 0xff) || inputStream.read() != ((FST_MAGIC) & 0xff)) {
+      return false;
+    }
+
+    return true;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/nativefst/NativeFSTIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/nativefst/NativeFSTIndexCreator.java
@@ -47,7 +47,7 @@ public class NativeFSTIndexCreator implements TextIndexCreator {
    * @throws IOException
    */
   public NativeFSTIndexCreator(File indexDir, String columnName, String[] sortedEntries) {
-    _fstIndexFile = new File(indexDir, columnName + V1Constants.Indexes.NATIVE_FST_INDEX_FILE_EXTENSION);
+    _fstIndexFile = new File(indexDir, columnName + V1Constants.Indexes.FST_INDEX_FILE_EXTENSION);
 
     _fstBuilder = new FSTBuilder();
     _dictId = 0;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/NativeFSTIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/NativeFSTIndexCreatorTest.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.creator;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteOrder;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.utils.nativefst.NativeFSTIndexCreator;
+import org.apache.pinot.segment.local.utils.nativefst.NativeFSTIndexReader;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.segment.spi.V1Constants.Indexes.NATIVE_FST_INDEX_FILE_EXTENSION;
+
+
+public class NativeFSTIndexCreatorTest {
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "NativeFSTIndex");
+
+  @BeforeClass
+  public void setUp()
+      throws IOException {
+    FileUtils.forceMkdir(INDEX_DIR);
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    FileUtils.deleteDirectory(INDEX_DIR);
+  }
+
+  @Test
+  public void testIndexWriterReader()
+      throws IOException {
+    String[] uniqueValues = new String[3];
+    uniqueValues[0] = "hello-world";
+    uniqueValues[1] = "hello-world123";
+    uniqueValues[2] = "still";
+
+    NativeFSTIndexCreator creator = new NativeFSTIndexCreator(INDEX_DIR, "testFSTColumn", uniqueValues);
+    creator.seal();
+    File fstFile = new File(INDEX_DIR, "testFSTColumn" + NATIVE_FST_INDEX_FILE_EXTENSION);
+    PinotDataBuffer pinotDataBuffer =
+        PinotDataBuffer.mapFile(fstFile, true, 0, fstFile.length(), ByteOrder.BIG_ENDIAN, "fstIndexFile");
+    NativeFSTIndexReader reader = new NativeFSTIndexReader(pinotDataBuffer);
+    int[] matchedDictIds = reader.getDictIds("hello.*").toArray();
+    Assert.assertEquals(2, matchedDictIds.length);
+    Assert.assertEquals(0, matchedDictIds[0]);
+    Assert.assertEquals(1, matchedDictIds[1]);
+
+    matchedDictIds = reader.getDictIds(".*llo").toArray();
+    Assert.assertEquals(0, matchedDictIds.length);
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/NativeFSTIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/NativeFSTIndexCreatorTest.java
@@ -30,7 +30,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.segment.spi.V1Constants.Indexes.NATIVE_FST_INDEX_FILE_EXTENSION;
+import static org.apache.pinot.segment.spi.V1Constants.Indexes.FST_INDEX_FILE_EXTENSION;
 
 
 public class NativeFSTIndexCreatorTest {
@@ -58,7 +58,7 @@ public class NativeFSTIndexCreatorTest {
 
     NativeFSTIndexCreator creator = new NativeFSTIndexCreator(INDEX_DIR, "testFSTColumn", uniqueValues);
     creator.seal();
-    File fstFile = new File(INDEX_DIR, "testFSTColumn" + NATIVE_FST_INDEX_FILE_EXTENSION);
+    File fstFile = new File(INDEX_DIR, "testFSTColumn" + FST_INDEX_FILE_EXTENSION);
     PinotDataBuffer pinotDataBuffer =
         PinotDataBuffer.mapFile(fstFile, true, 0, fstFile.length(), ByteOrder.BIG_ENDIAN, "fstIndexFile");
     NativeFSTIndexReader reader = new NativeFSTIndexReader(pinotDataBuffer);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
@@ -44,7 +44,6 @@ public class V1Constants {
     public static final String BITMAP_INVERTED_INDEX_FILE_EXTENSION = ".bitmap.inv";
     public static final String BITMAP_RANGE_INDEX_FILE_EXTENSION = ".bitmap.range";
     public static final String FST_INDEX_FILE_EXTENSION = ".lucene.fst";
-    public static final String NATIVE_FST_INDEX_FILE_EXTENSION = ".native.fst";
     public static final String JSON_INDEX_FILE_EXTENSION = ".json.idx";
     public static final String H3_INDEX_FILE_EXTENSION = ".h3.idx";
     public static final String BLOOM_FILTER_FILE_EXTENSION = ".bloom";

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -196,7 +196,7 @@ public class SegmentGeneratorConfig implements Serializable {
       extractH3IndexConfigsFromTableConfig(tableConfig);
       extractCompressionCodecConfigsFromTableConfig(tableConfig);
 
-      _fstTypeForFSTIndex = tableConfig.getIndexingConfig().getFstIndexType();
+      _fstTypeForFSTIndex = tableConfig.getIndexingConfig().getFSTIndexType();
 
       _nullHandlingEnabled = indexingConfig.isNullHandlingEnabled();
     }
@@ -507,11 +507,11 @@ public class SegmentGeneratorConfig implements Serializable {
     return _sequenceId;
   }
 
-  public void setFstIndexType(FSTType fstType) {
+  public void setFSTIndexType(FSTType fstType) {
     _fstTypeForFSTIndex = fstType;
   }
 
-  public FSTType getFstIndexType() {
+  public FSTType getFSTIndexType() {
     return _fstTypeForFSTIndex;
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -38,7 +38,7 @@ import org.apache.pinot.segment.spi.creator.name.FixedSegmentNameGenerator;
 import org.apache.pinot.segment.spi.creator.name.SegmentNameGenerator;
 import org.apache.pinot.segment.spi.creator.name.SimpleSegmentNameGenerator;
 import org.apache.pinot.segment.spi.index.creator.H3IndexConfig;
-import org.apache.pinot.spi.config.table.FSTIndexType;
+import org.apache.pinot.spi.config.table.FSTType;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
@@ -92,7 +92,7 @@ public class SegmentGeneratorConfig implements Serializable {
   private String _segmentEndTime = null;
   private SegmentVersion _segmentVersion = SegmentVersion.v3;
   private Schema _schema = null;
-  private FSTIndexType _fstIndexType = FSTIndexType.LUCENE;
+  private FSTType _fstTypeForFSTIndex = FSTType.LUCENE;
   private RecordReaderConfig _readerConfig = null;
   private List<StarTreeIndexConfig> _starTreeIndexConfigs = null;
   private boolean _enableDefaultStarTree = false;
@@ -196,7 +196,7 @@ public class SegmentGeneratorConfig implements Serializable {
       extractH3IndexConfigsFromTableConfig(tableConfig);
       extractCompressionCodecConfigsFromTableConfig(tableConfig);
 
-      _fstIndexType = tableConfig.getIndexingConfig().getFstIndexType();
+      _fstTypeForFSTIndex = tableConfig.getIndexingConfig().getFstIndexType();
 
       _nullHandlingEnabled = indexingConfig.isNullHandlingEnabled();
     }
@@ -507,12 +507,12 @@ public class SegmentGeneratorConfig implements Serializable {
     return _sequenceId;
   }
 
-  public void setFstIndexType(FSTIndexType fstIndexType) {
-    _fstIndexType = fstIndexType;
+  public void setFstIndexType(FSTType fstType) {
+    _fstTypeForFSTIndex = fstType;
   }
 
-  public FSTIndexType getFstIndexType() {
-    return _fstIndexType;
+  public FSTType getFstIndexType() {
+    return _fstTypeForFSTIndex;
   }
 
   /**

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -38,6 +38,7 @@ import org.apache.pinot.segment.spi.creator.name.FixedSegmentNameGenerator;
 import org.apache.pinot.segment.spi.creator.name.SegmentNameGenerator;
 import org.apache.pinot.segment.spi.creator.name.SimpleSegmentNameGenerator;
 import org.apache.pinot.segment.spi.index.creator.H3IndexConfig;
+import org.apache.pinot.spi.config.table.FSTIndexType;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
@@ -91,6 +92,7 @@ public class SegmentGeneratorConfig implements Serializable {
   private String _segmentEndTime = null;
   private SegmentVersion _segmentVersion = SegmentVersion.v3;
   private Schema _schema = null;
+  private FSTIndexType _fstIndexType = FSTIndexType.LUCENE;
   private RecordReaderConfig _readerConfig = null;
   private List<StarTreeIndexConfig> _starTreeIndexConfigs = null;
   private boolean _enableDefaultStarTree = false;
@@ -193,6 +195,8 @@ public class SegmentGeneratorConfig implements Serializable {
       extractFSTIndexColumnsFromTableConfig(tableConfig);
       extractH3IndexConfigsFromTableConfig(tableConfig);
       extractCompressionCodecConfigsFromTableConfig(tableConfig);
+
+      _fstIndexType = tableConfig.getIndexingConfig().getFstIndexType();
 
       _nullHandlingEnabled = indexingConfig.isNullHandlingEnabled();
     }
@@ -501,6 +505,14 @@ public class SegmentGeneratorConfig implements Serializable {
 
   public int getSequenceId() {
     return _sequenceId;
+  }
+
+  public void setFstIndexType(FSTIndexType fstIndexType) {
+    _fstIndexType = fstIndexType;
+  }
+
+  public FSTIndexType getFstIndexType() {
+    return _fstIndexType;
   }
 
   /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FSTIndexType.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FSTIndexType.java
@@ -1,0 +1,5 @@
+package org.apache.pinot.spi.config.table;
+
+public enum FSTIndexType {
+    LUCENE, NATIVE
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FSTIndexType.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FSTIndexType.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.spi.config.table;
 
 public enum FSTIndexType {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FSTType.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FSTType.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.spi.config.table;
 
-public enum FSTIndexType {
+/**
+ * Type of FST to be used
+ */
+public enum FSTType {
     LUCENE, NATIVE
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
@@ -41,6 +41,7 @@ public class IndexingConfig extends BaseJsonConfig {
   @Deprecated // Moved to {@link IngestionConfig#getStreamIngestionConfig}
   private Map<String, String> _streamConfigs;
   private String _segmentFormatVersion;
+  private FSTIndexType _fstIndexType;
   private String _columnMinMaxValueGeneratorMode;
   private List<String> _noDictionaryColumns; // TODO: replace this with noDictionaryConfig.
   private Map<String, String> _noDictionaryConfig;
@@ -84,6 +85,14 @@ public class IndexingConfig extends BaseJsonConfig {
 
   public int getRangeIndexVersion() {
     return _rangeIndexVersion;
+  }
+
+  public void setFstIndexType(FSTIndexType fstIndexType) {
+    _fstIndexType = fstIndexType;
+  }
+
+  public FSTIndexType getFstIndexType() {
+    return _fstIndexType;
   }
 
   public void setRangeIndexVersion(int rangeIndexVersion) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
@@ -41,7 +41,7 @@ public class IndexingConfig extends BaseJsonConfig {
   @Deprecated // Moved to {@link IngestionConfig#getStreamIngestionConfig}
   private Map<String, String> _streamConfigs;
   private String _segmentFormatVersion;
-  private FSTIndexType _fstIndexType;
+  private FSTType _fstTypeForFSTIndex;
   private String _columnMinMaxValueGeneratorMode;
   private List<String> _noDictionaryColumns; // TODO: replace this with noDictionaryConfig.
   private Map<String, String> _noDictionaryConfig;
@@ -87,12 +87,12 @@ public class IndexingConfig extends BaseJsonConfig {
     return _rangeIndexVersion;
   }
 
-  public void setFstIndexType(FSTIndexType fstIndexType) {
-    _fstIndexType = fstIndexType;
+  public void setFstIndexType(FSTType fstType) {
+    _fstTypeForFSTIndex = fstType;
   }
 
-  public FSTIndexType getFstIndexType() {
-    return _fstIndexType;
+  public FSTType getFstIndexType() {
+    return _fstTypeForFSTIndex;
   }
 
   public void setRangeIndexVersion(int rangeIndexVersion) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
@@ -87,11 +87,11 @@ public class IndexingConfig extends BaseJsonConfig {
     return _rangeIndexVersion;
   }
 
-  public void setFstIndexType(FSTType fstType) {
+  public void setFSTIndexType(FSTType fstType) {
     _fstTypeForFSTIndex = fstType;
   }
 
-  public FSTType getFstIndexType() {
+  public FSTType getFSTIndexType() {
     return _fstTypeForFSTIndex;
   }
 


### PR DESCRIPTION
This PR introduces the notion of subtypes to FST index -- allowing users to set a segment level flag indicating whether the index should be built using native FST or Lucene FST.

Supersedes #7684 