### PR TITLE
change default range index version to v2

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -135,7 +135,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   private static final String COLUMN_CARDINALITY_MAP_KEY = "columnCardinalityMap";
   // TODO: This might lead to flaky test, as this disk size is not deterministic
   //       as it depends on the iteration order of a HashSet.
-  private static final int DISK_SIZE_IN_BYTES = 20457966;
+  private static final int DISK_SIZE_IN_BYTES = 20989776;
   private static final int NUM_ROWS = 115545;
 
   private final List<ServiceStatus.ServiceStatusCallback> _serviceStatusCallbacks =

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
@@ -27,7 +27,7 @@ import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 
 public class IndexingConfig extends BaseJsonConfig {
 
-  public static final int DEFAULT_RANGE_INDEX_VERSION = 1;
+  public static final int DEFAULT_RANGE_INDEX_VERSION = 2;
 
   private List<String> _invertedIndexColumns;
   private List<String> _rangeIndexColumns;


### PR DESCRIPTION
The new range index has been shown to decrease query latency significantly and this enables it by default.