### PR TITLE
Segment retention for table

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -703,7 +703,9 @@ public class PinotHelixResourceManager {
       Preconditions.checkArgument(TableNameBuilder.isTableResource(tableNameWithType),
           "Table name: %s is not a valid table name with type suffix", tableNameWithType);
       HelixHelper.removeSegmentsFromIdealState(_helixZkManager, tableNameWithType, segmentNames);
-      _segmentDeletionManager.deleteSegments(tableNameWithType, segmentNames);
+      TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType);
+      long retentionMs = _segmentDeletionManager.getRetentionMsFromTableConfig(tableConfig);
+      _segmentDeletionManager.deleteSegments(tableNameWithType, segmentNames, retentionMs);
       return PinotResourceManagerResponse.success("Segment " + segmentNames + " deleted");
     } catch (final Exception e) {
       LOGGER.error("Caught exception while deleting segment: {} from table: {}", segmentNames, tableNameWithType, e);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -45,6 +45,7 @@ import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.utils.TimeUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.joda.time.DateTime;
 import org.slf4j.Logger;
@@ -276,11 +277,9 @@ public class SegmentDeletionManager {
     long retentionMs = _defaultDeletedSegmentsRetentionMs;
     if (tableConfig != null && tableConfig.getValidationConfig() != null) {
       SegmentsValidationAndRetentionConfig validationConfig = tableConfig.getValidationConfig();
-      if (!StringUtils.isEmpty(validationConfig.getDeletedSegmentRetentionTimeUnit())
-          && !StringUtils.isEmpty(validationConfig.getDeletedSegmentRetentionTimeValue())) {
+      if (!StringUtils.isEmpty(validationConfig.getDeletedSegmentRetentionPeriod())) {
         try {
-          retentionMs = TimeUnit.valueOf(validationConfig.getDeletedSegmentRetentionTimeUnit().toUpperCase())
-              .toMillis(Long.parseLong(validationConfig.getDeletedSegmentRetentionTimeValue()));
+          retentionMs = TimeUtils.convertPeriodToMillis(validationConfig.getDeletedSegmentRetentionPeriod());
         } catch (Exception e) {
           LOGGER.warn(String.format("Unable to parse deleted segment retention config for table %s, using to default "
               + "retention value %dms", tableConfig.getTableName(), _defaultDeletedSegmentsRetentionMs), e);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
@@ -64,17 +64,13 @@ public class RetentionManager extends ControllerPeriodicTask<Void> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RetentionManager.class);
 
-  private final int _deletedSegmentsRetentionInDays;
-
   public RetentionManager(PinotHelixResourceManager pinotHelixResourceManager,
       LeadControllerManager leadControllerManager, ControllerConf config, ControllerMetrics controllerMetrics) {
     super("RetentionManager", config.getRetentionControllerFrequencyInSeconds(),
         config.getRetentionManagerInitialDelayInSeconds(), pinotHelixResourceManager, leadControllerManager,
         controllerMetrics);
-    _deletedSegmentsRetentionInDays = config.getDeletedSegmentsRetentionInDays();
 
-    LOGGER.info("Starting RetentionManager with runFrequencyInSeconds: {}, deletedSegmentsRetentionInDays: {}",
-        getIntervalInSeconds(), _deletedSegmentsRetentionInDays);
+    LOGGER.info("Starting RetentionManager with runFrequencyInSeconds: {}", getIntervalInSeconds());
   }
 
   @Override
@@ -97,8 +93,8 @@ public class RetentionManager extends ControllerPeriodicTask<Void> {
 
   @Override
   protected void postprocess() {
-    LOGGER.info("Removing aged (more than {} days) deleted segments for all tables", _deletedSegmentsRetentionInDays);
-    _pinotHelixResourceManager.getSegmentDeletionManager().removeAgedDeletedSegments(_deletedSegmentsRetentionInDays);
+    LOGGER.info("Clean up aged deleted segments for all tables");
+    _pinotHelixResourceManager.getSegmentDeletionManager().removeAgedDeletedSegments(_pinotHelixResourceManager);
   }
 
   private void manageRetentionForTable(TableConfig tableConfig) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -23,7 +23,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.helix.HelixAdmin;
+import org.apache.helix.ZNRecord;
 import org.apache.helix.model.IdealState;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.common.lineage.SegmentLineage;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.metrics.PinotMetricUtils;
@@ -41,6 +44,7 @@ import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.zookeeper.data.Stat;
 import org.joda.time.Duration;
 import org.joda.time.Interval;
 import org.mockito.ArgumentMatchers;
@@ -49,7 +53,6 @@ import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.*;
 
@@ -103,7 +106,7 @@ public class RetentionManagerTest {
     SegmentDeletionManager deletionManager = pinotHelixResourceManager.getSegmentDeletionManager();
 
     // Verify that the removeAgedDeletedSegments() method in deletion manager is actually called.
-    verify(deletionManager, times(1)).removeAgedDeletedSegments(anyInt());
+    verify(deletionManager, times(1)).removeAgedDeletedSegments(any());
 
     // Verify that the deleteSegments method is actually called.
     verify(pinotHelixResourceManager, times(1)).deleteSegments(anyString(), anyList());
@@ -177,7 +180,7 @@ public class RetentionManagerTest {
           throws Throwable {
         return null;
       }
-    }).when(deletionManager).removeAgedDeletedSegments(anyInt());
+    }).when(deletionManager).removeAgedDeletedSegments(any());
     when(resourceManager.getSegmentDeletionManager()).thenReturn(deletionManager);
 
     // If and when PinotHelixResourceManager.deleteSegments() is invoked, make sure that the segments deleted
@@ -197,6 +200,15 @@ public class RetentionManagerTest {
         return null;
       }
     }).when(resourceManager).deleteSegments(anyString(), ArgumentMatchers.anyList());
+
+    // fake segment lineage.
+    SegmentLineage segmentLineage = new SegmentLineage(REALTIME_TABLE_NAME);
+
+    ZkHelixPropertyStore<ZNRecord> mockPropertyStore = mock(ZkHelixPropertyStore.class);
+    when(mockPropertyStore.get(anyString(), any(Stat.class), anyInt())).thenReturn(segmentLineage.toZNRecord());
+    when(mockPropertyStore.set(anyString(), any(ZNRecord.class), anyInt(), anyInt())).thenReturn(true);
+
+    when(resourceManager.getPropertyStore()).thenReturn(mockPropertyStore);
   }
 
   // This test makes sure that we clean up the segments marked OFFLINE in realtime for more than 7 days
@@ -229,7 +241,7 @@ public class RetentionManagerTest {
     SegmentDeletionManager deletionManager = pinotHelixResourceManager.getSegmentDeletionManager();
 
     // Verify that the removeAgedDeletedSegments() method in deletion manager is actually called.
-    verify(deletionManager, times(1)).removeAgedDeletedSegments(anyInt());
+    verify(deletionManager, times(1)).removeAgedDeletedSegments(any());
 
     // Verify that the deleteSegments method is actually called.
     verify(pinotHelixResourceManager, times(1)).deleteSegments(anyString(), anyList());
@@ -295,6 +307,15 @@ public class RetentionManagerTest {
     HelixAdmin helixAdmin = mock(HelixAdmin.class);
     when(helixAdmin.getResourceIdealState(HELIX_CLUSTER_NAME, REALTIME_TABLE_NAME)).thenReturn(idealState);
     when(pinotHelixResourceManager.getHelixAdmin()).thenReturn(helixAdmin);
+
+    // fake segment lineage.
+    SegmentLineage segmentLineage = new SegmentLineage(REALTIME_TABLE_NAME);
+
+    ZkHelixPropertyStore<ZNRecord> mockPropertyStore = mock(ZkHelixPropertyStore.class);
+    when(mockPropertyStore.get(anyString(), any(Stat.class), anyInt())).thenReturn(segmentLineage.toZNRecord());
+    when(mockPropertyStore.set(anyString(), any(ZNRecord.class), anyInt(), anyInt())).thenReturn(true);
+
+    when(pinotHelixResourceManager.getPropertyStore()).thenReturn(mockPropertyStore);
 
     return pinotHelixResourceManager;
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
@@ -327,8 +327,7 @@ public class SegmentDeletionManagerTest {
 
   public static PinotHelixResourceManager mockTableConfigWithRetentionPeriod(int retentionPeriod) {
     SegmentsValidationAndRetentionConfig mockValidationConfig = mock(SegmentsValidationAndRetentionConfig.class);
-    when(mockValidationConfig.getDeletedSegmentRetentionTimeUnit()).thenReturn("DAYS");
-    when(mockValidationConfig.getDeletedSegmentRetentionTimeValue()).thenReturn(String.valueOf(retentionPeriod));
+    when(mockValidationConfig.getDeletedSegmentRetentionPeriod()).thenReturn(String.format("%dd", retentionPeriod));
 
     TableConfig mockTableConfig = mock(TableConfig.class);
     when(mockTableConfig.getValidationConfig()).thenReturn(mockValidationConfig);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -29,6 +29,8 @@ import org.apache.pinot.spi.utils.TimeUtils;
 public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   private String _retentionTimeUnit;
   private String _retentionTimeValue;
+  private String _deletedSegmentRetentionTimeUnit;
+  private String _deletedSegmentRetentionTimeValue;
   @Deprecated
   private String _segmentPushFrequency; // DO NOT REMOVE, this is used in internal segment generation management
   @Deprecated
@@ -100,6 +102,22 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
 
   public void setRetentionTimeValue(String retentionTimeValue) {
     _retentionTimeValue = retentionTimeValue;
+  }
+
+  public String getDeletedSegmentRetentionTimeUnit() {
+    return _deletedSegmentRetentionTimeUnit;
+  }
+
+  public void setDeletedSegmentRetentionTimeUnit(String deletedSegmentRetentionTimeUnit) {
+    _deletedSegmentRetentionTimeUnit = deletedSegmentRetentionTimeUnit;
+  }
+
+  public String getDeletedSegmentRetentionTimeValue() {
+    return _deletedSegmentRetentionTimeValue;
+  }
+
+  public void setDeletedSegmentRetentionTimeValue(String deletedSegmentRetentionTimeValue) {
+    _deletedSegmentRetentionTimeValue = deletedSegmentRetentionTimeValue;
   }
 
   /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -29,8 +29,7 @@ import org.apache.pinot.spi.utils.TimeUtils;
 public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   private String _retentionTimeUnit;
   private String _retentionTimeValue;
-  private String _deletedSegmentRetentionTimeUnit;
-  private String _deletedSegmentRetentionTimeValue;
+  private String _deletedSegmentRetentionPeriod;
   @Deprecated
   private String _segmentPushFrequency; // DO NOT REMOVE, this is used in internal segment generation management
   @Deprecated
@@ -104,20 +103,12 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
     _retentionTimeValue = retentionTimeValue;
   }
 
-  public String getDeletedSegmentRetentionTimeUnit() {
-    return _deletedSegmentRetentionTimeUnit;
+  public String getDeletedSegmentRetentionPeriod() {
+    return _deletedSegmentRetentionPeriod;
   }
 
-  public void setDeletedSegmentRetentionTimeUnit(String deletedSegmentRetentionTimeUnit) {
-    _deletedSegmentRetentionTimeUnit = deletedSegmentRetentionTimeUnit;
-  }
-
-  public String getDeletedSegmentRetentionTimeValue() {
-    return _deletedSegmentRetentionTimeValue;
-  }
-
-  public void setDeletedSegmentRetentionTimeValue(String deletedSegmentRetentionTimeValue) {
-    _deletedSegmentRetentionTimeValue = deletedSegmentRetentionTimeValue;
+  public void setDeletedSegmentRetentionPeriod(String deletedSegmentRetentionPeriod) {
+    _deletedSegmentRetentionPeriod = deletedSegmentRetentionPeriod;
   }
 
   /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -50,6 +50,8 @@ public class TableConfigBuilder {
   private static final String DEFAULT_SEGMENT_PUSH_TYPE = "APPEND";
   private static final String REFRESH_SEGMENT_PUSH_TYPE = "REFRESH";
   private static final String DEFAULT_SEGMENT_ASSIGNMENT_STRATEGY = "BalanceNumSegmentAssignmentStrategy";
+  private static final String DEFAULT_SEGMENT_DELETION_RETENTION_TIME_UNIT = "DAYS";
+  private static final String DEFAULT_SEGMENT_DELETION_RETENTION_TIME_VALUE = "7";
   private static final String DEFAULT_NUM_REPLICAS = "1";
   private static final String DEFAULT_LOAD_MODE = "HEAP";
   private static final String MMAP_LOAD_MODE = "MMAP";
@@ -67,6 +69,8 @@ public class TableConfigBuilder {
   private boolean _allowNullTimeValue;
   private String _retentionTimeUnit;
   private String _retentionTimeValue;
+  private String _deletedSegmentRetentionTimeUnit = DEFAULT_SEGMENT_DELETION_RETENTION_TIME_UNIT;
+  private String _deletedSegmentRetentionTimeValue = DEFAULT_SEGMENT_DELETION_RETENTION_TIME_VALUE;
   @Deprecated
   private String _segmentPushFrequency;
   @Deprecated
@@ -373,6 +377,8 @@ public class TableConfigBuilder {
     validationConfig.setAllowNullTimeValue(_allowNullTimeValue);
     validationConfig.setRetentionTimeUnit(_retentionTimeUnit);
     validationConfig.setRetentionTimeValue(_retentionTimeValue);
+    validationConfig.setDeletedSegmentRetentionTimeUnit(_deletedSegmentRetentionTimeUnit);
+    validationConfig.setDeletedSegmentRetentionTimeValue(_deletedSegmentRetentionTimeValue);
     validationConfig.setSegmentPushFrequency(_segmentPushFrequency);
     validationConfig.setSegmentPushType(_segmentPushType);
     validationConfig.setSegmentAssignmentStrategy(_segmentAssignmentStrategy);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -50,8 +50,7 @@ public class TableConfigBuilder {
   private static final String DEFAULT_SEGMENT_PUSH_TYPE = "APPEND";
   private static final String REFRESH_SEGMENT_PUSH_TYPE = "REFRESH";
   private static final String DEFAULT_SEGMENT_ASSIGNMENT_STRATEGY = "BalanceNumSegmentAssignmentStrategy";
-  private static final String DEFAULT_SEGMENT_DELETION_RETENTION_TIME_UNIT = "DAYS";
-  private static final String DEFAULT_SEGMENT_DELETION_RETENTION_TIME_VALUE = "7";
+  private static final String DEFAULT_SEGMENT_DELETION_RETENTION_PERIOD = "7d";
   private static final String DEFAULT_NUM_REPLICAS = "1";
   private static final String DEFAULT_LOAD_MODE = "HEAP";
   private static final String MMAP_LOAD_MODE = "MMAP";
@@ -69,8 +68,7 @@ public class TableConfigBuilder {
   private boolean _allowNullTimeValue;
   private String _retentionTimeUnit;
   private String _retentionTimeValue;
-  private String _deletedSegmentRetentionTimeUnit = DEFAULT_SEGMENT_DELETION_RETENTION_TIME_UNIT;
-  private String _deletedSegmentRetentionTimeValue = DEFAULT_SEGMENT_DELETION_RETENTION_TIME_VALUE;
+  private String _deletedSegmentRetentionPeriod = DEFAULT_SEGMENT_DELETION_RETENTION_PERIOD;
   @Deprecated
   private String _segmentPushFrequency;
   @Deprecated
@@ -377,8 +375,7 @@ public class TableConfigBuilder {
     validationConfig.setAllowNullTimeValue(_allowNullTimeValue);
     validationConfig.setRetentionTimeUnit(_retentionTimeUnit);
     validationConfig.setRetentionTimeValue(_retentionTimeValue);
-    validationConfig.setDeletedSegmentRetentionTimeUnit(_deletedSegmentRetentionTimeUnit);
-    validationConfig.setDeletedSegmentRetentionTimeValue(_deletedSegmentRetentionTimeValue);
+    validationConfig.setDeletedSegmentRetentionPeriod(_deletedSegmentRetentionPeriod);
     validationConfig.setSegmentPushFrequency(_segmentPushFrequency);
     validationConfig.setSegmentPushType(_segmentPushType);
     validationConfig.setSegmentAssignmentStrategy(_segmentAssignmentStrategy);


### PR DESCRIPTION
Description
===
We would like to add a table level delete retention config that overwrites cluster level retention config. 

This table-level retention before delete in deep store is honored as long as the table exists and wasn't deleted. Once table is deleted. We will return to use the cluster-level retention for removing residual segments.

see discussion in #8072 for more details.

