### PR TITLE
fix FST Like query benchmark to remove SQL parsing from the measurement

### DIFF
--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkNativeAndLuceneBasedLike.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkNativeAndLuceneBasedLike.java
@@ -20,21 +20,21 @@ package org.apache.pinot.perf;
 
 import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.core.common.Operator;
-import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
-import org.apache.pinot.queries.BaseQueriesTest;
+import org.apache.pinot.core.common.Block;
+import org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2;
+import org.apache.pinot.core.plan.maker.PlanMaker;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
-import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.FSTType;
@@ -48,26 +48,29 @@ import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
 import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
-import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
-import org.testng.annotations.AfterClass;
+
 
 @BenchmarkMode(Mode.AverageTime)
-@OutputTimeUnit(TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
 @Fork(1)
-@Warmup(iterations = 3, time = 10)
-@Measurement(iterations = 5, time = 10)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
 @State(Scope.Benchmark)
-public class BenchmarkNativeAndLuceneBasedLike extends BaseQueriesTest {
+public class BenchmarkNativeAndLuceneBasedLike {
 
   private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "BenchmarkNativeAndLuceneBasedLike");
   private static final String TABLE_NAME = "MyTable";
@@ -76,84 +79,57 @@ public class BenchmarkNativeAndLuceneBasedLike extends BaseQueriesTest {
   private static final String URL_COL = "URL_COL";
   private static final String INT_COL_NAME = "INT_COL";
   private static final String NO_INDEX_STRING_COL_NAME = "NO_INDEX_COL";
-  private static final Integer INT_BASE_VALUE = 1000;
-  private static final Integer NUM_ROWS = 2500000;
 
+  @Param({"LUCENE", "NATIVE"})
+  private FSTType _fstType;
+  @Param("SELECT INT_COL, URL_COL FROM MyTable WHERE DOMAIN_NAMES LIKE '%domain%'")
+  String _query;
+  @Param("2500000")
+  int _numRows;
+  @Param("1000")
+  int _intBaseValue;
+
+  private PlanMaker _planMaker;
   private IndexSegment _indexSegment;
-  private List<IndexSegment> _indexSegments;
-  private IndexSegment _luceneBasedFSTIndexSegment;
-  private IndexSegment _nativeBasedFSTIndexSegment;
+  private QueryContext _queryContext;
 
-  String _query = "SELECT INT_COL, URL_COL FROM MyTable "
-      + "WHERE DOMAIN_NAMES LIKE '%domain%'";
-
-  @Override
-  protected String getFilter() {
-    return "";
-  }
-
-  @Override
-  protected IndexSegment getIndexSegment() {
-    return _indexSegment;
-  }
-
-  @Override
-  protected List<IndexSegment> getIndexSegments() {
-    return _indexSegments;
-  }
-
-  @Setup
+  @Setup(Level.Trial)
   public void setUp()
       throws Exception {
+    _planMaker = new InstancePlanMakerImplV2();
+    _queryContext = QueryContextConverterUtils.getQueryContextFromSQL(_query);
     FileUtils.deleteQuietly(INDEX_DIR);
-
-    List<IndexSegment> segments = new ArrayList<>();
-    for (FSTType fstType : Arrays.asList(FSTType.LUCENE, FSTType.NATIVE)) {
-      buildSegment(fstType);
-
-      IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
-      Set<String> fstIndexCols = new HashSet<>();
-      fstIndexCols.add(DOMAIN_NAMES_COL);
-      indexLoadingConfig.setFSTIndexColumns(fstIndexCols);
-      indexLoadingConfig.setFSTIndexType(fstType);
-
-      ImmutableSegment segment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), indexLoadingConfig);
-
-      segments.add(segment);
-
-      if (fstType == FSTType.LUCENE) {
-        _luceneBasedFSTIndexSegment = segment;
-      } else {
-        _nativeBasedFSTIndexSegment = segment;
-      }
-    }
-
-    _indexSegment = segments.get(ThreadLocalRandom.current().nextInt(2));
-    _indexSegments = segments;
+    buildSegment(_fstType);
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
+    Set<String> fstIndexCols = new HashSet<>();
+    fstIndexCols.add(DOMAIN_NAMES_COL);
+    indexLoadingConfig.setFSTIndexColumns(fstIndexCols);
+    indexLoadingConfig.setFSTIndexType(_fstType);
+    _indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), indexLoadingConfig);
   }
 
