### PR TITLE
create pulsar MessageId from toString representation

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/MessageIdStreamOffset.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/MessageIdStreamOffset.java
@@ -22,6 +22,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.impl.BatchMessageIdImpl;
+import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,11 +44,21 @@ public class MessageIdStreamOffset implements StreamPartitionMsgOffset {
    * throws {@link IOException} if message if format is invalid.
    * @param messageId
    */
-  public MessageIdStreamOffset(String messageId) {
-    try {
-      _messageId = MessageId.fromByteArray(messageId.getBytes(StandardCharsets.UTF_8));
-    } catch (IOException e) {
-      LOGGER.warn("Cannot parse message id " + messageId, e);
+  public MessageIdStreamOffset(String messageIdStringRepresentation) {
+    String messageParts = messageIdStringRepresentation.split(":");
+    if (messageParts.length == 3) {
+      Long ledgerId = Long.parseLong(messageIdParts[0];
+      Long entryId = Long.parseLong(messageIdParts[1];
+      int partitionId = Integer.parseInt(messageIdParts[2]);
+      _messageId = new MessageIdImpl(ledgerId, entryId, partitionId);
+    } else if (messageParts.length == 4) {
+      Long ledgerId = Long.parseLong(messageIdParts[0];
+      Long entryId = Long.parseLong(messageIdParts[1];
+      int partitionId = Integer.parseInt(messageIdParts[2]);
+      int batchId = Integer.parseInt(messageIdParts[3]);
+      _messageId = new BatchMessageIdImpl(ledgerId, entryId, partitionId, batchId);
+    } else {
+      LOOGER.error("Illegal Pulsar MessageId={}", messageIdStringRepresentation);
     }
   }
 


### PR DESCRIPTION
## Description
As I've written in  [my comment](https://github.com/apache/pinot/issues/7270#issuecomment-995777801) on #7270 these are the changes I did for converting a `MessageId.toString` representation to a `MessageId` implementation. A three part MessageId `ledger:entryId:partitionIndex` is converter to a `MessageIdImpl` while a four part MessageId `ledgerId:entryId:partionIndex:batchId` will be converted to a `BatchMessageIdImpl`

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
