### PR TITLE
Handle segment names that may contain characters typically used in DateTime fields

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
@@ -19,8 +19,8 @@
 package org.apache.pinot.segment.spi.creator.name;
 
 import com.google.common.base.Preconditions;
-import javax.annotation.Nullable;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 
 
 /**

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
@@ -50,6 +50,12 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
 
   @Override
   public String generateSegmentName(int sequenceId, @Nullable Object minTimeValue, @Nullable Object maxTimeValue) {
+      if(minTimeValue != null ) {
+        minTimeValue = minTimeValue.toString().replaceAll("[: \\/]", "_");
+      }
+      if(maxTimeValue != null) {
+        maxTimeValue = maxTimeValue.toString().replaceAll("[: \\/]", "_");
+      }
     Preconditions.checkArgument(
         minTimeValue == null || isValidSegmentName(minTimeValue.toString()));
     Preconditions.checkArgument(

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
@@ -20,6 +20,7 @@ package org.apache.pinot.segment.spi.creator.name;
 
 import com.google.common.base.Preconditions;
 import javax.annotation.Nullable;
+import java.util.regex.Pattern;
 
 
 /**
@@ -39,6 +40,8 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
   private final String _segmentNamePrefix;
   private final String _segmentNamePostfix;
 
+  private static final Pattern REPLACEMENT_REGEX = Pattern.compile("[: \\/]");
+
   public SimpleSegmentNameGenerator(String segmentNamePrefix, @Nullable String segmentNamePostfix) {
     Preconditions.checkArgument(
         segmentNamePrefix != null && isValidSegmentName(segmentNamePrefix));
@@ -51,10 +54,10 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
   @Override
   public String generateSegmentName(int sequenceId, @Nullable Object minTimeValue, @Nullable Object maxTimeValue) {
     if (minTimeValue != null) {
-      minTimeValue = minTimeValue.toString().replaceAll("[: \\/]", "_");
+      minTimeValue = REPLACEMENT_REGEX.matcher(minTimeValue.toString()).replaceAll("_");
     }
     if (maxTimeValue != null) {
-      maxTimeValue = maxTimeValue.toString().replaceAll("[: \\/]", "_");
+      maxTimeValue = REPLACEMENT_REGEX.matcher(maxTimeValue.toString()).replaceAll("_");
     }
     Preconditions.checkArgument(
         minTimeValue == null || isValidSegmentName(minTimeValue.toString()));

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
@@ -50,12 +50,12 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
 
   @Override
   public String generateSegmentName(int sequenceId, @Nullable Object minTimeValue, @Nullable Object maxTimeValue) {
-      if(minTimeValue != null ) {
-        minTimeValue = minTimeValue.toString().replaceAll("[: \\/]", "_");
-      }
-      if(maxTimeValue != null) {
-        maxTimeValue = maxTimeValue.toString().replaceAll("[: \\/]", "_");
-      }
+    if (minTimeValue != null) {
+      minTimeValue = minTimeValue.toString().replaceAll("[: \\/]", "_");
+    }
+    if (maxTimeValue != null) {
+      maxTimeValue = maxTimeValue.toString().replaceAll("[: \\/]", "_");
+    }
     Preconditions.checkArgument(
         minTimeValue == null || isValidSegmentName(minTimeValue.toString()));
     Preconditions.checkArgument(

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGeneratorTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGeneratorTest.java
@@ -61,6 +61,26 @@ public class SimpleSegmentNameGeneratorTest {
   }
 
   @Test
+  public void testWithDates() {
+    SegmentNameGenerator segmentNameGenerator = new SimpleSegmentNameGenerator(TABLE_NAME, null);
+
+    assertEquals(segmentNameGenerator.generateSegmentName(0,
+            "09-05-2015T09:58:00",
+            "09-05-2015T09:58:00"),
+            "testTable_09-05-2015T09_58_00_09-05-2015T09_58_00_0");
+
+    assertEquals(segmentNameGenerator.generateSegmentName(0,
+                    "09-05-2015 09:58:00",
+                    "09-05-2015 09:58:00"),
+            "testTable_09-05-2015_09_58_00_09-05-2015_09_58_00_0");
+
+    assertEquals(segmentNameGenerator.generateSegmentName(0,
+                    "09/05/2015 09:58:00",
+                    "09/05/2015 09:58:00"),
+            "testTable_09_05_2015_09_58_00_09_05_2015_09_58_00_0");
+  }
+
+  @Test
   public void testWithMalFormedTableNameSegmentNamePostfixTimeValue() {
     try {
       new SimpleSegmentNameGenerator(MALFORMED_TABLE_NAME, SEGMENT_NAME_POSTFIX);


### PR DESCRIPTION
I wanted to import a CSV file that contains a DateTime field. 

The CSV file looks like this:

```
ID,Date
10224738,09-05-2015T09:58:00
```
And then the schema file:

```
{
    "schemaName": "crimes",
    "dimensionFieldSpecs": [
      {
        "name": "ID",
        "dataType": "INT"
      }
    ],
    "dateTimeFieldSpecs": [{
      "name": "Date",
      "dataType": "STRING",
      "format" : "1:SECONDS:SIMPLE_DATE_FORMAT:MM-dd-yyyy'T'HH:mm:ss",
      "granularity": "1:HOURS"
    }]
}
```
  
But we get this error when running the ingestion job:

```
2021/11/16 11:37:50.382 ERROR [SegmentGenerationJobRunner] [pool-2-thread-1] Failed to generate Pinot segment for file - file:/data/mark.csv
java.lang.IllegalArgumentException: null
	at shaded.com.google.common.base.Preconditions.checkArgument(Preconditions.java:108) ~[pinot-all-0.9.0-SNAPSHOT-jar-with-dependencies.jar:0.9.0-SNAPSHOT-540e70e9e3e24bdb2a14f56b2c1264180abaeda8]
	at org.apache.pinot.segment.spi.creator.name.SimpleSegmentNameGenerator.generateSegmentName(SimpleSegmentNameGenerator.java:53) ~[pinot-all-0.9.0-SNAPSHOT-jar-with-dependencies.jar:0.9.0-SNAPSHOT-540e70e9e3e24bdb2a14f56b2c1264180abaeda8]
	at org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl.handlePostCreation(SegmentIndexCreationDriverImpl.java:268) ~[pinot-all-0.9.0-SNAPSHOT-jar-with-dependencies.jar:0.9.0-SNAPSHOT-540e70e9e3e24bdb2a14f56b2c1264180abaeda8]
	at org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl.build(SegmentIndexCreationDriverImpl.java:258) ~[pinot-all-0.9.0-SNAPSHOT-jar-with-dependencies.jar:0.9.0-SNAPSHOT-540e70e9e3e24bdb2a14f56b2c1264180abaeda8]
	at org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationTaskRunner.run(SegmentGenerationTaskRunner.java:119) ~[pinot-all-0.9.0-SNAPSHOT-jar-with-dependencies.jar:0.9.0-SNAPSHOT-540e70e9e3e24bdb2a14f56b2c1264180abaeda8]
	at org.apache.pinot.plugin.ingestion.batch.standalone.SegmentGenerationJobRunner.lambda$submitSegmentGenTask$1(SegmentGenerationJobRunner.java:263) ~[pinot-batch-ingestion-standalone-0.9.0-SNAPSHOT-shaded.jar:0.9.0-SNAPSHOT-540e70e9e3e24bdb2a14f56b2c1264180abaeda8]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:829) [?:?]
```

And the issue is that the min and max times don't pass the `isValidSegmentName` function that was added to `SimpleSegmentNameGenerator`  in https://github.com/apache/pinot/pull/7085. 

The min and max values are both `09-05-2015T09:58:00`  and the issue is that they have the `:` in their name. But we would have the same issue with other characters that may appear in date fields, such as a space or forward slash.

This PR replaces those problematic characters inside `SimpleSegmentNameGenerator` before the `isValidSegmentName` check.