### PR TITLE
remove consuming segment from `PartitionUpsertMetadataManager` to prevent memory leak

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -828,6 +828,10 @@ public class MutableSegmentImpl implements MutableSegment {
   public void destroy() {
     _logger.info("Trying to close RealtimeSegmentImpl : {}", _segmentName);
 
+    if (isUpsertEnabled() && _partitionUpsertMetadataManager != null) {
+      _partitionUpsertMetadataManager.removeSegment(this);
+    }
+
     // Gather statistics for off-heap mode
     if (_offHeap) {
       if (_numDocsIndexed > 0) {


### PR DESCRIPTION
Motivated by a heap dump from an OSS user where their realtime servers were OOM'd with a 16GB `_primaryKeyToRecordLocationMap`


Class Name | Shallow Heap | Retained Heap
-- | -- | --
java.util.concurrent.ConcurrentHashMap$Node[134217728] @ 0x727800000 | 536,870,928 | 16,829,827,816
table java.util.concurrent.ConcurrentHashMap @ 0x40343ec78 | 64 | 16,829,827,880
_primaryKeyToRecordLocationMap org.apache.pinot.segment.local.upsert.PartitionUpsertMetadataManager @ 0x40343ec48 | 48 | 16,829,835,136