### PR TITLE
make query stats always show even there's error

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -474,23 +474,23 @@ const QueryPage = () => {
               <AppLoader />
             ) : (
               <>
+                {queryStats.columns.length ? (
+                    <Grid item xs style={{ backgroundColor: 'white' }}>
+                      <CustomizedTables
+                          title="Query Response Stats"
+                          data={queryStats}
+                          showSearchBox={true}
+                          inAccordionFormat={true}
+                      />
+                    </Grid>
+                ) : null}
+
                 {resultError ? (
                   <Alert severity="error" className={classes.sqlError}>
                     {resultError}
                   </Alert>
                 ) : (
                   <>
-                    {queryStats.columns.length ? (
-                      <Grid item xs style={{ backgroundColor: 'white' }}>
-                        <CustomizedTables
-                          title="Query Response Stats"
-                          data={queryStats}
-                          showSearchBox={true}
-                          inAccordionFormat={true}
-                        />
-                      </Grid>
-                    ) : null}
-
                     <Grid item xs style={{ backgroundColor: 'white' }}>
                       {resultData.columns.length ? (
                         <>

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -234,7 +234,7 @@ const getQueryResults = (params, url, checkedOptions) => {
     // if sql api throws error, handle here
     if(typeof queryResponse === 'string'){
       errorStr = queryResponse;
-    } else if(queryResponse.exceptions.length){
+    } else if (queryResponse && queryResponse.exceptions && queryResponse.exceptions.length) {
       errorStr = JSON.stringify(queryResponse.exceptions, null, 2);
     } else
     {

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -228,57 +228,60 @@ const getQueryResults = (params, url, checkedOptions) => {
     let queryResponse = null;
     queryResponse = getAsObject(data);
 
-    // if sql api throws error, handle here
-    if(typeof queryResponse === 'string'){
-      return {error: queryResponse};
-    } else if(queryResponse.exceptions.length){
-      return {error: JSON.stringify(queryResponse.exceptions, null, 2)};
-    }
-
+    let errorStr = '';
     let dataArray = [];
     let columnList = [];
-    if (checkedOptions.querySyntaxPQL === true) {
-      if (queryResponse) {
-        if (queryResponse.selectionResults) {
-          // Selection query
-          columnList = queryResponse.selectionResults.columns;
-          dataArray = queryResponse.selectionResults.results;
-        } else if (!queryResponse.aggregationResults[0]?.groupByResult) {
-          // Simple aggregation query
-          columnList = _.map(
-            queryResponse.aggregationResults,
-            (aggregationResult) => {
-              return { title: aggregationResult.function };
-            }
-          );
+    // if sql api throws error, handle here
+    if(typeof queryResponse === 'string'){
+      errorStr = queryResponse;
+    } else if(queryResponse.exceptions.length){
+      errorStr = JSON.stringify(queryResponse.exceptions, null, 2);
+    } else
+    {
+      if (checkedOptions.querySyntaxPQL === true)
+      {
+        if (queryResponse)
+        {
+          if (queryResponse.selectionResults)
+          {
+            // Selection query
+            columnList = queryResponse.selectionResults.columns;
+            dataArray = queryResponse.selectionResults.results;
+          }
+          else if (!queryResponse.aggregationResults[0]?.groupByResult)
+          {
+            // Simple aggregation query
+            columnList = _.map(queryResponse.aggregationResults, (aggregationResult) => {
+              return {title: aggregationResult.function};
+            });
 
-          dataArray.push(
-            _.map(queryResponse.aggregationResults, (aggregationResult) => {
+            dataArray.push(_.map(queryResponse.aggregationResults, (aggregationResult) => {
               return aggregationResult.value;
-            })
-          );
-        } else if (queryResponse.aggregationResults[0]?.groupByResult) {
-          // Aggregation group by query
-          // TODO - Revisit
-          const columns = queryResponse.aggregationResults[0].groupByColumns;
-          columns.push(queryResponse.aggregationResults[0].function);
-          columnList = _.map(columns, (columnName) => {
-            return columnName;
-          });
+            }));
+          }
+          else if (queryResponse.aggregationResults[0]?.groupByResult)
+          {
+            // Aggregation group by query
+            // TODO - Revisit
+            const columns = queryResponse.aggregationResults[0].groupByColumns;
+            columns.push(queryResponse.aggregationResults[0].function);
+            columnList = _.map(columns, (columnName) => {
+              return columnName;
+            });
 
-          dataArray = _.map(
-            queryResponse.aggregationResults[0].groupByResult,
-            (aggregationGroup) => {
+            dataArray = _.map(queryResponse.aggregationResults[0].groupByResult, (aggregationGroup) => {
               const row = aggregationGroup.group;
               row.push(aggregationGroup.value);
               return row;
-            }
-          );
+            });
+          }
         }
       }
-    } else if (queryResponse.resultTable?.dataSchema?.columnNames?.length) {
-      columnList = queryResponse.resultTable.dataSchema.columnNames;
-      dataArray = queryResponse.resultTable.rows;
+      else if (queryResponse.resultTable?.dataSchema?.columnNames?.length)
+      {
+        columnList = queryResponse.resultTable.dataSchema.columnNames;
+        dataArray = queryResponse.resultTable.rows;
+      }
     }
 
     const columnStats = ['timeUsedMs',
@@ -306,6 +309,7 @@ const getQueryResults = (params, url, checkedOptions) => {
     ];
 
     return {
+      error: errorStr,
       result: {
         columns: columnList,
         records: dataArray,


### PR DESCRIPTION
fix the issue that currently if there's an error in the result, query stats are not shown on UI. 

this is particularly useful when partial response was sent back from the server, it will at least give broker level metrics for diagnosis

before:
![Screen Shot 2022-01-07 at 2 29 00 PM copy](https://user-images.githubusercontent.com/3581352/148615647-0e40c00b-d2c8-4846-b3e0-184742b25fca.png)

after:
![Screen Shot 2022-01-07 at 2 29 00 PM](https://user-images.githubusercontent.com/3581352/148615651-07683307-038a-4a7a-9a5e-8a23a2a2637c.png)

