### PR TITLE
Make pinot start components command extensible

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
@@ -68,6 +68,30 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
     return _help;
   }
 
+  public String getBrokerHost() {
+    return _brokerHost;
+  }
+
+  public int getBrokerPort() {
+    return _brokerPort;
+  }
+
+  public String getZkAddress() {
+    return _zkAddress;
+  }
+
+  public String getClusterName() {
+    return _clusterName;
+  }
+
+  public String getConfigFileName() {
+    return _configFileName;
+  }
+
+  public Map<String, Object> getConfigOverrides() {
+    return _configOverrides;
+  }
+
   @Override
   public String getName() {
     return "StartBroker";
@@ -137,7 +161,7 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
     }
   }
 
-  private Map<String, Object> getBrokerConf()
+  protected Map<String, Object> getBrokerConf()
       throws ConfigurationException, SocketException, UnknownHostException {
     Map<String, Object> properties = new HashMap<>();
     if (_configFileName != null) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
@@ -80,6 +80,42 @@ public class StartControllerCommand extends AbstractBaseAdminCommand implements 
     return _help;
   }
 
+  public ControllerConf.ControllerMode getControllerMode() {
+    return _controllerMode;
+  }
+
+  public String getControllerHost() {
+    return _controllerHost;
+  }
+
+  public String getControllerPort() {
+    return _controllerPort;
+  }
+
+  public String getDataDir() {
+    return _dataDir;
+  }
+
+  public String getZkAddress() {
+    return _zkAddress;
+  }
+
+  public String getClusterName() {
+    return _clusterName;
+  }
+
+  public String getConfigFileName() {
+    return _configFileName;
+  }
+
+  public boolean isTenantIsolation() {
+    return _tenantIsolation;
+  }
+
+  public Map<String, Object> getConfigOverrides() {
+    return _configOverrides;
+  }
+
   public StartControllerCommand setControllerPort(String controllerPort) {
     _controllerPort = controllerPort;
     return this;
@@ -160,7 +196,7 @@ public class StartControllerCommand extends AbstractBaseAdminCommand implements 
     }
   }
 
-  private Map<String, Object> getControllerConf()
+  protected Map<String, Object> getControllerConf()
       throws ConfigurationException, SocketException, UnknownHostException {
     Map<String, Object> properties = new HashMap<>();
     if (_configFileName != null) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartMinionCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartMinionCommand.java
@@ -68,6 +68,30 @@ public class StartMinionCommand extends AbstractBaseAdminCommand implements Comm
     return _help;
   }
 
+  public String getMinionHost() {
+    return _minionHost;
+  }
+
+  public int getMinionPort() {
+    return _minionPort;
+  }
+
+  public String getZkAddress() {
+    return _zkAddress;
+  }
+
+  public String getClusterName() {
+    return _clusterName;
+  }
+
+  public String getConfigFileName() {
+    return _configFileName;
+  }
+
+  public Map<String, Object> getConfigOverrides() {
+    return _configOverrides;
+  }
+
   @Override
   public String getName() {
     return "StartMinion";
@@ -111,7 +135,7 @@ public class StartMinionCommand extends AbstractBaseAdminCommand implements Comm
     }
   }
 
-  private Map<String, Object> getMinionConf()
+  protected Map<String, Object> getMinionConf()
       throws ConfigurationException, SocketException, UnknownHostException {
     Map<String, Object> properties = new HashMap<>();
     if (_configFileName != null) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServerCommand.java
@@ -80,6 +80,42 @@ public class StartServerCommand extends AbstractBaseAdminCommand implements Comm
     return _help;
   }
 
+  public String getServerHost() {
+    return _serverHost;
+  }
+
+  public int getServerPort() {
+    return _serverPort;
+  }
+
+  public int getServerAdminPort() {
+    return _serverAdminPort;
+  }
+
+  public String getDataDir() {
+    return _dataDir;
+  }
+
+  public String getSegmentDir() {
+    return _segmentDir;
+  }
+
+  public String getZkAddress() {
+    return _zkAddress;
+  }
+
+  public String getClusterName() {
+    return _clusterName;
+  }
+
+  public String getConfigFileName() {
+    return _configFileName;
+  }
+
+  public Map<String, Object> getConfigOverrides() {
+    return _configOverrides;
+  }
+
   public StartServerCommand setClusterName(String clusterName) {
     _clusterName = clusterName;
     return this;
@@ -168,7 +204,7 @@ public class StartServerCommand extends AbstractBaseAdminCommand implements Comm
     }
   }
 
-  private Map<String, Object> getServerConf()
+  protected Map<String, Object> getServerConf()
       throws ConfigurationException, SocketException, UnknownHostException {
     Map<String, Object> properties = new HashMap<>();
     if (_configFileName != null) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartZookeeperCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartZookeeperCommand.java
@@ -72,12 +72,12 @@ public class StartZookeeperCommand extends AbstractBaseAdminCommand implements C
     return "Start the Zookeeper process at the specified port.";
   }
 
-  StartZookeeperCommand setPort(int port) {
+  public StartZookeeperCommand setPort(int port) {
     _zkPort = port;
     return this;
   }
 
-  StartZookeeperCommand setDataDir(String dataDir) {
+  public StartZookeeperCommand setDataDir(String dataDir) {
     _dataDir = dataDir;
     return this;
   }


### PR DESCRIPTION
## Description
So users can extend those command and add new configs or components.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
