### PR TITLE
Fix the broker routing when segment is deleted

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/ClusterChangeMediator.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/ClusterChangeMediator.java
@@ -26,10 +26,12 @@ import org.apache.helix.HelixConstants.ChangeType;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.api.listeners.BatchMode;
 import org.apache.helix.api.listeners.ExternalViewChangeListener;
+import org.apache.helix.api.listeners.IdealStateChangeListener;
 import org.apache.helix.api.listeners.InstanceConfigChangeListener;
 import org.apache.helix.api.listeners.LiveInstanceChangeListener;
 import org.apache.helix.api.listeners.PreFetch;
 import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.LiveInstance;
 import org.apache.pinot.common.metrics.BrokerMeter;
@@ -51,7 +53,8 @@ import org.slf4j.LoggerFactory;
 @BatchMode(enabled = false)
 @PreFetch(enabled = false)
 public class ClusterChangeMediator
-    implements ExternalViewChangeListener, InstanceConfigChangeListener, LiveInstanceChangeListener {
+    implements IdealStateChangeListener, ExternalViewChangeListener, InstanceConfigChangeListener,
+               LiveInstanceChangeListener {
   private static final Logger LOGGER = LoggerFactory.getLogger(ClusterChangeMediator.class);
 
   // If no change got for 1 hour, proactively check changes
@@ -166,6 +169,15 @@ public class ClusterChangeMediator
       LOGGER.error("Caught InterruptedException while waiting for cluster change handling thread to die");
       Thread.currentThread().interrupt();
     }
+  }
+
+  @Override
+  public void onIdealStateChange(List<IdealState> idealStateList, NotificationContext changeContext)
+      throws InterruptedException {
+    // Ideal state list should be empty because Helix pre-fetch is disabled
+    assert idealStateList.isEmpty();
+
+    enqueueChange(ChangeType.IDEAL_STATE);
   }
 
   @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
+import org.apache.pinot.broker.routing.segmentpreselector.SegmentPreSelector;
 import org.apache.pinot.common.request.BrokerRequest;
 
 
@@ -32,11 +33,11 @@ import org.apache.pinot.common.request.BrokerRequest;
 public interface InstanceSelector {
 
   /**
-   * Initializes the instance selector with the enabled instances, external view, ideal state and online segments
-   * (segments with ONLINE/CONSUMING instances in the ideal state and selected by the pre-selector). Should be called
-   * only once before calling other methods.
+   * Initializes the instance selector with the enabled instances, ideal stateexternal view,  and online segments
+   * (segments with ONLINE/CONSUMING instances in the ideal state and pre-selected by the {@link SegmentPreSelector}).
+   * Should be called only once before calling other methods.
    */
-  void init(Set<String> enabledInstances, ExternalView externalView, IdealState idealState, Set<String> onlineSegments);
+  void init(Set<String> enabledInstances, IdealState idealState, ExternalView externalView, Set<String> onlineSegments);
 
   /**
    * Processes the instances change. Changed instances are pre-computed based on the current and previous enabled
@@ -45,10 +46,10 @@ public interface InstanceSelector {
   void onInstancesChange(Set<String> enabledInstances, List<String> changedInstances);
 
   /**
-   * Processes the external view change based on the given ideal state and online segments (segments with
-   * ONLINE/CONSUMING instances in the ideal state and selected by the pre-selector).
+   * Processes the segment assignment (ideal state or external view) change based on the given online segments (segments
+   * with ONLINE/CONSUMING instances in the ideal state and pre-selected by the {@link SegmentPreSelector}).
    */
-  void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<String> onlineSegments);
+  void onAssignmentChange(IdealState idealState, ExternalView externalView, Set<String> onlineSegments);
 
   /**
    * Selects the server instances for the given segments queried by the given broker request, returns a map from segment

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
@@ -77,7 +77,7 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
    * </pre>
    */
   @Override
