### PR TITLE
JSON indexing adapter

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/DefaultJsonIndexer.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/DefaultJsonIndexer.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index.creator;
+
+import java.io.IOException;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
+
+
+/**
+ * A JSON indexer which just assumes the forward index contains JSON.
+ * {@see JsonIndexer}
+ */
+public final class DefaultJsonIndexer implements JsonIndexer {
+
+  @Override
+  public <T extends ForwardIndexReaderContext> void index(int numDocs, ForwardIndexReader<T> source,
+      JsonIndexCreator target)
+      throws IOException {
+    try (T context = source.createContext()) {
+      for (int docId = 0; docId < numDocs; docId++) {
+        target.add(source.getString(docId, context));
+      }
+    }
+    target.seal();
+  }
+
+  @Override
+  public <T extends ForwardIndexReaderContext> void index(int numDocs, Dictionary dictionary,
+      ForwardIndexReader<T> source, JsonIndexCreator target)
+      throws IOException {
+    try (T context = source.createContext()) {
+      for (int docId = 0; docId < numDocs; docId++) {
+        target.add(dictionary.getStringValue(source.getDictId(docId, context)));
+      }
+    }
+    target.seal();
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/JsonIndexCreator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/JsonIndexCreator.java
@@ -29,7 +29,39 @@ public interface JsonIndexCreator extends Closeable {
   char KEY_VALUE_SEPARATOR = '\0';
 
   /**
-   * Adds the next json value.
+   * To be invoked once before each physical JSON document when streaming JSON into the index
+   * @param numFlattenedDocs the number of flattened documents to be streamed into the index
+   */
+  default void startDocument(int numFlattenedDocs) {
+  }
+
+  /**
+   * To be invoked after each JSON document when streaming JSON into the index.
+   */
+  default void endDocument() {
+  }
+
+  /**
+   * To be invoked once before each flattened document when streaming JSON into the index
+   */
+  default void startFlattenedDocument() {
+  }
+
+  /**
+   * To be invoked once after each flattened JSON document when streaming JSON into the index
+   */
+  default void endFlattenedDocument() {
+  }
+
+  /**
+   * Stream JSON fragments into the index.
+   * @param path the full path
+   * @param value the value
+   */
+  void add(String path, String value);
+
+  /**
+   * Adds a json value
    */
   void add(String jsonString)
       throws IOException;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/JsonIndexer.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/JsonIndexer.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index.creator;
+
+import java.io.IOException;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
+
+
+/**
+ * Pluggable interface to mediate between different JSON storage structures
+ * andJSON indexing.
+ */
+public interface JsonIndexer {
+  /**
+   * Abstracts the process of creating a JSON index from a forward index,
+   * meaning that the forward index need not be literally JSON to be indexed
+   * as such.
+   * @param numDocs the number of docs to read from the forward index.
+   * @param source the forward index
+   * @param target the JSON index creator
+   */
+  <T extends ForwardIndexReaderContext> void index(int numDocs, ForwardIndexReader<T> source, JsonIndexCreator target)
+      throws IOException;
+
+  /**
+   * Abstracts the process of creating a JSON index from a forward index,
+   * meaning that the forward index need not be literally JSON to be indexed
+   * as such.
+   * @param numDocs the number of docs to read from the forward index.
+   * @param source the forward index
+   * @param target the JSON index creator
+   */
+  <T extends ForwardIndexReaderContext> void index(int numDocs, Dictionary dictionary, ForwardIndexReader<T> source,
+      JsonIndexCreator target)
+      throws IOException;
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/JsonIndexers.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/JsonIndexers.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index.creator;
+
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+
+/**
+ * Registration point to allow overriding of JsonIndexing
+ */
+public final class JsonIndexers {
+
+  private JsonIndexers() {
+  }
+
+  private static final DefaultJsonIndexer DEFAULT_JSON_INDEXER = new DefaultJsonIndexer();
+  private static final Function<JsonIndexer, JsonIndexer> DEFAULT = Function.identity();
+  private static final AtomicReference<Function<JsonIndexer, JsonIndexer>> REGISTERED = new AtomicReference<>(DEFAULT);
+
+  /**
+   * Register a decorator which gets wraps the default JSON indexer so that it can intercept requests to
+   * index JSON columns.
+   * @param decorator wraps a JsonIndexer to create a new JsonIndexer with extra capabilities.
+   * @return false if a decorator has already been registered.
+   */
+  public static boolean registerDecorator(Function<JsonIndexer, JsonIndexer> decorator) {
+    return REGISTERED.compareAndSet(DEFAULT, decorator);
+  }
+
+  public static JsonIndexer newJsonIndexer() {
+    return Holder.DECORATOR.apply(DEFAULT_JSON_INDEXER);
+  }
+
+  static final class Holder {
+    public static final Function<JsonIndexer, JsonIndexer> DECORATOR = JsonIndexers.REGISTERED.get();
+  }
+}


### PR DESCRIPTION
This makes the process of indexing JSON documents in a forward index pluggable, so the forward index doesn't need to store the documents as strings.