### PR TITLE
Store Pulsar message id as hex string instead of .toString format

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/MessageIdStreamOffset.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/MessageIdStreamOffset.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.plugin.stream.pulsar;
 
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
+import org.apache.commons.codec.binary.Hex;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pulsar.client.api.MessageId;
 import org.slf4j.Logger;
@@ -44,8 +44,8 @@ public class MessageIdStreamOffset implements StreamPartitionMsgOffset {
    */
   public MessageIdStreamOffset(String messageId) {
     try {
-      _messageId = MessageId.fromByteArray(messageId.getBytes(StandardCharsets.UTF_8));
-    } catch (IOException e) {
+      _messageId = MessageId.fromByteArray(Hex.decodeHex(messageId));
+    } catch (Exception e) {
       LOGGER.warn("Cannot parse message id " + messageId, e);
     }
   }
@@ -67,6 +67,6 @@ public class MessageIdStreamOffset implements StreamPartitionMsgOffset {
 
   @Override
   public String toString() {
-    return _messageId.toString();
+    return Hex.encodeHexString(_messageId.toByteArray());
   }
 }


### PR DESCRIPTION
This PR addresses the issue #7270  .  The message id is not parsed correctly when data is consumed from Pulsar topic. This is because message id can have multiple string formats. The solution is to store the message-id byte array hex string in pinot state and parse last message-id from that hex string only.