### PR TITLE
Minor reformat for query schedulers

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/AbstractSchedulerGroup.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/AbstractSchedulerGroup.java
@@ -22,7 +22,6 @@ import com.google.common.base.Preconditions;
 import java.util.Iterator;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicInteger;
-import javax.annotation.Nonnull;
 
 
 /**
@@ -41,7 +40,7 @@ public abstract class AbstractSchedulerGroup implements SchedulerGroup {
   // Total reserved threads for currently running queries for this group
   protected final AtomicInteger _reservedThreads = new AtomicInteger(0);
 
-  public AbstractSchedulerGroup(@Nonnull String name) {
+  public AbstractSchedulerGroup(String name) {
     Preconditions.checkNotNull(name);
     _name = name;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/MultiLevelPriorityQueue.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/MultiLevelPriorityQueue.java
@@ -28,7 +28,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
@@ -67,8 +66,8 @@ public class MultiLevelPriorityQueue implements SchedulerPriorityQueue {
   private final SchedulerGroupFactory _groupFactory;
   private final PinotConfiguration _config;
 
-  public MultiLevelPriorityQueue(@Nonnull PinotConfiguration config, @Nonnull ResourceManager resourceManager,
-      @Nonnull SchedulerGroupFactory groupFactory, @Nonnull SchedulerGroupMapper groupMapper) {
+  public MultiLevelPriorityQueue(PinotConfiguration config, ResourceManager resourceManager,
+      SchedulerGroupFactory groupFactory, SchedulerGroupMapper groupMapper) {
     Preconditions.checkNotNull(config);
     Preconditions.checkNotNull(resourceManager);
     Preconditions.checkNotNull(groupFactory);
@@ -86,7 +85,7 @@ public class MultiLevelPriorityQueue implements SchedulerPriorityQueue {
   }
 
   @Override
-  public void put(@Nonnull SchedulerQueryContext query)
+  public void put(SchedulerQueryContext query)
       throws OutOfCapacityException {
     Preconditions.checkNotNull(query);
     _queueLock.lock();
@@ -127,7 +126,6 @@ public class MultiLevelPriorityQueue implements SchedulerPriorityQueue {
     }
   }
 
-  @Nonnull
   @Override
   public List<SchedulerQueryContext> drain() {
     List<SchedulerQueryContext> pending = new ArrayList<>();
@@ -209,8 +207,8 @@ public class MultiLevelPriorityQueue implements SchedulerPriorityQueue {
 
   private void checkGroupHasCapacity(SchedulerGroup groupContext)
       throws OutOfCapacityException {
-    if (groupContext.numPending() >= _maxPendingPerGroup && groupContext.totalReservedThreads() >= _resourceManager
-        .getTableThreadsHardLimit()) {
+    if (groupContext.numPending() >= _maxPendingPerGroup
+        && groupContext.totalReservedThreads() >= _resourceManager.getTableThreadsHardLimit()) {
       throw new OutOfCapacityException(String.format(
           "SchedulerGroup %s is out of capacity. numPending: %d, maxPending: %d, reservedThreads: %d "
               + "threadsHardLimit: %d", groupContext.name(), groupContext.numPending(), _maxPendingPerGroup,

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/PriorityScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/PriorityScheduler.java
@@ -26,7 +26,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import java.util.List;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.LongAccumulator;
-import javax.annotation.Nonnull;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
@@ -54,9 +53,8 @@ public abstract class PriorityScheduler extends QueryScheduler {
   @VisibleForTesting
   Thread _scheduler;
 
-  public PriorityScheduler(@Nonnull PinotConfiguration config, @Nonnull ResourceManager resourceManager,
-      @Nonnull QueryExecutor queryExecutor, @Nonnull SchedulerPriorityQueue queue, @Nonnull ServerMetrics metrics,
-      @Nonnull LongAccumulator latestQueryTime) {
+  public PriorityScheduler(PinotConfiguration config, ResourceManager resourceManager, QueryExecutor queryExecutor,
+      SchedulerPriorityQueue queue, ServerMetrics metrics, LongAccumulator latestQueryTime) {
     super(config, queryExecutor, resourceManager, metrics, latestQueryTime);
     Preconditions.checkNotNull(queue);
     _queryQueue = queue;
@@ -64,9 +62,8 @@ public abstract class PriorityScheduler extends QueryScheduler {
     _runningQueriesSemaphore = new Semaphore(_numRunners);
   }
 
-  @Nonnull
   @Override
-  public ListenableFuture<byte[]> submit(@Nonnull ServerQueryRequest queryRequest) {
+  public ListenableFuture<byte[]> submit(ServerQueryRequest queryRequest) {
     if (!_isRunning) {
       return immediateErrorResponse(queryRequest, QueryException.SERVER_SCHEDULER_DOWN_ERROR);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
@@ -28,7 +28,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.LongAccumulator;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.metrics.ServerGauge;
@@ -53,6 +52,7 @@ import org.slf4j.LoggerFactory;
  * Abstract class providing common scheduler functionality
  * including query runner and query worker pool
  */
