### PR TITLE
App assembler script should check that the correct delimiter is used for PLUGINS_DIR and PLUGINS_INCLUDE

### DIFF
--- a/pinot-tools/src/main/resources/appAssemblerScriptTemplate
+++ b/pinot-tools/src/main/resources/appAssemblerScriptTemplate
@@ -115,6 +115,12 @@ fi
 if [ -z "$PLUGINS_CLASSPATH" ] ; then
   if [ -z "$PLUGINS_DIR" ] ; then
     PLUGINS_DIR="$BASEDIR"/plugins
+  else
+    if [[ "$PLUGINS_DIR" = *,* ]]
+    then
+        echo "\$PLUGINS_DIR should use ; as the delimiter"
+        exit 1
+    fi
   fi
 
   export IFS=';'
@@ -122,6 +128,11 @@ if [ -z "$PLUGINS_CLASSPATH" ] ; then
     if [ -d "$DIR" ] ; then
       unset IFS
       if [ -n "$PLUGINS_INCLUDE" ] ; then
+        if [[ "$PLUGINS_INCLUDE" = *,* ]]
+        then
+            echo "\$PLUGINS_INCLUDE should use ; as the delimiter"
+            exit 1
+        fi
         export IFS=';'
         for PLUGIN_JAR in $PLUGINS_INCLUDE; do
             PLUGIN_JAR_PATH=$(find "$DIR" -path \*/"$PLUGIN_JAR"/"$PLUGIN_JAR"-\*.jar)


### PR DESCRIPTION
## Description
We added support loading plugins from multiple directories as part of https://github.com/apache/pinot/commit/9127286a365c25036dba2112bcfe367b33c3f361. It is a good idea to validate the correct delimiters are being used during the app assembler script.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
- no

Does this PR fix a zero-downtime upgrade introduced earlier?
- no

Does this PR otherwise need attention when creating release notes? 
- no, the delimiter related notes can be in the original multi directory support PR's release notes 

## Release Notes
- n/a

## Documentation
- n/a
