### PR TITLE
BUG FIX: semaphore issue in consuming segments

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1310,102 +1310,110 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       _segmentLogger.error(errorMsg);
       throw new RuntimeException(errorMsg + " for segment: " + _segmentNameStr);
     }
-    makeStreamConsumer("Starting");
-    makeStreamMetadataProvider("Starting");
 
-    SegmentPartitionConfig segmentPartitionConfig = indexingConfig.getSegmentPartitionConfig();
-    if (segmentPartitionConfig != null) {
-      Map<String, ColumnPartitionConfig> columnPartitionMap = segmentPartitionConfig.getColumnPartitionMap();
-      if (columnPartitionMap.size() == 1) {
-        Map.Entry<String, ColumnPartitionConfig> entry = columnPartitionMap.entrySet().iterator().next();
-        String partitionColumn = entry.getKey();
-        ColumnPartitionConfig columnPartitionConfig = entry.getValue();
-        String partitionFunctionName = columnPartitionConfig.getFunctionName();
+    try {
+      makeStreamConsumer("Starting");
+      makeStreamMetadataProvider("Starting");
 
-        // NOTE: Here we compare the number of partitions from the config and the stream, and log a warning and emit a
-        //       metric when they don't match, but use the one from the stream. The mismatch could happen when the
-        //       stream partitions are changed, but the table config has not been updated to reflect the change. In such
-        //       case, picking the number of partitions from the stream can keep the segment properly partitioned as
-        //       long as the partition function is not changed.
-        int numPartitions = columnPartitionConfig.getNumPartitions();
-        try {
-          // TODO: currentPartitionGroupConsumptionStatus should be fetched from idealState + segmentZkMetadata,
-          //  so that we get back accurate partitionGroups info
-          //  However this is not an issue for Kafka, since partitionGroups never expire and every partitionGroup has
-          //  a single partition
-          //  Fix this before opening support for partitioning in Kinesis
-          int numPartitionGroups = _streamMetadataProvider
-              .computePartitionGroupMetadata(_clientId, _partitionLevelStreamConfig,
-                  Collections.emptyList(), /*maxWaitTimeMs=*/5000).size();
+      SegmentPartitionConfig segmentPartitionConfig = indexingConfig.getSegmentPartitionConfig();
+      if (segmentPartitionConfig != null) {
+        Map<String, ColumnPartitionConfig> columnPartitionMap = segmentPartitionConfig.getColumnPartitionMap();
+        if (columnPartitionMap.size() == 1) {
+          Map.Entry<String, ColumnPartitionConfig> entry = columnPartitionMap.entrySet().iterator().next();
+          String partitionColumn = entry.getKey();
+          ColumnPartitionConfig columnPartitionConfig = entry.getValue();
+          String partitionFunctionName = columnPartitionConfig.getFunctionName();
 
-          if (numPartitionGroups != numPartitions) {
-            _segmentLogger.warn(
-                "Number of stream partitions: {} does not match number of partitions in the partition config: {}, "
-                    + "using number of stream " + "partitions", numPartitionGroups, numPartitions);
-            _serverMetrics.addMeteredTableValue(_tableNameWithType, ServerMeter.REALTIME_PARTITION_MISMATCH, 1);
-            numPartitions = numPartitionGroups;
+          // NOTE: Here we compare the number of partitions from the config and the stream, and log a warning and emit a
+          //       metric when they don't match, but use the one from the stream. The mismatch could happen when the
+          //       stream partitions are changed, but the table config has not been updated to reflect the change.
+          //       In such case, picking the number of partitions from the stream can keep the segment properly
+          //       partitioned as long as the partition function is not changed.
+          int numPartitions = columnPartitionConfig.getNumPartitions();
+          try {
+            // TODO: currentPartitionGroupConsumptionStatus should be fetched from idealState + segmentZkMetadata,
+            //  so that we get back accurate partitionGroups info
+            //  However this is not an issue for Kafka, since partitionGroups never expire and every partitionGroup has
+            //  a single partition
+            //  Fix this before opening support for partitioning in Kinesis
+            int numPartitionGroups = _streamMetadataProvider
+                .computePartitionGroupMetadata(_clientId, _partitionLevelStreamConfig,
+                    Collections.emptyList(), /*maxWaitTimeMs=*/5000).size();
+
+            if (numPartitionGroups != numPartitions) {
+              _segmentLogger.warn(
+                  "Number of stream partitions: {} does not match number of partitions in the partition config: {}, "
+                      + "using number of stream " + "partitions", numPartitionGroups, numPartitions);
+              _serverMetrics.addMeteredTableValue(_tableNameWithType, ServerMeter.REALTIME_PARTITION_MISMATCH, 1);
+              numPartitions = numPartitionGroups;
+            }
+          } catch (Exception e) {
+            _segmentLogger.warn("Failed to get number of stream partitions in 5s, "
+                + "using number of partitions in the partition config: {}", numPartitions, e);
+            makeStreamMetadataProvider("Timeout getting number of stream partitions");
           }
-        } catch (Exception e) {
-          _segmentLogger.warn(
-              "Failed to get number of stream partitions in 5s, using number of partitions in the partition config: {}",
-              numPartitions, e);
-          makeStreamMetadataProvider("Timeout getting number of stream partitions");
+
+          realtimeSegmentConfigBuilder.setPartitionColumn(partitionColumn);
+          realtimeSegmentConfigBuilder.setPartitionFunction(
+              PartitionFunctionFactory.getPartitionFunction(partitionFunctionName, numPartitions));
+          realtimeSegmentConfigBuilder.setPartitionId(_partitionGroupId);
+        } else {
+          _segmentLogger.warn("Cannot partition on multiple columns: {}", columnPartitionMap.keySet());
         }
-
-        realtimeSegmentConfigBuilder.setPartitionColumn(partitionColumn);
-        realtimeSegmentConfigBuilder
-            .setPartitionFunction(PartitionFunctionFactory.getPartitionFunction(partitionFunctionName, numPartitions));
-        realtimeSegmentConfigBuilder.setPartitionId(_partitionGroupId);
-      } else {
-        _segmentLogger.warn("Cannot partition on multiple columns: {}", columnPartitionMap.keySet());
       }
-    }
 
-    _realtimeSegment = new MutableSegmentImpl(realtimeSegmentConfigBuilder.build(), serverMetrics);
-    _startOffset = _streamPartitionMsgOffsetFactory.create(_segmentZKMetadata.getStartOffset());
-    _currentOffset = _streamPartitionMsgOffsetFactory.create(_startOffset);
-    _resourceTmpDir = new File(resourceDataDir, "_tmp");
-    if (!_resourceTmpDir.exists()) {
-      _resourceTmpDir.mkdirs();
-    }
-    _state = State.INITIAL_CONSUMING;
+      _realtimeSegment = new MutableSegmentImpl(realtimeSegmentConfigBuilder.build(), serverMetrics);
+      _startOffset = _streamPartitionMsgOffsetFactory.create(_segmentZKMetadata.getStartOffset());
+      _currentOffset = _streamPartitionMsgOffsetFactory.create(_startOffset);
+      _resourceTmpDir = new File(resourceDataDir, "_tmp");
+      if (!_resourceTmpDir.exists()) {
+        _resourceTmpDir.mkdirs();
+      }
+      _state = State.INITIAL_CONSUMING;
 
-    // fetch latest stream offset
-    try (StreamMetadataProvider metadataProvider = _streamConsumerFactory
-        .createPartitionMetadataProvider(_clientId, _partitionGroupId)) {
-      _latestStreamOffsetAtStartupTime = metadataProvider
-          .fetchStreamPartitionOffset(OffsetCriteria.LARGEST_OFFSET_CRITERIA, /*maxWaitTimeMs*/5000);
+      // fetch latest stream offset
+      try (StreamMetadataProvider metadataProvider = _streamConsumerFactory
+          .createPartitionMetadataProvider(_clientId, _partitionGroupId)) {
+        _latestStreamOffsetAtStartupTime =
+            metadataProvider.fetchStreamPartitionOffset(OffsetCriteria.LARGEST_OFFSET_CRITERIA, /*maxWaitTimeMs*/5000);
+      } catch (Exception e) {
+        _segmentLogger.warn("Cannot fetch latest stream offset for clientId {} and partitionGroupId {}", _clientId,
+            _partitionGroupId);
+      }
+
+      long now = now();
+      _consumeStartTime = now;
+      long maxConsumeTimeMillis = _partitionLevelStreamConfig.getFlushThresholdTimeMillis();
+      _consumeEndTime = segmentZKMetadata.getCreationTime() + maxConsumeTimeMillis;
+
+      // When we restart a server, the consuming segments retain their creationTime (derived from segment
+      // metadata), but a couple of corner cases can happen:
+      // (1) The server was down for a very long time, and the consuming segment is not yet completed.
+      // (2) The consuming segment was just about to be completed, but the server went down.
+      // In either of these two cases, if a different replica could not complete the segment, it is possible
+      // that we get a value for _consumeEndTime that is in the very near future, or even in the past. In such
+      // cases, we let some minimum consumption happen before we attempt to complete the segment (unless, of course
+      // the max consumption time has been configured to be less than the minimum time we use in this class).
+      long minConsumeTimeMillis =
+          Math.min(maxConsumeTimeMillis, TimeUnit.MILLISECONDS.convert(MINIMUM_CONSUME_TIME_MINUTES, TimeUnit.MINUTES));
+      if (_consumeEndTime - now < minConsumeTimeMillis) {
+        _consumeEndTime = now + minConsumeTimeMillis;
+      }
+
+      _segmentCommitterFactory =
+          new SegmentCommitterFactory(_segmentLogger, _protocolHandler, tableConfig, indexLoadingConfig, serverMetrics);
+
+      _segmentLogger
+          .info("Starting consumption on realtime consuming segment {} maxRowCount {} maxEndTime {}", _llcSegmentName,
+              _segmentMaxRowCount, new DateTime(_consumeEndTime, DateTimeZone.UTC).toString());
+      start();
     } catch (Exception e) {
-      _segmentLogger.warn("Cannot fetch latest stream offset for clientId {} and partitionGroupId {}", _clientId,
-          _partitionGroupId);
+      // In case of exception thrown here, segment goes to ERROR state. Then any attempt to reset the segment from
+      // ERROR -> OFFLINE -> CONSUMING via Helix Admin fails because the semaphore is acquired, but not released.
+      // Hence releasing the semaphore here to unblock reset operation via Helix Admin.
+      _partitionGroupConsumerSemaphore.release();
+      throw e;
     }
-
-    long now = now();
-    _consumeStartTime = now;
-    long maxConsumeTimeMillis = _partitionLevelStreamConfig.getFlushThresholdTimeMillis();
-    _consumeEndTime = segmentZKMetadata.getCreationTime() + maxConsumeTimeMillis;
-
-    // When we restart a server, the consuming segments retain their creationTime (derived from segment
-    // metadata), but a couple of corner cases can happen:
-    // (1) The server was down for a very long time, and the consuming segment is not yet completed.
-    // (2) The consuming segment was just about to be completed, but the server went down.
-    // In either of these two cases, if a different replica could not complete the segment, it is possible
-    // that we get a value for _consumeEndTime that is in the very near future, or even in the past. In such
-    // cases, we let some minimum consumption happen before we attempt to complete the segment (unless, of course
-    // the max consumption time has been configured to be less than the minimum time we use in this class).
-    long minConsumeTimeMillis =
-        Math.min(maxConsumeTimeMillis, TimeUnit.MILLISECONDS.convert(MINIMUM_CONSUME_TIME_MINUTES, TimeUnit.MINUTES));
-    if (_consumeEndTime - now < minConsumeTimeMillis) {
-      _consumeEndTime = now + minConsumeTimeMillis;
-    }
-
-    _segmentCommitterFactory =
-        new SegmentCommitterFactory(_segmentLogger, _protocolHandler, tableConfig, indexLoadingConfig, serverMetrics);
-
-    _segmentLogger
-        .info("Starting consumption on realtime consuming segment {} maxRowCount {} maxEndTime {}", _llcSegmentName,
-            _segmentMaxRowCount, new DateTime(_consumeEndTime, DateTimeZone.UTC).toString());
-    start();
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -345,9 +345,10 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
             new LLRealtimeSegmentDataManager(segmentZKMetadata, tableConfig, this, _indexDir.getAbsolutePath(),
                 indexLoadingConfig, schema, llcSegmentName, semaphore, _serverMetrics, partitionUpsertMetadataManager);
       } catch (Exception e) {
-        // In case of exception thrown here, segment goes to ERROR state. Then any attempt to manually reset the segment
-        // from ERROR state to OFFLINE state via Helix Admin fails because the semaphore never gets released. Hence
-        // releasing the semaphore here to unblock Helix Admin for manually reset operation.
+        // In case of exception thrown here, segment goes to ERROR state. Then any attempt to reset the segment from
+        // ERROR -> OFFLINE -> CONSUMING via Helix Admin fails because the semaphore never gets released and the
+        // semaphore.acquire() is called in constructor of LLRealtimeSegmentDataManager. Hence releasing the semaphore
+        // here to unblock reset operation via Helix Admin.
         semaphore.release();
         throw e;
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -340,18 +340,9 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       PartitionUpsertMetadataManager partitionUpsertMetadataManager =
           _tableUpsertMetadataManager != null ? _tableUpsertMetadataManager
               .getOrCreatePartitionManager(partitionGroupId) : null;
-      try {
-        segmentDataManager =
-            new LLRealtimeSegmentDataManager(segmentZKMetadata, tableConfig, this, _indexDir.getAbsolutePath(),
-                indexLoadingConfig, schema, llcSegmentName, semaphore, _serverMetrics, partitionUpsertMetadataManager);
-      } catch (Exception e) {
-        // In case of exception thrown here, segment goes to ERROR state. Then any attempt to reset the segment from
-        // ERROR -> OFFLINE -> CONSUMING via Helix Admin fails because the semaphore never gets released and the
-        // semaphore.acquire() is called in constructor of LLRealtimeSegmentDataManager. Hence releasing the semaphore
-        // here to unblock reset operation via Helix Admin.
-        semaphore.release();
-        throw e;
-      }
+      segmentDataManager =
+          new LLRealtimeSegmentDataManager(segmentZKMetadata, tableConfig, this, _indexDir.getAbsolutePath(),
+              indexLoadingConfig, schema, llcSegmentName, semaphore, _serverMetrics, partitionUpsertMetadataManager);
     } else {
       InstanceZKMetadata instanceZKMetadata = ZKMetadataProvider.getInstanceZKMetadata(_propertyStore, _instanceId);
       segmentDataManager = new HLRealtimeSegmentDataManager(segmentZKMetadata, tableConfig, instanceZKMetadata, this,

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -857,7 +857,7 @@ public class LLRealtimeSegmentDataManagerTest {
     }
 
     @Override
-    protected void start() {
+    protected void startConsumerThread() {
       // Do nothing.
     }
 


### PR DESCRIPTION
## Description
If any error happens during object creation of `LLRealtimeSegmentDataManager`, the segment goes to ERROR state in External View and any attempt via Helix Admin cannot reset the segment from `ERROR -> OFFLINE -> CONSUMING`. That's because the associated semaphore of the segment never gets released in case of exception and semaphore.acquire() is called in constructor of LLRealtimeSegmentDataManager. That means OFFLINE -> CONSUMING will always fail.
The fix is to release the semaphore if an exception is thrown in creation of LLRealtimeSegmentDataManager.
[This PR fixes the problems mentioned in #7874]
## Testing Done
On my local machine, changed the behavior of LLRealtimeSegmentDataManager to throw exception only when gets called for the first time. Then ran `LLCRealtimeClusterIntegrationTest` and verified the segment went to ERROR state in External View. Then using Swagger, called `/segments/<tableName>/<segmentName>/reset` REST endpoint and verified that segment state turned to OFFLINE. Without the fix, transition from OFFLINE to CONSUMING failed in acquiring semaphore. With the fix, the segment successfully went from OFFLINE to CONSUMING.