### PR TITLE
get parameters in logging statement right way round

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -398,8 +398,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
         messageBatch = _partitionGroupConsumer
             .fetchMessages(_currentOffset, null, _partitionLevelStreamConfig.getFetchTimeoutMillis());
         if (_segmentLogger.isDebugEnabled()) {
-          _segmentLogger.debug("message batch received. filter={} unfiltered={} endOfPartitionGroup={}",
-              messageBatch.getUnfilteredMessageCount(), messageBatch.getMessageCount(),
+          _segmentLogger.debug("message batch received. filtered={} unfiltered={} endOfPartitionGroup={}",
+              messageBatch.getMessageCount(), messageBatch.getUnfilteredMessageCount(),
               messageBatch.isEndOfPartitionGroup());
         }
         _endOfPartitionGroup = messageBatch.isEndOfPartitionGroup();


### PR DESCRIPTION
This debug logging identified cases where empty batches would be produced, which no longer choke the consume loop, but unfortunately the parameters are the wrong way round.