### PR TITLE
Removing outdated broker metric definitions

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
@@ -186,10 +186,6 @@ rules:
   name: "pinot_broker_brokerResponsesWithNumGroupsLimitReached_$2"
   labels:
     table: "$1"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.(\\w+)\\.requestConnectionTimeouts\"><>(\\w+)"
-  name: "pinot_broker_requestConnectionTimeouts_$2"
-  labels:
-    table: "$1"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.(\\w+)\\.queryQuotaExceeded\"><>(\\w+)"
   name: "pinot_broker_queryQuotaExceeded_$2"
   labels:

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -68,23 +68,9 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
 
   NUM_RESIZES("numResizes", false),
 
-  REQUEST_CONNECTION_TIMEOUTS("timeouts", false),
   HELIX_ZOOKEEPER_RECONNECTS("reconnects", true),
 
-  // This metric tracks the number of requests dropped by the broker after we get a connection to the server.
-  // Exceptions resulting when sending a request get counted in this metric. The metric is counted on a per-table
-  // basis.
-  REQUEST_DROPPED_DUE_TO_SEND_ERROR("requestDropped", false),
-
-  // This metric tracks the number of requests that had to be dropped because we could not get a connection
-  // to the server. Note that this may be because we have exhausted the (fixed-size) pool for the server, and
-  // also reached the maximum number of waiting requests for the server. The metric is counted on a per-table
-  // basis.
-  REQUEST_DROPPED_DUE_TO_CONNECTION_ERROR("requestDropped", false),
-
   REQUEST_DROPPED_DUE_TO_ACCESS_ERROR("requestsDropped", false),
-
-  ROUTING_TABLE_REBUILD_FAILURES("failures", false),
 
   GROUP_BY_SIZE("queries", false),
   TOTAL_SERVER_RESPONSE_SIZE("queries", false),
@@ -133,5 +119,9 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   @Override
   public boolean isGlobal() {
     return _global;
+  }
+
+  public static void main(String[] args) {
+    System.out.println(BrokerMeter.values().length);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -120,8 +120,4 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   public boolean isGlobal() {
     return _global;
   }
-
-  public static void main(String[] args) {
-    System.out.println(BrokerMeter.values().length);
-  }
 }


### PR DESCRIPTION
Some of the metrics under `BrokerMeter` are outdated and no longer used. These were part of the older broker -> server connection implementation and their usage was removed in `8d08bcc498b7f68dd8e1a34fde85b85cb15673bbq` (PR https://github.com/apache/pinot/issues/4815) 
 