### PR TITLE
faster metric scans

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
@@ -427,7 +427,7 @@ public class DataFetcher {
         _dictionary.readIntValues(dictIdBuffer, length, valueBuffer);
       } else {
         if (_reader.getValueType().isFixedWidth()) {
-          _reader.fillValues(docIds, length, valueBuffer, readerContext);
+          _reader.readValuesSV(docIds, length, valueBuffer, readerContext);
         } else if (_reader.getValueType() == FieldSpec.DataType.STRING) {
           for (int i = 0; i < length; i++) {
             valueBuffer[i] = Integer.parseInt(_reader.getString(docIds[i], readerContext));
@@ -451,7 +451,7 @@ public class DataFetcher {
         _dictionary.readLongValues(dictIdBuffer, length, valueBuffer);
       } else {
         if (_reader.getValueType().isFixedWidth()) {
-          _reader.fillValues(docIds, length, valueBuffer, readerContext);
+          _reader.readValuesSV(docIds, length, valueBuffer, readerContext);
         } else if (_reader.getValueType() == FieldSpec.DataType.STRING) {
           for (int i = 0; i < length; i++) {
             valueBuffer[i] = Long.parseLong(_reader.getString(docIds[i], readerContext));
@@ -475,7 +475,7 @@ public class DataFetcher {
         _dictionary.readFloatValues(dictIdBuffer, length, valueBuffer);
       } else {
         if (_reader.getValueType().isFixedWidth()) {
-          _reader.fillValues(docIds, length, valueBuffer, readerContext);
+          _reader.readValuesSV(docIds, length, valueBuffer, readerContext);
         } else if (_reader.getValueType() == FieldSpec.DataType.STRING) {
           for (int i = 0; i < length; i++) {
             valueBuffer[i] = Float.parseFloat(_reader.getString(docIds[i], readerContext));
@@ -499,7 +499,7 @@ public class DataFetcher {
         _dictionary.readDoubleValues(dictIdBuffer, length, valueBuffer);
       } else {
         if (_reader.getValueType().isFixedWidth()) {
-          _reader.fillValues(docIds, length, valueBuffer, readerContext);
+          _reader.readValuesSV(docIds, length, valueBuffer, readerContext);
         } else if (_reader.getValueType() == FieldSpec.DataType.STRING) {
           for (int i = 0; i < length; i++) {
             valueBuffer[i] = Double.parseDouble(_reader.getString(docIds[i], readerContext));

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
@@ -31,6 +31,7 @@ import org.apache.pinot.segment.spi.evaluator.TransformEvaluator;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.utils.BytesUtils;
 
 
@@ -425,34 +426,14 @@ public class DataFetcher {
         _reader.readDictIds(docIds, length, dictIdBuffer, readerContext);
         _dictionary.readIntValues(dictIdBuffer, length, valueBuffer);
       } else {
-        switch (_reader.getValueType()) {
-          case INT:
-            for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getInt(docIds[i], readerContext);
-            }
-            break;
-          case LONG:
-            for (int i = 0; i < length; i++) {
-              valueBuffer[i] = (int) _reader.getLong(docIds[i], readerContext);
-            }
-            break;
-          case FLOAT:
-            for (int i = 0; i < length; i++) {
-              valueBuffer[i] = (int) _reader.getFloat(docIds[i], readerContext);
-            }
-            break;
-          case DOUBLE:
-            for (int i = 0; i < length; i++) {
-              valueBuffer[i] = (int) _reader.getDouble(docIds[i], readerContext);
-            }
-            break;
-          case STRING:
-            for (int i = 0; i < length; i++) {
-              valueBuffer[i] = Integer.parseInt(_reader.getString(docIds[i], readerContext));
-            }
-            break;
-          default:
-            throw new IllegalStateException();
+        if (_reader.getValueType().isFixedWidth()) {
+          _reader.fillValues(docIds, length, valueBuffer, readerContext);
+        } else if (_reader.getValueType() == FieldSpec.DataType.STRING) {
+          for (int i = 0; i < length; i++) {
+            valueBuffer[i] = Integer.parseInt(_reader.getString(docIds[i], readerContext));
+          }
+        } else {
+          throw new IllegalStateException();
         }
       }
     }
@@ -469,34 +450,14 @@ public class DataFetcher {
         _reader.readDictIds(docIds, length, dictIdBuffer, readerContext);
         _dictionary.readLongValues(dictIdBuffer, length, valueBuffer);
       } else {
-        switch (_reader.getValueType()) {
-          case INT:
-            for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getInt(docIds[i], readerContext);
-            }
-            break;
-          case LONG:
-            for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getLong(docIds[i], readerContext);
-            }
-            break;
-          case FLOAT:
-            for (int i = 0; i < length; i++) {
-              valueBuffer[i] = (long) _reader.getFloat(docIds[i], readerContext);
-            }
-            break;
-          case DOUBLE:
-            for (int i = 0; i < length; i++) {
-              valueBuffer[i] = (long) _reader.getDouble(docIds[i], readerContext);
-            }
-            break;
-          case STRING:
-            for (int i = 0; i < length; i++) {
-              valueBuffer[i] = Long.parseLong(_reader.getString(docIds[i], readerContext));
-            }
-            break;
-          default:
-            throw new IllegalStateException();
+        if (_reader.getValueType().isFixedWidth()) {
+          _reader.fillValues(docIds, length, valueBuffer, readerContext);
+        } else if (_reader.getValueType() == FieldSpec.DataType.STRING) {
+          for (int i = 0; i < length; i++) {
+            valueBuffer[i] = Long.parseLong(_reader.getString(docIds[i], readerContext));
+          }
+        } else {
+          throw new IllegalStateException();
         }
       }
     }
@@ -513,34 +474,14 @@ public class DataFetcher {
         _reader.readDictIds(docIds, length, dictIdBuffer, readerContext);
         _dictionary.readFloatValues(dictIdBuffer, length, valueBuffer);
       } else {
-        switch (_reader.getValueType()) {
-          case INT:
-            for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getInt(docIds[i], readerContext);
-            }
-            break;
-          case LONG:
-            for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getLong(docIds[i], readerContext);
-            }
-            break;
-          case FLOAT:
-            for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getFloat(docIds[i], readerContext);
-            }
-            break;
-          case DOUBLE:
-            for (int i = 0; i < length; i++) {
-              valueBuffer[i] = (float) _reader.getDouble(docIds[i], readerContext);
-            }
-            break;
-          case STRING:
-            for (int i = 0; i < length; i++) {
-              valueBuffer[i] = Float.parseFloat(_reader.getString(docIds[i], readerContext));
-            }
-            break;
-          default:
-            throw new IllegalStateException();
+        if (_reader.getValueType().isFixedWidth()) {
+          _reader.fillValues(docIds, length, valueBuffer, readerContext);
+        } else if (_reader.getValueType() == FieldSpec.DataType.STRING) {
+          for (int i = 0; i < length; i++) {
+            valueBuffer[i] = Float.parseFloat(_reader.getString(docIds[i], readerContext));
+          }
+        } else {
+          throw new IllegalStateException();
         }
       }
     }
@@ -557,34 +498,14 @@ public class DataFetcher {
         _reader.readDictIds(docIds, length, dictIdBuffer, readerContext);
         _dictionary.readDoubleValues(dictIdBuffer, length, valueBuffer);
       } else {
-        switch (_reader.getValueType()) {
-          case INT:
-            for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getInt(docIds[i], readerContext);
-            }
-            break;
-          case LONG:
-            for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getLong(docIds[i], readerContext);
-            }
-            break;
-          case FLOAT:
-            for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getFloat(docIds[i], readerContext);
-            }
-            break;
-          case DOUBLE:
-            for (int i = 0; i < length; i++) {
-              valueBuffer[i] = _reader.getDouble(docIds[i], readerContext);
-            }
-            break;
-          case STRING:
-            for (int i = 0; i < length; i++) {
-              valueBuffer[i] = Double.parseDouble(_reader.getString(docIds[i], readerContext));
-            }
-            break;
-          default:
-            throw new IllegalStateException();
+        if (_reader.getValueType().isFixedWidth()) {
+          _reader.fillValues(docIds, length, valueBuffer, readerContext);
+        } else if (_reader.getValueType() == FieldSpec.DataType.STRING) {
+          for (int i = 0; i < length; i++) {
+            valueBuffer[i] = Double.parseDouble(_reader.getString(docIds[i], readerContext));
+          }
+        } else {
+         throw new IllegalStateException();
         }
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
@@ -31,7 +31,6 @@ import org.apache.pinot.segment.spi.evaluator.TransformEvaluator;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.utils.BytesUtils;
 
 
@@ -426,15 +425,7 @@ public class DataFetcher {
         _reader.readDictIds(docIds, length, dictIdBuffer, readerContext);
         _dictionary.readIntValues(dictIdBuffer, length, valueBuffer);
       } else {
-        if (_reader.getValueType().isFixedWidth()) {
-          _reader.readValuesSV(docIds, length, valueBuffer, readerContext);
-        } else if (_reader.getValueType() == FieldSpec.DataType.STRING) {
-          for (int i = 0; i < length; i++) {
-            valueBuffer[i] = Integer.parseInt(_reader.getString(docIds[i], readerContext));
-          }
-        } else {
-          throw new IllegalStateException();
-        }
+        _reader.readValuesSV(docIds, length, valueBuffer, readerContext);
       }
     }
 
@@ -450,15 +441,7 @@ public class DataFetcher {
         _reader.readDictIds(docIds, length, dictIdBuffer, readerContext);
         _dictionary.readLongValues(dictIdBuffer, length, valueBuffer);
       } else {
-        if (_reader.getValueType().isFixedWidth()) {
-          _reader.readValuesSV(docIds, length, valueBuffer, readerContext);
-        } else if (_reader.getValueType() == FieldSpec.DataType.STRING) {
-          for (int i = 0; i < length; i++) {
-            valueBuffer[i] = Long.parseLong(_reader.getString(docIds[i], readerContext));
-          }
-        } else {
-          throw new IllegalStateException();
-        }
+        _reader.readValuesSV(docIds, length, valueBuffer, readerContext);
       }
     }
 
@@ -474,15 +457,7 @@ public class DataFetcher {
         _reader.readDictIds(docIds, length, dictIdBuffer, readerContext);
         _dictionary.readFloatValues(dictIdBuffer, length, valueBuffer);
       } else {
-        if (_reader.getValueType().isFixedWidth()) {
-          _reader.readValuesSV(docIds, length, valueBuffer, readerContext);
-        } else if (_reader.getValueType() == FieldSpec.DataType.STRING) {
-          for (int i = 0; i < length; i++) {
-            valueBuffer[i] = Float.parseFloat(_reader.getString(docIds[i], readerContext));
-          }
-        } else {
-          throw new IllegalStateException();
-        }
+        _reader.readValuesSV(docIds, length, valueBuffer, readerContext);
       }
     }
 
@@ -498,15 +473,7 @@ public class DataFetcher {
         _reader.readDictIds(docIds, length, dictIdBuffer, readerContext);
         _dictionary.readDoubleValues(dictIdBuffer, length, valueBuffer);
       } else {
-        if (_reader.getValueType().isFixedWidth()) {
-          _reader.readValuesSV(docIds, length, valueBuffer, readerContext);
-        } else if (_reader.getValueType() == FieldSpec.DataType.STRING) {
-          for (int i = 0; i < length; i++) {
-            valueBuffer[i] = Double.parseDouble(_reader.getString(docIds[i], readerContext));
-          }
-        } else {
-         throw new IllegalStateException();
-        }
+        _reader.readValuesSV(docIds, length, valueBuffer, readerContext);
       }
     }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/BaseChunkSVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/BaseChunkSVForwardIndexReader.java
@@ -21,6 +21,10 @@ package org.apache.pinot.segment.local.segment.index.readers.forward;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
 import org.apache.pinot.segment.local.io.compression.ChunkCompressorFactory;
 import org.apache.pinot.segment.local.io.writer.impl.BaseChunkSVForwardIndexWriter;
 import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
@@ -168,8 +172,181 @@ public abstract class BaseChunkSVForwardIndexReader implements ForwardIndexReade
   }
 
   @Override
