### PR TITLE
Remove pinot-ingestion-job script

### DIFF
--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -489,17 +489,6 @@
               </jvmSettings>
             </program>
             <program>
-              <mainClass>org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand</mainClass>
-              <name>pinot-ingestion-job</name>
-              <jvmSettings>
-                <initialMemorySize>1G</initialMemorySize>
-                <maxMemorySize>1G</maxMemorySize>
-                <extraArguments>
-                  <extraArgument>-Dlog4j2.configurationFile=conf/log4j2.xml</extraArgument>
-                </extraArguments>
-              </jvmSettings>
-            </program>
-            <program>
               <mainClass>org.apache.pinot.tools.AuthQuickstart</mainClass>
               <name>quick-start-auth</name>
               <jvmSettings>


### PR DESCRIPTION
## Description
Since we removed the main method from `LaunchDataIngestionJobCommand` and make it a subcommand of pinot-admin, this script just doesn't work. 
```
bin/pinot-ingestion-job.sh
```
is replaced by
```
bin/pinot-admin.sh LaunchDataIngestionJob
```

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
