### PR TITLE
 Indicate QuickStart types for invalid/missing type

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.tools;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +29,7 @@ import org.apache.pinot.spi.plugin.PluginManager;
 public class AuthQuickstart extends Quickstart {
   @Override
   public List<String> types() {
-    return List.of("AUTH");
+    return Collections.singletonList("AUTH");
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
@@ -19,12 +19,17 @@
 package org.apache.pinot.tools;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.auth.BasicAuthUtils;
 import org.apache.pinot.spi.plugin.PluginManager;
 
 
 public class AuthQuickstart extends Quickstart {
+  @Override
+  public List<String> types() {
+    return List.of("AUTH");
+  }
 
   @Override
   public String getAuthToken() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/BatchQuickstartWithMinion.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/BatchQuickstartWithMinion.java
@@ -25,6 +25,10 @@ import org.apache.pinot.tools.admin.PinotAdministrator;
 
 
 public class BatchQuickstartWithMinion extends Quickstart {
+  @Override
+  public List<String> types() {
+    return List.of("OFFLINE_MINION", "BATCH_MINION", "OFFLINE-MINION", "BATCH-MINION");
+  }
 
   public String getBootstrapDataDir() {
     return "examples/minions/batch/baseballStats";

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/BatchQuickstartWithMinion.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/BatchQuickstartWithMinion.java
@@ -27,7 +27,7 @@ import org.apache.pinot.tools.admin.PinotAdministrator;
 public class BatchQuickstartWithMinion extends Quickstart {
   @Override
   public List<String> types() {
-    return List.of("OFFLINE_MINION", "BATCH_MINION", "OFFLINE-MINION", "BATCH-MINION");
+    return Arrays.asList("OFFLINE_MINION", "BATCH_MINION", "OFFLINE-MINION", "BATCH-MINION");
   }
 
   public String getBootstrapDataDir() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/HybridQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/HybridQuickstart.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.ZkStarter;
@@ -44,6 +45,11 @@ import static org.apache.pinot.tools.Quickstart.printStatus;
 
 
 public class HybridQuickstart extends QuickStartBase {
+  @Override
+  public List<String> types() {
+    return Collections.singletonList("HYBRID");
+  }
+
   private StreamDataServerStartable _kafkaStarter;
   private ZkStarter.ZookeeperInstance _zookeeperInstance;
   private File _schemaFile;
@@ -100,11 +106,6 @@ public class HybridQuickstart extends QuickStartBase {
     }
     _kafkaStarter.start();
     _kafkaStarter.createTopic("flights-realtime", KafkaStarterUtils.getTopicCreationProps(10));
-  }
-
-  @Override
-  public List<String> types() {
-    return List.of("HYBRID");
   }
 
   public void execute()

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/HybridQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/HybridQuickstart.java
@@ -102,6 +102,11 @@ public class HybridQuickstart extends QuickStartBase {
     _kafkaStarter.createTopic("flights-realtime", KafkaStarterUtils.getTopicCreationProps(10));
   }
 
+  @Override
+  public List<String> types() {
+    return List.of("HYBRID");
+  }
+
   public void execute()
       throws Exception {
     File quickstartTmpDir = new File(_tmpDir, String.valueOf(System.currentTimeMillis()));

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/JoinQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/JoinQuickStart.java
@@ -35,6 +35,11 @@ import static org.apache.pinot.tools.Quickstart.printStatus;
 
 public class JoinQuickStart extends QuickStartBase {
 
+  @Override
+  public List<String> types() {
+    return List.of("JOIN");
+  }
+
   public void execute()
       throws Exception {
     File quickstartTmpDir = new File(_tmpDir, String.valueOf(System.currentTimeMillis()));

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/JoinQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/JoinQuickStart.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.tools.admin.PinotAdministrator;
@@ -37,7 +38,7 @@ public class JoinQuickStart extends QuickStartBase {
 
   @Override
   public List<String> types() {
-    return List.of("JOIN");
+    return Collections.singletonList("JOIN");
   }
 
   public void execute()

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/JsonIndexQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/JsonIndexQuickStart.java
@@ -38,7 +38,7 @@ public class JsonIndexQuickStart extends QuickStartBase {
 
   @Override
   public List<String> types() {
-    return List.of("OFFLINE_JSON_INDEX", "OFFLINE-JSON-INDEX", "BATCH_JSON_INDEX", "BATCH-JSON-INDEX");
+    return Arrays.asList("OFFLINE_JSON_INDEX", "OFFLINE-JSON-INDEX", "BATCH_JSON_INDEX", "BATCH-JSON-INDEX");
   }
 
   public void execute()

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/JsonIndexQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/JsonIndexQuickStart.java
@@ -36,6 +36,11 @@ import static org.apache.pinot.tools.Quickstart.printStatus;
 
 public class JsonIndexQuickStart extends QuickStartBase {
 
+  @Override
+  public List<String> types() {
+    return List.of("OFFLINE_JSON_INDEX", "OFFLINE-JSON-INDEX", "BATCH_JSON_INDEX", "BATCH-JSON-INDEX");
+  }
+
   public void execute()
       throws Exception {
     File quickstartTmpDir = new File(_tmpDir, String.valueOf(System.currentTimeMillis()));

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/OfflineComplexTypeHandlingQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/OfflineComplexTypeHandlingQuickStart.java
@@ -35,6 +35,10 @@ import static org.apache.pinot.tools.Quickstart.printStatus;
 
 
 public class OfflineComplexTypeHandlingQuickStart extends QuickStartBase {
+  @Override
+  public List<String> types() {
+    return List.of("OFFLINE_COMPLEX_TYPE", "OFFLINE-COMPLEX-TYPE", "BATCH_COMPLEX_TYPE", "BATCH-COMPLEX-TYPE");
+  }
 
   public void execute()
       throws Exception {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/OfflineComplexTypeHandlingQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/OfflineComplexTypeHandlingQuickStart.java
@@ -19,17 +19,16 @@
 package org.apache.pinot.tools;
 
 import com.google.common.base.Preconditions;
-import org.apache.commons.io.FileUtils;
-import org.apache.pinot.tools.Quickstart.Color;
-import org.apache.pinot.tools.admin.PinotAdministrator;
-import org.apache.pinot.tools.admin.command.QuickstartRunner;
-
 import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.tools.Quickstart.Color;
+import org.apache.pinot.tools.admin.PinotAdministrator;
+import org.apache.pinot.tools.admin.command.QuickstartRunner;
 
 import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/OfflineComplexTypeHandlingQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/OfflineComplexTypeHandlingQuickStart.java
@@ -19,16 +19,17 @@
 package org.apache.pinot.tools;
 
 import com.google.common.base.Preconditions;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.tools.Quickstart.Color;
+import org.apache.pinot.tools.admin.PinotAdministrator;
+import org.apache.pinot.tools.admin.command.QuickstartRunner;
+
 import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import org.apache.commons.io.FileUtils;
-import org.apache.pinot.tools.Quickstart.Color;
-import org.apache.pinot.tools.admin.PinotAdministrator;
-import org.apache.pinot.tools.admin.command.QuickstartRunner;
 
 import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;
@@ -37,7 +38,7 @@ import static org.apache.pinot.tools.Quickstart.printStatus;
 public class OfflineComplexTypeHandlingQuickStart extends QuickStartBase {
   @Override
   public List<String> types() {
-    return List.of("OFFLINE_COMPLEX_TYPE", "OFFLINE-COMPLEX-TYPE", "BATCH_COMPLEX_TYPE", "BATCH-COMPLEX-TYPE");
+      return Arrays.asList("OFFLINE_COMPLEX_TYPE", "OFFLINE-COMPLEX-TYPE", "BATCH_COMPLEX_TYPE", "BATCH-COMPLEX-TYPE");
   }
 
   public void execute()

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.tools;
 
 import java.io.File;
+import java.util.List;
+
 import org.apache.commons.io.FileUtils;
 
 
@@ -29,6 +31,8 @@ public abstract class QuickStartBase {
     _tmpDir = new File(tmpDir);
     return this;
   }
+
+  public abstract List<String> types();
 
   public abstract void execute()
       throws Exception;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
@@ -20,7 +20,6 @@ package org.apache.pinot.tools;
 
 import java.io.File;
 import java.util.List;
-
 import org.apache.commons.io.FileUtils;
 
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
@@ -33,6 +33,11 @@ import org.apache.pinot.tools.admin.command.QuickstartRunner;
 
 
 public class Quickstart extends QuickStartBase {
+  @Override
+  public List<String> types() {
+    return List.of("OFFLINE", "BATCH");
+  }
+
   private static final String TAB = "\t\t";
   private static final String NEW_LINE = "\n";
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
@@ -35,7 +35,7 @@ import org.apache.pinot.tools.admin.command.QuickstartRunner;
 public class Quickstart extends QuickStartBase {
   @Override
   public List<String> types() {
-    return List.of("OFFLINE", "BATCH");
+    return Arrays.asList("OFFLINE", "BATCH");
   }
 
   private static final String TAB = "\t\t";

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeComplexTypeHandlingQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeComplexTypeHandlingQuickStart.java
@@ -20,11 +20,6 @@ package org.apache.pinot.tools;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import java.io.File;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.spi.stream.StreamDataProvider;
@@ -35,6 +30,12 @@ import org.apache.pinot.tools.admin.command.QuickstartRunner;
 import org.apache.pinot.tools.streams.MeetupRsvpJsonStream;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
 
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;
 
@@ -42,7 +43,8 @@ import static org.apache.pinot.tools.Quickstart.printStatus;
 public class RealtimeComplexTypeHandlingQuickStart extends QuickStartBase {
   @Override
   public List<String> types() {
-    return List.of("REALTIME_COMPLEX_TYPE", "REALTIME-COMPLEX-TYPE", "STREAM_COMPLEX_TYPE", "STREAM-COMPLEX-TYPE");
+      return Arrays.asList("REALTIME_COMPLEX_TYPE", "REALTIME-COMPLEX-TYPE",
+              "STREAM_COMPLEX_TYPE", "STREAM-COMPLEX-TYPE");
   }
   private StreamDataServerStartable _kafkaStarter;
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeComplexTypeHandlingQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeComplexTypeHandlingQuickStart.java
@@ -40,6 +40,10 @@ import static org.apache.pinot.tools.Quickstart.printStatus;
 
 
 public class RealtimeComplexTypeHandlingQuickStart extends QuickStartBase {
+  @Override
+  public List<String> types() {
+    return List.of("REALTIME_COMPLEX_TYPE", "REALTIME-COMPLEX-TYPE", "STREAM_COMPLEX_TYPE", "STREAM-COMPLEX-TYPE");
+  }
   private StreamDataServerStartable _kafkaStarter;
 
   public static void main(String[] args)

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeComplexTypeHandlingQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeComplexTypeHandlingQuickStart.java
@@ -20,6 +20,11 @@ package org.apache.pinot.tools;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.spi.stream.StreamDataProvider;
@@ -29,12 +34,6 @@ import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 import org.apache.pinot.tools.streams.MeetupRsvpJsonStream;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
-
-import java.io.File;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeJsonIndexQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeJsonIndexQuickStart.java
@@ -40,6 +40,11 @@ import static org.apache.pinot.tools.Quickstart.printStatus;
 
 
 public class RealtimeJsonIndexQuickStart extends QuickStartBase {
+  @Override
+  public List<String> types() {
+    return List.of("REALTIME_JSON_INDEX", "REALTIME-JSON-INDEX", "STREAM_JSON_INDEX", "STREAM-JSON-INDEX");
+  }
+
   private StreamDataServerStartable _kafkaStarter;
 
   public static void main(String[] args)

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeJsonIndexQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeJsonIndexQuickStart.java
@@ -20,6 +20,11 @@ package org.apache.pinot.tools;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.spi.stream.StreamDataProvider;
@@ -29,12 +34,6 @@ import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 import org.apache.pinot.tools.streams.MeetupRsvpJsonStream;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
-
-import java.io.File;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeJsonIndexQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeJsonIndexQuickStart.java
@@ -20,11 +20,6 @@ package org.apache.pinot.tools;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import java.io.File;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.spi.stream.StreamDataProvider;
@@ -35,6 +30,12 @@ import org.apache.pinot.tools.admin.command.QuickstartRunner;
 import org.apache.pinot.tools.streams.MeetupRsvpJsonStream;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
 
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;
 
@@ -42,7 +43,7 @@ import static org.apache.pinot.tools.Quickstart.printStatus;
 public class RealtimeJsonIndexQuickStart extends QuickStartBase {
   @Override
   public List<String> types() {
-    return List.of("REALTIME_JSON_INDEX", "REALTIME-JSON-INDEX", "STREAM_JSON_INDEX", "STREAM-JSON-INDEX");
+    return Arrays.asList("REALTIME_JSON_INDEX", "REALTIME-JSON-INDEX", "STREAM_JSON_INDEX", "STREAM-JSON-INDEX");
   }
 
   private StreamDataServerStartable _kafkaStarter;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
@@ -20,6 +20,11 @@ package org.apache.pinot.tools;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.spi.stream.StreamDataProvider;
@@ -29,12 +34,6 @@ import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 import org.apache.pinot.tools.streams.MeetupRsvpStream;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
-
-import java.io.File;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
@@ -20,11 +20,6 @@ package org.apache.pinot.tools;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import java.io.File;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.spi.stream.StreamDataProvider;
@@ -35,6 +30,12 @@ import org.apache.pinot.tools.admin.command.QuickstartRunner;
 import org.apache.pinot.tools.streams.MeetupRsvpStream;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
 
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;
 
@@ -42,7 +43,7 @@ import static org.apache.pinot.tools.Quickstart.printStatus;
 public class RealtimeQuickStart extends QuickStartBase {
   @Override
   public List<String> types() {
-    return List.of("REALTIME", "STREAM");
+    return Arrays.asList("REALTIME", "STREAM");
   }
 
   private StreamDataServerStartable _kafkaStarter;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
@@ -40,6 +40,11 @@ import static org.apache.pinot.tools.Quickstart.printStatus;
 
 
 public class RealtimeQuickStart extends QuickStartBase {
+  @Override
+  public List<String> types() {
+    return List.of("REALTIME", "STREAM");
+  }
+
   private StreamDataServerStartable _kafkaStarter;
 
   public static void main(String[] args)

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStartWithMinion.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStartWithMinion.java
@@ -34,7 +34,13 @@ import org.apache.pinot.tools.utils.KafkaStarterUtils;
 import java.io.File;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Properties;
+
 
 import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStartWithMinion.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStartWithMinion.java
@@ -49,6 +49,11 @@ import static org.apache.pinot.tools.Quickstart.printStatus;
  * tasks continuously optimize segments as data gets ingested into Realtime table.
  */
 public class RealtimeQuickStartWithMinion extends QuickStartBase {
+  @Override
+  public List<String> types() {
+    return List.of("REALTIME_MINION", "REALTIME-MINION");
+  }
+
   private StreamDataServerStartable _kafkaStarter;
 
   public static void main(String[] args)

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStartWithMinion.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStartWithMinion.java
@@ -20,15 +20,6 @@ package org.apache.pinot.tools;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import java.io.File;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.LineIterator;
 import org.apache.pinot.common.utils.ZkStarter;
@@ -39,6 +30,11 @@ import org.apache.pinot.tools.Quickstart.Color;
 import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
+
+import java.io.File;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
 
 import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;
@@ -51,7 +47,7 @@ import static org.apache.pinot.tools.Quickstart.printStatus;
 public class RealtimeQuickStartWithMinion extends QuickStartBase {
   @Override
   public List<String> types() {
-    return List.of("REALTIME_MINION", "REALTIME-MINION");
+    return Arrays.asList("REALTIME_MINION", "REALTIME-MINION");
   }
 
   private StreamDataServerStartable _kafkaStarter;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStartWithMinion.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStartWithMinion.java
@@ -20,6 +20,15 @@ package org.apache.pinot.tools;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import java.io.File;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.LineIterator;
 import org.apache.pinot.common.utils.ZkStarter;
@@ -30,17 +39,6 @@ import org.apache.pinot.tools.Quickstart.Color;
 import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
-
-import java.io.File;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.Properties;
-
 
 import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/UpsertJsonQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/UpsertJsonQuickStart.java
@@ -20,11 +20,6 @@ package org.apache.pinot.tools;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import java.io.File;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.spi.stream.StreamDataProvider;
@@ -35,6 +30,12 @@ import org.apache.pinot.tools.admin.command.QuickstartRunner;
 import org.apache.pinot.tools.streams.MeetupRsvpJsonStream;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
 
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
 import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;
 
@@ -42,7 +43,7 @@ import static org.apache.pinot.tools.Quickstart.printStatus;
 public class UpsertJsonQuickStart extends QuickStartBase {
   @Override
   public List<String> types() {
-    return List.of("UPSERT_JSON_INDEX", "UPSERT-JSON-INDEX");
+    return Arrays.asList("UPSERT_JSON_INDEX", "UPSERT-JSON-INDEX");
   }
 
   private StreamDataServerStartable _kafkaStarter;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/UpsertJsonQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/UpsertJsonQuickStart.java
@@ -40,6 +40,11 @@ import static org.apache.pinot.tools.Quickstart.printStatus;
 
 
 public class UpsertJsonQuickStart extends QuickStartBase {
+  @Override
+  public List<String> types() {
+    return List.of("UPSERT_JSON_INDEX", "UPSERT-JSON-INDEX");
+  }
+
   private StreamDataServerStartable _kafkaStarter;
 
   public static void main(String[] args)

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/UpsertJsonQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/UpsertJsonQuickStart.java
@@ -20,6 +20,11 @@ package org.apache.pinot.tools;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.spi.stream.StreamDataProvider;
@@ -29,12 +34,6 @@ import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 import org.apache.pinot.tools.streams.MeetupRsvpJsonStream;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
-
-import java.io.File;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 
 import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/UpsertQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/UpsertQuickStart.java
@@ -40,6 +40,11 @@ import static org.apache.pinot.tools.Quickstart.printStatus;
 
 
 public class UpsertQuickStart extends QuickStartBase {
+  @Override
+  public List<String> types() {
+    return List.of("UPSERT");
+  }
+
   private StreamDataServerStartable _kafkaStarter;
 
   public static void main(String[] args)

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/UpsertQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/UpsertQuickStart.java
@@ -20,11 +20,6 @@ package org.apache.pinot.tools;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import java.io.File;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.spi.stream.StreamDataProvider;
@@ -35,6 +30,13 @@ import org.apache.pinot.tools.admin.command.QuickstartRunner;
 import org.apache.pinot.tools.streams.MeetupRsvpStream;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
 
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;
 
@@ -42,7 +44,7 @@ import static org.apache.pinot.tools.Quickstart.printStatus;
 public class UpsertQuickStart extends QuickStartBase {
   @Override
   public List<String> types() {
-    return List.of("UPSERT");
+    return Collections.singletonList("UPSERT");
   }
 
   private StreamDataServerStartable _kafkaStarter;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/UpsertQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/UpsertQuickStart.java
@@ -20,6 +20,12 @@ package org.apache.pinot.tools;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.spi.stream.StreamDataProvider;
@@ -29,13 +35,6 @@ import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 import org.apache.pinot.tools.streams.MeetupRsvpStream;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
-
-import java.io.File;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 import static org.apache.pinot.tools.Quickstart.printStatus;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
@@ -94,8 +94,8 @@ public class QuickStartCommand extends AbstractBaseAdminCommand implements Comma
         return quickStartBase;
       }
     }
-    throw new UnsupportedOperationException("Unsupported QuickStart type: " + type + ". " +
-            "Valid types are: " + errroMessageFor(quickStarts));
+    throw new UnsupportedOperationException("Unsupported QuickStart type: " + type + ". "
+            + "Valid types are: " + errroMessageFor(quickStarts));
   }
 
   @Override
@@ -105,8 +105,8 @@ public class QuickStartCommand extends AbstractBaseAdminCommand implements Comma
     if (_type == null) {
       Set<Class<? extends QuickStartBase>> quickStarts = allQuickStarts();
 
-      throw new UnsupportedOperationException("No QuickStart type provided. " +
-              "Valid types are: " + errroMessageFor(quickStarts));
+      throw new UnsupportedOperationException("No QuickStart type provided. "
+              + "Valid types are: " + errroMessageFor(quickStarts));
     }
 
     QuickStartBase quickstart = selectQuickStart(_type);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
@@ -18,6 +18,10 @@
  */
 package org.apache.pinot.tools.admin.command;
 
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.tools.Command;
 import org.apache.pinot.tools.QuickStartBase;
@@ -25,11 +29,6 @@ import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
-
-import java.lang.reflect.InvocationTargetException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
 
 
 @CommandLine.Command(name = "QuickStart")

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
@@ -94,7 +94,8 @@ public class QuickStartCommand extends AbstractBaseAdminCommand implements Comma
         return quickStartBase;
       }
     }
-    throw new UnsupportedOperationException("Unsupported QuickStart type: " + type + ". Valid types are: " + errroMessageFor(quickStarts));
+    throw new UnsupportedOperationException("Unsupported QuickStart type: " + type + ". " +
+            "Valid types are: " + errroMessageFor(quickStarts));
   }
 
   @Override
@@ -104,7 +105,8 @@ public class QuickStartCommand extends AbstractBaseAdminCommand implements Comma
     if (_type == null) {
       Set<Class<? extends QuickStartBase>> quickStarts = allQuickStarts();
 
-      throw new UnsupportedOperationException("No QuickStart type provided. Valid types are: " + errroMessageFor(quickStarts));
+      throw new UnsupportedOperationException("No QuickStart type provided. " +
+              "Valid types are: " + errroMessageFor(quickStarts));
     }
 
     QuickStartBase quickstart = selectQuickStart(_type);
@@ -116,7 +118,8 @@ public class QuickStartCommand extends AbstractBaseAdminCommand implements Comma
     return true;
   }
 
-  private static List<String> errroMessageFor(Set<Class<? extends QuickStartBase>> quickStarts) throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+  private static List<String> errroMessageFor(Set<Class<? extends QuickStartBase>> quickStarts)
+          throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
     List<String> validTypes = new ArrayList<>();
     for (Class<? extends QuickStartBase> quickStart : quickStarts) {
       validTypes.addAll(quickStart.getDeclaredConstructor().newInstance().types());

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
@@ -19,23 +19,17 @@
 package org.apache.pinot.tools.admin.command;
 
 import org.apache.pinot.spi.plugin.PluginManager;
-import org.apache.pinot.tools.BatchQuickstartWithMinion;
 import org.apache.pinot.tools.Command;
-import org.apache.pinot.tools.HybridQuickstart;
-import org.apache.pinot.tools.JoinQuickStart;
-import org.apache.pinot.tools.JsonIndexQuickStart;
-import org.apache.pinot.tools.OfflineComplexTypeHandlingQuickStart;
 import org.apache.pinot.tools.QuickStartBase;
-import org.apache.pinot.tools.Quickstart;
-import org.apache.pinot.tools.RealtimeComplexTypeHandlingQuickStart;
-import org.apache.pinot.tools.RealtimeJsonIndexQuickStart;
-import org.apache.pinot.tools.RealtimeQuickStart;
-import org.apache.pinot.tools.RealtimeQuickStartWithMinion;
-import org.apache.pinot.tools.UpsertJsonQuickStart;
-import org.apache.pinot.tools.UpsertQuickStart;
+import org.reflections.Reflections;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
 
 
 @CommandLine.Command(name = "QuickStart")
@@ -91,74 +85,47 @@ public class QuickStartCommand extends AbstractBaseAdminCommand implements Comma
     return "Run Pinot QuickStart.";
   }
 
-  @Override
-  public boolean execute()
-      throws Exception {
-    PluginManager.get().init();
-    QuickStartBase quickstart;
-    switch (_type.toUpperCase()) {
-      case "OFFLINE":
-      case "BATCH":
-        quickstart = new Quickstart();
-        break;
-      case "OFFLINE_MINION":
-      case "BATCH_MINION":
-      case "OFFLINE-MINION":
-      case "BATCH-MINION":
-        quickstart = new BatchQuickstartWithMinion();
-        break;
-      case "REALTIME_MINION":
-      case "REALTIME-MINION":
-        quickstart = new RealtimeQuickStartWithMinion();
-        break;
-      case "REALTIME":
-      case "STREAM":
-        quickstart = new RealtimeQuickStart();
-        break;
-      case "HYBRID":
-        quickstart = new HybridQuickstart();
-        break;
-      case "JOIN":
-        quickstart = new JoinQuickStart();
-        break;
-      case "UPSERT":
-        quickstart = new UpsertQuickStart();
-        break;
-      case "OFFLINE_JSON_INDEX":
-      case "OFFLINE-JSON-INDEX":
-      case "BATCH_JSON_INDEX":
-      case "BATCH-JSON-INDEX":
-        quickstart = new JsonIndexQuickStart();
-        break;
-      case "REALTIME_JSON_INDEX":
-      case "REALTIME-JSON-INDEX":
-      case "STREAM_JSON_INDEX":
-      case "STREAM-JSON-INDEX":
-        quickstart = new RealtimeJsonIndexQuickStart();
-        break;
-      case "UPSERT_JSON_INDEX":
-      case "UPSERT-JSON-INDEX":
-        quickstart = new UpsertJsonQuickStart();
-        break;
-      case "OFFLINE_COMPLEX_TYPE":
-      case "OFFLINE-COMPLEX-TYPE":
-      case "BATCH_COMPLEX_TYPE":
-      case "BATCH-COMPLEX-TYPE":
-        quickstart = new OfflineComplexTypeHandlingQuickStart();
-        break;
-      case "REALTIME_COMPLEX_TYPE":
-      case "REALTIME-COMPLEX-TYPE":
-      case "STREAM_COMPLEX_TYPE":
-      case "STREAM-COMPLEX-TYPE":
-        quickstart = new RealtimeComplexTypeHandlingQuickStart();
-        break;
-      default:
-        throw new UnsupportedOperationException("Unsupported QuickStart type: " + _type);
+  public static QuickStartBase selectQuickStart(String type)
+          throws NoSuchMethodException, InvocationTargetException, InstantiationException, IllegalAccessException {
+    Set<Class<? extends QuickStartBase>> quickStarts = allQuickStarts();
+    for (Class<? extends QuickStartBase> quickStart : quickStarts) {
+      QuickStartBase quickStartBase = quickStart.getDeclaredConstructor().newInstance();
+      if (quickStartBase.types().contains(type)) {
+        return quickStartBase;
+      }
     }
+    throw new UnsupportedOperationException("Unsupported QuickStart type: " + type + ". Valid types are: " + errroMessageFor(quickStarts));
+  }
+
+  @Override
+  public boolean execute() throws Exception {
+    PluginManager.get().init();
+
+    if (_type == null) {
+      Set<Class<? extends QuickStartBase>> quickStarts = allQuickStarts();
+
+      throw new UnsupportedOperationException("No QuickStart type provided. Valid types are: " + errroMessageFor(quickStarts));
+    }
+
+    QuickStartBase quickstart = selectQuickStart(_type);
+
     if (_tmpDir != null) {
       quickstart.setTmpDir(_tmpDir);
     }
     quickstart.execute();
     return true;
+  }
+
+  private static List<String> errroMessageFor(Set<Class<? extends QuickStartBase>> quickStarts) throws InstantiationException, IllegalAccessException, InvocationTargetException, NoSuchMethodException {
+    List<String> validTypes = new ArrayList<>();
+    for (Class<? extends QuickStartBase> quickStart : quickStarts) {
+      validTypes.addAll(quickStart.getDeclaredConstructor().newInstance().types());
+    }
+    return validTypes;
+  }
+
+  private static Set<Class<? extends QuickStartBase>> allQuickStarts() {
+    Reflections reflections = new Reflections("org.apache.pinot.tools");
+    return reflections.getSubTypesOf(QuickStartBase.class);
   }
 }

--- a/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/TestQuickStartCommand.java
+++ b/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/TestQuickStartCommand.java
@@ -18,7 +18,20 @@
  */
 package org.apache.pinot.tools.admin.command;
 
-import org.apache.pinot.tools.*;
+import org.apache.pinot.tools.BatchQuickstartWithMinion;
+import org.apache.pinot.tools.RealtimeQuickStart;
+import org.apache.pinot.tools.HybridQuickstart;
+import org.apache.pinot.tools.JoinQuickStart;
+import org.apache.pinot.tools.UpsertQuickStart;
+import org.apache.pinot.tools.JsonIndexQuickStart;
+import org.apache.pinot.tools.RealtimeJsonIndexQuickStart;
+import org.apache.pinot.tools.UpsertJsonQuickStart;
+import org.apache.pinot.tools.OfflineComplexTypeHandlingQuickStart;
+import org.apache.pinot.tools.RealtimeQuickStartWithMinion;
+import org.apache.pinot.tools.RealtimeComplexTypeHandlingQuickStart;
+import org.apache.pinot.tools.QuickStartBase;
+import org.apache.pinot.tools.Quickstart;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/TestQuickStartCommand.java
+++ b/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/TestQuickStartCommand.java
@@ -18,24 +18,22 @@
  */
 package org.apache.pinot.tools.admin.command;
 
+import java.lang.reflect.InvocationTargetException;
 import org.apache.pinot.tools.BatchQuickstartWithMinion;
-import org.apache.pinot.tools.RealtimeQuickStart;
 import org.apache.pinot.tools.HybridQuickstart;
 import org.apache.pinot.tools.JoinQuickStart;
-import org.apache.pinot.tools.UpsertQuickStart;
 import org.apache.pinot.tools.JsonIndexQuickStart;
-import org.apache.pinot.tools.RealtimeJsonIndexQuickStart;
-import org.apache.pinot.tools.UpsertJsonQuickStart;
 import org.apache.pinot.tools.OfflineComplexTypeHandlingQuickStart;
-import org.apache.pinot.tools.RealtimeQuickStartWithMinion;
-import org.apache.pinot.tools.RealtimeComplexTypeHandlingQuickStart;
 import org.apache.pinot.tools.QuickStartBase;
 import org.apache.pinot.tools.Quickstart;
-
+import org.apache.pinot.tools.RealtimeComplexTypeHandlingQuickStart;
+import org.apache.pinot.tools.RealtimeJsonIndexQuickStart;
+import org.apache.pinot.tools.RealtimeQuickStart;
+import org.apache.pinot.tools.RealtimeQuickStartWithMinion;
+import org.apache.pinot.tools.UpsertJsonQuickStart;
+import org.apache.pinot.tools.UpsertQuickStart;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import java.lang.reflect.InvocationTargetException;
 
 public class TestQuickStartCommand {
 

--- a/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/TestQuickStartCommand.java
+++ b/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/TestQuickStartCommand.java
@@ -26,13 +26,15 @@ import java.lang.reflect.InvocationTargetException;
 
 public class TestQuickStartCommand {
 
-    @Test(expectedExceptions = UnsupportedOperationException.class, expectedExceptionsMessageRegExp = "^No QuickStart type provided. Valid types are: \\[.*\\]$")
+    @Test(expectedExceptions = UnsupportedOperationException.class,
+            expectedExceptionsMessageRegExp = "^No QuickStart type provided. Valid types are: \\[.*\\]$")
     public void testNoArg() throws Exception {
         QuickStartCommand quickStartCommand = new QuickStartCommand();
         quickStartCommand.execute();
     }
 
-    @Test(expectedExceptions = UnsupportedOperationException.class, expectedExceptionsMessageRegExp = "^Unsupported QuickStart type: foo. Valid types are: \\[.*\\]$")
+    @Test(expectedExceptions = UnsupportedOperationException.class,
+            expectedExceptionsMessageRegExp = "^Unsupported QuickStart type: foo. Valid types are: \\[.*\\]$")
     public void testInvalidQuickStart() throws Exception {
         QuickStartCommand quickStartCommand = new QuickStartCommand();
         quickStartCommand.setType("foo");
@@ -40,7 +42,8 @@ public class TestQuickStartCommand {
     }
 
     @Test
-    public void testMatchStringToCommand() throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+    public void testMatchStringToCommand()
+            throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
         Assert.assertEquals(quickStartClassFor("OFFLINE"), Quickstart.class);
         Assert.assertEquals(quickStartClassFor("BATCH"), Quickstart.class);
 
@@ -74,18 +77,27 @@ public class TestQuickStartCommand {
         Assert.assertEquals(quickStartClassFor("UPSERT_JSON_INDEX"), UpsertJsonQuickStart.class);
         Assert.assertEquals(quickStartClassFor("UPSERT-JSON-INDEX"), UpsertJsonQuickStart.class);
 
-        Assert.assertEquals(quickStartClassFor("OFFLINE_COMPLEX_TYPE"), OfflineComplexTypeHandlingQuickStart.class);
-        Assert.assertEquals(quickStartClassFor("OFFLINE-COMPLEX-TYPE"), OfflineComplexTypeHandlingQuickStart.class);
-        Assert.assertEquals(quickStartClassFor("BATCH_COMPLEX_TYPE"), OfflineComplexTypeHandlingQuickStart.class);
-        Assert.assertEquals(quickStartClassFor("BATCH-COMPLEX-TYPE"), OfflineComplexTypeHandlingQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("OFFLINE_COMPLEX_TYPE"),
+                OfflineComplexTypeHandlingQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("OFFLINE-COMPLEX-TYPE"),
+                OfflineComplexTypeHandlingQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("BATCH_COMPLEX_TYPE"),
+                OfflineComplexTypeHandlingQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("BATCH-COMPLEX-TYPE"),
+                OfflineComplexTypeHandlingQuickStart.class);
 
-        Assert.assertEquals(quickStartClassFor("REALTIME_COMPLEX_TYPE"), RealtimeComplexTypeHandlingQuickStart.class);
-        Assert.assertEquals(quickStartClassFor("REALTIME-COMPLEX-TYPE"), RealtimeComplexTypeHandlingQuickStart.class);
-        Assert.assertEquals(quickStartClassFor("STREAM_COMPLEX_TYPE"), RealtimeComplexTypeHandlingQuickStart.class);
-        Assert.assertEquals(quickStartClassFor("STREAM-COMPLEX-TYPE"), RealtimeComplexTypeHandlingQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("REALTIME_COMPLEX_TYPE"),
+                RealtimeComplexTypeHandlingQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("REALTIME-COMPLEX-TYPE"),
+                RealtimeComplexTypeHandlingQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("STREAM_COMPLEX_TYPE"),
+                RealtimeComplexTypeHandlingQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("STREAM-COMPLEX-TYPE"),
+                RealtimeComplexTypeHandlingQuickStart.class);
     }
 
-    private Class<? extends QuickStartBase> quickStartClassFor(String offline) throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+    private Class<? extends QuickStartBase> quickStartClassFor(String offline)
+            throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
         return QuickStartCommand.selectQuickStart(offline).getClass();
     }
 }

--- a/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/TestQuickStartCommand.java
+++ b/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/TestQuickStartCommand.java
@@ -1,0 +1,73 @@
+package org.apache.pinot.tools.admin.command;
+
+import org.apache.pinot.tools.*;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.InvocationTargetException;
+
+public class TestQuickStartCommand {
+
+    @Test(expectedExceptions = UnsupportedOperationException.class, expectedExceptionsMessageRegExp = "^No QuickStart type provided. Valid types are: \\[.*\\]$")
+    public void testNoArg() throws Exception {
+        QuickStartCommand quickStartCommand = new QuickStartCommand();
+        quickStartCommand.execute();
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class, expectedExceptionsMessageRegExp = "^Unsupported QuickStart type: foo. Valid types are: \\[.*\\]$")
+    public void testInvalidQuickStart() throws Exception {
+        QuickStartCommand quickStartCommand = new QuickStartCommand();
+        quickStartCommand.setType("foo");
+        quickStartCommand.execute();
+    }
+
+    @Test
+    public void testMatchStringToCommand() throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+        Assert.assertEquals(quickStartClassFor("OFFLINE"), Quickstart.class);
+        Assert.assertEquals(quickStartClassFor("BATCH"), Quickstart.class);
+
+        Assert.assertEquals(quickStartClassFor("OFFLINE_MINION"), BatchQuickstartWithMinion.class);
+        Assert.assertEquals(quickStartClassFor("BATCH_MINION"), BatchQuickstartWithMinion.class);
+        Assert.assertEquals(quickStartClassFor("OFFLINE-MINION"), BatchQuickstartWithMinion.class);
+        Assert.assertEquals(quickStartClassFor("BATCH-MINION"), BatchQuickstartWithMinion.class);
+
+        Assert.assertEquals(quickStartClassFor("REALTIME_MINION"), RealtimeQuickStartWithMinion.class);
+        Assert.assertEquals(quickStartClassFor("REALTIME-MINION"), RealtimeQuickStartWithMinion.class);
+
+        Assert.assertEquals(quickStartClassFor("REALTIME"), RealtimeQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("REALTIME"), RealtimeQuickStart.class);
+
+        Assert.assertEquals(quickStartClassFor("HYBRID"), HybridQuickstart.class);
+
+        Assert.assertEquals(quickStartClassFor("JOIN"), JoinQuickStart.class);
+
+        Assert.assertEquals(quickStartClassFor("UPSERT"), UpsertQuickStart.class);
+
+        Assert.assertEquals(quickStartClassFor("OFFLINE_JSON_INDEX"), JsonIndexQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("OFFLINE-JSON-INDEX"), JsonIndexQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("BATCH_JSON_INDEX"), JsonIndexQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("BATCH-JSON-INDEX"), JsonIndexQuickStart.class);
+
+        Assert.assertEquals(quickStartClassFor("REALTIME_JSON_INDEX"), RealtimeJsonIndexQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("REALTIME-JSON-INDEX"), RealtimeJsonIndexQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("STREAM_JSON_INDEX"), RealtimeJsonIndexQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("STREAM-JSON-INDEX"), RealtimeJsonIndexQuickStart.class);
+
+        Assert.assertEquals(quickStartClassFor("UPSERT_JSON_INDEX"), UpsertJsonQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("UPSERT-JSON-INDEX"), UpsertJsonQuickStart.class);
+
+        Assert.assertEquals(quickStartClassFor("OFFLINE_COMPLEX_TYPE"), OfflineComplexTypeHandlingQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("OFFLINE-COMPLEX-TYPE"), OfflineComplexTypeHandlingQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("BATCH_COMPLEX_TYPE"), OfflineComplexTypeHandlingQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("BATCH-COMPLEX-TYPE"), OfflineComplexTypeHandlingQuickStart.class);
+
+        Assert.assertEquals(quickStartClassFor("REALTIME_COMPLEX_TYPE"), RealtimeComplexTypeHandlingQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("REALTIME-COMPLEX-TYPE"), RealtimeComplexTypeHandlingQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("STREAM_COMPLEX_TYPE"), RealtimeComplexTypeHandlingQuickStart.class);
+        Assert.assertEquals(quickStartClassFor("STREAM-COMPLEX-TYPE"), RealtimeComplexTypeHandlingQuickStart.class);
+    }
+
+    private Class<? extends QuickStartBase> quickStartClassFor(String offline) throws InvocationTargetException, NoSuchMethodException, InstantiationException, IllegalAccessException {
+        return QuickStartCommand.selectQuickStart(offline).getClass();
+    }
+}

--- a/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/TestQuickStartCommand.java
+++ b/pinot-tools/src/test/java/org/apache/pinot/tools/admin/command/TestQuickStartCommand.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.tools.admin.command;
 
 import org.apache.pinot.tools.*;


### PR DESCRIPTION
At the moment if you run the QuickStart with a missing type you'll get this error:

```
docker run -p 9000:9000 apachepinot/pinot:0.9.0-SNAPSHOT-362f3e1ac-20211114-jdk11 QuickStart
```

```
java.lang.NullPointerException
	at org.apache.pinot.tools.admin.command.QuickStartCommand.execute(QuickStartCommand.java:99)
	at org.apache.pinot.tools.Command.call(Command.java:33)
	at org.apache.pinot.tools.Command.call(Command.java:29)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1953)
	at picocli.CommandLine.access$1300(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2352)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2346)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2311)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179)
	at picocli.CommandLine.execute(CommandLine.java:2078)
	at org.apache.pinot.tools.admin.PinotAdministrator.execute(PinotAdministrator.java:161)
	at org.apache.pinot.tools.admin.PinotAdministrator.main(PinotAdministrator.java:192)
```

And if you pass in an invalid type:

```
docker run -p 9000:9000 apachepinot/pinot:0.9.0-SNAPSHOT-362f3e1ac-20211114-jdk11 QuickStart -type foo
```

```
java.lang.UnsupportedOperationException: Unsupported QuickStart type: foo
	at org.apache.pinot.tools.admin.command.QuickStartCommand.execute(QuickStartCommand.java:156)
	at org.apache.pinot.tools.Command.call(Command.java:33)
	at org.apache.pinot.tools.Command.call(Command.java:29)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1953)
	at picocli.CommandLine.access$1300(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2352)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2346)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2311)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179)
	at picocli.CommandLine.execute(CommandLine.java:2078)
	at org.apache.pinot.tools.admin.PinotAdministrator.execute(PinotAdministrator.java:161)
	at org.apache.pinot.tools.admin.PinotAdministrator.main(PinotAdministrator.java:192)
```

Neither of these messages tells the user the valid types that they can pass in. 

So that's what this PR attempts to solve.
