### PR TITLE
St_* function error messages + support literal transform functions

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StAreaFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StAreaFunction.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.core.operator.transform.function.BaseTransformFunction;
+import org.apache.pinot.core.operator.transform.function.LiteralTransformFunction;
 import org.apache.pinot.core.operator.transform.function.TransformFunction;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.segment.local.utils.GeometrySerializer;
@@ -62,8 +63,10 @@ public class StAreaFunction extends BaseTransformFunction {
     TransformFunction transformFunction = arguments.get(0);
     Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
         "Argument must be single-valued for transform function: %s", getName());
-    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES,
-        "The argument must be of bytes type");
+    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
+        || transformFunction instanceof LiteralTransformFunction,
+        "The first argument must be of type BYTES, but was %s",
+        transformFunction.getResultMetadata().getDataType());
     _transformFunction = transformFunction;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StContainsFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StContainsFunction.java
@@ -58,13 +58,19 @@ public class StContainsFunction extends BaseTransformFunction {
     Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
         "First argument must be single-valued for transform function: %s", getName());
     Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
-        || transformFunction instanceof LiteralTransformFunction, "The first argument must be of bytes type");
+            || transformFunction instanceof LiteralTransformFunction,
+        "The first argument must be of type BYTES , but was %s",
+            transformFunction.getResultMetadata().getDataType()
+        );
     _firstArgument = transformFunction;
     transformFunction = arguments.get(1);
     Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
         "Second argument must be single-valued for transform function: %s", getName());
     Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
-        || transformFunction instanceof LiteralTransformFunction, "The second argument must be of bytes type");
+            || transformFunction instanceof LiteralTransformFunction,
+        "The second argument must be of type BYTES , but was %s",
+            transformFunction.getResultMetadata().getDataType()
+        );
     _secondArgument = transformFunction;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StDistanceFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StDistanceFunction.java
@@ -63,13 +63,19 @@ public class StDistanceFunction extends BaseTransformFunction {
     Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
         "First argument must be single-valued for transform function: %s", getName());
     Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
-        || transformFunction instanceof LiteralTransformFunction, "The first argument must be of bytes type");
+        || transformFunction instanceof LiteralTransformFunction,
+        "The first argument must be of type BYTES , but was %s",
+            transformFunction.getResultMetadata().getDataType()
+        );
     _firstArgument = transformFunction;
     transformFunction = arguments.get(1);
     Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
         "Second argument must be single-valued for transform function: %s", getName());
     Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
-        || transformFunction instanceof LiteralTransformFunction, "The second argument must be of bytes type");
+        || transformFunction instanceof LiteralTransformFunction,
+        "The second argument must be of type BYTES , but was %s",
+            transformFunction.getResultMetadata().getDataType()
+        );
     _secondArgument = transformFunction;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StEqualsFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StEqualsFunction.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.core.operator.transform.function.BaseTransformFunction;
+import org.apache.pinot.core.operator.transform.function.LiteralTransformFunction;
 import org.apache.pinot.core.operator.transform.function.TransformFunction;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.segment.local.utils.GeometrySerializer;
@@ -53,14 +54,22 @@ public class StEqualsFunction extends BaseTransformFunction {
     TransformFunction transformFunction = arguments.get(0);
     Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
         "First argument must be single-valued for transform function: %s", getName());
-    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES,
-        "The first argument must be of bytes type");
+    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
+            || transformFunction instanceof LiteralTransformFunction,
+        String.format("The %s argument must be of type %s , but was %s",
+            "first",
+            FieldSpec.DataType.BYTES,
+            transformFunction.getResultMetadata().getDataType()
+        ));
     _firstArgument = transformFunction;
     transformFunction = arguments.get(1);
     Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
         "Second argument must be single-valued for transform function: %s", getName());
-    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES,
-        "The second argument must be of bytes type");
+    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
+            || transformFunction instanceof LiteralTransformFunction,
+        "The second argument must be of type BYTES , but was %s",
+            transformFunction.getResultMetadata().getDataType()
+        );
     _secondArgument = transformFunction;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StEqualsFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StEqualsFunction.java
@@ -56,9 +56,7 @@ public class StEqualsFunction extends BaseTransformFunction {
         "First argument must be single-valued for transform function: %s", getName());
     Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
             || transformFunction instanceof LiteralTransformFunction,
-        String.format("The %s argument must be of type %s , but was %s",
-            "first",
-            FieldSpec.DataType.BYTES,
+        String.format("The first argument must be of type BYTES , but was %s",
             transformFunction.getResultMetadata().getDataType()
         ));
     _firstArgument = transformFunction;

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StWithinFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StWithinFunction.java
@@ -56,13 +56,17 @@ public class StWithinFunction extends BaseTransformFunction {
     Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
         "First argument must be single-valued for transform function: %s", getName());
     Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
-        || transformFunction instanceof LiteralTransformFunction, "The first argument must be of bytes type");
+        || transformFunction instanceof LiteralTransformFunction,
+        "The first argument must be of type BYTES, but was %s",
+        transformFunction.getResultMetadata().getDataType());
     _firstArgument = transformFunction;
     transformFunction = arguments.get(1);
     Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
         "Second argument must be single-valued for transform function: %s", getName());
     Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
-        || transformFunction instanceof LiteralTransformFunction, "The second argument must be of bytes type");
+        || transformFunction instanceof LiteralTransformFunction,
+        "The second argument must be of types BYTES, but was %s",
+        transformFunction.getResultMetadata().getDataType());
     _secondArgument = transformFunction;
   }
 


### PR DESCRIPTION
## Description

* Updates the error message returned by `St_Contains`, `St_Area`, `St_Distance`, and `St_Equals` to indicate to the user what argument type they actually passed to the function.
* `St_Equals` and `St_Area` accept literal transform functions (the same as the other `St_` functions)

The change to `St_Equals` lets us compare the location in a column against a literal location:

![image](https://user-images.githubusercontent.com/13220/149124212-4e3c6a3f-51ed-4f6a-9b68-15b828707a25.png)

And the change to `St_Area` does the same thing:

![image](https://user-images.githubusercontent.com/13220/149126656-c718c87d-b856-4ecf-8e42-cac69d86182c.png)


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
