### PR TITLE
Upgrade log4j to 2.17.1

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -345,10 +345,10 @@ org.apache.httpcomponents:httpmime:4.5.3
 org.apache.kafka:kafka-clients:2.0.0
 org.apache.kafka:kafka_2.10:0.9.0.1
 org.apache.kafka:kafka_2.11:2.0.0
-org.apache.logging.log4j:log4j-1.2-api:2.17.0
-org.apache.logging.log4j:log4j-api:2.17.0
-org.apache.logging.log4j:log4j-core:2.17.0
-org.apache.logging.log4j:log4j-slf4j-impl:2.17.0
+org.apache.logging.log4j:log4j-1.2-api:2.17.1
+org.apache.logging.log4j:log4j-api:2.17.1
+org.apache.logging.log4j:log4j-core:2.17.1
+org.apache.logging.log4j:log4j-slf4j-impl:2.17.1
 org.apache.lucene:lucene-analyzers-common:8.2.0
 org.apache.lucene:lucene-core:8.2.0
 org.apache.lucene:lucene-queries:8.2.0

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <snappy-java.version>1.1.1.7</snappy-java.version>
     <zstd-jni.version>1.4.9-5</zstd-jni.version>
     <lz4-java.version>1.7.1</lz4-java.version>
-    <log4j.version>2.17.0</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
     <netty.version>4.1.54.Final</netty.version>
     <netty-tcnative.version>2.0.36.Final</netty-tcnative.version>
     <reactivestreams.version>1.0.3</reactivestreams.version>


### PR DESCRIPTION
There's a new RCE vulnerability reported in log4j where the attacker can execute remote code by modifying the log4j configuration file to use JDBC Appender with a data source referencing a JNDI URI.

This log4j version fixes this issue by limiting JNDI data source names to the java protocol.

Link to source - https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44832