### PR TITLE
fix: Query console goes blank on syntax error

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -521,7 +521,7 @@ export default function CustomizedTables({
                             className={isCellClickable ? classes.isCellClickable : (isSticky ? classes.isSticky : '')}
                             onClick={() => {cellClickCallback && cellClickCallback(cell);}}
                           >
-                            {makeCell(cell, index)}
+                            {makeCell(cell || '--', index)}
                           </StyledTableCell>
                         );
                       })}


### PR DESCRIPTION
## Description
This PR fixes #8002 
Attaching screenshot for the reference.
![image](https://user-images.githubusercontent.com/6761317/149207585-09cf28d7-5cf7-42fb-9881-8f2764b082e8.png)

