### PR TITLE
do not use Objects.hash in ExpressionContext or FunctionContext

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/ExpressionContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/ExpressionContext.java
@@ -99,7 +99,11 @@ public class ExpressionContext {
 
   @Override
   public int hashCode() {
-    return Objects.hash(_type, _value, _function);
+    int hash = 31 * 31 * _type.hashCode();
+    if (_type == Type.FUNCTION) {
+      return hash + _function.hashCode();
+    }
+    return hash + 31 * _value.hashCode();
   }
 
   @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/FunctionContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/FunctionContext.java
@@ -84,7 +84,7 @@ public class FunctionContext {
 
   @Override
   public int hashCode() {
-    return Objects.hash(_type, _functionName, _arguments);
+    return 31 * 31 * _type.hashCode() + 31 * _functionName.hashCode() + _arguments.hashCode();
   }
 
   @Override


### PR DESCRIPTION
I noticed very high allocation rate from using `ExpressionContext` as a `HashMap` key when profiling a benchmark:
<img width="1307" alt="Screenshot 2022-02-04 at 00 19 36" src="https://user-images.githubusercontent.com/16439049/152452326-2e13ce08-b3aa-4b60-9575-e7fc0b998861.png">

This is because `Objects.hash` boxes its arguments.

Computing the hash code manually reduces allocation in benchmark runs significantly:

before
```
Benchmark                                                                               (_intBaseValue)  (_numRows)  Mode  Cnt        Score          Error   Units
BenchmarkFilteredAggregations.testFilteredAggregations:·gc.alloc.rate.norm                            0     1500000  avgt    5   477029.513 ±     4265.923    B/op
BenchmarkFilteredAggregations.testNonFilteredAggregations:·gc.alloc.rate.norm                         0     1500000  avgt    5  1453348.554 ±    38671.676    B/op
```

after
```
Benchmark                                                                               (_intBaseValue)  (_numRows)  Mode  Cnt        Score          Error   Units
BenchmarkFilteredAggregations.testFilteredAggregations:·gc.alloc.rate.norm                            0     1500000  avgt    5   372573.234 ±   299663.490    B/op
BenchmarkFilteredAggregations.testNonFilteredAggregations:·gc.alloc.rate.norm                         0     1500000  avgt    5  1085451.680 ±  1751019.851    B/op
```
