### PR TITLE
Fix controller error response field names

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/WebApplicationExceptionMapper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/WebApplicationExceptionMapper.java
@@ -20,15 +20,14 @@ package org.apache.pinot.controller.api.resources;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonProcessingException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
-import org.apache.pinot.spi.utils.JsonUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 @Provider
@@ -45,12 +44,8 @@ public class WebApplicationExceptionMapper implements ExceptionMapper<Throwable>
     }
 
     ErrorInfo einfo = new ErrorInfo(status, t.getMessage());
-    try {
-      return Response.status(status).entity(JsonUtils.objectToString(einfo)).type(MediaType.APPLICATION_JSON).build();
-    } catch (JsonProcessingException e) {
-      String err = String.format("{\"status\":%d, \"error\":%s}", einfo._code, einfo._error);
-      return Response.status(status).entity(err).type(MediaType.APPLICATION_JSON).build();
-    }
+    String err = String.format("{\"code\":%d, \"error\":%s}", einfo._code, einfo._error);
+    return Response.status(status).entity(err).type(MediaType.APPLICATION_JSON).build();
   }
 
   public static class ErrorInfo {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/WebApplicationExceptionMapper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/WebApplicationExceptionMapper.java
@@ -43,7 +43,7 @@ public class WebApplicationExceptionMapper implements ExceptionMapper<Throwable>
     }
 
     ErrorInfo einfo = new ErrorInfo(status, t.getMessage());
-    String err = String.format("{\"code\":%d, \"error\":%s}", einfo._code, einfo._error);
+    String err = String.format("{\"code\":%d, \"error\":\"%s\"}", einfo._code, einfo._error);
     return Response.status(status).entity(err).type(MediaType.APPLICATION_JSON).build();
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/WebApplicationExceptionMapper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/WebApplicationExceptionMapper.java
@@ -20,14 +20,13 @@ package org.apache.pinot.controller.api.resources;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 @Provider


### PR DESCRIPTION
## Description

Fix for https://github.com/apache/pinot/issues/7749

Return {code: '', error: ''} instead of {_code: '', _error: ''} for controller error response. So the right topper red dot will show the correct error message.

Before:
![image](https://user-images.githubusercontent.com/1202120/141497573-ddc6be55-2c9f-47ac-b141-a7d3b540360d.png)

After:
![image](https://user-images.githubusercontent.com/1202120/141497494-9b66fd1b-ab32-499d-8a89-6f8c5aa96342.png)

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
