### PR TITLE
Fixing Pinot Admin system exit logic

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
@@ -132,13 +132,13 @@ public class PinotAdministrator {
 
   @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false,
       description = "Print this message.")
-  boolean _help = false;
+  private boolean _help = false;
 
   @CommandLine.Option(names = {"-version", "-v", "--v", "--version"}, required = false,
       description = "Print the version of Pinot package.")
-  boolean _version = false;
+  private boolean _version = false;
 
-  int _status = 1;
+  private int _status = 1;
 
   public void execute(String[] args) {
     try {
@@ -190,8 +190,8 @@ public class PinotAdministrator {
     PluginManager.get().init();
     PinotAdministrator pinotAdministrator = new PinotAdministrator();
     pinotAdministrator.execute(args);
-    if (Boolean.parseBoolean(System.getProperties().getProperty("pinot.admin.system.exit"))
-        && (pinotAdministrator._status != 0)) {
+    if ((pinotAdministrator._status != 0)
+        && Boolean.parseBoolean(System.getProperties().getProperty("pinot.admin.system.exit"))) {
         System.exit(pinotAdministrator._status);
     }
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
@@ -138,7 +138,7 @@ public class PinotAdministrator {
       description = "Print the version of Pinot package.")
   boolean _version = false;
 
-  int _status = 0;
+  int _status = 1;
 
   public void execute(String[] args) {
     try {
@@ -190,13 +190,9 @@ public class PinotAdministrator {
     PluginManager.get().init();
     PinotAdministrator pinotAdministrator = new PinotAdministrator();
     pinotAdministrator.execute(args);
-    // Ignore `pinot.admin.system.exit` property for Pinot quickstarts.
-    if ((args.length > 0) && ("quickstart".equalsIgnoreCase(args[0]))) {
-      return;
-    }
-    if (Boolean.parseBoolean(System.getProperties().getProperty("pinot.admin.system.exit"))) {
-      // If status is true, cmd was successfully, so return 0 from process.
-      System.exit(pinotAdministrator._status);
+    if (Boolean.parseBoolean(System.getProperties().getProperty("pinot.admin.system.exit"))
+        && (pinotAdministrator._status != 0)) {
+        System.exit(pinotAdministrator._status);
     }
   }
 }


### PR DESCRIPTION
## Description
Pinot admin should only exit when status is not 0 and the flag `pinot.admin.system.exit` is set to true.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
