### PR TITLE
Speed up datatype transformer

### DIFF
--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkDataTypeTransformer.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkDataTypeTransformer.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.pinot.segment.local.recordtransformer.DataTypeTransformer;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+
+@State(Scope.Benchmark)
+public class BenchmarkDataTypeTransformer {
+
+  @Param({"10", "20", "30", "40", "50"})
+  int _columnCount;
+
+  private GenericRow _genericRow;
+  private DataTypeTransformer _dataTypeTransformer;
+
+  @Setup(Level.Trial)
+  public void setup() {
+    _genericRow = new GenericRow();
+    List<FieldSpec> fieldSpecs = fieldSpecs(_columnCount);
+    _dataTypeTransformer = new DataTypeTransformer(fieldSpecs);
+    for (FieldSpec fieldSpec : fieldSpecs) {
+      switch (fieldSpec.getDataType()) {
+        case STRING:
+          _genericRow.putValue(fieldSpec.getName(), UUID.randomUUID().toString());
+          break;
+        case DOUBLE:
+          _genericRow.putValue(fieldSpec.getName(), ThreadLocalRandom.current().nextDouble());
+          break;
+        default:
+          throw new RuntimeException("not measuring type" + fieldSpec.getDataType());
+      }
+    }
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  List<FieldSpec> fieldSpecs(int size) {
+    return IntStream.range(0, size)
+        .mapToObj(i -> i % 2 == 0 ? new DimensionFieldSpec("column" + i, FieldSpec.DataType.STRING, true)
+            : new DimensionFieldSpec("column" + i, FieldSpec.DataType.DOUBLE, true))
+        .collect(Collectors.toList());
+  }
+
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  @Benchmark
+  public GenericRow transform() {
+    return _dataTypeTransformer.transform(_genericRow);
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
@@ -27,6 +27,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -69,7 +71,7 @@ public class GenericRow implements Serializable {
    */
   public static final String SKIP_RECORD_KEY = "$SKIP_RECORD_KEY$";
 
-  private final Map<String, Object> _fieldToValueMap = new HashMap<>();
+  private final Map<String, Object> _fieldToValueMap = new LinkedHashMap<>();
   private final Set<String> _nullValueFields = new HashSet<>();
 
   /**
@@ -79,6 +81,14 @@ public class GenericRow implements Serializable {
   public void init(GenericRow row) {
     _fieldToValueMap.putAll(row._fieldToValueMap);
     _nullValueFields.addAll(row._nullValueFields);
+  }
+
+  /**
+   * Iterate over the contents of the row
+   * @return
+   */
+  public Iterator<Map.Entry<String, Object>> iterator() {
+    return _fieldToValueMap.entrySet().iterator();
   }
 
   /**


### PR DESCRIPTION
This speeds up the `DataTypeTransformer` by roughly 30%, based on profiling a very slow RealtimeToOfflineTask mapping phase in #8014, where over 30% of samples from a 5 minute profile were in this method.

before
```
Benchmark                               (_columnCount)  Mode  Cnt     Score    Error  Units
BenchmarkDataTypeTransformer.transform              10  avgt    5   487.921 ± 23.518  ns/op
BenchmarkDataTypeTransformer.transform              20  avgt    5  1026.615 ± 21.386  ns/op
BenchmarkDataTypeTransformer.transform              30  avgt    5  1540.456 ± 23.694  ns/op
BenchmarkDataTypeTransformer.transform              40  avgt    5  2086.853 ± 84.693  ns/op
BenchmarkDataTypeTransformer.transform              50  avgt    5  2649.823 ± 65.988  ns/op
```
after
```
Benchmark                               (_columnCount)  Mode  Cnt     Score     Error  Units
BenchmarkDataTypeTransformer.transform              10  avgt    5   386.467 ±   6.199  ns/op
BenchmarkDataTypeTransformer.transform              20  avgt    5   781.351 ±  30.718  ns/op
BenchmarkDataTypeTransformer.transform              30  avgt    5  1148.439 ±  52.494  ns/op
BenchmarkDataTypeTransformer.transform              40  avgt    5  1635.082 ±  97.129  ns/op
BenchmarkDataTypeTransformer.transform              50  avgt    5  2039.217 ± 100.647  ns/op
```