### PR TITLE
Update Helm Charts to honour readinessEnabled probes flags on the StatefulSets

### DIFF
--- a/kubernetes/helm/pinot/templates/broker/statefulset.yml
+++ b/kubernetes/helm/pinot/templates/broker/statefulset.yml
@@ -88,7 +88,7 @@ spec:
             path: {{ .Values.broker.probes.endpoint }}
             port: {{ .Values.broker.service.port }}
         {{- end }}
-        {{- if .Values.broker.probes.livenessEnabled }}
+        {{- if .Values.broker.probes.readinessEnabled }}
         readinessProbe:
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}

--- a/kubernetes/helm/pinot/templates/controller/statefulset.yaml
+++ b/kubernetes/helm/pinot/templates/controller/statefulset.yaml
@@ -80,7 +80,7 @@ spec:
             path: {{ .Values.controller.probes.endpoint }}
             port: {{ .Values.controller.service.port }}
         {{- end }}
-        {{- if .Values.controller.probes.livenessEnabled }}
+        {{- if .Values.controller.probes.readinessEnabled }}
         readinessProbe:
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}

--- a/kubernetes/helm/pinot/templates/minion/statefulset.yml
+++ b/kubernetes/helm/pinot/templates/minion/statefulset.yml
@@ -85,7 +85,7 @@ spec:
             path: {{ .Values.minion.probes.endpoint }}
             port: {{ .Values.minion.service.port }}
         {{- end }}
-        {{- if .Values.minion.probes.livenessEnabled }}
+        {{- if .Values.minion.probes.readinessEnabled }}
         readinessProbe:
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}

--- a/kubernetes/helm/pinot/templates/server/statefulset.yml
+++ b/kubernetes/helm/pinot/templates/server/statefulset.yml
@@ -88,7 +88,7 @@ spec:
             path: {{ .Values.server.probes.endpoint }}
             port: {{ .Values.server.service.adminPort }}
         {{- end }}
-        {{- if .Values.server.probes.livenessEnabled }}
+        {{- if .Values.server.probes.readinessEnabled }}
         readinessProbe:
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}


### PR DESCRIPTION
Update Helm Charts to honour readinessEnabled probes flags on the Controller, Broker, Server and Minion StatefulSet. Fixes #7890

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
