### PR TITLE
making PinotFS an interface and create BasePinotFS

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/PinotFSSegmentUploaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/PinotFSSegmentUploaderTest.java
@@ -31,7 +31,7 @@ import org.apache.pinot.common.exception.HttpErrorStatusException;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.StringUtil;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.BasePinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -89,7 +89,7 @@ public class PinotFSSegmentUploaderTest {
     Assert.assertNull(segmentURI);
   }
 
-  public static class AlwaysSucceedPinotFS extends PinotFS {
+  public static class AlwaysSucceedPinotFS extends BasePinotFS {
 
     @Override
     public void init(PinotConfiguration config) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PeerDownloadLLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PeerDownloadLLCRealtimeClusterIntegrationTest.java
@@ -41,8 +41,8 @@ import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.filesystem.BasePinotFS;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
-import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
@@ -246,7 +246,7 @@ public class PeerDownloadLLCRealtimeClusterIntegrationTest extends RealtimeClust
   }
 
   // MockPinotFS is a localPinotFS whose root directory is configured as _basePath;
-  public static class MockPinotFS extends PinotFS {
+  public static class MockPinotFS extends BasePinotFS {
     LocalPinotFS _localPinotFS = new LocalPinotFS();
     File _basePath;
 

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
@@ -59,7 +59,7 @@ import java.util.Arrays;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.BasePinotFS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,7 +67,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Azure Data Lake Storage Gen2 implementation for the PinotFS interface.
  */
-public class ADLSGen2PinotFS extends PinotFS {
+public class ADLSGen2PinotFS extends BasePinotFS {
   private static final Logger LOGGER = LoggerFactory.getLogger(ADLSGen2PinotFS.class);
 
   private static final String ACCOUNT_NAME = "accountName";

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/AzurePinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/AzurePinotFS.java
@@ -41,7 +41,7 @@ import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.BasePinotFS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
  * Azure implementation for the PinotFS interface. This class will implement using azure-data-lake libraries all
  * the basic FS methods needed within Pinot.
  */
-public class AzurePinotFS extends PinotFS {
+public class AzurePinotFS extends BasePinotFS {
   private static final Logger LOGGER = LoggerFactory.getLogger(AzurePinotFS.class);
   private static final int BUFFER_SIZE = 4096;
   private ADLStoreClient _adlStoreClient;

--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
@@ -46,14 +46,14 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.BasePinotFS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.google.common.base.Preconditions.checkState;
 
 
-public class GcsPinotFS extends PinotFS {
+public class GcsPinotFS extends BasePinotFS {
   public static final String PROJECT_ID = "projectId";
   public static final String GCP_KEY = "gcpKey";
 

--- a/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
@@ -35,7 +35,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.BasePinotFS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,7 +43,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Implementation of PinotFS for the Hadoop Filesystem
  */
-public class HadoopPinotFS extends PinotFS {
+public class HadoopPinotFS extends BasePinotFS {
   private static final Logger LOGGER = LoggerFactory.getLogger(HadoopPinotFS.class);
 
   private static final String PRINCIPAL = "hadoop.kerberos.principle";

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -36,7 +36,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.BasePinotFS;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
@@ -70,7 +70,7 @@ import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 /**
  * Implementation of PinotFS for AWS S3 file system
  */
-public class S3PinotFS extends PinotFS {
+public class S3PinotFS extends BasePinotFS {
   public static final String ACCESS_KEY = "accessKey";
   public static final String SECRET_KEY = "secretKey";
   public static final String REGION = "region";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/BasePinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/BasePinotFS.java
@@ -30,11 +30,6 @@ import org.slf4j.LoggerFactory;
 public abstract class BasePinotFS implements PinotFS {
   private static final Logger LOGGER = LoggerFactory.getLogger(BasePinotFS.class);
 
-  /**
-   * Moves the file or directory from the src to dst. Does not keep the original file. If the dst has parent directories
-   * that haven't been created, this method will create all the necessary parent directories.
-   * Note: In Pinot we recommend the full paths of both src and dst be specified.
-   */
   @Override
   public boolean move(URI srcUri, URI dstUri, boolean overwrite)
       throws IOException {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/BasePinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/BasePinotFS.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.filesystem;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public abstract class BasePinotFS implements PinotFS {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BasePinotFS.class);
+
+  /**
+   * Moves the file or directory from the src to dst. Does not keep the original file. If the dst has parent directories
+   * that haven't been created, this method will create all the necessary parent directories.
+   * Note: In Pinot we recommend the full paths of both src and dst be specified.
+   */
+  @Override
+  public boolean move(URI srcUri, URI dstUri, boolean overwrite)
+      throws IOException {
+    if (!exists(srcUri)) {
+      LOGGER.warn("Source {} does not exist", srcUri);
+      return false;
+    }
+    if (exists(dstUri)) {
+      if (overwrite) {
+        delete(dstUri, true);
+      } else {
+        // dst file exists, returning
+        LOGGER.warn("Cannot move {} to {}. Destination exists and overwrite flag set to false.", srcUri, dstUri);
+        return false;
+      }
+    } else {
+      // ensures the parent path of dst exists.
+      try {
+        Path parentPath = Paths.get(dstUri.getPath()).getParent();
+        URI parentUri = new URI(dstUri.getScheme(), dstUri.getAuthority(), parentPath.toString(), null, null);
+        mkdir(parentUri);
+      } catch (URISyntaxException e) {
+        throw new IOException(e);
+      }
+    }
+    return doMove(srcUri, dstUri);
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
@@ -38,7 +38,7 @@ import org.apache.pinot.spi.env.PinotConfiguration;
  * Implementation of PinotFS for a local filesystem. Methods in this class may throw a SecurityException at runtime
  * if access to the file is denied.
  */
-public class LocalPinotFS extends PinotFS {
+public class LocalPinotFS extends BasePinotFS {
 
   @Override
   public void init(PinotConfiguration configuration) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
@@ -24,14 +24,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -46,14 +41,13 @@ import org.slf4j.LoggerFactory;
  */
 @InterfaceAudience.Public
 @InterfaceStability.Stable
-public abstract class PinotFS implements Closeable, Serializable {
-  private static final Logger LOGGER = LoggerFactory.getLogger(PinotFS.class);
+public interface PinotFS extends Closeable, Serializable {
 
   /**
    * Initializes the configurations specific to that filesystem. For instance, any security related parameters can be
    * initialized here and will not be logged.
    */
-  public abstract void init(PinotConfiguration config);
+  void init(PinotConfiguration config);
 
   /**
    * Creates a new directory. If parent directories are not created, it will create them.
@@ -61,7 +55,7 @@ public abstract class PinotFS implements Closeable, Serializable {
    * @return true if mkdir is successful
    * @throws IOException on IO failure
    */
-  public abstract boolean mkdir(URI uri)
+  boolean mkdir(URI uri)
       throws IOException;
 
   /**
@@ -72,7 +66,7 @@ public abstract class PinotFS implements Closeable, Serializable {
    * @return true if delete is successful else false
    * @throws IOException on IO failure, e.g Uri is not present or not valid
    */
-  public abstract boolean delete(URI segmentUri, boolean forceDelete)
+  boolean delete(URI segmentUri, boolean forceDelete)
       throws IOException;
 
   /**
@@ -90,37 +84,13 @@ public abstract class PinotFS implements Closeable, Serializable {
    * @return true if move is successful
    * @throws IOException on IO failure
    */
-  public boolean move(URI srcUri, URI dstUri, boolean overwrite)
-      throws IOException {
-    if (!exists(srcUri)) {
-      LOGGER.warn("Source {} does not exist", srcUri);
-      return false;
-    }
-    if (exists(dstUri)) {
-      if (overwrite) {
-        delete(dstUri, true);
-      } else {
-        // dst file exists, returning
-        LOGGER.warn("Cannot move {} to {}. Destination exists and overwrite flag set to false.", srcUri, dstUri);
-        return false;
-      }
-    } else {
-      // ensures the parent path of dst exists.
-      try {
-        Path parentPath = Paths.get(dstUri.getPath()).getParent();
-        URI parentUri = new URI(dstUri.getScheme(), dstUri.getAuthority(), parentPath.toString(), null, null);
-        mkdir(parentUri);
-      } catch (URISyntaxException e) {
-        throw new IOException(e);
-      }
-    }
-    return doMove(srcUri, dstUri);
-  }
+  boolean move(URI srcUri, URI dstUri, boolean overwrite)
+      throws IOException;
 
   /**
    * Does the actual behavior of move in each FS.
    */
-  public abstract boolean doMove(URI srcUri, URI dstUri)
+  boolean doMove(URI srcUri, URI dstUri)
       throws IOException;
 
   /**
@@ -138,7 +108,7 @@ public abstract class PinotFS implements Closeable, Serializable {
    * @return true if copy is successful
    * @throws IOException on IO failure
    */
-  public abstract boolean copy(URI srcUri, URI dstUri)
+  boolean copy(URI srcUri, URI dstUri)
       throws IOException;
 
   /**
@@ -147,7 +117,7 @@ public abstract class PinotFS implements Closeable, Serializable {
    * @return true if path exists
    * @throws IOException on IO failure
    */
-  public abstract boolean exists(URI fileUri)
+  boolean exists(URI fileUri)
       throws IOException;
 
   /**
@@ -156,7 +126,7 @@ public abstract class PinotFS implements Closeable, Serializable {
    * @return the number of bytes
    * @throws IOException on IO failure, e.g if it's a directory.
    */
-  public abstract long length(URI fileUri)
+  long length(URI fileUri)
       throws IOException;
 
   /**
@@ -168,7 +138,7 @@ public abstract class PinotFS implements Closeable, Serializable {
    * @return an array of strings that contains file paths
    * @throws IOException on IO failure. See specific implementation
    */
-  public abstract String[] listFiles(URI fileUri, boolean recursive)
+  String[] listFiles(URI fileUri, boolean recursive)
       throws IOException;
 
   /**
@@ -177,7 +147,7 @@ public abstract class PinotFS implements Closeable, Serializable {
    * @param dstFile location of destination on local filesystem
    * @throws Exception if srcUri is not valid or not present, or timeout when downloading file to local
    */
-  public abstract void copyToLocalFile(URI srcUri, File dstFile)
+  void copyToLocalFile(URI srcUri, File dstFile)
       throws Exception;
 
   /**
@@ -187,7 +157,7 @@ public abstract class PinotFS implements Closeable, Serializable {
    * @param dstUri location of dst on remote filesystem
    * @throws Exception if fileUri is not valid or not present, or timeout when uploading file from local
    */
-  public abstract void copyFromLocalFile(File srcFile, URI dstUri)
+  void copyFromLocalFile(File srcFile, URI dstUri)
       throws Exception;
 
   /**
@@ -196,7 +166,7 @@ public abstract class PinotFS implements Closeable, Serializable {
    * @return true if uri is a directory, false otherwise.
    * @throws IOException on IO failure, e.g uri is not valid or not present
    */
-  public abstract boolean isDirectory(URI uri)
+  boolean isDirectory(URI uri)
       throws IOException;
 
   /**
@@ -206,7 +176,7 @@ public abstract class PinotFS implements Closeable, Serializable {
    * (00:00:00 GMT, January 1, 1970) or 0L if the file does not exist or if an I/O error occurs
    * @throws IOException if uri is not valid or not present
    */
-  public abstract long lastModified(URI uri)
+  long lastModified(URI uri)
       throws IOException;
 
   /**
@@ -215,7 +185,7 @@ public abstract class PinotFS implements Closeable, Serializable {
    * @param uri location of file or directory
    * @throws IOException if the parent directory doesn't exist
    */
-  public abstract boolean touch(URI uri)
+  boolean touch(URI uri)
       throws IOException;
 
   /**
@@ -227,7 +197,7 @@ public abstract class PinotFS implements Closeable, Serializable {
    * @return a new InputStream
    * @throws IOException on any IO error - missing file, not a file etc
    */
-  public abstract InputStream open(URI uri)
+  InputStream open(URI uri)
       throws IOException;
 
   /**
@@ -235,7 +205,7 @@ public abstract class PinotFS implements Closeable, Serializable {
    * By default, this method does nothing.
    * @throws IOException on IO failure
    */
-  public void close()
+  default void close()
       throws IOException {
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSFactoryTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSFactoryTest.java
@@ -58,7 +58,7 @@ public class PinotFSFactoryTest {
     Assert.assertTrue(PinotFSFactory.create("file") instanceof LocalPinotFS);
   }
 
-  public static class TestPinotFS extends PinotFS {
+  public static class TestPinotFS extends BasePinotFS {
     public int _initCalled = 0;
     private PinotConfiguration _configuration;
 

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSTest.java
@@ -72,7 +72,7 @@ public class PinotFSTest {
   /**
    * MockRemoteFS implementation used to test behavior of the Abstract class PinotFS
    */
-  private class MockRemoteFS extends PinotFS {
+  private class MockRemoteFS extends BasePinotFS {
     public int _doMoveCalls;
     public List<Map<String, URI>> _doMoveArgs;
 


### PR DESCRIPTION
Description
===

`PinotFS` should be an interface instead of abstract base class. Creating a BasePinotFS to accommodate the logics that requires member variables.

Release Notes
===
`PinotFS` is no longer an abstract class, instead user can continue to extend from `BasePinotFS` or change to implement `PinotFS`.