### PR TITLE
Validate the numbers of input and output files in HadoopSegmentCreationJob

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/HadoopSegmentCreationJob.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/HadoopSegmentCreationJob.java
@@ -133,7 +133,7 @@ public class HadoopSegmentCreationJob extends SegmentCreationJob {
       throw new RuntimeException("Job failed: " + job);
     }
 
-    moveSegmentsToOutputDir();
+    moveSegmentsToOutputDir(numDataFiles);
 
     cleanup(job);
   }
@@ -171,9 +171,18 @@ public class HadoopSegmentCreationJob extends SegmentCreationJob {
   protected void addAdditionalJobProperties(Job job) {
   }
 
-  protected void moveSegmentsToOutputDir()
+  protected void moveSegmentsToOutputDir(int numberOfDataFiles)
       throws IOException {
     Path segmentTarDir = new Path(new Path(_stagingDir, "output"), JobConfigConstants.SEGMENT_TAR_DIR);
+
+    // Validate whether the number of input files match with the number of output files,
+    // as there is 1:1 mapping between the input and output files.
+    int numberOfOutputFiles = _outputDirFileSystem.listStatus(segmentTarDir).length;
+    if (numberOfDataFiles != numberOfOutputFiles) {
+      throw new RuntimeException(
+          String.format("The number of input files doesn't match with the number of output files."
+              + " Number of input files: %d. Number of output files: %d", numberOfDataFiles, numberOfOutputFiles));
+    }
     movePath(_outputDirFileSystem, segmentTarDir.toString(), _outputDir, true);
   }
 


### PR DESCRIPTION
## Description
If the `exclude.sequence.id` property is set to `true`, segment name will not have the sequence id as the suffix. If there are multiple input files for the same day within the batch job, all these new segments will share the same segment name, which leads to the scenario that only 1 pinot segment instead of N stored in the file system.

This PR adds the validation between the number of input files and the number of output files, so that once these two number don't match, an exception will be thrown and then fail the job.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
