### PR TITLE
Remove deprecated method from StreamMetadataProvider

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamMetadataProvider.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamMetadataProvider.java
@@ -19,8 +19,6 @@
 package org.apache.pinot.core.realtime.impl.fakestream;
 
 import java.io.IOException;
-import java.util.concurrent.TimeoutException;
-import javax.annotation.Nonnull;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamMetadataProvider;
@@ -31,7 +29,7 @@ import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
  * StreamMetadataProvider implementation for the fake stream
  */
 public class FakeStreamMetadataProvider implements StreamMetadataProvider {
-  private int _numPartitions;
+  private final int _numPartitions;
 
   public FakeStreamMetadataProvider(StreamConfig streamConfig) {
     _numPartitions = FakeStreamConfigUtils.getNumPartitions(streamConfig);
@@ -42,14 +40,8 @@ public class FakeStreamMetadataProvider implements StreamMetadataProvider {
     return _numPartitions;
   }
 
-  public long fetchPartitionOffset(@Nonnull OffsetCriteria offsetCriteria, long timeoutMillis)
-      throws TimeoutException {
-    throw new UnsupportedOperationException("This method is deprecated");
-  }
-
   @Override
-  public StreamPartitionMsgOffset fetchStreamPartitionOffset(@Nonnull OffsetCriteria offsetCriteria, long timeoutMillis)
-      throws TimeoutException {
+  public StreamPartitionMsgOffset fetchStreamPartitionOffset(OffsetCriteria offsetCriteria, long timeoutMillis) {
     if (offsetCriteria.isSmallest()) {
       return FakeStreamConfigUtils.getSmallestOffset();
     } else {
@@ -60,6 +52,5 @@ public class FakeStreamMetadataProvider implements StreamMetadataProvider {
   @Override
   public void close()
       throws IOException {
-
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/src/main/java/org/apache/pinot/plugin/stream/kafka09/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/src/main/java/org/apache/pinot/plugin/stream/kafka09/KafkaStreamMetadataProvider.java
@@ -24,7 +24,6 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
 import kafka.api.PartitionOffsetRequestInfo;
 import kafka.common.TopicAndPartition;
 import kafka.javaapi.OffsetRequest;
@@ -145,11 +144,6 @@ public class KafkaStreamMetadataProvider extends KafkaConnectionHandler implemen
     throw new TimeoutException();
   }
 
-  public synchronized long fetchPartitionOffset(@Nonnull OffsetCriteria offsetCriteria, long timeoutMillis)
-      throws java.util.concurrent.TimeoutException {
-    throw new UnsupportedOperationException("The use of this method s not supported");
-  }
-
   /**
    * Fetches the numeric Kafka offset for this partition for a symbolic name ("largest" or "smallest").
    *
@@ -160,9 +154,8 @@ public class KafkaStreamMetadataProvider extends KafkaConnectionHandler implemen
    * @return An offset
    */
   @Override
-  public synchronized StreamPartitionMsgOffset fetchStreamPartitionOffset(@Nonnull OffsetCriteria offsetCriteria,
-      long timeoutMillis)
-      throws java.util.concurrent.TimeoutException {
+  public synchronized StreamPartitionMsgOffset fetchStreamPartitionOffset(OffsetCriteria offsetCriteria,
+      long timeoutMillis) {
     Preconditions.checkState(_isPartitionProvided,
         "Cannot fetch partition offset. StreamMetadataProvider created without partition information");
     Preconditions.checkNotNull(offsetCriteria);

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
@@ -22,8 +22,6 @@ import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Collections;
-import java.util.concurrent.TimeoutException;
-import javax.annotation.Nonnull;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.StreamConfig;
@@ -47,16 +45,10 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
     return _consumer.partitionsFor(_topic, Duration.ofMillis(timeoutMillis)).size();
   }
 
-  public synchronized long fetchPartitionOffset(@Nonnull OffsetCriteria offsetCriteria, long timeoutMillis)
-      throws java.util.concurrent.TimeoutException {
-    throw new UnsupportedOperationException("The use of this method is not supported");
-  }
-
   @Override
-  public StreamPartitionMsgOffset fetchStreamPartitionOffset(@Nonnull OffsetCriteria offsetCriteria, long timeoutMillis)
-      throws TimeoutException {
+  public StreamPartitionMsgOffset fetchStreamPartitionOffset(OffsetCriteria offsetCriteria, long timeoutMillis) {
     Preconditions.checkNotNull(offsetCriteria);
-    long offset = -1;
+    long offset;
     if (offsetCriteria.isLargest()) {
       offset = _consumer.endOffsets(Collections.singletonList(_topicPartition), Duration.ofMillis(timeoutMillis))
           .get(_topicPartition);
@@ -64,7 +56,7 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
       offset = _consumer.beginningOffsets(Collections.singletonList(_topicPartition), Duration.ofMillis(timeoutMillis))
           .get(_topicPartition);
     } else {
-      throw new IllegalArgumentException("Unknown initial offset value " + offsetCriteria.toString());
+      throw new IllegalArgumentException("Unknown initial offset value " + offsetCriteria);
     }
     return new LongMsgOffset(offset);
   }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisStreamMetadataProvider.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
-import javax.annotation.Nonnull;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.spi.stream.MessageBatch;
 import org.apache.pinot.spi.stream.OffsetCriteria;
@@ -74,7 +73,7 @@ public class KinesisStreamMetadataProvider implements StreamMetadataProvider {
   }
 
   @Override
-  public long fetchPartitionOffset(@Nonnull OffsetCriteria offsetCriteria, long timeoutMillis) {
+  public StreamPartitionMsgOffset fetchStreamPartitionOffset(OffsetCriteria offsetCriteria, long timeoutMillis) {
     throw new UnsupportedOperationException();
   }
 
@@ -146,8 +145,8 @@ public class KinesisStreamMetadataProvider implements StreamMetadataProvider {
       // 1. Root shards - Parent shardId will be null. Will find this case when creating new table.
       // 2. Parent expired - Parent shardId will not be part of shardIdToShard map
       // 3. Parent reached EOL and completely consumed.
-      if (parentShardId == null || !shardIdToShardMap.containsKey(parentShardId) || shardsEnded
-          .contains(parentShardId)) {
+      if (parentShardId == null || !shardIdToShardMap.containsKey(parentShardId) || shardsEnded.contains(
+          parentShardId)) {
         Map<String, String> shardToSequenceNumberMap = new HashMap<>();
         shardToSequenceNumberMap.put(newShardId, newShard.sequenceNumberRange().startingSequenceNumber());
         newStartOffset = new KinesisPartitionGroupOffset(shardToSequenceNumberMap);
@@ -186,6 +185,5 @@ public class KinesisStreamMetadataProvider implements StreamMetadataProvider {
 
   @Override
   public void close() {
-
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeoutException;
-import javax.annotation.Nonnull;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;
 
@@ -34,17 +33,13 @@ import org.apache.pinot.spi.annotations.InterfaceStability;
 @InterfaceAudience.Public
 @InterfaceStability.Stable
 public interface StreamMetadataProvider extends Closeable {
+
   /**
    * Fetches the number of partitions for a topic given the stream configs
    * @param timeoutMillis Fetch timeout
-   * @return
+   * @return number of partitions
    */
   int fetchPartitionCount(long timeoutMillis);
-
-  // Issue 5953 Retain this interface for 0.5.0, remove in 0.6.0
-  @Deprecated
-  long fetchPartitionOffset(@Nonnull OffsetCriteria offsetCriteria, long timeoutMillis)
-      throws java.util.concurrent.TimeoutException;
 
   /**
    * Fetches the offset for a given partition and offset criteria
@@ -52,14 +47,10 @@ public interface StreamMetadataProvider extends Closeable {
    *                       Depends on the semantics of the stream e.g. smallest, largest for Kafka
    * @param timeoutMillis fetch timeout
    * @return {@link StreamPartitionMsgOffset} based on the offset criteria provided
-   * @throws java.util.concurrent.TimeoutException if timed out trying to connect and fetch from stream
+   * @throws TimeoutException if timed out trying to connect and fetch from stream
    */
-  default StreamPartitionMsgOffset fetchStreamPartitionOffset(@Nonnull OffsetCriteria offsetCriteria,
-      long timeoutMillis)
-      throws java.util.concurrent.TimeoutException {
-    long offset = fetchPartitionOffset(offsetCriteria, timeoutMillis);
-    return new LongMsgOffset(offset);
-  }
+  StreamPartitionMsgOffset fetchStreamPartitionOffset(OffsetCriteria offsetCriteria, long timeoutMillis)
+      throws TimeoutException;
 
   /**
    * Computes the list of {@link PartitionGroupMetadata} for the latest state of the stream, using the current
@@ -71,7 +62,7 @@ public interface StreamMetadataProvider extends Closeable {
    */
   default List<PartitionGroupMetadata> computePartitionGroupMetadata(String clientId, StreamConfig streamConfig,
       List<PartitionGroupConsumptionStatus> partitionGroupConsumptionStatuses, int timeoutMillis)
-      throws TimeoutException, IOException {
+      throws IOException, TimeoutException {
     int partitionCount = fetchPartitionCount(timeoutMillis);
     List<PartitionGroupMetadata> newPartitionGroupMetadataList = new ArrayList<>(partitionCount);
 
@@ -87,8 +78,8 @@ public interface StreamMetadataProvider extends Closeable {
     // Use offset criteria from stream config
     StreamConsumerFactory streamConsumerFactory = StreamConsumerFactoryProvider.create(streamConfig);
     for (int i = partitionGroupConsumptionStatuses.size(); i < partitionCount; i++) {
-      try (StreamMetadataProvider partitionMetadataProvider = streamConsumerFactory
-          .createPartitionMetadataProvider(clientId, i)) {
+      try (StreamMetadataProvider partitionMetadataProvider = streamConsumerFactory.createPartitionMetadataProvider(
+          clientId, i)) {
         StreamPartitionMsgOffset streamPartitionMsgOffset =
             partitionMetadataProvider.fetchStreamPartitionOffset(streamConfig.getOffsetCriteria(), timeoutMillis);
         newPartitionGroupMetadataList.add(new PartitionGroupMetadata(i, streamPartitionMsgOffset));


### PR DESCRIPTION
## Release Note

One method is removed from `StreamMetadataProvider` interface:
- `long fetchPartitionOffset(OffsetCriteria offsetCriteria, long timeoutMillis) throws TimeoutException;`