### PR TITLE
Add username and password support to JDBC driver

### DIFF
--- a/pinot-clients/pinot-jdbc-client/pom.xml
+++ b/pinot-clients/pinot-jdbc-client/pom.xml
@@ -67,7 +67,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
-      <artifactId>pinot-common</artifactId>
+      <artifactId>pinot-core</artifactId>
+      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotDriver.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotDriver.java
@@ -71,18 +71,17 @@ public class PinotDriver implements Driver {
    * Created connection to Pinot Controller from provided properties.
    * The following properties can be provided -
    * tenant - Specify the tenant for which this connection is being created. If not provided, DefaultTenant is used.
-   *        The connection cannot handle queries for tables which are not present in the specified tenant.
+   * The connection cannot handle queries for tables which are not present in the specified tenant.
    * headers.Authorization - base64 token to query pinot. This is required in case Auth is enabled on pinot cluster.
    * user - Name of the user for which auth is enabled.
    * password - Password associated with the user for which auth is enabled.
-   *
    * You can also specify username and password in the URL, e.g. jdbc:pinot://localhost:9000?user=Foo&password=Bar
    * If username and password are specified at multiple places, the precedence takes place in the following order
    * (header.Authorization property) > (user and password specified in properties) > (username and password in URL)
    * @param url  jdbc connection url containing pinot controller machine host:port.
-   *             example - jdbc:pinot://localhost:9000
+   * example - jdbc:pinot://localhost:9000
    * @param info properties required for creating connection
-   * @return
+   * @return JDBC connection object to query pinot
    * @throws SQLException
    */
   @Override
@@ -162,7 +161,8 @@ public class PinotDriver implements Driver {
 
   private Map<String, String> getHeadersFromProperties(Properties info) {
     return info.entrySet().stream().filter(entry -> entry.getKey().toString().startsWith(INFO_HEADERS + ".")).map(
-            entry -> Pair.of(entry.getKey().toString().substring(INFO_HEADERS.length() + 1), entry.getValue().toString()))
+            entry -> Pair.of(entry.getKey().toString().substring(INFO_HEADERS.length() + 1),
+                entry.getValue().toString()))
         .collect(Collectors.toMap(Pair::getKey, Pair::getValue));
   }
 

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
@@ -20,9 +20,11 @@ package org.apache.pinot.client.utils;
 
 import java.math.BigDecimal;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Properties;
 import java.util.regex.Matcher;
@@ -32,6 +34,11 @@ import org.apache.commons.configuration.MapConfiguration;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.utils.TlsUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -88,6 +95,21 @@ public class DriverUtils {
     URI uri = URI.create(url);
     String controllerUrl = String.format("%s:%d", uri.getHost(), uri.getPort());
     return controllerUrl;
+  }
+
+  public static Map<String, String> getURLParams(String url) {
+    if (url.toLowerCase().startsWith("jdbc:")) {
+      url = url.substring(5);
+    }
+    URI uri = URI.create(url);
+    List<NameValuePair> params = URLEncodedUtils.parse(uri, StandardCharsets.UTF_8);
+
+    Map<String, String> paramsMap = new HashMap<>();
+    for(NameValuePair param: params) {
+      paramsMap.put(param.getName(), param.getValue());
+    }
+
+    return paramsMap;
   }
 
   public static Integer getSQLDataType(String columnDataType) {

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
@@ -105,7 +105,7 @@ public class DriverUtils {
     List<NameValuePair> params = URLEncodedUtils.parse(uri, StandardCharsets.UTF_8);
 
     Map<String, String> paramsMap = new HashMap<>();
-    for(NameValuePair param: params) {
+    for (NameValuePair param: params) {
       paramsMap.put(param.getName(), param.getValue());
     }
 

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
@@ -21,36 +21,42 @@ package org.apache.pinot.client.utils;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.net.ssl.SSLContext;
 import org.apache.commons.configuration.MapConfiguration;
-import org.apache.pinot.common.config.TlsConfig;
-import org.apache.pinot.common.utils.TlsUtils;
-import org.apache.pinot.spi.env.PinotConfiguration;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.pinot.common.config.TlsConfig;
+import org.apache.pinot.common.utils.TlsUtils;
+import org.apache.pinot.core.auth.BasicAuthUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
 public class DriverUtils {
-  public static final String SCHEME = "jdbc";
+  public static final String SCHEME = "jdbc:";
   public static final String DRIVER = "pinot";
   public static final Logger LOG = LoggerFactory.getLogger(DriverUtils.class);
   private static final String LIMIT_STATEMENT_REGEX = "\\s(limit)\\s";
 
   // SSL Properties
   public static final String PINOT_JDBC_TLS_PREFIX = "pinot.jdbc.tls";
+
+  // Auth Properties
+  public static final String USER_PROPERTY = "user";
+  public static final String PASSWORD_PROPERTY = "password";
+  public static final String AUTH_HEADER = "Authorization";
 
   private DriverUtils() {
   }
@@ -60,6 +66,22 @@ public class DriverUtils {
         new PinotConfiguration(new MapConfiguration(properties)), PINOT_JDBC_TLS_PREFIX);
     TlsUtils.installDefaultSSLSocketFactory(tlsConfig);
     return TlsUtils.getSslContext();
+  }
+
+  public static void handleAuth(String url, Properties info, Map<String, String> headers)
+      throws SQLException {
+    Map<String, String> urlParams = DriverUtils.getURLParams(url);
+    info.putAll(urlParams);
+
+    if (info.contains(USER_PROPERTY) && !headers.containsKey(AUTH_HEADER)) {
+      String username = info.getProperty(USER_PROPERTY);
+      String password = info.getProperty(PASSWORD_PROPERTY, "");
+      if (StringUtils.isAnyEmpty(username, password)) {
+        throw new SQLException("Empty username or password provided.");
+      }
+      String authToken = BasicAuthUtils.toBasicAuthToken(username, password);
+      headers.put(AUTH_HEADER, authToken);
+    }
   }
 
   public static List<String> getBrokersFromURL(String url) {
@@ -80,7 +102,7 @@ public class DriverUtils {
     try {
       String broker = brokers.get(0);
       String[] hostPort = broker.split(":");
-      URI uri = new URI(SCHEME + ":" + DRIVER, hostPort[0], hostPort[1]);
+      URI uri = new URI(SCHEME + DRIVER, hostPort[0], hostPort[1]);
       return uri.toString();
     } catch (Exception e) {
       LOG.warn("Broker list is either empty or has incorrect format", e);
@@ -89,7 +111,7 @@ public class DriverUtils {
   }
 
   public static String getControllerFromURL(String url) {
-    if (url.toLowerCase().startsWith("jdbc:")) {
+    if (url.regionMatches(true, 0, SCHEME, 0, SCHEME.length())) {
       url = url.substring(5);
     }
     URI uri = URI.create(url);
@@ -98,8 +120,8 @@ public class DriverUtils {
   }
 
   public static Map<String, String> getURLParams(String url) {
-    if (url.toLowerCase().startsWith("jdbc:")) {
-      url = url.substring(5);
+    if (url.regionMatches(true, 0, SCHEME, 0, SCHEME.length())) {
+      url = url.substring(SCHEME.length());
     }
     URI uri = URI.create(url);
     List<NameValuePair> params = URLEncodedUtils.parse(uri, StandardCharsets.UTF_8);


### PR DESCRIPTION
This PR handles the issue #8031 . The PR adds support to parse username and password from JDBC params and generate auth token.
The user can provide authorization token directly in the properties as `headers.Authorization` 
OR
they can provide username and password either in JDBC properties or as params in connection URL

Example - 

### Using Auth property
```java
      Properties properties = new Properties();
      properties.put("headers.Authorization", "your_auth_token");
      String url = "jdbc:pinot://localhost:9000";
      DriverManager.getConnection(url, properties);
```

### Using username and password properties
```java
      Properties properties = new Properties();
      properties.put("user", "your_username");
      properties.put("password", "your_password");
      String url = "jdbc:pinot://localhost:9000";
      DriverManager.getConnection(url, properties);
```


### Using username and password in URL
```java
      Properties properties = new Properties();
      String url = "jdbc:pinot://localhost:9000?user=your_username&password=your_password";
      DriverManager.getConnection(url, properties);
```

In case auth is provided in multiple places, the `Authorization` property takes first precedence followed by `user, password` property and finally the `user & password` in URL.
