### PR TITLE
Fixing TraceContext NPE issue

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/util/trace/TraceContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/trace/TraceContext.java
@@ -137,7 +137,10 @@ public final class TraceContext {
   static void registerThreadToRequest(TraceEntry parentTraceEntry) {
     Trace trace = new Trace(parentTraceEntry._trace);
     TRACE_ENTRY_THREAD_LOCAL.set(new TraceEntry(parentTraceEntry._requestId, trace));
-    REQUEST_TO_TRACES_MAP.get(parentTraceEntry._requestId).add(trace);
+    Queue<Trace> traces = REQUEST_TO_TRACES_MAP.get(parentTraceEntry._requestId);
+    if (traces != null) {
+      traces.add(trace);
+    }
   }
 
   /**


### PR DESCRIPTION
## Description
When query timed out it's possible that one thread tries to register the trace after the request is already unregistered. So need to check null before putting the trace.

Sample stacktrace:
```
2022/02/04 00:01:06.604 ERROR [ServerQueryExecutorV1Impl] [pqr-7] Exception processing requestId 1193
java.lang.RuntimeException: Caught exception while running CombinePlanNode.
        at org.apache.pinot.core.plan.CombinePlanNode.run(CombinePlanNode.java:164) 
        at org.apache.pinot.core.plan.InstanceResponsePlanNode.run(InstanceResponsePlanNode.java:41) 
        at org.apache.pinot.core.plan.GlobalPlanImplV0.execute(GlobalPlanImplV0.java:45) 
        at org.apache.pinot.core.query.executor.ServerQueryExecutorV1Impl.processQuery(ServerQueryExecutorV1Impl.java:290) 
        at org.apache.pinot.core.query.executor.ServerQueryExecutorV1Impl.processQuery(ServerQueryExecutorV1Impl.java:192) 
        at org.apache.pinot.core.query.executor.QueryExecutor.processQuery(QueryExecutor.java:60) 
        at org.apache.pinot.core.query.scheduler.QueryScheduler.processQueryAndSerialize(QueryScheduler.java:154) 
        at org.apache.pinot.core.query.scheduler.QueryScheduler.lambda$createQueryFutureTask$0(QueryScheduler.java:138) 
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
        at shaded.com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:111)
        at shaded.com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:58)
        at shaded.com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:75)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:829) [?:?]
Caused by: java.util.concurrent.ExecutionException: java.lang.NullPointerException
        at java.util.concurrent.FutureTask.report(FutureTask.java:122) ~[?:?]
        at java.util.concurrent.FutureTask.get(FutureTask.java:205) ~[?:?]
5:10
        at org.apache.pinot.core.plan.CombinePlanNode.run(CombinePlanNode.java:154) 
        ... 15 more
Caused by: java.lang.NullPointerException
        at org.apache.pinot.core.util.trace.TraceContext.registerThreadToRequest(TraceContext.java:140) 
        at org.apache.pinot.core.util.trace.TraceCallable.call(TraceCallable.java:41) 
        ... 8 more
```

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
