### PR TITLE
Shade a few dependencies in `pinot-spi` and `pinot-avro-base`

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-avro-base/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/pom.xml
@@ -76,6 +76,22 @@
                       <shadedPattern>shaded.com.google.common.base</shadedPattern>
                     </relocation>
                     <relocation>
+                      <pattern>com.google.common.cache</pattern>
+                      <shadedPattern>shaded.com.google.common.cache</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.apache.avro</pattern>
+                      <shadedPattern>shaded.org.apache.avro</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.apache.log4j</pattern>
+                      <shadedPattern>shaded.org.apache.log4j</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.apache.logging</pattern>
+                      <shadedPattern>shaded.org.apache.logging</shadedPattern>
+                    </relocation>
+                    <relocation>
                       <pattern>com.fasterxml.jackson</pattern>
                       <shadedPattern>shaded.com.fasterxml.jackson</shadedPattern>
                     </relocation>

--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -173,6 +173,22 @@
                       <shadedPattern>shaded.com.google.common.base</shadedPattern>
                     </relocation>
                     <relocation>
+                      <pattern>com.google.common.cache</pattern>
+                      <shadedPattern>shaded.com.google.common.cache</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.apache.avro</pattern>
+                      <shadedPattern>shaded.org.apache.avro</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.apache.log4j</pattern>
+                      <shadedPattern>shaded.org.apache.log4j</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.apache.logging</pattern>
+                      <shadedPattern>shaded.org.apache.logging</shadedPattern>
+                    </relocation>
+                    <relocation>
                       <pattern>com.fasterxml.jackson</pattern>
                       <shadedPattern>shaded.com.fasterxml.jackson</shadedPattern>
                     </relocation>


### PR DESCRIPTION
In this PR, a few dependencies are shaded in `pinot-spi` and `pinot-avro-base` modules, as we encounter version conflicts.