-  void updateSegmentMaps(ExternalView externalView, IdealState idealState, Set<String> onlineSegments,
+  void updateSegmentMaps(IdealState idealState, ExternalView externalView, Set<String> onlineSegments,
       Map<String, List<String>> segmentToOnlineInstancesMap, Map<String, List<String>> segmentToOfflineInstancesMap,
       Map<String, List<String>> instanceToSegmentsMap) {
     // Iterate over the ideal state to fill up 'idealStateSegmentToInstancesMap' which is a map from segment to set of

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/EmptySegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/EmptySegmentPruner.java
@@ -60,7 +60,7 @@ public class EmptySegmentPruner implements SegmentPruner {
   }
 
   @Override
-  public void init(ExternalView externalView, IdealState idealState, Set<String> onlineSegments) {
+  public void init(IdealState idealState, ExternalView externalView, Set<String> onlineSegments) {
     // Bulk load info for all online segments
     int numSegments = onlineSegments.size();
     List<String> segments = new ArrayList<>(numSegments);
@@ -89,7 +89,7 @@ public class EmptySegmentPruner implements SegmentPruner {
   }
 
   @Override
-  public synchronized void onExternalViewChange(ExternalView externalView, IdealState idealState,
+  public synchronized void onAssignmentChange(IdealState idealState, ExternalView externalView,
       Set<String> onlineSegments) {
     // NOTE: We don't update all the segment ZK metadata for every external view change, but only the new added/removed
     //       ones. The refreshed segment ZK metadata change won't be picked up.

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPruner.java
@@ -21,6 +21,7 @@ package org.apache.pinot.broker.routing.segmentpruner;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
+import org.apache.pinot.broker.routing.segmentpreselector.SegmentPreSelector;
 import org.apache.pinot.common.request.BrokerRequest;
 
 
@@ -30,17 +31,17 @@ import org.apache.pinot.common.request.BrokerRequest;
 public interface SegmentPruner {
 
   /**
-   * Initializes the segment pruner with the external view, ideal state and online segments (segments with
-   * ONLINE/CONSUMING instances in the ideal state and selected by the pre-selector). Should be called only once before
-   * calling other methods.
+   * Initializes the segment pruner with the ideal state, external view and online segments (segments with
+   * ONLINE/CONSUMING instances in the ideal state and pre-selected by the {@link SegmentPreSelector}). Should be called
+   * only once before calling other methods.
    */
-  void init(ExternalView externalView, IdealState idealState, Set<String> onlineSegments);
+  void init(IdealState idealState, ExternalView externalView, Set<String> onlineSegments);
 
   /**
-   * Processes the external view change based on the given ideal state and online segments (segments with
-   * ONLINE/CONSUMING instances in the ideal state and selected by the pre-selector).
+   * Processes the segment assignment (ideal state or external view) change based on the given online segments (segments
+   * with ONLINE/CONSUMING instances in the ideal state and pre-selected by the {@link SegmentPreSelector}).
    */
-  void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<String> onlineSegments);
+  void onAssignmentChange(IdealState idealState, ExternalView externalView, Set<String> onlineSegments);
 
   /**
    * Refreshes the metadata for the given segment (called when segment is getting refreshed).

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
@@ -80,8 +80,8 @@ public class TimeSegmentPruner implements SegmentPruner {
     _propertyStore = propertyStore;
     _segmentZKMetadataPathPrefix = ZKMetadataProvider.constructPropertyStorePathForResource(_tableNameWithType) + "/";
     _timeColumn = tableConfig.getValidationConfig().getTimeColumnName();
-    Preconditions
-        .checkNotNull(_timeColumn, "Time column must be configured in table config for table: %s", _tableNameWithType);
+    Preconditions.checkNotNull(_timeColumn, "Time column must be configured in table config for table: %s",
+        _tableNameWithType);
 
     Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
     Preconditions.checkNotNull(schema, "Failed to find schema for table: %s", _tableNameWithType);
@@ -92,7 +92,7 @@ public class TimeSegmentPruner implements SegmentPruner {
   }
 
   @Override
-  public void init(ExternalView externalView, IdealState idealState, Set<String> onlineSegments) {
+  public void init(IdealState idealState, ExternalView externalView, Set<String> onlineSegments) {
     // Bulk load time info for all online segments
     int numSegments = onlineSegments.size();
     List<String> segments = new ArrayList<>(numSegments);
@@ -130,7 +130,7 @@ public class TimeSegmentPruner implements SegmentPruner {
   }
 
   @Override
-  public synchronized void onExternalViewChange(ExternalView externalView, IdealState idealState,
+  public synchronized void onAssignmentChange(IdealState idealState, ExternalView externalView,
       Set<String> onlineSegments) {
     // NOTE: We don't update all the segment ZK metadata for every external view change, but only the new added/removed
     //       ones. The refreshed segment ZK metadata change won't be picked up.

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/OfflineSegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/OfflineSegmentSelector.java
@@ -32,12 +32,12 @@ public class OfflineSegmentSelector implements SegmentSelector {
   private volatile Set<String> _segments;
 
   @Override
-  public void init(ExternalView externalView, IdealState idealState, Set<String> onlineSegments) {
-    onExternalViewChange(externalView, idealState, onlineSegments);
+  public void init(IdealState idealState, ExternalView externalView, Set<String> onlineSegments) {
+    onAssignmentChange(idealState, externalView, onlineSegments);
   }
 
   @Override
-  public void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<String> onlineSegments) {
+  public void onAssignmentChange(IdealState idealState, ExternalView externalView, Set<String> onlineSegments) {
     // TODO: for new added segments, before all replicas are up, consider not selecting them to avoid causing
     //       hotspot servers
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/RealtimeSegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/RealtimeSegmentSelector.java
@@ -58,12 +58,12 @@ public class RealtimeSegmentSelector implements SegmentSelector {
   private volatile Set<String> _llcSegments;
 
   @Override
-  public void init(ExternalView externalView, IdealState idealState, Set<String> onlineSegments) {
-    onExternalViewChange(externalView, idealState, onlineSegments);
+  public void init(IdealState idealState, ExternalView externalView, Set<String> onlineSegments) {
+    onAssignmentChange(idealState, externalView, onlineSegments);
   }
 
   @Override
-  public void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<String> onlineSegments) {
+  public void onAssignmentChange(IdealState idealState, ExternalView externalView, Set<String> onlineSegments) {
     // Group HLC segments by their group id
     // NOTE: Use TreeMap so that group ids are sorted and the result is deterministic
     Map<String, Set<String>> groupIdToHLCSegmentsMap = new TreeMap<>();

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelector.java
@@ -21,6 +21,7 @@ package org.apache.pinot.broker.routing.segmentselector;
 import java.util.Set;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
+import org.apache.pinot.broker.routing.segmentpreselector.SegmentPreSelector;
 import org.apache.pinot.common.request.BrokerRequest;
 
 
@@ -43,17 +44,17 @@ import org.apache.pinot.common.request.BrokerRequest;
 public interface SegmentSelector {
 
   /**
-   * Initializes the segment selector with the external view, ideal state and online segments (segments with
-   * ONLINE/CONSUMING instances in the ideal state and selected by the pre-selector). Should be called only once before
-   * calling other methods.
+   * Initializes the segment selector with the ideal state, external view and online segments (segments with
+   * ONLINE/CONSUMING instances in the ideal state and pre-selected by the {@link SegmentPreSelector}). Should be called
+   * only once before calling other methods.
    */
-  void init(ExternalView externalView, IdealState idealState, Set<String> onlineSegments);
+  void init(IdealState idealState, ExternalView externalView, Set<String> onlineSegments);
 
   /**
-   * Processes the external view change based on the given ideal state and online segments (segments with
-   * ONLINE/CONSUMING instances in ideal state and selected by the pre-selector).
+   * Processes the segment assignment (ideal state or external view) change based on the given online segments (segments
+   * with ONLINE/CONSUMING instances in the ideal state and pre-selected by the {@link SegmentPreSelector}).
    */
-  void onExternalViewChange(ExternalView externalView, IdealState idealState, Set<String> onlineSegments);
+  void onAssignmentChange(IdealState idealState, ExternalView externalView, Set<String> onlineSegments);
 
   /**
    * Selects the segments queried by the given broker request. The segments selected should cover the whole dataset

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -64,26 +64,26 @@ public class InstanceSelectorTest {
 
     // Replica-group instance selector should be returned
     when(routingConfig.getInstanceSelectorType()).thenReturn(RoutingConfig.REPLICA_GROUP_INSTANCE_SELECTOR_TYPE);
-    assertTrue(InstanceSelectorFactory
-        .getInstanceSelector(tableConfig, brokerMetrics) instanceof ReplicaGroupInstanceSelector);
+    assertTrue(InstanceSelectorFactory.getInstanceSelector(tableConfig,
+        brokerMetrics) instanceof ReplicaGroupInstanceSelector);
 
     // Strict replica-group instance selector should be returned
     when(routingConfig.getInstanceSelectorType()).thenReturn(RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE);
-    assertTrue(InstanceSelectorFactory
-        .getInstanceSelector(tableConfig, brokerMetrics) instanceof StrictReplicaGroupInstanceSelector);
+    assertTrue(InstanceSelectorFactory.getInstanceSelector(tableConfig,
+        brokerMetrics) instanceof StrictReplicaGroupInstanceSelector);
 
     // Should be backward-compatible with legacy config
     when(routingConfig.getInstanceSelectorType()).thenReturn(null);
     when(tableConfig.getTableType()).thenReturn(TableType.OFFLINE);
-    when(routingConfig.getRoutingTableBuilderName())
-        .thenReturn(InstanceSelectorFactory.LEGACY_REPLICA_GROUP_OFFLINE_ROUTING);
-    assertTrue(InstanceSelectorFactory
-        .getInstanceSelector(tableConfig, brokerMetrics) instanceof ReplicaGroupInstanceSelector);
+    when(routingConfig.getRoutingTableBuilderName()).thenReturn(
+        InstanceSelectorFactory.LEGACY_REPLICA_GROUP_OFFLINE_ROUTING);
+    assertTrue(InstanceSelectorFactory.getInstanceSelector(tableConfig,
+        brokerMetrics) instanceof ReplicaGroupInstanceSelector);
     when(tableConfig.getTableType()).thenReturn(TableType.REALTIME);
-    when(routingConfig.getRoutingTableBuilderName())
-        .thenReturn(InstanceSelectorFactory.LEGACY_REPLICA_GROUP_REALTIME_ROUTING);
-    assertTrue(InstanceSelectorFactory
-        .getInstanceSelector(tableConfig, brokerMetrics) instanceof ReplicaGroupInstanceSelector);
+    when(routingConfig.getRoutingTableBuilderName()).thenReturn(
+        InstanceSelectorFactory.LEGACY_REPLICA_GROUP_REALTIME_ROUTING);
+    assertTrue(InstanceSelectorFactory.getInstanceSelector(tableConfig,
+        brokerMetrics) instanceof ReplicaGroupInstanceSelector);
   }
 
   @Test
@@ -97,10 +97,10 @@ public class InstanceSelectorTest {
         new StrictReplicaGroupInstanceSelector(offlineTableName, brokerMetrics);
 
     Set<String> enabledInstances = new HashSet<>();
-    ExternalView externalView = new ExternalView(offlineTableName);
-    Map<String, Map<String, String>> externalViewSegmentAssignment = externalView.getRecord().getMapFields();
     IdealState idealState = new IdealState(offlineTableName);
     Map<String, Map<String, String>> idealStateSegmentAssignment = idealState.getRecord().getMapFields();
+    ExternalView externalView = new ExternalView(offlineTableName);
+    Map<String, Map<String, String>> externalViewSegmentAssignment = externalView.getRecord().getMapFields();
     Set<String> onlineSegments = new HashSet<>();
 
     // 'instance0' and 'instance1' are in the same replica-group, 'instance2' and 'instance3' are in the same
@@ -126,41 +126,41 @@ public class InstanceSelectorTest {
     //   [segment2, segment3] -> [instance1, instance3, errorInstance1]
     String segment0 = "segment0";
     String segment1 = "segment1";
-    Map<String, String> externalViewInstanceStateMap0 = new TreeMap<>();
-    externalViewInstanceStateMap0.put(instance0, ONLINE);
-    externalViewInstanceStateMap0.put(instance2, ONLINE);
-    externalViewInstanceStateMap0.put(errorInstance0, ERROR);
     Map<String, String> idealStateInstanceStateMap0 = new TreeMap<>();
     idealStateInstanceStateMap0.put(instance0, ONLINE);
     idealStateInstanceStateMap0.put(instance2, ONLINE);
     idealStateInstanceStateMap0.put(errorInstance0, ONLINE);
-    externalViewSegmentAssignment.put(segment0, externalViewInstanceStateMap0);
-    externalViewSegmentAssignment.put(segment1, externalViewInstanceStateMap0);
     idealStateSegmentAssignment.put(segment0, idealStateInstanceStateMap0);
     idealStateSegmentAssignment.put(segment1, idealStateInstanceStateMap0);
+    Map<String, String> externalViewInstanceStateMap0 = new TreeMap<>();
+    externalViewInstanceStateMap0.put(instance0, ONLINE);
+    externalViewInstanceStateMap0.put(instance2, ONLINE);
+    externalViewInstanceStateMap0.put(errorInstance0, ERROR);
+    externalViewSegmentAssignment.put(segment0, externalViewInstanceStateMap0);
+    externalViewSegmentAssignment.put(segment1, externalViewInstanceStateMap0);
     onlineSegments.add(segment0);
     onlineSegments.add(segment1);
     String segment2 = "segment2";
     String segment3 = "segment3";
-    Map<String, String> externalViewInstanceStateMap1 = new TreeMap<>();
-    externalViewInstanceStateMap1.put(instance1, ONLINE);
-    externalViewInstanceStateMap1.put(instance3, ONLINE);
-    externalViewInstanceStateMap1.put(errorInstance1, ERROR);
     Map<String, String> idealStateInstanceStateMap1 = new TreeMap<>();
     idealStateInstanceStateMap1.put(instance1, ONLINE);
     idealStateInstanceStateMap1.put(instance3, ONLINE);
     idealStateInstanceStateMap1.put(errorInstance1, ONLINE);
-    externalViewSegmentAssignment.put(segment2, externalViewInstanceStateMap1);
-    externalViewSegmentAssignment.put(segment3, externalViewInstanceStateMap1);
     idealStateSegmentAssignment.put(segment2, idealStateInstanceStateMap1);
     idealStateSegmentAssignment.put(segment3, idealStateInstanceStateMap1);
+    Map<String, String> externalViewInstanceStateMap1 = new TreeMap<>();
+    externalViewInstanceStateMap1.put(instance1, ONLINE);
+    externalViewInstanceStateMap1.put(instance3, ONLINE);
+    externalViewInstanceStateMap1.put(errorInstance1, ERROR);
+    externalViewSegmentAssignment.put(segment2, externalViewInstanceStateMap1);
+    externalViewSegmentAssignment.put(segment3, externalViewInstanceStateMap1);
     onlineSegments.add(segment2);
     onlineSegments.add(segment3);
     List<String> segments = Arrays.asList(segment0, segment1, segment2, segment3);
 
-    balancedInstanceSelector.init(enabledInstances, externalView, idealState, onlineSegments);
-    replicaGroupInstanceSelector.init(enabledInstances, externalView, idealState, onlineSegments);
-    strictReplicaGroupInstanceSelector.init(enabledInstances, externalView, idealState, onlineSegments);
+    balancedInstanceSelector.init(enabledInstances, idealState, externalView, onlineSegments);
+    replicaGroupInstanceSelector.init(enabledInstances, idealState, externalView, onlineSegments);
+    strictReplicaGroupInstanceSelector.init(enabledInstances, idealState, externalView, onlineSegments);
 
     // For the 1st request:
     //   BalancedInstanceSelector:
@@ -294,12 +294,12 @@ public class InstanceSelectorTest {
     assertTrue(selectionResult.getUnavailableSegments().isEmpty());
 
     // Remove segment0 and add segment4
-    externalViewSegmentAssignment.remove(segment0);
     idealStateSegmentAssignment.remove(segment0);
+    externalViewSegmentAssignment.remove(segment0);
     onlineSegments.remove(segment0);
     String segment4 = "segment4";
-    externalViewSegmentAssignment.put(segment4, externalViewInstanceStateMap0);
     idealStateSegmentAssignment.put(segment4, idealStateInstanceStateMap0);
+    externalViewSegmentAssignment.put(segment4, externalViewInstanceStateMap0);
     onlineSegments.add(segment4);
     segments = Arrays.asList(segment1, segment2, segment3, segment4);
 
@@ -364,9 +364,9 @@ public class InstanceSelectorTest {
     assertTrue(selectionResult.getUnavailableSegments().isEmpty());
 
     // Process the changes
-    balancedInstanceSelector.onExternalViewChange(externalView, idealState, onlineSegments);
-    replicaGroupInstanceSelector.onExternalViewChange(externalView, idealState, onlineSegments);
-    strictReplicaGroupInstanceSelector.onExternalViewChange(externalView, idealState, onlineSegments);
+    balancedInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
+    replicaGroupInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
+    strictReplicaGroupInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
 
     // For the 7th request:
     //   BalancedInstanceSelector:
@@ -504,9 +504,9 @@ public class InstanceSelectorTest {
     externalViewInstanceStateMap2.put(instance2, ONLINE);
     externalViewInstanceStateMap2.put(errorInstance0, ERROR);
     externalViewSegmentAssignment.put(segment1, externalViewInstanceStateMap2);
-    balancedInstanceSelector.onExternalViewChange(externalView, idealState, onlineSegments);
-    replicaGroupInstanceSelector.onExternalViewChange(externalView, idealState, onlineSegments);
-    strictReplicaGroupInstanceSelector.onExternalViewChange(externalView, idealState, onlineSegments);
+    balancedInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
+    replicaGroupInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
+    strictReplicaGroupInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
 
     // For the 11th request:
     //   BalancedInstanceSelector:
@@ -591,29 +591,29 @@ public class InstanceSelectorTest {
         new StrictReplicaGroupInstanceSelector(offlineTableName, brokerMetrics);
 
     Set<String> enabledInstances = new HashSet<>();
-    ExternalView externalView = new ExternalView(offlineTableName);
-    Map<String, Map<String, String>> externalViewSegmentAssignment = externalView.getRecord().getMapFields();
     IdealState idealState = new IdealState(offlineTableName);
     Map<String, Map<String, String>> idealStateSegmentAssignment = idealState.getRecord().getMapFields();
+    ExternalView externalView = new ExternalView(offlineTableName);
+    Map<String, Map<String, String>> externalViewSegmentAssignment = externalView.getRecord().getMapFields();
     Set<String> onlineSegments = new HashSet<>();
 
     String instance = "instance";
     String errorInstance = "errorInstance";
     String segment0 = "segment0";
     String segment1 = "segment1";
+    Map<String, String> idealStateInstanceStateMap = new TreeMap<>();
+    idealStateInstanceStateMap.put(instance, CONSUMING);
+    idealStateInstanceStateMap.put(errorInstance, ONLINE);
+    idealStateSegmentAssignment.put(segment0, idealStateInstanceStateMap);
+    idealStateSegmentAssignment.put(segment1, idealStateInstanceStateMap);
     Map<String, String> externalViewInstanceStateMap0 = new TreeMap<>();
     externalViewInstanceStateMap0.put(instance, CONSUMING);
     externalViewInstanceStateMap0.put(errorInstance, ERROR);
     Map<String, String> externalViewInstanceStateMap1 = new TreeMap<>();
     externalViewInstanceStateMap1.put(instance, CONSUMING);
     externalViewInstanceStateMap1.put(errorInstance, ERROR);
-    Map<String, String> idealStateInstanceStateMap = new TreeMap<>();
-    idealStateInstanceStateMap.put(instance, CONSUMING);
-    idealStateInstanceStateMap.put(errorInstance, ONLINE);
     externalViewSegmentAssignment.put(segment0, externalViewInstanceStateMap0);
     externalViewSegmentAssignment.put(segment1, externalViewInstanceStateMap1);
-    idealStateSegmentAssignment.put(segment0, idealStateInstanceStateMap);
-    idealStateSegmentAssignment.put(segment1, idealStateInstanceStateMap);
     onlineSegments.add(segment0);
     onlineSegments.add(segment1);
     List<String> segments = Arrays.asList(segment0, segment1);
@@ -629,8 +629,8 @@ public class InstanceSelectorTest {
     //     (disabled) errorInstance: ERROR
     //   }
     // }
-    balancedInstanceSelector.init(enabledInstances, externalView, idealState, onlineSegments);
-    strictReplicaGroupInstanceSelector.init(enabledInstances, externalView, idealState, onlineSegments);
+    balancedInstanceSelector.init(enabledInstances, idealState, externalView, onlineSegments);
+    strictReplicaGroupInstanceSelector.init(enabledInstances, idealState, externalView, onlineSegments);
     BrokerRequest brokerRequest = mock(BrokerRequest.class);
     InstanceSelector.SelectionResult selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
     assertTrue(selectionResult.getSegmentToInstanceMap().isEmpty());
@@ -684,7 +684,18 @@ public class InstanceSelectorTest {
       assertEquals(selectionResult.getSegmentToInstanceMap().size(), 2);
       assertTrue(selectionResult.getUnavailableSegments().isEmpty());
 
-      // Change the CONSUMING instance to ONLINE, both segments should be available
+      // Change ideal state for the CONSUMING instance to ONLINE, both segments should be available
+      idealStateInstanceStateMap.put(instance, ONLINE);
+      balancedInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
+      strictReplicaGroupInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
+      selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
+      assertEquals(selectionResult.getSegmentToInstanceMap().size(), 2);
+      assertTrue(selectionResult.getUnavailableSegments().isEmpty());
+      selectionResult = strictReplicaGroupInstanceSelector.select(brokerRequest, segments);
+      assertEquals(selectionResult.getSegmentToInstanceMap().size(), 2);
+      assertTrue(selectionResult.getUnavailableSegments().isEmpty());
+
+      // Change external view for the CONSUMING instance to ONLINE, both segments should be available
       // {
       //   segment0: {
       //     (enabled)  instance: ONLINE,
@@ -697,8 +708,8 @@ public class InstanceSelectorTest {
       // }
       externalViewInstanceStateMap0.put(instance, ONLINE);
       externalViewInstanceStateMap1.put(instance, ONLINE);
-      balancedInstanceSelector.onExternalViewChange(externalView, idealState, onlineSegments);
-      strictReplicaGroupInstanceSelector.onExternalViewChange(externalView, idealState, onlineSegments);
+      balancedInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
+      strictReplicaGroupInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
       selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
       assertEquals(selectionResult.getSegmentToInstanceMap().size(), 2);
       assertTrue(selectionResult.getUnavailableSegments().isEmpty());
@@ -706,8 +717,19 @@ public class InstanceSelectorTest {
       assertEquals(selectionResult.getSegmentToInstanceMap().size(), 2);
       assertTrue(selectionResult.getUnavailableSegments().isEmpty());
 
-      // Switch the instance state for segment1, both segments should be available for BalancedInstanceSelector, but
-      // unavailable for StrictReplicaGroupInstanceSelector
+      // Remove ONLINE instance from the ideal state, both segments should be unavailable
+      idealStateInstanceStateMap.remove(instance);
+      balancedInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
+      strictReplicaGroupInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
+      selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
+      assertTrue(selectionResult.getSegmentToInstanceMap().isEmpty());
+      assertEquals(selectionResult.getUnavailableSegments(), Arrays.asList(segment0, segment1));
+      selectionResult = strictReplicaGroupInstanceSelector.select(brokerRequest, segments);
+      assertTrue(selectionResult.getSegmentToInstanceMap().isEmpty());
+      assertEquals(selectionResult.getUnavailableSegments(), Arrays.asList(segment0, segment1));
+
+      // Add back the ONLINE instance to the ideal state, switch the instance state for segment1, both segments should
+      // be available for BalancedInstanceSelector, but unavailable for StrictReplicaGroupInstanceSelector
       // {
       //   segment0: {
       //     (enabled)  instance: ONLINE,
@@ -718,10 +740,11 @@ public class InstanceSelectorTest {
       //     (enabled)  errorInstance: ONLINE
       //   }
       // }
+      idealStateInstanceStateMap.put(instance, ONLINE);
       externalViewInstanceStateMap1.put(instance, ERROR);
       externalViewInstanceStateMap1.put(errorInstance, ONLINE);
-      balancedInstanceSelector.onExternalViewChange(externalView, idealState, onlineSegments);
-      strictReplicaGroupInstanceSelector.onExternalViewChange(externalView, idealState, onlineSegments);
+      balancedInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
+      strictReplicaGroupInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
       selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
       assertEquals(selectionResult.getSegmentToInstanceMap().size(), 2);
       assertTrue(selectionResult.getUnavailableSegments().isEmpty());
@@ -744,8 +767,8 @@ public class InstanceSelectorTest {
       externalViewInstanceStateMap0.put(instance, OFFLINE);
       externalViewInstanceStateMap1.put(instance, OFFLINE);
       externalViewInstanceStateMap1.put(errorInstance, ERROR);
-      balancedInstanceSelector.onExternalViewChange(externalView, idealState, onlineSegments);
-      strictReplicaGroupInstanceSelector.onExternalViewChange(externalView, idealState, onlineSegments);
+      balancedInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
+      strictReplicaGroupInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
       selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
       assertTrue(selectionResult.getSegmentToInstanceMap().isEmpty());
       assertTrue(selectionResult.getUnavailableSegments().isEmpty());
@@ -788,8 +811,8 @@ public class InstanceSelectorTest {
       //   }
       // }
       externalViewInstanceStateMap0.put(errorInstance, ONLINE);
-      balancedInstanceSelector.onExternalViewChange(externalView, idealState, onlineSegments);
-      strictReplicaGroupInstanceSelector.onExternalViewChange(externalView, idealState, onlineSegments);
+      balancedInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
+      strictReplicaGroupInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
       selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
       assertEquals(selectionResult.getSegmentToInstanceMap().size(), 1);
       assertEquals(selectionResult.getUnavailableSegments(), Collections.singletonList(segment1));
@@ -829,11 +852,12 @@ public class InstanceSelectorTest {
       //     (enabled)  errorInstance: ERROR
       //   }
       // }
+      idealStateInstanceStateMap.put(instance, CONSUMING);
       externalViewInstanceStateMap0.put(instance, CONSUMING);
       externalViewInstanceStateMap0.put(errorInstance, ERROR);
       externalViewInstanceStateMap1.put(instance, CONSUMING);
-      balancedInstanceSelector.onExternalViewChange(externalView, idealState, onlineSegments);
-      strictReplicaGroupInstanceSelector.onExternalViewChange(externalView, idealState, onlineSegments);
+      balancedInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
+      strictReplicaGroupInstanceSelector.onAssignmentChange(idealState, externalView, onlineSegments);
       selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
       assertTrue(selectionResult.getSegmentToInstanceMap().isEmpty());
       assertEquals(selectionResult.getUnavailableSegments(), Arrays.asList(segment0, segment1));

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerTest.java
@@ -101,9 +101,8 @@ public class SegmentPrunerTest extends ControllerTest {
   @BeforeClass
   public void setUp() {
     startZk();
-    _zkClient =
-        new ZkClient(getZkUrl(), ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT,
-            new ZNRecordSerializer());
+    _zkClient = new ZkClient(getZkUrl(), ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT,
+        new ZNRecordSerializer());
     _propertyStore =
         new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(_zkClient), "/SegmentPrunerTest/PROPERTYSTORE", null);
   }
@@ -133,8 +132,8 @@ public class SegmentPrunerTest extends ControllerTest {
     assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
 
     // Segment partition config is missing
-    when(routingConfig.getSegmentPrunerTypes())
-        .thenReturn(Collections.singletonList(RoutingConfig.PARTITION_SEGMENT_PRUNER_TYPE));
+    when(routingConfig.getSegmentPrunerTypes()).thenReturn(
+        Collections.singletonList(RoutingConfig.PARTITION_SEGMENT_PRUNER_TYPE));
     segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
     assertEquals(segmentPruners.size(), 1);
     assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
@@ -166,15 +165,15 @@ public class SegmentPrunerTest extends ControllerTest {
     assertEquals(segmentPruners.size(), 1);
     assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
     when(tableConfig.getTableType()).thenReturn(TableType.OFFLINE);
-    when(routingConfig.getRoutingTableBuilderName())
-        .thenReturn(SegmentPrunerFactory.LEGACY_PARTITION_AWARE_OFFLINE_ROUTING);
+    when(routingConfig.getRoutingTableBuilderName()).thenReturn(
+        SegmentPrunerFactory.LEGACY_PARTITION_AWARE_OFFLINE_ROUTING);
     segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
     assertEquals(segmentPruners.size(), 2);
     assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
     assertTrue(segmentPruners.get(1) instanceof PartitionSegmentPruner);
     when(tableConfig.getTableType()).thenReturn(TableType.REALTIME);
-    when(routingConfig.getRoutingTableBuilderName())
-        .thenReturn(SegmentPrunerFactory.LEGACY_PARTITION_AWARE_REALTIME_ROUTING);
+    when(routingConfig.getRoutingTableBuilderName()).thenReturn(
+        SegmentPrunerFactory.LEGACY_PARTITION_AWARE_REALTIME_ROUTING);
     segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
     assertEquals(segmentPruners.size(), 2);
     assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
@@ -200,8 +199,8 @@ public class SegmentPrunerTest extends ControllerTest {
     assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
 
     // Validation config is missing
-    when(routingConfig.getSegmentPrunerTypes())
-        .thenReturn(Collections.singletonList(RoutingConfig.TIME_SEGMENT_PRUNER_TYPE));
+    when(routingConfig.getSegmentPrunerTypes()).thenReturn(
+        Collections.singletonList(RoutingConfig.TIME_SEGMENT_PRUNER_TYPE));
     segmentPruners = SegmentPrunerFactory.getSegmentPruners(tableConfig, _propertyStore);
     assertEquals(segmentPruners.size(), 1);
     assertTrue(segmentPruners.get(0) instanceof EmptySegmentPruner);
@@ -231,14 +230,14 @@ public class SegmentPrunerTest extends ControllerTest {
     BrokerRequest brokerRequest1 = compiler.compileToBrokerRequest(QUERY_1);
     BrokerRequest brokerRequest2 = compiler.compileToBrokerRequest(QUERY_2);
     BrokerRequest brokerRequest3 = compiler.compileToBrokerRequest(QUERY_3);
-    // NOTE: External view and ideal state are not used in the current implementation.
-    ExternalView externalView = Mockito.mock(ExternalView.class);
+    // NOTE: Ideal state and external view are not used in the current implementation
     IdealState idealState = Mockito.mock(IdealState.class);
+    ExternalView externalView = Mockito.mock(ExternalView.class);
 
     PartitionSegmentPruner segmentPruner =
         new PartitionSegmentPruner(OFFLINE_TABLE_NAME, PARTITION_COLUMN, _propertyStore);
     Set<String> onlineSegments = new HashSet<>();
-    segmentPruner.init(externalView, idealState, onlineSegments);
+    segmentPruner.init(idealState, externalView, onlineSegments);
     assertEquals(segmentPruner.prune(brokerRequest1, Collections.emptySet()), Collections.emptySet());
     assertEquals(segmentPruner.prune(brokerRequest2, Collections.emptySet()), Collections.emptySet());
     assertEquals(segmentPruner.prune(brokerRequest3, Collections.emptySet()), Collections.emptySet());
@@ -257,9 +256,9 @@ public class SegmentPrunerTest extends ControllerTest {
     onlineSegments.add(segmentWithoutPartitionMetadata);
     SegmentZKMetadata segmentZKMetadataWithoutPartitionMetadata =
         new SegmentZKMetadata(segmentWithoutPartitionMetadata);
-    ZKMetadataProvider
-        .setSegmentZKMetadata(_propertyStore, OFFLINE_TABLE_NAME, segmentZKMetadataWithoutPartitionMetadata);
-    segmentPruner.onExternalViewChange(externalView, idealState, onlineSegments);
+    ZKMetadataProvider.setSegmentZKMetadata(_propertyStore, OFFLINE_TABLE_NAME,
+        segmentZKMetadataWithoutPartitionMetadata);
+    segmentPruner.onAssignmentChange(idealState, externalView, onlineSegments);
     assertEquals(
         segmentPruner.prune(brokerRequest1, new HashSet<>(Collections.singletonList(segmentWithoutPartitionMetadata))),
         Collections.singletonList(segmentWithoutPartitionMetadata));
@@ -279,7 +278,7 @@ public class SegmentPrunerTest extends ControllerTest {
     String segment1 = "segment1";
     onlineSegments.add(segment1);
     setSegmentZKPartitionMetadata(OFFLINE_TABLE_NAME, segment1, "Murmur", 4, 0);
-    segmentPruner.onExternalViewChange(externalView, idealState, onlineSegments);
+    segmentPruner.onAssignmentChange(idealState, externalView, onlineSegments);
     assertEquals(segmentPruner.prune(brokerRequest1, new HashSet<>(Arrays.asList(segment0, segment1))),
         new HashSet<>(Arrays.asList(segment0, segment1)));
     assertEquals(segmentPruner.prune(brokerRequest2, new HashSet<>(Arrays.asList(segment0, segment1))),
@@ -289,7 +288,7 @@ public class SegmentPrunerTest extends ControllerTest {
 
     // Update partition metadata without refreshing should have no effect
     setSegmentZKPartitionMetadata(OFFLINE_TABLE_NAME, segment0, "Modulo", 4, 1);
-    segmentPruner.onExternalViewChange(externalView, idealState, onlineSegments);
+    segmentPruner.onAssignmentChange(idealState, externalView, onlineSegments);
     assertEquals(segmentPruner.prune(brokerRequest1, new HashSet<>(Arrays.asList(segment0, segment1))),
         new HashSet<>(Arrays.asList(segment0, segment1)));
     assertEquals(segmentPruner.prune(brokerRequest2, new HashSet<>(Arrays.asList(segment0, segment1))),
@@ -316,16 +315,16 @@ public class SegmentPrunerTest extends ControllerTest {
     BrokerRequest brokerRequest5 = compiler.compileToBrokerRequest(QUERY_8);
     BrokerRequest brokerRequest6 = compiler.compileToBrokerRequest(QUERY_9);
     BrokerRequest brokerRequest7 = compiler.compileToBrokerRequest(QUERY_10);
-    // NOTE: External view and ideal state are not used in the current implementation.
-    ExternalView externalView = Mockito.mock(ExternalView.class);
+    // NOTE: Ideal state and external view are not used in the current implementation
     IdealState idealState = Mockito.mock(IdealState.class);
+    ExternalView externalView = Mockito.mock(ExternalView.class);
 
     TableConfig tableConfig = getTableConfig(RAW_TABLE_NAME, TableType.REALTIME);
     setSchemaDateTimeFieldSpec(RAW_TABLE_NAME, TimeUnit.DAYS);
 
     TimeSegmentPruner segmentPruner = new TimeSegmentPruner(tableConfig, _propertyStore);
     Set<String> onlineSegments = new HashSet<>();
-    segmentPruner.init(externalView, idealState, onlineSegments);
+    segmentPruner.init(idealState, externalView, onlineSegments);
     assertEquals(segmentPruner.prune(brokerRequest1, Collections.emptySet()), Collections.emptySet());
     assertEquals(segmentPruner.prune(brokerRequest2, Collections.emptySet()), Collections.emptySet());
     assertEquals(segmentPruner.prune(brokerRequest3, Collections.emptySet()), Collections.emptySet());
@@ -339,7 +338,7 @@ public class SegmentPrunerTest extends ControllerTest {
     segmentPruner = new TimeSegmentPruner(tableConfig, _propertyStore);
     String newSegment = "newSegment";
     onlineSegments.add(newSegment);
-    segmentPruner.init(externalView, idealState, onlineSegments);
+    segmentPruner.init(idealState, externalView, onlineSegments);
     assertEquals(segmentPruner.prune(brokerRequest1, Collections.singleton(newSegment)),
         Collections.singletonList(newSegment));
     assertEquals(segmentPruner.prune(brokerRequest2, Collections.singleton(newSegment)),
@@ -361,9 +360,9 @@ public class SegmentPrunerTest extends ControllerTest {
     SegmentZKMetadata segmentZKMetadataWithoutTimeRangeMetadata =
         new SegmentZKMetadata(segmentWithoutTimeRangeMetadata);
     segmentZKMetadataWithoutTimeRangeMetadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
-    ZKMetadataProvider
-        .setSegmentZKMetadata(_propertyStore, REALTIME_TABLE_NAME, segmentZKMetadataWithoutTimeRangeMetadata);
-    segmentPruner.onExternalViewChange(externalView, idealState, onlineSegments);
+    ZKMetadataProvider.setSegmentZKMetadata(_propertyStore, REALTIME_TABLE_NAME,
+        segmentZKMetadataWithoutTimeRangeMetadata);
+    segmentPruner.onAssignmentChange(idealState, externalView, onlineSegments);
     assertEquals(
         segmentPruner.prune(brokerRequest1, new HashSet<>(Collections.singletonList(segmentWithoutTimeRangeMetadata))),
         Collections.singletonList(segmentWithoutTimeRangeMetadata));
@@ -399,7 +398,7 @@ public class SegmentPrunerTest extends ControllerTest {
     onlineSegments.add(segment2);
     setSegmentZKTimeRangeMetadata(REALTIME_TABLE_NAME, segment2, 50, 65, TimeUnit.DAYS);
 
-    segmentPruner.onExternalViewChange(externalView, idealState, onlineSegments);
+    segmentPruner.onAssignmentChange(idealState, externalView, onlineSegments);
     assertEquals(segmentPruner.prune(brokerRequest1, new HashSet<>(Arrays.asList(segment0, segment1, segment2))),
         new HashSet<>(Arrays.asList(segment0, segment1, segment2)));
     assertEquals(segmentPruner.prune(brokerRequest2, new HashSet<>(Arrays.asList(segment0, segment1, segment2))),
@@ -457,9 +456,9 @@ public class SegmentPrunerTest extends ControllerTest {
     BrokerRequest brokerRequest3 = compiler.compileToBrokerRequest(SDF_QUERY_3);
     BrokerRequest brokerRequest4 = compiler.compileToBrokerRequest(SDF_QUERY_4);
     BrokerRequest brokerRequest5 = compiler.compileToBrokerRequest(SDF_QUERY_5);
-
-    ExternalView externalView = Mockito.mock(ExternalView.class);
+    // NOTE: Ideal state and external view are not used in the current implementation
     IdealState idealState = Mockito.mock(IdealState.class);
+    ExternalView externalView = Mockito.mock(ExternalView.class);
 
     TableConfig tableConfig = getTableConfig(RAW_TABLE_NAME, TableType.REALTIME);
     setSchemaDateTimeFieldSpecSDF(RAW_TABLE_NAME, SDF_PATTERN);
@@ -485,7 +484,7 @@ public class SegmentPrunerTest extends ControllerTest {
     setSegmentZKTimeRangeMetadata(REALTIME_TABLE_NAME, segment2, dateTimeFormatSpec.fromFormatToMillis("20200401"),
         dateTimeFormatSpec.fromFormatToMillis("20200430"), TimeUnit.MILLISECONDS);
 
-    segmentPruner.init(externalView, idealState, onlineSegments);
+    segmentPruner.init(idealState, externalView, onlineSegments);
     assertEquals(segmentPruner.prune(brokerRequest1, onlineSegments), Collections.singleton(segment0));
     assertEquals(segmentPruner.prune(brokerRequest2, onlineSegments), new HashSet<>(Arrays.asList(segment0, segment1)));
     assertEquals(segmentPruner.prune(brokerRequest3, onlineSegments), Collections.singleton(segment1));
@@ -499,9 +498,9 @@ public class SegmentPrunerTest extends ControllerTest {
     BrokerRequest brokerRequest1 = compiler.compileToBrokerRequest(QUERY_1);
     BrokerRequest brokerRequest2 = compiler.compileToBrokerRequest(QUERY_2);
     BrokerRequest brokerRequest3 = compiler.compileToBrokerRequest(QUERY_3);
-
-    ExternalView externalView = Mockito.mock(ExternalView.class);
+    // NOTE: Ideal state and external view are not used in the current implementation
     IdealState idealState = Mockito.mock(IdealState.class);
+    ExternalView externalView = Mockito.mock(ExternalView.class);
 
     TableConfig tableConfig = getTableConfig(RAW_TABLE_NAME, TableType.REALTIME);
 
@@ -514,7 +513,7 @@ public class SegmentPrunerTest extends ControllerTest {
     String segment1 = "segment1";
     onlineSegments.add(segment1);
     setSegmentZKTotalDocsMetadata(REALTIME_TABLE_NAME, segment1, 0);
-    segmentPruner.init(externalView, idealState, onlineSegments);
+    segmentPruner.init(idealState, externalView, onlineSegments);
     assertEquals(segmentPruner.prune(brokerRequest1, new HashSet<>(Arrays.asList(segment0, segment1))),
         new HashSet<>(Collections.singletonList(segment0)));
     assertEquals(segmentPruner.prune(brokerRequest2, new HashSet<>(Arrays.asList(segment0, segment1))),
@@ -525,7 +524,7 @@ public class SegmentPrunerTest extends ControllerTest {
     // init with empty list of segments
     segmentPruner = new EmptySegmentPruner(tableConfig, _propertyStore);
     onlineSegments.clear();
-    segmentPruner.init(externalView, idealState, onlineSegments);
+    segmentPruner.init(idealState, externalView, onlineSegments);
     assertEquals(segmentPruner.prune(brokerRequest1, Collections.emptySet()), Collections.emptySet());
     assertEquals(segmentPruner.prune(brokerRequest2, Collections.emptySet()), Collections.emptySet());
     assertEquals(segmentPruner.prune(brokerRequest3, Collections.emptySet()), Collections.emptySet());
@@ -533,7 +532,7 @@ public class SegmentPrunerTest extends ControllerTest {
     // Segments without metadata (not updated yet) should not be pruned
     String newSegment = "newSegment";
     onlineSegments.add(newSegment);
-    segmentPruner.onExternalViewChange(externalView, idealState, onlineSegments);
+    segmentPruner.onAssignmentChange(idealState, externalView, onlineSegments);
     assertEquals(segmentPruner.prune(brokerRequest1, Collections.singleton(newSegment)),
         Collections.singleton(newSegment));
     assertEquals(segmentPruner.prune(brokerRequest2, Collections.singleton(newSegment)),
@@ -548,9 +547,9 @@ public class SegmentPrunerTest extends ControllerTest {
     SegmentZKMetadata segmentZKMetadataWithoutTotalDocsMetadata =
         new SegmentZKMetadata(segmentWithoutTotalDocsMetadata);
     segmentZKMetadataWithoutTotalDocsMetadata.setStatus(CommonConstants.Segment.Realtime.Status.IN_PROGRESS);
-    ZKMetadataProvider
-        .setSegmentZKMetadata(_propertyStore, REALTIME_TABLE_NAME, segmentZKMetadataWithoutTotalDocsMetadata);
-    segmentPruner.onExternalViewChange(externalView, idealState, onlineSegments);
+    ZKMetadataProvider.setSegmentZKMetadata(_propertyStore, REALTIME_TABLE_NAME,
+        segmentZKMetadataWithoutTotalDocsMetadata);
+    segmentPruner.onAssignmentChange(idealState, externalView, onlineSegments);
     assertEquals(segmentPruner.prune(brokerRequest1, Collections.singleton(segmentWithoutTotalDocsMetadata)),
         Collections.singleton(segmentWithoutTotalDocsMetadata));
     assertEquals(segmentPruner.prune(brokerRequest2, Collections.singleton(segmentWithoutTotalDocsMetadata)),
@@ -563,7 +562,7 @@ public class SegmentPrunerTest extends ControllerTest {
     String segmentWithNegativeTotalDocsMetadata = "segmentWithNegativeTotalDocsMetadata";
     onlineSegments.add(segmentWithNegativeTotalDocsMetadata);
     setSegmentZKTotalDocsMetadata(REALTIME_TABLE_NAME, segmentWithNegativeTotalDocsMetadata, -1);
-    segmentPruner.onExternalViewChange(externalView, idealState, onlineSegments);
+    segmentPruner.onAssignmentChange(idealState, externalView, onlineSegments);
     assertEquals(segmentPruner.prune(brokerRequest1, Collections.singleton(segmentWithNegativeTotalDocsMetadata)),
         Collections.singleton(segmentWithNegativeTotalDocsMetadata));
     assertEquals(segmentPruner.prune(brokerRequest2, Collections.singleton(segmentWithNegativeTotalDocsMetadata)),
@@ -581,7 +580,7 @@ public class SegmentPrunerTest extends ControllerTest {
     onlineSegments.add(segment2);
     setSegmentZKTotalDocsMetadata(REALTIME_TABLE_NAME, segment2, -1);
 
-    segmentPruner.onExternalViewChange(externalView, idealState, onlineSegments);
+    segmentPruner.onAssignmentChange(idealState, externalView, onlineSegments);
     assertEquals(segmentPruner.prune(brokerRequest1, new HashSet<>(Arrays.asList(segment0, segment1, segment2))),
         new HashSet<>(Arrays.asList(segment0, segment2)));
     assertEquals(segmentPruner.prune(brokerRequest2, new HashSet<>(Arrays.asList(segment0, segment1, segment2))),

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelectorTest.java
@@ -62,12 +62,12 @@ public class SegmentSelectorTest {
     Map<String, String> onlineInstanceStateMap = Collections.singletonMap("server", ONLINE);
     Map<String, String> consumingInstanceStateMap = Collections.singletonMap("server", CONSUMING);
     Set<String> onlineSegments = new HashSet<>();
-    // NOTE: Ideal state is not used in the current implementation.
+    // NOTE: Ideal state is not used in the current implementation
     IdealState idealState = mock(IdealState.class);
 
     // Should return an empty list when there is no segment
     RealtimeSegmentSelector segmentSelector = new RealtimeSegmentSelector();
-    segmentSelector.init(externalView, idealState, onlineSegments);
+    segmentSelector.init(idealState, externalView, onlineSegments);
     BrokerRequest brokerRequest = mock(BrokerRequest.class);
     assertTrue(segmentSelector.select(brokerRequest).isEmpty());
 
@@ -86,7 +86,7 @@ public class SegmentSelectorTest {
       }
       hlcSegments[i] = hlcSegmentsForGroup;
     }
-    segmentSelector.onExternalViewChange(externalView, idealState, onlineSegments);
+    segmentSelector.onAssignmentChange(idealState, externalView, onlineSegments);
 
     // Only HLC segments exist, should select the HLC segments from the first group
     assertEqualsNoOrder(segmentSelector.select(brokerRequest).toArray(), hlcSegments[0]);
@@ -110,7 +110,7 @@ public class SegmentSelectorTest {
         }
       }
     }
-    segmentSelector.onExternalViewChange(externalView, idealState, onlineSegments);
+    segmentSelector.onAssignmentChange(idealState, externalView, onlineSegments);
 
     // Both HLC and LLC segments exist, should select the LLC segments
     assertEqualsNoOrder(segmentSelector.select(brokerRequest).toArray(), expectedSelectedLLCSegments);
@@ -125,7 +125,7 @@ public class SegmentSelectorTest {
         onlineSegments.remove(hlcSegment);
       }
     }
-    segmentSelector.onExternalViewChange(externalView, idealState, onlineSegments);
+    segmentSelector.onAssignmentChange(idealState, externalView, onlineSegments);
     assertEqualsNoOrder(segmentSelector.select(brokerRequest).toArray(), expectedSelectedLLCSegments);
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManagerTest.java
@@ -115,7 +115,7 @@ public class TimeBoundaryManagerTest extends ControllerTest {
 
     // Start with no segment
     TimeBoundaryManager timeBoundaryManager = new TimeBoundaryManager(tableConfig, _propertyStore);
-    timeBoundaryManager.init(externalView, idealState, onlineSegments);
+    timeBoundaryManager.init(idealState, externalView, onlineSegments);
     assertNull(timeBoundaryManager.getTimeBoundaryInfo());
 
     // Add the first segment should update the time boundary
@@ -123,7 +123,7 @@ public class TimeBoundaryManagerTest extends ControllerTest {
     onlineSegments.add(segment0);
     segmentAssignment.put(segment0, onlineInstanceStateMap);
     setSegmentZKMetadata(rawTableName, segment0, 2, timeUnit);
-    timeBoundaryManager.init(externalView, idealState, onlineSegments);
+    timeBoundaryManager.init(idealState, externalView, onlineSegments);
     verifyTimeBoundaryInfo(timeBoundaryManager.getTimeBoundaryInfo(), timeUnit.convert(1, TimeUnit.DAYS));
 
     // Add a new segment with larger end time but no ONLINE instance should not update the time boundary
@@ -131,12 +131,12 @@ public class TimeBoundaryManagerTest extends ControllerTest {
     onlineSegments.add(segment1);
     segmentAssignment.put(segment1, offlineInstanceStateMap);
     setSegmentZKMetadata(rawTableName, segment1, 4, timeUnit);
-    timeBoundaryManager.onExternalViewChange(externalView, idealState, onlineSegments);
+    timeBoundaryManager.onAssignmentChange(idealState, externalView, onlineSegments);
     verifyTimeBoundaryInfo(timeBoundaryManager.getTimeBoundaryInfo(), timeUnit.convert(1, TimeUnit.DAYS));
 
     // Turn the new segment ONLINE should update the time boundary
     segmentAssignment.put(segment1, onlineInstanceStateMap);
-    timeBoundaryManager.onExternalViewChange(externalView, idealState, onlineSegments);
+    timeBoundaryManager.onAssignmentChange(idealState, externalView, onlineSegments);
     verifyTimeBoundaryInfo(timeBoundaryManager.getTimeBoundaryInfo(), timeUnit.convert(3, TimeUnit.DAYS));
 
     // Add new segment with larger end time but 0 total docs, should not update time boundary
@@ -144,7 +144,7 @@ public class TimeBoundaryManagerTest extends ControllerTest {
     onlineSegments.add(segmentEmpty);
     segmentAssignment.put(segmentEmpty, onlineInstanceStateMap);
     setSegmentZKMetadataWithTotalDocs(rawTableName, segmentEmpty, 6, timeUnit, 0);
-    timeBoundaryManager.onExternalViewChange(externalView, idealState, onlineSegments);
+    timeBoundaryManager.onAssignmentChange(idealState, externalView, onlineSegments);
     verifyTimeBoundaryInfo(timeBoundaryManager.getTimeBoundaryInfo(), timeUnit.convert(3, TimeUnit.DAYS));
 
     // Add a new segment with smaller end time should not change the time boundary
@@ -152,18 +152,18 @@ public class TimeBoundaryManagerTest extends ControllerTest {
     onlineSegments.add(segment2);
     segmentAssignment.put(segment2, onlineInstanceStateMap);
     setSegmentZKMetadata(rawTableName, segment2, 3, timeUnit);
-    timeBoundaryManager.onExternalViewChange(externalView, idealState, onlineSegments);
+    timeBoundaryManager.onAssignmentChange(idealState, externalView, onlineSegments);
     verifyTimeBoundaryInfo(timeBoundaryManager.getTimeBoundaryInfo(), timeUnit.convert(3, TimeUnit.DAYS));
 
     // Remove the segment with largest end time should update the time boundary
     onlineSegments.remove(segment1);
     segmentAssignment.remove(segment1);
-    timeBoundaryManager.onExternalViewChange(externalView, idealState, onlineSegments);
+    timeBoundaryManager.onAssignmentChange(idealState, externalView, onlineSegments);
     verifyTimeBoundaryInfo(timeBoundaryManager.getTimeBoundaryInfo(), timeUnit.convert(2, TimeUnit.DAYS));
 
     // Change segment ZK metadata without refreshing should not update the time boundary
     setSegmentZKMetadata(rawTableName, segment2, 5, timeUnit);
-    timeBoundaryManager.onExternalViewChange(externalView, idealState, onlineSegments);
+    timeBoundaryManager.onAssignmentChange(idealState, externalView, onlineSegments);
     verifyTimeBoundaryInfo(timeBoundaryManager.getTimeBoundaryInfo(), timeUnit.convert(2, TimeUnit.DAYS));
 
     // Refresh the changed segment should update the time boundary
@@ -181,7 +181,7 @@ public class TimeBoundaryManagerTest extends ControllerTest {
     String segment0 = "segment0";
     onlineSegments.add(segment0);
     setSegmentZKMetadata(rawTableName, segment0, 2, timeUnit);
-    timeBoundaryManager.init(externalView, idealState, onlineSegments);
+    timeBoundaryManager.init(idealState, externalView, onlineSegments);
     long expectedTimeValue;
     if (timeUnit == TimeUnit.DAYS) {
       // Time boundary should be endTime - 1 DAY when time unit is DAYS


### PR DESCRIPTION
# Issue
When a segment is deleted, or moved from one server to another server, it follows these steps:
1. Ideal state is modified by the controller
2. Controller sends messages to servers to offload and delete the segment
3. Servers deletes the segment and update their current state
4. Controller gathers current states of the servers and updates the external view
5. Broker watches external view and updates the routing to not query the servers

Between step 3 to 5, broker will still query the server for the deleted segment, but the segment is already offloaded from the server.

# Solution
Broker should also watch on ideal state change, and update the routing when the segment is deleted or moved in the ideal state. If a segment/instance is in the external view but not in the ideal state, broker should not query the segment/instance as it will be dropped soon in the external view.