### PR TITLE
async-http-client upgraded

### DIFF
--- a/pinot-clients/pinot-java-client/pom.xml
+++ b/pinot-clients/pinot-java-client/pom.xml
@@ -61,12 +61,16 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.ning</groupId>
+      <groupId>org.asynchttpclient</groupId>
       <artifactId>async-http-client</artifactId>
       <exclusions>
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-unix-common</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
@@ -22,9 +22,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.ning.http.client.AsyncHttpClient;
-import com.ning.http.client.AsyncHttpClientConfig;
-import com.ning.http.client.Response;
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.JdkSslContext;
+import io.netty.handler.ssl.SslContext;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -33,6 +35,11 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.BoundRequestBuilder;
+import org.asynchttpclient.DefaultAsyncHttpClientConfig.Builder;
+import org.asynchttpclient.Dsl;
+import org.asynchttpclient.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,25 +59,38 @@ public class JsonAsyncHttpPinotClientTransport implements PinotClientTransport {
   public JsonAsyncHttpPinotClientTransport() {
     _headers = new HashMap<>();
     _scheme = CommonConstants.HTTP_PROTOCOL;
-    _httpClient = new AsyncHttpClient();
+    _httpClient = Dsl.asyncHttpClient();
   }
 
   public JsonAsyncHttpPinotClientTransport(Map<String, String> headers, String scheme,
-      @Nullable SSLContext sslContext) {
+    @Nullable SSLContext sslContext) {
     _headers = headers;
     _scheme = scheme;
 
-    AsyncHttpClientConfig.Builder builder = new AsyncHttpClientConfig.Builder();
+    Builder builder = Dsl.config();
     if (sslContext != null) {
-      builder.setSSLContext(sslContext);
+      builder.setSslContext(new JdkSslContext(sslContext, true, ClientAuth.OPTIONAL));
     }
 
-    _httpClient = new AsyncHttpClient(builder.build());
+    _httpClient = Dsl.asyncHttpClient(builder.build());
+  }
+
+  public JsonAsyncHttpPinotClientTransport(Map<String, String> headers, String scheme,
+    @Nullable SslContext sslContext) {
+    _headers = headers;
+    _scheme = scheme;
+
+    Builder builder = Dsl.config();
+    if (sslContext != null) {
+      builder.setSslContext(sslContext);
+    }
+
+    _httpClient = Dsl.asyncHttpClient(builder.build());
   }
 
   @Override
   public BrokerResponse executeQuery(String brokerAddress, String query)
-      throws PinotClientException {
+    throws PinotClientException {
     try {
       return executeQueryAsync(brokerAddress, query).get();
     } catch (Exception e) {
@@ -97,7 +117,7 @@ public class JsonAsyncHttpPinotClientTransport implements PinotClientTransport {
         url = _scheme + "://" + brokerAddress + "/query";
       }
 
-      AsyncHttpClient.BoundRequestBuilder requestBuilder = _httpClient.preparePost(url);
+      BoundRequestBuilder requestBuilder = _httpClient.preparePost(url);
 
       if (_headers != null) {
         _headers.forEach((k, v) -> requestBuilder.addHeader(k, v));
@@ -135,7 +155,11 @@ public class JsonAsyncHttpPinotClientTransport implements PinotClientTransport {
     if (_httpClient.isClosed()) {
       throw new PinotClientException("Connection is already closed!");
     }
-    _httpClient.close();
+    try {
+      _httpClient.close();
+    } catch (IOException exception) {
+      throw new PinotClientException("Error while closing connection!");
+    }
   }
 
   private static class BrokerResponseFuture implements Future<BrokerResponse> {
@@ -185,7 +209,7 @@ public class JsonAsyncHttpPinotClientTransport implements PinotClientTransport {
               "Pinot returned HTTP status " + httpResponse.getStatusCode() + ", expected 200");
         }
 
-        String responseBody = httpResponse.getResponseBody("UTF-8");
+        String responseBody = httpResponse.getResponseBody(StandardCharsets.UTF_8);
         return BrokerResponse.fromJson(OBJECT_READER.readTree(responseBody));
       } catch (Exception e) {
         throw new ExecutionException(e);

--- a/pinot-clients/pinot-jdbc-client/pom.xml
+++ b/pinot-clients/pinot-jdbc-client/pom.xml
@@ -75,12 +75,16 @@
       <artifactId>jackson-databind</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.ning</groupId>
+      <groupId>org.asynchttpclient</groupId>
       <artifactId>async-http-client</artifactId>
       <exclusions>
         <exclusion>
           <groupId>io.netty</groupId>
           <artifactId>netty</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-unix-common</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/PinotControllerTransport.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/PinotControllerTransport.java
@@ -18,8 +18,7 @@
  */
 package org.apache.pinot.client.controller;
 
-import com.ning.http.client.AsyncHttpClient;
-import com.ning.http.client.Response;
+import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
@@ -27,6 +26,10 @@ import org.apache.pinot.client.PinotClientException;
 import org.apache.pinot.client.controller.response.ControllerTenantBrokerResponse;
 import org.apache.pinot.client.controller.response.SchemaResponse;
 import org.apache.pinot.client.controller.response.TableResponse;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.BoundRequestBuilder;
+import org.asynchttpclient.Dsl;
+import org.asynchttpclient.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,7 +38,7 @@ public class PinotControllerTransport {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotControllerTransport.class);
 
-  AsyncHttpClient _httpClient = new AsyncHttpClient();
+  AsyncHttpClient _httpClient = Dsl.asyncHttpClient();
   Map<String, String> _headers;
 
   public PinotControllerTransport() {
@@ -48,7 +51,7 @@ public class PinotControllerTransport {
   public TableResponse getAllTables(String controllerAddress) {
     try {
       String url = "http://" + controllerAddress + "/tables";
-      AsyncHttpClient.BoundRequestBuilder requestBuilder = _httpClient.prepareGet(url);
+      BoundRequestBuilder requestBuilder = _httpClient.prepareGet(url);
       if (_headers != null) {
         _headers.forEach((k, v) -> requestBuilder.addHeader(k, v));
       }
@@ -66,7 +69,7 @@ public class PinotControllerTransport {
   public SchemaResponse getTableSchema(String table, String controllerAddress) {
     try {
       String url = "http://" + controllerAddress + "/tables/" + table + "/schema";
-      AsyncHttpClient.BoundRequestBuilder requestBuilder = _httpClient.prepareGet(url);
+      BoundRequestBuilder requestBuilder = _httpClient.prepareGet(url);
       if (_headers != null) {
         _headers.forEach((k, v) -> requestBuilder.addHeader(k, v));
       }
@@ -84,7 +87,7 @@ public class PinotControllerTransport {
   public ControllerTenantBrokerResponse getBrokersFromController(String controllerAddress, String tenant) {
     try {
       String url = "http://" + controllerAddress + "/v2/brokers/tenants/" + tenant;
-      AsyncHttpClient.BoundRequestBuilder requestBuilder = _httpClient.prepareGet(url);
+      BoundRequestBuilder requestBuilder = _httpClient.prepareGet(url);
       if (_headers != null) {
         _headers.forEach((k, v) -> requestBuilder.addHeader(k, v));
       }
@@ -105,6 +108,10 @@ public class PinotControllerTransport {
     if (_httpClient.isClosed()) {
       throw new PinotClientException("Connection is already closed!");
     }
-    _httpClient.close();
+    try {
+      _httpClient.close();
+    } catch (IOException exception) {
+      throw new PinotClientException("Error while closing connection!");
+    }
   }
 }

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/ControllerResponseFuture.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/ControllerResponseFuture.java
@@ -18,11 +18,12 @@
  */
 package org.apache.pinot.client.controller.response;
 
-import com.ning.http.client.Response;
+import java.nio.charset.StandardCharsets;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.client.PinotClientException;
+import org.asynchttpclient.Response;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,7 +75,7 @@ abstract class ControllerResponseFuture<T> implements Future<T> {
         throw new PinotClientException("Pinot returned HTTP status " + httpResponse.getStatusCode() + ", expected 200");
       }
 
-      String responseBody = httpResponse.getResponseBody("UTF-8");
+      String responseBody = httpResponse.getResponseBody(StandardCharsets.UTF_8);
 
       return responseBody;
     } catch (Exception e) {

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/ControllerTenantBrokerResponse.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/ControllerTenantBrokerResponse.java
@@ -21,13 +21,13 @@ package org.apache.pinot.client.controller.response;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import com.ning.http.client.Response;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import org.asynchttpclient.Response;
 
 
 public class ControllerTenantBrokerResponse {

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/SchemaResponse.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/SchemaResponse.java
@@ -21,11 +21,11 @@ package org.apache.pinot.client.controller.response;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import com.ning.http.client.Response;
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import org.asynchttpclient.Response;
 
 
 public class SchemaResponse {

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/TableResponse.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/TableResponse.java
@@ -21,13 +21,13 @@ package org.apache.pinot.client.controller.response;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
-import com.ning.http.client.Response;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import org.asynchttpclient.Response;
 
 
 public class TableResponse {

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     <zkclient.version>0.7</zkclient.version>
     <jackson.version>2.10.0</jackson.version>
     <zookeeper.version>3.5.8</zookeeper.version>
-    <async-http-client.version>1.9.21</async-http-client.version>
+    <async-http-client.version>2.12.3</async-http-client.version>
     <jersey.version>2.28</jersey.version>
     <grizzly.version>2.4.4</grizzly.version>
     <swagger.version>1.5.16</swagger.version>
@@ -720,7 +720,7 @@
         <version>3.3.4</version>
       </dependency>
       <dependency>
-        <groupId>com.ning</groupId>
+        <groupId>org.asynchttpclient</groupId>
         <artifactId>async-http-client</artifactId>
         <version>${async-http-client.version}</version>
       </dependency>


### PR DESCRIPTION
## Description
Changed updated org to AsyncHttpClient. Its the **same library** just shifted to different org
Pumped version to 2.12.3
Refactored pinot-java-client and pinot-jdbc-client as per new version

The older `async-http-client` was giving issues while connecting to `https` endpoints.
async-http-client issue link :  [ https://github.com/AsyncHttpClient/async-http-client/issues/934](https://github.com/AsyncHttpClient/async-http-client/issues/934)
pinot issue link : [https://github.com/apache/pinot/issues/7382](https://github.com/apache/pinot/issues/7382)

## Upgrade Notes
No downtime upgrade

## Release Notes

## Documentation

