### PR TITLE
Fix JSON path expressions in SQL queries.

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -31,7 +31,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -1648,7 +1647,9 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         }
         break;
       default:
-        columnNameWithPathExpression = columnNameToCheck = splits[0];
+        columnNameToCheck = splits[0];
+        columnNameWithPathExpression = columnNameToCheck;
+        break;
     }
 
     if (columnNameMap != null) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1624,7 +1624,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     // as column name.
     String[] tableSplit = StringUtils.split(columnName, ".", 2);
     if (tableSplit.length == 2) {
-      if ( (isCaseInsensitive && rawTableName.equalsIgnoreCase(tableSplit[0])) || rawTableName.equals(tableSplit[0])) {
+      if ((isCaseInsensitive && rawTableName.equalsIgnoreCase(tableSplit[0])) || rawTableName.equals(tableSplit[0])) {
         columnName = tableSplit[1];
       }
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1622,7 +1622,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
     // If first part is a table name, then treat the second part as column name; otherwise, treat the entire identifier
     // as column name.
-    String actualColumnName = null;
+    String actualColumnName = columnName;
     String[] tableSplit = StringUtils.split(columnName, ".", 2);
     if (tableSplit.length == 2) {
       if ((isCaseInsensitive && rawTableName.equalsIgnoreCase(tableSplit[0])) || rawTableName.equals(tableSplit[0])) {
@@ -1644,7 +1644,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       actualColumnName = actualColumnName.toLowerCase();
     }
     if (columnNameMap != null) {
-      actualColumnName = columnNameMap.get(columnName);
+      actualColumnName = columnNameMap.get(actualColumnName);
       if (actualColumnName != null) {
         return pathExpression == null ? actualColumnName : actualColumnName + "." + pathExpression;
       }
@@ -1655,7 +1655,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         return actualAlias;
       }
     }
-    throw new BadQueryRequestException("Unknown column '" + columnName + "' in the query");
+    throw new BadQueryRequestException("Unknown columnName '" + columnName + "' found in the query");
   }
 
   private static Map<String, String> getOptionsFromJson(JsonNode request, String optionsKey) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1614,48 +1614,48 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
    * - Case-insensitive cluster
    * - Column name in the format of [table_name].[column_name]
    */
-  private static String getActualColumnName(String rawTableName, String columnName,
+  private static String getActualColumnName(String rawTableName, String sqlColumnName,
       @Nullable Map<String, String> columnNameMap, @Nullable Map<String, String> aliasMap, boolean isCaseInsensitive) {
-    if ("*".equals(columnName)) {
-      return columnName;
+    if ("*".equals(sqlColumnName)) {
+      return sqlColumnName;
     }
 
+    String columnName = sqlColumnName;
     // If first part is a table name, then treat the second part as column name; otherwise, treat the entire identifier
     // as column name.
-    String actualColumnName = columnName;
     String[] tableSplit = StringUtils.split(columnName, ".", 2);
     if (tableSplit.length == 2) {
       if ((isCaseInsensitive && rawTableName.equalsIgnoreCase(tableSplit[0])) || rawTableName.equals(tableSplit[0])) {
-        actualColumnName = tableSplit[1];
+        columnName = tableSplit[1];
       }
     }
 
     // Split again to check if the column name is suffixed by a path expression.
-    String[] columnSplit = StringUtils.split(actualColumnName, ".", 2);
+    String[] columnSplit = StringUtils.split(columnName, ".", 2);
     String pathExpression = null;
     if (columnSplit.length == 2) {
       // Column name is suffixed by a path expression.
-      actualColumnName = columnSplit[0];
+      columnName = columnSplit[0];
       pathExpression = columnSplit[1];
     }
 
     if (isCaseInsensitive) {
       // Adjust column name for case insensitivity.
-      actualColumnName = actualColumnName.toLowerCase();
+      columnName = columnName.toLowerCase();
     }
     if (columnNameMap != null) {
-      actualColumnName = columnNameMap.get(actualColumnName);
+      String actualColumnName = columnNameMap.get(columnName);
       if (actualColumnName != null) {
         return pathExpression == null ? actualColumnName : actualColumnName + "." + pathExpression;
       }
     }
     if (aliasMap != null) {
-      String actualAlias = aliasMap.get(actualColumnName);
+      String actualAlias = aliasMap.get(columnName);
       if (actualAlias != null) {
         return actualAlias;
       }
     }
-    throw new BadQueryRequestException("Unknown columnName '" + columnName + "' found in the query");
+    throw new BadQueryRequestException("Unknown columnName '" + sqlColumnName + "' found in the query");
   }
 
   private static Map<String, String> getOptionsFromJson(JsonNode request, String optionsKey) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1622,39 +1622,40 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
     // If first part is a table name, then treat the second part as column name; otherwise, treat the entire identifier
     // as column name.
+    String actualColumnName = null;
     String[] tableSplit = StringUtils.split(columnName, ".", 2);
     if (tableSplit.length == 2) {
       if ((isCaseInsensitive && rawTableName.equalsIgnoreCase(tableSplit[0])) || rawTableName.equals(tableSplit[0])) {
-        columnName = tableSplit[1];
+        actualColumnName = tableSplit[1];
       }
     }
 
     // Split again to check if the column name is suffixed by a path expression.
-    String[] columnSplit = StringUtils.split(columnName, ".", 2);
+    String[] columnSplit = StringUtils.split(actualColumnName, ".", 2);
     String pathExpression = null;
     if (columnSplit.length == 2) {
       // Column name is suffixed by a path expression.
-      columnName = columnSplit[0];
+      actualColumnName = columnSplit[0];
       pathExpression = columnSplit[1];
     }
 
     if (isCaseInsensitive) {
       // Adjust column name for case insensitivity.
-      columnName = columnName.toLowerCase();
+      actualColumnName = actualColumnName.toLowerCase();
     }
     if (columnNameMap != null) {
-      String actualColumnName = columnNameMap.get(columnName);
+      actualColumnName = columnNameMap.get(columnName);
       if (actualColumnName != null) {
         return pathExpression == null ? actualColumnName : actualColumnName + "." + pathExpression;
       }
     }
     if (aliasMap != null) {
-      String actualAlias = aliasMap.get(columnName);
+      String actualAlias = aliasMap.get(actualColumnName);
       if (actualAlias != null) {
         return actualAlias;
       }
     }
-    throw new BadQueryRequestException("Unknown columnName '" + columnName + "' found in the query");
+    throw new BadQueryRequestException("Unknown column '" + columnName + "' in the query");
   }
 
   private static Map<String, String> getOptionsFromJson(JsonNode request, String optionsKey) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1647,7 +1647,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         }
         break;
       default:
-        columnNameToCheck = splits[0];
+        columnNameToCheck = isCaseInsensitive ? splits[0].toLowerCase() : splits[0];
         columnNameWithPathExpression = columnNameToCheck;
         break;
     }

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/ArrayAwareJacksonJsonProviderTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/ArrayAwareJacksonJsonProviderTest.java
@@ -59,7 +59,7 @@ public class ArrayAwareJacksonJsonProviderTest {
     }
   }
 
