### PR TITLE
Power of 2 fixed size chunks

### DIFF
--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkFixedByteSVForwardIndexReader.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkFixedByteSVForwardIndexReader.java
@@ -1,0 +1,147 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.io.writer.impl.FixedByteChunkSVForwardIndexWriter;
+import org.apache.pinot.segment.local.segment.index.readers.forward.ChunkReaderContext;
+import org.apache.pinot.segment.local.segment.index.readers.forward.FixedByteChunkSVForwardIndexReader;
+import org.apache.pinot.segment.local.segment.index.readers.forward.FixedBytePower2ChunkSVForwardIndexReader;
+import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.infra.Blackhole;
+
+
+@State(Scope.Benchmark)
+public class BenchmarkFixedByteSVForwardIndexReader {
+
+  private static final File INDEX_DIR =
+      new File(FileUtils.getTempDirectory(), "BenchmarkFixedByteSVForwardIndexReader");
+
+  @Param("10000")
+  int _blockSize;
+
+  @Param("1000")
+  int _numBlocks;
+
+  private int[] _docIds;
+  private double[] _doubleBuffer;
+  private long[] _longBuffer;
+  private FixedByteChunkSVForwardIndexReader _compressedReader;
+  private FixedBytePower2ChunkSVForwardIndexReader _compressedPow2Reader;
+
+  @Setup(Level.Trial)
+  public void setup()
+      throws IOException {
+    FileUtils.forceMkdir(INDEX_DIR);
+    File compressedIndexFile = new File(INDEX_DIR, UUID.randomUUID().toString());
+    File pow2CompressedIndexFile = new File(INDEX_DIR, UUID.randomUUID().toString());
+    _doubleBuffer = new double[_blockSize];
+    _longBuffer = new long[_blockSize];
+    try (FixedByteChunkSVForwardIndexWriter writer = new FixedByteChunkSVForwardIndexWriter(compressedIndexFile,
+        ChunkCompressionType.LZ4, _numBlocks * _blockSize, 1000, Long.BYTES, 3);
+        FixedByteChunkSVForwardIndexWriter pow2Writer = new FixedByteChunkSVForwardIndexWriter(pow2CompressedIndexFile,
+            ChunkCompressionType.LZ4, _numBlocks * _blockSize, 1000, Long.BYTES, 4)) {
+      for (int i = 0; i < _numBlocks * _blockSize; i++) {
+        long next = ThreadLocalRandom.current().nextLong();
+        writer.putLong(next);
+        pow2Writer.putLong(next);
+      }
+    }
+    _compressedReader = new FixedByteChunkSVForwardIndexReader(PinotDataBuffer.loadBigEndianFile(compressedIndexFile),
+        FieldSpec.DataType.LONG);
+    _compressedPow2Reader =
+        new FixedBytePower2ChunkSVForwardIndexReader(PinotDataBuffer.loadBigEndianFile(pow2CompressedIndexFile),
+            FieldSpec.DataType.LONG);
+    _docIds = new int[_blockSize];
+  }
+
+  @TearDown(Level.Trial)
+  public void teardown()
+      throws IOException {
+    FileUtils.deleteDirectory(INDEX_DIR);
+  }
+
+  @Benchmark
+  public void readCompressedDoublesNonContiguousV3(Blackhole bh)
+      throws IOException {
+    readCompressedDoublesNonContiguous(bh, _compressedReader);
+  }
+
+  @Benchmark
+  public void readCompressedDoublesNonContiguousV4(Blackhole bh)
+      throws IOException {
+    readCompressedDoublesNonContiguous(bh, _compressedPow2Reader);
+  }
+
+  @Benchmark
+  public void readCompressedLongsNonContiguousV3(Blackhole bh)
+      throws IOException {
+    readCompressedLongsNonContiguous(bh, _compressedReader);
+  }
+
+  @Benchmark
+  public void readCompressedLongsNonContiguousV4(Blackhole bh)
+      throws IOException {
+    readCompressedLongsNonContiguous(bh, _compressedPow2Reader);
+  }
+
+  private void readCompressedLongsNonContiguous(Blackhole bh, ForwardIndexReader<ChunkReaderContext> reader)
+      throws IOException {
+    try (ChunkReaderContext context = reader.createContext()) {
+      for (int block = 0; block < _numBlocks / 2; block++) {
+        for (int i = 0; i < _docIds.length; i++) {
+          _docIds[i] = block * _blockSize + i * 2;
+        }
+        for (int i = 0; i < _docIds.length; i++) {
+          _longBuffer[i] = reader.getLong(_docIds[i], context);
+        }
+        bh.consume(_longBuffer);
+      }
+    }
+  }
+
+  private void readCompressedDoublesNonContiguous(Blackhole bh, ForwardIndexReader<ChunkReaderContext> reader)
+      throws IOException {
+    try (ChunkReaderContext context = reader.createContext()) {
+      for (int block = 0; block < _numBlocks / 2; block++) {
+        for (int i = 0; i < _docIds.length; i++) {
+          _docIds[i] = block * _blockSize + i * 2;
+        }
+        for (int i = 0; i < _docIds.length; i++) {
+          _doubleBuffer[i] = reader.getDouble(_docIds[i], context);
+        }
+        bh.consume(_doubleBuffer);
+      }
+    }
+  }
+}

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkRawForwardIndexReader.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkRawForwardIndexReader.java
@@ -27,7 +27,7 @@ import java.util.function.LongSupplier;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.io.writer.impl.VarByteChunkSVForwardIndexWriter;
 import org.apache.pinot.segment.local.io.writer.impl.VarByteChunkSVForwardIndexWriterV4;
