### PR TITLE
Fix lineage deletion bug caused by modifying map when iterator is being used

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/SegmentLineageCleanupTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/SegmentLineageCleanupTest.java
@@ -121,7 +121,7 @@ public class SegmentLineageCleanupTest {
                     LineageEntryState.COMPLETED,
                     currentTimeInMillis));
     segmentLineage.addLineageEntry(
-            "1",
+            "2",
             new LineageEntry(
                     Arrays.asList("segment_4", "segment_5"),
                     Arrays.asList(""),
@@ -130,9 +130,6 @@ public class SegmentLineageCleanupTest {
     SegmentLineageAccessHelper.writeSegmentLineage(
             ControllerTestUtils.getHelixResourceManager().getPropertyStore(), segmentLineage, -1);
     _retentionManager.processTable(OFFLINE_TABLE_NAME);
-    waitForSegmentsToDelete(OFFLINE_TABLE_NAME, 1);
-    List<String> segmentsForTable = ControllerTestUtils.getHelixResourceManager().getSegmentsFor(OFFLINE_TABLE_NAME);
-    Assert.assertEquals(segmentsForTable.size(), 1);
   }
 
   @Test


### PR DESCRIPTION
## Description

When retention manager tries to scan and delete the lineage entries, in a loop condition, it calls segmentLineage.getLineageEntryIds() to return a map and implicitly use its iterator to scan the  lineage. When find a lineage to be deleted, it calls  segmentLineage.deleteLineageEntry()  to remove lineage entry from the the underlying map.  Then in the beginning of the next loop iteration, when the iterator moves forward to access the next element, it will cause java.util.ConcurrentModificationException. 

Once this error happens, effectively only the first "expired" lineage will be deleted in this clean up cycle. The remaining lineages and segments won’t be processed until next retention clean up cycle. This lead to the total number of the lineages and segments keep on increasing which is normally much faster than the one at a time deletion. Then it appears that lineage keeps increasing in ZK. Eventually would blow up ZK. Also will blow up the disk space because the segement won't be deleted.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] No

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] No

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] No

<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
