### PR TITLE
check cron schedules from table configs after subscribing child changes

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -29,6 +29,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
+import org.I0Itec.zkclient.IZkChildListener;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.helix.AccessOption;
 import org.apache.helix.task.TaskState;
 import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMeter;
@@ -88,6 +91,8 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
   private final Map<String, TaskTypeMetricsUpdater> _taskTypeMetricsUpdaterMap = new ConcurrentHashMap<>();
   private final Map<TaskState, Integer> _taskStateToCountMap = new ConcurrentHashMap<>();
 
+  private final ZkTableConfigChangeListener _zkTableConfigChangeListener = new ZkTableConfigChangeListener();
+
   public PinotTaskManager(PinotHelixTaskResourceManager helixTaskResourceManager,
       PinotHelixResourceManager helixResourceManager, LeadControllerManager leadControllerManager,
       ControllerConf controllerConf, ControllerMetrics controllerMetrics) {
@@ -104,39 +109,59 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       try {
         _scheduler = new StdSchedulerFactory().getScheduler();
         _scheduler.start();
-        LOGGER.info("Subscribe to tables change under PropertyStore path: {}", TABLE_CONFIG_PARENT_PATH);
-        _pinotHelixResourceManager.getPropertyStore().subscribeChildChanges(TABLE_CONFIG_PARENT_PATH,
-            (parentPath, tables) -> {
-              if (_tableTaskSchedulerUpdaterMap.isEmpty()) {
-                // Initial setup
-                for (String tableNameWithType : tables) {
-                  subscribeTableConfigChanges(tableNameWithType);
-                }
-              } else {
-                Set<String> existingTables = new HashSet<>(_tableTaskSchedulerUpdaterMap.keySet());
-                Set<String> tablesToAdd = new HashSet<>();
-                for (String tableNameWithType : tables) {
-                  if (!existingTables.remove(tableNameWithType)) {
-                    tablesToAdd.add(tableNameWithType);
-                  }
-                }
-                for (String tableNameWithType : tablesToAdd) {
-                  subscribeTableConfigChanges(tableNameWithType);
-                }
-                if (!existingTables.isEmpty()) {
-                  LOGGER.info("Found tables to clean up cron task scheduler: {}", existingTables);
-                  for (String tableNameWithType : existingTables) {
-                    cleanUpCronTaskSchedulerForTable(tableNameWithType);
-                  }
-                }
-              }
-            });
+        synchronized (_zkTableConfigChangeListener) {
+          // Subscribe child changes before reading the data to avoid missing changes
+          LOGGER.info("Check and subscribe to tables change under PropertyStore path: {}", TABLE_CONFIG_PARENT_PATH);
+          _pinotHelixResourceManager.getPropertyStore()
+              .subscribeChildChanges(TABLE_CONFIG_PARENT_PATH, _zkTableConfigChangeListener);
+          List<String> tables = _pinotHelixResourceManager.getPropertyStore()
+              .getChildNames(TABLE_CONFIG_PARENT_PATH, AccessOption.PERSISTENT);
+          if (CollectionUtils.isNotEmpty(tables)) {
+            checkTableConfigChanges(tables);
+          }
+        }
       } catch (SchedulerException e) {
         throw new RuntimeException("Caught exception while setting up the scheduler", e);
       }
     } else {
       _scheduler = null;
     }
+  }
+
+  private class ZkTableConfigChangeListener implements IZkChildListener {
+
+    @Override
+    public synchronized void handleChildChange(String path, List<String> tableNamesWithType) {
+      checkTableConfigChanges(tableNamesWithType);
+    }
+  }
+
+  private void checkTableConfigChanges(List<String> tableNamesWithType) {
+    LOGGER.info("Checking task config changes of tables: {}", tableNamesWithType);
+    if (_tableTaskSchedulerUpdaterMap.isEmpty()) {
+      // Initial setup
+      for (String tableNameWithType : tableNamesWithType) {
+        subscribeTableConfigChanges(tableNameWithType);
+      }
+    } else {
+      Set<String> existingTables = new HashSet<>(_tableTaskSchedulerUpdaterMap.keySet());
+      Set<String> tablesToAdd = new HashSet<>();
+      for (String tableNameWithType : tableNamesWithType) {
+        if (!existingTables.remove(tableNameWithType)) {
+          tablesToAdd.add(tableNameWithType);
+        }
+      }
+      for (String tableNameWithType : tablesToAdd) {
+        subscribeTableConfigChanges(tableNameWithType);
+      }
+      if (!existingTables.isEmpty()) {
+        LOGGER.info("Found tables to clean up cron task scheduler: {}", existingTables);
+        for (String tableNameWithType : existingTables) {
+          cleanUpCronTaskSchedulerForTable(tableNameWithType);
+        }
+      }
+    }
+    LOGGER.info("Checked task config changes of tables: {}", tableNamesWithType);
   }
 
   private String getPropertyStorePathForTable(String tableWithType) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.I0Itec.zkclient.IZkChildListener;
 import org.apache.commons.collections.CollectionUtils;
@@ -136,8 +137,12 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
     }
   }
 
-  private void checkTableConfigChanges(List<String> tableNamesWithType) {
-    LOGGER.info("Checking task config changes of tables: {}", tableNamesWithType);
+  private void checkTableConfigChanges(List<String> allTableNamesWithType) {
+    LOGGER.info("Checking task config changes of tables: {}", allTableNamesWithType);
+    // Just check on tables the current controller is leader for, and skip the rest.
+    List<String> tableNamesWithType =
+        allTableNamesWithType.stream().filter(_leadControllerManager::isLeaderForTable).collect(Collectors.toList());
+    LOGGER.info("Current controller is only leader for tables: {}", tableNamesWithType);
     if (_tableTaskSchedulerUpdaterMap.isEmpty()) {
       // Initial setup
       for (String tableNameWithType : tableNamesWithType) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -138,11 +138,10 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
   }
 
   private void checkTableConfigChanges(List<String> allTableNamesWithType) {
-    LOGGER.info("Checking task config changes of tables: {}", allTableNamesWithType);
+    LOGGER.info("Checking task config changes in table configs");
     // Just check on tables the current controller is leader for, and skip the rest.
     List<String> tableNamesWithType =
         allTableNamesWithType.stream().filter(_leadControllerManager::isLeaderForTable).collect(Collectors.toList());
-    LOGGER.info("Current controller is only leader for tables: {}", tableNamesWithType);
     if (_tableTaskSchedulerUpdaterMap.isEmpty()) {
       // Initial setup
       for (String tableNameWithType : tableNamesWithType) {
@@ -166,7 +165,6 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
         }
       }
     }
-    LOGGER.info("Checked task config changes of tables: {}", tableNamesWithType);
   }
 
   private String getPropertyStorePathForTable(String tableWithType) {


### PR DESCRIPTION
When controller restarts, subscribing ChildChanges events alone would miss cron schedules from the existing tables, until a new table is added or old table is dropped, when ZK ChildChanges event is triggered. 

The fix here follows the convention used in TableCache.java, i.e. looping through child nodes immediately after setting up subscriber on the ZK ChildChanges events. 

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
