### PR TITLE
Add allowRefresh option to UploadSegment

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -157,6 +157,7 @@ public class ZKMetadataProvider {
           .create(constructPropertyStorePathForSegment(tableNameWithType, segmentZKMetadata.getSegmentName()),
               segmentZKMetadata.toZNRecord(), AccessOption.PERSISTENT);
     } catch (Exception e) {
+      LOGGER.error("Caught exception while creating segmentZkMetadata for table: {}", tableNameWithType, e);
       return false;
     }
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -98,6 +98,7 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   public static class QueryParameters {
+    public static final String OVERWRITE_IF_EXISTS = "overwriteIfExists";
     public static final String ENABLE_PARALLEL_PUSH_PROTECTION = "enableParallelPushProtection";
     public static final String TABLE_NAME = "tableName";
     public static final String TABLE_TYPE = "tableType";
@@ -811,7 +812,8 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   /**
-   * Upload segment with segment file using  table name, type and enableParallelPushProtection as a request parameters.
+   * Upload segment with segment file using  table name, type, enableParallelPushProtection and overwriteIfExists as a
+   * request parameters.
    *
    * @param uri URI
    * @param segmentName Segment name
@@ -824,16 +826,19 @@ public class FileUploadDownloadClient implements Closeable {
    * @throws HttpErrorStatusException
    */
   public SimpleHttpResponse uploadSegment(URI uri, String segmentName, File segmentFile, String tableName,
-      TableType tableType, boolean enableParallelPushProtection)
+      TableType tableType, boolean enableParallelPushProtection, boolean overwriteIfExists)
       throws IOException, HttpErrorStatusException {
     NameValuePair tableNameValuePair = new BasicNameValuePair(QueryParameters.TABLE_NAME, tableName);
     NameValuePair tableTypeValuePair = new BasicNameValuePair(QueryParameters.TABLE_TYPE, tableType.name());
     NameValuePair enableParallelPushProtectionValuePair =
         new BasicNameValuePair(QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION,
             String.valueOf(enableParallelPushProtection));
+    NameValuePair overwriteIfExistsValuePair =
+        new BasicNameValuePair(QueryParameters.OVERWRITE_IF_EXISTS, String.valueOf(overwriteIfExists));
 
-    List<NameValuePair> parameters =
-        Arrays.asList(tableNameValuePair, tableTypeValuePair, enableParallelPushProtectionValuePair);
+    List<NameValuePair> parameters = Arrays
+        .asList(tableNameValuePair, tableTypeValuePair, enableParallelPushProtectionValuePair,
+            overwriteIfExistsValuePair);
     return uploadSegment(uri, segmentName, segmentFile, null, parameters, DEFAULT_SOCKET_TIMEOUT_MS);
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -98,7 +98,7 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   public static class QueryParameters {
-    public static final String OVERWRITE_IF_EXISTS = "overwriteIfExists";
+    public static final String ALLOW_REFRESH = "allowRefresh";
     public static final String ENABLE_PARALLEL_PUSH_PROTECTION = "enableParallelPushProtection";
     public static final String TABLE_NAME = "tableName";
     public static final String TABLE_TYPE = "tableType";
@@ -812,7 +812,7 @@ public class FileUploadDownloadClient implements Closeable {
   }
 
   /**
-   * Upload segment with segment file using  table name, type, enableParallelPushProtection and overwriteIfExists as a
+   * Upload segment with segment file using  table name, type, enableParallelPushProtection and allowRefresh as
    * request parameters.
    *
    * @param uri URI
@@ -821,24 +821,24 @@ public class FileUploadDownloadClient implements Closeable {
    * @param tableName Table name with or without type suffix
    * @param tableType Table type
    * @param enableParallelPushProtection enable protection against concurrent segment uploads for the same segment
+   * @param allowRefresh whether to refresh a segment if it already exists
    * @return Response
    * @throws IOException
    * @throws HttpErrorStatusException
    */
   public SimpleHttpResponse uploadSegment(URI uri, String segmentName, File segmentFile, String tableName,
-      TableType tableType, boolean enableParallelPushProtection, boolean overwriteIfExists)
+      TableType tableType, boolean enableParallelPushProtection, boolean allowRefresh)
       throws IOException, HttpErrorStatusException {
     NameValuePair tableNameValuePair = new BasicNameValuePair(QueryParameters.TABLE_NAME, tableName);
     NameValuePair tableTypeValuePair = new BasicNameValuePair(QueryParameters.TABLE_TYPE, tableType.name());
     NameValuePair enableParallelPushProtectionValuePair =
         new BasicNameValuePair(QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION,
             String.valueOf(enableParallelPushProtection));
-    NameValuePair overwriteIfExistsValuePair =
-        new BasicNameValuePair(QueryParameters.OVERWRITE_IF_EXISTS, String.valueOf(overwriteIfExists));
+    NameValuePair allowRefreshValuePair =
+        new BasicNameValuePair(QueryParameters.ALLOW_REFRESH, String.valueOf(allowRefresh));
 
     List<NameValuePair> parameters = Arrays
-        .asList(tableNameValuePair, tableTypeValuePair, enableParallelPushProtectionValuePair,
-            overwriteIfExistsValuePair);
+        .asList(tableNameValuePair, tableTypeValuePair, enableParallelPushProtectionValuePair, allowRefreshValuePair);
     return uploadSegment(uri, segmentName, segmentFile, null, parameters, DEFAULT_SOCKET_TIMEOUT_MS);
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -187,7 +187,8 @@ public class PinotSegmentUploadDownloadRestletResource {
   }
 
   private SuccessResponse uploadSegment(@Nullable String tableName, TableType tableType, FormDataMultiPart multiPart,
-      boolean enableParallelPushProtection, HttpHeaders headers, Request request, boolean moveSegmentToFinalLocation) {
+      boolean enableParallelPushProtection, HttpHeaders headers, Request request, boolean moveSegmentToFinalLocation,
+      boolean overwriteIfExists) {
     String uploadTypeStr = null;
     String crypterClassNameInHeader = null;
     String downloadUri = null;
@@ -301,7 +302,7 @@ public class PinotSegmentUploadDownloadRestletResource {
 
       // Zk operations
       completeZkOperations(enableParallelPushProtection, headers, finalSegmentFile, tableNameWithType, segmentMetadata,
-          segmentName, zkDownloadUri, moveSegmentToFinalLocation, crypterClassName);
+          segmentName, zkDownloadUri, moveSegmentToFinalLocation, crypterClassName, overwriteIfExists);
 
       return new SuccessResponse("Successfully uploaded segment: " + segmentName + " of table: " + tableNameWithType);
     } catch (WebApplicationException e) {
@@ -391,7 +392,7 @@ public class PinotSegmentUploadDownloadRestletResource {
 
   private void completeZkOperations(boolean enableParallelPushProtection, HttpHeaders headers, File uploadedSegmentFile,
       String tableNameWithType, SegmentMetadata segmentMetadata, String segmentName, String zkDownloadURI,
-      boolean moveSegmentToFinalLocation, String crypter)
+      boolean moveSegmentToFinalLocation, String crypter, boolean overwriteIfExists)
       throws Exception {
     String basePath = ControllerFilePathProvider.getInstance().getDataDirURI().toString();
     String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
@@ -399,7 +400,8 @@ public class PinotSegmentUploadDownloadRestletResource {
     ZKOperator zkOperator = new ZKOperator(_pinotHelixResourceManager, _controllerConf, _controllerMetrics);
     zkOperator
         .completeSegmentOperations(tableNameWithType, segmentMetadata, finalSegmentLocationURI, uploadedSegmentFile,
-            enableParallelPushProtection, headers, zkDownloadURI, moveSegmentToFinalLocation, crypter);
+            enableParallelPushProtection, headers, zkDownloadURI, moveSegmentToFinalLocation, crypter,
+            overwriteIfExists);
   }
 
   private void decryptFile(String crypterClassName, File tempEncryptedFile, File tempDecryptedFile) {
@@ -431,12 +433,14 @@ public class PinotSegmentUploadDownloadRestletResource {
       @DefaultValue("OFFLINE") String tableType,
       @ApiParam(value = "Whether to enable parallel push protection") @DefaultValue("false")
       @QueryParam(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION)
-          boolean enableParallelPushProtection, @Context HttpHeaders headers, @Context Request request,
-      @Suspended final AsyncResponse asyncResponse) {
+          boolean enableParallelPushProtection,
+      @ApiParam(value = "Whether to overwrite if segment already exists") @DefaultValue("true")
+      @QueryParam(FileUploadDownloadClient.QueryParameters.OVERWRITE_IF_EXISTS) boolean overwriteIfExists,
+      @Context HttpHeaders headers, @Context Request request, @Suspended final AsyncResponse asyncResponse) {
     try {
       asyncResponse.resume(
           uploadSegment(tableName, TableType.valueOf(tableType.toUpperCase()), null, enableParallelPushProtection,
-              headers, request, false));
+              headers, request, false, overwriteIfExists));
     } catch (Throwable t) {
       asyncResponse.resume(t);
     }
@@ -462,12 +466,14 @@ public class PinotSegmentUploadDownloadRestletResource {
       @DefaultValue("OFFLINE") String tableType,
       @ApiParam(value = "Whether to enable parallel push protection") @DefaultValue("false")
       @QueryParam(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION)
-          boolean enableParallelPushProtection, @Context HttpHeaders headers, @Context Request request,
-      @Suspended final AsyncResponse asyncResponse) {
+          boolean enableParallelPushProtection,
+      @ApiParam(value = "Whether to overwrite if segment already exists") @DefaultValue("true")
+      @QueryParam(FileUploadDownloadClient.QueryParameters.OVERWRITE_IF_EXISTS) boolean overwriteIfExists,
+      @Context HttpHeaders headers, @Context Request request, @Suspended final AsyncResponse asyncResponse) {
     try {
       asyncResponse.resume(
           uploadSegment(tableName, TableType.valueOf(tableType.toUpperCase()), multiPart, enableParallelPushProtection,
-              headers, request, true));
+              headers, request, true, overwriteIfExists));
     } catch (Throwable t) {
       asyncResponse.resume(t);
     }
@@ -495,12 +501,14 @@ public class PinotSegmentUploadDownloadRestletResource {
       @DefaultValue("OFFLINE") String tableType,
       @ApiParam(value = "Whether to enable parallel push protection") @DefaultValue("false")
       @QueryParam(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION)
-          boolean enableParallelPushProtection, @Context HttpHeaders headers, @Context Request request,
-      @Suspended final AsyncResponse asyncResponse) {
+          boolean enableParallelPushProtection,
+      @ApiParam(value = "Whether to overwrite if segment already exists") @DefaultValue("true")
+      @QueryParam(FileUploadDownloadClient.QueryParameters.OVERWRITE_IF_EXISTS) boolean overwriteIfExists,
+      @Context HttpHeaders headers, @Context Request request, @Suspended final AsyncResponse asyncResponse) {
     try {
       asyncResponse.resume(
           uploadSegment(tableName, TableType.valueOf(tableType.toUpperCase()), null, enableParallelPushProtection,
-              headers, request, true));
+              headers, request, true, overwriteIfExists));
     } catch (Throwable t) {
       asyncResponse.resume(t);
     }
@@ -526,12 +534,14 @@ public class PinotSegmentUploadDownloadRestletResource {
       @DefaultValue("OFFLINE") String tableType,
       @ApiParam(value = "Whether to enable parallel push protection") @DefaultValue("false")
       @QueryParam(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION)
-          boolean enableParallelPushProtection, @Context HttpHeaders headers, @Context Request request,
-      @Suspended final AsyncResponse asyncResponse) {
+          boolean enableParallelPushProtection,
+      @ApiParam(value = "Whether to overwrite if segment already exists") @DefaultValue("true")
+      @QueryParam(FileUploadDownloadClient.QueryParameters.OVERWRITE_IF_EXISTS) boolean overwriteIfExists,
+      @Context HttpHeaders headers, @Context Request request, @Suspended final AsyncResponse asyncResponse) {
     try {
       asyncResponse.resume(
           uploadSegment(tableName, TableType.valueOf(tableType.toUpperCase()), multiPart, enableParallelPushProtection,
-              headers, request, true));
+              headers, request, true, overwriteIfExists));
     } catch (Throwable t) {
       asyncResponse.resume(t);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -188,7 +188,7 @@ public class PinotSegmentUploadDownloadRestletResource {
 
   private SuccessResponse uploadSegment(@Nullable String tableName, TableType tableType, FormDataMultiPart multiPart,
       boolean enableParallelPushProtection, HttpHeaders headers, Request request, boolean moveSegmentToFinalLocation,
-      boolean overwriteIfExists) {
+      boolean allowRefresh) {
     String uploadTypeStr = null;
     String crypterClassNameInHeader = null;
     String downloadUri = null;
@@ -302,7 +302,7 @@ public class PinotSegmentUploadDownloadRestletResource {
 
       // Zk operations
       completeZkOperations(enableParallelPushProtection, headers, finalSegmentFile, tableNameWithType, segmentMetadata,
-          segmentName, zkDownloadUri, moveSegmentToFinalLocation, crypterClassName, overwriteIfExists);
+          segmentName, zkDownloadUri, moveSegmentToFinalLocation, crypterClassName, allowRefresh);
 
       return new SuccessResponse("Successfully uploaded segment: " + segmentName + " of table: " + tableNameWithType);
     } catch (WebApplicationException e) {
@@ -392,7 +392,7 @@ public class PinotSegmentUploadDownloadRestletResource {
 
   private void completeZkOperations(boolean enableParallelPushProtection, HttpHeaders headers, File uploadedSegmentFile,
       String tableNameWithType, SegmentMetadata segmentMetadata, String segmentName, String zkDownloadURI,
-      boolean moveSegmentToFinalLocation, String crypter, boolean overwriteIfExists)
+      boolean moveSegmentToFinalLocation, String crypter, boolean allowRefresh)
       throws Exception {
     String basePath = ControllerFilePathProvider.getInstance().getDataDirURI().toString();
     String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
@@ -400,8 +400,7 @@ public class PinotSegmentUploadDownloadRestletResource {
     ZKOperator zkOperator = new ZKOperator(_pinotHelixResourceManager, _controllerConf, _controllerMetrics);
     zkOperator
         .completeSegmentOperations(tableNameWithType, segmentMetadata, finalSegmentLocationURI, uploadedSegmentFile,
-            enableParallelPushProtection, headers, zkDownloadURI, moveSegmentToFinalLocation, crypter,
-            overwriteIfExists);
+            enableParallelPushProtection, headers, zkDownloadURI, moveSegmentToFinalLocation, crypter, allowRefresh);
   }
 
   private void decryptFile(String crypterClassName, File tempEncryptedFile, File tempDecryptedFile) {
@@ -434,13 +433,13 @@ public class PinotSegmentUploadDownloadRestletResource {
       @ApiParam(value = "Whether to enable parallel push protection") @DefaultValue("false")
       @QueryParam(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION)
           boolean enableParallelPushProtection,
-      @ApiParam(value = "Whether to overwrite if segment already exists") @DefaultValue("true")
-      @QueryParam(FileUploadDownloadClient.QueryParameters.OVERWRITE_IF_EXISTS) boolean overwriteIfExists,
+      @ApiParam(value = "Whether to refresh if the segment already exists") @DefaultValue("true")
+      @QueryParam(FileUploadDownloadClient.QueryParameters.ALLOW_REFRESH) boolean allowRefresh,
       @Context HttpHeaders headers, @Context Request request, @Suspended final AsyncResponse asyncResponse) {
     try {
       asyncResponse.resume(
           uploadSegment(tableName, TableType.valueOf(tableType.toUpperCase()), null, enableParallelPushProtection,
-              headers, request, false, overwriteIfExists));
+              headers, request, false, allowRefresh));
     } catch (Throwable t) {
       asyncResponse.resume(t);
     }
@@ -467,13 +466,13 @@ public class PinotSegmentUploadDownloadRestletResource {
       @ApiParam(value = "Whether to enable parallel push protection") @DefaultValue("false")
       @QueryParam(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION)
           boolean enableParallelPushProtection,
-      @ApiParam(value = "Whether to overwrite if segment already exists") @DefaultValue("true")
-      @QueryParam(FileUploadDownloadClient.QueryParameters.OVERWRITE_IF_EXISTS) boolean overwriteIfExists,
+      @ApiParam(value = "Whether to refresh if the segment already exists") @DefaultValue("true")
+      @QueryParam(FileUploadDownloadClient.QueryParameters.ALLOW_REFRESH) boolean allowRefresh,
       @Context HttpHeaders headers, @Context Request request, @Suspended final AsyncResponse asyncResponse) {
     try {
       asyncResponse.resume(
           uploadSegment(tableName, TableType.valueOf(tableType.toUpperCase()), multiPart, enableParallelPushProtection,
-              headers, request, true, overwriteIfExists));
+              headers, request, true, allowRefresh));
     } catch (Throwable t) {
       asyncResponse.resume(t);
     }
@@ -502,13 +501,13 @@ public class PinotSegmentUploadDownloadRestletResource {
       @ApiParam(value = "Whether to enable parallel push protection") @DefaultValue("false")
       @QueryParam(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION)
           boolean enableParallelPushProtection,
-      @ApiParam(value = "Whether to overwrite if segment already exists") @DefaultValue("true")
-      @QueryParam(FileUploadDownloadClient.QueryParameters.OVERWRITE_IF_EXISTS) boolean overwriteIfExists,
+      @ApiParam(value = "Whether to refresh if the segment already exists") @DefaultValue("true")
+      @QueryParam(FileUploadDownloadClient.QueryParameters.ALLOW_REFRESH) boolean allowRefresh,
       @Context HttpHeaders headers, @Context Request request, @Suspended final AsyncResponse asyncResponse) {
     try {
       asyncResponse.resume(
           uploadSegment(tableName, TableType.valueOf(tableType.toUpperCase()), null, enableParallelPushProtection,
-              headers, request, true, overwriteIfExists));
+              headers, request, true, allowRefresh));
     } catch (Throwable t) {
       asyncResponse.resume(t);
     }
@@ -535,13 +534,13 @@ public class PinotSegmentUploadDownloadRestletResource {
       @ApiParam(value = "Whether to enable parallel push protection") @DefaultValue("false")
       @QueryParam(FileUploadDownloadClient.QueryParameters.ENABLE_PARALLEL_PUSH_PROTECTION)
           boolean enableParallelPushProtection,
-      @ApiParam(value = "Whether to overwrite if segment already exists") @DefaultValue("true")
-      @QueryParam(FileUploadDownloadClient.QueryParameters.OVERWRITE_IF_EXISTS) boolean overwriteIfExists,
+      @ApiParam(value = "Whether to refresh if the segment already exists") @DefaultValue("true")
+      @QueryParam(FileUploadDownloadClient.QueryParameters.ALLOW_REFRESH) boolean allowRefresh,
       @Context HttpHeaders headers, @Context Request request, @Suspended final AsyncResponse asyncResponse) {
     try {
       asyncResponse.resume(
           uploadSegment(tableName, TableType.valueOf(tableType.toUpperCase()), multiPart, enableParallelPushProtection,
-              headers, request, true, overwriteIfExists));
+              headers, request, true, allowRefresh));
     } catch (Throwable t) {
       asyncResponse.resume(t);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
@@ -61,7 +61,7 @@ public class ZKOperator {
   public void completeSegmentOperations(String tableNameWithType, SegmentMetadata segmentMetadata,
       URI finalSegmentLocationURI, File currentSegmentLocation, boolean enableParallelPushProtection,
       HttpHeaders headers, String zkDownloadURI, boolean moveSegmentToFinalLocation, String crypter,
-      boolean overwriteIfExists)
+      boolean allowRefresh)
       throws Exception {
     String segmentName = segmentMetadata.getName();
     ZNRecord segmentMetadataZNRecord =
@@ -82,12 +82,12 @@ public class ZKOperator {
 
     // We reach here if a segment with the same name already exists.
 
-    if (!overwriteIfExists) {
+    if (!allowRefresh) {
       // We cannot perform this check up-front in UploadSegment API call. If a segment doesn't exist during the check
-      // done up-front but ends up getting created before the check here, we could incorrectly overwrite an existing
+      // done up-front but ends up getting created before the check here, we could incorrectly refresh an existing
       // segment.
       throw new ControllerApplicationException(LOGGER,
-          "Segment: " + segmentName + " already exists in table: " + tableNameWithType + ". Overwrite not permitted.",
+          "Segment: " + segmentName + " already exists in table: " + tableNameWithType + ". Refresh not permitted.",
           Response.Status.CONFLICT);
     }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1796,13 +1796,13 @@ public class PinotHelixResourceManager {
   }
 
   /**
-   * Construct segmentZkMetadata for the realtime or offline table.
+   * Construct segmentZkMetadata for new segment of offline or realtime table.
    *
-   * @param tableNameWithType
-   * @param segmentMetadata
-   * @param downloadUrl
-   * @param crypter
-   * @return
+   * @param tableNameWithType Table name with type
+   * @param segmentMetadata Segment metadata
+   * @param downloadUrl Download URL
+   * @param crypter Crypter
+   * @return SegmentZkMetadata of the input segment
    */
   public SegmentZKMetadata constructZkMetadataForNewSegment(String tableNameWithType, SegmentMetadata segmentMetadata,
       String downloadUrl, @Nullable String crypter) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/upload/ZKOperatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/upload/ZKOperatorTest.java
@@ -108,7 +108,7 @@ public class ZKOperatorTest {
     assertEquals(segmentZKMetadata.getCrypterName(), "crypter");
     assertEquals(segmentZKMetadata.getSegmentUploadStartTime(), -1);
 
-    // Upload the same segment with overwriteIfExists = false. Validate that an exception is thrown.
+    // Upload the same segment with allowRefresh = false. Validate that an exception is thrown.
     try {
       zkOperator.completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, null, null, false, httpHeaders,
           "otherDownloadUrl", false, "otherCrypter", false);

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -449,7 +449,7 @@ public abstract class ClusterTest extends ControllerTest {
         File segmentTarFile = segmentTarFiles.get(0);
         assertEquals(fileUploadDownloadClient
                 .uploadSegment(uploadSegmentHttpURI, segmentTarFile.getName(), segmentTarFile, tableName,
-                    tableType.OFFLINE, enableParallelPushProtection)
+                    tableType.OFFLINE, enableParallelPushProtection, true)
                 .getStatusCode(),
             HttpStatus.SC_OK);
       } else {
@@ -460,7 +460,7 @@ public abstract class ClusterTest extends ControllerTest {
           futures.add(executorService.submit(() -> {
             return fileUploadDownloadClient
                 .uploadSegment(uploadSegmentHttpURI, segmentTarFile.getName(), segmentTarFile, tableName,
-                    tableType.OFFLINE, enableParallelPushProtection)
+                    tableType.OFFLINE, enableParallelPushProtection, true)
                 .getStatusCode();
           }));
         }


### PR DESCRIPTION
Currently, when a segment is uploaded, we always overwrite if a
segment with the same name already exists. Having an overwrite
parameter in the UploadSegment API will give clients finer
control during uploading segments.

Note that the default value is set to true to retain existing
behavior.