-  @Test
+  //@Test
   public void testGetArrayIndex() {
     JsonFunctions.ArrayAwareJacksonJsonProvider jp = new JsonFunctions.ArrayAwareJacksonJsonProvider();
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/ArrayAwareJacksonJsonProviderTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/ArrayAwareJacksonJsonProviderTest.java
@@ -59,7 +59,7 @@ public class ArrayAwareJacksonJsonProviderTest {
     }
   }
 
-  //@Test
+  @Test
   public void testGetArrayIndex() {
     JsonFunctions.ArrayAwareJacksonJsonProvider jp = new JsonFunctions.ArrayAwareJacksonJsonProvider();
 

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
@@ -307,6 +307,16 @@ public class ClusterIntegrationTestUtils {
     TarGzCompressionUtils.createTarGzFile(indexDir, segmentTarFile);
   }
 
+  /**
+   * Builds one Pinot segment from the given records.
+   *
+   * @param records records that will go in the segment.
+   * @param tableConfig Pinot table config
+   * @param schema Pinot schema
+   * @param segmentIndex Segment index number
+   * @param segmentDir Output directory for the un-tarred segments
+   * @param tarDir Output directory for the tarred segments
+   */
   public static void buildSegmentFromRows(List<GenericRow> records, TableConfig tableConfig,
       org.apache.pinot.spi.data.Schema schema, int segmentIndex, File segmentDir, File tarDir)
       throws Exception {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/JSONClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/JSONClusterIntegrationTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.integration.tests;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/JSONClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/JSONClusterIntegrationTest.java
@@ -1,0 +1,147 @@
+package org.apache.pinot.integration.tests;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.util.TestUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class JSONClusterIntegrationTest extends BaseClusterIntegrationTest {
+
+  private static final String INT_COLUMN = "intColumn";
+  private static final String LONG_COLUMN = "longColumn";
+  private static final String STRING_COLUMN = "stringColumn";
+  private static final String JSON_COLUMN = "jsonColumn";
+  private static final String JSON_COLUMN_WITHOUT_INDEX = "jsonColumnWithoutIndex";
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+
+    // Start the Pinot cluster
+    startZk();
+    startController();
+    startBroker();
+    startServer();
+
+    // Create and upload the schema and table config
+    String rawTableName = getTableName();
+
+    Schema schema = new Schema.SchemaBuilder().setSchemaName(rawTableName)
+        .addSingleValueDimension(INT_COLUMN, FieldSpec.DataType.INT)
+        .addSingleValueDimension(LONG_COLUMN, FieldSpec.DataType.LONG)
+        .addSingleValueDimension(STRING_COLUMN, FieldSpec.DataType.STRING)
+        .addSingleValueDimension(JSON_COLUMN, FieldSpec.DataType.JSON)
+        .addSingleValueDimension(JSON_COLUMN_WITHOUT_INDEX, FieldSpec.DataType.JSON).build();
+    addSchema(schema);
+
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName)
+            .setJsonIndexColumns(Collections.singletonList(JSON_COLUMN)).build();
+
+    addTableConfig(tableConfig);
+
+    // Create and upload segments
+    ClusterIntegrationTestUtils.buildSegmentFromRows(getRecords(), tableConfig, schema, 0, _segmentDir, _tarDir);
+    uploadSegments(rawTableName, _tarDir);
+
+    // Wait for all documents loaded
+    waitForAllDocsLoaded(60_000);
+  }
+
+  protected long getCountStarResult() {
+    return 15;
+  }
+
+  private static List<GenericRow> getRecords() {
+    List<GenericRow> records = new ArrayList<>();
+    records.add(createRecord(1, 1, "daffy duck",
+        "{\"name\": {\"first\": \"daffy\", \"last\": \"duck\"}, \"id\": 101, \"data\": [\"a\", \"b\", \"c\", \"d\"]}"));
+    records.add(createRecord(2, 2, "mickey mouse",
+        "{\"name\": {\"first\": \"mickey\", \"last\": \"mouse\"}, \"id\": 111, \"data\": [\"e\", \"b\", \"c\", "
+            + "\"d\"]}"));
+    records.add(createRecord(3, 3, "donald duck",
+        "{\"name\": {\"first\": \"donald\", \"last\": \"duck\"}, \"id\": 121, \"data\": [\"f\", \"b\", \"c\", "
+            + "\"d\"]}"));
+    records.add(createRecord(4, 4, "scrooge mcduck",
+        "{\"name\": {\"first\": \"scrooge\", \"last\": \"mcduck\"}, \"id\": 131, \"data\": [\"g\", \"b\", \"c\", "
+            + "\"d\"]}"));
+    records.add(createRecord(5, 5, "minnie mouse",
+        "{\"name\": {\"first\": \"minnie\", \"last\": \"mouse\"}, \"id\": 141, \"data\": [\"h\", \"b\", \"c\", "
+            + "\"d\"]}"));
+    records.add(createRecord(6, 6, "daisy duck",
+        "{\"name\": {\"first\": \"daisy\", \"last\": \"duck\"}, \"id\": 161.5, \"data\": [\"i\", \"b\", \"c\", "
+            + "\"d\"]}"));
+    records.add(createRecord(7, 7, "pluto dog",
+        "{\"name\": {\"first\": \"pluto\", \"last\": \"dog\"}, \"id\": 161, \"data\": [\"j\", \"b\", \"c\", \"d\"]}"));
+    records.add(createRecord(8, 8, "goofy dwag",
+        "{\"name\": {\"first\": \"goofy\", \"last\": \"dwag\"}, \"id\": 171, \"data\": [\"k\", \"b\", \"c\", \"d\"]}"));
+    records.add(createRecord(9, 9, "ludwik von drake",
+        "{\"name\": {\"first\": \"ludwik\", \"last\": \"von drake\"}, \"id\": 181, \"data\": [\"l\", \"b\", \"c\", "
+            + "\"d\"]}"));
+    records.add(createRecord(10, 10, "nested array",
+        "{\"name\":{\"first\":\"nested\",\"last\":\"array\"},\"id\":111,\"data\":[{\"e\":[{\"x\":[{\"i1\":1,"
+            + "\"i2\":2}]},{\"y\":[{\"i1\":1,\"i2\":2}]},{\"z\":[{\"i1\":1,\"i2\":2}]}]},{\"b\":[{\"x\":[{\"i1\":1,"
+            + "\"i2\":2}]},{\"y\":[{\"i1\":1,\"i2\":2}]},{\"z\":[{\"i1\":10,\"i2\":20}]}]}]}"));
+    records.add(createRecord(11, 11, "multi-dimensional-1 array",
+        "{\"name\": {\"first\": \"multi-dimensional-1\",\"last\": \"array\"},\"id\": 111,\"data\": [[[1,2],[3,4]],"
+            + "[[\"a\",\"b\"],[\"c\",\"d\"]]]}"));
+    records.add(createRecord(12, 12, "multi-dimensional-2 array",
+        "{\"name\": {\"first\": \"multi-dimensional-2\",\"last\": \"array\"},\"id\": 111,\"data\": [[[1,2],[3,4]],"
+            + "[[\"a\",\"b\"],[\"c\",\"d\"]]]}"));
+    records.add(createRecord(13, 13, "multi-dimensional-1 array",
+        "{\"name\": {\"first\": \"multi-dimensional-1\",\"last\": \"array\"},\"id\": 111,\"data\": [[[1,2],[3,4]],"
+            + "[[\"a\",\"b\"],[\"c\",\"d\"]]]}"));
+    records.add(createRecord(13, 13, "days",
+        "{\"name\": {\"first\": \"multi-dimensional-1\",\"last\": \"array\"},\"days\": 111}"));
+    records.add(createRecord(14, 14, "top level array", "[{\"i1\":1,\"i2\":2}, {\"i1\":3,\"i2\":4}]"));
+
+    return records;
+  }
+
+  private static GenericRow createRecord(int intValue, long longValue, String stringValue, String jsonValue) {
+    GenericRow record = new GenericRow();
+    record.putValue(INT_COLUMN, intValue);
+    record.putValue(LONG_COLUMN, longValue);
+    record.putValue(STRING_COLUMN, stringValue);
+    record.putValue(JSON_COLUMN, jsonValue);
+    record.putValue(JSON_COLUMN_WITHOUT_INDEX, jsonValue);
+
+    return record;
+  }
+
+  @Test
+  public void testPathExpressionQueries()
+      throws Exception {
+    JsonNode queryResponse = postSqlQuery(
+        "SELECT jsonColumn.name.first, jsonColumn.data[1] FROM mytable WHERE " + "jsonColumn.name.last = 'duck'");
+    Assert.assertEquals(queryResponse.get("resultTable").get("rows").toString(),
+        "[[\"daffy\",\"b\"],[\"donald\",\"b\"],[\"daisy\",\"b\"]]");
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws Exception {
+    dropOfflineTable(getTableName());
+
+    stopServer();
+    stopBroker();
+    stopController();
+    stopZk();
+
+    FileUtils.deleteDirectory(_tempDir);
+  }
+}


### PR DESCRIPTION
## Description
PR #7590 introduced a regression that caused JSON path expressions in queries to stop working. This PR fixes the regression and adds an integration test that would catch such regressions in future.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
