### PR TITLE
Check interrupt flag in acquire

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/AcquireReleaseColumnsSegmentOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/AcquireReleaseColumnsSegmentOperator.java
@@ -66,7 +66,7 @@ public class AcquireReleaseColumnsSegmentOperator extends BaseOperator<Intermedi
    */
   public void acquire() {
     // do not acquire if interrupted (similar to the check inside the nextBlock())
-    if (Thread.currentThread().isInterrupted()) {
+    if (Thread.interrupted()) {
       throw new EarlyTerminationException();
     }
     _indexSegment.acquire(_fetchContext);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/AcquireReleaseColumnsSegmentOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/AcquireReleaseColumnsSegmentOperator.java
@@ -23,6 +23,7 @@ import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.plan.PlanNode;
 import org.apache.pinot.segment.spi.FetchContext;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.spi.exception.EarlyTerminationException;
 
 
 /**
@@ -64,6 +65,10 @@ public class AcquireReleaseColumnsSegmentOperator extends BaseOperator<Intermedi
    * Acquires the indexSegment using the provided fetchContext
    */
   public void acquire() {
+    // do not acquire if interrupted (similar to the check inside the nextBlock())
+    if (Thread.currentThread().isInterrupted()) {
+      throw new EarlyTerminationException();
+    }
     _indexSegment.acquire(_fetchContext);
   }
 


### PR DESCRIPTION
A similar check happens in `nextBlock`. Adding it to `acquire`, so that acquire also exits early (it would've exited from `nextBlock()` anyway, but this check saves the computation from happening in acquire too.)