### PR TITLE
Frontend dev proxy configuration update

### DIFF
--- a/pinot-controller/src/main/resources/webpack.config.js
+++ b/pinot-controller/src/main/resources/webpack.config.js
@@ -46,10 +46,13 @@ module.exports = (env, argv) => {
     devServer: {
       compress: true,
       hot: true,
-      open: true,
-      proxy: {
-        '/': 'http://localhost:9000'
-      }
+      proxy: [
+        {
+            context: "/",
+            target: "http://localhost:9000",
+            changeOrigin: true,
+        },
+      ],
     },
     module: {
       rules: [


### PR DESCRIPTION
## Description
Proxy configuration that allows the frontend to proxy to a backend during development was broken. Updated the configuration and like before, it points to local port 9000 where Pinot backend is deployed locally by default.