### PR TITLE
Prevent partial path traversal in untar.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/TarGzCompressionUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/TarGzCompressionUtils.java
@@ -124,6 +124,10 @@ public class TarGzCompressionUtils {
   public static List<File> untar(InputStream inputStream, File outputDir)
       throws IOException {
     String outputDirCanonicalPath = outputDir.getCanonicalPath();
+    // Prevent partial path traversal
+    if (!outputDirCanonicalPath.endsWith(File.separator)) {
+      outputDirCanonicalPath += File.separator;
+    }
     List<File> untarredFiles = new ArrayList<>();
     try (InputStream bufferedIn = new BufferedInputStream(inputStream);
         InputStream gzipIn = new GzipCompressorInputStream(bufferedIn);
@@ -146,7 +150,13 @@ public class TarGzCompressionUtils {
           }
         } else {
           File parentFile = outputFile.getParentFile();
-          if (!parentFile.getCanonicalPath().startsWith(outputDirCanonicalPath)) {
+          String parentFileCanonicalPath = parentFile.getCanonicalPath();
+
+          // Ensure parentFile's canonical path is separator terminated, since outputDirCanonicalPath is.
+          if (!parentFileCanonicalPath.endsWith(File.separator)) {
+            parentFileCanonicalPath += File.separator;
+          }
+          if (!parentFileCanonicalPath.startsWith(outputDirCanonicalPath)) {
             throw new IOException(String
                 .format("Trying to create directory: %s outside of the output directory: %s", parentFile, outputDir));
           }


### PR DESCRIPTION
The `File.getCanonicalPath` method  transforms the path into a canonical form preventing such attack types as `..` in path
segments. If the result of `outputDir.getCanonicalPath()` is not slash terminated it allows for partial path
traversal.

Consider `"/usr/outnot".startsWith("/usr/out")`. The check is bypassed although it is not the
out directory. The terminating slash may be removed in various places. On Linux `println(new
File("/var/"))` returns /var, but `println(new File("/var", "/"))` - `/var/`, however `println(new
File("/var", "/").getCanonicalPath())` - `/var`

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