-  @AfterClass
+  @TearDown(Level.Trial)
   public void tearDown() {
-    _nativeBasedFSTIndexSegment.destroy();
-    _luceneBasedFSTIndexSegment.destroy();
-
+    _indexSegment.destroy();
     FileUtils.deleteQuietly(INDEX_DIR);
   }
 
   private List<GenericRow> createTestData(int numRows) {
-    List<GenericRow> rows = new ArrayList<>();
-
-    List<String> domainNames = getDomainNames();
-    List<String> urlSufficies = getURLSufficies();
-    List<String> noIndexData = getNoIndexData();
-
+    List<GenericRow> rows = new ArrayList<>(numRows);
+    String[] domainNames = new String[]{
+        "www.domain1.com", "www.domain1.co.ab", "www.domain1.co.bc",
+        "www.domain1.co.cd", "www.sd.domain1.com", "www.sd.domain1.co.ab", "www.sd.domain1.co.bc",
+        "www.sd.domain1.co.cd", "www.domain2.com", "www.domain2.co.ab", "www.domain2.co.bc", "www.domain2.co.cd",
+        "www.sd.domain2.com", "www.sd.domain2.co.ab", "www.sd.domain2.co.bc", "www.sd.domain2.co.cd"
+    };
+    String[] urlSuffixes = new String[] {"/a", "/b", "/c", "/d"};
+    String[] noIndexData = new String[]{"test1", "test2", "test3", "test4", "test5"};
     for (int i = 0; i < numRows; i++) {
-      String domain = domainNames.get(i % domainNames.size());
-      String url = domain + urlSufficies.get(i % urlSufficies.size());
-
+      String domain = domainNames[i % domainNames.length];
+      String url = domain + urlSuffixes[i % urlSuffixes.length];
       GenericRow row = new GenericRow();
-      row.putField(INT_COL_NAME, INT_BASE_VALUE + i);
-      row.putField(NO_INDEX_STRING_COL_NAME, noIndexData.get(i % noIndexData.size()));
+      row.putField(INT_COL_NAME, _intBaseValue + i);
+      row.putField(NO_INDEX_STRING_COL_NAME, noIndexData[i % noIndexData.length]);
       row.putField(DOMAIN_NAMES_COL, domain);
       row.putField(URL_COL, url);
       rows.add(row);
@@ -163,15 +139,14 @@ public class BenchmarkNativeAndLuceneBasedLike extends BaseQueriesTest {
 
   private void buildSegment(FSTType fstType)
       throws Exception {
-    List<GenericRow> rows = createTestData(NUM_ROWS);
+    List<GenericRow> rows = createTestData(_numRows);
     List<FieldConfig> fieldConfigs = new ArrayList<>();
     fieldConfigs.add(
         new FieldConfig(DOMAIN_NAMES_COL, FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null));
     fieldConfigs
         .add(new FieldConfig(URL_COL, FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null));
-
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setInvertedIndexColumns(Arrays.asList(DOMAIN_NAMES_COL)).setFieldConfigList(fieldConfigs).build();
+        .setInvertedIndexColumns(Collections.singletonList(DOMAIN_NAMES_COL)).setFieldConfigList(fieldConfigs).build();
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
         .addSingleValueDimension(DOMAIN_NAMES_COL, FieldSpec.DataType.STRING)
         .addSingleValueDimension(URL_COL, FieldSpec.DataType.STRING)
@@ -182,7 +157,6 @@ public class BenchmarkNativeAndLuceneBasedLike extends BaseQueriesTest {
     config.setTableName(TABLE_NAME);
     config.setSegmentName(SEGMENT_NAME);
     config.setFSTIndexType(fstType);
-
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
     try (RecordReader recordReader = new GenericRowRecordReader(rows)) {
       driver.init(config, recordReader);
@@ -190,44 +164,10 @@ public class BenchmarkNativeAndLuceneBasedLike extends BaseQueriesTest {
     }
   }
 
-  private List<String> getURLSufficies() {
-    return Arrays.asList("/a", "/b", "/c", "/d");
-  }
-
-  private List<String> getNoIndexData() {
-    return Arrays.asList("test1", "test2", "test3", "test4", "test5");
-  }
-
-  private List<String> getDomainNames() {
-    return Arrays
-        .asList("www.domain1.com", "www.domain1.co.ab", "www.domain1.co.bc", "www.domain1.co.cd", "www.sd.domain1.com",
-            "www.sd.domain1.co.ab", "www.sd.domain1.co.bc", "www.sd.domain1.co.cd", "www.domain2.com",
-            "www.domain2.co.ab", "www.domain2.co.bc", "www.domain2.co.cd", "www.sd.domain2.com", "www.sd.domain2.co.ab",
-            "www.sd.domain2.co.bc", "www.sd.domain2.co.cd");
-  }
-
-  private void executeTest(String query, Blackhole blackhole) {
-    Operator<IntermediateResultsBlock> operator = getOperatorForSqlQuery(query);
-
-    blackhole.consume(operator.nextBlock());
-  }
-
   @Benchmark
-  public void testLuceneBasedFSTLike(Blackhole blackhole) {
-    _indexSegments = Arrays.asList(_luceneBasedFSTIndexSegment);
-
-    for (int i = 0; i < 10000; i++) {
-      executeTest(_query, blackhole);
-    }
-  }
-
-  @Benchmark
-  public void testNativeBasedFSTLike(Blackhole blackhole) {
-    _indexSegments = Arrays.asList(_nativeBasedFSTIndexSegment);
-
-    for (int i = 0; i < 10000; i++) {
-      executeTest(_query, blackhole);
-    }
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public Block query() {
+    return _planMaker.makeSegmentPlanNode(_indexSegment, _queryContext).run().nextBlock();
   }
 
   public static void main(String[] args)

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkNativeAndLuceneBasedLike.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkNativeAndLuceneBasedLike.java
@@ -83,7 +83,8 @@ public class BenchmarkNativeAndLuceneBasedLike {
 
   @Param({"LUCENE", "NATIVE"})
   private FSTType _fstType;
-  @Param("SELECT INT_COL, URL_COL FROM MyTable WHERE DOMAIN_NAMES LIKE '%domain%'")
+  @Param({"SELECT INT_COL, URL_COL FROM MyTable WHERE DOMAIN_NAMES LIKE '%domain%'",
+      "SELECT INT_COL, URL_COL FROM MyTable WHERE DOMAIN_NAMES LIKE 'www.domain%'"})
   String _query;
   @Param("2500000")
   int _numRows;


### PR DESCRIPTION
I noticed that the FST Like benchmark results vary a lot:

```
Benchmark                                                 Mode  Cnt  Score   Error  Units
BenchmarkNativeAndLuceneBasedLike.testLuceneBasedFSTLike  avgt   25  3.127 ± 0.578   s/op
BenchmarkNativeAndLuceneBasedLike.testNativeBasedFSTLike  avgt   25  3.440 ± 0.555   s/op
```

When running these benchmarks with `-prof jfr` to figure out what they were actually measuring I noticed a couple of things:

1. Most of the time is spent parsing SQL creating the query context
<img width="1530" alt="Screenshot 2022-01-31 at 17 54 48" src="https://user-images.githubusercontent.com/16439049/151846946-0b3aa09b-a0ba-43bb-af13-a120406e311e.png">
2. Because the benchmark doesn't properly segregate the FST types or clean up after itself properly (it uses a testng `AfterClass` annotation which JMH doesn't know anything about), the `testNativeBasedFSTLike` sometimes measures the Lucene implementation, but when it does measure the Native implementation, the SQL parsing frames are much narrower relative to the construction of the filter operator.

<img width="1546" alt="Screenshot 2022-01-31 at 17 58 54" src="https://user-images.githubusercontent.com/16439049/151847574-9073b823-d2ea-4f03-82c8-84e33aca94e2.png">

After a couple of changes to use proper JMH lifecycle and to factor out SQL parsing into the setup, most of the benchmark time is spent in construction of the filter operator:

Lucene:
<img width="1509" alt="Screenshot 2022-01-31 at 17 48 12" src="https://user-images.githubusercontent.com/16439049/151845914-9b5440f8-c643-43e1-b873-6fd2e031fcbd.png">
Native:
<img width="1540" alt="Screenshot 2022-01-31 at 17 48 48" src="https://user-images.githubusercontent.com/16439049/151846014-a8d5cd66-d61d-419d-8f5e-d0c72807dc4d.png">

The results are more stable and tell a different story, which should help drive future improvement in this space:

```
Benchmark                                (_fstType)  (_intBaseValue)  (_numRows)                                                                 (_query)  Mode  Cnt    Score    Error  Units
BenchmarkNativeAndLuceneBasedLike.query      LUCENE             1000     2500000  SELECT INT_COL, URL_COL FROM MyTable WHERE DOMAIN_NAMES LIKE '%domain%'  avgt   25   65.626 ±  1.454  us/op
BenchmarkNativeAndLuceneBasedLike.query      NATIVE             1000     2500000  SELECT INT_COL, URL_COL FROM MyTable WHERE DOMAIN_NAMES LIKE '%domain%'  avgt   25  232.908 ± 17.302  us/op
```