### PR TITLE
Add timeColumn, timeUnit and totalDocs to the json segment metadata

### DIFF
--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/SegmentMetadataImplTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/SegmentMetadataImplTest.java
@@ -84,8 +84,11 @@ public class SegmentMetadataImplTest {
     Assert.assertEquals(jsonMeta.get("crc").asLong(), Long.valueOf(metadata.getCrc()).longValue());
     Assert.assertTrue(jsonMeta.get("creatorName").isNull());
     assertEquals(jsonMeta.get("creationTimeMillis").asLong(), metadata.getIndexCreationTime());
+    assertEquals(jsonMeta.get("timeColumn").asText(), metadata.getTimeColumn());
+    assertEquals(jsonMeta.get("timeUnit").asText(), metadata.getTimeUnit().name());
     assertEquals(jsonMeta.get("startTimeMillis").asLong(), metadata.getTimeInterval().getStartMillis());
     assertEquals(jsonMeta.get("endTimeMillis").asLong(), metadata.getTimeInterval().getEndMillis());
+    assertEquals(jsonMeta.get("totalDocs").asInt(), metadata.getTotalDocs());
     assertEquals(jsonMeta.get("custom").get("k1").asText(), metadata.getCustomMap().get("k1"));
     assertEquals(jsonMeta.get("custom").get("k2").asText(), metadata.getCustomMap().get("k2"));
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/SegmentMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/SegmentMetadataImpl.java
@@ -387,6 +387,8 @@ public class SegmentMetadataImpl implements SegmentMetadata {
     dateFormat.setTimeZone(timeZone);
     String creationTimeStr = _creationTime != Long.MIN_VALUE ? dateFormat.format(new Date(_creationTime)) : null;
     segmentMetadata.put("creationTimeReadable", creationTimeStr);
+    segmentMetadata.put("timeColumn", _timeColumn);
+    segmentMetadata.put("timeUnit", _timeUnit != null ? _timeUnit.name() : null);
     segmentMetadata.put("timeGranularitySec", _timeGranularity != null ? _timeGranularity.getStandardSeconds() : null);
     if (_timeInterval == null) {
       segmentMetadata.set("startTimeMillis", null);
@@ -402,6 +404,7 @@ public class SegmentMetadataImpl implements SegmentMetadata {
 
     segmentMetadata.put("segmentVersion", ((_segmentVersion != null) ? _segmentVersion.toString() : null));
     segmentMetadata.put("creatorName", _creatorName);
+    segmentMetadata.put("totalDocs", _totalDocs);
 
     ObjectNode customConfigs = JsonUtils.newObjectNode();
     for (String key : _customMap.keySet()) {


### PR DESCRIPTION
Add the missing `timeColumn`, `timeUnit` and `totalDocs` info to the json segment metadata