### PR TITLE
exit group-by marking loop early

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGenerator.java
@@ -270,6 +270,9 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
         if (!_flags[outGroupIds[i]]) {
           _numKeys++;
           _flags[outGroupIds[i]] = true;
+          if (_numKeys == _globalGroupIdUpperBound) {
+            return;
+          }
         }
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGenerator.java
@@ -266,13 +266,10 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
 
     private void processSingleValue(int numDocs, int[] dictIds, int[] outGroupIds) {
       System.arraycopy(dictIds, 0, outGroupIds, 0, numDocs);
-      for (int i = 0; i < numDocs; i++) {
+      for (int i = 0; i < numDocs && _numKeys < _globalGroupIdUpperBound; i++) {
         if (!_flags[outGroupIds[i]]) {
           _numKeys++;
           _flags[outGroupIds[i]] = true;
-          if (_numKeys == _globalGroupIdUpperBound) {
-            return;
-          }
         }
       }
     }
@@ -287,8 +284,8 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
         // if the flag is false, then increase the key num
         if (!_flags[groupId]) {
           _numKeys++;
+          _flags[groupId] = true;
         }
-        _flags[groupId] = true;
       }
     }
 
@@ -299,8 +296,8 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
         for (int groupId : groupIds) {
           if (!_flags[groupId]) {
             _numKeys++;
+            _flags[groupId] = true;
           }
-          _flags[groupId] = true;
         }
         outGroupIds[i] = groupIds;
       }


### PR DESCRIPTION
For low cardinality one dimensional group by queries, it's possible to exit the group marking loop much earlier than the 10k default block size.