### PR TITLE
Storage quota checker NPE for Dimension Tables

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidator.java
@@ -115,7 +115,7 @@ public class SegmentValidator {
     TableSizeReader tableSizeReader =
         new TableSizeReader(_executor, _connectionManager, _controllerMetrics, _pinotHelixResourceManager);
     StorageQuotaChecker quotaChecker =
-        new StorageQuotaChecker(offlineTableConfig, tableSizeReader, _controllerMetrics, _isLeaderForTable);
+        new StorageQuotaChecker(offlineTableConfig, tableSizeReader, _controllerMetrics, _isLeaderForTable, _pinotHelixResourceManager);
     return quotaChecker.isSegmentStorageWithinQuota(metadata.getName(), FileUtils.sizeOfDirectory(segmentFile),
         _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidator.java
@@ -114,8 +114,8 @@ public class SegmentValidator {
     }
     TableSizeReader tableSizeReader =
         new TableSizeReader(_executor, _connectionManager, _controllerMetrics, _pinotHelixResourceManager);
-    StorageQuotaChecker quotaChecker =
-        new StorageQuotaChecker(offlineTableConfig, tableSizeReader, _controllerMetrics, _isLeaderForTable, _pinotHelixResourceManager);
+    StorageQuotaChecker quotaChecker = new StorageQuotaChecker(offlineTableConfig, tableSizeReader,
+        _controllerMetrics, _isLeaderForTable, _pinotHelixResourceManager);
     return quotaChecker.isSegmentStorageWithinQuota(metadata.getName(), FileUtils.sizeOfDirectory(segmentFile),
         _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/StorageQuotaChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/StorageQuotaChecker.java
@@ -49,11 +49,13 @@ public class StorageQuotaChecker {
   private final boolean _isLeaderForTable;
 
   public StorageQuotaChecker(TableConfig tableConfig, TableSizeReader tableSizeReader,
-      ControllerMetrics controllerMetrics, boolean isLeaderForTable) {
+      ControllerMetrics controllerMetrics, boolean isLeaderForTable,
+      PinotHelixResourceManager pinotHelixResourceManager) {
     _tableConfig = tableConfig;
     _tableSizeReader = tableSizeReader;
     _controllerMetrics = controllerMetrics;
     _isLeaderForTable = isLeaderForTable;
+    _pinotHelixResourceManager = pinotHelixResourceManager;
   }
 
   public static class QuotaCheckerResponse {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/validation/StorageQuotaCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/validation/StorageQuotaCheckerTest.java
@@ -29,7 +29,6 @@ import org.apache.pinot.spi.config.table.QuotaConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
@@ -46,38 +45,96 @@ public class StorageQuotaCheckerTest {
   private static final int NUM_REPLICAS = 2;
 
   private TableSizeReader _tableSizeReader;
-  private TableConfig _tableConfig;
-  private ControllerMetrics _controllerMetrics;
   private StorageQuotaChecker _storageQuotaChecker;
-
-  @BeforeClass
-  public void setUp() {
-    _tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(OFFLINE_TABLE_NAME).setNumReplicas(NUM_REPLICAS).build();
-    _tableSizeReader = mock(TableSizeReader.class);
-    _controllerMetrics = new ControllerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
-    _storageQuotaChecker = new StorageQuotaChecker(_tableConfig, _tableSizeReader, _controllerMetrics, true,
-        mock(PinotHelixResourceManager.class));
-  }
-
-  private boolean isSegmentWithinQuota()
-      throws InvalidConfigException {
-    return _storageQuotaChecker
-        .isSegmentStorageWithinQuota(SEGMENT_NAME, SEGMENT_SIZE_IN_BYTES, 1000)._isSegmentWithinQuota;
-  }
 
   @Test
   public void testNoQuota()
       throws InvalidConfigException {
-    _tableConfig.setQuotaConfig(null);
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(OFFLINE_TABLE_NAME).setNumReplicas(NUM_REPLICAS).build();
+    _tableSizeReader = mock(TableSizeReader.class);
+    ControllerMetrics controllerMetrics = new ControllerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+    _storageQuotaChecker = new StorageQuotaChecker(tableConfig, _tableSizeReader, controllerMetrics, true,
+        mock(PinotHelixResourceManager.class));
+    tableConfig.setQuotaConfig(null);
+    assertTrue(isSegmentWithinQuota());
+  }
+
+  @Test
+  public void testDimensionTable()
+      throws InvalidConfigException {
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setIsDimTable(true).setTableName(OFFLINE_TABLE_NAME)
+            .setNumReplicas(NUM_REPLICAS).build();
+    _tableSizeReader = mock(TableSizeReader.class);
+    ControllerMetrics controllerMetrics = new ControllerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+    _storageQuotaChecker = new StorageQuotaChecker(tableConfig, _tableSizeReader, controllerMetrics, true,
+        mock(PinotHelixResourceManager.class));
+    tableConfig.setQuotaConfig(null);
     assertTrue(isSegmentWithinQuota());
   }
 
   @Test
   public void testNoStorageQuotaConfig()
       throws InvalidConfigException {
-    _tableConfig.setQuotaConfig(new QuotaConfig(null, null));
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(OFFLINE_TABLE_NAME).setNumReplicas(NUM_REPLICAS).build();
+    _tableSizeReader = mock(TableSizeReader.class);
+    ControllerMetrics controllerMetrics  = new ControllerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+    _storageQuotaChecker = new StorageQuotaChecker(tableConfig, _tableSizeReader, controllerMetrics, true,
+        mock(PinotHelixResourceManager.class));
+    tableConfig.setQuotaConfig(new QuotaConfig(null, null));
     assertTrue(isSegmentWithinQuota());
+  }
+
+  @Test
+  public void testWithinQuota()
+      throws InvalidConfigException {
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(OFFLINE_TABLE_NAME).setNumReplicas(NUM_REPLICAS).build();
+    _tableSizeReader = mock(TableSizeReader.class);
+    ControllerMetrics controllerMetrics = new ControllerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+    _storageQuotaChecker = new StorageQuotaChecker(tableConfig, _tableSizeReader, controllerMetrics, true,
+        mock(PinotHelixResourceManager.class));
+    tableConfig.setQuotaConfig(new QuotaConfig("2.8K", null));
+
+    // No response from server, should pass without updating metrics
+    mockTableSizeResult(-1, 0);
+    assertTrue(isSegmentWithinQuota());
+    assertEquals(
+        controllerMetrics.getValueOfTableGauge(OFFLINE_TABLE_NAME, ControllerGauge.OFFLINE_TABLE_ESTIMATED_SIZE), 0);
+
+    // Within quota but with missing segments, should pass without updating metrics
+    mockTableSizeResult(4 * 1024, 1);
+    assertTrue(isSegmentWithinQuota());
+    assertEquals(
+        controllerMetrics.getValueOfTableGauge(OFFLINE_TABLE_NAME, ControllerGauge.OFFLINE_TABLE_ESTIMATED_SIZE), 0);
+
+    // Exceed quota and with missing segments, should fail without updating metrics
+    mockTableSizeResult(8 * 1024, 1);
+    assertFalse(isSegmentWithinQuota());
+    assertEquals(
+        controllerMetrics.getValueOfTableGauge(OFFLINE_TABLE_NAME, ControllerGauge.OFFLINE_TABLE_ESTIMATED_SIZE), 0);
+
+    // Within quota without missing segments, should pass and update metrics
+    mockTableSizeResult(3 * 1024, 0);
+    assertTrue(isSegmentWithinQuota());
+    assertEquals(
+        controllerMetrics.getValueOfTableGauge(OFFLINE_TABLE_NAME, ControllerGauge.OFFLINE_TABLE_ESTIMATED_SIZE),
+        3 * 1024);
+
+    // Exceed quota without missing segments, should fail and update metrics
+    mockTableSizeResult(4 * 1024, 0);
+    assertFalse(isSegmentWithinQuota());
+    assertEquals(
+        controllerMetrics.getValueOfTableGauge(OFFLINE_TABLE_NAME, ControllerGauge.OFFLINE_TABLE_ESTIMATED_SIZE),
+        4 * 1024);
+  }
+
+  private boolean isSegmentWithinQuota()
+      throws InvalidConfigException {
+    return _storageQuotaChecker
+        .isSegmentStorageWithinQuota(SEGMENT_NAME, SEGMENT_SIZE_IN_BYTES, 1000)._isSegmentWithinQuota;
   }
 
   public void mockTableSizeResult(long tableSizeInBytes, int numMissingSegments)
@@ -87,43 +144,5 @@ public class StorageQuotaCheckerTest {
     tableSizeResult._segments = Collections.emptyMap();
     tableSizeResult._missingSegments = numMissingSegments;
     when(_tableSizeReader.getTableSubtypeSize(OFFLINE_TABLE_NAME, 1000)).thenReturn(tableSizeResult);
-  }
-
-  @Test
-  public void testWithinQuota()
-      throws InvalidConfigException {
-    _tableConfig.setQuotaConfig(new QuotaConfig("2.8K", null));
-
-    // No response from server, should pass without updating metrics
-    mockTableSizeResult(-1, 0);
-    assertTrue(isSegmentWithinQuota());
-    assertEquals(
-        _controllerMetrics.getValueOfTableGauge(OFFLINE_TABLE_NAME, ControllerGauge.OFFLINE_TABLE_ESTIMATED_SIZE), 0);
-
-    // Within quota but with missing segments, should pass without updating metrics
-    mockTableSizeResult(4 * 1024, 1);
-    assertTrue(isSegmentWithinQuota());
-    assertEquals(
-        _controllerMetrics.getValueOfTableGauge(OFFLINE_TABLE_NAME, ControllerGauge.OFFLINE_TABLE_ESTIMATED_SIZE), 0);
-
-    // Exceed quota and with missing segments, should fail without updating metrics
-    mockTableSizeResult(8 * 1024, 1);
-    assertFalse(isSegmentWithinQuota());
-    assertEquals(
-        _controllerMetrics.getValueOfTableGauge(OFFLINE_TABLE_NAME, ControllerGauge.OFFLINE_TABLE_ESTIMATED_SIZE), 0);
-
-    // Within quota without missing segments, should pass and update metrics
-    mockTableSizeResult(3 * 1024, 0);
-    assertTrue(isSegmentWithinQuota());
-    assertEquals(
-        _controllerMetrics.getValueOfTableGauge(OFFLINE_TABLE_NAME, ControllerGauge.OFFLINE_TABLE_ESTIMATED_SIZE),
-        3 * 1024);
-
-    // Exceed quota without missing segments, should fail and update metrics
-    mockTableSizeResult(4 * 1024, 0);
-    assertFalse(isSegmentWithinQuota());
-    assertEquals(
-        _controllerMetrics.getValueOfTableGauge(OFFLINE_TABLE_NAME, ControllerGauge.OFFLINE_TABLE_ESTIMATED_SIZE),
-        4 * 1024);
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/validation/StorageQuotaCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/validation/StorageQuotaCheckerTest.java
@@ -23,6 +23,7 @@ import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.metrics.PinotMetricUtils;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.TableSizeReader;
 import org.apache.pinot.spi.config.table.QuotaConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -55,7 +56,8 @@ public class StorageQuotaCheckerTest {
         new TableConfigBuilder(TableType.OFFLINE).setTableName(OFFLINE_TABLE_NAME).setNumReplicas(NUM_REPLICAS).build();
     _tableSizeReader = mock(TableSizeReader.class);
     _controllerMetrics = new ControllerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
-    _storageQuotaChecker = new StorageQuotaChecker(_tableConfig, _tableSizeReader, _controllerMetrics, true);
+    _storageQuotaChecker = new StorageQuotaChecker(_tableConfig, _tableSizeReader, _controllerMetrics, true,
+        mock(PinotHelixResourceManager.class));
   }
 
   private boolean isSegmentWithinQuota()

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/validation/StorageQuotaCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/validation/StorageQuotaCheckerTest.java
@@ -80,7 +80,7 @@ public class StorageQuotaCheckerTest {
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(OFFLINE_TABLE_NAME).setNumReplicas(NUM_REPLICAS).build();
     _tableSizeReader = mock(TableSizeReader.class);
-    ControllerMetrics controllerMetrics  = new ControllerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+    ControllerMetrics controllerMetrics = new ControllerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
     _storageQuotaChecker = new StorageQuotaChecker(tableConfig, _tableSizeReader, controllerMetrics, true,
         mock(PinotHelixResourceManager.class));
     tableConfig.setQuotaConfig(new QuotaConfig(null, null));


### PR DESCRIPTION
Fixes a null pointer exception on https://github.com/apache/pinot/blob/master/pinot-controller/src/main/java/org/apache/pinot/controller/validation/StorageQuotaChecker.java#L95 because the Helix Resource Manager isn't initialised. That then stops dimension tables from being uploaded. 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
