### PR TITLE
Small improvements in Docker build

### DIFF
--- a/docker/images/pinot/Dockerfile
+++ b/docker/images/pinot/Dockerfile
@@ -52,9 +52,8 @@ RUN  wget http://archive.apache.org/dist/thrift/0.12.0/thrift-0.12.0.tar.gz -O /
      ./configure --with-cpp=no --with-c_glib=no --with-java=yes --with-python=no --with-ruby=no --with-erlang=no --with-go=no --with-nodejs=no --with-php=no && \
      make install
 
-RUN git clone ${PINOT_GIT_URL} ${PINOT_BUILD_DIR} && \
+RUN git clone --depth 1 -b ${PINOT_BRANCH} ${PINOT_GIT_URL} ${PINOT_BUILD_DIR} && \
     cd ${PINOT_BUILD_DIR} && \
-    git checkout ${PINOT_BRANCH} && \
     mvn install package -DskipTests -Pbin-dist -Pbuild-shaded-jar -Dkafka.version=${KAFKA_VERSION} -Djdk.version=${JDK_VERSION} && \
     mkdir -p ${PINOT_HOME}/configs && \
     mkdir -p ${PINOT_HOME}/data && \

--- a/docker/images/pinot/Dockerfile
+++ b/docker/images/pinot/Dockerfile
@@ -25,7 +25,7 @@ LABEL MAINTAINER=dev@pinot.apache.org
 ARG PINOT_BRANCH=master
 ARG KAFKA_VERSION=2.0
 ARG JDK_VERSION=11
-ARG PINOT_GIT_URL="https://github.com/apache/incubator-pinot.git"
+ARG PINOT_GIT_URL="https://github.com/apache/pinot.git"
 RUN echo "Trying to build Pinot from [ ${PINOT_GIT_URL} ] on branch [ ${PINOT_BRANCH} ] with Kafka version [ ${KAFKA_VERSION} ]"
 ENV PINOT_HOME=/opt/pinot
 ENV PINOT_BUILD_DIR=/opt/pinot-build

--- a/docker/images/pinot/README.md
+++ b/docker/images/pinot/README.md
@@ -29,7 +29,7 @@ There is a docker build script which will build a given Git repo/branch and tag 
 Usage:
 
 ```SHELL
-./docker-build.sh [Docker Tag] [Git Branch] [Pinot Git URL] [Kafka Version] [Java Version] [JDK Version] [OpenJDK Image ]
+./docker-build.sh [Docker Tag] [Git Branch] [Pinot Git URL] [Kafka Version] [Java Version] [JDK Version]
 ```
 
 This script will check out Pinot Repo `[Pinot Git URL]` on branch `[Git Branch]` and build the docker image for that.
@@ -47,8 +47,6 @@ The docker image is tagged as `[Docker Tag]`.
 `Java Version`: The Java Build and Runtime image version. Default is `11`
 
 `JDK Version`: The JDK parameter to build pinot, set as part of maven build option: `-Djdk.version=${JDK_VERSION}`. Default is `11`
-
-`OpenJDK Image`: Base image to use for Pinot build and runtime. Default is `openjdk`.
 
 * Example of building and tagging a snapshot on your own fork:
 ```SHELL

--- a/docker/images/pinot/docker-build.sh
+++ b/docker/images/pinot/docker-build.sh
@@ -56,6 +56,13 @@ else
   JAVA_VERSION=8
 fi
 
-echo "Trying to build Pinot docker image from Git URL: [ ${PINOT_GIT_URL} ] on branch: [ ${PINOT_BRANCH} ] and tag it as: [ ${DOCKER_TAG} ]. Kafka Dependencies: [ ${KAFKA_VERSION} ]. Java Version: [ ${JAVA_VERSION} ]."
+if [[ "$#" -gt 5 ]]
+then
+  JDK_VERSION=$5
+else
+  JDK_VERSION=$JAVA_VERSION
+fi
 
-docker build --no-cache -t ${DOCKER_TAG} --build-arg PINOT_BRANCH=${PINOT_BRANCH} --build-arg PINOT_GIT_URL=${PINOT_GIT_URL} --build-arg KAFKA_VERSION=${KAFKA_VERSION} --build-arg JAVA_VERSION=${JAVA_VERSION} -f Dockerfile .
+echo "Trying to build Pinot docker image from Git URL: [ ${PINOT_GIT_URL} ] on branch: [ ${PINOT_BRANCH} ] and tag it as: [ ${DOCKER_TAG} ]. Kafka Dependencies: [ ${KAFKA_VERSION} ]. Java Version: [ ${JAVA_VERSION} ]. JDK Version: [ ${JDK_VERSION} ]."
+
+docker build --no-cache -t ${DOCKER_TAG} --build-arg PINOT_BRANCH=${PINOT_BRANCH} --build-arg PINOT_GIT_URL=${PINOT_GIT_URL} --build-arg KAFKA_VERSION=${KAFKA_VERSION} --build-arg JAVA_VERSION=${JAVA_VERSION} --build-arg JDK_VERSION=${JDK_VERSION} -f Dockerfile .


### PR DESCRIPTION
## Description
4 small improvements in container image builds. See commits message.

The most important improvement is to allow overriding Dockerfile JDK_VERSION from `docker-build.sh`
That's actually a bug fix, because without this change the `docker-build.sh` fails to produce a container image.
Why? The script set `JAVA_VERSION` to 8. This makes Docker build to pick `openjdk:8` as a base image. 
But `Dockefile` has  `JDK_VERSION`  hard-coded as 11. This is passed as a system property to Maven build
and Maven actives the `other-jdk-maven-compiler-plugin` profile. This profile assumes JDK9+, 
it tries to set  `-release` flag when invoking javac. This fails the build process, because JDK8
does not support the the flag. 

Other improvements are rather cosmetic. Perhaps the shallow clone is worth mentioning. I assume git history
is not needed during the build, otherwise the shallow build could cause troubles. 

## Documentation
Interestingly enough `readme.md` described the JDK_VERSION parameter, even the docker-build.sh 
did not support it (before this changeset). I removed the `OpenJDK Image` parameter, which is still not
supported by the script.

The readme is talking about special measures when building on M1 MacBook. This looks outdated too.  The official OpenJDK container images do support arm64 architecture so I assume it should just work. So perhaps that part of readme should be updated too. Caveat: I have no M1 machine to validate this assumption. 