### PR TITLE
return exception when unavailable segments on empty broker response

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -466,9 +466,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     if (offlineBrokerRequest == null && realtimeBrokerRequest == null) {
       LOGGER.info("No server found for request {}: {}", requestId, query);
       _brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.NO_SERVER_FOUND_EXCEPTIONS, 1);
-      BrokerResponseNative brokerResponse = BrokerResponseNative.empty();
-      brokerResponse.setExceptions(exceptions);
-      return brokerResponse;
+      return new BrokerResponseNative(exceptions);
     }
     long routingEndTimeNs = System.nanoTime();
     _brokerMetrics.addPhaseTiming(rawTableName, BrokerQueryPhase.QUERY_ROUTING, routingEndTimeNs - routingStartTimeNs);
@@ -495,7 +493,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       String errorMessage = e.getMessage();
       LOGGER.info("{} {}: {}", errorMessage, requestId, query);
       _brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.REQUEST_TIMEOUT_BEFORE_SCATTERED_EXCEPTIONS, 1);
-      exceptions.add(QueryException.getException(QueryException.BROKER_TIMEOUT_ERROR, errorMessage))
+      exceptions.add(QueryException.getException(QueryException.BROKER_TIMEOUT_ERROR, errorMessage));
       return new BrokerResponseNative(exceptions);
     }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -459,7 +459,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     List<QueryProcessingException> exceptions = new ArrayList<>();
     if (numUnavailableSegments > 0) {
       exceptions.add(new QueryProcessingException(QueryException.BROKER_SEGMENT_UNAVAILABLE_ERROR_CODE,
-          String.format("%d segments %s unavailable", numUnavailableSegments, unavailableSegments)))
+          String.format("%d segments %s unavailable", numUnavailableSegments, unavailableSegments)));
     }
 
     if (offlineBrokerRequest == null && realtimeBrokerRequest == null) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -459,7 +459,12 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     if (offlineBrokerRequest == null && realtimeBrokerRequest == null) {
       LOGGER.info("No server found for request {}: {}", requestId, query);
       _brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.NO_SERVER_FOUND_EXCEPTIONS, 1);
-      return BrokerResponseNative.EMPTY_RESULT;
+      BrokerResponseNative brokerResponse = BrokerResponseNative.EMPTY_RESULT;
+      if (numUnavailableSegments > 0) {
+        brokerResponse.addToExceptions(new QueryProcessingException(QueryException.BROKER_SEGMENT_UNAVAILABLE_ERROR_CODE,
+                String.format("%d segments %s unavailable", numUnavailableSegments, unavailableSegments)));
+      }
+      return brokerResponse;
     }
     long routingEndTimeNs = System.nanoTime();
     _brokerMetrics.addPhaseTiming(rawTableName, BrokerQueryPhase.QUERY_ROUTING, routingEndTimeNs - routingStartTimeNs);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -461,7 +461,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       _brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.NO_SERVER_FOUND_EXCEPTIONS, 1);
       BrokerResponseNative brokerResponse = BrokerResponseNative.EMPTY_RESULT;
       if (numUnavailableSegments > 0) {
-        brokerResponse.addToExceptions(new QueryProcessingException(QueryException.BROKER_SEGMENT_UNAVAILABLE_ERROR_CODE,
+        brokerResponse.addToExceptions(
+            new QueryProcessingException(QueryException.BROKER_SEGMENT_UNAVAILABLE_ERROR_CODE,
                 String.format("%d segments %s unavailable", numUnavailableSegments, unavailableSegments)));
       }
       return brokerResponse;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -495,10 +495,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       String errorMessage = e.getMessage();
       LOGGER.info("{} {}: {}", errorMessage, requestId, query);
       _brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.REQUEST_TIMEOUT_BEFORE_SCATTERED_EXCEPTIONS, 1);
-      BrokerResponseNative brokerResponse =
-          new BrokerResponseNative(QueryException.getException(QueryException.BROKER_TIMEOUT_ERROR, errorMessage));
-      brokerResponse.setExceptions(exceptions);
-      return brokerResponse;
+      exceptions.add(QueryException.getException(QueryException.BROKER_TIMEOUT_ERROR, errorMessage))
+      return new BrokerResponseNative(exceptions);
     }
 
     // Execute the query

--- a/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
@@ -106,6 +106,8 @@ public class QueryException {
   public static final ProcessingException DATA_TABLE_DESERIALIZATION_ERROR =
       new ProcessingException(DATA_TABLE_DESERIALIZATION_ERROR_CODE);
   public static final ProcessingException FUTURE_CALL_ERROR = new ProcessingException(FUTURE_CALL_ERROR_CODE);
+  public static final ProcessingException BROKER_SEGMENT_UNAVAILABLE_ERROR =
+      new ProcessingException(BROKER_SEGMENT_UNAVAILABLE_ERROR_CODE);
   public static final ProcessingException BROKER_TIMEOUT_ERROR = new ProcessingException(BROKER_TIMEOUT_ERROR_CODE);
   public static final ProcessingException BROKER_RESOURCE_MISSING_ERROR =
       new ProcessingException(BROKER_RESOURCE_MISSING_ERROR_CODE);

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
@@ -446,10 +446,6 @@ public class BrokerResponseNative implements BrokerResponse {
     _processingExceptions.add(processingException);
   }
 
-  public void addToExceptions(List<QueryProcessingException> processingExceptions) {
-    _processingExceptions.addAll(processingExceptions);
-  }
-
   @JsonIgnore
   @Override
   public int getExceptionsSize() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
@@ -446,6 +446,10 @@ public class BrokerResponseNative implements BrokerResponse {
     _processingExceptions.add(processingException);
   }
 
+  public void addToExceptions(List<QueryProcessingException> processingExceptions) {
+    _processingExceptions.addAll(processingExceptions);
+  }
+
   @JsonIgnore
   @Override
   public int getExceptionsSize() {


### PR DESCRIPTION
## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
This fixes #7811. In #7264 we added exceptions when not all segments are available, but this was one case that was missed. Specifically if all servers are unavailable, both realtime and offline requests become null, but there are still unavailable segments. This adds the exception to the broker response.

There's no unit tests here which makes it quite difficult for me to setup something. But I tested locally by running  the realtime quickstart
- i ran the query and saw results
- i "dropped" the server and saw no results
- i then applied this fix, reran the server drop, and saw the exception
![image](https://user-images.githubusercontent.com/4760722/143162746-5bd7abae-6299-4486-918b-c3a635ff488e.png)

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
This will get encompassed whenever the new error code documentation is done.