+  public void readValuesSV(int[] docIds, int length, int[] values, ChunkReaderContext context) {
+    if (getValueType().isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
+      switch (getValueType()) {
+        case INT: {
+          int minOffset = docIds[0] * Integer.BYTES;
+          IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();
+          buffer.get(values, 0, length);
+        }
+        break;
+        case LONG: {
+          int minOffset = docIds[0] * Long.BYTES;
+          LongBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Long.BYTES).asLongBuffer();
+          for (int i = 0; i < buffer.limit(); i++) {
+            values[i] = (int) buffer.get(i);
+          }
+        }
+        break;
+        case FLOAT: {
+          int minOffset = docIds[0] * Float.BYTES;
+          FloatBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Float.BYTES).asFloatBuffer();
+          for (int i = 0; i < buffer.limit(); i++) {
+            values[i] = (int) buffer.get(i);
+          }
+        }
+        break;
+        case DOUBLE: {
+          int minOffset = docIds[0] * Double.BYTES;
+          DoubleBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Double.BYTES).asDoubleBuffer();
+          for (int i = 0; i < buffer.limit(); i++) {
+            values[i] = (int) buffer.get(i);
+          }
+        }
+        break;
+        default:
+          throw new IllegalArgumentException();
+      }
+    } else {
+      ForwardIndexReader.super.readValuesSV(docIds, length, values, context);
+    }
+  }
+
+  @Override
+  public void readValuesSV(int[] docIds, int length, long[] values, ChunkReaderContext context) {
+    if (getValueType().isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
+      switch (getValueType()) {
+        case INT: {
+          int minOffset = docIds[0] * Integer.BYTES;
+          IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();
+          for (int i = 0; i < buffer.limit(); i++) {
+            values[i] = buffer.get(i);
+          }
+        }
+        break;
+        case LONG: {
+          int minOffset = docIds[0] * Long.BYTES;
+          LongBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Long.BYTES).asLongBuffer();
+          buffer.get(values, 0, length);
+        }
+        break;
+        case FLOAT: {
+          int minOffset = docIds[0] * Float.BYTES;
+          FloatBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Float.BYTES).asFloatBuffer();
+          for (int i = 0; i < buffer.limit(); i++) {
+            values[i] = (long) buffer.get(i);
+          }
+        }
+        break;
+        case DOUBLE: {
+          int minOffset = docIds[0] * Double.BYTES;
+          DoubleBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Double.BYTES).asDoubleBuffer();
+          for (int i = 0; i < buffer.limit(); i++) {
+            values[i] = (long) buffer.get(i);
+          }
+        }
+        break;
+        default:
+          throw new IllegalArgumentException();
+      }
+    } else {
+      ForwardIndexReader.super.readValuesSV(docIds, length, values, context);
+    }
+  }
+
+  @Override
+  public void readValuesSV(int[] docIds, int length, float[] values, ChunkReaderContext context) {
+    if (getValueType().isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
+      switch (getValueType()) {
+        case INT: {
+          int minOffset = docIds[0] * Integer.BYTES;
+          IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();
+          for (int i = 0; i < buffer.limit(); i++) {
+            values[i] = buffer.get(i);
+          }
+        }
+        break;
+        case LONG: {
+          int minOffset = docIds[0] * Long.BYTES;
+          LongBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Long.BYTES).asLongBuffer();
+          for (int i = 0; i < buffer.limit(); i++) {
+            values[i] = buffer.get(i);
+          }
+        }
+        break;
+        case FLOAT: {
+          int minOffset = docIds[0] * Float.BYTES;
+          FloatBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Float.BYTES).asFloatBuffer();
+          buffer.get(values, 0, length);
+        }
+        break;
+        case DOUBLE: {
+          int minOffset = docIds[0] * Double.BYTES;
+          DoubleBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Double.BYTES).asDoubleBuffer();
+          for (int i = 0; i < buffer.limit(); i++) {
+            values[i] = (float) buffer.get(i);
+          }
+        }
+        break;
+        default:
+          throw new IllegalArgumentException();
+      }
+    } else {
+      ForwardIndexReader.super.readValuesSV(docIds, length, values, context);
+    }
+  }
+
+  @Override
+  public void readValuesSV(int[] docIds, int length, double[] values, ChunkReaderContext context) {
+    if (getValueType().isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
+      switch (getValueType()) {
+        case INT: {
+          int minOffset = docIds[0] * Integer.BYTES;
+          IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();
+          for (int i = 0; i < buffer.limit(); i++) {
+            values[i] = buffer.get(i);
+          }
+        }
+        break;
+        case LONG: {
+          int minOffset = docIds[0] * Long.BYTES;
+          getLong(0, context);
+          LongBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Long.BYTES).asLongBuffer();
+          for (int i = 0; i < buffer.limit(); i++) {
+            values[i] = buffer.get(i);
+          }
+        }
+        break;
+        case FLOAT: {
+          int minOffset = docIds[0] * Float.BYTES;
+          FloatBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Float.BYTES).asFloatBuffer();
+          for (int i = 0; i < buffer.limit(); i++) {
+            values[i] = buffer.get(i);
+          }
+        }
+        break;
+        case DOUBLE: {
+          int minOffset = docIds[0] * Double.BYTES;
+          DoubleBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Double.BYTES).asDoubleBuffer();
+          buffer.get(values, 0, length);
+        }
+        break;
+        default:
+          throw new IllegalArgumentException();
+      }
+    } else {
+      ForwardIndexReader.super.readValuesSV(docIds, length, values, context);
+    }
+  }
+
+  @Override
   public void close() {
     // NOTE: DO NOT close the PinotDataBuffer here because it is tracked by the caller and might be reused later. The
     // caller is responsible of closing the PinotDataBuffer.
+  }
+
+  private boolean isContiguousRange(int[] docIds, int length) {
+    return docIds[length - 1] - docIds[0] == length - 1;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedByteChunkSVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedByteChunkSVForwardIndexReader.java
@@ -19,6 +19,10 @@
 package org.apache.pinot.segment.local.segment.index.readers.forward;
 
 import java.nio.ByteBuffer;
+import java.nio.DoubleBuffer;
+import java.nio.FloatBuffer;
+import java.nio.IntBuffer;
+import java.nio.LongBuffer;
 import javax.annotation.Nullable;
 import org.apache.pinot.segment.local.io.writer.impl.FixedByteChunkSVForwardIndexWriter;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
@@ -45,6 +49,179 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
       return new ChunkReaderContext(_chunkSize);
     } else {
       return null;
+    }
+  }
+
+  @Override
+  public void fillValues(int[] docIds, int length, int[] values, ChunkReaderContext context) {
+    int range = docIds[length - 1] - docIds[0];
+    if (!_isCompressed && range == length - 1) {
+      switch (getValueType().getStoredType()) {
+        case INT: {
+          int minOffset = docIds[0] * Integer.BYTES;
+          IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();
+          buffer.get(values, 0, length);
+        }
+        break;
+        case LONG: {
+          int minOffset = docIds[0] * Long.BYTES;
+          LongBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Long.BYTES).asLongBuffer();
+          for (int i = 0; i < length; i++) {
+            values[i] = (int) buffer.get(i);
+          }
+        }
+        break;
+        case FLOAT: {
+          int minOffset = docIds[0] * Float.BYTES;
+          FloatBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Float.BYTES).asFloatBuffer();
+          for (int i = 0; i < length; i++) {
+            values[i] = (int) buffer.get(i);
+          }
+        }
+        break;
+        case DOUBLE: {
+          int minOffset = docIds[0] * Double.BYTES;
+          DoubleBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Double.BYTES).asDoubleBuffer();
+          for (int i = 0; i < length; i++) {
+            values[i] = (int) buffer.get(i);
+          }
+        }
+        break;
+        default:
+          throw new IllegalArgumentException();
+      }
+    } else {
+      super.fillValues(docIds, length, values, context);
+    }
+  }
+
+  @Override
+  public void fillValues(int[] docIds, int length, long[] values, ChunkReaderContext context) {
+    int range = docIds[length - 1] - docIds[0];
+    if (!_isCompressed && range == length - 1) {
+      switch (getValueType().getStoredType()) {
+        case INT: {
+          int minOffset = docIds[0] * Integer.BYTES;
+          IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();
+          for (int i = 0; i < length; i++) {
+            values[i] = buffer.get(i);
+          }
+        }
+        break;
+        case LONG: {
+          int minOffset = docIds[0] * Long.BYTES;
+          LongBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Long.BYTES).asLongBuffer();
+          buffer.get(values, 0, length);
+        }
+        break;
+        case FLOAT: {
+          int minOffset = docIds[0] * Float.BYTES;
+          FloatBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Float.BYTES).asFloatBuffer();
+          for (int i = 0; i < length; i++) {
+            values[i] = (long) buffer.get(i);
+          }
+        }
+        break;
+        case DOUBLE: {
+          int minOffset = docIds[0] * Double.BYTES;
+          DoubleBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Double.BYTES).asDoubleBuffer();
+          for (int i = 0; i < length; i++) {
+            values[i] = (long) buffer.get(i);
+          }
+        }
+        break;
+        default:
+          throw new IllegalArgumentException();
+      }
+    } else {
+      super.fillValues(docIds, length, values, context);
+    }
+  }
+
+  @Override
+  public void fillValues(int[] docIds, int length, float[] values, ChunkReaderContext context) {
+    int range = docIds[length - 1] - docIds[0];
+    if (!_isCompressed && range == length - 1) {
+      switch (getValueType().getStoredType()) {
+        case INT: {
+          int minOffset = docIds[0] * Integer.BYTES;
+          IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();
+          for (int i = 0; i < length; i++) {
+            values[i] = buffer.get(i);
+          }
+        }
+        break;
+        case LONG: {
+          int minOffset = docIds[0] * Long.BYTES;
+          LongBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Long.BYTES).asLongBuffer();
+          for (int i = 0; i < length; i++) {
+            values[i] = buffer.get(i);
+          }
+        }
+        break;
+        case FLOAT: {
+          int minOffset = docIds[0] * Float.BYTES;
+          FloatBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Float.BYTES).asFloatBuffer();
+          buffer.get(values, 0, length);
+        }
+        break;
+        case DOUBLE: {
+          int minOffset = docIds[0] * Double.BYTES;
+          DoubleBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Double.BYTES).asDoubleBuffer();
+          for (int i = 0; i < length; i++) {
+            values[i] = (float) buffer.get(i);
+          }
+        }
+        break;
+        default:
+          throw new IllegalArgumentException();
+      }
+    } else {
+      super.fillValues(docIds, length, values, context);
+    }
+  }
+
+  @Override
+  public void fillValues(int[] docIds, int length, double[] values, ChunkReaderContext context) {
+    int range = docIds[length - 1] - docIds[0];
+    if (!_isCompressed && range == length - 1) {
+      switch (getValueType().getStoredType()) {
+        case INT: {
+          int minOffset = docIds[0] * Integer.BYTES;
+          IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();
+          for (int i = 0; i < length; i++) {
+            values[i] = buffer.get(i);
+          }
+        }
+        break;
+        case LONG: {
+          int minOffset = docIds[0] * Long.BYTES;
+          getLong(0, context);
+          LongBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Long.BYTES).asLongBuffer();
+          for (int i = 0; i < length; i++) {
+            values[i] = buffer.get(i);
+          }
+        }
+        break;
+        case FLOAT: {
+          int minOffset = docIds[0] * Float.BYTES;
+          FloatBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Float.BYTES).asFloatBuffer();
+          for (int i = 0; i < length; i++) {
+            values[i] = buffer.get(i);
+          }
+        }
+        break;
+        case DOUBLE: {
+          int minOffset = docIds[0] * Double.BYTES;
+          DoubleBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Double.BYTES).asDoubleBuffer();
+          buffer.get(values, 0, length);
+        }
+        break;
+        default:
+          throw new IllegalArgumentException();
+      }
+    } else {
+      super.fillValues(docIds, length, values, context);
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedByteChunkSVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedByteChunkSVForwardIndexReader.java
@@ -19,10 +19,6 @@
 package org.apache.pinot.segment.local.segment.index.readers.forward;
 
 import java.nio.ByteBuffer;
-import java.nio.DoubleBuffer;
-import java.nio.FloatBuffer;
-import java.nio.IntBuffer;
-import java.nio.LongBuffer;
 import javax.annotation.Nullable;
 import org.apache.pinot.segment.local.io.writer.impl.FixedByteChunkSVForwardIndexWriter;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
@@ -49,175 +45,6 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
       return new ChunkReaderContext(_chunkSize);
     } else {
       return null;
-    }
-  }
-
-  @Override
-  public void readValuesSV(int[] docIds, int length, int[] values, ChunkReaderContext context) {
-    if (getValueType().getStoredType().isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
-      switch (getValueType().getStoredType()) {
-        case INT: {
-          int minOffset = docIds[0] * Integer.BYTES;
-          IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();
-          buffer.get(values, 0, length);
-        }
-        break;
-        case LONG: {
-          int minOffset = docIds[0] * Long.BYTES;
-          LongBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Long.BYTES).asLongBuffer();
-          for (int i = 0; i < buffer.limit(); i++) {
-            values[i] = (int) buffer.get(i);
-          }
-        }
-        break;
-        case FLOAT: {
-          int minOffset = docIds[0] * Float.BYTES;
-          FloatBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Float.BYTES).asFloatBuffer();
-          for (int i = 0; i < buffer.limit(); i++) {
-            values[i] = (int) buffer.get(i);
-          }
-        }
-        break;
-        case DOUBLE: {
-          int minOffset = docIds[0] * Double.BYTES;
-          DoubleBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Double.BYTES).asDoubleBuffer();
-          for (int i = 0; i < buffer.limit(); i++) {
-            values[i] = (int) buffer.get(i);
-          }
-        }
-        break;
-        default:
-          throw new IllegalArgumentException();
-      }
-    } else {
-      super.readValuesSV(docIds, length, values, context);
-    }
-  }
-
-  @Override
-  public void readValuesSV(int[] docIds, int length, long[] values, ChunkReaderContext context) {
-    if (getValueType().getStoredType().isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
-      switch (getValueType().getStoredType()) {
-        case INT: {
-          int minOffset = docIds[0] * Integer.BYTES;
-          IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();
-          for (int i = 0; i < buffer.limit(); i++) {
-            values[i] = buffer.get(i);
-          }
-        }
-        break;
-        case LONG: {
-          int minOffset = docIds[0] * Long.BYTES;
-          LongBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Long.BYTES).asLongBuffer();
-          buffer.get(values, 0, length);
-        }
-        break;
-        case FLOAT: {
-          int minOffset = docIds[0] * Float.BYTES;
-          FloatBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Float.BYTES).asFloatBuffer();
-          for (int i = 0; i < buffer.limit(); i++) {
-            values[i] = (long) buffer.get(i);
-          }
-        }
-        break;
-        case DOUBLE: {
-          int minOffset = docIds[0] * Double.BYTES;
-          DoubleBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Double.BYTES).asDoubleBuffer();
-          for (int i = 0; i < buffer.limit(); i++) {
-            values[i] = (long) buffer.get(i);
-          }
-        }
-        break;
-        default:
-          throw new IllegalArgumentException();
-      }
-    } else {
-      super.readValuesSV(docIds, length, values, context);
-    }
-  }
-
-  @Override
-  public void readValuesSV(int[] docIds, int length, float[] values, ChunkReaderContext context) {
-    if (getValueType().getStoredType().isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
-      switch (getValueType().getStoredType()) {
-        case INT: {
-          int minOffset = docIds[0] * Integer.BYTES;
-          IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();
-          for (int i = 0; i < buffer.limit(); i++) {
-            values[i] = buffer.get(i);
-          }
-        }
-        break;
-        case LONG: {
-          int minOffset = docIds[0] * Long.BYTES;
-          LongBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Long.BYTES).asLongBuffer();
-          for (int i = 0; i < buffer.limit(); i++) {
-            values[i] = buffer.get(i);
-          }
-        }
-        break;
-        case FLOAT: {
-          int minOffset = docIds[0] * Float.BYTES;
-          FloatBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Float.BYTES).asFloatBuffer();
-          buffer.get(values, 0, length);
-        }
-        break;
-        case DOUBLE: {
-          int minOffset = docIds[0] * Double.BYTES;
-          DoubleBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Double.BYTES).asDoubleBuffer();
-          for (int i = 0; i < buffer.limit(); i++) {
-            values[i] = (float) buffer.get(i);
-          }
-        }
-        break;
-        default:
-          throw new IllegalArgumentException();
-      }
-    } else {
-      super.readValuesSV(docIds, length, values, context);
-    }
-  }
-
-  @Override
-  public void readValuesSV(int[] docIds, int length, double[] values, ChunkReaderContext context) {
-    if (getValueType().getStoredType().isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
-      switch (getValueType().getStoredType()) {
-        case INT: {
-          int minOffset = docIds[0] * Integer.BYTES;
-          IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();
-          for (int i = 0; i < buffer.limit(); i++) {
-            values[i] = buffer.get(i);
-          }
-        }
-        break;
-        case LONG: {
-          int minOffset = docIds[0] * Long.BYTES;
-          getLong(0, context);
-          LongBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Long.BYTES).asLongBuffer();
-          for (int i = 0; i < buffer.limit(); i++) {
-            values[i] = buffer.get(i);
-          }
-        }
-        break;
-        case FLOAT: {
-          int minOffset = docIds[0] * Float.BYTES;
-          FloatBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Float.BYTES).asFloatBuffer();
-          for (int i = 0; i < buffer.limit(); i++) {
-            values[i] = buffer.get(i);
-          }
-        }
-        break;
-        case DOUBLE: {
-          int minOffset = docIds[0] * Double.BYTES;
-          DoubleBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Double.BYTES).asDoubleBuffer();
-          buffer.get(values, 0, length);
-        }
-        break;
-        default:
-          throw new IllegalArgumentException();
-      }
-    } else {
-      super.readValuesSV(docIds, length, values, context);
     }
   }
 
