### PR TITLE
Move AuthToken generator to pinot-common

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
@@ -28,6 +28,7 @@ import org.apache.pinot.broker.api.AccessControl;
 import org.apache.pinot.broker.api.HttpRequesterIdentity;
 import org.apache.pinot.broker.api.RequesterIdentity;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.utils.AuthUtils;
 import org.apache.pinot.core.auth.BasicAuthPrincipal;
 import org.apache.pinot.core.auth.BasicAuthUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -85,7 +86,7 @@ public class BasicAuthAccessControlFactory extends AccessControlFactory {
 
       Collection<String> tokens = identity.getHttpHeaders().get(HEADER_AUTHORIZATION);
       Optional<BasicAuthPrincipal> principalOpt =
-          tokens.stream().map(BasicAuthUtils::normalizeBase64Token).map(_token2principal::get).filter(Objects::nonNull)
+          tokens.stream().map(AuthUtils::normalizeBase64Token).map(_token2principal::get).filter(Objects::nonNull)
               .findFirst();
 
       if (!principalOpt.isPresent()) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/AuthUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/AuthUtils.java
@@ -1,0 +1,41 @@
+package org.apache.pinot.common.utils;
+
+import java.util.Base64;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
+
+
+public class AuthUtils {
+  private AuthUtils() {
+  }
+
+  /**
+   * Convert a pair of name and password into a http header-compliant base64 encoded token
+   *
+   * @param name user name
+   * @param password password
+   * @return base64 encoded basic auth token
+   */
+  @Nullable
+  public static String toBase64AuthToken(String name, String password) {
+    if (StringUtils.isBlank(name)) {
+      return null;
+    }
+    String identifier = String.format("%s:%s", name, password);
+    return normalizeBase64Token(String.format("Basic %s", Base64.getEncoder().encodeToString(identifier.getBytes())));
+  }
+
+  /**
+   * Normalize a base64 encoded auth token by stripping redundant padding (spaces, '=')
+   *
+   * @param token base64 encoded auth token
+   * @return normalized auth token
+   */
+  @Nullable
+  public static String normalizeBase64Token(String token) {
+    if (token == null) {
+      return null;
+    }
+    return StringUtils.remove(token.trim(), '=');
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/AuthUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/AuthUtils.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.common.utils;
 
 import java.util.Base64;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/BasicAuthAccessControlFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/BasicAuthAccessControlFactory.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.HttpHeaders;
+import org.apache.pinot.common.utils.AuthUtils;
 import org.apache.pinot.core.auth.BasicAuthPrincipal;
 import org.apache.pinot.core.auth.BasicAuthUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -100,7 +101,7 @@ public class BasicAuthAccessControlFactory implements AccessControlFactory {
         return Optional.empty();
       }
 
-      return authHeaders.stream().map(BasicAuthUtils::normalizeBase64Token).map(_token2principal::get)
+      return authHeaders.stream().map(AuthUtils::normalizeBase64Token).map(_token2principal::get)
           .filter(Objects::nonNull).findFirst();
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthUtils.java
@@ -20,13 +20,12 @@ package org.apache.pinot.core.auth;
 
 import com.google.common.base.Preconditions;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.utils.AuthUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
 
@@ -74,7 +73,7 @@ public final class BasicAuthUtils {
       Set<String> tables = extractSet(configuration, String.format("%s.%s.%s", prefix, name, TABLES));
       Set<String> permissions = extractSet(configuration, String.format("%s.%s.%s", prefix, name, PERMISSIONS));
 
-      return new BasicAuthPrincipal(name, toBasicAuthToken(name, password), tables, permissions);
+      return new BasicAuthPrincipal(name, AuthUtils.toBase64AuthToken(name, password), tables, permissions);
     }).collect(Collectors.toList());
   }
 
@@ -84,35 +83,5 @@ public final class BasicAuthUtils {
       return Arrays.stream(input.split(",")).map(String::trim).collect(Collectors.toSet());
     }
     return Collections.emptySet();
-  }
-
-  /**
-   * Convert a pair of name and password into a http header-compliant base64 encoded token
-   *
-   * @param name user name
-   * @param password password
-   * @return base64 encoded basic auth token
-   */
-  @Nullable
-  public static String toBasicAuthToken(String name, String password) {
-    if (StringUtils.isBlank(name)) {
-      return null;
-    }
-    String identifier = String.format("%s:%s", name, password);
-    return normalizeBase64Token(String.format("Basic %s", Base64.getEncoder().encodeToString(identifier.getBytes())));
-  }
-
-  /**
-   * Normalize a base64 encoded auth token by stripping redundant padding (spaces, '=')
-   *
-   * @param token base64 encoded auth token
-   * @return normalized auth token
-   */
-  @Nullable
-  public static String normalizeBase64Token(String token) {
-    if (token == null) {
-      return null;
-    }
-    return StringUtils.remove(token.trim(), '=');
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/server/access/BasicAuthAccessFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/access/BasicAuthAccessFactory.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.commons.lang.StringUtils;
+import org.apache.pinot.common.utils.AuthUtils;
 import org.apache.pinot.core.auth.BasicAuthPrincipal;
 import org.apache.pinot.core.auth.BasicAuthUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -64,7 +65,7 @@ public class BasicAuthAccessFactory implements AccessControlFactory {
     public boolean hasDataAccess(RequesterIdentity requesterIdentity, String tableName) {
       Collection<String> tokens = getTokens(requesterIdentity);
       return tokens.stream()
-          .map(BasicAuthUtils::normalizeBase64Token)
+          .map(AuthUtils::normalizeBase64Token)
           .map(_token2principal::get)
           .filter(Objects::nonNull)
           .findFirst()

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/AccessControlTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/AccessControlTest.java
@@ -31,7 +31,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.config.TlsConfig;
-import org.apache.pinot.core.auth.BasicAuthUtils;
+import org.apache.pinot.common.utils.AuthUtils;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.server.access.AccessControl;
 import org.apache.pinot.server.access.AccessControlFactory;
@@ -127,9 +127,9 @@ public class AccessControlTest {
   @Test
   public void testGrpcBasicAuth() {
     testBasicAuth(new GrpcRequesterIdentity(
-        ImmutableMap.of("authorization", BasicAuthUtils.toBasicAuthToken("admin123", "verysecret"))), true);
+        ImmutableMap.of("authorization", AuthUtils.toBase64AuthToken("admin123", "verysecret"))), true);
     testBasicAuth(new GrpcRequesterIdentity(
-        ImmutableMap.of("authorization", BasicAuthUtils.toBasicAuthToken("user456", "kindasecret"))), false);
+        ImmutableMap.of("authorization", AuthUtils.toBase64AuthToken("user456", "kindasecret"))), false);
 
     testBasicAuth(new GrpcRequesterIdentity(
         ImmutableMap.of("authorization", "Basic YWRtaW4xMjM6dmVyeXNlY3JldA")), true);
@@ -141,10 +141,10 @@ public class AccessControlTest {
   public void testHttpBasicAuth() {
     HttpHeaders headers = new ContainerRequest(null, null, null, null, new MapPropertiesDelegate());
     headers.getRequestHeaders()
-        .put("authorization", Arrays.asList(BasicAuthUtils.toBasicAuthToken("admin123", "verysecret")));
+        .put("authorization", Arrays.asList(AuthUtils.toBase64AuthToken("admin123", "verysecret")));
     testBasicAuth(new HttpRequesterIdentity(headers), true);
     headers.getRequestHeaders()
-        .put("authorization", Arrays.asList(BasicAuthUtils.toBasicAuthToken("user456", "kindasecret")));
+        .put("authorization", Arrays.asList(AuthUtils.toBase64AuthToken("user456", "kindasecret")));
     testBasicAuth(new HttpRequesterIdentity(headers), false);
     headers.getRequestHeaders().put("authorization", Arrays.asList("Basic YWRtaW4xMjM6dmVyeXNlY3JldA"));
     testBasicAuth(new HttpRequesterIdentity(headers), true);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.pinot.core.auth.BasicAuthUtils;
+import org.apache.pinot.common.utils.AuthUtils;
 import org.apache.pinot.spi.plugin.PluginManager;
 
 
@@ -34,7 +34,7 @@ public class AuthQuickstart extends Quickstart {
 
   @Override
   public String getAuthToken() {
-    return BasicAuthUtils.toBasicAuthToken("admin", "verysecret");
+    return AuthUtils.toBase64AuthToken("admin", "verysecret");
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AbstractBaseAdminCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AbstractBaseAdminCommand.java
@@ -36,7 +36,7 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
 import org.apache.pinot.common.utils.http.HttpClient;
-import org.apache.pinot.core.auth.BasicAuthUtils;
+import org.apache.pinot.common.utils.AuthUtils;
 import org.apache.pinot.tools.AbstractBaseCommand;
 import org.apache.pinot.tools.utils.PinotConfigUtils;
 
@@ -150,7 +150,7 @@ public class AbstractBaseAdminCommand extends AbstractBaseCommand {
     }
 
     if (StringUtils.isNotBlank(user)) {
-      return BasicAuthUtils.toBasicAuthToken(user, password);
+      return AuthUtils.toBase64AuthToken(user, password);
     }
 
     return null;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AbstractBaseAdminCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AbstractBaseAdminCommand.java
@@ -35,8 +35,8 @@ import javax.annotation.Nullable;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
-import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.common.utils.AuthUtils;
+import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.tools.AbstractBaseCommand;
 import org.apache.pinot.tools.utils.PinotConfigUtils;
 


### PR DESCRIPTION
The AuthTokenUtils class is present in the `pinot-core` package. However, the logic for token generation is also needed in pinot clients such as JDBC, Presto, etc. when username and password are provided by the user.
It doesn't make sense to import `pinot-core` in these clients.
In future, there should be an API to retrieve access tokens for clients that want to make API calls.