### PR TITLE
add option to wrap lines in custom code mirror

### DIFF
--- a/pinot-controller/src/main/resources/app/components/CustomCodemirror.tsx
+++ b/pinot-controller/src/main/resources/app/components/CustomCodemirror.tsx
@@ -18,7 +18,7 @@
  * under the License.
  */
 
-import React, {  } from 'react';
+import React, { useState } from 'react';
 import { UnControlled as CodeMirror } from 'react-codemirror2';
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/theme/material.css';
@@ -26,7 +26,7 @@ import 'codemirror/addon/lint/lint.css';
 import 'codemirror/mode/javascript/javascript';
 import 'codemirror/addon/lint/lint';
 import 'codemirror/addon/lint/json-lint';
-import { makeStyles } from '@material-ui/core';
+import {FormControlLabel, FormGroup, makeStyles, Switch} from '@material-ui/core';
 import clsx from 'clsx';
 
 declare global {
@@ -41,17 +41,37 @@ type Props = {
   data: Object,
   isEditable?: Object,
   returnCodemirrorValue?: Function,
-  customClass?: string
+  customClass?: string,
+  showLineWrapToggle? : boolean,
 };
 
 const useStyles = makeStyles((theme) => ({
   codeMirror: {
     '& .CodeMirror': { height: 600, border: '1px solid #BDCCD9', fontSize: '13px' },
-  }
+  },
+  switch: {
+    '& .MuiFormControlLabel-root': { marginLeft: '0px'},
+  },
 }));
 
-const CustomCodemirror = ({data, isEditable, returnCodemirrorValue, customClass = ''}: Props) => {
+
+const CustomCodemirror = ({data, isEditable, returnCodemirrorValue, customClass = '', showLineWrapToggle=false}: Props) => {
   const classes = useStyles();
+
+  const [isWrappedToggled, setWrappedToggled] = useState(false);
+  const wrapToggle = (
+      <Switch color="primary"/>
+  )
+  const wrapToggleGroup = (
+      <FormGroup className={clsx(classes.switch)}>
+        <FormControlLabel
+            control={wrapToggle}
+            label="Wrap lines"
+            checked={isWrappedToggled}
+            onChange={(event, checked) => setWrappedToggled(checked)}
+        />
+      </FormGroup>
+  )
 
   const jsonoptions = {
     lineNumbers: true,
@@ -60,19 +80,23 @@ const CustomCodemirror = ({data, isEditable, returnCodemirrorValue, customClass 
     gutters: ['CodeMirror-lint-markers'],
     lint: isEditable || false,
     theme: 'default',
-    readOnly: !isEditable
+    readOnly: !isEditable,
+    lineWrapping: isWrappedToggled,
   };
 
   return (
-    <CodeMirror
-      options={jsonoptions}
-      value={typeof data === 'string' ? data : JSON.stringify(data, null, 2)}
-      className={clsx(classes.codeMirror, customClass)}
-      autoCursor={false}
-      onChange={(editor, d, value) => {
-        returnCodemirrorValue && returnCodemirrorValue(value);
-      }}
-    />
+    <>
+      {showLineWrapToggle && wrapToggleGroup}
+      <CodeMirror
+        options={jsonoptions}
+        value={typeof data === 'string' ? data : JSON.stringify(data, null, 2)}
+        className={clsx(classes.codeMirror, customClass)}
+        autoCursor={false}
+        onChange={(editor, d, value) => {
+          returnCodemirrorValue && returnCodemirrorValue(value);
+        }}
+      />
+    </>
   );
 };
 

--- a/pinot-controller/src/main/resources/app/pages/ZookeeperPage.tsx
+++ b/pinot-controller/src/main/resources/app/pages/ZookeeperPage.tsx
@@ -193,13 +193,13 @@ const ZookeeperPage = () => {
             >
               {lastRefresh && renderLastRefresh()}
               <div className={classes.codeMirrorDiv}>
-                <CustomCodemirror data={currentNodeData} />
+                <CustomCodemirror data={currentNodeData} showLineWrapToggle />
               </div>
             </TabPanel>
             <TabPanel value={value} index={1} dir={theme.direction}>
               {lastRefresh && renderLastRefresh()}
               <div className={classes.codeMirrorDiv}>
-                <CustomCodemirror data={currentNodeMetadata} />
+                <CustomCodemirror data={currentNodeMetadata} showLineWrapToggle />
               </div>
             </TabPanel>
           </Grid>


### PR DESCRIPTION
## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
Many of the zookeeper nodes contain quite long metadata, and it's challenging to scroll horizontally to read them.

- Adds a toggle to wrap lines for the CustomCodeMirror
- uses it in the zk browser

Note: i had to test with material-ui: 4.12.3 becuase the zookeeper browser is refusing to load locally due to some makeStyles issue

Edit table looks the same
![image](https://user-images.githubusercontent.com/4760722/144492717-d6833db7-9039-419c-b2fe-4252d0e6554c.png)

but zk browser now can wrap lines
![pinot_wrap_lines](https://user-images.githubusercontent.com/4760722/144493420-267b192d-9d95-4e6c-8161-911fc04029dd.gif)

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