+@SuppressWarnings("UnstableApiUsage")
 public abstract class QueryScheduler {
   private static final Logger LOGGER = LoggerFactory.getLogger(QueryScheduler.class);
 
@@ -78,13 +78,13 @@ public abstract class QueryScheduler {
    * @param resourceManager for managing server thread resources
    * @param serverMetrics server metrics collector
    */
-  public QueryScheduler(@Nonnull PinotConfiguration config, @Nonnull QueryExecutor queryExecutor,
-      @Nonnull ResourceManager resourceManager, @Nonnull ServerMetrics serverMetrics,
-      @Nonnull LongAccumulator latestQueryTime) {
+  public QueryScheduler(PinotConfiguration config, QueryExecutor queryExecutor, ResourceManager resourceManager,
+      ServerMetrics serverMetrics, LongAccumulator latestQueryTime) {
     Preconditions.checkNotNull(config);
     Preconditions.checkNotNull(queryExecutor);
     Preconditions.checkNotNull(resourceManager);
     Preconditions.checkNotNull(serverMetrics);
+    Preconditions.checkNotNull(latestQueryTime);
 
     _serverMetrics = serverMetrics;
     _resourceManager = resourceManager;
@@ -103,8 +103,7 @@ public abstract class QueryScheduler {
    * @return Listenable future for query result representing serialized response. It is possible that the
    *    future may return immediately or be scheduled for execution at a later time.
    */
-  @Nonnull
-  public abstract ListenableFuture<byte[]> submit(@Nonnull ServerQueryRequest queryRequest);
+  public abstract ListenableFuture<byte[]> submit(ServerQueryRequest queryRequest);
 
   /**
    * Query scheduler name for logging
@@ -133,8 +132,8 @@ public abstract class QueryScheduler {
    * @return Future task that can be scheduled for execution on an ExecutorService. Ideally, this future
    * should be executed on a different executor service than {@code e} to avoid deadlock.
    */
-  protected ListenableFutureTask<byte[]> createQueryFutureTask(@Nonnull ServerQueryRequest queryRequest,
-      @Nonnull ExecutorService executorService) {
+  protected ListenableFutureTask<byte[]> createQueryFutureTask(ServerQueryRequest queryRequest,
+      ExecutorService executorService) {
     return ListenableFutureTask.create(() -> processQueryAndSerialize(queryRequest, executorService));
   }
 
@@ -144,10 +143,8 @@ public abstract class QueryScheduler {
    * @param executorService Executor service to use for parallelizing query processing
    * @return serialized query response
    */
-  @SuppressWarnings("Duplicates")
   @Nullable
-  protected byte[] processQueryAndSerialize(@Nonnull ServerQueryRequest queryRequest,
-      @Nonnull ExecutorService executorService) {
+  protected byte[] processQueryAndSerialize(ServerQueryRequest queryRequest, ExecutorService executorService) {
     _latestQueryTime.accumulate(System.currentTimeMillis());
     DataTable dataTable;
     try {
@@ -236,12 +233,11 @@ public abstract class QueryScheduler {
     // Please add new entries at the end
     if (_queryLogRateLimiter.tryAcquire() || forceLog(schedulerWaitMs, numDocsScanned)) {
       LOGGER.info("Processed requestId={},table={},segments(queried/processed/matched/consuming)={}/{}/{}/{},"
-              + "schedulerWaitMs={},reqDeserMs={},totalExecMs={},resSerMs={},totalTimeMs={},"
-              + "minConsumingFreshnessMs={},broker={},"
-              + "numDocsScanned={},scanInFilter={},scanPostFilter={},sched={},"
-              + "threadCpuTimeNs(total/thread/sysActivity/resSer)={}/{}/{}/{}", requestId,
-          tableNameWithType, numSegmentsQueried, numSegmentsProcessed, numSegmentsMatched, numSegmentsConsuming,
-          schedulerWaitMs, timerContext.getPhaseDurationMs(ServerQueryPhase.REQUEST_DESERIALIZATION),
+              + "schedulerWaitMs={},reqDeserMs={},totalExecMs={},resSerMs={},totalTimeMs={},minConsumingFreshnessMs={},"
+              + "broker={},numDocsScanned={},scanInFilter={},scanPostFilter={},sched={},"
+              + "threadCpuTimeNs(total/thread/sysActivity/resSer)={}/{}/{}/{}", requestId, tableNameWithType,
+          numSegmentsQueried, numSegmentsProcessed, numSegmentsMatched, numSegmentsConsuming, schedulerWaitMs,
+          timerContext.getPhaseDurationMs(ServerQueryPhase.REQUEST_DESERIALIZATION),
           timerContext.getPhaseDurationMs(ServerQueryPhase.QUERY_PROCESSING),
           timerContext.getPhaseDurationMs(ServerQueryPhase.RESPONSE_SERIALIZATION),
           timerContext.getPhaseDurationMs(ServerQueryPhase.TOTAL_QUERY_TIME), minConsumingFreshnessMs,
@@ -297,7 +293,7 @@ public abstract class QueryScheduler {
    * @return serialized response bytes
    */
   @Nullable
-  private byte[] serializeDataTable(@Nonnull ServerQueryRequest queryRequest, @Nonnull DataTable dataTable) {
+  private byte[] serializeDataTable(ServerQueryRequest queryRequest, DataTable dataTable) {
     TimerContext timerContext = queryRequest.getTimerContext();
     TimerContext.Timer responseSerializationTimer =
         timerContext.startNewPhaseTimer(ServerQueryPhase.RESPONSE_SERIALIZATION);
@@ -319,11 +315,8 @@ public abstract class QueryScheduler {
   }
 
   /**
-   * Error response future in case of internal error where query response is not available. This can happen
-   * if the query can not be executed or
-   * @param queryRequest
-   * @param error error code to send
-   * @return
+   * Error response future in case of internal error where query response is not available. This can happen if the query
+   * can not be executed.
    */
   protected ListenableFuture<byte[]> immediateErrorResponse(ServerQueryRequest queryRequest,
       ProcessingException error) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QuerySchedulerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QuerySchedulerFactory.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.query.scheduler;
 import com.google.common.base.Preconditions;
 import java.lang.reflect.Constructor;
 import java.util.concurrent.atomic.LongAccumulator;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration.Configuration;
 import org.apache.pinot.common.metrics.ServerMetrics;
@@ -56,9 +55,8 @@ public class QuerySchedulerFactory {
    * @param queryExecutor QueryExecutor to use
    * @return returns an instance of query scheduler
    */
-  public static @Nonnull
-  QueryScheduler create(@Nonnull PinotConfiguration schedulerConfig, @Nonnull QueryExecutor queryExecutor,
-      ServerMetrics serverMetrics, @Nonnull LongAccumulator latestQueryTime) {
+  public static QueryScheduler create(PinotConfiguration schedulerConfig, QueryExecutor queryExecutor,
+      ServerMetrics serverMetrics, LongAccumulator latestQueryTime) {
     Preconditions.checkNotNull(schedulerConfig);
     Preconditions.checkNotNull(queryExecutor);
 
@@ -89,8 +87,8 @@ public class QuerySchedulerFactory {
     return new FCFSQueryScheduler(schedulerConfig, queryExecutor, serverMetrics, latestQueryTime);
   }
 
-  private static @Nullable
-  QueryScheduler getQuerySchedulerByClassName(String className, PinotConfiguration schedulerConfig,
+  @Nullable
+  private static QueryScheduler getQuerySchedulerByClassName(String className, PinotConfiguration schedulerConfig,
       QueryExecutor queryExecutor) {
     try {
       Constructor<?> constructor =

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/SchedulerPriorityQueue.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/SchedulerPriorityQueue.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.query.scheduler;
 
 import java.util.List;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 
@@ -36,7 +35,7 @@ public interface SchedulerPriorityQueue {
    */
   // TODO: throw OutOfCapacity or drop from the front of the queue ?
   // It may be more beneficial to drop oldest queries to move forward
-  void put(@Nonnull SchedulerQueryContext query)
+  void put(SchedulerQueryContext query)
       throws OutOfCapacityException;
 
   /**
@@ -52,6 +51,5 @@ public interface SchedulerPriorityQueue {
    * @return Non-null list of all the pending queries in the queue
    *         List is empty if there are no pending queries
    */
-  @Nonnull
   List<SchedulerQueryContext> drain();
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/SchedulerQueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/SchedulerQueryContext.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.query.scheduler;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.SettableFuture;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 
@@ -35,18 +34,16 @@ public class SchedulerQueryContext {
   private final SettableFuture<byte[]> _resultFuture;
   private SchedulerGroup _schedulerGroup;
 
-  public SchedulerQueryContext(@Nonnull ServerQueryRequest queryRequest) {
+  public SchedulerQueryContext(ServerQueryRequest queryRequest) {
     Preconditions.checkNotNull(queryRequest);
     _queryRequest = queryRequest;
     _resultFuture = SettableFuture.create();
   }
 
-  @Nonnull
   public ServerQueryRequest getQueryRequest() {
     return _queryRequest;
   }
 
-  @Nonnull
   public SettableFuture<byte[]> getResultFuture() {
     return _resultFuture;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/fcfs/BoundedFCFSScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/fcfs/BoundedFCFSScheduler.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.query.scheduler.fcfs;
 
 import java.util.concurrent.atomic.LongAccumulator;
-import javax.annotation.Nonnull;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.query.executor.QueryExecutor;
 import org.apache.pinot.core.query.scheduler.MultiLevelPriorityQueue;
@@ -39,8 +38,8 @@ import org.apache.pinot.spi.env.PinotConfiguration;
  * concrete classes. All the scheduling logic resides in {@link PriorityScheduler}
  */
 public class BoundedFCFSScheduler extends PriorityScheduler {
-  public static BoundedFCFSScheduler create(@Nonnull PinotConfiguration config, @Nonnull QueryExecutor queryExecutor,
-      @Nonnull ServerMetrics serverMetrics, @Nonnull LongAccumulator latestQueryTime) {
+  public static BoundedFCFSScheduler create(PinotConfiguration config, QueryExecutor queryExecutor,
+      ServerMetrics serverMetrics, LongAccumulator latestQueryTime) {
     final ResourceManager rm = new PolicyBasedResourceManager(config);
     final SchedulerGroupFactory groupFactory = new SchedulerGroupFactory() {
       @Override
@@ -52,9 +51,8 @@ public class BoundedFCFSScheduler extends PriorityScheduler {
     return new BoundedFCFSScheduler(config, rm, queryExecutor, queue, serverMetrics, latestQueryTime);
   }
 
-  private BoundedFCFSScheduler(@Nonnull PinotConfiguration config, @Nonnull ResourceManager resourceManager,
-      @Nonnull QueryExecutor queryExecutor, @Nonnull SchedulerPriorityQueue queue, @Nonnull ServerMetrics metrics,
-      @Nonnull LongAccumulator latestQueryTime) {
+  private BoundedFCFSScheduler(PinotConfiguration config, ResourceManager resourceManager, QueryExecutor queryExecutor,
+      SchedulerPriorityQueue queue, ServerMetrics metrics, LongAccumulator latestQueryTime) {
     super(config, resourceManager, queryExecutor, queue, metrics, latestQueryTime);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/fcfs/FCFSQueryScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/fcfs/FCFSQueryScheduler.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.query.scheduler.fcfs;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListenableFutureTask;
 import java.util.concurrent.atomic.LongAccumulator;
-import javax.annotation.Nonnull;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.metrics.ServerQueryPhase;
@@ -40,14 +39,13 @@ import org.apache.pinot.spi.env.PinotConfiguration;
  */
 public class FCFSQueryScheduler extends QueryScheduler {
 
-  public FCFSQueryScheduler(@Nonnull PinotConfiguration config, @Nonnull QueryExecutor queryExecutor,
-      @Nonnull ServerMetrics serverMetrics, @Nonnull LongAccumulator latestQueryTime) {
+  public FCFSQueryScheduler(PinotConfiguration config, QueryExecutor queryExecutor, ServerMetrics serverMetrics,
+      LongAccumulator latestQueryTime) {
     super(config, queryExecutor, new UnboundedResourceManager(config), serverMetrics, latestQueryTime);
   }
 
-  @Nonnull
   @Override
-  public ListenableFuture<byte[]> submit(@Nonnull ServerQueryRequest queryRequest) {
+  public ListenableFuture<byte[]> submit(ServerQueryRequest queryRequest) {
     if (!_isRunning) {
       return immediateErrorResponse(queryRequest, QueryException.SERVER_SCHEDULER_DOWN_ERROR);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/fcfs/FCFSSchedulerGroup.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/fcfs/FCFSSchedulerGroup.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.query.scheduler.fcfs;
 
-import javax.annotation.Nonnull;
 import org.apache.pinot.core.query.scheduler.AbstractSchedulerGroup;
 import org.apache.pinot.core.query.scheduler.SchedulerGroup;
 import org.apache.pinot.core.query.scheduler.SchedulerGroupAccountant;
@@ -27,7 +26,7 @@ import org.apache.pinot.core.query.scheduler.SchedulerQueryContext;
 
 public class FCFSSchedulerGroup extends AbstractSchedulerGroup {
 
-  public FCFSSchedulerGroup(@Nonnull String group) {
+  public FCFSSchedulerGroup(String group) {
     super(group);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/resources/BoundedAccountingExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/resources/BoundedAccountingExecutor.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.query.scheduler.resources;
 import com.google.common.base.Preconditions;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Semaphore;
-import javax.annotation.Nonnull;
 import org.apache.pinot.core.query.scheduler.SchedulerGroupAccountant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,10 +41,10 @@ public class BoundedAccountingExecutor extends QueryExecutorService {
 
   private final Executor _delegateExecutor;
   private final int _bounds;
-  private Semaphore _semaphore;
+  private final Semaphore _semaphore;
   private final SchedulerGroupAccountant _accountant;
 
-  public BoundedAccountingExecutor(@Nonnull Executor s, int bounds, @Nonnull SchedulerGroupAccountant accountant) {
+  public BoundedAccountingExecutor(Executor s, int bounds, SchedulerGroupAccountant accountant) {
     Preconditions.checkNotNull(s);
     Preconditions.checkNotNull(accountant);
     Preconditions.checkArgument(bounds > 0);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/tokenbucket/TokenPriorityScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/tokenbucket/TokenPriorityScheduler.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.query.scheduler.tokenbucket;
 
 import java.util.concurrent.atomic.LongAccumulator;
-import javax.annotation.Nonnull;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.query.executor.QueryExecutor;
 import org.apache.pinot.core.query.scheduler.MultiLevelPriorityQueue;
@@ -42,8 +41,8 @@ public class TokenPriorityScheduler extends PriorityScheduler {
   public static final String TOKEN_LIFETIME_MS_KEY = "token_lifetime_ms";
   private static final int DEFAULT_TOKEN_LIFETIME_MS = 100;
 
-  public static TokenPriorityScheduler create(@Nonnull PinotConfiguration config, @Nonnull QueryExecutor queryExecutor,
-      @Nonnull ServerMetrics metrics, @Nonnull LongAccumulator latestQueryTime) {
+  public static TokenPriorityScheduler create(PinotConfiguration config, QueryExecutor queryExecutor,
+      ServerMetrics metrics, LongAccumulator latestQueryTime) {
     final ResourceManager rm = new PolicyBasedResourceManager(config);
     final SchedulerGroupFactory groupFactory = new SchedulerGroupFactory() {
       @Override
@@ -62,9 +61,9 @@ public class TokenPriorityScheduler extends PriorityScheduler {
     return new TokenPriorityScheduler(config, rm, queryExecutor, queue, metrics, latestQueryTime);
   }
 
-  private TokenPriorityScheduler(@Nonnull PinotConfiguration config, @Nonnull ResourceManager resourceManager,
-      @Nonnull QueryExecutor queryExecutor, @Nonnull MultiLevelPriorityQueue queue, @Nonnull ServerMetrics metrics,
-      @Nonnull LongAccumulator latestQueryTime) {
+  private TokenPriorityScheduler(PinotConfiguration config, ResourceManager resourceManager,
+      QueryExecutor queryExecutor, MultiLevelPriorityQueue queue, ServerMetrics metrics,
+      LongAccumulator latestQueryTime) {
     super(config, resourceManager, queryExecutor, queue, metrics, latestQueryTime);
   }
 


### PR DESCRIPTION
No code change.
Remove nonnull annotation as it can be easily mixed with nullable annotation.