### PR TITLE
Fixed segment upload error return

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -308,7 +308,7 @@ public class PinotSegmentUploadDownloadRestletResource {
       throw e;
     } catch (Exception e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_SEGMENT_UPLOAD_ERROR, 1L);
-      throw new ControllerApplicationException(LOGGER, "Caught internal server exception while uploading segment",
+      throw new ControllerApplicationException(LOGGER, "Exception while uploading segment:" + e.getMessage(),
           Response.Status.INTERNAL_SERVER_ERROR, e);
     } finally {
       FileUtils.deleteQuietly(tempEncryptedFile);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -308,7 +308,7 @@ public class PinotSegmentUploadDownloadRestletResource {
       throw e;
     } catch (Exception e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_SEGMENT_UPLOAD_ERROR, 1L);
-      throw new ControllerApplicationException(LOGGER, "Exception while uploading segment:" + e.getMessage(),
+      throw new ControllerApplicationException(LOGGER, "Exception while uploading segment: " + e.getMessage(),
           Response.Status.INTERNAL_SERVER_ERROR, e);
     } finally {
       FileUtils.deleteQuietly(tempEncryptedFile);


### PR DESCRIPTION
## Description
If a segment is uploaded that is not in tar.gz format, we just get back an internal error message. It is useful
to return the actual message. 
Unfortunately, we return a 5xx error code when this should be a 4xx. The only way we can distinguish the invalid
file format case in pinot is by comparing the error message string. The apache commons lib raises the same exception
(java.io.IOException) whether the input is bad or we had trouble accessing the file system. Will let that be for now
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
