### PR TITLE
Support BOOLEAN type in recommender engine

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/BooleanGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/BooleanGenerator.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.recommender.data.generator;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Random;
+
+
+public class BooleanGenerator implements Generator {
+
+  private static final double DEFAULT_NUMBER_OF_VALUES_PER_ENTRY = 1;
+
+  private final double _numberOfValuesPerEntry;
+  private final Random _random;
+
+  public BooleanGenerator(Double numberOfValuesPerEntry) {
+    this(numberOfValuesPerEntry, new Random(System.currentTimeMillis()));
+  }
+
+  @VisibleForTesting
+  BooleanGenerator(Double numberOfValuesPerEntry, Random random) {
+    _numberOfValuesPerEntry =
+        numberOfValuesPerEntry != null ? numberOfValuesPerEntry : DEFAULT_NUMBER_OF_VALUES_PER_ENTRY;
+    _random = random;
+  }
+
+  @Override
+  public void init() {
+  }
+
+  @Override
+  public Object next() {
+    if (_numberOfValuesPerEntry == 1) {
+      return getNextBooleanAsInteger();
+    }
+    return MultiValueGeneratorHelper
+        .generateMultiValueEntries(_numberOfValuesPerEntry, _random, this::getNextBooleanAsInteger);
+  }
+
+  private int getNextBooleanAsInteger() {
+    return _random.nextBoolean() ? 1 : 0;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/GeneratorFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/GeneratorFactory.java
@@ -24,11 +24,15 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public class GeneratorFactory {
+
   private GeneratorFactory() {
   }
 
   public static Generator getGeneratorFor(DataType type, Integer cardinality, Double numberOfValuesPerEntry,
       Integer entryLength, TimeUnit timeUnit) {
+    if (type == DataType.BOOLEAN) {
+      return new BooleanGenerator(numberOfValuesPerEntry);
+    }
     if (type == DataType.STRING) {
       return new StringGenerator(cardinality, numberOfValuesPerEntry, entryLength);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/io/InputManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/io/InputManager.java
@@ -75,6 +75,7 @@ import static org.apache.pinot.controller.recommender.rules.io.params.Recommende
 @SuppressWarnings("unused")
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE)
 public class InputManager {
+
   private static final Logger LOGGER = LoggerFactory.getLogger(InputManager.class);
 
   /******************************Deserialized from input json*********************************/
@@ -135,6 +136,7 @@ public class InputManager {
     put(FieldSpec.DataType.DOUBLE, Double.BYTES);
     put(FieldSpec.DataType.BYTES, Byte.BYTES);
     put(FieldSpec.DataType.STRING, Character.BYTES);
+    put(FieldSpec.DataType.BOOLEAN, Integer.BYTES); // Stored internally as an INTEGER
     put(null, DEFAULT_NULL_SIZE);
   }};
   protected final QueryOptimizer _queryOptimizer = new QueryOptimizer();

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/recommender/data/generator/BooleanGeneratorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/recommender/data/generator/BooleanGeneratorTest.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.controller.recommender.data.generator;
+
+import java.util.List;
+import java.util.Random;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+
+public class BooleanGeneratorTest {
+
+  @Test
+  public void testNext() {
+    Random random = mock(Random.class);
+    when(random.nextBoolean()).thenReturn(false, true, false, false, true, true, false, true, false, true);
+
+    // long generator
+    BooleanGenerator generator = new BooleanGenerator(1.0, random);
+    int[] expectedValues = { //
+        0, 1, 0, 0, 1, //
+        1, 0, 1, 0, 1
+    };
+    for (int expected : expectedValues) {
+      assertEquals(generator.next(), expected);
+    }
+  }
+
+  @Test
+  public void testNextMultiValued() {
+    Random random = mock(Random.class);
+    when(random.nextBoolean())
+        .thenReturn(false, true, false, false, false, true, true, true, true, false, true, false, false, true, true,
+            false, false, false, true, true, false, true, true, true);
+    when(random.nextDouble()).thenReturn(0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9); // for MV generation
+
+    double numValuesPerEntry = 2.4;
+    BooleanGenerator generator = new BooleanGenerator(numValuesPerEntry, random);
+    int[][] expectedValues = {
+        {0, 1, 0}, // rnd < 0.4
+        {0, 0, 1}, // rnd < 0.4
+        {1, 1, 1}, // rnd < 0.4
+        {0, 1, 0}, // rnd < 0.4
+        {0, 1},  // rnd >= 0.4
+        {1, 0},  // rnd >= 0.4
+        {0, 0},  // rnd >= 0.4
+        {1, 1},  // rnd >= 0.4
+        {0, 1},  // rnd >= 0.4
+        {1, 1},  // rnd >= 0.4
+    };
+    for (int[] expected : expectedValues) {
+      List<Integer> actual = (List<Integer>) generator.next();
+      assertEquals(actual.toArray(), expected);
+    }
+  }
+}

--- a/pinot-controller/src/test/resources/recommenderInput/SortedInvertedIndexInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/SortedInvertedIndexInput.json
@@ -71,6 +71,15 @@
         "dataType": "DOUBLE",
         "cardinality":4,
         "numValuesPerEntry":1.00000001
+      },
+      {
+        "name": "ja",
+        "dataType": "BOOLEAN"
+      },
+      {
+        "name": "jb",
+        "dataType": "BOOLEAN",
+        "numValuesPerEntry": 3
       }
     ],
     "metricFieldSpecs": [


### PR DESCRIPTION
## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
This change makes the recommender engine support the BOOLEAN type. See issue https://github.com/apache/pinot/issues/7983

I've added tests covering the changes; Additionally, I've tested a previously failing recommendation input against the changes.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
