### PR TITLE
Support for TIMESTAMP data type in Configuration Recommendation Engin…

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/NumberGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/NumberGenerator.java
@@ -78,6 +78,7 @@ public class NumberGenerator implements Generator {
       case INT:
         return newValue;
       case LONG:
+      case TIMESTAMP:
         return (long) newValue;
       case FLOAT:
         return newValue + 0.5f;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/TimeGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/TimeGenerator.java
@@ -50,7 +50,7 @@ public class TimeGenerator implements Generator {
   @Override
   public Object next() {
     Object next = _numberGenerator.next();
-    if (_dataType == FieldSpec.DataType.LONG) {
+    if (_dataType == FieldSpec.DataType.LONG || _dataType == FieldSpec.DataType.TIMESTAMP) {
       return ((long) next) + _initialValue.longValue();
     }
     return ((int) next) + _initialValue.intValue();
@@ -59,12 +59,12 @@ public class TimeGenerator implements Generator {
   @VisibleForTesting
   static Number convert(Date date, TimeUnit timeUnit, FieldSpec.DataType dataType) {
     long convertedTime = timeUnit.convert(date.getTime(), TimeUnit.MILLISECONDS);
-    if (dataType == FieldSpec.DataType.LONG) {
+    if (dataType == FieldSpec.DataType.LONG || dataType == FieldSpec.DataType.TIMESTAMP) {
       return convertedTime;
     }
     if (dataType == FieldSpec.DataType.INT) {
       return (int) convertedTime;
     }
-    throw new IllegalArgumentException("Time column can be only INT or LONG: " + dataType);
+    throw new IllegalArgumentException("Time column can be only INT, LONG or TIMESTAMP: " + dataType);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/io/InputManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/io/InputManager.java
@@ -130,6 +130,7 @@ public class InputManager {
   Map<FieldSpec.DataType, Integer> _dataTypeSizeMap = new HashMap<FieldSpec.DataType, Integer>() {{
     put(FieldSpec.DataType.INT, Integer.BYTES);
     put(FieldSpec.DataType.LONG, Long.BYTES);
+    put(FieldSpec.DataType.TIMESTAMP, Long.BYTES);
     put(FieldSpec.DataType.FLOAT, Float.BYTES);
     put(FieldSpec.DataType.DOUBLE, Double.BYTES);
     put(FieldSpec.DataType.BYTES, Byte.BYTES);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/recommender/data/generator/NumberGeneratorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/recommender/data/generator/NumberGeneratorTest.java
@@ -49,6 +49,12 @@ public class NumberGeneratorTest {
       assertEquals(generator.next(), expected);
     }
 
+    // timestamp generator
+    generator = new NumberGenerator(cardinality, FieldSpec.DataType.TIMESTAMP, numValuesPerEntry, random);
+    for (long expected : expectedValues) {
+      assertEquals(generator.next(), expected);
+    }
+
     // double generator
     generator = new NumberGenerator(cardinality, FieldSpec.DataType.FLOAT, numValuesPerEntry, random);
     float[] expectedValueFloat = { //

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/recommender/data/generator/TimeGeneratorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/recommender/data/generator/TimeGeneratorTest.java
@@ -40,6 +40,11 @@ public class TimeGeneratorTest {
     assertTrue(convertedTime instanceof Long);
     assertEquals(3600L, convertedTime);
 
+    // seconds (timestamp)
+    convertedTime = TimeGenerator.convert(date, TimeUnit.SECONDS, FieldSpec.DataType.TIMESTAMP);
+    assertTrue(convertedTime instanceof Long);
+    assertEquals(3600L, convertedTime);
+
     // minutes
     convertedTime = TimeGenerator.convert(date, TimeUnit.MINUTES, FieldSpec.DataType.INT);
     assertTrue(convertedTime instanceof Integer);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/recommender/realtime/provisioning/MemoryEstimatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/recommender/realtime/provisioning/MemoryEstimatorTest.java
@@ -87,6 +87,7 @@ public class MemoryEstimatorTest {
       assertEquals(extract(metadata, "column.colMetric.cardinality = (\\d+)"), "900");
       assertEquals(extract(metadata, "column.colTime.cardinality = (\\d+)"), "250");
       assertEquals(extract(metadata, "column.colTime2.cardinality = (\\d+)"), "750");
+      assertEquals(extract(metadata, "column.colTime3.cardinality = (\\d+)"), "850");
       assertEquals(extract(metadata, "column.colInt.maxNumberOfMultiValues = (\\d+)"), "3");
       assertEquals(extract(metadata, "column.colFloat.maxNumberOfMultiValues = (\\d+)"), "2");
       assertEquals(extract(metadata, "column.colString.maxNumberOfMultiValues = (\\d+)"), "0");
@@ -94,6 +95,7 @@ public class MemoryEstimatorTest {
       assertEquals(extract(metadata, "column.colMetric.maxNumberOfMultiValues = (\\d+)"), "0");
       assertEquals(extract(metadata, "column.colTime.maxNumberOfMultiValues = (\\d+)"), "0");
       assertEquals(extract(metadata, "column.colTime2.maxNumberOfMultiValues = (\\d+)"), "0");
+      assertEquals(extract(metadata, "column.colTime3.maxNumberOfMultiValues = (\\d+)"), "0");
     });
   }
 

--- a/pinot-controller/src/test/resources/memory_estimation/schema-with-metadata__dateTimeFieldSpec.json
+++ b/pinot-controller/src/test/resources/memory_estimation/schema-with-metadata__dateTimeFieldSpec.json
@@ -49,6 +49,14 @@
       "format": "1:MILLISECONDS:EPOCH",
       "granularity": "1:MILLISECONDS",
       "cardinality": 750
+    },
+    {
+      "name": "colTime3",
+      "dataType": "TIMESTAMP",
+      "format": "1:MILLISECONDS:EPOCH",
+      "granularity": "1:MILLISECONDS",
+      "cardinality": 850
     }
+
   ]
 }


### PR DESCRIPTION
…e (#8086)

## Description
Allows the configuration recommendation engine to generate a sample segment for a schema that contains a field with a TIMESTAMP data type. The sample segment is then used by the memory estimator to estimate how much memory would be used per host, for various combinations of numHostsToProvision and numHoursToConsume.

Given that the TIMESTAMP data type is implemented internally as a LONG data type, the NumberGenerator and TimeGenerator classes have been modified to allow the data generator to generate LONG numbers for TIMESTAMP fields.

InputManager has also been modified to define the number of bytes for a TIMESTAMP field to be the same as a LONG. 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
