### PR TITLE
Fix and refactor error handling on Controller endpoints

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -543,9 +543,10 @@ public class FileUploadDownloadClient implements Closeable {
     StatusLine statusLine = response.getStatusLine();
     String reason;
     try {
-      reason = JsonUtils.stringToJsonNode(EntityUtils.toString(response.getEntity())).get("_error").asText();
+      String entityStr = EntityUtils.toString(response.getEntity());
+      reason = JsonUtils.stringToObject(entityStr, SimpleHttpErrorInfo.class).getError();
     } catch (Exception e) {
-      reason = "Failed to get reason";
+      reason = String.format("Failed to get a reason, exception: %s", e.toString());
     }
     String errorMessage = String.format("Got error status code: %d (%s) with reason: \"%s\" while sending request: %s",
         statusLine.getStatusCode(), statusLine.getReasonPhrase(), reason, request.getURI());

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/SimpleHttpErrorInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/SimpleHttpErrorInfo.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+/**
+ * Http error info including error message and status code
+ */
+public class SimpleHttpErrorInfo {
+  private int _code;
+  private String _error;
+
+  @JsonCreator
+  public SimpleHttpErrorInfo(@JsonProperty("code") int code, @JsonProperty("error") String message) {
+    _code = code;
+    _error = message;
+  }
+
+  public int getCode() {
+    return _code;
+  }
+
+  public void setCode(int code) {
+    _code = code;
+  }
+
+  public String getError() {
+    return _error;
+  }
+
+  public void setError(String error) {
+    _error = error;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/WebApplicationExceptionMapper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/WebApplicationExceptionMapper.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.controller.api.resources;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/WebApplicationExceptionMapper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/WebApplicationExceptionMapper.java
@@ -25,6 +25,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.ExceptionMapper;
 import javax.ws.rs.ext.Provider;
+import org.apache.pinot.common.utils.SimpleHttpErrorInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,20 +42,7 @@ public class WebApplicationExceptionMapper implements ExceptionMapper<Throwable>
     } else {
       status = ((WebApplicationException) t).getResponse().getStatus();
     }
-
-    ErrorInfo einfo = new ErrorInfo(status, t.getMessage());
-    String err = String.format("{\"code\":%d, \"error\":\"%s\"}", einfo._code, einfo._error);
-    return Response.status(status).entity(err).type(MediaType.APPLICATION_JSON).build();
-  }
-
-  public static class ErrorInfo {
-    @JsonCreator
-    public ErrorInfo(@JsonProperty("code") int code, @JsonProperty("error") String message) {
-      _code = code;
-      _error = message;
-    }
-
-    public int _code;
-    public String _error;
+    SimpleHttpErrorInfo errorInfo = new SimpleHttpErrorInfo(status, t.getMessage());
+    return Response.status(status).entity(errorInfo).type(MediaType.APPLICATION_JSON).build();
   }
 }


### PR DESCRIPTION
## Description
`FileUploadDownloadClient` uses `ErrorInfo` POJO created in `WebApplicationExceptionMapper` on Controller resources. Currently the json representing the POJO is created using a string. This is not ideal because any refactoring on the POJO doesn't automatically get checked - it's a string and it's not typed-checked at compile time. In fact this happened two times recently and each time the json string got updated as a fix PR (https://github.com/apache/pinot/pull/7428 and https://github.com/apache/pinot/pull/7757).
In this PR, the string manipulation for creating the json is replaced with the actual object and the class representing the object is pulled to a common place, so that `FileUploadDownloadClient` can use the same class for deserialization in a type-checked way.

## Testing Done
Locally added a small storage quota to generate a quota error in `OfflineClusterIntegrationTest`.
Error message before the fix:
```
Got error status code: 403 (Forbidden) with reason: "Failed to get reason" while sending request: http://localhost:18998/v2/segments?tableName=mytable to controller: some.host.name, version: Unknown
```
Error message after the fix:
```
Got error status code: 403 (Forbidden) with reason: "Quota check failed for segment: mytable_16282_16312_10 % of table: mytable_OFFLINE, reason: Storage quota exceeded for Table mytable_OFFLINE. New estimated size: 1.57M > total allowed storage size: 1K, where new estimated size = existing estimated uncompressed size of all replicas: 0B - existing segment sizes of all replicas: 0B + (incoming uncompressed segment size: 1.57M * number replicas: 1), total allowed storage size = configured quota: 1K * number replicas: 1" while sending request: http://localhost:18998/v2/segments?tableName=mytable to controller: some.host.name, version: Unknown
```