### PR TITLE
added extraEnv, envFrom to statefulset template

### DIFF
--- a/kubernetes/helm/presto/templates/coordinator/statefulset.yml
+++ b/kubernetes/helm/presto/templates/coordinator/statefulset.yml
@@ -62,6 +62,12 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args: [ "run" ]
+        env:
+{{- if .Values.coordinator.extraEnv }}
+{{ toYaml .Values.coordinator.extraEnv | indent 10 }}
+{{- end}}
+        envFrom:
+{{ toYaml .Values.coordinator.envFrom | indent 10 }} 
         ports:
           - containerPort: {{ .Values.coordinator.port }}
             protocol: TCP

--- a/kubernetes/helm/presto/templates/worker/statefulset.yml
+++ b/kubernetes/helm/presto/templates/worker/statefulset.yml
@@ -62,6 +62,12 @@ spec:
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args: [ "run" ]
+        env:
+{{- if .Values.worker.extraEnv }}
+{{ toYaml .Values.worker.extraEnv | indent 10 }}
+{{- end}}
+        envFrom:
+{{ toYaml .Values.worker.envFrom | indent 10 }} 
         ports:
           - containerPort: {{ .Values.worker.port }}
             protocol: TCP

--- a/kubernetes/helm/presto/values.yaml
+++ b/kubernetes/helm/presto/values.yaml
@@ -101,6 +101,20 @@ coordinator:
   updateStrategy:
     type: RollingUpdate
 
+  # Use envFrom to define all of the ConfigMap or Secret data as container environment variables.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables
+  # ref: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
+  envFrom: []
+  #  - configMapRef:
+  #      name: special-config
+  #  - secretRef:
+  #      name: test-secret
+
+  # Use extraEnv to add individual key value pairs as container environment variables.
+  # ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+  extraEnv: []
+  #  - name: TZ
+  #    value: Asia/Seoul
 
 worker:
   name: worker
@@ -160,3 +174,18 @@ worker:
 
   updateStrategy:
     type: RollingUpdate
+
+  # Use envFrom to define all of the ConfigMap or Secret data as container environment variables.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables
+  # ref: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
+  envFrom: []
+  #  - configMapRef:
+  #      name: special-config
+  #  - secretRef:
+  #      name: test-secret
+
+  # Use extraEnv to add individual key value pairs as container environment variables.
+  # ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+  extraEnv: []
+  #  - name: TZ
+  #    value: Asia/Seoul


### PR DESCRIPTION
## Description
- There was no way to inject env var like TZ to presto container on presto's helm chart.
- I added extraEnv, envFrom to presto helm template, and initialized those values with empty array.
- It works fine and users will be able to use custom env vars from presto containers.

<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [x] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
- You can set extraEnv, envFrom on presto helm values.

<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
