### PR TITLE
disallow duplicate segment name in tar file

### DIFF
--- a/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/src/test/java/org/apache/pinot/plugin/segmentwriter/filebased/FileBasedSegmentWriterTest.java
+++ b/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/src/test/java/org/apache/pinot/plugin/segmentwriter/filebased/FileBasedSegmentWriterTest.java
@@ -381,11 +381,12 @@ public class FileBasedSegmentWriterTest {
     segmentWriter.collect(getGenericRow("record7", 1616238000000L));
     segmentWriter.collect(getGenericRow("record8", 1616238000000L));
     segmentWriter.collect(getGenericRow("record9", 1616238000000L));
-    segmentWriter.flush();
-
-    // verify tar was not overwritten
-    segmentTars = _outputDir.listFiles();
-    Assert.assertEquals(segmentTars.length, 2);
+    try {
+      segmentWriter.flush();
+      Assert.fail();
+    } catch (RuntimeException e) {
+      // expected.
+    }
 
     segmentWriter.close();
     FileUtils.deleteQuietly(_outputDir);


### PR DESCRIPTION
Currently FileBasedSegmentWriter allows duplicate segment name generated when running the file generation and upload process.

This was originally designed to avoid issues such as 2 instances of the segment writer were running in the same machine and generates files duplicately. 

However this causes trouble.
1. for offline table, the duplicated segment name will be overwritten on server even though a new file name with extra timestamp is generated in the segment writer side.
2. for realtime table, this is simply broken.

This PR propose to: 
1. overwrite the local file and logs a warning when it happens if user configures it to overwrite segment.
2. throw exception when user doesn't config overwrite flag and a duplicate segment name was created.
    - also thrown meaningful error message indicating how to change the segment name generator to avoid duplicates. 