### PR TITLE
bump roaringbitmap version

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -379,8 +379,8 @@ org.eclipse.jetty:jetty-util:9.4.39.v20210325
 org.javassist:javassist:3.19.0-GA
 org.lz4:lz4-java:1.7.1
 org.quartz-scheduler:quartz:2.3.2
-org.roaringbitmap:RoaringBitmap:0.9.22
-org.roaringbitmap:shims:0.9.22
+org.roaringbitmap:RoaringBitmap:0.9.23
+org.roaringbitmap:shims:0.9.23
 org.webjars:swagger-ui:3.18.2
 org.wildfly.openssl:wildfly-openssl:1.0.7.Final
 org.xerial.larray:larray-buffer:0.4.1

--- a/pom.xml
+++ b/pom.xml
@@ -436,7 +436,7 @@
       <dependency>
         <groupId>org.roaringbitmap</groupId>
         <artifactId>RoaringBitmap</artifactId>
-        <version>0.9.22</version>
+        <version>0.9.23</version>
       </dependency>
       <dependency>
         <groupId>com.101tec</groupId>


### PR DESCRIPTION
## Description
Updates RoaringBitmap to 0.9.23, which includes a performance improvement for range queries in some cases:

```
Benchmark                    (_dataType)  (_decile)  (_numDocs)                          (_scenario)  (_seed)  Mode  Cnt      Score     Error  Units
BenchmarkRangeIndex.queryV2         LONG          5    10000000                          NORMAL(0,1)       42  avgt    5   1535.029 ±  92.381  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000                NORMAL(10000000,1000)       42  avgt    5   5785.355 ± 136.707  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000                          EXP(0.0001)       42  avgt    5   8749.233 ± 611.313  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000                             EXP(0.5)       42  avgt    5   3180.582 ±   9.839  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000              UNIFORM(0,100000000000)       42  avgt    5  20036.268 ± 521.648  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000  UNIFORM(100000000000, 100000000100)       42  avgt    5   3167.836 ± 270.252  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000                   POWER(0,1000000,3)       42  avgt    5      2.687 ±   0.169  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000                POWER(0,1000000000,1)       42  avgt    5      2.750 ±   0.344  us/op
```

```
Benchmark                    (_dataType)  (_decile)  (_numDocs)                          (_scenario)  (_seed)  Mode  Cnt      Score     Error  Units
BenchmarkRangeIndex.queryV2         LONG          5    10000000                          NORMAL(0,1)       42  avgt    5   1506.798 ±  35.190  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000                NORMAL(10000000,1000)       42  avgt    5   5558.664 ± 125.293  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000                          EXP(0.0001)       42  avgt    5   8785.747 ± 649.172  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000                             EXP(0.5)       42  avgt    5   3226.282 ±  11.844  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000              UNIFORM(0,100000000000)       42  avgt    5  13849.725 ± 721.279  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000  UNIFORM(100000000000, 100000000100)       42  avgt    5   2097.835 ±  54.656  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000                   POWER(0,1000000,3)       42  avgt    5      2.622 ±   0.053  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000                POWER(0,1000000000,1)       42  avgt    5      2.668 ±   0.028  us/op
```

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
