### PR TITLE
Add Ingress to Broker and Controller helm charts

### DIFF
--- a/kubernetes/helm/pinot/Chart.yaml
+++ b/kubernetes/helm/pinot/Chart.yaml
@@ -18,10 +18,10 @@
 #
 
 apiVersion: v1
-appVersion: 0.2.5-SNAPSHOT
+appVersion: 0.2.6-SNAPSHOT
 name: pinot
 description: Apache Pinot is a realtime distributed OLAP datastore, which is used to deliver scalable real time analytics with low latency. It can ingest data from offline data sources (such as Hadoop and flat files) as well as online sources (such as Kafka). Pinot is designed to scale horizontally.
-version: 0.2.5-SNAPSHOT
+version: 0.2.6-SNAPSHOT
 keywords:
   - olap
   - analytics

--- a/kubernetes/helm/pinot/templates/broker/ingress.yaml
+++ b/kubernetes/helm/pinot/templates/broker/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.broker.ingress.v1beta1.enabled -}}
+{{- $ingressPath := .Values.broker.ingress.path -}}
+{{- $serviceName := include "pinot.broker.fullname" . -}}
+{{- $servicePort := .Values.broker.service.port -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $serviceName }}
+{{- if .Values.broker.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.broker.ingress.annotations | indent 4 }}
+{{- end }}
+  labels:
+{{- include "pinot.brokerLabels" . | nindent 4 }}
+spec:
+{{- if .Values.broker.ingress.tls }}
+  tls:
+{{ toYaml .Values.broker.ingress.tls | indent 4 }}
+{{- end }}
+  rules:
+    {{- range .Values.broker.ingress.hosts }}
+  - host: {{ . }}
+    http:
+      paths:
+        - path: {{ $ingressPath }}
+          backend:
+            serviceName: {{ $serviceName }}
+            servicePort: {{ $servicePort }}
+    {{- end }}
+{{- end }}
+
+{{- if .Values.broker.ingress.v1.enabled -}}
+{{- end }}

--- a/kubernetes/helm/pinot/templates/controller/ingress.yaml
+++ b/kubernetes/helm/pinot/templates/controller/ingress.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.controller.ingress.v1beta1.enabled -}}
+{{- $ingressPath := .Values.controller.ingress.path -}}
+{{- $serviceName := include "pinot.controller.fullname" . -}}
+{{- $servicePort := .Values.controller.service.port -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $serviceName }}
+{{- if .Values.controller.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.controller.ingress.annotations | indent 4 }}
+{{- end }}
+  labels:
+{{- include "pinot.controllerLabels" . | nindent 4 }}
+spec:
+{{- if .Values.controller.ingress.tls }}
+  tls:
+{{ toYaml .Values.controller.ingress.tls | indent 4 }}
+{{- end }}
+  rules:
+    {{- range .Values.controller.ingress.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end }}
+{{- end }}
+
+{{- if .Values.controller.ingress.v1.enabled -}}
+{{- end }}

--- a/kubernetes/helm/pinot/values.yaml
+++ b/kubernetes/helm/pinot/values.yaml
@@ -106,6 +106,16 @@ controller:
     port: 9000
     annotations: {}
 
+  ingress:
+    v1beta1:
+      enabled: false
+      annotations: { }
+      tls: { }
+      path: /
+      hosts: [ ]
+    v1:
+      enabled: false
+
   resources: {}
 
   nodeSelector: {}
@@ -182,6 +192,16 @@ broker:
     port: 8099
     # For example, in private GKE cluster, you might add cloud.google.com/load-balancer-type: Internal
     annotations: {}
+
+  ingress:
+    v1beta1:
+      enabled: false
+      annotations: {}
+      tls: {}
+      path: /
+      hosts: []
+    v1:
+      enabled: false
 
   resources: {}
 


### PR DESCRIPTION
## Description
This enables Ingress out of the box for anyone using Helm to deploy Pinot to Kubernetes.
All one need to do is override the default values inside the values.yaml file.

Ingress is disabled as default.

**Important:** One needs to be running Kubernetes that supports `apiVersion: extensions/v1beta1`.

Related issue: https://github.com/apache/pinot/issues/7996

Sample result  `helm template pinot` when Ingress is enabled:
```bash
# Source: pinot/templates/broker/ingress.yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: pinot-broker
  labels:
    helm.sh/chart: pinot-0.2.6-SNAPSHOT
    app: pinot
    chart: pinot-0.2.6-SNAPSHOT
    release: pinot
    app.kubernetes.io/version: "0.2.6-SNAPSHOT"
    app.kubernetes.io/managed-by: Helm
    heritage: Helm
    component: broker
spec:
  rules:
  - host: localhost
    http:
      paths:
        - path: /
          backend:
            serviceName: pinot-broker
            servicePort: 8099
---
# Source: pinot/templates/controller/ingress.yaml
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: pinot-controller
  labels:
    helm.sh/chart: pinot-0.2.6-SNAPSHOT
    app: pinot
    chart: pinot-0.2.6-SNAPSHOT
    release: pinot
    app.kubernetes.io/version: "0.2.6-SNAPSHOT"
    app.kubernetes.io/managed-by: Helm
    heritage: Helm
    component: controller
spec:
  rules:
    - host: localhost
      http:
        paths:
          - path: /
            backend:
              serviceName: pinot-controller
              servicePort: 9000
```
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [x] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
Now it is possible to enable an Ingress resource for the Broker and the Controller through the helm chart by setting it as `enabled` and adding the necessary configurations.