### PR TITLE
use a single react hook for table status modal

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -377,19 +377,20 @@ export default function CustomizedTables({
     return (<span>{str.toString()}</span>);
   };
 
-  const makeCell = (cellData, idx) => {
+  const [modalStatus, setModalOpen] = React.useState({});
+  const handleModalOpen = (rowIndex) => () => setModalOpen({...modalStatus, [rowIndex]: true});
+  const handleModalClose = (rowIndex) => () => setModalOpen({...modalStatus, [rowIndex]: false});
+
+  const makeCell = (cellData, rowIndex) => {
     if (Object.prototype.toString.call(cellData) === '[object Object]') {
       if (_.has(cellData, 'component') && cellData.component) {
-        const [isModalOpen, setModalOpen] = React.useState(false);
-        const handleModalOpen = () => setModalOpen(true);
-        const handleModalClose = () => setModalOpen(false);
+
 
         let cell = (styleCell(cellData.value))
         let statusModal = (
             <Dialog
-                key={idx}
-                onClose={handleModalClose}
-                open={isModalOpen}
+                onClose={handleModalClose(rowIndex)}
+                open={_.get(modalStatus, rowIndex, false)}
                 fullWidth={true}
                 maxWidth={'xl'}
             >
@@ -399,13 +400,12 @@ export default function CustomizedTables({
         cell = (
             React.cloneElement(
                 cell,
-                {onClick: handleModalOpen},
+                {onClick: handleModalOpen(rowIndex)},
             )
         );
         if (_.has(cellData, 'tooltip') && cellData.tooltip) {
           cell = (
               <Tooltip
-                  key={idx}
                   title={cellData.tooltip}
                   placement="top"
                   arrow
@@ -423,7 +423,6 @@ export default function CustomizedTables({
       } else if (_.has(cellData, 'tooltip') && cellData.tooltip) {
         return (
             <Tooltip
-                key={idx}
                 title={cellData.tooltip}
                 placement="top"
                 arrow
@@ -522,7 +521,7 @@ export default function CustomizedTables({
                             className={isCellClickable ? classes.isCellClickable : (isSticky ? classes.isSticky : '')}
                             onClick={() => {cellClickCallback && cellClickCallback(cell);}}
                           >
-                            {makeCell(cell, idx)}
+                            {makeCell(cell, index)}
                           </StyledTableCell>
                         );
                       })}


### PR DESCRIPTION
## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
Apologies for the issues here. This is hopefully the last bug here and a quirk with react hooks and keys I was not aware of. 
- React keys need to be unique. I'm just removing the integer key since it wasn't doing anything anyway
- React hooks need to exist in the same order at all times.
  - By putting the hook instantiation in `makeCell`, this caused chaging the rows per page or switching from a page with N rows to N-M rows to cause that order to change, and react would crash the page.

In this PR, we switch to storing modal state in an object keyed by the row index. I have tested this by
- creating 21 tables after RealtimeQuickstart and killing the server
- I opened multiple modals with no issue
- I switched the number of rows per page with no issue
- I clicked through the pagination component with no issue

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
