### PR TITLE
avoid converting bitmaps to sets for the sake of merging in distinct count

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctCountQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctCountQueriesTest.java
@@ -53,6 +53,7 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.roaringbitmap.RoaringBitmap;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -231,7 +232,7 @@ public class DistinctCountQueriesTest extends BaseQueriesTest {
     assertNotNull(aggregationResult);
     assertEquals(aggregationResult.size(), 6);
     for (int i = 0; i < 6; i++) {
-      assertEquals(((Set) aggregationResult.get(i)).size(), expectedResult);
+      assertEquals(getSize(aggregationResult.get(i)), expectedResult);
     }
 
     // Inter segment
@@ -267,7 +268,7 @@ public class DistinctCountQueriesTest extends BaseQueriesTest {
       Integer key = (Integer) groupKey._keys[0];
       assertTrue(_values.contains(key));
       for (int i = 0; i < 6; i++) {
-        assertEquals(((Set<Integer>) aggregationGroupByResult.getResultForGroupId(i, groupKey._groupId)).size(), 1);
+        assertEquals(getSize(aggregationGroupByResult.getResultForGroupId(i, groupKey._groupId)), 1);
       }
     }
     assertEquals(numGroups, _values.size());
@@ -302,5 +303,14 @@ public class DistinctCountQueriesTest extends BaseQueriesTest {
       throws IOException {
     _indexSegment.destroy();
     FileUtils.deleteDirectory(INDEX_DIR);
+  }
+
+  private static int getSize(Object set) {
+    if (set instanceof RoaringBitmap) {
+      return ((RoaringBitmap) set).getCardinality();
+    } else if (set instanceof Set) {
+      return ((Set) set).size();
+    }
+    return 0;
   }
 }


### PR DESCRIPTION
## Description
This makes very large distinct counts of dictionarised columns more efficient.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
