### PR TITLE
Fetch Pulsar offsets from Consumer interface instead of Reader

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarConfig.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarConfig.java
@@ -39,6 +39,7 @@ public class PulsarConfig {
   private String _subscriberId;
   private String _bootstrapServers;
   private MessageId _initialMessageId;
+  private SubscriptionInitialPosition _subscriptionInitialPosition;
 
   public PulsarConfig(StreamConfig streamConfig, String subscriberId) {
     Map<String, String> streamConfigMap = streamConfig.getStreamConfigsMap();
@@ -53,8 +54,10 @@ public class PulsarConfig {
 
     if (offsetCriteria.isSmallest()) {
       _initialMessageId = MessageId.earliest;
+      _subscriptionInitialPosition = SubscriptionInitialPosition.Earliest;
     } else if (offsetCriteria.isLargest()) {
       _initialMessageId = MessageId.latest;
+      _subscriptionInitialPosition = SubscriptionInitialPosition.Latest;
     } else {
       throw new IllegalArgumentException("Unknown initial offset value " + offsetCriteria);
     }
@@ -77,9 +80,6 @@ public class PulsarConfig {
   }
 
   public SubscriptionInitialPosition getInitialSubscriberPosition() {
-    if (_initialMessageId == MessageId.earliest) {
-      return SubscriptionInitialPosition.Earliest;
-    }
-    return SubscriptionInitialPosition.Latest;
+   return _subscriptionInitialPosition;
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarConfig.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarConfig.java
@@ -19,8 +19,6 @@
 package org.apache.pinot.plugin.stream.pulsar;
 
 import com.google.common.base.Preconditions;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.StreamConfig;
@@ -57,12 +55,8 @@ public class PulsarConfig {
       _initialMessageId = MessageId.earliest;
     } else if (offsetCriteria.isLargest()) {
       _initialMessageId = MessageId.latest;
-    } else if (offsetCriteria.isCustom()) {
-      try {
-        _initialMessageId = MessageId.fromByteArray(offsetCriteria.getOffsetString().getBytes(StandardCharsets.UTF_8));
-      } catch (IOException e) {
-        throw new RuntimeException("Invalid offset string found: " + offsetCriteria.getOffsetString());
-      }
+    } else {
+      throw new IllegalArgumentException("Unknown initial offset value " + offsetCriteria);
     }
   }
 

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarConfig.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarConfig.java
@@ -26,6 +26,7 @@ import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 
 
 /**
@@ -79,5 +80,12 @@ public class PulsarConfig {
 
   public MessageId getInitialMessageId() {
     return _initialMessageId;
+  }
+
+  public SubscriptionInitialPosition getInitialSubscriberPosition() {
+    if (_initialMessageId == MessageId.earliest) {
+      return SubscriptionInitialPosition.Earliest;
+    }
+    return SubscriptionInitialPosition.Latest;
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarConfig.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarConfig.java
@@ -52,15 +52,8 @@ public class PulsarConfig {
 
     OffsetCriteria offsetCriteria = streamConfig.getOffsetCriteria();
 
-    if (offsetCriteria.isSmallest()) {
-      _initialMessageId = MessageId.earliest;
-      _subscriptionInitialPosition = SubscriptionInitialPosition.Earliest;
-    } else if (offsetCriteria.isLargest()) {
-      _initialMessageId = MessageId.latest;
-      _subscriptionInitialPosition = SubscriptionInitialPosition.Latest;
-    } else {
-      throw new IllegalArgumentException("Unknown initial offset value " + offsetCriteria);
-    }
+    _subscriptionInitialPosition = PulsarUtils.offsetCriteriaToSubscription(offsetCriteria);
+    _initialMessageId = PulsarUtils.offsetCriteriaToMessageId(offsetCriteria);
   }
 
   public String getPulsarTopicName() {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarPartitionLevelConnectionHandler.java
@@ -53,7 +53,7 @@ public class PulsarPartitionLevelConnectionHandler {
       _pulsarClient = PulsarClient.builder().serviceUrl(_config.getBootstrapServers()).build();
 
       _reader = _pulsarClient.newReader().topic(getPartitionedTopicName(partition))
-          .startMessageId(_config.getInitialMessageId()).create();
+          .startMessageId(_config.getInitialMessageId()).startMessageIdInclusive().create();
 
       LOGGER.info("Created consumer with id {} for topic {}", _reader, _config.getPulsarTopicName());
     } catch (Exception e) {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
@@ -130,15 +130,14 @@ public class PulsarStreamMetadataProvider extends PulsarPartitionLevelConnection
               .subscriptionInitialPosition(_config.getInitialSubscriberPosition())
               .subscriptionName("Pinot_" + UUID.randomUUID()).subscribe();
 
-          //TODO: Make timeout values configurable
-          Message message = consumer.receive(3, TimeUnit.SECONDS);
+          Message message = consumer.receive(timeoutMillis, TimeUnit.MILLISECONDS);
           if (message != null) {
             newPartitionGroupMetadataList.add(
                 new PartitionGroupMetadata(p, new MessageIdStreamOffset(message.getMessageId())));
           } else {
             MessageId lastMessageId;
             try {
-              lastMessageId = (MessageId) consumer.getLastMessageIdAsync().get(3, TimeUnit.SECONDS);
+              lastMessageId = (MessageId) consumer.getLastMessageIdAsync().get(timeoutMillis, TimeUnit.MILLISECONDS);
             } catch (TimeoutException t) {
               lastMessageId = MessageId.latest;
             }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
@@ -122,6 +122,7 @@ public class PulsarStreamMetadataProvider extends PulsarPartitionLevelConnection
               partitionGroupConsumptionStatus.getStartOffset()));
     }
 
+    PulsarConfig pulsarConfig = new PulsarConfig(streamConfig, clientId);
     Consumer consumer = null;
     try {
       List<String> partitionedTopicNameList = _pulsarClient.getPartitionsForTopic(_topic).get();
@@ -132,7 +133,7 @@ public class PulsarStreamMetadataProvider extends PulsarPartitionLevelConnection
         for (int p = newPartitionStartIndex; p < partitionedTopicNameList.size(); p++) {
 
           consumer = _pulsarClient.newConsumer().topic(partitionedTopicNameList.get(p))
-              .subscriptionInitialPosition(_config.getInitialSubscriberPosition())
+              .subscriptionInitialPosition(pulsarConfig.getInitialSubscriberPosition())
               .subscriptionName(ConsumerName.generateRandomName()).subscribe();
 
           Message message = consumer.receive(timeoutMillis, TimeUnit.MILLISECONDS);

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
@@ -35,6 +35,7 @@ import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.util.ConsumerName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -128,7 +129,7 @@ public class PulsarStreamMetadataProvider extends PulsarPartitionLevelConnection
 
           Consumer consumer = _pulsarClient.newConsumer().topic(getPartitionedTopicName(p))
               .subscriptionInitialPosition(_config.getInitialSubscriberPosition())
-              .subscriptionName("Pinot_" + UUID.randomUUID()).subscribe();
+              .subscriptionName(ConsumerName.generateRandomName()).subscribe();
 
           Message message = consumer.receive(timeoutMillis, TimeUnit.MILLISECONDS);
           if (message != null) {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
@@ -163,7 +163,9 @@ public class PulsarStreamMetadataProvider extends PulsarPartitionLevelConnection
 
   private void closeConsumer(Consumer consumer) {
     try {
-      consumer.close();
+      if (consumer != null) {
+        consumer.close();
+      }
     } catch (Exception e) {
       LOGGER.warn("Caught exception while shutting down Pulsar consumer with id {}", consumer, e);
     }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
@@ -130,7 +130,7 @@ public class PulsarStreamMetadataProvider extends PulsarPartitionLevelConnection
               .subscriptionInitialPosition(_config.getInitialSubscriberPosition())
               .subscriptionName("Pinot_" + UUID.randomUUID()).subscribe();
 
-
+          //TODO: Make timeout values configurable
           Message message = consumer.receive(3, TimeUnit.SECONDS);
           if (message != null) {
             newPartitionGroupMetadataList.add(

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarUtils.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarUtils.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.plugin.stream.pulsar;
 
 import org.apache.pinot.spi.stream.OffsetCriteria;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.SubscriptionInitialPosition;
 
 
@@ -34,6 +35,18 @@ public class PulsarUtils {
     }
     if (offsetCriteria.isSmallest()) {
       return SubscriptionInitialPosition.Earliest;
+    }
+
+    throw new IllegalArgumentException("Unknown initial offset value " + offsetCriteria);
+  }
+
+  public static MessageId offsetCriteriaToMessageId(OffsetCriteria offsetCriteria)
+      throws IllegalArgumentException {
+    if (offsetCriteria.isLargest()) {
+      return MessageId.latest;
+    }
+    if (offsetCriteria.isSmallest()) {
+      return MessageId.earliest;
     }
 
     throw new IllegalArgumentException("Unknown initial offset value " + offsetCriteria);

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarUtils.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarUtils.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.pulsar;
+
+import org.apache.pinot.spi.stream.OffsetCriteria;
+import org.apache.pulsar.client.api.SubscriptionInitialPosition;
+
+
+public class PulsarUtils {
+
+  private PulsarUtils() {
+  }
+
+  public static SubscriptionInitialPosition offsetCriteriaToSubscription(OffsetCriteria offsetCriteria)
+      throws IllegalArgumentException {
+    if (offsetCriteria.isLargest()) {
+      return SubscriptionInitialPosition.Latest;
+    }
+    if (offsetCriteria.isSmallest()) {
+      return SubscriptionInitialPosition.Earliest;
+    }
+
+    throw new IllegalArgumentException("Unknown initial offset value " + offsetCriteria);
+  }
+}


### PR DESCRIPTION
The Pulsar Plugin fails to consume data if the `auto.offset.reset` property is set to `largest`. The reason is the reader interface always resets to after the last message in the topic. The solution is either to use large fetch timeouts so that records pushed are consumed before a new pulsar consumer is created. 
OR
Ditch the Pulsar Reader interface and use the Consumer interface. The Consumer interface can return the last valid message-id in the topic and hence the PulsarConsumer can begin consumption after that.