### PR TITLE
Bump-up azure-storage-file-datalake version

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -430,10 +430,10 @@ of these licenses.
 MIT License
 -----------
 com.azure:azure-core-http-netty:1.7.1
-com.azure:azure-core:1.12.0
+com.azure:azure-core:1.15.0
 com.azure:azure-storage-blob:12.10.0
 com.azure:azure-storage-common:12.10.0
-com.azure:azure-storage-file-datalake:12.4.0
+com.azure:azure-storage-file-datalake:12.5.0
 com.azure:azure-storage-internal-avro:12.0.2
 com.microsoft.azure:azure-data-lake-store-sdk:2.3.9
 net.sf.jopt-simple:jopt-simple:4.6

--- a/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-storage-file-datalake</artifactId>
-      <version>12.4.0</version>
+      <version>12.5.0</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>


### PR DESCRIPTION
## Description
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
No

Does this PR fix a zero-downtime upgrade introduced earlier?
No

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
No
