### PR TITLE
Long running commands shouldn't exit on completion

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/Command.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/Command.java
@@ -43,4 +43,8 @@ public interface Command extends Callable<Integer> {
   // Should return true if -help option is specified for the command, false otherwise.
   // This is to facilitate PinotAdministrator to print help for individual commands.
   public boolean getHelp();
+
+  default boolean isLongRunning() {
+    return false;
+  }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
@@ -139,7 +139,7 @@ public class PinotAdministrator {
   boolean _version = false;
 
   int _status = 0;
-  boolean shouldExitOnCompletion = true;
+  boolean _shouldExitOnCompletion = true;
 
   public void execute(String[] args) {
     try {
@@ -161,7 +161,7 @@ public class PinotAdministrator {
       } else {
         _status = commandLine.execute(args);
         String subCommandName = parseResult.subcommand().commandSpec().name();
-        shouldExitOnCompletion = !SUBCOMMAND_MAP.get(subCommandName).isLongRunning();
+        _shouldExitOnCompletion = !SUBCOMMAND_MAP.get(subCommandName).isLongRunning();
       }
     } catch (Exception e) {
       LOGGER.error("Exception caught: ", e);
@@ -194,7 +194,7 @@ public class PinotAdministrator {
     PinotAdministrator pinotAdministrator = new PinotAdministrator();
     pinotAdministrator.execute(args);
     // Ignore `pinot.admin.system.exit` property for Pinot quickstarts.
-    if ((args.length > 0) && !pinotAdministrator.shouldExitOnCompletion) {
+    if ((args.length > 0) && !pinotAdministrator._shouldExitOnCompletion) {
       return;
     }
     if (Boolean.parseBoolean(System.getProperties().getProperty("pinot.admin.system.exit"))) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
@@ -139,6 +139,7 @@ public class PinotAdministrator {
   boolean _version = false;
 
   int _status = 0;
+  boolean shouldExitOnCompletion = true;
 
   public void execute(String[] args) {
     try {
@@ -159,6 +160,8 @@ public class PinotAdministrator {
         }
       } else {
         _status = commandLine.execute(args);
+        String subCommandName = parseResult.subcommand().commandSpec().name();
+        shouldExitOnCompletion = !SUBCOMMAND_MAP.get(subCommandName).isLongRunning();
       }
     } catch (Exception e) {
       LOGGER.error("Exception caught: ", e);
@@ -191,7 +194,7 @@ public class PinotAdministrator {
     PinotAdministrator pinotAdministrator = new PinotAdministrator();
     pinotAdministrator.execute(args);
     // Ignore `pinot.admin.system.exit` property for Pinot quickstarts.
-    if ((args.length > 0) && ("quickstart".equalsIgnoreCase(args[0]))) {
+    if ((args.length > 0) && !pinotAdministrator.shouldExitOnCompletion) {
       return;
     }
     if (Boolean.parseBoolean(System.getProperties().getProperty("pinot.admin.system.exit"))) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/GitHubEventsQuickStartCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/GitHubEventsQuickStartCommand.java
@@ -71,4 +71,9 @@ public class GitHubEventsQuickStartCommand extends AbstractBaseAdminCommand impl
     new GitHubEventsQuickstart().execute(_personalAccessToken);
     return true;
   }
+
+  @Override
+  public boolean isLongRunning() {
+    return true;
+  }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
@@ -130,4 +130,9 @@ public class QuickStartCommand extends AbstractBaseAdminCommand implements Comma
     Reflections reflections = new Reflections("org.apache.pinot.tools");
     return reflections.getSubTypesOf(QuickStartBase.class);
   }
+
+  @Override
+  public boolean isLongRunning() {
+    return true;
+  }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
@@ -154,4 +154,9 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
     }
     return properties;
   }
+
+  @Override
+  public boolean isLongRunning() {
+    return true;
+  }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
@@ -183,4 +183,9 @@ public class StartControllerCommand extends AbstractBaseAdminCommand implements 
     }
     return properties;
   }
+
+  @Override
+  public boolean isLongRunning() {
+    return true;
+  }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartKafkaCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartKafkaCommand.java
@@ -89,4 +89,9 @@ public class StartKafkaCommand extends AbstractBaseAdminCommand implements Comma
     savePID(System.getProperty("java.io.tmpdir") + File.separator + ".kafka.pid");
     return true;
   }
+
+  @Override
+  public boolean isLongRunning() {
+    return true;
+  }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartMinionCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartMinionCommand.java
@@ -152,4 +152,9 @@ public class StartMinionCommand extends AbstractBaseAdminCommand implements Comm
   public void setConfigFileName(String configFileName) {
     _configFileName = configFileName;
   }
+
+  @Override
+  public boolean isLongRunning() {
+    return true;
+  }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServerCommand.java
@@ -187,4 +187,9 @@ public class StartServerCommand extends AbstractBaseAdminCommand implements Comm
     }
     return properties;
   }
+
+  @Override
+  public boolean isLongRunning() {
+    return true;
+  }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
@@ -321,4 +321,9 @@ public class StartServiceManagerCommand extends AbstractBaseAdminCommand impleme
     _bootstrapConfigurations.add(new SimpleImmutableEntry<>(role, config));
     return this;
   }
+
+  @Override
+  public boolean isLongRunning() {
+    return true;
+  }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartZookeeperCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartZookeeperCommand.java
@@ -119,4 +119,9 @@ public class StartZookeeperCommand extends AbstractBaseAdminCommand implements C
     StartZookeeperCommand zkc = new StartZookeeperCommand();
     zkc.execute();
   }
+
+  @Override
+  public boolean isLongRunning() {
+    return true;
+  }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StreamGitHubEventsCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StreamGitHubEventsCommand.java
@@ -112,4 +112,9 @@ public class StreamGitHubEventsCommand extends AbstractBaseAdminCommand implemen
     }
     return true;
   }
+
+  @Override
+  public boolean isLongRunning() {
+    return true;
+  }
 }


### PR DESCRIPTION
We have some PinotAdministrator commands that shouldn't `System.exit(..)` once they've completed. This PR lets us distinguish between the different commands.

I'm not sure what's the best way to write a test for this...any ideas? 