### PR TITLE
Change error to warn in catchupToFinalOffset

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1162,7 +1162,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     }
     if (_currentOffset.compareTo(endOffset) != 0) {
       // Timeout?
-      _segmentLogger.error("Could not consume up to {} (current offset {})", endOffset, _currentOffset);
+      _segmentLogger.warn("Could not consume up to {} (current offset {})", endOffset, _currentOffset);
       return false;
     }
 


### PR DESCRIPTION
If non-winner replicas are asked to catchup but they cannot, an ERROR is logged. This isn't really an ERROR as the failure to catchup can be because of non-erroneous reasons. And even if they fail to catchup, it is handled in the caller by simply downloading from the winner. 
Changing this to WARN, so that it doesn't throw one off when debugging other issues.