### PR TITLE
Add discovery feature for broker to auto load services

### DIFF
--- a/pinot-broker/pom.xml
+++ b/pinot-broker/pom.xml
@@ -97,6 +97,10 @@
       <groupId>com.jcabi</groupId>
       <artifactId>jcabi-log</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.glassfish.hk2</groupId>
+      <artifactId>hk2-locator</artifactId>
+    </dependency>
 
     <!-- Test -->
     <dependency>

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -50,7 +50,9 @@ public class BrokerAdminApiApplication extends ResourceConfig {
       BrokerMetrics brokerMetrics, PinotConfiguration brokerConf) {
     packages(RESOURCE_PACKAGE);
     property(PINOT_CONFIGURATION, brokerConf);
-
+    if (brokerConf.getProperty(CommonConstants.Broker.BROKER_SERVICE_AUTO_DISCOVERY, false)) {
+      register(ServiceAutoDiscoveryFeature.class);
+    }
     register(new AbstractBinder() {
       @Override
       protected void configure() {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -51,7 +51,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     packages(RESOURCE_PACKAGE);
     property(PINOT_CONFIGURATION, brokerConf);
     if (brokerConf.getProperty(CommonConstants.Broker.BROKER_SERVICE_AUTO_DISCOVERY, false)) {
-      register(ServiceAutoDiscoveryFeature.class);
+      register(BrokerServiceAutoDiscoveryFeature.class);
     }
     register(new AbstractBinder() {
       @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerServiceAutoDiscoveryFeature.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerServiceAutoDiscoveryFeature.java
@@ -68,8 +68,8 @@ import org.slf4j.LoggerFactory;
  * pinot-integration-tests/src/main/java/org/apache/pinot/broker/integration/tests/BrokerTestAutoLoadedService.java
  * </code>
  */
-public class ServiceAutoDiscoveryFeature implements Feature {
-    private static final Logger LOGGER = LoggerFactory.getLogger(ServiceAutoDiscoveryFeature.class);
+public class BrokerServiceAutoDiscoveryFeature implements Feature {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BrokerServiceAutoDiscoveryFeature.class);
 
     @Inject
     ServiceLocator _serviceLocator;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ServiceAutoDiscoveryFeature.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ServiceAutoDiscoveryFeature.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.broker;
+
+import java.io.IOException;
+import javax.inject.Inject;
+import javax.ws.rs.core.Feature;
+import javax.ws.rs.core.FeatureContext;
+import org.glassfish.hk2.api.DynamicConfigurationService;
+import org.glassfish.hk2.api.MultiException;
+import org.glassfish.hk2.api.Populator;
+import org.glassfish.hk2.api.ServiceLocator;
+import org.glassfish.hk2.utilities.ClasspathDescriptorFileFinder;
+import org.glassfish.hk2.utilities.DuplicatePostProcessor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Auto scan and discovery classes annotated with Service tags. This enables the feature similar to Spring's
+ * auto-discovery, that if a class is annotated with some tags like @Service, the class will be auto-loaded
+ * The code are mostly from https://mkyong.com/webservices/jax-rs/jersey-and-hk2-dependency-injection-auto-scanning/
+ * <p>
+ * To make a class auto-loaded, what we need to do is to add the below dependency into project:
+ * <p>
+ * <pre>
+ *      &lt;dependency&gt;
+ *         &lt;groupId&gt;org.glassfish.hk2&lt;/groupId&gt;
+ *         &lt;artifactId&gt;hk2-metadata-generator&lt;/artifactId&gt;
+ *         &lt;version&gt;${hk2.version}&lt;/version&gt;
+ *       &lt;/dependency&gt;
+ *
+ * </pre>
+ * <p>
+ * And then annotate your class with @Service tag, like below:
+ * <p>
+ * <pre>{@code
+ *  import org.jvnet.hk2.annotations.Service;
+ *  {@literal @}Service
+ *  public class WriteApiContextProvider {
+ *    public SomeResult doComputation() {
+ *       ...
+ *    }
+ *  }
+ * }
+ * </pre>
+ * <p>
+ * The class will be written into <code>META-INF/hk2-locator/default</code> path in the JAR. The ServiceAutoDiscovery
+ * feature will know that this class needs to be loaded.
+ *
+ * <p>
+ * Examples are in <code>
+ * pinot-integration-tests/src/main/java/org/apache/pinot/broker/integration/tests/BrokerTestAutoLoadedService.java
+ * </code>
+ */
+public class ServiceAutoDiscoveryFeature implements Feature {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServiceAutoDiscoveryFeature.class);
+
+    @Inject
+    ServiceLocator _serviceLocator;
+
+    @Override
+    public boolean configure(FeatureContext context) {
+        DynamicConfigurationService dcs =
+                _serviceLocator.getService(DynamicConfigurationService.class);
+        Populator populator = dcs.getPopulator();
+        try {
+            // Populator - populate HK2 service locators from inhabitants files
+            // ClasspathDescriptorFileFinder - find files from META-INF/hk2-locator/default
+            populator.populate(
+                    new ClasspathDescriptorFileFinder(this.getClass().getClassLoader()),
+                    new DuplicatePostProcessor());
+
+        } catch (IOException | MultiException ex) {
+            LOGGER.error("Failed to register service locator. Auto-discovery will fail, but app will continue", ex);
+        }
+        return true;
+    }
+}

--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -207,6 +207,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-common</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-tools</artifactId>
       <exclusions>
         <exclusion>
@@ -228,6 +232,10 @@
           <artifactId>netty</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.hk2</groupId>
+      <artifactId>hk2-locator</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
@@ -372,6 +380,11 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.glassfish.hk2</groupId>
+      <artifactId>hk2-metadata-generator</artifactId>
+      <version>${hk2.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/pinot-integration-tests/src/main/java/org/apache/pinot/broker/api/resources/EchoWithAutoDiscovery.java
+++ b/pinot-integration-tests/src/main/java/org/apache/pinot/broker/api/resources/EchoWithAutoDiscovery.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.broker.api.resources;
+
+import io.swagger.annotations.Api;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.apache.pinot.broker.integration.tests.BrokerTestAutoLoadedService;
+
+/**
+ * This class is a typical "echo" service that will return whatever string you call GET with a path.
+ * It is both an integration test and a demonstration of how to dynamically add an endpoint to broker,
+ * create auto-service discovery
+ */
+@Api(tags = "Test")
+@Path("/test")
+public class EchoWithAutoDiscovery {
+    @Inject
+    public BrokerTestAutoLoadedService _injectedService;
+    @GET
+    @Path("/echo/{table}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String echo(@PathParam("table") String table) {
+        return _injectedService.echo(table);
+    }
+}

--- a/pinot-integration-tests/src/main/java/org/apache/pinot/broker/integration/tests/BrokerTestAutoLoadedService.java
+++ b/pinot-integration-tests/src/main/java/org/apache/pinot/broker/integration/tests/BrokerTestAutoLoadedService.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.integration.tests;
+
+import javax.inject.Singleton;
+import org.jvnet.hk2.annotations.Service;
+
+@Service
+@Singleton
+public class BrokerTestAutoLoadedService {
+    public String echo(String echoText) {
+        return echoText;
+    }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BrokerServiceDiscoveryIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BrokerServiceDiscoveryIntegrationTest.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.util.TestUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+/**
+ * Integration test that converts Avro data for 12 segments and runs queries against it.
+ */
+public class BrokerServiceDiscoveryIntegrationTest extends BaseClusterIntegrationTestSet {
+  private static final String TENANT_NAME = "TestTenant";
+
+  @Override
+  protected String getBrokerTenant() {
+    return TENANT_NAME;
+  }
+
+  @Override
+  protected String getServerTenant() {
+    return TENANT_NAME;
+  }
+
+  protected PinotConfiguration getDefaultBrokerConfiguration() {
+    PinotConfiguration config = new PinotConfiguration();
+    config.setProperty(CommonConstants.Broker.BROKER_SERVICE_AUTO_DISCOVERY, true);
+    return config;
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+
+    // Start the Pinot cluster
+    startZk();
+    startController();
+    startBrokers(1);
+    startServers(1);
+
+  }
+  @AfterClass
+  public void tearDown()
+          throws Exception {
+
+    // Brokers and servers has been stopped
+    stopBroker();
+    stopController();
+    stopZk();
+    FileUtils.deleteDirectory(_tempDir);
+  }
+
+  @Test
+  public void testBrokerExtraEndpointsAutoLoaded()
+      throws Exception {
+    String response = sendGetRequest(_brokerBaseApiUrl + "/test/echo/doge");
+    Assert.assertEquals(response, "doge");
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -224,6 +224,8 @@ public class CommonConstants {
 
     public static final String BROKER_TLS_PREFIX = "pinot.broker.tls";
     public static final String BROKER_NETTYTLS_ENABLED = "pinot.broker.nettytls.enabled";
+    //Set to true to load all services tagged and compiled with hk2-metadata-generator. Default to False
+    public static final String BROKER_SERVICE_AUTO_DISCOVERY = "pinot.broker.service.auto.discovery";
 
     public static class Request {
       public static final String PQL = "pql";

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,7 @@
     <async-http-client.version>2.12.3</async-http-client.version>
     <jersey.version>2.28</jersey.version>
     <grizzly.version>2.4.4</grizzly.version>
+    <hk2.version>2.5.0</hk2.version>
     <swagger.version>1.5.16</swagger.version>
     <hadoop.version>2.7.0</hadoop.version>
     <scala.version>2.13.3</scala.version>
@@ -1174,6 +1175,11 @@
         <groupId>org.glassfish.jersey.inject</groupId>
         <artifactId>jersey-hk2</artifactId>
         <version>${jersey.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.hk2</groupId>
+        <artifactId>hk2-locator</artifactId>
+        <version>${hk2.version}</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.media</groupId>


### PR DESCRIPTION
## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
Added an optional "Auto Discovery" feature in PinotBroker so services tagged with `@Service` tag can be auto-loaded.

This will make Pinot Broker's Jersey behave very similar like Spring Framework in terms of service discovery.

1. Main idea is behind [mkyong's article in detail in here](https://mkyong.com/webservices/jax-rs/jersey-and-hk2-dependency-injection-auto-scanning/)
2. Added a property boolean named `pinot.broker.service.auto.discovery` to enable this behavior

Steps needed to make a class auto-created in PinotBroker:
1. Add `hk2-metadata-generator` module as a dependency in your JAR file
2. Tag your class with `@org.jvnet.hk2.annotations.Service` tag 
3. Set `pinot.broker.service.auto.discovery=true` in your Broker's property config
4. Make sure your JAR file is loaded in class path(of coz)
5. (Optional) inject your class instance to other places

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)
No
Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)
No
Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options: `pinot.broker.service.auto.discovery` so Jersey services can be created automatically and then later injected to Endpoints.
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->
Release note: Added Service Auto-discovery feature into PinotBroker so classes annotated with `@Service` and built with `hk2-metadata-generator` module can be automatically loaded.

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->

## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
Will add later