### PR TITLE
Nicer error message if you have a typo in your schema file

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
@@ -32,11 +32,14 @@ import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.data.TimeGranularitySpec.TimeFormat;
 import org.apache.pinot.spi.utils.BytesUtils;
+import org.codehaus.jackson.map.JsonMappingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
+
+import static org.testng.AssertJUnit.fail;
 
 
 public class SchemaTest {
@@ -252,6 +255,16 @@ public class SchemaTest {
         .addTime(incomingTimeGranularitySpec, outgoingTimeGranularitySpec).build();
     Assert.assertEquals(schema11, schema12);
   }
+
+  @Test(expectedExceptions = com.fasterxml.jackson.databind.JsonMappingException.class,
+      expectedExceptionsMessageRegExp = "'booleanDimension' field is missing 'dataType' property.*")
+  public void testMissingDataType()
+      throws Exception {
+    URL resourceUrl = getClass().getClassLoader().getResource("missingDataType.schema");
+    Assert.assertNotNull(resourceUrl);
+    Schema.fromFile(new File(resourceUrl.getFile()));
+  }
+
 
   @Test
   public void testSerializeDeserialize()

--- a/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.data;
 
+import com.fasterxml.jackson.databind.JsonMappingException;
 import java.io.File;
 import java.net.URL;
 import java.sql.Timestamp;
@@ -254,7 +255,7 @@ public class SchemaTest {
     Assert.assertEquals(schema11, schema12);
   }
 
-  @Test(expectedExceptions = com.fasterxml.jackson.databind.JsonMappingException.class,
+  @Test(expectedExceptions = JsonMappingException.class,
       expectedExceptionsMessageRegExp = "'booleanDimension' field is missing 'dataType' property.*")
   public void testMissingDataType()
       throws Exception {

--- a/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
@@ -258,9 +258,10 @@ public class SchemaTest {
       expectedExceptionsMessageRegExp = "'booleanDimension' field is missing 'dataType' property.*")
   public void testMissingDataType()
       throws Exception {
-    URL resourceUrl = getClass().getClassLoader().getResource("missingDataType.schema");
+    String resource = "missingDataType.schema";
+    URL resourceUrl = getClass().getClassLoader().getResource(resource);
     if (resourceUrl == null) {
-      throw new SkipException("Missing resource: " + resourceUrl);
+      throw new SkipException("Missing resource: " + resource);
     }
     Schema.fromFile(new File(resourceUrl.getFile()));
   }
@@ -269,9 +270,10 @@ public class SchemaTest {
   @Test
   public void testSerializeDeserialize()
       throws Exception {
-    URL resourceUrl = getClass().getClassLoader().getResource("schemaTest.schema");
+    String resource = "schemaTest.schema";
+    URL resourceUrl = getClass().getClassLoader().getResource(resource);
     if (resourceUrl == null) {
-      throw new SkipException("Missing resource: " + resourceUrl);
+      throw new SkipException("Missing resource: " + resource);
     }
     Schema schema = Schema.fromFile(new File(resourceUrl.getFile()));
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
@@ -35,6 +35,7 @@ import org.apache.pinot.spi.utils.BytesUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
 
@@ -258,7 +259,9 @@ public class SchemaTest {
   public void testMissingDataType()
       throws Exception {
     URL resourceUrl = getClass().getClassLoader().getResource("missingDataType.schema");
-    Assert.assertNotNull(resourceUrl);
+    if (resourceUrl == null) {
+      throw new SkipException("Missing resource: " + resourceUrl);
+    }
     Schema.fromFile(new File(resourceUrl.getFile()));
   }
 
@@ -267,7 +270,9 @@ public class SchemaTest {
   public void testSerializeDeserialize()
       throws Exception {
     URL resourceUrl = getClass().getClassLoader().getResource("schemaTest.schema");
-    Assert.assertNotNull(resourceUrl);
+    if (resourceUrl == null) {
+      throw new SkipException("Missing resource: " + resourceUrl);
+    }
     Schema schema = Schema.fromFile(new File(resourceUrl.getFile()));
 
     Schema schemaToCompare = Schema.fromString(schema.toPrettyJsonString());

--- a/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
@@ -32,14 +32,11 @@ import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.data.TimeGranularitySpec.TimeFormat;
 import org.apache.pinot.spi.utils.BytesUtils;
-import org.codehaus.jackson.map.JsonMappingException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
-
-import static org.testng.AssertJUnit.fail;
 
 
 public class SchemaTest {

--- a/pinot-common/src/test/resources/missingDataType.schema
+++ b/pinot-common/src/test/resources/missingDataType.schema
@@ -1,0 +1,10 @@
+{
+  "dimensionFieldSpecs": [
+    {
+      "name": "booleanDimension",
+      "type": "BOOLEAN",
+      "defaultNullValue": false
+    }
+  ],
+  "schemaName": "invalid"
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -188,6 +188,7 @@ public final class Schema implements Serializable {
     Preconditions.checkNotNull(columnName);
     Preconditions
         .checkState(!_fieldSpecMap.containsKey(columnName), "Field spec already exists for column: " + columnName);
+    Preconditions.checkArgument(fieldSpec.getDataType() != null, "'%s' field is missing 'dataType' property", columnName);
 
     FieldType fieldType = fieldSpec.getFieldType();
     switch (fieldType) {
@@ -213,9 +214,6 @@ public final class Schema implements Serializable {
         throw new UnsupportedOperationException("Unsupported field type: " + fieldType);
     }
 
-    if (fieldSpec.getDataType() == null) {
-      throw new UnsupportedOperationException(String.format("'%s' field is missing 'dataType' property", columnName));
-    }
 
     _hasJSONColumn |= fieldSpec.getDataType().equals(DataType.JSON);
     _fieldSpecMap.put(columnName, fieldSpec);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -213,6 +213,10 @@ public final class Schema implements Serializable {
         throw new UnsupportedOperationException("Unsupported field type: " + fieldType);
     }
 
+    if (fieldSpec.getDataType() == null) {
+      throw new UnsupportedOperationException(String.format("'%s' field is missing 'dataType' property", columnName));
+    }
+
     _hasJSONColumn |= fieldSpec.getDataType().equals(DataType.JSON);
     _fieldSpecMap.put(columnName, fieldSpec);
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -185,10 +185,13 @@ public final class Schema implements Serializable {
   public void addField(FieldSpec fieldSpec) {
     Preconditions.checkNotNull(fieldSpec);
     String columnName = fieldSpec.getName();
-    Preconditions.checkNotNull(columnName);
+    Preconditions.checkNotNull(columnName,
+        "Schema spec is missing `columnName` property for one of the fields.");
     Preconditions
-        .checkState(!_fieldSpecMap.containsKey(columnName), "Field spec already exists for column: " + columnName);
-    Preconditions.checkArgument(fieldSpec.getDataType() != null, "'%s' field is missing 'dataType' property", columnName);
+        .checkState(!_fieldSpecMap.containsKey(columnName),
+            "Field spec already exists for column: " + columnName);
+    Preconditions.checkArgument(fieldSpec.getDataType() != null,
+        "'%s' field is missing 'dataType' property", columnName);
 
     FieldType fieldType = fieldSpec.getFieldType();
     switch (fieldType) {
@@ -213,7 +216,6 @@ public final class Schema implements Serializable {
       default:
         throw new UnsupportedOperationException("Unsupported field type: " + fieldType);
     }
-
 
     _hasJSONColumn |= fieldSpec.getDataType().equals(DataType.JSON);
     _fieldSpecMap.put(columnName, fieldSpec);


### PR DESCRIPTION
I had a typo in my schema file where instead of `dataType` I had `type`:

```
{
  "dimensionFieldSpecs": [
    {
      "name": "booleanDimension",
      "type": "BOOLEAN",
      "defaultNullValue": false
    }
  ],
  "schemaName": "invalid"
}
```

The error message when trying to add a schema doesn't make it clear what mistake has been made:

```
2021/11/18 07:40:19.075 ERROR [AddTableCommand] [main] Got exception while reading Pinot schema from file: [/config/testschema.json]
shaded.com.fasterxml.jackson.databind.JsonMappingException: N/A
 at [Source: (File); line: 52, column: 5] (through reference chain: org.apache.pinot.spi.data.Schema["dimensionFieldSpecs"])
	at shaded.com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:278)
	at shaded.com.fasterxml.jackson.databind.deser.SettableBeanProperty._throwAsIOE(SettableBeanProperty.java:611)
	at shaded.com.fasterxml.jackson.databind.deser.SettableBeanProperty._throwAsIOE(SettableBeanProperty.java:599)
	at shaded.com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:143)
	at shaded.com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:288)
	at shaded.com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:151)
	at shaded.com.fasterxml.jackson.databind.ObjectReader._bindAndClose(ObjectReader.java:1719)
	at shaded.com.fasterxml.jackson.databind.ObjectReader.readValue(ObjectReader.java:1310)
	at org.apache.pinot.spi.utils.JsonUtils.fileToObject(JsonUtils.java:92)
	at org.apache.pinot.spi.data.Schema.fromFile(Schema.java:87)
	at org.apache.pinot.tools.admin.command.AddTableCommand.uploadSchema(AddTableCommand.java:160)
	at org.apache.pinot.tools.admin.command.AddTableCommand.execute(AddTableCommand.java:203)
	at org.apache.pinot.tools.Command.call(Command.java:33)
	at org.apache.pinot.tools.Command.call(Command.java:29)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1953)
	at picocli.CommandLine.access$1300(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2352)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2346)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2311)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179)
	at picocli.CommandLine.execute(CommandLine.java:2078)
	at org.apache.pinot.tools.admin.PinotAdministrator.execute(PinotAdministrator.java:161)
	at org.apache.pinot.tools.admin.PinotAdministrator.main(PinotAdministrator.java:192)
Caused by: java.lang.NullPointerException
	at org.apache.pinot.spi.data.Schema.addField(Schema.java:216)
	at org.apache.pinot.spi.data.Schema.setDimensionFieldSpecs(Schema.java:132)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at shaded.com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:141)
	... 19 more
```

This PR checks if `schema.getDataType()` is null before reading it in `Schema#addField` and if it's null, will throw an error message that indicates where the problem is. The new error message looks like this:

```
com.fasterxml.jackson.databind.JsonMappingException: 'booleanDimension' field is missing 'dataType' property
 at [Source: (File); line: 8, column: 3] (through reference chain: org.apache.pinot.spi.data.Schema["dimensionFieldSpecs"])

	at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:278)
	at com.fasterxml.jackson.databind.deser.SettableBeanProperty._throwAsIOE(SettableBeanProperty.java:611)
	at com.fasterxml.jackson.databind.deser.SettableBeanProperty._throwAsIOE(SettableBeanProperty.java:599)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:143)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.vanillaDeserialize(BeanDeserializer.java:288)
	at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:151)
	at com.fasterxml.jackson.databind.ObjectReader._bindAndClose(ObjectReader.java:1719)
	at com.fasterxml.jackson.databind.ObjectReader.readValue(ObjectReader.java:1310)
	at org.apache.pinot.spi.utils.JsonUtils.fileToObject(JsonUtils.java:92)
	at org.apache.pinot.spi.data.Schema.fromFile(Schema.java:87)
	at org.apache.pinot.common.data.SchemaTest.testMissingDataType(SchemaTest.java:264)
Caused by: java.lang.UnsupportedOperationException: 'booleanDimension' field is missing 'dataType' property
	at org.apache.pinot.spi.data.Schema.addField(Schema.java:217)
	at org.apache.pinot.spi.data.Schema.setDimensionFieldSpecs(Schema.java:132)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at com.fasterxml.jackson.databind.deser.impl.MethodProperty.deserializeAndSet(MethodProperty.java:141)
	... 31 more
```

I think the user would be able to figure out what they need to fix based on that message.