### PR TITLE
Separate the exception for transform and indexing for consuming records

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -149,7 +149,6 @@ public class ComplexTypeTransformer implements RecordTransformer {
     }
   }
 
-  @Nullable
   @Override
   public GenericRow transform(GenericRow record) {
     flattenMap(record, new ArrayList<>(record.getFieldToValueMap().keySet()));


### PR DESCRIPTION
Currently the exception from transforming and indexing the records are mixed together, which is hard for debugging. This PR splits them into different exception messages.