### PR TITLE
Disable JsonStatementOptimizer.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/QueryOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/QueryOptimizer.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.query.optimizer;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.request.BrokerRequest;
@@ -50,7 +51,7 @@ public class QueryOptimizer {
           new TimePredicateFilterOptimizer(), new MergeRangeFilterOptimizer());
 
   private static final List<StatementOptimizer> STATEMENT_OPTIMIZERS =
-      Arrays.asList(new StringPredicateFilterOptimizer());
+      Collections.singletonList(new StringPredicateFilterOptimizer());
 
   /**
    * Optimizes the given PQL query.

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/QueryOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/QueryOptimizer.java
@@ -33,7 +33,6 @@ import org.apache.pinot.core.query.optimizer.filter.MergeEqInFilterOptimizer;
 import org.apache.pinot.core.query.optimizer.filter.MergeRangeFilterOptimizer;
 import org.apache.pinot.core.query.optimizer.filter.NumericalFilterOptimizer;
 import org.apache.pinot.core.query.optimizer.filter.TimePredicateFilterOptimizer;
-import org.apache.pinot.core.query.optimizer.statement.JsonStatementOptimizer;
 import org.apache.pinot.core.query.optimizer.statement.StatementOptimizer;
 import org.apache.pinot.core.query.optimizer.statement.StringPredicateFilterOptimizer;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -51,7 +50,7 @@ public class QueryOptimizer {
           new TimePredicateFilterOptimizer(), new MergeRangeFilterOptimizer());
 
   private static final List<StatementOptimizer> STATEMENT_OPTIMIZERS =
-      Arrays.asList(new JsonStatementOptimizer(), new StringPredicateFilterOptimizer());
+      Arrays.asList(new StringPredicateFilterOptimizer());
 
   /**
    * Optimizes the given PQL query.

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/statement/JsonStatementOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/statement/JsonStatementOptimizer.java
@@ -48,6 +48,9 @@ import org.apache.pinot.spi.utils.Pair;
 
 
 /**
+ * NOTE: This class is not in an active code path, but exists to allow us to experiment and gain better understanding
+ * of identifier dot notation usage in SQL.
+ *
  * This class will rewrite a query that has json path expressions into a query that uses JSON_EXTRACT_SCALAR and
  * JSON_MATCH functions.
  *

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/statement/JsonStatementOptimizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/statement/JsonStatementOptimizerTest.java
@@ -30,9 +30,12 @@ import org.testng.annotations.Test;
 
 
 /**
+ * NOTE: These test cases are inactive since {@link JsonStatementOptimizer} is currently disabled.
+ *
  * Test cases to verify that {@link JsonStatementOptimizer} is properly rewriting queries that use JSON path expressions
  * into equivalent queries that use JSON_MATCH and JSON_EXTRACT_SCALAR functions.
  */
