### PR TITLE
set keys; 1 modal per click; better json in diff viewer

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -377,20 +377,21 @@ export default function CustomizedTables({
     return (<span>{str.toString()}</span>);
   };
 
-  const [isModalOpen, setModalOpen] = React.useState(false);
-  const handleModalOpen = () => setModalOpen(true);
-  const handleModalClose = () => setModalOpen(false);
-
-  const makeCell = (cellData) => {
+  const makeCell = (cellData, idx) => {
     if (Object.prototype.toString.call(cellData) === '[object Object]') {
       if (_.has(cellData, 'component') && cellData.component) {
+        const [isModalOpen, setModalOpen] = React.useState(false);
+        const handleModalOpen = () => setModalOpen(true);
+        const handleModalClose = () => setModalOpen(false);
+
         let cell = (styleCell(cellData.value))
         let statusModal = (
             <Dialog
-                maxWidth="xl"
+                key={idx}
                 onClose={handleModalClose}
                 open={isModalOpen}
-                scroll="paper"
+                fullWidth={true}
+                maxWidth={'xl'}
             >
               {cellData.component}
             </Dialog>
@@ -403,7 +404,12 @@ export default function CustomizedTables({
         );
         if (_.has(cellData, 'tooltip') && cellData.tooltip) {
           cell = (
-              <Tooltip title={cellData.tooltip} placement="top" arrow>
+              <Tooltip
+                  key={idx}
+                  title={cellData.tooltip}
+                  placement="top"
+                  arrow
+              >
                 {cell}
               </Tooltip>
           )
@@ -416,7 +422,12 @@ export default function CustomizedTables({
         );
       } else if (_.has(cellData, 'tooltip') && cellData.tooltip) {
         return (
-            <Tooltip title={cellData.tooltip} placement="top" arrow>
+            <Tooltip
+                key={idx}
+                title={cellData.tooltip}
+                placement="top"
+                arrow
+            >
               {styleCell(cellData.value)}
             </Tooltip>
         );
@@ -511,7 +522,7 @@ export default function CustomizedTables({
                             className={isCellClickable ? classes.isCellClickable : (isSticky ? classes.isSticky : '')}
                             onClick={() => {cellClickCallback && cellClickCallback(cell);}}
                           >
-                            {makeCell(cell)}
+                            {makeCell(cell, idx)}
                           </StyledTableCell>
                         );
                       })}

--- a/pinot-controller/src/main/resources/app/utils/Utils.tsx
+++ b/pinot-controller/src/main/resources/app/utils/Utils.tsx
@@ -70,10 +70,10 @@ const getSegmentStatus = (idealStateObj, externalViewObj) => {
   if (idealSegmentCount !== externalSegmentCount) {
     let segmentStatusComponent = (
         <ReactDiffViewer
-            oldValue={JSON.stringify(idealStateObj)}
-            newValue={JSON.stringify(externalViewObj)}
+            oldValue={JSON.stringify(idealStateObj, null, 2)}
+            newValue={JSON.stringify(externalViewObj, null, 2)}
             splitView={true}
-            hideLineNumbers
+            showDiffOnly={true}
             leftTitle={"Ideal State"}
             rightTitle={"External View"}
             compareMethod={DiffMethod.WORDS}
@@ -92,10 +92,10 @@ const getSegmentStatus = (idealStateObj, externalViewObj) => {
       if (!_.isEqual(idealStateObj[segmentKey], externalViewObj[segmentKey])) {
         let segmentStatusComponent = (
             <ReactDiffViewer
-                oldValue={JSON.stringify(idealStateObj)}
-                newValue={JSON.stringify(externalViewObj)}
+                oldValue={JSON.stringify(idealStateObj, null, 2)}
+                newValue={JSON.stringify(externalViewObj, null, 2)}
                 splitView={true}
-                hideLineNumbers
+                showDiffOnly={true}
                 leftTitle={"Ideal State"}
                 rightTitle={"External View"}
                 compareMethod={DiffMethod.WORDS}


### PR DESCRIPTION
## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
This includes a few fixes from #7899
- split the json with newlines so the diff viewer knows how to split it
- use different react state for each modal
  - once I ran this with multiple tables on our cluster, I realized it was opening every modal if you clicked on any of them
- give each component a key. this might be overkill, but hopefully helps react render better

I tested this by created 10 meetup tables and then killing the server. Now you get only 1 modal opening.

Testing on a real cluster also looks much better. You can see options to expand lines. clear errors. line numbers.
![image](https://user-images.githubusercontent.com/4760722/147045936-85d792dc-6be6-481d-904d-53e083c29aab.png)


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
