### PR TITLE
Enhance Pinot streaming consumer interface

### DIFF
--- a/pinot-connectors/presto-pinot-driver/pom.xml
+++ b/pinot-connectors/presto-pinot-driver/pom.xml
@@ -536,7 +536,7 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-api</artifactId>
-            <version>1.30.0</version>
+            <version>1.41.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1465,8 +1465,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     if (_partitionGroupConsumer != null) {
       closePartitionGroupConsumer();
     }
-    _segmentLogger.info("Creating new stream consumer {} for partition group {} , reason: {}", _clientId,
-        _partitionGroupConsumptionStatus.getPartitionGroupId(), reason);
+    _segmentLogger.info("Creating new stream consumer for topic partition {} , reason: {}", _clientId, reason);
     _partitionGroupConsumer =
         _streamConsumerFactory.createPartitionGroupConsumer(_clientId, _partitionGroupConsumptionStatus);
     _partitionGroupConsumer.start(_partitionGroupConsumptionStatus.getStartOffset());

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -663,7 +663,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
               break;
             case COMMIT:
               _state = State.COMMITTING;
-              _currentOffset = _partitionGroupConsumer.commit(_currentOffset);
+              _currentOffset = _partitionGroupConsumer.checkpoint(_currentOffset);
               long buildTimeSeconds = response.getBuildTimeSeconds();
               buildSegmentForCommit(buildTimeSeconds * 1000L);
               if (_segmentBuildDescriptor == null) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumer.java
@@ -21,11 +21,20 @@ package org.apache.pinot.spi.stream;
 import java.io.Closeable;
 import java.util.concurrent.TimeoutException;
 
