### PR TITLE
refine segment consistency check

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessor.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessor.java
@@ -143,6 +143,7 @@ public class SegmentPreProcessor implements AutoCloseable {
         DefaultColumnHandler defaultColumnHandler = DefaultColumnHandlerFactory
             .getDefaultColumnHandler(null, _segmentMetadata, _indexLoadingConfig, _schema, null);
         if (defaultColumnHandler.needUpdateDefaultColumns()) {
+          LOGGER.debug("Found default columns need updates");
           return true;
         }
       }
@@ -150,15 +151,18 @@ public class SegmentPreProcessor implements AutoCloseable {
       for (ColumnIndexType type : ColumnIndexType.values()) {
         if (IndexHandlerFactory.getIndexHandler(type, _segmentMetadata, _indexLoadingConfig)
             .needUpdateIndices(segmentReader)) {
+          LOGGER.debug("Found index type: {} needs updates", type);
           return true;
         }
       }
       // Check if there is need to create/modify/remove star-trees.
       if (needProcessStarTrees()) {
+        LOGGER.debug("Found startree index needs updates");
         return true;
       }
       // Check if there is need to update column min max value.
       if (needUpdateColumnMinMaxValue()) {
+        LOGGER.debug("Found min max values need updates");
         return true;
       }
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessor.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessor.java
@@ -143,7 +143,7 @@ public class SegmentPreProcessor implements AutoCloseable {
         DefaultColumnHandler defaultColumnHandler = DefaultColumnHandlerFactory
             .getDefaultColumnHandler(null, _segmentMetadata, _indexLoadingConfig, _schema, null);
         if (defaultColumnHandler.needUpdateDefaultColumns()) {
-          LOGGER.debug("Found default columns need updates");
+          LOGGER.info("Found default columns need updates");
           return true;
         }
       }
@@ -151,18 +151,18 @@ public class SegmentPreProcessor implements AutoCloseable {
       for (ColumnIndexType type : ColumnIndexType.values()) {
         if (IndexHandlerFactory.getIndexHandler(type, _segmentMetadata, _indexLoadingConfig)
             .needUpdateIndices(segmentReader)) {
-          LOGGER.debug("Found index type: {} needs updates", type);
+          LOGGER.info("Found index type: {} needs updates", type);
           return true;
         }
       }
       // Check if there is need to create/modify/remove star-trees.
       if (needProcessStarTrees()) {
-        LOGGER.debug("Found startree index needs updates");
+        LOGGER.info("Found startree index needs updates");
         return true;
       }
       // Check if there is need to update column min max value.
       if (needUpdateColumnMinMaxValue()) {
-        LOGGER.debug("Found min max values need updates");
+        LOGGER.info("Found min max values need updates");
         return true;
       }
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/bloomfilter/BloomFilterHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/bloomfilter/BloomFilterHandler.java
@@ -71,15 +71,15 @@ public class BloomFilterHandler implements IndexHandler {
     // Check if any existing bloomfilter need to be removed.
     for (String column : existingColumns) {
       if (!columnsToAddBF.remove(column)) {
-        LOGGER.debug("Need to remove existing bloom filter from segment: {}, column: {}", segmentName, column);
+        LOGGER.info("Need to remove existing bloom filter from segment: {}, column: {}", segmentName, column);
         return true;
       }
     }
     // Check if any new bloomfilter need to be added.
     for (String column : columnsToAddBF) {
       ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
-      if (columnMetadata != null && columnMetadata.hasDictionary()) {
-        LOGGER.debug("Need to create new bloom filter for segment: {}, column: {}", segmentName, column);
+      if (shouldCreateBloomFilter(columnMetadata)) {
+        LOGGER.info("Need to create new bloom filter for segment: {}, column: {}", segmentName, column);
         return true;
       }
     }
@@ -102,13 +102,15 @@ public class BloomFilterHandler implements IndexHandler {
     }
     for (String column : columnsToAddBF) {
       ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
-      if (columnMetadata != null) {
-        if (columnMetadata.hasDictionary()) {
-          createBloomFilterForColumn(segmentWriter, columnMetadata, indexCreatorProvider);
-        }
-        // TODO: Support raw index
+      if (shouldCreateBloomFilter(columnMetadata)) {
+        createBloomFilterForColumn(segmentWriter, columnMetadata, indexCreatorProvider);
       }
     }
+  }
+
+  private boolean shouldCreateBloomFilter(ColumnMetadata columnMetadata) {
+    // TODO: Support raw index
+    return columnMetadata != null && columnMetadata.hasDictionary();
   }
 
   private void createBloomFilterForColumn(SegmentDirectory.Writer segmentWriter, ColumnMetadata columnMetadata,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/FSTIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/FSTIndexHandler.java
@@ -79,8 +79,24 @@ public class FSTIndexHandler implements IndexHandler {
 
   @Override
   public boolean needUpdateIndices(SegmentDirectory.Reader segmentReader) {
+    String segmentName = _segmentMetadata.getName();
     Set<String> existingColumns = segmentReader.toSegmentDirectory().getColumnsWithIndex(ColumnIndexType.FST_INDEX);
-    return !existingColumns.equals(_columnsToAddIdx);
+    // Check if any existing index need to be removed.
+    for (String column : existingColumns) {
+      if (!_columnsToAddIdx.remove(column)) {
+        LOGGER.debug("Need to remove existing FST index from segment: {}, column: {}", segmentName, column);
+        return true;
+      }
+    }
+    // Check if any new index need to be added.
+    for (String column : _columnsToAddIdx) {
+      ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
+      if (columnMetadata != null) {
+        LOGGER.debug("Need to create new FST index for segment: {}, column: {}", segmentName, column);
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/FSTIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/FSTIndexHandler.java
@@ -84,15 +84,15 @@ public class FSTIndexHandler implements IndexHandler {
     // Check if any existing index need to be removed.
     for (String column : existingColumns) {
       if (!_columnsToAddIdx.remove(column)) {
-        LOGGER.debug("Need to remove existing FST index from segment: {}, column: {}", segmentName, column);
+        LOGGER.info("Need to remove existing FST index from segment: {}, column: {}", segmentName, column);
         return true;
       }
     }
     // Check if any new index need to be added.
     for (String column : _columnsToAddIdx) {
       ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
-      if (columnMetadata != null) {
-        LOGGER.debug("Need to create new FST index for segment: {}, column: {}", segmentName, column);
+      if (shouldCreateFSTIndex(columnMetadata)) {
+        LOGGER.info("Need to create new FST index for segment: {}, column: {}", segmentName, column);
         return true;
       }
     }
@@ -114,11 +114,19 @@ public class FSTIndexHandler implements IndexHandler {
     }
     for (String column : _columnsToAddIdx) {
       ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
-      if (columnMetadata != null) {
-        checkUnsupportedOperationsForFSTIndex(columnMetadata);
+      if (shouldCreateFSTIndex(columnMetadata)) {
         createFSTIndexForColumn(segmentWriter, columnMetadata, indexCreatorProvider);
       }
     }
+  }
+
+  private boolean shouldCreateFSTIndex(ColumnMetadata columnMetadata) {
+    if (columnMetadata != null) {
+      // Fail fast upon unsupported operations.
+      checkUnsupportedOperationsForFSTIndex(columnMetadata);
+      return true;
+    }
+    return false;
   }
 
   private void checkUnsupportedOperationsForFSTIndex(ColumnMetadata columnMetadata) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/H3IndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/H3IndexHandler.java
@@ -62,9 +62,25 @@ public class H3IndexHandler implements IndexHandler {
 
   @Override
   public boolean needUpdateIndices(SegmentDirectory.Reader segmentReader) {
+    String segmentName = _segmentMetadata.getName();
     Set<String> columnsToAddIdx = new HashSet<>(_h3Configs.keySet());
     Set<String> existingColumns = segmentReader.toSegmentDirectory().getColumnsWithIndex(ColumnIndexType.H3_INDEX);
-    return !existingColumns.equals(columnsToAddIdx);
+    // Check if any existing index need to be removed.
+    for (String column : existingColumns) {
+      if (!columnsToAddIdx.remove(column)) {
+        LOGGER.debug("Need to remove existing H3 index from segment: {}, column: {}", segmentName, column);
+        return true;
+      }
+    }
+    // Check if any new index need to be added.
+    for (String column : columnsToAddIdx) {
+      ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
+      if (columnMetadata != null) {
+        LOGGER.debug("Need to create new H3 index for segment: {}, column: {}", segmentName, column);
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/H3IndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/H3IndexHandler.java
@@ -68,15 +68,15 @@ public class H3IndexHandler implements IndexHandler {
     // Check if any existing index need to be removed.
     for (String column : existingColumns) {
       if (!columnsToAddIdx.remove(column)) {
-        LOGGER.debug("Need to remove existing H3 index from segment: {}, column: {}", segmentName, column);
+        LOGGER.info("Need to remove existing H3 index from segment: {}, column: {}", segmentName, column);
         return true;
       }
     }
     // Check if any new index need to be added.
     for (String column : columnsToAddIdx) {
       ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
-      if (columnMetadata != null) {
-        LOGGER.debug("Need to create new H3 index for segment: {}, column: {}", segmentName, column);
+      if (shouldCreateH3Index(columnMetadata)) {
+        LOGGER.info("Need to create new H3 index for segment: {}, column: {}", segmentName, column);
         return true;
       }
     }
@@ -99,10 +99,14 @@ public class H3IndexHandler implements IndexHandler {
     }
     for (String column : columnsToAddIdx) {
       ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
-      if (columnMetadata != null) {
+      if (shouldCreateH3Index(columnMetadata)) {
         createH3IndexForColumn(segmentWriter, columnMetadata, indexCreatorProvider);
       }
     }
+  }
+
+  private boolean shouldCreateH3Index(ColumnMetadata columnMetadata) {
+    return columnMetadata != null;
   }
 
   private void createH3IndexForColumn(SegmentDirectory.Writer segmentWriter, ColumnMetadata columnMetadata,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/InvertedIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/InvertedIndexHandler.java
@@ -56,9 +56,26 @@ public class InvertedIndexHandler implements IndexHandler {
 
   @Override
   public boolean needUpdateIndices(SegmentDirectory.Reader segmentReader) {
+    String segmentName = _segmentMetadata.getName();
     Set<String> existingColumns =
         segmentReader.toSegmentDirectory().getColumnsWithIndex(ColumnIndexType.INVERTED_INDEX);
-    return !existingColumns.equals(_columnsToAddIdx);
+    // Check if any existing index need to be removed.
+    for (String column : existingColumns) {
+      if (!_columnsToAddIdx.remove(column)) {
+        LOGGER.debug("Need to remove existing inverted index from segment: {}, column: {}", segmentName, column);
+        return true;
+      }
+    }
+    // Check if any new index need to be added.
+    for (String column : _columnsToAddIdx) {
+      ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
+      // Only create inverted index on dictionary-encoded unsorted columns.
+      if (columnMetadata != null && !columnMetadata.isSorted() && columnMetadata.hasDictionary()) {
+        LOGGER.debug("Need to create new inverted index for segment: {}, column: {}", segmentName, column);
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandler.java
@@ -64,15 +64,15 @@ public class JsonIndexHandler implements IndexHandler {
     // Check if any existing index need to be removed.
     for (String column : existingColumns) {
       if (!_columnsToAddIdx.remove(column)) {
-        LOGGER.debug("Need to remove existing json index from segment: {}, column: {}", segmentName, column);
+        LOGGER.info("Need to remove existing json index from segment: {}, column: {}", segmentName, column);
         return true;
       }
     }
     // Check if any new index need to be added.
     for (String column : _columnsToAddIdx) {
       ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
-      if (columnMetadata != null) {
-        LOGGER.debug("Need to create new json index for segment: {}, column: {}", segmentName, column);
+      if (shouldCreateJsonIndex(columnMetadata)) {
+        LOGGER.info("Need to create new json index for segment: {}, column: {}", segmentName, column);
         return true;
       }
     }
@@ -94,10 +94,14 @@ public class JsonIndexHandler implements IndexHandler {
     }
     for (String column : _columnsToAddIdx) {
       ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
-      if (columnMetadata != null) {
+      if (shouldCreateJsonIndex(columnMetadata)) {
         createJsonIndexForColumn(segmentWriter, columnMetadata, indexCreatorProvider);
       }
     }
+  }
+
+  private boolean shouldCreateJsonIndex(ColumnMetadata columnMetadata) {
+    return columnMetadata != null;
   }
 
   private void createJsonIndexForColumn(SegmentDirectory.Writer segmentWriter, ColumnMetadata columnMetadata,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/TextIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/TextIndexHandler.java
@@ -93,8 +93,24 @@ public class TextIndexHandler implements IndexHandler {
 
   @Override
   public boolean needUpdateIndices(SegmentDirectory.Reader segmentReader) {
+    String segmentName = _segmentMetadata.getName();
     Set<String> existingColumns = segmentReader.toSegmentDirectory().getColumnsWithIndex(ColumnIndexType.TEXT_INDEX);
-    return !existingColumns.equals(_columnsToAddIdx);
+    // Check if any existing index need to be removed.
+    for (String column : existingColumns) {
+      if (!_columnsToAddIdx.remove(column)) {
+        LOGGER.debug("Need to remove existing text index from segment: {}, column: {}", segmentName, column);
+        return true;
+      }
+    }
+    // Check if any new index need to be added.
+    for (String column : _columnsToAddIdx) {
+      ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
+      if (columnMetadata != null) {
+        LOGGER.debug("Need to create new text index for segment: {}, column: {}", segmentName, column);
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/TextIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/TextIndexHandler.java
@@ -98,15 +98,15 @@ public class TextIndexHandler implements IndexHandler {
     // Check if any existing index need to be removed.
     for (String column : existingColumns) {
       if (!_columnsToAddIdx.remove(column)) {
-        LOGGER.debug("Need to remove existing text index from segment: {}, column: {}", segmentName, column);
+        LOGGER.info("Need to remove existing text index from segment: {}, column: {}", segmentName, column);
         return true;
       }
     }
     // Check if any new index need to be added.
     for (String column : _columnsToAddIdx) {
       ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
-      if (columnMetadata != null) {
-        LOGGER.debug("Need to create new text index for segment: {}, column: {}", segmentName, column);
+      if (shouldCreateTextIndex(columnMetadata)) {
+        LOGGER.info("Need to create new text index for segment: {}, column: {}", segmentName, column);
         return true;
       }
     }
@@ -128,11 +128,19 @@ public class TextIndexHandler implements IndexHandler {
     }
     for (String column : _columnsToAddIdx) {
       ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
-      if (columnMetadata != null) {
-        checkUnsupportedOperationsForTextIndex(columnMetadata);
+      if (shouldCreateTextIndex(columnMetadata)) {
         createTextIndexForColumn(segmentWriter, columnMetadata, indexCreatorProvider);
       }
     }
+  }
+
+  private boolean shouldCreateTextIndex(ColumnMetadata columnMetadata) {
+    if (columnMetadata != null) {
+      // Fail fast upon unsupported operations.
+      checkUnsupportedOperationsForTextIndex(columnMetadata);
+      return true;
+    }
+    return false;
   }
 
   /**

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
@@ -28,7 +28,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -1117,29 +1116,31 @@ public class SegmentPreProcessorTest {
     }
 
     // No preprocessing needed if required to add certain index on non-existing, sorted or non-dictionary column.
-    for (Consumer<IndexLoadingConfig> prepFunc : createConfigPrepFunctionNeedNoops()) {
+    for (Map.Entry<String, Consumer<IndexLoadingConfig>> entry : createConfigPrepFunctionNeedNoops().entrySet()) {
+      String testCase = entry.getKey();
       IndexLoadingConfig config = new IndexLoadingConfig();
-      prepFunc.accept(config);
+      entry.getValue().accept(config);
       try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
           .load(_indexDir.toURI(), new SegmentDirectoryLoaderContext(null, null, null, _configuration));
           SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, config,
               _newColumnsSchemaWithH3Json)) {
-        assertFalse(processor.needProcess());
+        assertFalse(processor.needProcess(), testCase);
       }
     }
 
     // Require to add different types of indices. Add one new index a time
     // to test the index handlers separately.
     IndexLoadingConfig config = new IndexLoadingConfig();
-    for (Runnable prepFunc : createConfigPrepFunctions(config)) {
-      prepFunc.run();
+    for (Map.Entry<String, Consumer<IndexLoadingConfig>> entry : createConfigPrepFunctions().entrySet()) {
+      String testCase = entry.getKey();
+      entry.getValue().accept(config);
       try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
           .load(_indexDir.toURI(), new SegmentDirectoryLoaderContext(null, null, null, _configuration));
           SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, config,
               _newColumnsSchemaWithH3Json)) {
-        assertTrue(processor.needProcess());
+        assertTrue(processor.needProcess(), testCase);
         processor.process();
-        assertFalse(processor.needProcess());
+        assertFalse(processor.needProcess(), testCase);
       }
     }
 
@@ -1149,7 +1150,7 @@ public class SegmentPreProcessorTest {
     indexingConfig.setEnableDefaultStarTree(true);
     _tableConfig.setIndexingConfig(indexingConfig);
     IndexLoadingConfig configWithStarTreeIndex = new IndexLoadingConfig(null, _tableConfig);
-    createConfigPrepFunctions(configWithStarTreeIndex).forEach(Runnable::run);
+    createConfigPrepFunctions().forEach((k, v) -> v.accept(configWithStarTreeIndex));
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(), new SegmentDirectoryLoaderContext(null, null, null, _configuration));
         SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, configWithStarTreeIndex,
@@ -1199,48 +1200,54 @@ public class SegmentPreProcessorTest {
     configuration.save();
   }
 
-  private static List<Runnable> createConfigPrepFunctions(IndexLoadingConfig config) {
-    return Arrays.asList(
-        () -> config.setInvertedIndexColumns(new HashSet<>(Collections.singletonList("column3"))),
-        () -> config.setRangeIndexColumns(new HashSet<>(Collections.singletonList("column3"))),
-        () -> config.setTextIndexColumns(new HashSet<>(Collections.singletonList("column3"))),
-        () -> config.setFSTIndexColumns(new HashSet<>(Collections.singletonList("column3"))),
-        () -> config.setBloomFilterConfigs(ImmutableMap.of("column3", new BloomFilterConfig(0.1, 1024, true))),
-        () -> config
-            .setH3IndexConfigs(ImmutableMap.of("newH3Col", new H3IndexConfig(ImmutableMap.of("resolutions", "5")))),
-        () -> config.setJsonIndexColumns(new HashSet<>(Collections.singletonList("newJsonCol")))
-    );
+  private static Map<String, Consumer<IndexLoadingConfig>> createConfigPrepFunctions() {
+    Map<String, Consumer<IndexLoadingConfig>> testCases = new HashMap<>();
+    testCases.put("addInvertedIndex", (IndexLoadingConfig config) ->
+        config.setInvertedIndexColumns(new HashSet<>(Collections.singletonList("column3"))));
+    testCases.put("addRangeIndex", (IndexLoadingConfig config) ->
+        config.setRangeIndexColumns(new HashSet<>(Collections.singletonList("column3"))));
+    testCases.put("addTextIndex", (IndexLoadingConfig config) ->
+        config.setTextIndexColumns(new HashSet<>(Collections.singletonList("column3"))));
+    testCases.put("addFSTIndex", (IndexLoadingConfig config) ->
+        config.setFSTIndexColumns(new HashSet<>(Collections.singletonList("column3"))));
+    testCases.put("addBloomFilter", (IndexLoadingConfig config) ->
+        config.setBloomFilterConfigs(ImmutableMap.of("column3", new BloomFilterConfig(0.1, 1024, true))));
+    testCases.put("addH3Index", (IndexLoadingConfig config) ->
+        config.setH3IndexConfigs(ImmutableMap.of("newH3Col", new H3IndexConfig(ImmutableMap.of("resolutions", "5")))));
+    testCases.put("addJsonIndex", (IndexLoadingConfig config) ->
+        config.setJsonIndexColumns(new HashSet<>(Collections.singletonList("newJsonCol"))));
+    return testCases;
   }
 
-  private static List<Consumer<IndexLoadingConfig>> createConfigPrepFunctionNeedNoops() {
-    return Arrays.asList(
-        // daysSinceEpoch is a sorted column, thus inverted index and range index skip it.
-        (IndexLoadingConfig config) -> config
-            .setInvertedIndexColumns(new HashSet<>(Collections.singletonList("daysSinceEpoch"))),
-        (IndexLoadingConfig config) -> config
-            .setRangeIndexColumns(new HashSet<>(Collections.singletonList("daysSinceEpoch"))),
-        // column4 is unsorted non-dictionary encoded column, so inverted index and bloom filter skip it.
-        // In fact, the validation logic when updating index configs already blocks this to happen.
-        (IndexLoadingConfig config) -> config
-            .setInvertedIndexColumns(new HashSet<>(Collections.singletonList("column4"))),
-        (IndexLoadingConfig config) -> config
-            .setBloomFilterConfigs(ImmutableMap.of("column4", new BloomFilterConfig(0.1, 1024, true))),
-        // No index is added on non-existing columns.
-        // The validation logic when updating index configs already blocks this to happen.
-        (IndexLoadingConfig config) -> config
-            .setInvertedIndexColumns(new HashSet<>(Collections.singletonList("newColumnX"))),
-        (IndexLoadingConfig config) -> config
-            .setRangeIndexColumns(new HashSet<>(Collections.singletonList("newColumnX"))),
-        (IndexLoadingConfig config) -> config
-            .setTextIndexColumns(new HashSet<>(Collections.singletonList("newColumnX"))),
-        (IndexLoadingConfig config) -> config
-            .setFSTIndexColumns(new HashSet<>(Collections.singletonList("newColumnX"))),
-        (IndexLoadingConfig config) -> config
-            .setBloomFilterConfigs(ImmutableMap.of("newColumnX", new BloomFilterConfig(0.1, 1024, true))),
-        (IndexLoadingConfig config) -> config
-            .setH3IndexConfigs(ImmutableMap.of("newColumnX", new H3IndexConfig(ImmutableMap.of("resolutions", "5")))),
-        (IndexLoadingConfig config) -> config
-            .setJsonIndexColumns(new HashSet<>(Collections.singletonList("newColumnX")))
-    );
+  private static Map<String, Consumer<IndexLoadingConfig>> createConfigPrepFunctionNeedNoops() {
+    Map<String, Consumer<IndexLoadingConfig>> testCases = new HashMap<>();
+    // daysSinceEpoch is a sorted column, thus inverted index and range index skip it.
+    testCases.put("addInvertedIndexOnSortedColumn", (IndexLoadingConfig config) -> config
+        .setInvertedIndexColumns(new HashSet<>(Collections.singletonList("daysSinceEpoch"))));
+    testCases.put("addRangeIndexOnSortedColumn", (IndexLoadingConfig config) -> config
+        .setRangeIndexColumns(new HashSet<>(Collections.singletonList("daysSinceEpoch"))));
+    // column4 is unsorted non-dictionary encoded column, so inverted index and bloom filter skip it.
+    // In fact, the validation logic when updating index configs already blocks this to happen.
+    testCases.put("addInvertedIndexOnNonDictColumn", (IndexLoadingConfig config) -> config
+        .setInvertedIndexColumns(new HashSet<>(Collections.singletonList("column4"))));
+    testCases.put("addBloomFilterOnNonDictColumn", (IndexLoadingConfig config) -> config
+        .setBloomFilterConfigs(ImmutableMap.of("column4", new BloomFilterConfig(0.1, 1024, true))));
+    // No index is added on non-existing columns.
+    // The validation logic when updating index configs already blocks this to happen.
+    testCases.put("addInvertedIndexOnAbsentColumn", (IndexLoadingConfig config) -> config
+        .setInvertedIndexColumns(new HashSet<>(Collections.singletonList("newColumnX"))));
+    testCases.put("addRangeIndexOnAbsentColumn", (IndexLoadingConfig config) -> config
+        .setRangeIndexColumns(new HashSet<>(Collections.singletonList("newColumnX"))));
+    testCases.put("addTextIndexOnAbsentColumn", (IndexLoadingConfig config) -> config
+        .setTextIndexColumns(new HashSet<>(Collections.singletonList("newColumnX"))));
+    testCases.put("addFSTIndexOnAbsentColumn", (IndexLoadingConfig config) -> config
+        .setFSTIndexColumns(new HashSet<>(Collections.singletonList("newColumnX"))));
+    testCases.put("addBloomFilterOnAbsentColumn", (IndexLoadingConfig config) -> config
+        .setBloomFilterConfigs(ImmutableMap.of("newColumnX", new BloomFilterConfig(0.1, 1024, true))));
+    testCases.put("addH3IndexOnAbsentColumn", (IndexLoadingConfig config) -> config
+        .setH3IndexConfigs(ImmutableMap.of("newColumnX", new H3IndexConfig(ImmutableMap.of("resolutions", "5")))));
+    testCases.put("addJsonIndexOnAbsentColumn", (IndexLoadingConfig config) -> config
+        .setJsonIndexColumns(new HashSet<>(Collections.singletonList("newColumnX"))));
+    return testCases;
   }
 }


### PR DESCRIPTION
## Description
This PR refines the checks about whether there is a need to update indices during segment loading like adding indices. Previously, the check was based on Set equality, but that could be false positive, e.g. a sorted column is skipped for inverted index and range index. So in this PR, we aligns the logic between needUpdateIndices() and updateIndices() methods of IndexHandler to be more precise on such checks.


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
