### PR TITLE
Adding pinot client connection config to allow skip fail on broker response exception

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.client;
 
 import java.util.List;
+import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -31,19 +32,32 @@ import org.slf4j.LoggerFactory;
  * A connection to Pinot, normally created through calls to the {@link ConnectionFactory}.
  */
 public class Connection {
+  public static final String FAIL_ON_EXCEPTIONS = "failOnExceptions";
   private static final Logger LOGGER = LoggerFactory.getLogger(Connection.class);
+
   private final PinotClientTransport _transport;
   private final BrokerSelector _brokerSelector;
+  private final boolean _failOnExceptions;
 
   Connection(List<String> brokerList, PinotClientTransport transport) {
-    LOGGER.info("Creating connection to broker list {}", brokerList);
-    _brokerSelector = new SimpleBrokerSelector(brokerList);
-    _transport = transport;
+    this(new Properties(), new SimpleBrokerSelector(brokerList), transport);
+  }
+
+  Connection(Properties properties, List<String> brokerList, PinotClientTransport transport) {
+    this(properties, new SimpleBrokerSelector(brokerList), transport);
+    LOGGER.info("Created connection to broker list {}", brokerList);
   }
 
   Connection(BrokerSelector brokerSelector, PinotClientTransport transport) {
+    this(new Properties(), brokerSelector, transport);
+  }
+
+  Connection(Properties properties, BrokerSelector brokerSelector, PinotClientTransport transport) {
     _brokerSelector = brokerSelector;
     _transport = transport;
+
+    // Default fail Pinot query if response contains any exception.
+    _failOnExceptions = Boolean.parseBoolean(properties.getProperty(FAIL_ON_EXCEPTIONS, "TRUE"));
   }
 
   /**
@@ -123,7 +137,7 @@ public class Connection {
           "Could not find broker to query for table: " + (tableName == null ? "null" : tableName));
     }
     BrokerResponse response = _transport.executeQuery(brokerHostPort, request);
-    if (response.hasExceptions()) {
+    if (response.hasExceptions() && _failOnExceptions) {
       throw new PinotClientException("Query had processing exceptions: \n" + response.getExceptions());
     }
     return new ResultSetGroup(response);

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/ResultSetGroupTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/ResultSetGroupTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.InputStream;
 import java.util.Collections;
+import java.util.Properties;
 import java.util.concurrent.Future;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -116,9 +117,28 @@ public class ResultSetGroupTest {
     }
   }
 
+  @Test
+  public void testDeserializeExceptionResultSetSkipFail() {
+    try {
+      final ResultSetGroup resultSet = getResultSetSkipError("exception.json");
+      Assert.assertTrue(resultSet.getExceptions().size() > 0);
+    } catch (PinotClientException e) {
+      Assert.fail("Execute should have thrown an exception");
+    }
+  }
+
   private ResultSetGroup getResultSet(String resourceName) {
     _dummyJsonTransport._resource = resourceName;
     Connection connection = ConnectionFactory.fromHostList(Collections.singletonList("dummy"), _dummyJsonTransport);
+    return connection.execute("dummy");
+  }
+
+  private ResultSetGroup getResultSetSkipError(String resourceName) {
+    _dummyJsonTransport._resource = resourceName;
+    Properties props = new Properties();
+    props.setProperty("failOnExceptions", "false");
+    Connection connection =
+        ConnectionFactory.fromHostList(props, Collections.singletonList("dummy"), _dummyJsonTransport);
     return connection.execute("dummy");
   }
 


### PR DESCRIPTION
## Description
Follow up https://github.com/apache/pinot/issues/7770
1.  Add a new field of Exceptions inside ResultSetGroup for client side to reveal pinot query exceptions if needed.
2. Add a constructor parameter for pinot connection with config
3. Allow skip fail on broker response exception

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
