### PR TITLE
pinot-druid-benchmark: set the multiValueDelimiterEnabled to false 

### DIFF
--- a/contrib/pinot-druid-benchmark/README.md
+++ b/contrib/pinot-druid-benchmark/README.md
@@ -247,6 +247,7 @@ recordReaderSpec:
   configClassName: 'org.apache.pinot.plugin.inputformat.csv.CSVRecordReaderConfig'
   configs:
     delimiter: '|'
+    multiValueDelimiterEnabled: false
     header: 'l_orderkey|l_partkey|l_suppkey|l_linenumber|l_quantity|l_extendedprice|l_discount|l_tax|l_returnflag|l_linestatus|l_shipdate|l_commitdate|l_receiptdate|l_shipinstruct|l_shipmode|l_comment|'
 tableSpec:
   tableName: 'tpch_lineitem'


### PR DESCRIPTION
I ran into trouble when running the benchmark.
When importing the TPC-H data, the exception occurs:
```bash
java.lang.RuntimeException: Caught exception while transforming data type for column: l_comment
...
Caused by: java.lang.IllegalArgumentException: Cannot read single-value from Object[]: [y express dolphins use blithely,  s] for column: l_comment
...
```
The corresponding row in TPC-H data that causes this exception is 
```text
21339361|1373339|73391|4|29|40955.83|0.04|0.04|A|F|1992-01-02|1992-03-14|1992-01-19|DELIVER IN PERSON|MAIL|y express dolphins use blithely; s|
```
which has a semicolon in the `l_comment` column.

For `org.apache.pinot.plugin.inputformat.csv.CSVRecordReaderConfig`,  `multiValueDelimiterEnabled` is set to `true` by default, and the `DEFAULT_MULTI_VALUE_DELIMITER` is `;`.

To avoid the `l_comment` being parsed as multiple values, the `multiValueDelimiterEnabled` has to be set to `true` explicitly in the job-spec.yml file.