### PR TITLE
expose API with git branch and commit info

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotVersionRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotVersionRestletResource.java
@@ -49,4 +49,13 @@ public class PinotVersionRestletResource {
       throw new RuntimeException(e);
     }
   }
+
+  @GET
+  @Path("/commit")
+  @Produces(MediaType.TEXT_PLAIN)
+  @ApiOperation(value = "Get the branch and commit this instance of pinot was built from")
+  @ApiResponses(value = {@ApiResponse(code = 200, message = "Success")})
+  public String getCommitInfo() {
+    return Utils.getGitInfo();
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1469,6 +1469,7 @@
                 <Implementation-Version>${project.version}-${buildNumber}</Implementation-Version>
                 <Implementation-Vendor-Id>${project.groupId}</Implementation-Vendor-Id>
                 <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
+                <Implementation-Commit>${buildNumber}</Implementation-Commit>
               </manifestEntries>
             </archive>
           </configuration>


### PR DESCRIPTION
This is added for benchmarking purposes, to make it easy to describe what's running in a benchmark. 