### PR TITLE
set default Dockerfile CMD to -help

### DIFF
--- a/docker/images/pinot/Dockerfile
+++ b/docker/images/pinot/Dockerfile
@@ -84,4 +84,4 @@ WORKDIR ${PINOT_HOME}
 
 ENTRYPOINT ["./bin/pinot-admin.sh"]
 
-CMD ["run"]
+CMD ["-help"]


### PR DESCRIPTION
Default docker entrypoint is set to `"run"` which is an invalid argument to the ENTRYPOINT `pinot-admin.sh`.

setting it to -help instead.