### PR TITLE
Extend enableParallePushProtection support in UploadSegment API

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -141,6 +141,26 @@ public class ZKMetadataProvider {
     }
   }
 
+  /**
+   * Creates a new znode for SegmentZkMetadata. This call is atomic. If there are concurrent calls trying to create the
+   * same znode, only one of them would succeed.
+   *
+   * @param propertyStore Helix property store
+   * @param tableNameWithType Table name with type
+   * @param segmentZKMetadata Segment Zk metadata
+   * @return boolean indicating success/failure
+   */
+  public static boolean createSegmentZkMetadata(ZkHelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType,
+      SegmentZKMetadata segmentZKMetadata) {
+    try {
+      return propertyStore
+          .create(constructPropertyStorePathForSegment(tableNameWithType, segmentZKMetadata.getSegmentName()),
+              segmentZKMetadata.toZNRecord(), AccessOption.PERSISTENT);
+    } catch (Exception e) {
+      return false;
+    }
+  }
+
   public static boolean setSegmentZKMetadata(ZkHelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType,
       SegmentZKMetadata segmentZKMetadata, int expectedVersion) {
     // NOTE: Helix will throw ZkBadVersionException if version does not match

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -811,6 +811,33 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   /**
+   * Upload segment with segment file using  table name, type and enableParallelPushProtection as a request parameters.
+   *
+   * @param uri URI
+   * @param segmentName Segment name
+   * @param segmentFile Segment file
+   * @param tableName Table name with or without type suffix
+   * @param tableType Table type
+   * @param enableParallelPushProtection enable protection against concurrent segment uploads for the same segment
+   * @return Response
+   * @throws IOException
+   * @throws HttpErrorStatusException
+   */
+  public SimpleHttpResponse uploadSegment(URI uri, String segmentName, File segmentFile, String tableName,
+      TableType tableType, boolean enableParallelPushProtection)
+      throws IOException, HttpErrorStatusException {
+    NameValuePair tableNameValuePair = new BasicNameValuePair(QueryParameters.TABLE_NAME, tableName);
+    NameValuePair tableTypeValuePair = new BasicNameValuePair(QueryParameters.TABLE_TYPE, tableType.name());
+    NameValuePair enableParallelPushProtectionValuePair =
+        new BasicNameValuePair(QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION,
+            String.valueOf(enableParallelPushProtection));
+
+    List<NameValuePair> parameters =
+        Arrays.asList(tableNameValuePair, tableTypeValuePair, enableParallelPushProtectionValuePair);
+    return uploadSegment(uri, segmentName, segmentFile, null, parameters, DEFAULT_SOCKET_TIMEOUT_MS);
+  }
+
+  /**
    * Upload segment with segment file input stream.
    *
    * Note: table name has to be set as a parameter.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
@@ -75,7 +75,7 @@ public class ZKOperator {
       }
       LOGGER.info("Adding new segment {} from table {}", segmentName, tableNameWithType);
       processNewSegment(segmentMetadata, finalSegmentLocationURI, currentSegmentLocation, zkDownloadURI, headers,
-          crypter, tableNameWithType, segmentName, moveSegmentToFinalLocation);
+          crypter, tableNameWithType, segmentName, moveSegmentToFinalLocation, enableParallelPushProtection);
       return;
     }
 
@@ -222,8 +222,36 @@ public class ZKOperator {
 
   private void processNewSegment(SegmentMetadata segmentMetadata, URI finalSegmentLocationURI,
       File currentSegmentLocation, String zkDownloadURI, HttpHeaders headers, String crypter, String tableNameWithType,
-      String segmentName, boolean moveSegmentToFinalLocation)
+      String segmentName, boolean moveSegmentToFinalLocation, boolean enableParallelPushProtection)
       throws Exception {
+    SegmentZKMetadata newSegmentZKMetadata = _pinotHelixResourceManager
+        .constructZkMetadataForNewSegment(tableNameWithType, segmentMetadata, zkDownloadURI, crypter);
+
+    // Lock if enableParallelPushProtection is true.
+    if (enableParallelPushProtection) {
+      newSegmentZKMetadata.setSegmentUploadStartTime(System.currentTimeMillis());
+    }
+
+    // Update zk metadata customer map
+    String segmentZKMetadataCustomMapModifierStr = headers != null ? headers
+        .getHeaderString(FileUploadDownloadClient.CustomHeaders.SEGMENT_ZK_METADATA_CUSTOM_MAP_MODIFIER) : null;
+    if (segmentZKMetadataCustomMapModifierStr != null) {
+      SegmentZKMetadataCustomMapModifier segmentZKMetadataCustomMapModifier =
+          new SegmentZKMetadataCustomMapModifier(segmentZKMetadataCustomMapModifierStr);
+      newSegmentZKMetadata
+          .setCustomMap(segmentZKMetadataCustomMapModifier.modifyMap(newSegmentZKMetadata.getCustomMap()));
+    }
+
+    int expectedVersion = -1;
+
+    if (!_pinotHelixResourceManager.createSegmentZkMetadata(tableNameWithType, newSegmentZKMetadata)) {
+      throw new RuntimeException(
+          "Failed to create ZK metadata for segment: " + segmentName + " of table: " + tableNameWithType);
+    } else {
+      // Update version because zk metadata update is successful.
+      ++expectedVersion;
+    }
+
     // For v1 segment uploads, we will not move the segment
     if (moveSegmentToFinalLocation) {
       try {
@@ -232,29 +260,36 @@ public class ZKOperator {
             .info("Moved segment {} from temp location {} to {}", segmentName, currentSegmentLocation.getAbsolutePath(),
                 finalSegmentLocationURI.getPath());
       } catch (Exception e) {
+        // Cleanup the Zk entry and the segment from the permanent directory if it exists.
         LOGGER
             .error("Could not move segment {} from table {} to permanent directory", segmentName, tableNameWithType, e);
-        throw new RuntimeException(e);
+        _pinotHelixResourceManager.deleteSegment(tableNameWithType, segmentName);
+        LOGGER.info("Deleted zk entry and segment {} for table {}.", segmentName, tableNameWithType);
+        throw e;
       }
     } else {
       LOGGER.info("Skipping segment move, keeping segment {} from table {} at {}", segmentName, tableNameWithType,
           zkDownloadURI);
     }
-    _pinotHelixResourceManager.addNewSegment(tableNameWithType, segmentMetadata, zkDownloadURI, crypter);
 
-    // Update zk metadata customer map
-    String segmentZKMetadataCustomMapModifierStr = headers != null ? headers
-        .getHeaderString(FileUploadDownloadClient.CustomHeaders.SEGMENT_ZK_METADATA_CUSTOM_MAP_MODIFIER) : null;
-    if (segmentZKMetadataCustomMapModifierStr != null) {
-      ZNRecord segmentMetadataZnRecord =
-          _pinotHelixResourceManager.getSegmentMetadataZnRecord(tableNameWithType, segmentName);
-      SegmentZKMetadata segmentZKMetadata = new SegmentZKMetadata(segmentMetadataZnRecord);
+    try {
+      _pinotHelixResourceManager.assignTableSegment(tableNameWithType, segmentMetadata.getName());
+    } catch (Exception e) {
+      // assignTableSegment removes the zk entry. Call deleteSegment to remove the segment from permanent location.
+      LOGGER
+          .error("Caught exception while calling assignTableSegment for adding segment: {} to table: {}", segmentName,
+              tableNameWithType, e);
+      _pinotHelixResourceManager.deleteSegment(tableNameWithType, segmentName);
+      LOGGER.info("Deleted zk entry and segment {} for table {}.", segmentName, tableNameWithType);
+      throw e;
+    }
 
-      SegmentZKMetadataCustomMapModifier segmentZKMetadataCustomMapModifier =
-          new SegmentZKMetadataCustomMapModifier(segmentZKMetadataCustomMapModifierStr);
-      segmentZKMetadata.setCustomMap(segmentZKMetadataCustomMapModifier.modifyMap(segmentZKMetadata.getCustomMap()));
-      if (!_pinotHelixResourceManager
-          .updateZkMetadata(tableNameWithType, segmentZKMetadata, segmentMetadataZnRecord.getVersion())) {
+    if (enableParallelPushProtection) {
+      // Release lock.
+      newSegmentZKMetadata.setSegmentUploadStartTime(-1);
+      if (!_pinotHelixResourceManager.updateZkMetadata(tableNameWithType, newSegmentZKMetadata, expectedVersion)) {
+        _pinotHelixResourceManager.deleteSegment(tableNameWithType, segmentName);
+        LOGGER.info("Deleted zk entry and segment {} for table {}.", segmentName, tableNameWithType);
         throw new RuntimeException(
             "Failed to update ZK metadata for segment: " + segmentName + " of table: " + tableNameWithType);
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
@@ -242,14 +242,9 @@ public class ZKOperator {
           .setCustomMap(segmentZKMetadataCustomMapModifier.modifyMap(newSegmentZKMetadata.getCustomMap()));
     }
 
-    int expectedVersion = -1;
-
     if (!_pinotHelixResourceManager.createSegmentZkMetadata(tableNameWithType, newSegmentZKMetadata)) {
       throw new RuntimeException(
           "Failed to create ZK metadata for segment: " + segmentName + " of table: " + tableNameWithType);
-    } else {
-      // Update version because zk metadata update is successful.
-      ++expectedVersion;
     }
 
     // For v1 segment uploads, we will not move the segment
@@ -285,9 +280,9 @@ public class ZKOperator {
     }
 
     if (enableParallelPushProtection) {
-      // Release lock.
+      // Release lock. Expected version will be 0 as we hold a lock and no updates could take place meanwhile.
       newSegmentZKMetadata.setSegmentUploadStartTime(-1);
-      if (!_pinotHelixResourceManager.updateZkMetadata(tableNameWithType, newSegmentZKMetadata, expectedVersion)) {
+      if (!_pinotHelixResourceManager.updateZkMetadata(tableNameWithType, newSegmentZKMetadata, 0)) {
         _pinotHelixResourceManager.deleteSegment(tableNameWithType, segmentName);
         LOGGER.info("Deleted zk entry and segment {} for table {}.", segmentName, tableNameWithType);
         throw new RuntimeException(

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/upload/ZKOperatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/upload/ZKOperatorTest.java
@@ -18,9 +18,12 @@
  */
 package org.apache.pinot.controller.api.upload;
 
+import java.io.File;
+import java.net.URI;
 import javax.ws.rs.core.HttpHeaders;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.ControllerTestUtils;
 import org.apache.pinot.segment.spi.SegmentMetadata;
@@ -28,6 +31,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -38,7 +42,6 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
-
 
 public class ZKOperatorTest {
   private static final String TABLE_NAME = "operatorTestTable";
@@ -64,8 +67,33 @@ public class ZKOperatorTest {
     when(segmentMetadata.getCrc()).thenReturn("12345");
     when(segmentMetadata.getIndexCreationTime()).thenReturn(123L);
     HttpHeaders httpHeaders = mock(HttpHeaders.class);
+
+    // Test if Zk segment metadata is removed if exception is thrown when moving segment to final location.
+    try {
+      // Create mock finalSegmentLocationURI and currentSegmentLocation.
+      URI finalSegmentLocationURI =
+          URIUtils.getUri("mockPath", OFFLINE_TABLE_NAME, URIUtils.encode(segmentMetadata.getName()));
+      File currentSegmentLocation = new File(new File("foo/bar"), "mockChild");
+
+      zkOperator
+          .completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, finalSegmentLocationURI,
+              currentSegmentLocation, true, httpHeaders, "downloadUrl",
+              true, "crypter");
+      fail();
+    } catch (Exception e) {
+      // Expected
+    }
+
+    // Wait for the segment Zk entry to be deleted.
+    TestUtils.waitForCondition(aVoid -> {
+      SegmentZKMetadata segmentZKMetadata =
+          ControllerTestUtils.getHelixResourceManager().getSegmentZKMetadata(OFFLINE_TABLE_NAME, SEGMENT_NAME);
+      return segmentZKMetadata == null;
+    }, 30_000L, "Failed to delete segmentZkMetadata.");
+
+
     zkOperator
-        .completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, null, null, false, httpHeaders, "downloadUrl",
+        .completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, null, null, true, httpHeaders, "downloadUrl",
             false, "crypter");
 
     SegmentZKMetadata segmentZKMetadata =
@@ -78,11 +106,12 @@ public class ZKOperatorTest {
     assertEquals(segmentZKMetadata.getRefreshTime(), Long.MIN_VALUE);
     assertEquals(segmentZKMetadata.getDownloadUrl(), "downloadUrl");
     assertEquals(segmentZKMetadata.getCrypterName(), "crypter");
+    assertEquals(segmentZKMetadata.getSegmentUploadStartTime(), -1);
 
     // Refresh the segment with unmatched IF_MATCH field
     when(httpHeaders.getHeaderString(HttpHeaders.IF_MATCH)).thenReturn("123");
     try {
-      zkOperator.completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, null, null, false, httpHeaders,
+      zkOperator.completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, null, null, true, httpHeaders,
           "otherDownloadUrl", false, null);
       fail();
     } catch (Exception e) {
@@ -93,7 +122,7 @@ public class ZKOperatorTest {
     // downloadURL and crypter
     when(httpHeaders.getHeaderString(HttpHeaders.IF_MATCH)).thenReturn("12345");
     when(segmentMetadata.getIndexCreationTime()).thenReturn(456L);
-    zkOperator.completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, null, null, false, httpHeaders,
+    zkOperator.completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, null, null, true, httpHeaders,
         "otherDownloadUrl", false, "otherCrypter");
     segmentZKMetadata =
         ControllerTestUtils.getHelixResourceManager().getSegmentZKMetadata(OFFLINE_TABLE_NAME, SEGMENT_NAME);
@@ -107,6 +136,7 @@ public class ZKOperatorTest {
     // DownloadURL and crypter should not unchanged
     assertEquals(segmentZKMetadata.getDownloadUrl(), "downloadUrl");
     assertEquals(segmentZKMetadata.getCrypterName(), "crypter");
+    assertEquals(segmentZKMetadata.getSegmentUploadStartTime(), -1);
 
     // Refresh the segment with a different segment (different CRC)
     when(segmentMetadata.getCrc()).thenReturn("23456");
@@ -115,7 +145,7 @@ public class ZKOperatorTest {
     // 1 second delay to avoid "org.apache.helix.HelixException: Specified EXTERNALVIEW operatorTestTable_OFFLINE is
     // not found!" exception from being thrown sporadically.
     Thread.sleep(1000L);
-    zkOperator.completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, null, null, false, httpHeaders,
+    zkOperator.completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, null, null, true, httpHeaders,
         "otherDownloadUrl", false, "otherCrypter");
     segmentZKMetadata =
         ControllerTestUtils.getHelixResourceManager().getSegmentZKMetadata(OFFLINE_TABLE_NAME, SEGMENT_NAME);

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -57,6 +57,7 @@ import org.apache.pinot.plugin.inputformat.avro.AvroRecordExtractor;
 import org.apache.pinot.plugin.inputformat.avro.AvroUtils;
 import org.apache.pinot.server.starter.helix.DefaultHelixStarterServerConfig;
 import org.apache.pinot.server.starter.helix.HelixServerStarter;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordExtractor;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -414,6 +415,53 @@ public abstract class ClusterTest extends ControllerTest {
               return uploadSegmentWithOnlyMetadata(tableName, uploadSegmentHttpURI, fileUploadDownloadClient,
                   segmentTarFile);
             }
+          }));
+        }
+        executorService.shutdown();
+        for (Future<Integer> future : futures) {
+          assertEquals((int) future.get(), HttpStatus.SC_OK);
+        }
+      }
+    }
+  }
+
+  /**
+   * tarDirPaths contains a list of directories that contain segment files. API uploads all segments inside the given
+   * list of directories to the cluster.
+   *
+   * @param tarDirPaths List of directories containing segments
+   */
+  protected void uploadSegments(String tableName, List<File> tarDirPaths, TableType tableType,
+      boolean enableParallelPushProtection)
+      throws Exception {
+    List<File> segmentTarFiles = new ArrayList<>();
+
+    for (File tarDir : tarDirPaths) {
+      Collections.addAll(segmentTarFiles, tarDir.listFiles());
+    }
+    assertNotNull(segmentTarFiles);
+    int numSegments = segmentTarFiles.size();
+    assertTrue(numSegments > 0);
+
+    URI uploadSegmentHttpURI = FileUploadDownloadClient.getUploadSegmentHttpURI(LOCAL_HOST, _controllerPort);
+    try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient()) {
+      if (numSegments == 1) {
+        File segmentTarFile = segmentTarFiles.get(0);
+        assertEquals(fileUploadDownloadClient
+                .uploadSegment(uploadSegmentHttpURI, segmentTarFile.getName(), segmentTarFile, tableName,
+                    tableType.OFFLINE, enableParallelPushProtection)
+                .getStatusCode(),
+            HttpStatus.SC_OK);
+      } else {
+        // Upload all segments in parallel
+        ExecutorService executorService = Executors.newFixedThreadPool(numSegments);
+        List<Future<Integer>> futures = new ArrayList<>(numSegments);
+        for (File segmentTarFile : segmentTarFiles) {
+          futures.add(executorService.submit(() -> {
+            return fileUploadDownloadClient
+                .uploadSegment(uploadSegmentHttpURI, segmentTarFile.getName(), segmentTarFile, tableName,
+                    tableType.OFFLINE, enableParallelPushProtection)
+                .getStatusCode();
           }));
         }
         executorService.shutdown();


### PR DESCRIPTION
The current implementation doesn't protect against concurrent `UploadSegment` calls for a non-existing segment.

The current implementation of `processNewSegment` in `ZKOperator` is as follows:

- Move segment to permanent directory
- Set SegmentZkMetadata
- AssignTableSegments
- Update customZkMetadata map

Assume there are two concurrent uploadSegment calls for the same non-existing segment:

- Calls C1 and C2 will try to move to permanent directory. There could be a race here and either C1 or C2 can win. Additionally, move() implementation in PinotFS is not atomic.

- Now, only one of C1 and C2 can set SegmentZkMetadata. This is guaranteed in today's code because updates to Zk are made atomic with expectedVersion as -1 so only one of C1 or C2 will end up creating the ZNode for non-existing segment. But there is no guarantee that the call that succeeded to move the segment to permanent location sets the Zk metadata.

To fix this issue, `enableParallelPushProtection` can be extended to protect against concurrent calls when uploading non-existent segments as well.

Made the following changes:

- Added locking to `processNewSegment` in `ZKOperator` codepath if enableParallelPushProtection is enabled.
- Reordered code so that "MoveSegmentToFinalLocation", AssignTableSegments, customZkMetadata map update is done within the lock.
- Enhanced exception handling to clean up segmentZkMetadata and stale segments in permanent directory.

Testing:

- Unit test verifying that lock is released after upload when enableParallelPushProtection=true for non-existing segments.
- Unit test verifying that segmentZkMetadata is cleaned up if exception is raised.
- Integration test uploading concurrent segments with the same name.
