### PR TITLE
For DISTINCT_COUNT, automatically convert Set to HyperLogLog when cardinality is too high

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -165,13 +165,12 @@ public class AggregationFunctionFactory {
                 throw new IllegalArgumentException("Third argument of lastWithTime Function should be literal."
                     + " The function can be used as lastWithTime(dataColumn, timeColumn, 'dataType')");
               }
-              FieldSpec.DataType fieldDataType
-                  = FieldSpec.DataType.valueOf(dataType.getLiteral().toUpperCase());
+              FieldSpec.DataType fieldDataType = FieldSpec.DataType.valueOf(dataType.getLiteral().toUpperCase());
               switch (fieldDataType) {
                 case BOOLEAN:
                 case INT:
-                  return new LastIntValueWithTimeAggregationFunction(
-                      firstArgument, timeCol, fieldDataType == FieldSpec.DataType.BOOLEAN);
+                  return new LastIntValueWithTimeAggregationFunction(firstArgument, timeCol,
+                      fieldDataType == FieldSpec.DataType.BOOLEAN);
                 case LONG:
                   return new LastLongValueWithTimeAggregationFunction(firstArgument, timeCol);
                 case FLOAT:
@@ -190,7 +189,7 @@ public class AggregationFunctionFactory {
           case MINMAXRANGE:
             return new MinMaxRangeAggregationFunction(firstArgument);
           case DISTINCTCOUNT:
-            return new DistinctCountAggregationFunction(firstArgument);
+            return new DistinctCountAggregationFunction(arguments);
           case DISTINCTCOUNTBITMAP:
             return new DistinctCountBitmapAggregationFunction(firstArgument);
           case SEGMENTPARTITIONEDDISTINCTCOUNT:
@@ -220,7 +219,7 @@ public class AggregationFunctionFactory {
           case MINMAXRANGEMV:
             return new MinMaxRangeMVAggregationFunction(firstArgument);
           case DISTINCTCOUNTMV:
-            return new DistinctCountMVAggregationFunction(firstArgument);
+            return new DistinctCountMVAggregationFunction(arguments);
           case DISTINCTCOUNTBITMAPMV:
             return new DistinctCountBitmapMVAggregationFunction(firstArgument);
           case DISTINCTCOUNTHLLMV:

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctCountQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctCountQueriesTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.queries;
 
+import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -295,6 +296,99 @@ public class DistinctCountQueriesTest extends BaseQueriesTest {
         assertEquals(groupByResult.getValue(), Integer.toString(1));
       }
     }
+  }
+
+  @Test
+  public void testConvertToHLL() {
+    // Dictionary based
+    String query = "SELECT DISTINCTCOUNT(intColumn, 'hllConversionThreshold=10'), "
+        + "DISTINCTCOUNT(longColumn, 'hllConversionThreshold=10'), "
+        + "DISTINCTCOUNT(floatColumn, 'hllConversionThreshold=10'), "
+        + "DISTINCTCOUNT(doubleColumn, 'hllConversionThreshold=10'), "
+        + "DISTINCTCOUNT(stringColumn, 'hllConversionThreshold=10'), "
+        + "DISTINCTCOUNT(bytesColumn, 'hllConversionThreshold=10') FROM testTable";
+
+    // Inner segment
+    String[] interSegmentsExpectedResults = new String[6];
+    for (Object operator : Arrays.asList(getOperatorForSqlQuery(query), getOperatorForSqlQueryWithFilter(query))) {
+      assertTrue(operator instanceof DictionaryBasedAggregationOperator);
+      IntermediateResultsBlock resultsBlock = ((DictionaryBasedAggregationOperator) operator).nextBlock();
+      QueriesTestUtils.testInnerSegmentExecutionStatistics(((Operator) operator).getExecutionStatistics(), NUM_RECORDS,
+          0, 0, NUM_RECORDS);
+      List<Object> aggregationResult = resultsBlock.getAggregationResult();
+      assertNotNull(aggregationResult);
+      assertEquals(aggregationResult.size(), 6);
+      for (int i = 0; i < 6; i++) {
+        assertTrue(aggregationResult.get(i) instanceof HyperLogLog);
+        HyperLogLog hll = (HyperLogLog) aggregationResult.get(i);
+
+        // Check log2m is 12
+        assertEquals(hll.sizeof(), 2732);
+
+        int actualResult = (int) hll.cardinality();
+        int expectedResult = _values.size();
+        // Allow 5% error for HLL
+        assertEquals(actualResult, expectedResult, expectedResult * 0.05);
+
+        interSegmentsExpectedResults[i] = Integer.toString(actualResult);
+      }
+    }
+
+    // Inter segments
+    for (BrokerResponseNative brokerResponse : Arrays.asList(getBrokerResponseForPqlQuery(query),
+        getBrokerResponseForPqlQueryWithFilter(query))) {
+      QueriesTestUtils.testInterSegmentAggregationResult(brokerResponse, 4 * NUM_RECORDS, 0, 0, 4 * NUM_RECORDS,
+          interSegmentsExpectedResults);
+    }
+
+    // Regular aggregation
+    query = query + " WHERE intColumn >= 500";
+
+    // Inner segment
+    int expectedResult = 0;
+    for (Integer value : _values) {
+      if (value >= 500) {
+        expectedResult++;
+      }
+    }
+    Operator operator = getOperatorForSqlQuery(query);
+    assertTrue(operator instanceof AggregationOperator);
+    List<Object> aggregationResult = ((AggregationOperator) operator).nextBlock().getAggregationResult();
+    assertNotNull(aggregationResult);
+    assertEquals(aggregationResult.size(), 6);
+    for (int i = 0; i < 6; i++) {
+      assertTrue(aggregationResult.get(i) instanceof HyperLogLog);
+      HyperLogLog hll = (HyperLogLog) aggregationResult.get(i);
+
+      // Check log2m is 12
+      assertEquals(hll.sizeof(), 2732);
+
+      int actualResult = (int) hll.cardinality();
+      // Allow 5% error for HLL
+      assertEquals(actualResult, expectedResult, expectedResult * 0.05);
+    }
+
+    // Inter segment
+    BrokerResponseNative brokerResponse = getBrokerResponseForPqlQuery(query);
+    List<AggregationResult> aggregationResults = brokerResponse.getAggregationResults();
+    assertNotNull(aggregationResults);
+    assertEquals(aggregationResults.size(), 6);
+    for (int i = 0; i < 6; i++) {
+      assertEquals(Integer.parseInt((String) aggregationResults.get(i).getValue()), expectedResult,
+          expectedResult * 0.05);
+    }
+
+    // Change log2m
+    query = "SELECT DISTINCTCOUNT(intColumn, 'hllLog2m=8;hllConversionThreshold=10') FROM testTable";
+    operator = getOperatorForSqlQuery(query);
+    assertTrue(operator instanceof DictionaryBasedAggregationOperator);
+    aggregationResult = ((DictionaryBasedAggregationOperator) operator).nextBlock().getAggregationResult();
+    assertNotNull(aggregationResult);
+    assertEquals(aggregationResult.size(), 1);
+    assertTrue(aggregationResult.get(0) instanceof HyperLogLog);
+    HyperLogLog hll = (HyperLogLog) aggregationResult.get(0);
+    // Check log2m is 8
+    assertEquals(hll.sizeof(), 172);
   }
 
   @AfterClass


### PR DESCRIPTION
## Description
For `DISTINCT_COUNT` and `DISTINCT_COUNT_MV` aggregation function, currently we use `Set` to store all the values, which can cause memory issues and potentially exhaust the memory for Servers or Brokers. This PR adds the support to automatically convert the `Set` to `HyperLogLog` if the set size grows too big to protect the servers. This conversion only applies to aggregation only queries, but not the group-by queries.

By default, when the set size exceeds 100K, it will be converted to a HyperLogLog with log2m of 12.
The log2m and threshold can be configured using the second argument (literal) of the function:
- `hllLog2m`: log2m of the converted HyperLogLog (default 12)
- `hllConversionThreshold`: set size threshold to trigger the conversion, non-positive means never convert (default 100K)

Example query:
`SELECT DISTINCTCOUNT(myCol, 'hllLog2m=8;hllConversionThreshold=10') FROM myTable`

## Release Notes
Add second argument (literal) to `DISTINCT_COUNT` and `DISTINCT_COUNT_MV` aggregation function for optional parameters:
- `hllLog2m`: log2m of the converted HyperLogLog (default 12)
- `hllConversionThreshold`: set size threshold to trigger the conversion, non-positive means never convert (default 100K)

For `DISTINCT_COUNT` and `DISTINCT_COUNT_MV` aggregation only queries, if the result is over 100K, the query will use `HyperLogLog` and return approximate result by default. To get back to the 100% accurate behavior, set `hllConversionThreshold` to a non-positive value.