### PR TITLE
allow JSON forward indexes

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -379,6 +379,13 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
             case BYTES:
               forwardIndexCreator.putBytes((byte[]) columnValueToIndex);
               break;
+            case JSON:
+              if (columnValueToIndex instanceof String) {
+                forwardIndexCreator.putString((String) columnValueToIndex);
+              } else if (columnValueToIndex instanceof byte[]) {
+                forwardIndexCreator.putBytes((byte[]) columnValueToIndex);
+              } 
+              break;
             default:
               throw new IllegalStateException();
           }


### PR DESCRIPTION
Currently if a `ForwardIndexWriter` implementation has datatype `JSON`, an exception is thrown during indexing.