### PR TITLE
adding new segment url builder to util

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -292,6 +292,10 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", _baseUrl, "tables", tableName, "segments");
   }
 
+  public String forSegmentMetadata(String tableName) {
+    return StringUtil.join("/", _baseUrl, "segments", tableName, "metadata");
+  }
+
   public String forSegmentMetadata(String tableName, String segmentName) {
     return StringUtil.join("/", _baseUrl, "segments", tableName, segmentName, "metadata");
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
@@ -31,7 +30,6 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.ingestion.batch.spec.Constants;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
@@ -132,7 +130,7 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
 
       JsonNode segmentMetadataFromAllEndpoint = tableSegmentsMetadata.elements().next();
       String segmentName = URLEncoder.encode(segmentMetadataFromAllEndpoint.get("segmentName").asText(),
-          StandardCharsets.UTF_8);
+          "UTF-8");
       jsonOutputStr = sendGetRequest(
           _controllerRequestURLBuilder.forSegmentMetadata(getTableName(), segmentName));
       JsonNode segmentMetadataFromDirectEndpoint = JsonUtils.stringToJsonNode(jsonOutputStr);


### PR DESCRIPTION
makes it easier to acquire all segment metadata.
also added integration test for all the segment metadata endpoints previously it was not tested.