### PR TITLE
added logic to handle semicolon in the query

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -103,28 +103,24 @@ public class CalciteSqlParser {
    * @return sql query without semicolons
    *
    */
-  private static String checkForSemicolonInTheQuery(String sql) {
+  private static String removeTerminatingSemicolon(String sql) {
     // Check if the query has semicolon
-    int semiColonIndex = sql.indexOf(';');
-    if (semiColonIndex > -1) {
-      // Split the input query based on semicolon
-      String[] sqlSplit = sql.split(";");
+    int semiColonIndex = sql.lastIndexOf(';');
+    int sqlLength = sql.length();
+    // If the semicolon is present in the sql, the termination has to be done
+    boolean stripSemiColon = semiColonIndex >= 0;
 
-      // If only semicolons are present in the input query
-      if (sqlSplit.length == 0) {
-        new SqlCompilationException("Caught exception while parsing query: " + sql);
-      } else {
-        // After spliting take the string present at 0th index and then parse the SQL
-        sql = sqlSplit[0];
-      }
+    // Remove only those semicolons only if they are followed by whitespaces
+    for (int i = semiColonIndex + 1; i < sqlLength && stripSemiColon; i++) {
+      stripSemiColon = Character.isWhitespace(sql.charAt(i));
     }
-    return sql;
+    return stripSemiColon ? sql.substring(0, semiColonIndex) : sql;
   }
 
   public static PinotQuery compileToPinotQuery(String sql)
       throws SqlCompilationException {
-    // Remove semicolon if present in the query
-    sql = checkForSemicolonInTheQuery(sql);
+    // Removes the terminating semicolon if any
+    sql = removeTerminatingSemicolon(sql);
 
     // Extract OPTION statements from sql as Calcite Parser doesn't parse it.
     List<String> options = extractOptionsFromSql(sql);

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -96,8 +96,36 @@ public class CalciteSqlParser {
   private static final Pattern OPTIONS_REGEX_PATTEN =
       Pattern.compile("option\\s*\\(([^\\)]+)\\)", Pattern.CASE_INSENSITIVE);
 
+  /**
+   * Checks for the presence of semicolon in the sql query and modifies the query accordingly
+   *
+   * @param sql sql query
+   * @return sql query without semicolons
+   *
+   */
+  private static String checkForSemicolonInTheQuery(String sql) {
+    // Check if the query has semicolon
+    int semiColonIndex = sql.indexOf(';');
+    if (semiColonIndex > -1) {
+      // Split the input query based on semicolon
+      String[] sqlSplit = sql.split(";");
+
+      // If only semicolons are present in the input query
+      if (sqlSplit.length == 0) {
+        new SqlCompilationException("Caught exception while parsing query: " + sql);
+      } else {
+        // After spliting take the string present at 0th index and then parse the SQL
+        sql = sqlSplit[0];
+      }
+    }
+    return sql;
+  }
+
   public static PinotQuery compileToPinotQuery(String sql)
       throws SqlCompilationException {
+    // Remove semicolon if present in the query
+    sql = checkForSemicolonInTheQuery(sql);
+
     // Extract OPTION statements from sql as Calcite Parser doesn't parse it.
     List<String> options = extractOptionsFromSql(sql);
     if (!options.isEmpty()) {

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -109,7 +109,7 @@ public class CalciteSqlParser {
     int sqlLength = sql.length();
     boolean stripSemiColon = semiColonIndex >= 0;
 
-    // Remove only those semicolons only if they are followed by whitespaces
+    // check if semicolons are followed by whitespaces, only then termination should be done
     for (int i = semiColonIndex + 1; i < sqlLength && stripSemiColon; i++) {
       stripSemiColon = Character.isWhitespace(sql.charAt(i));
     }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -107,7 +107,6 @@ public class CalciteSqlParser {
     // Check if the query has semicolon
     int semiColonIndex = sql.lastIndexOf(';');
     int sqlLength = sql.length();
-    // If the semicolon is present in the sql, the termination has to be done
     boolean stripSemiColon = semiColonIndex >= 0;
 
     // Remove only those semicolons only if they are followed by whitespaces

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -104,12 +104,15 @@ public class CalciteSqlParser {
    *
    */
   private static String removeTerminatingSemicolon(String sql) {
+    // trim all the leading and trailing whitespaces
+    sql = sql.trim();
+
     // Check if the query has semicolon
     int semiColonIndex = sql.lastIndexOf(';');
     int sqlLength = sql.length();
     boolean stripSemiColon = semiColonIndex >= 0;
 
-    // check if semicolons are followed by whitespaces, only then termination should be done
+    // check if semicolons is followed by whitespaces, only then it needs to be terminated
     for (int i = semiColonIndex + 1; i < sqlLength && stripSemiColon; i++) {
       stripSemiColon = Character.isWhitespace(sql.charAt(i));
     }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -106,17 +106,13 @@ public class CalciteSqlParser {
   private static String removeTerminatingSemicolon(String sql) {
     // trim all the leading and trailing whitespaces
     sql = sql.trim();
-
-    // Check if the query has semicolon
-    int semiColonIndex = sql.lastIndexOf(';');
     int sqlLength = sql.length();
-    boolean stripSemiColon = semiColonIndex >= 0;
 
-    // check if semicolons is followed by whitespaces, only then it needs to be terminated
-    for (int i = semiColonIndex + 1; i < sqlLength && stripSemiColon; i++) {
-      stripSemiColon = Character.isWhitespace(sql.charAt(i));
+    // Terminate the semicolon only if the last character of the query is semicolon
+    if (sql.charAt(sqlLength - 1) == ';') {
+      return sql.substring(0, sqlLength - 1);
     }
-    return stripSemiColon ? sql.substring(0, semiColonIndex) : sql;
+    return sql;
   }
 
   public static PinotQuery compileToPinotQuery(String sql)

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -2418,6 +2418,12 @@ public class CalciteSqlCompilerTest {
     pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1);
     Assert.assertTrue(pinotQuery.getQueryOptions().containsKey("skipUpsert"));
+
+    // Check for the query where the literal has semicolon
+    sql = "select col1, count(*) from foo where col1 = 'x;y' option(skipUpsert=true);";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1);
+    Assert.assertTrue(pinotQuery.getQueryOptions().containsKey("skipUpsert"));
   }
 
   @Test
@@ -2430,5 +2436,9 @@ public class CalciteSqlCompilerTest {
 
     Assert.expectThrows(SqlCompilationException.class,
             () -> CalciteSqlParser.compileToPinotQuery("SELECT col1, count(*) FROM foo GROUP BY ; col1"));
+
+    Assert.expectThrows(SqlCompilationException.class,
+            () -> CalciteSqlParser.compileToPinotQuery("SELECT col1, count(*) FROM foo GROUP BY col1; SELECT col2,"
+                    + "count(*) FROM foo GROUP BY col2"));
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -2405,6 +2405,13 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getIdentifier().getName(), "col1");
     Assert.assertEquals(pinotQuery.getSelectList().get(1).getIdentifier().getName(), "col2");
 
+    // Query having leading and trailing whitespaces
+    sql = "         SELECT col1, col2 FROM foo;             ";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    Assert.assertEquals(pinotQuery.getSelectListSize(), 2);
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getIdentifier().getName(), "col1");
+    Assert.assertEquals(pinotQuery.getSelectList().get(1).getIdentifier().getName(), "col2");
+
     sql = "SELECT col1, count(*) FROM foo group by col1;";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 2);
@@ -2437,8 +2444,14 @@ public class CalciteSqlCompilerTest {
     Assert.expectThrows(SqlCompilationException.class,
             () -> CalciteSqlParser.compileToPinotQuery("SELECT col1, count(*) FROM foo GROUP BY ; col1"));
 
+    // Query having multiple SQL statements
     Assert.expectThrows(SqlCompilationException.class,
             () -> CalciteSqlParser.compileToPinotQuery("SELECT col1, count(*) FROM foo GROUP BY col1; SELECT col2,"
                     + "count(*) FROM foo GROUP BY col2"));
+
+    // Query having multiple SQL statements with trailing and leading whitespaces
+    Assert.expectThrows(SqlCompilationException.class,
+            () -> CalciteSqlParser.compileToPinotQuery("        SELECT col1, count(*) FROM foo GROUP BY col1;   "
+                    + "SELECT col2, count(*) FROM foo GROUP BY col2             "));
   }
 }


### PR DESCRIPTION
## Description
Currently if we have a semicolon in the query, Pinot throws exception. However, semicolon are used in the SQL query to mark the termination of the query, and if a semicolon is present in the Pinot query exception shouldn't be thrown.
This PR implements the fix for the same

Issue Link: https://github.com/apache/pinot/issues/7713

