### PR TITLE
fix check before creating a table

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1258,14 +1258,15 @@ public class PinotHelixResourceManager {
    */
   public void addTable(TableConfig tableConfig)
       throws IOException {
-    validateTableTenantConfig(tableConfig);
     String tableNameWithType = tableConfig.getTableName();
-    SegmentsValidationAndRetentionConfig segmentsConfig = tableConfig.getValidationConfig();
-
     if (getTableConfig(tableNameWithType) != null) {
       throw new TableAlreadyExistsException("Table " + tableNameWithType + " already exists");
     }
+
+    validateTableTenantConfig(tableConfig);
+    SegmentsValidationAndRetentionConfig segmentsConfig = tableConfig.getValidationConfig();
     TableType tableType = tableConfig.getTableType();
+
     switch (tableType) {
       case OFFLINE:
         // now lets build an ideal state

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
@@ -173,10 +173,6 @@ public class PinotTableRestletResourceTest {
     realtimeTableConfig = _realtimeBuilder.setTableName(REALTIME_TABLE_NAME).setTimeColumnName("timeColumn").build();
     String realtimeTableConfigString = realtimeTableConfig.toJsonString();
     ControllerTestUtils.sendPostRequest(_createTableUrl, realtimeTableConfigString);
-
-    // TODO: check whether we should allow POST request to create REALTIME table that already exists
-    // Create a REALTIME table that already exists which should succeed
-    ControllerTestUtils.sendPostRequest(_createTableUrl, realtimeTableConfigString);
   }
 
   @Test


### PR DESCRIPTION
Summary
===
This fixes #8091. table creation should check that table config doesn't exist.


Release Note
===
REALTIME table now doesn't support creation of a duplicate table name. It will now fail with a `TableAlreadyExistException`

