### PR TITLE
update log4j 2 to avoid CVE-2021-44228

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -345,10 +345,10 @@ org.apache.httpcomponents:httpmime:4.5.3
 org.apache.kafka:kafka-clients:2.0.0
 org.apache.kafka:kafka_2.10:0.9.0.1
 org.apache.kafka:kafka_2.11:2.0.0
-org.apache.logging.log4j:log4j-1.2-api:2.11.2
-org.apache.logging.log4j:log4j-api:2.11.2
-org.apache.logging.log4j:log4j-core:2.11.2
-org.apache.logging.log4j:log4j-slf4j-impl:2.11.2
+org.apache.logging.log4j:log4j-1.2-api:2.15.0
+org.apache.logging.log4j:log4j-api:2.15.0
+org.apache.logging.log4j:log4j-core:2.15.0
+org.apache.logging.log4j:log4j-slf4j-impl:2.15.0
 org.apache.lucene:lucene-analyzers-common:8.2.0
 org.apache.lucene:lucene-core:8.2.0
 org.apache.lucene:lucene-queries:8.2.0

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <snappy-java.version>1.1.1.7</snappy-java.version>
     <zstd-jni.version>1.4.9-5</zstd-jni.version>
     <lz4-java.version>1.7.1</lz4-java.version>
-    <log4j.version>2.11.2</log4j.version>
+    <log4j.version>2.15.0</log4j.version>
     <netty.version>4.1.54.Final</netty.version>
     <netty-tcnative.version>2.0.36.Final</netty-tcnative.version>
     <reactivestreams.version>1.0.3</reactivestreams.version>


### PR DESCRIPTION
[CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228) was announced this morning affecting log4j 2 until 2.15.0. I verified that there are no transitive dependencies on older versions of log4j 2:

```
mvn dependency:tree | grep log4j                
[INFO] +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:compile
[INFO] |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:compile
[INFO] |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:runtime
[INFO] +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:compile
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:compile
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:compile
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:runtime
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:compile
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:compile
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:compile
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:runtime
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:compile
[INFO] +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:compile
[INFO] |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:compile
[INFO] |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:runtime
[INFO] +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:compile
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:compile
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:compile
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:runtime
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:compile
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:compile
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:compile
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:runtime
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:compile
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:compile
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:compile
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:runtime
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:compile
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:compile
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:compile
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:runtime
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:compile
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:compile
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:compile
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:runtime
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:compile
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:compile
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:compile
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:runtime
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:compile
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:compile
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:compile
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:runtime
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:compile
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO]    +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO]    |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO]    |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO]    +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO]    +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO]    |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO]    |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO]    +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:compile
[INFO] |  |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:compile
[INFO] |  |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:runtime
[INFO] |  |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:compile
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  |  \- log4j:log4j:jar:1.2.17:compile
[INFO] |  +- org.slf4j:slf4j-log4j12:jar:1.7.10:compile
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:compile
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:compile
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:runtime
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:compile
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided
[INFO] |     |  \- log4j:log4j:jar:1.2.17:provided
[INFO] |     +- org.slf4j:slf4j-log4j12:jar:1.7.10:provided
[INFO] |  +- org.apache.logging.log4j:log4j-slf4j-impl:jar:2.15.0:provided
[INFO] |  |  +- org.apache.logging.log4j:log4j-api:jar:2.15.0:provided
[INFO] |  |  \- org.apache.logging.log4j:log4j-core:jar:2.15.0:provided
[INFO] |  +- org.apache.logging.log4j:log4j-1.2-api:jar:2.15.0:provided

```