+@Test(enabled = false)
 public class JsonStatementOptimizerTest {
   private static final QueryOptimizer OPTIMIZER = new QueryOptimizer();
   private static final CalciteSqlCompiler SQL_COMPILER = new CalciteSqlCompiler();
@@ -48,7 +51,7 @@ public class JsonStatementOptimizerTest {
 
   /** Test that a json path expression in SELECT list is properly converted to a JSON_EXTRACT_SCALAR function within
    * an AS function. */
-  @Test
+  @Test(enabled = false)
   public void testJsonSelect() {
     // SELECT using json column.
     TestHelper.assertEqualsQuery("SELECT jsonColumn FROM testTable", "SELECT jsonColumn FROM testTable",
@@ -72,7 +75,7 @@ public class JsonStatementOptimizerTest {
 
   /** Test that a predicate comparing a json path expression with literal is properly converted into a JSON_MATCH
    * function. */
-  @Test
+  @Test(enabled = false)
   public void testJsonFilter() {
     // Comparing json path expression with a string value.
     TestHelper.assertEqualsQuery("SELECT * FROM testTable WHERE jsonColumn.name.first = 'daffy'",
@@ -103,7 +106,7 @@ public class JsonStatementOptimizerTest {
   }
 
   /** Test that a json path expression in GROUP BY clause is properly converted into a JSON_EXTRACT_SCALAR function. */
-  @Test
+  @Test(enabled = false)
   public void testJsonGroupBy() {
     TestHelper.assertEqualsQuery("SELECT jsonColumn.id, count(*) FROM testTable GROUP BY jsonColumn.id",
         "SELECT JSON_EXTRACT_SCALAR(jsonColumn, '$.id', 'STRING', 'null') AS \"jsonColumn.id\", count(*) FROM "
@@ -117,7 +120,7 @@ public class JsonStatementOptimizerTest {
   }
 
   /** Test that a json path expression in HAVING clause is properly converted into a JSON_EXTRACT_SCALAR function. */
-  @Test
+  @Test(enabled = false)
   public void testJsonGroupByHaving() {
     TestHelper.assertEqualsQuery(
         "SELECT jsonColumn.name.last, count(*) FROM testTable GROUP BY jsonColumn.name.last HAVING jsonColumn.name"
@@ -137,7 +140,7 @@ public class JsonStatementOptimizerTest {
   }
 
   /** Test a complex SQL statement with json path expression in SELECT, WHERE, and GROUP BY clauses. */
-  @Test
+  @Test(enabled = false)
   public void testJsonSelectFilterGroupBy() {
     TestHelper.assertEqualsQuery(
         "SELECT jsonColumn.name.last, count(*) FROM testTable WHERE jsonColumn.id = 101 GROUP BY jsonColumn.name.last",
@@ -154,7 +157,7 @@ public class JsonStatementOptimizerTest {
   }
 
   /** Test an aggregation function over json path expression in SELECT clause. */
-  @Test
+  @Test(enabled = false)
   public void testTransformFunctionOverJsonPathSelectExpression() {
     // Apply string transform function on json path expression.
     TestHelper.assertEqualsQuery("SELECT UPPER(jsonColumn.name.first) FROM testTable",
@@ -182,7 +185,7 @@ public class JsonStatementOptimizerTest {
   }
 
   /** Test a numerical function over json path expression in SELECT clause. */
-  @Test
+  @Test(enabled = false)
   public void testNumericalFunctionOverJsonPathSelectExpression() {
 
     // Test without user-specified alias.
@@ -201,7 +204,7 @@ public class JsonStatementOptimizerTest {
             + "') - 5) AS \"max(minus(jsonColumn.id,'5'))\" FROM testTable", TABLE_CONFIG_WITH_INDEX, SCHEMA);
   }
 
-  @Test
+  @Test(enabled = false)
   public void testTopLevelArrayPathExpressions() {
     // SELECT using json path expression with top-level array addressing.
     TestHelper.assertEqualsQuery("SELECT jsonColumn[0] FROM testTable",

--- a/pinot-core/src/test/java/org/apache/pinot/queries/JsonExtractScalarTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/JsonExtractScalarTest.java
@@ -96,7 +96,8 @@ public class JsonExtractScalarTest extends BaseJsonQueryTest {
         + ", '$.name', 'STRING'), '$.last', 'STRING') FROM testTable LIMIT 3", expecteds1);
   }
 
-  @Test(dataProvider = "nativeJsonColumns")
+  /* NOTE: This test cases is inactive since {@link JsonStatementOptimizer} is currently disabled. */
+  @Test(dataProvider = "nativeJsonColumns", enabled = false)
   public void testJsonSelect(String column) {
     // SELECT using a simple json path expression.
     Object[][] expecteds1 = {{"duck"}, {"mouse"}, {"duck"}};
@@ -107,8 +108,9 @@ public class JsonExtractScalarTest extends BaseJsonQueryTest {
     checkResult("SELECT " + column + ".data[0].e[2].z[0].i1 FROM testTable", expecteds2);
   }
 
+  /* NOTE: This test cases is inactive since {@link JsonStatementOptimizer} is currently disabled. */
   /** Test that a json path expression in GROUP BY clause is properly converted into a JSON_EXTRACT_SCALAR function. */
-  @Test(dataProvider = "nativeJsonColumns")
+  @Test(dataProvider = "nativeJsonColumns", enabled = false)
   public void testJsonGroupBy(String column) {
     Object[][] expecteds1 =
         {
@@ -118,8 +120,9 @@ public class JsonExtractScalarTest extends BaseJsonQueryTest {
     checkResult("SELECT " + column + ".id, count(*) FROM testTable GROUP BY " + column + ".id", expecteds1);
   }
 
+  /* NOTE: This test cases is inactive since {@link JsonStatementOptimizer} is currently disabled. */
   /** Test that a json path expression in HAVING clause is properly converted into a JSON_EXTRACT_SCALAR function. */
-  @Test(dataProvider = "nativeJsonColumns")
+  @Test(dataProvider = "nativeJsonColumns", enabled = false)
   public void testJsonGroupByHaving(String column) {
     Object[][] expecteds1 = {{"mouse", 8L}};
     checkResult(
@@ -128,8 +131,9 @@ public class JsonExtractScalarTest extends BaseJsonQueryTest {
             + ".last = 'mouse'", expecteds1);
   }
 
+  /* NOTE: This test cases is inactive since {@link JsonStatementOptimizer} is currently disabled. */
   /** Test a complex SQL statement with json path expression in SELECT, WHERE, and GROUP BY clauses. */
-  @Test(dataProvider = "nativeJsonColumns")
+  @Test(dataProvider = "nativeJsonColumns", enabled = false)
   public void testJsonSelectFilterGroupBy(String column) {
     Object[][] expecteds1 = {{"duck", 4L}};
     checkResult(
@@ -138,8 +142,9 @@ public class JsonExtractScalarTest extends BaseJsonQueryTest {
         expecteds1);
   }
 
+  /* NOTE: This test cases is inactive since {@link JsonStatementOptimizer} is currently disabled. */
   /** Test a numerical function over json path expression in SELECT clause. */
-  @Test(dataProvider = "nativeJsonColumns")
+  @Test(dataProvider = "nativeJsonColumns", enabled = false)
   public void testNumericalFunctionOverJsonPathSelectExpression(String column) {
 
     // Test without user-specified alias.

--- a/pinot-core/src/test/java/org/apache/pinot/queries/JsonPathQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/JsonPathQueriesTest.java
@@ -30,7 +30,8 @@ import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-
+/* NOTE: These test cases are inactive since {@link JsonStatementOptimizer} is currently disabled. */
+@Test(enabled = false)
 public class JsonPathQueriesTest extends BaseJsonQueryTest {
 
   private static final Schema SCHEMA = new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME)
@@ -81,7 +82,7 @@ public class JsonPathQueriesTest extends BaseJsonQueryTest {
 
   /** Test that a json path expression in SELECT list is properly converted to a JSON_EXTRACT_SCALAR function within
    * an AS function. */
-  @Test
+  @Test(enabled = false)
   public void testJsonSelect() {
     // SELECT using a simple json path expression.
     Object[][] expecteds1 = {{"duck"}, {"mouse"}, {"duck"}};
@@ -94,7 +95,7 @@ public class JsonPathQueriesTest extends BaseJsonQueryTest {
 
   /** Test that a predicate comparing a json path expression with literal is properly converted into a JSON_MATCH
    * function. */
-  @Test
+  @Test(enabled = false)
   public void testJsonFilter() {
     // Comparing json path expression with a string value.
     Object[][] expecteds1 =
@@ -126,7 +127,7 @@ public class JsonPathQueriesTest extends BaseJsonQueryTest {
   }
 
   /** Test that a json path expression in GROUP BY clause is properly converted into a JSON_EXTRACT_SCALAR function. */
-  @Test
+  @Test(enabled = false)
   public void testJsonGroupBy() {
     Object[][] expecteds1 =
         {{"111", 20L}, {"101", 4L}, {"null", 8L}, {"181", 4L}, {"161.5", 4L}, {"171", 4L}, {"161", 4L}, {"141", 4L},
@@ -137,7 +138,7 @@ public class JsonPathQueriesTest extends BaseJsonQueryTest {
   }
 
   /** Test that a json path expression in HAVING clause is properly converted into a JSON_EXTRACT_SCALAR function. */
-  @Test
+  @Test(enabled = false)
   public void testJsonGroupByHaving() {
     Object[][] expecteds1 = {{"mouse", 8L}};
     checkResult(
@@ -149,7 +150,7 @@ public class JsonPathQueriesTest extends BaseJsonQueryTest {
   }
 
   /** Test a complex SQL statement with json path expression in SELECT, WHERE, and GROUP BY clauses. */
-  @Test
+  @Test(enabled = false)
   public void testJsonSelectFilterGroupBy() {
     Object[][] expecteds1 = {{"duck", 4L}};
     checkResult(
@@ -161,7 +162,7 @@ public class JsonPathQueriesTest extends BaseJsonQueryTest {
   }
 
   /** Test an aggregation function over json path expression in SELECT clause. */
-  @Test
+  @Test(enabled = false)
   public void testTransformFunctionOverJsonPathSelectExpression() {
     // Apply string transform function on json path expression.
     Object[][] expecteds1 = {{"DAFFY"}};
@@ -198,7 +199,7 @@ public class JsonPathQueriesTest extends BaseJsonQueryTest {
   }
 
   /** Test a numerical function over json path expression in SELECT clause. */
-  @Test
+  @Test(enabled = false)
   public void testNumericalFunctionOverJsonPathSelectExpression() {
 
     // Test without user-specified alias.
@@ -217,7 +218,7 @@ public class JsonPathQueriesTest extends BaseJsonQueryTest {
     checkResult("SELECT MAX(jsonColumnWithoutIndex.id - 5) FROM testTable", expecteds3);
   }
 
-  @Test
+  @Test(enabled = false)
   public void testTopLevelArrayPathExpressions() {
     // SELECT using json path expressions that refers to second element of a top-level array.
     Object[][] expecteds1 = {{"{\"i1\":3,\"i2\":4}"}, {"{\"i1\":3,\"i2\":4}"}, {"{\"i1\":3,\"i2\":4}"}, {"{\"i1\":3,"


### PR DESCRIPTION
## Description
Disabling JsonStatementOptimizer (the class that processes identifier dot notation on JSON columns), until we can gain more confidence in using dot notation.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
