### PR TITLE
Add ignoreMerger for partial upsert

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
@@ -119,6 +119,14 @@ public class PartialUpsertHandler {
 
   /**
    * Merges 2 records and returns the merged record.
+   * We used a map to indicate all configured fields for partial upsert. For these fields
+   * (1) If the prev value is null, return the new value
+   * (2) If the prev record is not null, the new value is null, return the prev value.
+   * (3) If neither values are not null, then merge the value and return.
+   * For un-configured fields, they are using default override behavior, regardless null values.
+   *
+   * For example, overwrite merger will only override the prev value if the new value is not null.
+   * Null values will override existing values if not configured. They can be ignored by using ignoreMerger.
    *
    * @param previousRecord the last derived full record during ingestion.
    * @param newRecord the new consumed record.

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/merger/IgnoreMerger.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/merger/IgnoreMerger.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.upsert.merger;
+
+/**
+ * Merges 2 records and returns the merged record.
+ * By default, ignore the new value from incoming row. Then return the merged record.
+ */
+public class IgnoreMerger implements PartialUpsertMerger {
+  IgnoreMerger() {
+  }
+
+  @Override
+  public Object merge(Object previousValue, Object currentValue) {
+    return previousValue;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/merger/PartialUpsertMergerFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/merger/PartialUpsertMergerFactory.java
@@ -27,6 +27,7 @@ public class PartialUpsertMergerFactory {
 
   private static final AppendMerger APPEND_MERGER = new AppendMerger();
   private static final IncrementMerger INCREMENT_MERGER = new IncrementMerger();
+  private static final IgnoreMerger IGNORE_MERGER = new IgnoreMerger();
   private static final OverwriteMerger OVERWRITE_MERGER = new OverwriteMerger();
   private static final UnionMerger UNION_MERGER = new UnionMerger();
 
@@ -36,6 +37,8 @@ public class PartialUpsertMergerFactory {
         return APPEND_MERGER;
       case INCREMENT:
         return INCREMENT_MERGER;
+      case IGNORE:
+        return IGNORE_MERGER;
       case OVERWRITE:
         return OVERWRITE_MERGER;
       case UNION:

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/merger/PartialUpsertMergerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/merger/PartialUpsertMergerTest.java
@@ -42,6 +42,13 @@ public class PartialUpsertMergerTest {
   }
 
   @Test
+  public void testIgnoreMergers() {
+    IgnoreMerger ignoreMerger = new IgnoreMerger();
+    assertEquals(null, ignoreMerger.merge(null, 3));
+    assertEquals(3, ignoreMerger.merge(3, null));
+  }
+
+  @Test
   public void testOverwriteMergers() {
     OverwriteMerger overwriteMerger = new OverwriteMerger();
     assertEquals("newValue", overwriteMerger.merge("oldValue", "newValue"));

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
@@ -37,7 +37,7 @@ public class UpsertConfig extends BaseJsonConfig {
 
   public enum Strategy {
     // Todo: add CUSTOM strategies
-    APPEND, INCREMENT, OVERWRITE, UNION
+    APPEND, IGNORE, INCREMENT, OVERWRITE, UNION
   }
 
   public enum HashFunction {


### PR DESCRIPTION
## Description

Add ignore mergers.

Recently we got interesting use cases from industry about partial upsert.

Users have two event as follows, t is the timestamp column and t1<t2

{t1, a1, b1, c1, d1}
{t2, a2, nil, nil, nil}

user specified field "a" as Overwrite field, and "b", "c", "d" field are empty in the second event.
she expected merge result to be {a2, b1, c1, d1}
However the merge result was {a2, nil, nil, nil} which is the same as full upsert.

The reason of this issue is because she didn't specify the mergers for "b", "c", "d" fields. Thus these fields will use the default behavior, "Overwrite regardless null".

```
{
  "upsertConfig": {
    "mode": "PARTIAL",
    "partialUpsertStrategies":{
      "a": "OVERWRITE"
    }
  }
}
```
Her issue can be fixed with the following config, since the "overwrite" merger behavior is "Overwrite unless null".

```
{
  "upsertConfig": {
    "mode": "PARTIAL",
    "partialUpsertStrategies":{
      "a": "OVERWRITE",
      "b": "OVERWRITE",
      "c": "OVERWRITE",
      "d": "OVERWRITE"
    }
  }
}
```

Even though the overwrite mergers works here (because it ignore null value), the behavior is ignore but not overwrite which is confusing. In this PR, i created ignore merger to address this so partial upsert can have a cleaner interface.

```
{
  "upsertConfig": {
    "mode": "PARTIAL",
    "partialUpsertStrategies":{
      "a": "OVERWRITE",
      "b": "IGNORE",
      "c": "IGNORE",
      "d": "IGNORE"
    }
  }
}
```

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
