### PR TITLE
[Codestyle] Auto-format line breaks

### DIFF
--- a/config/codestyle-intellij.xml
+++ b/config/codestyle-intellij.xml
@@ -102,7 +102,7 @@
     <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
   </codeStyleSettings>
   <Properties>
-    <option name="KEEP_BLANK_LINES" value="true" />
+    <option name="KEEP_BLANK_LINES" value="true"/>
   </Properties>
   <codeStyleSettings language="CSS">
     <indentOptions>
@@ -184,7 +184,8 @@
     </indentOptions>
   </codeStyleSettings>
   <codeStyleSettings language="JAVA">
-    <option name="RIGHT_MARGIN" value="120" />
+    <option name="RIGHT_MARGIN" value="120"/>
+    <option name="KEEP_LINE_BREAKS" value="false"/>
     <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1"/>
     <option name="KEEP_BLANK_LINES_IN_CODE" value="1"/>
     <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0"/>
@@ -197,9 +198,9 @@
     <option name="CALL_PARAMETERS_WRAP" value="1"/>
     <option name="METHOD_PARAMETERS_WRAP" value="1"/>
     <option name="RESOURCE_LIST_WRAP" value="1"/>
-    <option name="EXTENDS_LIST_WRAP" value="1" />
+    <option name="EXTENDS_LIST_WRAP" value="1"/>
     <option name="THROWS_LIST_WRAP" value="1"/>
-    <option name="EXTENDS_KEYWORD_WRAP" value="1" />
+    <option name="EXTENDS_KEYWORD_WRAP" value="1"/>
     <option name="THROWS_KEYWORD_WRAP" value="2"/>
     <option name="METHOD_CALL_CHAIN_WRAP" value="1"/>
     <option name="BINARY_OPERATION_WRAP" value="1"/>
@@ -207,17 +208,17 @@
     <option name="TERNARY_OPERATION_WRAP" value="1"/>
     <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
     <option name="FOR_STATEMENT_WRAP" value="1"/>
-    <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true" />
-    <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true" />
+    <option name="ARRAY_INITIALIZER_LBRACE_ON_NEXT_LINE" value="true"/>
+    <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true"/>
     <option name="ASSIGNMENT_WRAP" value="1"/>
     <option name="WRAP_COMMENTS" value="true"/>
-    <option name="ASSERT_STATEMENT_WRAP" value="1" />
+    <option name="ASSERT_STATEMENT_WRAP" value="1"/>
     <option name="IF_BRACE_FORCE" value="3"/>
     <option name="DOWHILE_BRACE_FORCE" value="3"/>
     <option name="WHILE_BRACE_FORCE" value="3"/>
     <option name="FOR_BRACE_FORCE" value="3"/>
-    <option name="WRAP_LONG_LINES" value="true" />
-    <option name="PARAMETER_ANNOTATION_WRAP" value="1" />
+    <option name="WRAP_LONG_LINES" value="true"/>
+    <option name="PARAMETER_ANNOTATION_WRAP" value="1"/>
     <option name="VARIABLE_ANNOTATION_WRAP" value="2"/>
     <option name="ENUM_CONSTANTS_WRAP" value="5"/>
     <option name="PARENT_SETTINGS_INSTALLED" value="true"/>
@@ -446,7 +447,7 @@
     <option name="TERNARY_OPERATION_WRAP" value="1"/>
     <option name="TERNARY_OPERATION_SIGNS_ON_NEXT_LINE" value="true"/>
     <option name="FOR_STATEMENT_WRAP" value="1"/>
-    <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true" />
+    <option name="ARRAY_INITIALIZER_RBRACE_ON_NEXT_LINE" value="true"/>
     <option name="ARRAY_INITIALIZER_WRAP" value="1"/>
     <option name="IF_BRACE_FORCE" value="3"/>
     <option name="DOWHILE_BRACE_FORCE" value="3"/>


### PR DESCRIPTION
Enable auto-format on line breaks to auto-reformat cases where too many line breaks are added

For places where line breaks can help with the readability, the auto-formatter can be turned off by comments: `@formatter:off`