### PR TITLE
Allow quickstart to get table files from filesystem.

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
@@ -31,11 +31,17 @@ import org.apache.pinot.tools.utils.PinotConfigUtils;
 
 public abstract class QuickStartBase {
   protected File _dataDir = FileUtils.getTempDirectory();
+  protected String _bootstrapDataDir;
   protected String _zkExternalAddress;
   protected String _configFilePath;
 
   public QuickStartBase setDataDir(String dataDir) {
     _dataDir = new File(dataDir);
+    return this;
+  }
+
+  public QuickStartBase setBootstrapDataDir(String bootstrapDataDir) {
+    _bootstrapDataDir = bootstrapDataDir;
     return this;
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
@@ -58,13 +58,13 @@ public abstract class QuickStartBase {
    *
    * @return bootstrap path if specified by command line argument -bootstrapTableDir; otherwise, default.
    */
-  public String getBootstrapDataDir(String defaultBootstrapDataDir) {
-    return _bootstrapDataDir != null ? _bootstrapDataDir : defaultBootstrapDataDir;
+  public String getBootstrapDataDir(String bootstrapDataDir) {
+    return _bootstrapDataDir != null ? _bootstrapDataDir : bootstrapDataDir;
   }
 
   /** @return Table name if specified by command line argument -bootstrapTableDir; otherwise, default. */
-  public String getTableName(String defaultBootstrapDataDir) {
-    return Paths.get(getBootstrapDataDir(defaultBootstrapDataDir)).getFileName().toString();
+  public String getTableName(String bootstrapDataDir) {
+    return Paths.get(getBootstrapDataDir(bootstrapDataDir)).getFileName().toString();
   }
 
   /** @return true if bootstrapTableDir is not specified by command line argument -bootstrapTableDir, else false.*/

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
@@ -20,6 +20,7 @@ package org.apache.pinot.tools;
 
 import com.google.common.collect.ImmutableMap;
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.configuration.ConfigurationException;
@@ -43,6 +44,32 @@ public abstract class QuickStartBase {
   public QuickStartBase setBootstrapDataDir(String bootstrapDataDir) {
     _bootstrapDataDir = bootstrapDataDir;
     return this;
+  }
+
+  /**
+   * Assuming that database name is DBNAME, bootstrap path must have the file structure specified below to properly
+   * load the table:
+   *  DBNAME
+   *  ├── ingestionJobSpec.yaml
+   *  ├── rawdata
+   *  │   └── DBNAME_data.csv
+   *  ├── DBNAME_offline_table_config.json
+   *  └── DBNAME_schema.json
+   *
+   * @return bootstrap path if specified by command line argument -bootstrapTableDir; otherwise, default.
+   */
+  public String getBootstrapDataDir(String defaultBootstrapDataDir) {
+    return _bootstrapDataDir != null ? _bootstrapDataDir : defaultBootstrapDataDir;
+  }
+
+  /** @return Table name if specified by command line argument -bootstrapTableDir; otherwise, default. */
+  public String getTableName(String defaultBootstrapDataDir) {
+    return Paths.get(getBootstrapDataDir(defaultBootstrapDataDir)).getFileName().toString();
+  }
+
+  /** @return true if bootstrapTableDir is not specified by command line argument -bootstrapTableDir, else false.*/
+  public boolean useDefaultBootstrapTableDir() {
+    return _bootstrapDataDir == null;
   }
 
   public QuickStartBase setZkExternalAddress(String zkExternalAddress) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
@@ -22,7 +22,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.io.File;
+import java.io.IOException;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -39,6 +41,7 @@ public class Quickstart extends QuickStartBase {
 
   private static final String TAB = "\t\t";
   private static final String NEW_LINE = "\n";
+  private static final String DEFAULT_BOOTSTRAP_DIRECTORY = "examples/batch/baseballStats";
 
   public enum Color {
     RESET("\u001B[0m"), GREEN("\u001B[32m"), YELLOW("\u001B[33m"), CYAN("\u001B[36m");
@@ -54,8 +57,28 @@ public class Quickstart extends QuickStartBase {
     }
   }
 
+  /**
+   * Assuming that database name is DBNAME, bootstrap path must have the file structure specified below to properly
+   * load the table:
+   *  DBNAME
+   *  ├── ingestionJobSpec.yaml
+   *  ├── rawdata
+   *  │   └── DBNAME_data.csv
+   *  ├── DBNAME_offline_table_config.json
+   *  └── DBNAME_schema.json
+   *
+   * @return bootstrap path if specified by command line argument -bootstrapTableDir; otherwise, null.
+   */
   public String getBootstrapDataDir() {
-    return "examples/batch/baseballStats";
+    return _bootstrapDataDir != null ? _bootstrapDataDir : DEFAULT_BOOTSTRAP_DIRECTORY;
+  }
+
+  public String getTableName() {
+    return Paths.get(getBootstrapDataDir()).getFileName().toString();
+  }
+
+  public boolean isUsingDefaultResourceTable() {
+    return _bootstrapDataDir == null;
   }
 
   public int getNumMinions() {
@@ -91,30 +114,17 @@ public class Quickstart extends QuickStartBase {
 
   public void execute()
       throws Exception {
+    String tableName = getTableName();
     File quickstartTmpDir = new File(_dataDir, String.valueOf(System.currentTimeMillis()));
-    File baseDir = new File(quickstartTmpDir, "baseballStats");
+    File baseDir = new File(quickstartTmpDir, tableName);
     File dataDir = new File(baseDir, "rawdata");
     Preconditions.checkState(dataDir.mkdirs());
 
-    File schemaFile = new File(baseDir, "baseballStats_schema.json");
-    File tableConfigFile = new File(baseDir, "baseballStats_offline_table_config.json");
-    File ingestionJobSpecFile = new File(baseDir, "ingestionJobSpec.yaml");
-    File dataFile = new File(dataDir, "baseballStats_data.csv");
-
-    ClassLoader classLoader = Quickstart.class.getClassLoader();
-    URL resource = classLoader.getResource(getBootstrapDataDir() + "/baseballStats_schema.json");
-    com.google.common.base.Preconditions.checkNotNull(resource);
-    FileUtils.copyURLToFile(resource, schemaFile);
-    resource = classLoader.getResource(getBootstrapDataDir() + "/rawdata/baseballStats_data.csv");
-    com.google.common.base.Preconditions.checkNotNull(resource);
-    FileUtils.copyURLToFile(resource, dataFile);
-    resource = classLoader.getResource(getBootstrapDataDir() + "/ingestionJobSpec.yaml");
-    if (resource != null) {
-      FileUtils.copyURLToFile(resource, ingestionJobSpecFile);
+    if (isUsingDefaultResourceTable()) {
+      copyResourceTableToTmpDirectory(getBootstrapDataDir(), tableName, baseDir, dataDir);
+    } else {
+      copyFilesystemTableToTmpDirectory(getBootstrapDataDir(), tableName, baseDir);
     }
-    resource = classLoader.getResource(getBootstrapDataDir() + "/baseballStats_offline_table_config.json");
-    com.google.common.base.Preconditions.checkNotNull(resource);
-    FileUtils.copyURLToFile(resource, tableConfigFile);
 
     QuickstartTableRequest request = new QuickstartTableRequest(baseDir.getAbsolutePath());
     QuickstartRunner runner =
@@ -133,13 +143,74 @@ public class Quickstart extends QuickStartBase {
         e.printStackTrace();
       }
     }));
-    printStatus(Color.CYAN, "***** Bootstrap baseballStats table *****");
+    printStatus(Color.CYAN, "***** Bootstrap " + tableName + " table *****");
     runner.bootstrapTable();
 
     waitForBootstrapToComplete(runner);
 
     printStatus(Color.YELLOW, "***** Offline quickstart setup complete *****");
 
+    if (isUsingDefaultResourceTable()) {
+      // Quickstart is using the default baseballStats sample table, so run sample queries.
+      runSampleQueries(runner);
+    }
+
+    printStatus(Color.GREEN, "You can always go to http://localhost:9000 to play around in the query console");
+  }
+
+  private static void copyResourceTableToTmpDirectory(String sourcePath, String tableName, File baseDir, File dataDir)
+      throws IOException {
+
+    File schemaFile = new File(baseDir, tableName + "_schema.json");
+    File tableConfigFile = new File(baseDir, tableName + "_offline_table_config.json");
+    File ingestionJobSpecFile = new File(baseDir, "ingestionJobSpec.yaml");
+    File dataFile = new File(dataDir, tableName + "_data.csv");
+
+    ClassLoader classLoader = Quickstart.class.getClassLoader();
+    URL resource = classLoader.getResource(sourcePath + File.separator + tableName + "_schema.json");
+    com.google.common.base.Preconditions.checkNotNull(resource);
+    FileUtils.copyURLToFile(resource, schemaFile);
+    resource =
+        classLoader.getResource(sourcePath + File.separator + "rawdata" + File.separator + tableName + "_data.csv");
+    com.google.common.base.Preconditions.checkNotNull(resource);
+    FileUtils.copyURLToFile(resource, dataFile);
+    resource = classLoader.getResource(sourcePath + File.separator + "ingestionJobSpec.yaml");
+    if (resource != null) {
+      FileUtils.copyURLToFile(resource, ingestionJobSpecFile);
+    }
+    resource = classLoader.getResource(sourcePath + File.separator + tableName + "_offline_table_config.json");
+    com.google.common.base.Preconditions.checkNotNull(resource);
+    FileUtils.copyURLToFile(resource, tableConfigFile);
+  }
+
+  private static void copyFilesystemTableToTmpDirectory(String sourcePath, String tableName, File baseDir)
+      throws IOException {
+    File fileDb = new File(sourcePath);
+
+    if (!fileDb.exists() || !fileDb.isDirectory()) {
+      throw new RuntimeException("Directory " + fileDb.getAbsolutePath() + " not found.");
+    }
+
+    File schemaFile = new File(fileDb, tableName + "_schema.json");
+    if (!schemaFile.exists()) {
+      throw new RuntimeException("Schema file " + schemaFile.getAbsolutePath() + " not found.");
+    }
+
+    File tableFile = new File(fileDb, tableName + "_offline_table_config.json");
+    if (!tableFile.exists()) {
+      throw new RuntimeException("Table table " + tableFile.getAbsolutePath() + " not found.");
+    }
+
+    File data = new File(fileDb, "rawdata" + File.separator + tableName + "_data.csv");
+    if (!data.exists()) {
+      throw new RuntimeException(("Data file " + data.getAbsolutePath() + " not found. "));
+    }
+
+    FileUtils.copyDirectory(fileDb, baseDir);
+  }
+
+  private static void runSampleQueries(QuickstartRunner runner)
+      throws Exception {
     String q1 = "select count(*) from baseballStats limit 1";
     printStatus(Color.YELLOW, "Total number of documents in the table");
     printStatus(Color.CYAN, "Query : " + q1);
@@ -173,8 +244,6 @@ public class Quickstart extends QuickStartBase {
     printStatus(Color.CYAN, "Query : " + q5);
     printStatus(Color.YELLOW, prettyPrintResponse(runner.runQuery(q5)));
     printStatus(Color.GREEN, "***************************************************");
-
-    printStatus(Color.GREEN, "You can always go to http://localhost:9000 to play around in the query console");
   }
 
   public static void main(String[] args)

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Lists;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -55,30 +54,6 @@ public class Quickstart extends QuickStartBase {
     Color(String code) {
       _code = code;
     }
-  }
-
-  /**
-   * Assuming that database name is DBNAME, bootstrap path must have the file structure specified below to properly
-   * load the table:
-   *  DBNAME
-   *  ├── ingestionJobSpec.yaml
-   *  ├── rawdata
-   *  │   └── DBNAME_data.csv
-   *  ├── DBNAME_offline_table_config.json
-   *  └── DBNAME_schema.json
-   *
-   * @return bootstrap path if specified by command line argument -bootstrapTableDir; otherwise, null.
-   */
-  public String getBootstrapDataDir() {
-    return _bootstrapDataDir != null ? _bootstrapDataDir : DEFAULT_BOOTSTRAP_DIRECTORY;
-  }
-
-  public String getTableName() {
-    return Paths.get(getBootstrapDataDir()).getFileName().toString();
-  }
-
-  public boolean isUsingDefaultResourceTable() {
-    return _bootstrapDataDir == null;
   }
 
   public int getNumMinions() {
@@ -114,16 +89,16 @@ public class Quickstart extends QuickStartBase {
 
   public void execute()
       throws Exception {
-    String tableName = getTableName();
+    String tableName = getTableName(DEFAULT_BOOTSTRAP_DIRECTORY);
     File quickstartTmpDir = new File(_dataDir, String.valueOf(System.currentTimeMillis()));
     File baseDir = new File(quickstartTmpDir, tableName);
     File dataDir = new File(baseDir, "rawdata");
     Preconditions.checkState(dataDir.mkdirs());
 
-    if (isUsingDefaultResourceTable()) {
-      copyResourceTableToTmpDirectory(getBootstrapDataDir(), tableName, baseDir, dataDir);
+    if (useDefaultBootstrapTableDir()) {
+      copyResourceTableToTmpDirectory(getBootstrapDataDir(DEFAULT_BOOTSTRAP_DIRECTORY), tableName, baseDir, dataDir);
     } else {
-      copyFilesystemTableToTmpDirectory(getBootstrapDataDir(), tableName, baseDir);
+      copyFilesystemTableToTmpDirectory(getBootstrapDataDir(DEFAULT_BOOTSTRAP_DIRECTORY), tableName, baseDir);
     }
 
     QuickstartTableRequest request = new QuickstartTableRequest(baseDir.getAbsolutePath());
@@ -150,7 +125,7 @@ public class Quickstart extends QuickStartBase {
 
     printStatus(Color.YELLOW, "***** Offline quickstart setup complete *****");
 
-    if (isUsingDefaultResourceTable()) {
+    if (useDefaultBootstrapTableDir()) {
       // Quickstart is using the default baseballStats sample table, so run sample queries.
       runSampleQueries(runner);
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickStartCommand.java
@@ -39,6 +39,10 @@ public class QuickStartCommand extends AbstractBaseAdminCommand implements Comma
       description = "Type of quickstart, supported: STREAM/BATCH/HYBRID")
   private String _type;
 
+  @CommandLine.Option(names = {"-bootstrapTableDir"}, required = false,
+      description = "Directory containing table schema, config, and data.")
+  private String _bootstrapTableDir;
+
   @CommandLine.Option(names = {"-tmpDir", "-quickstartDir", "-dataDir"}, required = false,
       description = "Temp Directory to host quickstart data")
   private String _tmpDir;
@@ -76,6 +80,14 @@ public class QuickStartCommand extends AbstractBaseAdminCommand implements Comma
 
   public void setTmpDir(String tmpDir) {
     _tmpDir = tmpDir;
+  }
+
+  public String getBootstrapDataDir() {
+    return _bootstrapTableDir;
+  }
+
+  public void setBootstrapTableDir(String bootstrapTableDir) {
+    _bootstrapTableDir = bootstrapTableDir;
   }
 
   public String getZkExternalAddress() {
@@ -128,6 +140,10 @@ public class QuickStartCommand extends AbstractBaseAdminCommand implements Comma
 
     if (_tmpDir != null) {
       quickstart.setDataDir(_tmpDir);
+    }
+
+    if (_bootstrapTableDir != null) {
+      quickstart.setBootstrapDataDir(_bootstrapTableDir);
     }
 
     if (_zkExternalAddress != null) {


### PR DESCRIPTION
## Description
Add command line option -bootstrapTableDir that will allow Quickstart to load table schema, config, and data files from a directory on the filesystem. This option along with the recently added -configFile option will make it easy to debug using Quickstart (`-configFile /tmp/config.conf -bootstrapTableDir /tmp/mytable`)

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
