### PR TITLE
Tune local kafka cluster config to be more stable

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/utils/MiniKafkaCluster.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/utils/MiniKafkaCluster.java
@@ -79,13 +79,11 @@ public final class MiniKafkaCluster implements Closeable {
     props.put("port", Integer.toString(port));
     props.put("log.dir", new File(TEMP_DIR, "log").getPath());
     props.put("zookeeper.connect", _zkServer.getZkAddress());
-    props.put("replica.socket.timeout.ms", "1500");
-    props.put("controller.socket.timeout.ms", "1500");
+    props.put("zookeeper.session.timeout.ms", "30000");
     props.put("controlled.shutdown.enable", "true");
     props.put("delete.topic.enable", "true");
     props.put("auto.create.topics.enable", "true");
     props.put("offsets.topic.replication.factor", "1");
-    props.put("controlled.shutdown.retry.backoff.ms", "100");
     props.put("log.cleaner.dedupe.buffer.size", "2097152");
     return props;
   }


### PR DESCRIPTION
Make the timeout longer so that the test is more stable in a resource limited environment.

Default for the following timeout are:
`replica.socket.timeout.ms`: 30s
`controller.socket.timeout.ms`: 30s
`controlled.shutdown.retry.backoff.ms`: 5s

Reference: https://kafka.apache.org/documentation/#brokerconfigs

One example failure test run: https://github.com/apache/pinot/runs/4388914598