-
 /**
  * Consumer interface for consuming from a partition group of a stream
  */
 public interface PartitionGroupConsumer extends Closeable {
+
+  /**
+   * Starts the stream consumption
+   * This is useful in cases where starting a consumer involves making one or more remote calls before consumption
+   * begins.
+   * @param startOffset Offset (inclusive) at which the consumption should begin
+   */
+  default void start(StreamPartitionMsgOffset startOffset) {
+
+  }
 
   /**
    * Fetch messages and offsets from the stream partition group
@@ -39,4 +48,16 @@ public interface PartitionGroupConsumer extends Closeable {
    */
   MessageBatch fetchMessages(StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset endOffset, int timeoutMs)
       throws TimeoutException;
+
+  /**
+   * Commits the current stream partition group in the source
+   * This is useful in systems that requires preserving some state on the source system in order support recovery by
+   * re-consumption of data (aka checkpointing in the source)
+   *
+   * @param lastOffset commit the stream at this offset (exclusive)
+   * @return Returns the offset that should be used as starting offset during recovery / re-consumption
+   */
+  default StreamPartitionMsgOffset commit(StreamPartitionMsgOffset lastOffset) {
+    return lastOffset;
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumer.java
@@ -62,10 +62,12 @@ public interface PartitionGroupConsumer extends Closeable {
   /**
    * Checkpoints the consumption state of the stream partition group in the source
    *
-   * This is useful in systems that require preserving consumption state on the source in order to resume or replay
-   * consumption of data.
-   * The offset returned will be used for offset comparisons and persisted to the ZK segment metadata. Hence, the
-   * returned value should be same or equivalent (in comparison) to the lastOffset provided in the input.
+   * This is useful in streaming systems that require preserving consumption state on the source in order to resume or
+   * replay consumption of data. The consumer implementation is responsible for managing this state.
+   *
+   * The offset returned will be used for offset comparisons within the local server (say, for catching up) and also,
+   * persisted to the ZK segment metadata. Hence, the returned value should be same or equivalent to the lastOffset
+   * provided as input (that is, compareTo of the input and returned offset should be 0).
    *
    * @param lastOffset checkpoint the stream at this offset (exclusive)
    * @return Returns the offset that should be used as the next upcoming offset for the stream partition group

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataProducer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataProducer.java
@@ -22,7 +22,7 @@ import java.util.Properties;
 
 
 /**
- * StreamDataServerStartable is the interface for stream data sources. E.g. KafkaServerStartable, KinesisServerStarable.
+ * StreamDataProducer is the interface for stream data sources. E.g. KafkaDataProducer.
  */
 public interface StreamDataProducer {
   void init(Properties props);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -486,9 +486,9 @@ public class CommonConstants {
        */
       public enum CompletionMode {
         // default behavior - if the in memory segment in the non-winner server is equivalent to the committed
-        // segment, then build and
-        // replace, else download
-        DEFAULT, // non-winner servers always download the segment, never build it
+        // segment, then build and replace, else download
+        DEFAULT,
+        // non-winner servers always download the segment, never build it
         DOWNLOAD
       }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/streams/MeetupRsvpJsonStream.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/streams/MeetupRsvpJsonStream.java
@@ -45,12 +45,12 @@ public class MeetupRsvpJsonStream extends MeetupRsvpStream {
           try {
             JsonNode messageJson = JsonUtils.stringToJsonNode(message);
             String rsvpId = messageJson.get("rsvp_id").asText();
-            _producer.produce("meetupRSVPEvents", rsvpId.getBytes(UTF_8), message.getBytes(UTF_8));
+            _producer.produce(_topicName, rsvpId.getBytes(UTF_8), message.getBytes(UTF_8));
           } catch (Exception e) {
             LOGGER.error("Caught exception while processing the message: {}", message, e);
           }
         } else {
-          _producer.produce("meetupRSVPEvents", message.getBytes(UTF_8));
+          _producer.produce(_topicName, message.getBytes(UTF_8));
         }
       }
     };

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/streams/MeetupRsvpStream.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/streams/MeetupRsvpStream.java
@@ -40,6 +40,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 public class MeetupRsvpStream {
   protected static final Logger LOGGER = LoggerFactory.getLogger(MeetupRsvpStream.class);
+  private static final String DEFAULT_TOPIC_NAME = "meetupRSVPEvents";
+  protected String _topicName = DEFAULT_TOPIC_NAME;
 
   protected final boolean _partitionByKey;
   protected final StreamDataProducer _producer;
@@ -61,6 +63,12 @@ public class MeetupRsvpStream {
     properties.put("serializer.class", "kafka.serializer.DefaultEncoder");
     properties.put("request.required.acks", "1");
     _producer = StreamDataProvider.getStreamDataProducer(KafkaStarterUtils.KAFKA_PRODUCER_CLASS_NAME, properties);
+  }
+
+  public MeetupRsvpStream(boolean partitionByKey, StreamDataProducer producer, String topicName) {
+    _partitionByKey = partitionByKey;
+    _producer = producer;
+    _topicName = topicName;
   }
 
   public void run()
@@ -117,10 +125,10 @@ public class MeetupRsvpStream {
 
         if (_keepPublishing) {
           if (_partitionByKey) {
-            _producer.produce("meetupRSVPEvents", eventId.getBytes(UTF_8),
+            _producer.produce(_topicName, eventId.getBytes(UTF_8),
                 extractedJson.toString().getBytes(UTF_8));
           } else {
-            _producer.produce("meetupRSVPEvents", extractedJson.toString().getBytes(UTF_8));
+            _producer.produce(_topicName, extractedJson.toString().getBytes(UTF_8));
           }
         }
       } catch (Exception e) {

--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
     TODO: figure out a way to inject kafka dependency instead of explicitly setting the kafka module dependency -->
     <kafka.version>2.0</kafka.version>
     <protobuf.version>3.12.0</protobuf.version>
-    <grpc.version>1.30.0</grpc.version>
+    <grpc.version>1.41.0</grpc.version>
 
     <!-- Checkstyle violation prop.-->
     <checkstyle.violation.severity>warning</checkstyle.violation.severity>


### PR DESCRIPTION
## Description
This PR is related to the issue #7988. We are expanding the Pinot's realtime consumer interface to accommodate other (non-kafka) streaming systems.

Changes introduced:
* 2 new apis in `PartitionGroupConsumer`  - `start` and `checkpoint`. These APIs are backward-compatible with existing consumer plugins. 
* some minor code/comment clean-up 