### PR TITLE
Timeout if waiting server channel lock takes a long time

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerTimer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerTimer.java
@@ -32,6 +32,8 @@ public enum BrokerTimer implements AbstractMetrics.Timer {
 
   // The latency of sending the request from broker to server
   NETTY_CONNECTION_SEND_REQUEST_LATENCY(false),
+  // The latency of waiting the lock of NETTY channel from broker to server
+  NETTY_LOCK_WAIT_TIME_MS(false),
 
   // aggregated thread cpu time in nanoseconds for query processing from offline servers
   OFFLINE_THREAD_CPU_TIME_NS(false),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerTimer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerTimer.java
@@ -32,8 +32,6 @@ public enum BrokerTimer implements AbstractMetrics.Timer {
 
   // The latency of sending the request from broker to server
   NETTY_CONNECTION_SEND_REQUEST_LATENCY(false),
-  // The latency of waiting the lock of NETTY channel from broker to server
-  NETTY_LOCK_WAIT_TIME_MS(false),
 
   // aggregated thread cpu time in nanoseconds for query processing from offline servers
   OFFLINE_THREAD_CPU_TIME_NS(false),

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
@@ -112,16 +112,15 @@ public class QueryRouter {
     }
 
     // Create the asynchronous query response with the request map
-    long startTimeMs = System.currentTimeMillis();
     AsyncQueryResponse asyncQueryResponse =
-        new AsyncQueryResponse(this, requestId, requestMap.keySet(), startTimeMs, timeoutMs);
+        new AsyncQueryResponse(this, requestId, requestMap.keySet(), System.currentTimeMillis(), timeoutMs);
     _asyncQueryResponseMap.put(requestId, asyncQueryResponse);
     for (Map.Entry<ServerRoutingInstance, InstanceRequest> entry : requestMap.entrySet()) {
       ServerRoutingInstance serverRoutingInstance = entry.getKey();
       ServerChannels serverChannels = serverRoutingInstance.isTlsEnabled() ? _serverChannelsTls : _serverChannels;
       try {
         serverChannels.sendRequest(rawTableName, asyncQueryResponse, serverRoutingInstance, entry.getValue(),
-            startTimeMs, timeoutMs);
+            timeoutMs);
         asyncQueryResponse.markRequestSubmitted(serverRoutingInstance);
       } catch (Exception e) {
         LOGGER.error("Caught exception while sending request {} to server: {}, marking query failed", requestId,

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
@@ -112,14 +112,16 @@ public class QueryRouter {
     }
 
     // Create the asynchronous query response with the request map
+    long startTimeMs = System.currentTimeMillis();
     AsyncQueryResponse asyncQueryResponse =
-        new AsyncQueryResponse(this, requestId, requestMap.keySet(), System.currentTimeMillis(), timeoutMs);
+        new AsyncQueryResponse(this, requestId, requestMap.keySet(), startTimeMs, timeoutMs);
     _asyncQueryResponseMap.put(requestId, asyncQueryResponse);
     for (Map.Entry<ServerRoutingInstance, InstanceRequest> entry : requestMap.entrySet()) {
       ServerRoutingInstance serverRoutingInstance = entry.getKey();
       ServerChannels serverChannels = serverRoutingInstance.isTlsEnabled() ? _serverChannelsTls : _serverChannels;
       try {
-        serverChannels.sendRequest(rawTableName, asyncQueryResponse, serverRoutingInstance, entry.getValue());
+        serverChannels.sendRequest(rawTableName, asyncQueryResponse, serverRoutingInstance, entry.getValue(),
+            startTimeMs, timeoutMs);
         asyncQueryResponse.markRequestSubmitted(serverRoutingInstance);
       } catch (Exception e) {
         LOGGER.error("Caught exception while sending request {} to server: {}, marking query failed", requestId,

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
@@ -146,7 +146,6 @@ public class ServerChannels {
     private void sendRequestOrTimeOut(String rawTableName, AsyncQueryResponse asyncQueryResponse,
         ServerRoutingInstance serverRoutingInstance, byte[] requestBytes, long timeoutMs)
         throws Exception {
-      _channelLock.lock();
       if (_channelLock.tryLock(timeoutMs, TimeUnit.MILLISECONDS)) {
         try {
           sendRequest(rawTableName, asyncQueryResponse, serverRoutingInstance, requestBytes);

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
@@ -87,7 +87,7 @@ public class ServerChannels {
       throws Exception {
     byte[] requestBytes = _serializer.serialize(instanceRequest);
     _serverToChannelMap.computeIfAbsent(serverRoutingInstance, ServerChannel::new)
-        .sendRequestOrTimeOut(rawTableName, asyncQueryResponse, serverRoutingInstance, requestBytes, timeoutMs);
+        .sendRequest(rawTableName, asyncQueryResponse, serverRoutingInstance, requestBytes, timeoutMs);
   }
 
   public void shutDown() {
@@ -100,7 +100,7 @@ public class ServerChannels {
     final ServerRoutingInstance _serverRoutingInstance;
     final Bootstrap _bootstrap;
     // lock to protect channel as requests must be written into channel sequentially
-    private final ReentrantLock _channelLock = new ReentrantLock();
+    final ReentrantLock _channelLock = new ReentrantLock();
     Channel _channel;
 
     ServerChannel(ServerRoutingInstance serverRoutingInstance) {
@@ -143,7 +143,7 @@ public class ServerChannels {
       }
     }
 
-    private void sendRequestOrTimeOut(String rawTableName, AsyncQueryResponse asyncQueryResponse,
+    private void sendRequest(String rawTableName, AsyncQueryResponse asyncQueryResponse,
         ServerRoutingInstance serverRoutingInstance, byte[] requestBytes, long timeoutMs)
         throws Exception {
       if (_channelLock.tryLock(timeoutMs, TimeUnit.MILLISECONDS)) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
@@ -33,6 +33,7 @@ import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.ReentrantLock;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.common.metrics.BrokerGauge;
@@ -152,6 +153,8 @@ public class ServerChannels {
         } finally {
           _channelLock.unlock();
         }
+      } else {
+        throw new TimeoutException("Timeout while acquiring channel lock");
       }
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
@@ -83,12 +83,11 @@ public class ServerChannels {
   }
 
   public void sendRequest(String rawTableName, AsyncQueryResponse asyncQueryResponse,
-      ServerRoutingInstance serverRoutingInstance, InstanceRequest instanceRequest, long startTimeMs, long timeoutMs)
+      ServerRoutingInstance serverRoutingInstance, InstanceRequest instanceRequest, long timeoutMs)
       throws Exception {
     byte[] requestBytes = _serializer.serialize(instanceRequest);
     _serverToChannelMap.computeIfAbsent(serverRoutingInstance, ServerChannel::new)
-        .sendRequestOrTimeOut(rawTableName, asyncQueryResponse, serverRoutingInstance, requestBytes, startTimeMs,
-            timeoutMs);
+        .sendRequestOrTimeOut(rawTableName, asyncQueryResponse, serverRoutingInstance, requestBytes, timeoutMs);
   }
 
   public void shutDown() {
@@ -145,12 +144,10 @@ public class ServerChannels {
     }
 
     private void sendRequestOrTimeOut(String rawTableName, AsyncQueryResponse asyncQueryResponse,
-        ServerRoutingInstance serverRoutingInstance, byte[] requestBytes, long startTimeMs, long timeoutMs)
+        ServerRoutingInstance serverRoutingInstance, byte[] requestBytes, long timeoutMs)
         throws Exception {
       _channelLock.lock();
       if (_channelLock.tryLock(timeoutMs, TimeUnit.MILLISECONDS)) {
-        _brokerMetrics.addTimedTableValue(rawTableName, BrokerTimer.NETTY_LOCK_WAIT_TIME_MS,
-            System.currentTimeMillis() - startTimeMs, TimeUnit.MILLISECONDS);
         try {
           sendRequest(rawTableName, asyncQueryResponse, serverRoutingInstance, requestBytes);
         } finally {


### PR DESCRIPTION
## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->

We currently timeout a query at different phase:
* After building query router, check timeout. 
* When waiting server response, check timeout and cancel waiting if need
* Timeout when reducing response

But we don't time out when "waiting the channel lock and sending request". It may cause some problem. Say we have a QPS = 100, Latency_SLA = 10s.

Now broker received 100 requests, they need to be send to a same server, let's ignore the time spending on building query router for sake of simplicity now. Let's say the 1st request is an extremely large request (or the server side reading the request from netty TCP channel extremely slowly for some reasons), thus writing the 1st request to channel takes 20s.

As we only have 1 TCP connection between broker and each server. The requests must be write to the channel ***sequentially***, and currently we don't  time out when "waiting channel lock and sending request", all the other 99 requests will continue to be written to channel, whereas they already exceed the 10s SLA.

This PR:
* make requests be able to time out early when "waiting the channel lock". 
* move the request serialization logic out of critical section.

NOTE: Once a thread acquired the channel lock and start sending request by writing bytes to TCP channel, we can not abort it, even if the "sending" exceed the latency SLA, this is because server side can not read partial requests from channel then throw it, it must read a complete request. Thus the "head line of blocking" effect still exist.  If we wanna completely solve the issue, we need consider gRPC or HTTP/2, which can split large request into small chunks, and multiplex/interleave multiple requests on a single TCP connection, which make it possible of abort a single request without impacting others.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
