### PR TITLE
all getSegmentStatus to handle segments missing in externalview

### DIFF
--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -488,10 +488,10 @@ const getSegmentStatus = (idealSegment, externalViewSegment) => {
   let goodCount = 0;
   // There is a possibility that the segment is in ideal state but not in external view
   // making external view segment as null.
-  const totalCount = externalViewSegment !== null ? Object.keys(externalViewSegment).length : 0;
+  const totalCount = externalViewSegment ? Object.keys(externalViewSegment).length : 0;
   Object.keys(idealSegment).map((replicaName)=>{
     const idealReplicaState = idealSegment[replicaName];
-    const externalReplicaState = externalViewSegment[replicaName];
+    const externalReplicaState = externalViewSegment ? externalViewSegment[replicaName] : '';
     if(idealReplicaState === externalReplicaState || (externalReplicaState === 'CONSUMING')){
       goodCount += 1;
     }

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -486,7 +486,9 @@ const getSegmentStatus = (idealSegment, externalViewSegment) => {
     return 'Good';
   }
   let goodCount = 0;
-  const totalCount = Object.keys(externalViewSegment).length;
+  // There is a possibility that the segment is in ideal state but not in external view
+  // making external view segment as null.
+  const totalCount = externalViewSegment !== null ? Object.keys(externalViewSegment).length : 0;
   Object.keys(idealSegment).map((replicaName)=>{
     const idealReplicaState = idealSegment[replicaName];
     const externalReplicaState = externalViewSegment[replicaName];
@@ -494,7 +496,7 @@ const getSegmentStatus = (idealSegment, externalViewSegment) => {
       goodCount += 1;
     }
   });
-  if(goodCount === 0){
+  if(goodCount === 0 || totalCount === 0){
     return 'Bad';
   } else if(goodCount === totalCount){
     return  'Good';


### PR DESCRIPTION
## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
This allows the controller to handle the case where the externalview is missing a segment that is in the ideal state. I'm not sure yet how this happens in our cluster, but it keeps the whole controller table UI from loading which makes it hard to even identify the missing segment. There's likely room to either
1) improve the status from "bad" to something like "missing"
2) find the bug that's leading to segments missing in the external view

I want to say this is related to #7779, but we've seen it in clusters without tiered storage as well.

To test, locally I ran the realtime quickstart, deleted the segment from externalview, and opened the page in the UI. The segment now reports as BAD
![image](https://user-images.githubusercontent.com/4760722/142699644-352a53a6-a58e-453f-8550-cf0c12abdf5b.png)
and has no server
![image](https://user-images.githubusercontent.com/4760722/142699666-e3afeb47-44e0-4dd4-8060-72b747e71235.png)

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)

Nothing of note that needs attention
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
