### PR TITLE
replication factor to be obtained from tenant configuration in case of dimension table

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/StorageQuotaChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/StorageQuotaChecker.java
@@ -19,20 +19,19 @@
 package org.apache.pinot.controller.validation;
 
 import com.google.common.base.Preconditions;
+import java.util.Set;
+import javax.inject.Inject;
 import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.TableSizeReader;
 import org.apache.pinot.spi.config.table.QuotaConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TenantConfig;
 import org.apache.pinot.spi.utils.DataSizeUtils;
-import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import javax.inject.Inject;
-import java.util.Set;
-
 
 /**
  * Class to check if a new segment is within the configured storage quota for the table


### PR DESCRIPTION
## Description
As Dimension table are replicated on all the server by default, we should be getting the replication factor by taking the tenant id and number of server present in the tenant id. This would ensure that the allowedSize is calculated properly
Issue Link: https://github.com/apache/pinot/issues/7843