### PR TITLE
[7867] Handle Select * with Extra Columns

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1471,7 +1471,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       }
       //if query has a '*' selection along with other columns
       if (selectStarExpr != null) {
-        expandStarExpressionToActualColumns(pinotQuery, columnNameMap, selectStarExpr);
+        expandStarExpressionsToActualColumns(pinotQuery, columnNameMap, selectStarExpr);
       }
       Expression filterExpression = pinotQuery.getFilterExpression();
       if (filterExpression != null) {
@@ -1498,7 +1498,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     }
   }
 
-  private static void expandStarExpressionToActualColumns(PinotQuery pinotQuery, Map<String, String> columnNameMap,
+  private static void expandStarExpressionsToActualColumns(PinotQuery pinotQuery, Map<String, String> columnNameMap,
       Expression selectStarExpr) {
     List<Expression> originalSelections = pinotQuery.getSelectList();
     //expand '*'

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1464,8 +1464,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       for (Expression expression : pinotQuery.getSelectList()) {
         fixColumnName(rawTableName, expression, columnNameMap, aliasMap, isCaseInsensitive);
         //check if the select expression is '*'
-        if (!hasStar && expression.isSetIdentifier() && expression.getIdentifier().getName()
-            .equals("*")) {
+        if (!hasStar && expression.equals(STAR)) {
           hasStar = true;
         }
       }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1528,8 +1528,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   }
 
   private static boolean isDefaultVirtualColumn(String value) {
-    return value.equals(CommonConstants.Segment.BuiltInVirtualColumn.DOCID) ||
-        value.equals(CommonConstants.Segment.BuiltInVirtualColumn.SEGMENTNAME) || value.equals(
+    return value.equals(CommonConstants.Segment.BuiltInVirtualColumn.DOCID) || value.equals(
+        CommonConstants.Segment.BuiltInVirtualColumn.SEGMENTNAME) || value.equals(
         CommonConstants.Segment.BuiltInVirtualColumn.HOSTNAME);
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1503,13 +1503,14 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     //expand *
     List<Expression> expandedSelections = new ArrayList<>();
     for (String tableCol : columnNameMap.values()) {
-      Expression identifierExpression = RequestUtils.createIdentifierExpression(tableCol);
+      Expression newSelection = RequestUtils.createIdentifierExpression(tableCol);
       //we exclude default virtual columns and those columns that are already a part of originalSelections to dedup
-      if (tableCol.charAt(0) != '$' && !originalSelections.contains(identifierExpression)) {
-        expandedSelections.add(identifierExpression);
+      if (tableCol.charAt(0) != '$' && !originalSelections.contains(newSelection)) {
+        expandedSelections.add(newSelection);
       }
     }
-    //sort with natural ordering
+    //sort with natural ordering. expandedSelections DOES NOT contain any columns that were requested in the original
+    // query
     expandedSelections.sort(null);
     List<Expression> finalSelections = new ArrayList<>();
     for (Expression selection : originalSelections) {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SelectStarWithOtherColsRewriteTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SelectStarWithOtherColsRewriteTest.java
@@ -95,10 +95,10 @@ public class SelectStarWithOtherColsRewriteTest {
     BaseBrokerRequestHandler.updateColumnNames("baseballStats", pinotQuery, false, COL_MAP);
     List<Expression> newSelections = pinotQuery.getSelectList();
     int playerIdCount = 0, homeRunsCount = 0;
-    for(Expression expression : newSelections) {
+    for (Expression expression : newSelections) {
       if (expression.getIdentifier().getName().equals("playerID")) {
         playerIdCount++;
-      } else if(expression.getIdentifier().getName().equals("homeRuns")) {
+      } else if (expression.getIdentifier().getName().equals("homeRuns")) {
         homeRunsCount++;
       }
     }
@@ -165,7 +165,8 @@ public class SelectStarWithOtherColsRewriteTest {
     List<Expression> newSelections = pinotQuery.getSelectList();
     Assert.assertTrue(newSelections.get(0).isSetFunctionCall());
     Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperator(), "AS");
-    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "playerID");
+    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+        "playerID");
     Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "pid");
     Assert.assertEquals(newSelections.get(1).getIdentifier().getName(), "homeRuns");
     Assert.assertEquals(newSelections.get(2).getIdentifier().getName(), "playerStint");
@@ -214,24 +215,30 @@ public class SelectStarWithOtherColsRewriteTest {
 
   @Test
   public void testAll() {
-    String sql = "SELECT abs(homeRuns),sqrt(groundedIntoDoublePlays),*,$segmentName,$hostName,playerStint as pstint,playerID  FROM baseballStats";
+    String sql =
+        "SELECT abs(homeRuns),sqrt(groundedIntoDoublePlays),*,$segmentName,$hostName,playerStint as pstint,playerID  "
+            + "FROM baseballStats";
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
     BaseBrokerRequestHandler.updateColumnNames("baseballStats", pinotQuery, false, COL_MAP);
     List<Expression> newSelections = pinotQuery.getSelectList();
     Assert.assertTrue(newSelections.get(0).isSetFunctionCall());
     Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperator(), "ABS");
-    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "homeRuns");
+    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+        "homeRuns");
     Assert.assertTrue(newSelections.get(1).isSetFunctionCall());
     Assert.assertEquals(newSelections.get(1).getFunctionCall().getOperator(), "SQRT");
-    Assert.assertEquals(newSelections.get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "groundedIntoDoublePlays");
+    Assert.assertEquals(newSelections.get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+        "groundedIntoDoublePlays");
     Assert.assertEquals(newSelections.get(2).getIdentifier().getName(), "homeRuns");
     Assert.assertEquals(newSelections.get(3).getIdentifier().getName(), "playerStint");
     Assert.assertEquals(newSelections.get(4).getIdentifier().getName(), "groundedIntoDoublePlays");
     Assert.assertEquals(newSelections.get(5).getIdentifier().getName(), "$segmentName");
     Assert.assertEquals(newSelections.get(6).getIdentifier().getName(), "$hostName");
     Assert.assertEquals(newSelections.get(7).getFunctionCall().getOperator(), "AS");
-    Assert.assertEquals(newSelections.get(7).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "playerStint");
-    Assert.assertEquals(newSelections.get(7).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "pstint");
+    Assert.assertEquals(newSelections.get(7).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+        "playerStint");
+    Assert.assertEquals(newSelections.get(7).getFunctionCall().getOperands().get(1).getIdentifier().getName(),
+        "pstint");
     Assert.assertEquals(newSelections.get(8).getIdentifier().getName(), "playerID");
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SelectStarWithOtherColsRewriteTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SelectStarWithOtherColsRewriteTest.java
@@ -94,7 +94,8 @@ public class SelectStarWithOtherColsRewriteTest {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
     BaseBrokerRequestHandler.updateColumnNames("baseballStats", pinotQuery, false, COL_MAP);
     List<Expression> newSelections = pinotQuery.getSelectList();
-    int playerIdCount = 0, homeRunsCount = 0;
+    int playerIdCount = 0;
+    int homeRunsCount = 0;
     for (Expression expression : newSelections) {
       if (expression.getIdentifier().getName().equals("playerID")) {
         playerIdCount++;

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SelectStarWithOtherColsRewriteTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SelectStarWithOtherColsRewriteTest.java
@@ -50,8 +50,11 @@ public class SelectStarWithOtherColsRewriteTest {
     COL_MAP = builder.build();
   }
 
+  /**
+   * When the query contains only '*', it should be expanded into columns.
+   */
   @Test
-  public void testShouldExpandOnlyStar() {
+  public void testShouldExpandWhenOnlyStarIsSelected() {
     String sql = "SELECT * FROM baseballStats";
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
     BaseBrokerRequestHandler.updateColumnNames("baseballStats", pinotQuery, false, COL_MAP);
@@ -101,7 +104,7 @@ public class SelectStarWithOtherColsRewriteTest {
    * Columns should not be deduped
    */
   @Test
-  public void testShouldDedupColumns() {
+  public void testShouldNotDedupMultipleRequestedColumns() {
     String sql = "SELECT playerID,*,G_old FROM baseballStats";
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
     BaseBrokerRequestHandler.updateColumnNames("baseballStats", pinotQuery, false, COL_MAP);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SelectStarWithOtherColsRewriteTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SelectStarWithOtherColsRewriteTest.java
@@ -21,12 +21,10 @@ package org.apache.pinot.broker.requesthandler;
 
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.PinotQuery;
-import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -72,6 +70,7 @@ public class SelectStarWithOtherColsRewriteTest {
           break;
         case "$hostName":
           throw new RuntimeException("Extra default column returned");
+        default:
       }
     }
     Assert.assertEquals(docIdCnt, 1);
@@ -88,7 +87,7 @@ public class SelectStarWithOtherColsRewriteTest {
     BaseBrokerRequestHandler.updateColumnNames("baseballStats", pinotQuery, false, COL_MAP);
     List<Expression> newSelections = pinotQuery.getSelectList();
     int playerIdCnt = 0;
-    int G_oldCount = 0;
+    int goldCount = 0;
     for (Expression newSelection : newSelections) {
       String colName = newSelection.getIdentifier().getName();
       switch (colName) {
@@ -96,12 +95,13 @@ public class SelectStarWithOtherColsRewriteTest {
           playerIdCnt++;
           break;
         case "G_old":
-          G_oldCount++;
+          goldCount++;
           break;
+        default:
       }
     }
     Assert.assertEquals(playerIdCnt, 1, "playerID does not occur once");
-    Assert.assertEquals(G_oldCount, 1, "G_old occurs does not occur once");
+    Assert.assertEquals(goldCount, 1, "G_old occurs does not occur once");
   }
 
   /**
@@ -181,15 +181,17 @@ public class SelectStarWithOtherColsRewriteTest {
     List<Expression> newSelections = pinotQuery.getSelectList();
     Assert.assertTrue(newSelections.get(0).isSetFunctionCall());
     Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperator(), "ADD");
-    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "homeRuns");
-    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "groundedIntoDoublePlays");
+    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+        "homeRuns");
+    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(),
+        "groundedIntoDoublePlays");
     //homeRuns is returned as well
     int homeRunsCnt = 0;
     int groundedIntoDoublePlaysCnt = 0;
     for (Expression selection : newSelections) {
       if (selection.isSetIdentifier() && selection.getIdentifier().getName().equals("homeRuns")) {
         homeRunsCnt++;
-      } else if(selection.isSetIdentifier() && selection.getIdentifier().getName().equals("groundedIntoDoublePlays")) {
+      } else if (selection.isSetIdentifier() && selection.getIdentifier().getName().equals("groundedIntoDoublePlays")) {
         groundedIntoDoublePlaysCnt++;
       }
     }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SelectStarWithOtherColsRewriteTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SelectStarWithOtherColsRewriteTest.java
@@ -20,10 +20,12 @@
 package org.apache.pinot.broker.requesthandler;
 
 import com.google.common.collect.ImmutableMap;
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -59,32 +61,152 @@ public class SelectStarWithOtherColsRewriteTest {
     Assert.assertEquals(newSelections.get(5).getIdentifier().getName(), "$hostName");
   }
 
+  /**
+   * When duplicate columns are requested, they should be deduped, that is, each column should be returned only once
+   */
   @Test
   public void testDupCols() {
     String sql = "SELECT playerID,homeRuns,* FROM baseballStats";
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
     BaseBrokerRequestHandler.updateColumnNames("baseballStats", pinotQuery, false, COL_MAP);
     List<Expression> newSelections = pinotQuery.getSelectList();
-    Assert.assertEquals(newSelections.get(0).getIdentifier().getName(), "playerID");
-    Assert.assertEquals(newSelections.get(1).getIdentifier().getName(), "homeRuns");
-    Assert.assertEquals(newSelections.get(2).getIdentifier().getName(), "homeRuns");
-    Assert.assertEquals(newSelections.get(3).getIdentifier().getName(), "playerStint");
-    Assert.assertEquals(newSelections.get(4).getIdentifier().getName(), "groundedIntoDoublePlays");
-    Assert.assertEquals(newSelections.get(5).getIdentifier().getName(), "playerID");
+    int playerIdCount = 0, homeRunsCount = 0;
+    for(Expression expression : newSelections) {
+      if (expression.getIdentifier().getName().equals("playerID")) {
+        playerIdCount++;
+      } else if(expression.getIdentifier().getName().equals("homeRuns")) {
+        homeRunsCount++;
+      }
+    }
+    Assert.assertEquals(playerIdCount, 1);
+    Assert.assertEquals(homeRunsCount, 1);
   }
 
+  /**
+   * Selections should be returned in the requested order
+   */
   @Test
-  public void testOrder() {
+  public void testSelectionOrder() {
+//    SELECT playerID,intentionalWalks,* FROM baseballStats order by numberOfGames desc -> problemetic query, col:
+//    runs does not have any values in any of the rows
     String sql = "SELECT playerID,*,homeRuns FROM baseballStats";
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
     BaseBrokerRequestHandler.updateColumnNames("baseballStats", pinotQuery, false, COL_MAP);
     List<Expression> newSelections = pinotQuery.getSelectList();
     Assert.assertEquals(newSelections.get(0).getIdentifier().getName(), "playerID");
+    Assert.assertEquals(newSelections.get(1).getIdentifier().getName(), "playerStint");
+    Assert.assertEquals(newSelections.get(2).getIdentifier().getName(), "groundedIntoDoublePlays");
+    Assert.assertEquals(newSelections.get(3).getIdentifier().getName(), "homeRuns");
+  }
+
+  /**
+   * Only requested default columns should be returned
+   */
+  @Test
+  public void shouldNotReturnExtraDefaultVirtualCols() {
+    String sql = "SELECT $segmentName,* FROM baseballStats";
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    BaseBrokerRequestHandler.updateColumnNames("baseballStats", pinotQuery, false, COL_MAP);
+    List<Expression> newSelections = pinotQuery.getSelectList();
+    for (Expression expression : newSelections) {
+      String colName = expression.getIdentifier().getName();
+      if (CommonConstants.Segment.BuiltInVirtualColumn.DOCID.equals(colName)
+          || CommonConstants.Segment.BuiltInVirtualColumn.HOSTNAME.equals(colName)) {
+        throw new RuntimeException("Contains extra virtual col");
+      }
+    }
+  }
+
+  /**
+   * When the same column is requested twice, once with an alias and once as part of *, then it should be returned twice
+   */
+  @Test
+  public void testAliasing() {
+    String sql = "SELECT playerID as pid,* FROM baseballStats";
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    BaseBrokerRequestHandler.updateColumnNames("baseballStats", pinotQuery, false, COL_MAP);
+    List<Expression> newSelections = pinotQuery.getSelectList();
+    Assert.assertTrue(newSelections.get(0).isSetFunctionCall());
+    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperator(), "AS");
+    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "pid");
+    Assert.assertEquals(newSelections.get(4).getIdentifier().getName(), "playerID");
+  }
+
+  /**
+   * When the same column is requested twice, once with an alias and once as part of *, then it should be returned twice
+   */
+  @Test
+  public void testAliasingWithDedup() {
+    String sql = "SELECT playerID as pid,*, playerID FROM baseballStats";
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    BaseBrokerRequestHandler.updateColumnNames("baseballStats", pinotQuery, false, COL_MAP);
+    List<Expression> newSelections = pinotQuery.getSelectList();
+    Assert.assertTrue(newSelections.get(0).isSetFunctionCall());
+    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperator(), "AS");
+    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "playerID");
+    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "pid");
     Assert.assertEquals(newSelections.get(1).getIdentifier().getName(), "homeRuns");
     Assert.assertEquals(newSelections.get(2).getIdentifier().getName(), "playerStint");
     Assert.assertEquals(newSelections.get(3).getIdentifier().getName(), "groundedIntoDoublePlays");
     Assert.assertEquals(newSelections.get(4).getIdentifier().getName(), "playerID");
-    Assert.assertEquals(newSelections.get(5).getIdentifier().getName(), "homeRuns");
   }
 
+  @Test
+  public void testFunctionsOnCols() {
+    String sql = "SELECT sqrt(homeRuns),* FROM baseballStats";
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    BaseBrokerRequestHandler.updateColumnNames("baseballStats", pinotQuery, false, COL_MAP);
+    List<Expression> newSelections = pinotQuery.getSelectList();
+    int funcs = 0;
+    for (Expression selection : newSelections) {
+      if (selection.isSetFunctionCall()) {
+        funcs++;
+        Assert.assertEquals(selection.getFunctionCall().getOperator(), "SQRT");
+        Assert.assertEquals(selection.getFunctionCall().getOperands().get(0).getIdentifier().getName(), "homeRuns");
+      }
+    }
+    Assert.assertEquals(funcs, 1);
+  }
+
+  /**
+   * When multiple unqualified * are present, all are expanded
+   */
+  @Test
+  public void testMultipleUnqualifiedStars() {
+    String sql = "SELECT *,* FROM baseballStats";
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    BaseBrokerRequestHandler.updateColumnNames("baseballStats", pinotQuery, false, COL_MAP);
+    List<Expression> newSelections = pinotQuery.getSelectList();
+    Assert.assertEquals(newSelections.get(0).getIdentifier().getName(), "homeRuns");
+    Assert.assertEquals(newSelections.get(1).getIdentifier().getName(), "playerStint");
+    Assert.assertEquals(newSelections.get(2).getIdentifier().getName(), "groundedIntoDoublePlays");
+    Assert.assertEquals(newSelections.get(3).getIdentifier().getName(), "playerID");
+    Assert.assertEquals(newSelections.get(4).getIdentifier().getName(), "homeRuns");
+    Assert.assertEquals(newSelections.get(5).getIdentifier().getName(), "playerStint");
+    Assert.assertEquals(newSelections.get(6).getIdentifier().getName(), "groundedIntoDoublePlays");
+    Assert.assertEquals(newSelections.get(7).getIdentifier().getName(), "playerID");
+  }
+
+  @Test
+  public void testAll() {
+    String sql = "SELECT abs(homeRuns),sqrt(groundedIntoDoublePlays),*,$segmentName,$hostName,playerStint as pstint,playerID  FROM baseballStats";
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
+    BaseBrokerRequestHandler.updateColumnNames("baseballStats", pinotQuery, false, COL_MAP);
+    List<Expression> newSelections = pinotQuery.getSelectList();
+    Assert.assertTrue(newSelections.get(0).isSetFunctionCall());
+    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperator(), "ABS");
+    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "homeRuns");
+    Assert.assertTrue(newSelections.get(1).isSetFunctionCall());
+    Assert.assertEquals(newSelections.get(1).getFunctionCall().getOperator(), "SQRT");
+    Assert.assertEquals(newSelections.get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "groundedIntoDoublePlays");
+    Assert.assertEquals(newSelections.get(2).getIdentifier().getName(), "homeRuns");
+    Assert.assertEquals(newSelections.get(3).getIdentifier().getName(), "playerStint");
+    Assert.assertEquals(newSelections.get(4).getIdentifier().getName(), "groundedIntoDoublePlays");
+    Assert.assertEquals(newSelections.get(5).getIdentifier().getName(), "$segmentName");
+    Assert.assertEquals(newSelections.get(6).getIdentifier().getName(), "$hostName");
+    Assert.assertEquals(newSelections.get(7).getFunctionCall().getOperator(), "AS");
+    Assert.assertEquals(newSelections.get(7).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "playerStint");
+    Assert.assertEquals(newSelections.get(7).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "pstint");
+    Assert.assertEquals(newSelections.get(8).getIdentifier().getName(), "playerID");
+  }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SelectStarWithOtherColsRewriteTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SelectStarWithOtherColsRewriteTest.java
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.pinot.broker.requesthandler;
 
 import com.google.common.collect.ImmutableMap;

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SelectStarWithOtherColsRewriteTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SelectStarWithOtherColsRewriteTest.java
@@ -54,8 +54,8 @@ public class SelectStarWithOtherColsRewriteTest {
     BaseBrokerRequestHandler.updateColumnNames("baseballStats", pinotQuery, false, COL_MAP);
     List<Expression> newSelections = pinotQuery.getSelectList();
     Assert.assertEquals(newSelections.size(), 2, "More selections than requested");
-    Assert.assertEquals(newSelections.get(1).getIdentifier().getName(), "homeRuns");
-    Assert.assertEquals(newSelections.get(2).getIdentifier().getName(), "playerStint");
+    Assert.assertEquals(newSelections.get(0).getIdentifier().getName(), "homeRuns");
+    Assert.assertEquals(newSelections.get(1).getIdentifier().getName(), "playerStint");
   }
 
   @Test
@@ -64,11 +64,8 @@ public class SelectStarWithOtherColsRewriteTest {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
     BaseBrokerRequestHandler.updateColumnNames("baseballStats", pinotQuery, false, COL_MAP);
     List<Expression> newSelections = pinotQuery.getSelectList();
-    Assert.assertEquals(newSelections.size(), 4, "More selections than requested");
-    Assert.assertEquals(newSelections.get(1).getIdentifier().getName(), "homeRuns");
-    Assert.assertEquals(newSelections.get(2).getIdentifier().getName(), "playerStint");
-    Assert.assertEquals(newSelections.get(3).getIdentifier().getName(), "groundedIntoDoublePlays");
-    Assert.assertEquals(newSelections.get(4).getIdentifier().getName(), "playerID");
+    Assert.assertEquals(newSelections.size(), 1, "More selections than requested");
+    Assert.assertEquals(newSelections.get(0).getIdentifier().getName(), "*");
   }
 
   @Test


### PR DESCRIPTION
## Description

This handles cases like `select $segmentName, * from table limit 1`. Pinot currently doesn't support extra cols with `*`. [Issue](https://github.com/apache/pinot/issues/7867). We expand the `*` on the broker side to actual columns. Note that while the SQL standard does not allow adding additional columns along with `*`, almost all vendors have their own extension to this rule. 

Behaviour:

**tableName**: baseballStats

**Schema**: 

| Column Name      | 
| ----------- | 
|playerID|
|homeRuns|
|playerStint|
|groundedIntoDoublePlays|
|G_old|


| Query      | Expands To (Cols. are in order unless explicitly specified) | Comments |
| ----------- | ----------- | ----------- |
| SELECT $docId,*,$segmentName FROM baseballStats      |   $docId, G_old, groundedIntoDoublePlays, homeRuns, playerID, playerStint, $segmentName    | No extra default columns are added | 
| SELECT playerID,*,G_old FROM baseballStats   |playerID, G_old, groundedIntoDoublePlays, homeRuns, playerID, playerStint, G_old|playerID and G_old are not deduped|
|SELECT playerID,*,G_old FROM baseballStats|playerID, G_old, groundedIntoDoublePlays, homeRuns, playerID, playerStint, G_old|Selection order is maintained, * is expanded with natural ordering. Selection order overrides natural order|
|SELECT playerID as pid,* FROM baseballStats|AS(playerID, pid), G_old, groundedIntoDoublePlays, homeRuns, playerID, playerStint|Aliased column is returned along with original column playerId|
|SELECT sqrt(homeRuns),* FROM baseballStats|SQRT(homeRuns), G_old, groundedIntoDoublePlays, homeRuns, playerID, playerStint|f(homeRuns) is returned along with homeRuns|
|SELECT add(homeRuns,groundedIntoDoublePlays),* FROM baseballStats|ADD(homeRuns, groundedIntoDoublePlays), G_old, groundedIntoDoublePlays, homeRuns, playerID, playerStint|f(homeRuns, groundedIntoDoublePlays) is returned along with both the columns|
|SELECT *, * FROM baseballStats|G_old, groundedIntoDoublePlays, homeRuns, playerID, playerStint, G_old, groundedIntoDoublePlays, homeRuns, playerID, playerStint|Each * is expanded|



## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes 

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes 

Does this PR otherwise need attention when creating release notes? Things to consider:
* [ ] Yes