### PR TITLE
Include commons-lang3

### DIFF
--- a/pinot-clients/pom.xml
+++ b/pinot-clients/pom.xml
@@ -48,6 +48,10 @@
       <artifactId>pinot-spi</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
     <!-- test -->
     <dependency>
       <groupId>org.testng</groupId>


### PR DESCRIPTION
At the moment if I try to use the JDBC connector I get this error:

```
Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/commons/lang3/tuple/Pair
	at org.apache.pinot.client.PinotDriver.connect(PinotDriver.java:60)
	at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:677)
	at java.sql/java.sql.DriverManager.getConnection(DriverManager.java:251)
	at Query3.main(Query3.java:16)
Caused by: java.lang.ClassNotFoundException: org.apache.commons.lang3.tuple.Pair
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 4 more
```

I need to manually include `org.apache.commons:commons-lang3` to have it work. I think we should include that library with the connector.

cc @KKcorps 