### PR TITLE
fix controller config validation failure for customized TLS listeners

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -379,16 +379,16 @@ public class ControllerConf extends PinotConfiguration {
         getControllerPort() == null ? Arrays.asList("http") : Arrays.asList());
   }
 
-  public String getControllerAccessProtocolProperty(String protocol, String property) {
-    return getProperty(CONTROLLER_ACCESS_PROTOCOLS + "." + protocol + "." + property);
+  public String getControllerAccessProtocolProperty(String name, String property) {
+    return getProperty(CONTROLLER_ACCESS_PROTOCOLS + "." + name + "." + property);
   }
 
-  public String getControllerAccessProtocolProperty(String protocol, String property, String defaultValue) {
-    return getProperty(CONTROLLER_ACCESS_PROTOCOLS + "." + protocol + "." + property, defaultValue);
+  public String getControllerAccessProtocolProperty(String name, String property, String defaultValue) {
+    return getProperty(CONTROLLER_ACCESS_PROTOCOLS + "." + name + "." + property, defaultValue);
   }
 
-  public boolean getControllerAccessProtocolProperty(String protocol, String property, boolean defaultValue) {
-    return getProperty(CONTROLLER_ACCESS_PROTOCOLS + "." + protocol + "." + property, defaultValue);
+  public boolean getControllerAccessProtocolProperty(String name, String property, boolean defaultValue) {
+    return getProperty(CONTROLLER_ACCESS_PROTOCOLS + "." + name + "." + property, defaultValue);
   }
 
   public String getDataDir() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -379,16 +379,16 @@ public class ControllerConf extends PinotConfiguration {
         getControllerPort() == null ? Arrays.asList("http") : Arrays.asList());
   }
 
-  public String getControllerAccessProtocolProperty(String name, String property) {
-    return getProperty(CONTROLLER_ACCESS_PROTOCOLS + "." + name + "." + property);
+  public String getControllerAccessProtocolProperty(String protocol, String property) {
+    return getProperty(CONTROLLER_ACCESS_PROTOCOLS + "." + protocol + "." + property);
   }
 
-  public String getControllerAccessProtocolProperty(String name, String property, String defaultValue) {
-    return getProperty(CONTROLLER_ACCESS_PROTOCOLS + "." + name + "." + property, defaultValue);
+  public String getControllerAccessProtocolProperty(String protocol, String property, String defaultValue) {
+    return getProperty(CONTROLLER_ACCESS_PROTOCOLS + "." + protocol + "." + property, defaultValue);
   }
 
-  public boolean getControllerAccessProtocolProperty(String name, String property, boolean defaultValue) {
-    return getProperty(CONTROLLER_ACCESS_PROTOCOLS + "." + name + "." + property, defaultValue);
+  public boolean getControllerAccessProtocolProperty(String protocol, String property, boolean defaultValue) {
+    return getProperty(CONTROLLER_ACCESS_PROTOCOLS + "." + protocol + "." + property, defaultValue);
   }
 
   public String getDataDir() {


### PR DESCRIPTION
## Description
This is a fix of a config validation error when using the new TLS listerner specs intoduced in #8082.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes

## Documentation
