### PR TITLE
make buildSegmentInternal raise error out explicitly

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentGenerationException.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentGenerationException.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager.realtime;
+
+/**
+ * Exception specifically used to capture and rethrow during segment generation.
+ */
+public class SegmentGenerationException extends Exception {
+
+  public SegmentGenerationException(String msg, Exception cause) {
+    super(msg, cause);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -901,9 +901,8 @@ public class LLRealtimeSegmentDataManagerTest {
     }
 
     @Override
-    protected boolean buildSegmentAndReplace() {
+    protected void buildSegmentAndReplace() throws Exception {
       _buildAndReplaceCalled = true;
-      return true;
     }
 
     @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -835,7 +835,7 @@ public class LLRealtimeSegmentDataManagerTest {
       return consumer;
     }
 
-    public SegmentBuildDescriptor invokeBuildForCommit(long leaseTime) {
+    public SegmentBuildDescriptor invokeBuildForCommit(long leaseTime) throws Exception {
       super.buildSegmentForCommit(leaseTime);
       return getSegmentBuildDescriptor();
     }
@@ -902,13 +902,13 @@ public class LLRealtimeSegmentDataManagerTest {
 
     @Override
     protected void buildSegmentAndReplace()
-        throws Exception {
+        throws SegmentGenerationException {
       _buildAndReplaceCalled = true;
     }
 
     @Override
     protected SegmentBuildDescriptor buildSegmentInternal(boolean forCommit)
-        throws Exception {
+        throws SegmentGenerationException {
       _buildSegmentCalled = true;
       if (_failSegmentBuild) {
         return null;

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -901,12 +901,14 @@ public class LLRealtimeSegmentDataManagerTest {
     }
 
     @Override
-    protected void buildSegmentAndReplace() throws Exception {
+    protected void buildSegmentAndReplace()
+        throws Exception {
       _buildAndReplaceCalled = true;
     }
 
     @Override
-    protected SegmentBuildDescriptor buildSegmentInternal(boolean forCommit) {
+    protected SegmentBuildDescriptor buildSegmentInternal(boolean forCommit)
+        throws Exception {
       _buildSegmentCalled = true;
       if (_failSegmentBuild) {
         return null;


### PR DESCRIPTION
this fixes the issue when datamanager doesn't log segment error properly and shown to user. stacktrace basically only returns a null value and not useful for debugging.
