### PR TITLE
Fix the issue that Pinot upsert table's uploaded segments get deleted when server restarts.

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -208,6 +208,11 @@ public class PinotLLCRealtimeSegmentManager {
     // From all segment names in the ideal state, find unique partition group ids and their latest segment
     Map<Integer, LLCSegmentName> partitionGroupIdToLatestSegment = new HashMap<>();
     for (String segment : idealState.getRecord().getMapFields().keySet()) {
+      // With Pinot upsert table allowing uploads of segments, the segment name of an upsert table segment may not
+      // conform to LLCSegment format. We can skip such segments because they are NOT the consuming segments.
+      if (!LLCSegmentName.isLowLevelConsumerSegmentName(segment)) {
+        continue;
+      }
       LLCSegmentName llcSegmentName = new LLCSegmentName(segment);
       int partitionGroupId = llcSegmentName.getPartitionGroupId();
       partitionGroupIdToLatestSegment.compute(partitionGroupId, (k, latestSegment) -> {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -288,7 +288,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     boolean isLLCSegment = SegmentName.isLowLevelConsumerSegmentName(segmentName);
     if (segmentDir.exists()) {
       // Segment already exists on disk
-      if (segmentZKMetadata.getStatus() == Status.DONE) {
+      if (segmentZKMetadata.getStatus() == Status.DONE || segmentZKMetadata.getStatus() == Status.UPLOADED) {
         // Metadata has been committed, load the local segment
         try {
           addSegment(ImmutableSegmentLoader.load(segmentDir, indexLoadingConfig, schema));


### PR DESCRIPTION
Fix the issue that Pinot upsert table's uploaded segments get deleted when server restarts. The root cause is that we did not consider the new segment status introduced for upsert table uploaded segments.

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
