### PR TITLE
Fix EXPLAIN PLAN output when all segments get pruned out on the server side.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -77,6 +77,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerQueryExecutorV1Impl.class);
   private static final String IN_PARTITIONED_SUBQUERY = "inPartitionedSubquery";
+  private static final DataTable EXPLAIN_PLAN_RESULTS_NO_MATCHING_SEGMENT = getExplainPlanResultsForNoMatchingSegment();
 
   private InstanceDataManager _instanceDataManager;
   private ServerMetrics _serverMetrics;
@@ -279,6 +280,10 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
     LOGGER.debug("Matched {} segments after pruning", numSelectedSegments);
     if (numSelectedSegments == 0) {
       // Only return metadata for streaming query
+      if (isExplain) {
+        return EXPLAIN_PLAN_RESULTS_NO_MATCHING_SEGMENT;
+      }
+
       DataTable dataTable = DataTableUtils.buildEmptyDataTable(queryContext);
       Map<String, String> metadata = dataTable.getMetadata();
       metadata.put(MetadataKey.TOTAL_DOCS.getName(), String.valueOf(numTotalDocs));
@@ -304,6 +309,21 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
 
       return dataTable;
     }
+  }
+
+  /** @return EXPLAIN_PLAN query result {@link DataTable} when no segments get selected for query execution.*/
+  private static DataTable getExplainPlanResultsForNoMatchingSegment() {
+    DataTableBuilder dataTableBuilder = new DataTableBuilder(DataSchema.EXPLAIN_RESULT_SCHEMA);
+    try {
+      dataTableBuilder.startRow();
+      dataTableBuilder.setColumn(0, "NO_MATCHING_SEGMENT");
+      dataTableBuilder.setColumn(1, 1);
+      dataTableBuilder.setColumn(2, 0);
+      dataTableBuilder.finishRow();
+    } catch (IOException ioe) {
+      LOGGER.error("Unable to create EXPLAIN PLAN result table.", ioe);
+    }
+    return dataTableBuilder.build();
   }
 
   /** @return EXPLAIN PLAN query result {@link DataTable}. */

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -1808,19 +1808,28 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   @Test
   public void testExplainPlanQuery()
       throws Exception {
-    String query = "EXPLAIN PLAN FOR SELECT count(*) AS count, Carrier AS name FROM mytable GROUP BY name ORDER BY 1";
-    String response = postSqlQuery(query, _brokerBaseApiUrl).get("resultTable").toString();
+    String query1 = "EXPLAIN PLAN FOR SELECT count(*) AS count, Carrier AS name FROM mytable GROUP BY name ORDER BY 1";
+    String response1 = postSqlQuery(query1, _brokerBaseApiUrl).get("resultTable").toString();
 
     // Replace string "docs:[0-9]+" with "docs:*" so that test doesn't fail when number of documents change. This is
     // needed because both OfflineClusterIntegrationTest and MultiNodesOfflineClusterIntegrationTest run this test
     // case with different number of documents in the segment.
-    response = response.replaceAll("docs:[0-9]+", "docs:*");
+    response1 = response1.replaceAll("docs:[0-9]+", "docs:*");
 
-    assertEquals(response, "{\"dataSchema\":{\"columnNames\":[\"Operator\",\"Operator_Id\",\"Parent_Id\"],"
+    assertEquals(response1, "{\"dataSchema\":{\"columnNames\":[\"Operator\",\"Operator_Id\",\"Parent_Id\"],"
         + "\"columnDataTypes\":[\"STRING\",\"INT\",\"INT\"]},\"rows\":[[\"BROKER_REDUCE(sort:[count(*) ASC],limit:10)"
         + "\",0,-1],[\"COMBINE_GROUPBY_ORDERBY\",1,0],[\"AGGREGATE_GROUPBY_ORDERBY(groupKeys:Carrier, "
         + "aggregations:count(*))\",2,1],[\"TRANSFORM_PASSTHROUGH(Carrier)\",3,2],[\"PROJECT(Carrier)\",4,3],"
         + "[\"FILTER_MATCH_ENTIRE_SEGMENT(docs:*)\",5,4]]}");
+
+    // In the query below, FlightNum column has an inverted index and there is no data satisfying the predicate
+    // "FlightNum < 0". Hence, all segments are pruned out before query execution on the server side.
+    String query2 = "EXPLAIN PLAN FOR SELECT * FROM mytable WHERE FlightNum < 0";
+    String response2 = postSqlQuery(query2, _brokerBaseApiUrl).get("resultTable").toString();
+
+    assertEquals(response2, "{\"dataSchema\":{\"columnNames\":[\"Operator\",\"Operator_Id\",\"Parent_Id\"],"
+        + "\"columnDataTypes\":[\"STRING\",\"INT\",\"INT\"]},\"rows\":[[\"BROKER_REDUCE(limit:10)\",0,-1],"
+        + "[\"NO_MATCHING_SEGMENT\",1,0]]}");
   }
 
   @Test


### PR DESCRIPTION
## Description
Assuming that table `mytable` has an index on column `FlightNum` (where `FlightNum` contains only positive integers), the server will prune out all the segments for the query `SELECT * FROM mytable WHERE FlightNum < 0`. We found (see #8008) that no EXPLAIN PLAN output is generated for this case. This PR fixes the issue.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
