### PR TITLE
Pass in Headers when creating PinotConnection. Fix #7773

### DIFF
--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotDriver.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotDriver.java
@@ -69,7 +69,7 @@ public class PinotDriver implements Driver {
       PinotClientTransport pinotClientTransport = factory.buildTransport();
       String controllerUrl = DriverUtils.getControllerFromURL(url);
       String tenant = info.getProperty(INFO_TENANT, DEFAULT_TENANT);
-      if(!headers.isEmpty()) {
+      if (!headers.isEmpty()) {
         return new PinotConnection(info, controllerUrl, pinotClientTransport, tenant, new PinotControllerTransport(headers));
       }
       return new PinotConnection(info, controllerUrl, pinotClientTransport, tenant);

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotDriver.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotDriver.java
@@ -33,6 +33,7 @@ import java.util.Properties;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pinot.client.controller.PinotControllerTransport;
 import org.apache.pinot.client.utils.DriverUtils;
 import org.slf4j.LoggerFactory;
 
@@ -68,6 +69,9 @@ public class PinotDriver implements Driver {
       PinotClientTransport pinotClientTransport = factory.buildTransport();
       String controllerUrl = DriverUtils.getControllerFromURL(url);
       String tenant = info.getProperty(INFO_TENANT, DEFAULT_TENANT);
+      if(!headers.isEmpty()){
+        return new PinotConnection(info, controllerUrl, pinotClientTransport, tenant, new PinotControllerTransport(headers));
+      }
       return new PinotConnection(info, controllerUrl, pinotClientTransport, tenant);
     } catch (Exception e) {
       throw new SQLException(String.format("Failed to connect to url : %s", url), e);

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotDriver.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotDriver.java
@@ -70,7 +70,8 @@ public class PinotDriver implements Driver {
       String controllerUrl = DriverUtils.getControllerFromURL(url);
       String tenant = info.getProperty(INFO_TENANT, DEFAULT_TENANT);
       if (!headers.isEmpty()) {
-        return new PinotConnection(info, controllerUrl, pinotClientTransport, tenant, new PinotControllerTransport(headers));
+        PinotControllerTransport pinotControllerTransport = new PinotControllerTransport(headers);
+        return new PinotConnection(info, controllerUrl, pinotClientTransport, tenant, pinotControllerTransport);
       }
       return new PinotConnection(info, controllerUrl, pinotClientTransport, tenant);
     } catch (Exception e) {

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotDriver.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotDriver.java
@@ -69,7 +69,7 @@ public class PinotDriver implements Driver {
       PinotClientTransport pinotClientTransport = factory.buildTransport();
       String controllerUrl = DriverUtils.getControllerFromURL(url);
       String tenant = info.getProperty(INFO_TENANT, DEFAULT_TENANT);
-      if(!headers.isEmpty()){
+      if(!headers.isEmpty()) {
         return new PinotConnection(info, controllerUrl, pinotClientTransport, tenant, new PinotControllerTransport(headers));
       }
       return new PinotConnection(info, controllerUrl, pinotClientTransport, tenant);


### PR DESCRIPTION
Prerequisite:

pinot/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotDriver.java

headers map is not empty {JDBC with headers for Auth enabled client}
As of now:
return new PinotConnection(controllerUrl, pinotClientTransport, tenant);

It should be:
if(!headers.isEmpty)
return new PinotConnection(controllerUrl, pinotClientTransport, tenant, new PinotControllerTransport(headers));
return new PinotConnection(controllerUrl, pinotClientTransport, tenant);