### PR TITLE
remove unused Number2ObjectPair class and auxiliaries

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/Pairs.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/Pairs.java
@@ -90,46 +90,6 @@ public class Pairs {
     }
   }
 
-  public static Comparator<Number2ObjectPair> getAscendingnumber2ObjectPairComparator() {
-    return new AscendingNumber2ObjectPairComparator();
-  }
-
-  public static Comparator<Number2ObjectPair> getDescendingnumber2ObjectPairComparator() {
-    return new DescendingNumber2ObjectPairComparator();
-  }
-
-  public static class Number2ObjectPair<T> {
-    Number _a;
-    T _b;
-
-    public Number2ObjectPair(Number a, T b) {
-      _a = a;
-      _b = b;
-    }
-
-    public Number getA() {
-      return _a;
-    }
-
-    public T getB() {
-      return _b;
-    }
-  }
-
-  public static class AscendingNumber2ObjectPairComparator implements Comparator<Number2ObjectPair> {
-    @Override
-    public int compare(Number2ObjectPair o1, Number2ObjectPair o2) {
-      return new Double(o1._a.doubleValue()).compareTo(new Double(o2._a.doubleValue()));
-    }
-  }
-
-  public static class DescendingNumber2ObjectPairComparator implements Comparator<Number2ObjectPair> {
-    @Override
-    public int compare(Number2ObjectPair o1, Number2ObjectPair o2) {
-      return new Double(o2._a.doubleValue()).compareTo(new Double(o1._a.doubleValue()));
-    }
-  }
-
   /**
    * Utility class to store a primitive 'int' and 'double' pair.
    */
@@ -273,9 +233,9 @@ public class Pairs {
       Comparable c2 = (Comparable) pair2.getObjectValue();
 
       int cmpValue = c1.compareTo(c2);
-      if (cmpValue == -1) {
+      if (cmpValue < 0) {
         return (_descending) ? 1 : -1;
-      } else if (cmpValue == 1) {
+      } else if (cmpValue > 0) {
         return (_descending) ? -1 : 1;
       } else {
         return 0;


### PR DESCRIPTION
## Description
AFAICT this class is unused.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
