### PR TITLE
Add getName() to PartitionFunction interface

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -727,7 +727,7 @@ public class PinotLLCRealtimeSegmentManager {
       PartitionFunction partitionFunction = columnMetadata.getPartitionFunction();
       if (partitionFunction != null) {
         ColumnPartitionMetadata columnPartitionMetadata =
-            new ColumnPartitionMetadata(partitionFunction.toString(), partitionFunction.getNumPartitions(),
+            new ColumnPartitionMetadata(partitionFunction.getName(), partitionFunction.getNumPartitions(),
                 columnMetadata.getPartitions());
         return new SegmentPartitionMetadata(Collections.singletonMap(entry.getKey(), columnPartitionMetadata));
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/ZKMetadataUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/ZKMetadataUtils.java
@@ -67,7 +67,7 @@ public class ZKMetadataUtils {
 
         if (partitionFunction != null) {
           ColumnPartitionMetadata columnPartitionMetadata =
-              new ColumnPartitionMetadata(partitionFunction.toString(), partitionFunction.getNumPartitions(),
+              new ColumnPartitionMetadata(partitionFunction.getName(), partitionFunction.getNumPartitions(),
                   columnMetadata.getPartitions());
           columnPartitionMap.put(column, columnPartitionMetadata);
         }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -422,7 +422,7 @@ public class MutableSegmentImpl implements MutableSegment {
   public SegmentPartitionConfig getSegmentPartitionConfig() {
     if (_partitionColumn != null) {
       return new SegmentPartitionConfig(Collections.singletonMap(_partitionColumn,
-          new ColumnPartitionConfig(_partitionFunction.toString(), _partitionFunction.getNumPartitions())));
+          new ColumnPartitionConfig(_partitionFunction.getName(), _partitionFunction.getNumPartitions())));
     } else {
       return null;
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -752,7 +752,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
 
     PartitionFunction partitionFunction = columnIndexCreationInfo.getPartitionFunction();
     if (partitionFunction != null) {
-      properties.setProperty(getKeyFor(column, PARTITION_FUNCTION), partitionFunction.toString());
+      properties.setProperty(getKeyFor(column, PARTITION_FUNCTION), partitionFunction.getName());
       properties.setProperty(getKeyFor(column, NUM_PARTITIONS), columnIndexCreationInfo.getNumPartitions());
       properties.setProperty(getKeyFor(column, PARTITION_VALUES), columnIndexCreationInfo.getPartitions());
     }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/ByteArrayPartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/ByteArrayPartitionFunction.java
@@ -45,10 +45,16 @@ public class ByteArrayPartitionFunction implements PartitionFunction {
   }
 
   @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
   public int getNumPartitions() {
     return _numPartitions;
   }
 
+  // Keep it for backward-compatibility, use getName() instead
   @Override
   public String toString() {
     return NAME;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/HashCodePartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/HashCodePartitionFunction.java
@@ -42,10 +42,16 @@ public class HashCodePartitionFunction implements PartitionFunction {
   }
 
   @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
   public int getNumPartitions() {
     return _numPartitions;
   }
 
+  // Keep it for backward-compatibility, use getName() instead
   @Override
   public String toString() {
     return NAME;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/ModuloPartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/ModuloPartitionFunction.java
@@ -65,10 +65,16 @@ public class ModuloPartitionFunction implements PartitionFunction {
   }
 
   @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
   public int getNumPartitions() {
     return _numPartitions;
   }
 
+  // Keep it for backward-compatibility, use getName() instead
   @Override
   public String toString() {
     return NAME;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/MurmurPartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/MurmurPartitionFunction.java
@@ -47,10 +47,16 @@ public class MurmurPartitionFunction implements PartitionFunction {
   }
 
   @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
   public int getNumPartitions() {
     return _numPartitions;
   }
 
+  // Keep it for backward-compatibility, use getName() instead
   @Override
   public String toString() {
     return NAME;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/PartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/PartitionFunction.java
@@ -29,6 +29,7 @@ import java.io.Serializable;
  * with the same value are expected to produce the same result.
  */
 public interface PartitionFunction extends Serializable {
+
   /**
    * Method to compute and return partition id for the given value.
    *
@@ -36,6 +37,12 @@ public interface PartitionFunction extends Serializable {
    * @return partition id for the value.
    */
   int getPartition(Object value);
+
+  /**
+   * Returns the name of the partition function.
+   * @return Name of the partition function.
+   */
+  String getName();
 
   /**
    * Returns the total number of possible partitions.

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/PartitionFunctionFactory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/PartitionFunctionFactory.java
@@ -20,7 +20,6 @@ package org.apache.pinot.segment.spi.partition;
 
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Nonnull;
 
 
 /**
@@ -67,7 +66,7 @@ public class PartitionFunctionFactory {
   // a custom partition function could be used in the realtime stream partitioning or offline segment partitioning.
   // The PartitionFunctionFactory should be able to support these default implementations, as well as instantiate
   // based on config
-  public static PartitionFunction getPartitionFunction(@Nonnull String functionName, int numPartitions) {
+  public static PartitionFunction getPartitionFunction(String functionName, int numPartitions) {
     PartitionFunctionType function = PartitionFunctionType.fromString(functionName);
     switch (function) {
       case Modulo:

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
@@ -18,11 +18,14 @@
  */
 package org.apache.pinot.segment.spi.partition;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Random;
-import org.testng.Assert;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 
 /**
@@ -54,31 +57,31 @@ public class PartitionFunctionTest {
       String functionName = "MoDuLo";
       PartitionFunction partitionFunction =
           PartitionFunctionFactory.getPartitionFunction(functionName, expectedNumPartitions);
-      Assert.assertEquals(partitionFunction.toString().toLowerCase(), functionName.toLowerCase());
-      Assert.assertEquals(partitionFunction.getNumPartitions(), expectedNumPartitions);
+
+      testBasicProperties(partitionFunction, functionName, expectedNumPartitions);
 
       // Test int values.
       for (int j = 0; j < 1000; j++) {
         int value = random.nextInt();
-        Assert.assertEquals(partitionFunction.getPartition(value), (value % expectedNumPartitions));
+        assertEquals(partitionFunction.getPartition(value), (value % expectedNumPartitions));
       }
 
       // Test long values.
       for (int j = 0; j < 1000; j++) {
         long value = random.nextLong();
-        Assert.assertEquals(partitionFunction.getPartition(value), (value % expectedNumPartitions));
+        assertEquals(partitionFunction.getPartition(value), (value % expectedNumPartitions));
       }
 
       // Test Integer represented as String.
       for (int j = 0; j < 1000; j++) {
         int value = random.nextInt();
-        Assert.assertEquals(partitionFunction.getPartition(Integer.toString(value)), (value % expectedNumPartitions));
+        assertEquals(partitionFunction.getPartition(Integer.toString(value)), (value % expectedNumPartitions));
       }
 
       // Test Long represented as String.
       for (int j = 0; j < 1000; j++) {
         long value = random.nextLong();
-        Assert.assertEquals(partitionFunction.getPartition(Long.toString(value)), (value % expectedNumPartitions));
+        assertEquals(partitionFunction.getPartition(Long.toString(value)), (value % expectedNumPartitions));
       }
     }
   }
@@ -104,16 +107,15 @@ public class PartitionFunctionTest {
       }
 
       String functionName = "mUrmur";
-
       PartitionFunction partitionFunction =
           PartitionFunctionFactory.getPartitionFunction(functionName, expectedNumPartitions);
-      Assert.assertEquals(partitionFunction.toString().toLowerCase(), functionName.toLowerCase());
-      Assert.assertEquals(partitionFunction.getNumPartitions(), expectedNumPartitions);
+
+      testBasicProperties(partitionFunction, functionName, expectedNumPartitions);
 
       for (int j = 0; j < 1000; j++) {
         int value = random.nextInt();
         String stringValue = Integer.toString(value);
-        Assert.assertTrue(partitionFunction.getPartition(stringValue) < expectedNumPartitions,
+        assertTrue(partitionFunction.getPartition(stringValue) < expectedNumPartitions,
             "Illegal: " + partitionFunction.getPartition(stringValue) + " " + expectedNumPartitions);
       }
     }
@@ -142,12 +144,12 @@ public class PartitionFunctionTest {
       String functionName = "bYteArray";
       PartitionFunction partitionFunction =
           PartitionFunctionFactory.getPartitionFunction(functionName, expectedNumPartitions);
-      Assert.assertEquals(partitionFunction.toString().toLowerCase(), functionName.toLowerCase());
-      Assert.assertEquals(partitionFunction.getNumPartitions(), expectedNumPartitions);
+
+      testBasicProperties(partitionFunction, functionName, expectedNumPartitions);
 
       for (int j = 0; j < 1000; j++) {
         Integer value = random.nextInt();
-        Assert.assertTrue(partitionFunction.getPartition(value) < expectedNumPartitions,
+        assertTrue(partitionFunction.getPartition(value) < expectedNumPartitions,
             "Illegal: " + partitionFunction.getPartition(value) + " " + expectedNumPartitions);
       }
     }
@@ -169,14 +171,24 @@ public class PartitionFunctionTest {
       String functionName = "HaShCoDe";
       PartitionFunction partitionFunction =
           PartitionFunctionFactory.getPartitionFunction(functionName, expectedNumPartitions);
-      Assert.assertEquals(partitionFunction.toString().toLowerCase(), functionName.toLowerCase());
-      Assert.assertEquals(partitionFunction.getNumPartitions(), expectedNumPartitions);
+
+      testBasicProperties(partitionFunction, functionName, expectedNumPartitions);
 
       for (int j = 0; j < 1000; j++) {
         Integer value = random.nextInt();
-        Assert.assertEquals(partitionFunction.getPartition(value), Math.abs(value.hashCode()) % expectedNumPartitions);
+        assertEquals(partitionFunction.getPartition(value), Math.abs(value.hashCode()) % expectedNumPartitions);
       }
     }
+  }
+
+  private void testBasicProperties(PartitionFunction partitionFunction, String functionName, int numPartitions) {
+    assertEquals(partitionFunction.getName().toLowerCase(), functionName.toLowerCase());
+    assertEquals(partitionFunction.getNumPartitions(), numPartitions);
+
+    JsonNode jsonNode = JsonUtils.objectToJsonNode(partitionFunction);
+    assertEquals(jsonNode.size(), 2);
+    assertEquals(jsonNode.get("name").asText().toLowerCase(), functionName.toLowerCase());
+    assertEquals(jsonNode.get("numPartitions").asInt(), numPartitions);
   }
 
   /**
@@ -206,7 +218,7 @@ public class PartitionFunctionTest {
     for (int expectedMurmurValue : expectedMurmurValues) {
       random.nextBytes(array);
       int actualMurmurValue = murmurPartitionFunction.murmur2(array);
-      Assert.assertEquals(actualMurmurValue, expectedMurmurValue);
+      assertEquals(actualMurmurValue, expectedMurmurValue);
     }
   }
 
@@ -265,7 +277,7 @@ public class PartitionFunctionTest {
       random.nextBytes(array);
       String nextString = new String(array, UTF_8);
       int actualPartition = partitionFunction.getPartition(nextString);
-      Assert.assertEquals(actualPartition, expectedPartition);
+      assertEquals(actualPartition, expectedPartition);
     }
   }
 }


### PR DESCRIPTION
Add `getName()` to `PartitionFunction` interface, and replace the current usage of `toString()`
`getName()` is required in order to serialize the name of the `PartitionFunction` in json