-import org.apache.pinot.segment.local.segment.index.readers.forward.BaseChunkSVForwardIndexReader;
+import org.apache.pinot.segment.local.segment.index.readers.forward.ChunkReaderContext;
 import org.apache.pinot.segment.local.segment.index.readers.forward.VarByteChunkSVForwardIndexReader;
 import org.apache.pinot.segment.local.segment.index.readers.forward.VarByteChunkSVForwardIndexReaderV4;
 import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
@@ -200,7 +200,7 @@ public class BenchmarkRawForwardIndexReader {
     try (PinotDataBuffer buffer = PinotDataBuffer.loadBigEndianFile(state._file);
         VarByteChunkSVForwardIndexReader reader =
             new VarByteChunkSVForwardIndexReader(buffer, FieldSpec.DataType.BYTES);
-        BaseChunkSVForwardIndexReader.ChunkReaderContext context = reader.createContext()) {
+        ChunkReaderContext context = reader.createContext()) {
       for (int i = 0; i < state._records; i++) {
         bh.consume(reader.getBytes(i, context));
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/BaseChunkSVForwardIndexWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/BaseChunkSVForwardIndexWriter.java
@@ -65,12 +65,14 @@ public abstract class BaseChunkSVForwardIndexWriter implements Closeable {
    * @param chunkSize Size of chunk
    * @param sizeOfEntry Size of entry (in bytes), max size for variable byte implementation.
    * @param version version of File
+   * @param fixed if the data type is fixed width (required for version validation)
    * @throws IOException if the file isn't found or can't be mapped
    */
   protected BaseChunkSVForwardIndexWriter(File file, ChunkCompressionType compressionType, int totalDocs,
-      int numDocsPerChunk, int chunkSize, int sizeOfEntry, int version)
+      int numDocsPerChunk, int chunkSize, int sizeOfEntry, int version, boolean fixed)
       throws IOException {
-    Preconditions.checkArgument(version == DEFAULT_VERSION || version == CURRENT_VERSION);
+    Preconditions.checkArgument(version == DEFAULT_VERSION || version == CURRENT_VERSION
+        || (fixed && version == 4));
     _chunkSize = chunkSize;
     _chunkCompressor = ChunkCompressorFactory.getCompressor(compressionType);
     _headerEntryChunkOffsetSize = getHeaderEntryChunkOffsetSize(version);
@@ -87,6 +89,7 @@ public abstract class BaseChunkSVForwardIndexWriter implements Closeable {
       case 2:
         return FILE_HEADER_ENTRY_CHUNK_OFFSET_SIZE_V1V2;
       case 3:
+      case 4:
         return FILE_HEADER_ENTRY_CHUNK_OFFSET_SIZE_V3;
       default:
         throw new IllegalStateException("Invalid version: " + version);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/FixedByteChunkSVForwardIndexWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/FixedByteChunkSVForwardIndexWriter.java
@@ -71,8 +71,8 @@ public class FixedByteChunkSVForwardIndexWriter extends BaseChunkSVForwardIndexW
   public FixedByteChunkSVForwardIndexWriter(File file, ChunkCompressionType compressionType, int totalDocs,
       int numDocsPerChunk, int sizeOfEntry, int writerVersion)
       throws IOException {
-    super(file, compressionType, totalDocs, normalizeChunkSize(writerVersion, numDocsPerChunk),
-        (sizeOfEntry * normalizeChunkSize(writerVersion, numDocsPerChunk)), sizeOfEntry,
+    super(file, compressionType, totalDocs, normalizeDocsPerChunk(writerVersion, numDocsPerChunk),
+        (sizeOfEntry * normalizeDocsPerChunk(writerVersion, numDocsPerChunk)), sizeOfEntry,
         writerVersion, true);
     _chunkDataOffset = 0;
   }
@@ -114,7 +114,7 @@ public class FixedByteChunkSVForwardIndexWriter extends BaseChunkSVForwardIndexW
     }
   }
 
-  private static int normalizeChunkSize(int version, int numDocsPerChunk) {
+  private static int normalizeDocsPerChunk(int version, int numDocsPerChunk) {
     // V4 uses power of 2 chunk sizes for random access efficiency
     if (version >= 4 && (numDocsPerChunk & (numDocsPerChunk - 1)) != 0) {
       return 1 << (32 - Integer.numberOfLeadingZeros(numDocsPerChunk - 1));

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/FixedByteChunkSVForwardIndexWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/FixedByteChunkSVForwardIndexWriter.java
@@ -71,8 +71,9 @@ public class FixedByteChunkSVForwardIndexWriter extends BaseChunkSVForwardIndexW
   public FixedByteChunkSVForwardIndexWriter(File file, ChunkCompressionType compressionType, int totalDocs,
       int numDocsPerChunk, int sizeOfEntry, int writerVersion)
       throws IOException {
-    super(file, compressionType, totalDocs, numDocsPerChunk, (sizeOfEntry * numDocsPerChunk), sizeOfEntry,
-        writerVersion);
+    super(file, compressionType, totalDocs, normalizeChunkSize(writerVersion, numDocsPerChunk),
+        (sizeOfEntry * normalizeChunkSize(writerVersion, numDocsPerChunk)), sizeOfEntry,
+        writerVersion, true);
     _chunkDataOffset = 0;
   }
 
@@ -111,5 +112,13 @@ public class FixedByteChunkSVForwardIndexWriter extends BaseChunkSVForwardIndexW
     if (_chunkDataOffset == _chunkSize) {
       writeChunk();
     }
+  }
+
+  private static int normalizeChunkSize(int version, int numDocsPerChunk) {
+    // V4 uses power of 2 chunk sizes for random access efficiency
+    if (version >= 4 && (numDocsPerChunk & (numDocsPerChunk - 1)) != 0) {
+      return 1 << (32 - Integer.numberOfLeadingZeros(numDocsPerChunk - 1));
+    }
+    return numDocsPerChunk;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkSVForwardIndexWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkSVForwardIndexWriter.java
@@ -80,7 +80,7 @@ public class VarByteChunkSVForwardIndexWriter extends BaseChunkSVForwardIndexWri
     super(file, compressionType, totalDocs, numDocsPerChunk,
         numDocsPerChunk * (CHUNK_HEADER_ENTRY_ROW_OFFSET_SIZE + lengthOfLongestEntry),
         // chunkSize
-        lengthOfLongestEntry, writerVersion);
+        lengthOfLongestEntry, writerVersion, false);
 
     _chunkHeaderOffset = 0;
     _chunkHeaderSize = numDocsPerChunk * CHUNK_HEADER_ENTRY_ROW_OFFSET_SIZE;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/DefaultIndexReaderProvider.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/DefaultIndexReaderProvider.java
@@ -30,6 +30,7 @@ import org.apache.pinot.segment.local.segment.index.readers.forward.FixedBitMVFo
 import org.apache.pinot.segment.local.segment.index.readers.forward.FixedBitSVForwardIndexReaderV2;
 import org.apache.pinot.segment.local.segment.index.readers.forward.FixedByteChunkMVForwardIndexReader;
 import org.apache.pinot.segment.local.segment.index.readers.forward.FixedByteChunkSVForwardIndexReader;
+import org.apache.pinot.segment.local.segment.index.readers.forward.FixedBytePower2ChunkSVForwardIndexReader;
 import org.apache.pinot.segment.local.segment.index.readers.forward.VarByteChunkMVForwardIndexReader;
 import org.apache.pinot.segment.local.segment.index.readers.forward.VarByteChunkSVForwardIndexReader;
 import org.apache.pinot.segment.local.segment.index.readers.forward.VarByteChunkSVForwardIndexReaderV4;
@@ -89,10 +90,12 @@ public class DefaultIndexReaderProvider implements IndexReaderProvider {
     } else {
       FieldSpec.DataType storedType = columnMetadata.getDataType().getStoredType();
       if (columnMetadata.isSingleValue()) {
-        if (storedType.isFixedWidth()) {
-          return new FixedByteChunkSVForwardIndexReader(dataBuffer, storedType);
-        }
         int version = dataBuffer.getInt(0);
+        if (storedType.isFixedWidth()) {
+          return version >= FixedBytePower2ChunkSVForwardIndexReader.VERSION
+              ? new FixedBytePower2ChunkSVForwardIndexReader(dataBuffer, storedType)
+              : new FixedByteChunkSVForwardIndexReader(dataBuffer, storedType);
+        }
         if (version >= VarByteChunkSVForwardIndexWriterV4.VERSION) {
           return new VarByteChunkSVForwardIndexReaderV4(dataBuffer, storedType);
         }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/ChunkReaderContext.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/ChunkReaderContext.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.readers.forward;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
+import org.apache.pinot.segment.spi.memory.CleanerUtil;
+
+
+/**
+ * Context for the chunk-based forward index readers.
+ * <p>Information saved in the context can be used by subsequent reads as cache:
+ * <ul>
+ *   <li>
+ *     Chunk Buffer from the previous read. Useful if the subsequent read is from the same buffer, as it avoids extra
+ *     chunk decompression.
+ *   </li>
+ *   <li>Id for the chunk</li>
+ * </ul>
+ */
+public class ChunkReaderContext implements ForwardIndexReaderContext {
+  private final ByteBuffer _chunkBuffer;
+  private int _chunkId;
+
+  public ChunkReaderContext(int maxChunkSize) {
+    _chunkBuffer = ByteBuffer.allocateDirect(maxChunkSize);
+    _chunkId = -1;
+  }
+
+  public ByteBuffer getChunkBuffer() {
+    return _chunkBuffer;
+  }
+
+  public int getChunkId() {
+    return _chunkId;
+  }
+
+  public void setChunkId(int chunkId) {
+    _chunkId = chunkId;
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    if (CleanerUtil.UNMAP_SUPPORTED) {
+      CleanerUtil.getCleaner().freeBuffer(_chunkBuffer);
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBytePower2ChunkSVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBytePower2ChunkSVForwardIndexReader.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.readers.forward;
+
+import java.nio.ByteBuffer;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.local.io.writer.impl.FixedByteChunkSVForwardIndexWriter;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+
+/**
+ * Chunk-based single-value raw (non-dictionary-encoded) forward index reader for values of fixed length data type (INT,
+ * LONG, FLOAT, DOUBLE).
+ * <p>For data layout, please refer to the documentation for {@link FixedByteChunkSVForwardIndexWriter}
+ */
+public final class FixedBytePower2ChunkSVForwardIndexReader extends BaseChunkSVForwardIndexReader {
+  public static final int VERSION = 4;
+
+  private final int _shift;
+
+  public FixedBytePower2ChunkSVForwardIndexReader(PinotDataBuffer dataBuffer, DataType valueType) {
+    super(dataBuffer, valueType);
+    _shift = Integer.numberOfTrailingZeros(_numDocsPerChunk);
+  }
+
+  @Nullable
+  @Override
+  public ChunkReaderContext createContext() {
+    if (_isCompressed) {
+      return new ChunkReaderContext(_numDocsPerChunk * _valueType.size());
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public int getInt(int docId, ChunkReaderContext context) {
+    if (_isCompressed) {
+      int chunkRowId = docId & (_numDocsPerChunk - 1);
+      ByteBuffer chunkBuffer = getChunkBuffer(docId, context);
+      return chunkBuffer.getInt(chunkRowId * Integer.BYTES);
+    } else {
+      return _rawData.getInt(docId * Integer.BYTES);
+    }
+  }
+
+  @Override
+  public long getLong(int docId, ChunkReaderContext context) {
+    if (_isCompressed) {
+      int chunkRowId = docId & (_numDocsPerChunk - 1);
+      ByteBuffer chunkBuffer = getChunkBuffer(docId, context);
+      return chunkBuffer.getLong(chunkRowId * Long.BYTES);
+    } else {
+      return _rawData.getLong(docId * Long.BYTES);
+    }
+  }
+
+  @Override
+  public float getFloat(int docId, ChunkReaderContext context) {
+    if (_isCompressed) {
+      int chunkRowId = docId & (_numDocsPerChunk - 1);
+      ByteBuffer chunkBuffer = getChunkBuffer(docId, context);
+      return chunkBuffer.getFloat(chunkRowId * Float.BYTES);
+    } else {
+      return _rawData.getFloat(docId * Float.BYTES);
+    }
+  }
+
+  @Override
+  public double getDouble(int docId, ChunkReaderContext context) {
+    if (_isCompressed) {
+      int chunkRowId = docId & (_numDocsPerChunk - 1);
+      ByteBuffer chunkBuffer = getChunkBuffer(docId, context);
+      return chunkBuffer.getDouble(chunkRowId * Double.BYTES);
+    } else {
+      return _rawData.getDouble(docId * Double.BYTES);
+    }
+  }
+
+  /**
+   * Helper method to return the chunk buffer that contains the value at the given document id.
+   * <ul>
+   *   <li> If the chunk already exists in the reader context, returns the same. </li>
+   *   <li> Otherwise, loads the chunk for the row, and sets it in the reader context. </li>
+   * </ul>
+   * @param docId Document id
+   * @param context Reader context
+   * @return Chunk for the row
+   */
+  protected ByteBuffer getChunkBuffer(int docId, ChunkReaderContext context) {
+    int chunkId = docId >>> _shift;
+    if (context.getChunkId() == chunkId) {
+      return context.getChunkBuffer();
+    }
+    return decompressChunk(chunkId, context);
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/MultiValueFixedByteRawIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/MultiValueFixedByteRawIndexCreatorTest.java
@@ -30,7 +30,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.segment.creator.impl.fwd.MultiValueFixedByteRawIndexCreator;
-import org.apache.pinot.segment.local.segment.index.readers.forward.BaseChunkSVForwardIndexReader.ChunkReaderContext;
+import org.apache.pinot.segment.local.segment.index.readers.forward.ChunkReaderContext;
 import org.apache.pinot.segment.local.segment.index.readers.forward.FixedByteChunkMVForwardIndexReader;
 import org.apache.pinot.segment.spi.V1Constants.Indexes;
 import org.apache.pinot.segment.spi.compression.ChunkCompressionType;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/MultiValueVarByteRawIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/MultiValueVarByteRawIndexCreatorTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 import java.util.Random;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.segment.creator.impl.fwd.MultiValueVarByteRawIndexCreator;
-import org.apache.pinot.segment.local.segment.index.readers.forward.BaseChunkSVForwardIndexReader.ChunkReaderContext;
+import org.apache.pinot.segment.local.segment.index.readers.forward.ChunkReaderContext;
 import org.apache.pinot.segment.local.segment.index.readers.forward.VarByteChunkMVForwardIndexReader;
 import org.apache.pinot.segment.spi.V1Constants.Indexes;
 import org.apache.pinot.segment.spi.compression.ChunkCompressionType;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/RawIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/RawIndexCreatorTest.java
@@ -31,7 +31,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
-import org.apache.pinot.segment.local.segment.index.readers.forward.BaseChunkSVForwardIndexReader;
+import org.apache.pinot.segment.local.segment.index.readers.forward.ChunkReaderContext;
 import org.apache.pinot.segment.local.segment.index.readers.forward.FixedByteChunkSVForwardIndexReader;
 import org.apache.pinot.segment.local.segment.index.readers.forward.VarByteChunkMVForwardIndexReader;
 import org.apache.pinot.segment.local.segment.index.readers.forward.VarByteChunkSVForwardIndexReader;
@@ -169,11 +169,9 @@ public class RawIndexCreatorTest {
   public void testStringRawIndexCreator()
       throws Exception {
     PinotDataBuffer indexBuffer = getIndexBufferForColumn(STRING_COLUMN);
-    try (VarByteChunkSVForwardIndexReader rawIndexReader = new VarByteChunkSVForwardIndexReader(
-        indexBuffer,
+    try (VarByteChunkSVForwardIndexReader rawIndexReader = new VarByteChunkSVForwardIndexReader(indexBuffer,
         DataType.STRING);
-        BaseChunkSVForwardIndexReader.ChunkReaderContext readerContext = rawIndexReader
-            .createContext()) {
+        ChunkReaderContext readerContext = rawIndexReader.createContext()) {
       _recordReader.rewind();
       for (int row = 0; row < NUM_ROWS; row++) {
         GenericRow expectedRow = _recordReader.next();
@@ -193,9 +191,8 @@ public class RawIndexCreatorTest {
       throws Exception {
     PinotDataBuffer indexBuffer = getIndexBufferForColumn(column);
     try (FixedByteChunkSVForwardIndexReader rawIndexReader = new FixedByteChunkSVForwardIndexReader(
-        indexBuffer,
-        dataType); BaseChunkSVForwardIndexReader.ChunkReaderContext readerContext = rawIndexReader
-        .createContext()) {
+        indexBuffer, dataType);
+        ChunkReaderContext readerContext = rawIndexReader.createContext()) {
       _recordReader.rewind();
       for (int row = 0; row < NUM_ROWS; row++) {
         GenericRow expectedRow = _recordReader.next();
@@ -216,7 +213,7 @@ public class RawIndexCreatorTest {
     try (VarByteChunkMVForwardIndexReader rawIndexReader = new VarByteChunkMVForwardIndexReader(
         indexBuffer,
         DataType.STRING);
-        BaseChunkSVForwardIndexReader.ChunkReaderContext readerContext = rawIndexReader
+        ChunkReaderContext readerContext = rawIndexReader
             .createContext()) {
       _recordReader.rewind();
       int maxNumberOfMultiValues = _segmentDirectory.getSegmentMetadata()
@@ -250,7 +247,7 @@ public class RawIndexCreatorTest {
     PinotDataBuffer indexBuffer = getIndexBufferForColumn(BYTES_MV_COLUMN);
     try (VarByteChunkMVForwardIndexReader rawIndexReader = new VarByteChunkMVForwardIndexReader(
         indexBuffer, DataType.BYTES);
-        BaseChunkSVForwardIndexReader.ChunkReaderContext readerContext = rawIndexReader
+        ChunkReaderContext readerContext = rawIndexReader
             .createContext()) {
       _recordReader.rewind();
       int maxNumberOfMultiValues = _segmentDirectory.getSegmentMetadata()
@@ -373,8 +370,8 @@ public class RawIndexCreatorTest {
    * @param docId Document id
    * @return Value read from index
    */
-  private Object readValueFromIndex(FixedByteChunkSVForwardIndexReader rawIndexReader,
-      BaseChunkSVForwardIndexReader.ChunkReaderContext readerContext, int docId) {
+  private Object readValueFromIndex(FixedByteChunkSVForwardIndexReader rawIndexReader, ChunkReaderContext readerContext,
+      int docId) {
     switch (rawIndexReader.getValueType()) {
       case INT:
         return rawIndexReader.getInt(docId, readerContext);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/VarByteChunkSVForwardIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/VarByteChunkSVForwardIndexTest.java
@@ -27,7 +27,7 @@ import org.apache.commons.lang.RandomStringUtils;
 import org.apache.pinot.segment.local.io.writer.impl.BaseChunkSVForwardIndexWriter;
 import org.apache.pinot.segment.local.io.writer.impl.VarByteChunkSVForwardIndexWriter;
 import org.apache.pinot.segment.local.segment.creator.impl.fwd.SingleValueVarByteRawIndexCreator;
-import org.apache.pinot.segment.local.segment.index.readers.forward.BaseChunkSVForwardIndexReader;
+import org.apache.pinot.segment.local.segment.index.readers.forward.ChunkReaderContext;
 import org.apache.pinot.segment.local.segment.index.readers.forward.VarByteChunkSVForwardIndexReader;
 import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
@@ -117,11 +117,11 @@ public class VarByteChunkSVForwardIndexTest {
 
     try (VarByteChunkSVForwardIndexReader fourByteOffsetReader = new VarByteChunkSVForwardIndexReader(
         PinotDataBuffer.mapReadOnlyBigEndianFile(outFileFourByte), DataType.STRING);
-        BaseChunkSVForwardIndexReader.ChunkReaderContext fourByteOffsetReaderContext = fourByteOffsetReader
+        ChunkReaderContext fourByteOffsetReaderContext = fourByteOffsetReader
             .createContext();
         VarByteChunkSVForwardIndexReader eightByteOffsetReader = new VarByteChunkSVForwardIndexReader(
             PinotDataBuffer.mapReadOnlyBigEndianFile(outFileEightByte), DataType.STRING);
-        BaseChunkSVForwardIndexReader.ChunkReaderContext eightByteOffsetReaderContext = eightByteOffsetReader
+        ChunkReaderContext eightByteOffsetReaderContext = eightByteOffsetReader
             .createContext()) {
       for (int i = 0; i < NUM_ENTRIES; i++) {
         Assert.assertEquals(fourByteOffsetReader.getString(i, fourByteOffsetReaderContext), expected[i]);
@@ -164,7 +164,7 @@ public class VarByteChunkSVForwardIndexTest {
     File file = new File(resource.getFile());
     try (VarByteChunkSVForwardIndexReader reader = new VarByteChunkSVForwardIndexReader(
         PinotDataBuffer.mapReadOnlyBigEndianFile(file), DataType.STRING);
-        BaseChunkSVForwardIndexReader.ChunkReaderContext readerContext = reader.createContext()) {
+        ChunkReaderContext readerContext = reader.createContext()) {
       for (int i = 0; i < numDocs; i++) {
         String actual = reader.getString(i, readerContext);
         Assert.assertEquals(actual, data[i % data.length]);
@@ -237,7 +237,7 @@ public class VarByteChunkSVForwardIndexTest {
 
     PinotDataBuffer buffer = PinotDataBuffer.mapReadOnlyBigEndianFile(outFile);
     try (VarByteChunkSVForwardIndexReader reader = new VarByteChunkSVForwardIndexReader(buffer, DataType.STRING);
-        BaseChunkSVForwardIndexReader.ChunkReaderContext readerContext = reader.createContext()) {
+        ChunkReaderContext readerContext = reader.createContext()) {
       for (int i = 0; i < numDocs; i++) {
         Assert.assertEquals(reader.getString(i, readerContext), expected[i]);
       }
@@ -257,7 +257,7 @@ public class VarByteChunkSVForwardIndexTest {
     }
 
     try (VarByteChunkSVForwardIndexReader reader = new VarByteChunkSVForwardIndexReader(buffer, DataType.STRING);
-        BaseChunkSVForwardIndexReader.ChunkReaderContext readerContext = reader.createContext()) {
+        ChunkReaderContext readerContext = reader.createContext()) {
       for (int i = 0; i < numDocs; i++) {
         Assert.assertEquals(reader.getString(i, readerContext), expected[i]);
       }


### PR DESCRIPTION
This introduces a simple evolution of the raw index format for fixed width data types which merely enforces that chunk sizes are a power of 2. For example, if a chunk size of 1000 is chosen, the writer will round up to 1024. This allows the reader to assume that the chunk size is a power of 2 and replace integer remainder calculations and divisions with masks and shifts respectively. The format is otherwise identical. 


This has a good impact when the index is compressed and the accesses are non-contiguous but there are many accesses per chunk:

```
Benchmark                                                                    (_blockSize)  (_numBlocks)  Mode  Cnt   Score   Error  Units
BenchmarkFixedByteSVForwardIndexReader.readCompressedDoublesNonContiguousV3         10000          1000  avgt    5  39.976 ± 0.439  ms/op
BenchmarkFixedByteSVForwardIndexReader.readCompressedDoublesNonContiguousV4         10000          1000  avgt    5  33.110 ± 0.588  ms/op
BenchmarkFixedByteSVForwardIndexReader.readCompressedLongsNonContiguousV3           10000          1000  avgt    5  46.568 ± 0.440  ms/op
BenchmarkFixedByteSVForwardIndexReader.readCompressedLongsNonContiguousV4           10000          1000  avgt    5  31.989 ± 0.419  ms/op
```