### PR TITLE
Infer SDF for Timestamp in dimension field spec

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.common.utils;
 
 import java.sql.Timestamp;
+import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -131,7 +132,7 @@ public class PinotDataTypeTest {
         {LONG_ARRAY, TIMESTAMP_ARRAY, new long[] {1000000L, 2000000L},
             new Timestamp[] { new Timestamp(1000000L), new Timestamp(2000000L) }},
         {TIMESTAMP_ARRAY, TIMESTAMP_ARRAY, new Timestamp[] { new Timestamp(1000000L), new Timestamp(2000000L) },
-        new Timestamp[] { new Timestamp(1000000L), new Timestamp(2000000L) }},
+            new Timestamp[] { new Timestamp(1000000L), new Timestamp(2000000L) }},
         {BYTES_ARRAY, BYTES_ARRAY, new byte[][] { "foo".getBytes(UTF_8), "bar".getBytes(UTF_8) },
             new byte[][] { "foo".getBytes(UTF_8), "bar".getBytes(UTF_8) }}
     };
@@ -186,11 +187,14 @@ public class PinotDataTypeTest {
 
   @Test
   public void testTimestamp() {
-    Timestamp timestamp = new Timestamp(System.currentTimeMillis());
-    assertEquals(TIMESTAMP.convert(timestamp.getTime(), LONG), timestamp);
-    assertEquals(TIMESTAMP.convert(timestamp.toString(), STRING), timestamp);
-    assertEquals(TIMESTAMP.convert(timestamp.getTime(), JSON), timestamp);
-    assertEquals(TIMESTAMP.convert(timestamp.toString(), JSON), timestamp);
+    Timestamp timestamp1 = new Timestamp(System.currentTimeMillis());
+    Timestamp timestamp2 = new Timestamp(1643173200000L);
+    assertEquals(TIMESTAMP.convert(timestamp1.getTime(), LONG), timestamp1);
+    assertEquals(TIMESTAMP.convert(timestamp1.toString(), STRING), timestamp1);
+    assertEquals(TIMESTAMP.convert(timestamp1.getTime(), JSON), timestamp1);
+    assertEquals(TIMESTAMP.convert(timestamp1.toString(), JSON), timestamp1);
+    assertEquals(TIMESTAMP.convert(new SimpleDateFormat("MM/dd/yyyy").format(timestamp2), STRING),
+        timestamp2);
   }
 
   @Test


### PR DESCRIPTION
## Description

Created a way to automatically infer and convert to a `Timestamp` in the dimension field spec. See https://github.com/apache/pinot/issues/8117

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