@@ -263,9 +90,5 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
     } else {
       return _rawData.getDouble(docId * Double.BYTES);
     }
-  }
-
-  private boolean isContiguousRange(int[] docIds, int length) {
-    return docIds[length - 1] - docIds[0] == length - 1;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedByteChunkSVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedByteChunkSVForwardIndexReader.java
@@ -53,9 +53,8 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
   }
 
   @Override
-  public void fillValues(int[] docIds, int length, int[] values, ChunkReaderContext context) {
-    int range = docIds[length - 1] - docIds[0];
-    if (!_isCompressed && range == length - 1) {
+  public void readValuesSV(int[] docIds, int length, int[] values, ChunkReaderContext context) {
+    if (!_isCompressed && isContiguousRange(docIds, length)) {
       switch (getValueType().getStoredType()) {
         case INT: {
           int minOffset = docIds[0] * Integer.BYTES;
@@ -91,14 +90,13 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
           throw new IllegalArgumentException();
       }
     } else {
-      super.fillValues(docIds, length, values, context);
+      super.readValuesSV(docIds, length, values, context);
     }
   }
 
   @Override
-  public void fillValues(int[] docIds, int length, long[] values, ChunkReaderContext context) {
-    int range = docIds[length - 1] - docIds[0];
-    if (!_isCompressed && range == length - 1) {
+  public void readValuesSV(int[] docIds, int length, long[] values, ChunkReaderContext context) {
+    if (!_isCompressed && isContiguousRange(docIds, length)) {
       switch (getValueType().getStoredType()) {
         case INT: {
           int minOffset = docIds[0] * Integer.BYTES;
@@ -134,14 +132,13 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
           throw new IllegalArgumentException();
       }
     } else {
-      super.fillValues(docIds, length, values, context);
+      super.readValuesSV(docIds, length, values, context);
     }
   }
 
   @Override
-  public void fillValues(int[] docIds, int length, float[] values, ChunkReaderContext context) {
-    int range = docIds[length - 1] - docIds[0];
-    if (!_isCompressed && range == length - 1) {
+  public void readValuesSV(int[] docIds, int length, float[] values, ChunkReaderContext context) {
+    if (!_isCompressed && isContiguousRange(docIds, length)) {
       switch (getValueType().getStoredType()) {
         case INT: {
           int minOffset = docIds[0] * Integer.BYTES;
@@ -177,14 +174,13 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
           throw new IllegalArgumentException();
       }
     } else {
-      super.fillValues(docIds, length, values, context);
+      super.readValuesSV(docIds, length, values, context);
     }
   }
 
   @Override
-  public void fillValues(int[] docIds, int length, double[] values, ChunkReaderContext context) {
-    int range = docIds[length - 1] - docIds[0];
-    if (!_isCompressed && range == length - 1) {
+  public void readValuesSV(int[] docIds, int length, double[] values, ChunkReaderContext context) {
+    if (!_isCompressed && isContiguousRange(docIds, length)) {
       switch (getValueType().getStoredType()) {
         case INT: {
           int minOffset = docIds[0] * Integer.BYTES;
@@ -221,7 +217,7 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
           throw new IllegalArgumentException();
       }
     } else {
-      super.fillValues(docIds, length, values, context);
+      super.readValuesSV(docIds, length, values, context);
     }
   }
 
@@ -267,5 +263,9 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
     } else {
       return _rawData.getDouble(docId * Double.BYTES);
     }
+  }
+
+  private boolean isContiguousRange(int[] docIds, int length) {
+    return docIds[length - 1] - docIds[0] == length - 1;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedByteChunkSVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedByteChunkSVForwardIndexReader.java
@@ -65,7 +65,7 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
         case LONG: {
           int minOffset = docIds[0] * Long.BYTES;
           LongBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Long.BYTES).asLongBuffer();
-          for (int i = 0; i < length; i++) {
+          for (int i = 0; i < buffer.limit(); i++) {
             values[i] = (int) buffer.get(i);
           }
         }
@@ -73,7 +73,7 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
         case FLOAT: {
           int minOffset = docIds[0] * Float.BYTES;
           FloatBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Float.BYTES).asFloatBuffer();
-          for (int i = 0; i < length; i++) {
+          for (int i = 0; i < buffer.limit(); i++) {
             values[i] = (int) buffer.get(i);
           }
         }
@@ -81,7 +81,7 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
         case DOUBLE: {
           int minOffset = docIds[0] * Double.BYTES;
           DoubleBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Double.BYTES).asDoubleBuffer();
-          for (int i = 0; i < length; i++) {
+          for (int i = 0; i < buffer.limit(); i++) {
             values[i] = (int) buffer.get(i);
           }
         }
@@ -101,7 +101,7 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
         case INT: {
           int minOffset = docIds[0] * Integer.BYTES;
           IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();
-          for (int i = 0; i < length; i++) {
+          for (int i = 0; i < buffer.limit(); i++) {
             values[i] = buffer.get(i);
           }
         }
@@ -115,7 +115,7 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
         case FLOAT: {
           int minOffset = docIds[0] * Float.BYTES;
           FloatBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Float.BYTES).asFloatBuffer();
-          for (int i = 0; i < length; i++) {
+          for (int i = 0; i < buffer.limit(); i++) {
             values[i] = (long) buffer.get(i);
           }
         }
@@ -123,7 +123,7 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
         case DOUBLE: {
           int minOffset = docIds[0] * Double.BYTES;
           DoubleBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Double.BYTES).asDoubleBuffer();
-          for (int i = 0; i < length; i++) {
+          for (int i = 0; i < buffer.limit(); i++) {
             values[i] = (long) buffer.get(i);
           }
         }
@@ -143,7 +143,7 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
         case INT: {
           int minOffset = docIds[0] * Integer.BYTES;
           IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();
-          for (int i = 0; i < length; i++) {
+          for (int i = 0; i < buffer.limit(); i++) {
             values[i] = buffer.get(i);
           }
         }
@@ -151,7 +151,7 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
         case LONG: {
           int minOffset = docIds[0] * Long.BYTES;
           LongBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Long.BYTES).asLongBuffer();
-          for (int i = 0; i < length; i++) {
+          for (int i = 0; i < buffer.limit(); i++) {
             values[i] = buffer.get(i);
           }
         }
@@ -165,7 +165,7 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
         case DOUBLE: {
           int minOffset = docIds[0] * Double.BYTES;
           DoubleBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Double.BYTES).asDoubleBuffer();
-          for (int i = 0; i < length; i++) {
+          for (int i = 0; i < buffer.limit(); i++) {
             values[i] = (float) buffer.get(i);
           }
         }
@@ -185,7 +185,7 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
         case INT: {
           int minOffset = docIds[0] * Integer.BYTES;
           IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();
-          for (int i = 0; i < length; i++) {
+          for (int i = 0; i < buffer.limit(); i++) {
             values[i] = buffer.get(i);
           }
         }
@@ -194,7 +194,7 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
           int minOffset = docIds[0] * Long.BYTES;
           getLong(0, context);
           LongBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Long.BYTES).asLongBuffer();
-          for (int i = 0; i < length; i++) {
+          for (int i = 0; i < buffer.limit(); i++) {
             values[i] = buffer.get(i);
           }
         }
@@ -202,7 +202,7 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
         case FLOAT: {
           int minOffset = docIds[0] * Float.BYTES;
           FloatBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Float.BYTES).asFloatBuffer();
-          for (int i = 0; i < length; i++) {
+          for (int i = 0; i < buffer.limit(); i++) {
             values[i] = buffer.get(i);
           }
         }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedByteChunkSVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedByteChunkSVForwardIndexReader.java
@@ -54,7 +54,7 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
 
   @Override
   public void readValuesSV(int[] docIds, int length, int[] values, ChunkReaderContext context) {
-    if (!_isCompressed && isContiguousRange(docIds, length)) {
+    if (getValueType().getStoredType().isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
       switch (getValueType().getStoredType()) {
         case INT: {
           int minOffset = docIds[0] * Integer.BYTES;
@@ -96,7 +96,7 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
 
   @Override
   public void readValuesSV(int[] docIds, int length, long[] values, ChunkReaderContext context) {
-    if (!_isCompressed && isContiguousRange(docIds, length)) {
+    if (getValueType().getStoredType().isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
       switch (getValueType().getStoredType()) {
         case INT: {
           int minOffset = docIds[0] * Integer.BYTES;
@@ -138,7 +138,7 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
 
   @Override
   public void readValuesSV(int[] docIds, int length, float[] values, ChunkReaderContext context) {
-    if (!_isCompressed && isContiguousRange(docIds, length)) {
+    if (getValueType().getStoredType().isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
       switch (getValueType().getStoredType()) {
         case INT: {
           int minOffset = docIds[0] * Integer.BYTES;
@@ -180,7 +180,7 @@ public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForward
 
   @Override
   public void readValuesSV(int[] docIds, int length, double[] values, ChunkReaderContext context) {
-    if (!_isCompressed && isContiguousRange(docIds, length)) {
+    if (getValueType().getStoredType().isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
       switch (getValueType().getStoredType()) {
         case INT: {
           int minOffset = docIds[0] * Integer.BYTES;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
@@ -109,7 +109,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * @param values Values to fill
    * @param context Reader context
    */
-  default void fillValues(int[] docIds, int length, int[] values, T context) {
+  default void readValuesSV(int[] docIds, int length, int[] values, T context) {
     switch (getValueType().getStoredType()) {
       case INT:
         for (int i = 0; i < length; i++) {
@@ -143,7 +143,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * @param values Values to fill
    * @param context Reader context
    */
-  default void fillValues(int[] docIds, int length, long[] values, T context) {
+  default void readValuesSV(int[] docIds, int length, long[] values, T context) {
     switch (getValueType().getStoredType()) {
       case INT:
         for (int i = 0; i < length; i++) {
@@ -177,7 +177,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * @param values Values to fill
    * @param context Reader context
    */
-  default void fillValues(int[] docIds, int length, float[] values, T context) {
+  default void readValuesSV(int[] docIds, int length, float[] values, T context) {
     switch (getValueType().getStoredType()) {
       case INT:
         for (int i = 0; i < length; i++) {
@@ -211,7 +211,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * @param values Values to fill
    * @param context Reader context
    */
-  default void fillValues(int[] docIds, int length, double[] values, T context) {
+  default void readValuesSV(int[] docIds, int length, double[] values, T context) {
     switch (getValueType().getStoredType()) {
       case INT:
         for (int i = 0; i < length; i++) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
@@ -131,6 +131,11 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
           values[i] = (int) getDouble(docIds[i], context);
         }
         break;
+      case STRING:
+        for (int i = 0; i < length; i++) {
+          values[i] = Integer.parseInt(getString(docIds[i], context));
+        }
+        break;
       default:
         throw new IllegalArgumentException();
     }
@@ -163,6 +168,11 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
       case DOUBLE:
         for (int i = 0; i < length; i++) {
           values[i] = (long) getDouble(docIds[i], context);
+        }
+        break;
+      case STRING:
+        for (int i = 0; i < length; i++) {
+          values[i] = Long.parseLong(getString(docIds[i], context));
         }
         break;
       default:
@@ -199,6 +209,11 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
           values[i] = (float) getDouble(docIds[i], context);
         }
         break;
+      case STRING:
+        for (int i = 0; i < length; i++) {
+          values[i] = Float.parseFloat(getString(docIds[i], context));
+        }
+        break;
       default:
         throw new IllegalArgumentException();
     }
@@ -231,6 +246,11 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
       case DOUBLE:
         for (int i = 0; i < length; i++) {
           values[i] = getDouble(docIds[i], context);
+        }
+        break;
+      case STRING:
+        for (int i = 0; i < length; i++) {
+          values[i] = Double.parseDouble(getString(docIds[i], context));
         }
         break;
       default:

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
@@ -110,7 +110,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * @param context Reader context
    */
   default void readValuesSV(int[] docIds, int length, int[] values, T context) {
-    switch (getValueType().getStoredType()) {
+    switch (getValueType()) {
       case INT:
         for (int i = 0; i < length; i++) {
           values[i] = getInt(docIds[i], context);
@@ -149,7 +149,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * @param context Reader context
    */
   default void readValuesSV(int[] docIds, int length, long[] values, T context) {
-    switch (getValueType().getStoredType()) {
+    switch (getValueType()) {
       case INT:
         for (int i = 0; i < length; i++) {
           values[i] = getInt(docIds[i], context);
@@ -188,7 +188,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * @param context Reader context
    */
   default void readValuesSV(int[] docIds, int length, float[] values, T context) {
-    switch (getValueType().getStoredType()) {
+    switch (getValueType()) {
       case INT:
         for (int i = 0; i < length; i++) {
           values[i] = getInt(docIds[i], context);
@@ -227,7 +227,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * @param context Reader context
    */
   default void readValuesSV(int[] docIds, int length, double[] values, T context) {
-    switch (getValueType().getStoredType()) {
+    switch (getValueType()) {
       case INT:
         for (int i = 0; i < length; i++) {
           values[i] = getInt(docIds[i], context);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
@@ -103,6 +103,142 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    */
 
   /**
+   * Fills the values
+   * @param docIds Array containing the document ids to read
+   * @param length Number of values to read
+   * @param values Values to fill
+   * @param context Reader context
+   */
+  default void fillValues(int[] docIds, int length, int[] values, T context) {
+    switch (getValueType().getStoredType()) {
+      case INT:
+        for (int i = 0; i < length; i++) {
+          values[i] = getInt(docIds[i], context);
+        }
+        break;
+      case LONG:
+        for (int i = 0; i < length; i++) {
+          values[i] = (int) getLong(docIds[i], context);
+        }
+        break;
+      case FLOAT:
+        for (int i = 0; i < length; i++) {
+          values[i] = (int) getFloat(docIds[i], context);
+        }
+        break;
+      case DOUBLE:
+        for (int i = 0; i < length; i++) {
+          values[i] = (int) getDouble(docIds[i], context);
+        }
+        break;
+      default:
+        throw new IllegalArgumentException();
+    }
+  }
+
+  /**
+   * Fills the values
+   * @param docIds Array containing the document ids to read
+   * @param length Number of values to read
+   * @param values Values to fill
+   * @param context Reader context
+   */
+  default void fillValues(int[] docIds, int length, long[] values, T context) {
+    switch (getValueType().getStoredType()) {
+      case INT:
+        for (int i = 0; i < length; i++) {
+          values[i] = getInt(docIds[i], context);
+        }
+        break;
+      case LONG:
+        for (int i = 0; i < length; i++) {
+          values[i] = getLong(docIds[i], context);
+        }
+        break;
+      case FLOAT:
+        for (int i = 0; i < length; i++) {
+          values[i] = (long) getFloat(docIds[i], context);
+        }
+        break;
+      case DOUBLE:
+        for (int i = 0; i < length; i++) {
+          values[i] = (long) getDouble(docIds[i], context);
+        }
+        break;
+      default:
+        throw new IllegalArgumentException();
+    }
+  }
+
+  /**
+   * Fills the values
+   * @param docIds Array containing the document ids to read
+   * @param length Number of values to read
+   * @param values Values to fill
+   * @param context Reader context
+   */
+  default void fillValues(int[] docIds, int length, float[] values, T context) {
+    switch (getValueType().getStoredType()) {
+      case INT:
+        for (int i = 0; i < length; i++) {
+          values[i] = getInt(docIds[i], context);
+        }
+        break;
+      case LONG:
+        for (int i = 0; i < length; i++) {
+          values[i] = getLong(docIds[i], context);
+        }
+        break;
+      case FLOAT:
+        for (int i = 0; i < length; i++) {
+          values[i] = getFloat(docIds[i], context);
+        }
+        break;
+      case DOUBLE:
+        for (int i = 0; i < length; i++) {
+          values[i] = (float) getDouble(docIds[i], context);
+        }
+        break;
+      default:
+        throw new IllegalArgumentException();
+    }
+  }
+
+  /**
+   * Fills the values
+   * @param docIds Array containing the document ids to read
+   * @param length Number of values to read
+   * @param values Values to fill
+   * @param context Reader context
+   */
+  default void fillValues(int[] docIds, int length, double[] values, T context) {
+    switch (getValueType().getStoredType()) {
+      case INT:
+        for (int i = 0; i < length; i++) {
+          values[i] = getInt(docIds[i], context);
+        }
+        break;
+      case LONG:
+        for (int i = 0; i < length; i++) {
+          values[i] = getLong(docIds[i], context);
+        }
+        break;
+      case FLOAT:
+        for (int i = 0; i < length; i++) {
+          values[i] = getFloat(docIds[i], context);
+        }
+        break;
+      case DOUBLE:
+        for (int i = 0; i < length; i++) {
+          values[i] = getDouble(docIds[i], context);
+        }
+        break;
+      default:
+        throw new IllegalArgumentException();
+    }
+  }
+
+  /**
    * Reads the INT value at the given document id.
    *
    * @param docId Document id


### PR DESCRIPTION
This change is motivated by a profile where a user performed a summation over a raw column in a group by query, and a significant amount of time was spent in bounds checks:

<img width="760" alt="Screenshot 2021-12-17 at 13 35 02" src="https://user-images.githubusercontent.com/16439049/146552488-72a7e2a3-f80c-49db-8177-9dc72ed503ef.png">
<img width="1434" alt="Screenshot 2021-12-17 at 13 35 31" src="https://user-images.githubusercontent.com/16439049/146552535-3202ab69-9c63-4394-ab7e-0ba088f36a81.png">

This change adds methods `fillValues` to the `ForwardIndexReader` interface which can avoid bounds checks and perform vectorized copies when the range of docIds is contiguous. There is no way to avoid bounds checks with the current APIs otherwise as there is no way for the compiler to infer that the docIds array is monotonic.

With

```
    "noDictionaryColumns": [
      "clicks"
    ]
```

This speeds up `select platform, sum(clicks) from complexWebsite group by platform` on a 7.5M row segment by ~25%: 60ms down to 45ms. 

Summation is not the best case for the change because it requires conversion from `long` to `double` - accumulating the sum as a `long` would amplify the effect.