### PR TITLE
Revert "replication factor to be obtained from tenant configuration in case of dimension table"

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/StorageQuotaChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/StorageQuotaChecker.java
@@ -19,19 +19,16 @@
 package org.apache.pinot.controller.validation;
 
 import com.google.common.base.Preconditions;
-import java.util.Set;
-import javax.inject.Inject;
 import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMetrics;
-import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.TableSizeReader;
 import org.apache.pinot.spi.config.table.QuotaConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.config.table.TenantConfig;
 import org.apache.pinot.spi.utils.DataSizeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 
 /**
  * Class to check if a new segment is within the configured storage quota for the table
@@ -39,9 +36,6 @@ import org.slf4j.LoggerFactory;
  */
 public class StorageQuotaChecker {
   private static final Logger LOGGER = LoggerFactory.getLogger(StorageQuotaChecker.class);
-
-  @Inject
-  PinotHelixResourceManager _pinotHelixResourceManager;
 
   private final TableSizeReader _tableSizeReader;
   private final TableConfig _tableConfig;
@@ -86,18 +80,7 @@ public class StorageQuotaChecker {
     // 3. update predicted segment sizes
     // 4. is the updated size within quota
     QuotaConfig quotaConfig = _tableConfig.getQuotaConfig();
-    int numReplicas;
-
-    if (_tableConfig.isDimTable()) {
-      // If the table is a dimension table then fetch the tenant config and get the number of server belonging
-      // to the tenant
-      TenantConfig tenantConfig = _tableConfig.getTenantConfig();
-      Set<String> serverInstances = _pinotHelixResourceManager.getAllInstancesForServerTenant(tenantConfig.getServer());
-      numReplicas = serverInstances.size();
-    } else {
-      numReplicas = _tableConfig.getValidationConfig().getReplicationNumber();
-    }
-
+    int numReplicas = _tableConfig.getValidationConfig().getReplicationNumber();
     final String tableNameWithType = _tableConfig.getTableName();
 
     if (quotaConfig == null || quotaConfig.getStorage() == null) {


### PR DESCRIPTION
Reverts apache/pinot#7848

Hi @Manis99803 and @Jackie-Jiang,

I'm proposing a revert here since I don't think this is the right way to calculate the storage quota for a dimension tables. Dimension tables, by design, are expected to be distributed to all the servers in a tenant so there is not much value in multiplying the size with server count. 

Using this logic, a table which used to satisfy quota requirements will exceed the limit even if you simply add more servers to a tenant, which is counterintuitive. Server administrators may need to update quota limits for all dimension tables with cluster size changes, which can be cumbersome.

I propose keeping the old notation where the quota value represents the limit for a single replica of the table, which is easier to reason about.

Let me know what you think
