### PR TITLE
Update Log4j to 2.17.1 to address CVE-2021-44832

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -345,10 +345,10 @@ org.apache.httpcomponents:httpmime:4.5.3
 org.apache.kafka:kafka-clients:2.0.0
 org.apache.kafka:kafka_2.10:0.9.0.1
 org.apache.kafka:kafka_2.11:2.0.0
-org.apache.logging.log4j:log4j-1.2-api:2.17.0
-org.apache.logging.log4j:log4j-api:2.17.0
-org.apache.logging.log4j:log4j-core:2.17.0
-org.apache.logging.log4j:log4j-slf4j-impl:2.17.0
+org.apache.logging.log4j:log4j-1.2-api:2.17.1
+org.apache.logging.log4j:log4j-api:2.17.1
+org.apache.logging.log4j:log4j-core:2.17.1
+org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
 org.apache.lucene:lucene-analyzers-common:8.2.0
 org.apache.lucene:lucene-core:8.2.0
 org.apache.lucene:lucene-queries:8.2.0

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <snappy-java.version>1.1.1.7</snappy-java.version>
     <zstd-jni.version>1.4.9-5</zstd-jni.version>
     <lz4-java.version>1.7.1</lz4-java.version>
-    <log4j.version>2.17.0</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
     <netty.version>4.1.54.Final</netty.version>
     <netty-tcnative.version>2.0.36.Final</netty-tcnative.version>
     <reactivestreams.version>1.0.3</reactivestreams.version>


### PR DESCRIPTION
## Description
Updating Log4j version to 2.17.1 because of CVE-2021-44832 vulnerability.
https://nvd.nist.gov/vuln/detail/CVE-2021-44832
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
