### PR TITLE
Refresh ZK metadata when dimension table is updated

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTable.java
@@ -29,30 +29,29 @@ import org.apache.pinot.spi.data.readers.PrimaryKey;
 
 class DimensionTable {
 
-  private Map<PrimaryKey, GenericRow> _lookupTable = new HashMap<>();
-  private Schema _tableSchema;
-  private List<String> _primaryKeyColumns;
+  private final Map<PrimaryKey, GenericRow> _lookupTable;
+  private final Schema _tableSchema;
+  private final List<String> _primaryKeyColumns;
 
-  public void populate(Schema tableSchema, List<String> primaryKeyColumns) {
-    _tableSchema = tableSchema;
-    _primaryKeyColumns = primaryKeyColumns;
+  DimensionTable(Schema tableSchema, List<String> primaryKeyColumns) {
+    this(tableSchema, primaryKeyColumns, new HashMap<>());
   }
 
-  public void populate(Map<PrimaryKey, GenericRow> lookupTable, Schema tableSchema, List<String> primaryKeyColumns) {
+  DimensionTable(Schema tableSchema, List<String> primaryKeyColumns, Map<PrimaryKey, GenericRow> lookupTable) {
     _lookupTable = lookupTable;
     _tableSchema = tableSchema;
     _primaryKeyColumns = primaryKeyColumns;
   }
 
-  public List<String> getPrimaryKeyColumns() {
+  List<String> getPrimaryKeyColumns() {
     return _primaryKeyColumns;
   }
 
-  public GenericRow get(PrimaryKey pk) {
+  GenericRow get(PrimaryKey pk) {
     return _lookupTable.get(pk);
   }
 
-  public FieldSpec getFieldSpecFor(String columnName) {
+  FieldSpec getFieldSpecFor(String columnName) {
     return _tableSchema.getFieldSpecFor(columnName);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTable.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.data.manager.offline;
 
 import java.util.HashMap;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTable.java
@@ -1,0 +1,40 @@
+package org.apache.pinot.core.data.manager.offline;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.PrimaryKey;
+
+
+class DimensionTable {
+
+  private Map<PrimaryKey, GenericRow> _lookupTable = new HashMap<>();
+  private Schema _tableSchema;
+  private List<String> _primaryKeyColumns;
+
+  public void populate(Schema tableSchema, List<String> primaryKeyColumns) {
+    _tableSchema = tableSchema;
+    _primaryKeyColumns = primaryKeyColumns;
+  }
+
+  public void populate(Map<PrimaryKey, GenericRow> lookupTable, Schema tableSchema, List<String> primaryKeyColumns) {
+    _lookupTable = lookupTable;
+    _tableSchema = tableSchema;
+    _primaryKeyColumns = primaryKeyColumns;
+  }
+
+  public List<String> getPrimaryKeyColumns() {
+    return _primaryKeyColumns;
+  }
+
+  public GenericRow get(PrimaryKey pk) {
+    return _lookupTable.get(pk);
+  }
+
+  public FieldSpec getFieldSpecFor(String columnName) {
+    return _tableSchema.getFieldSpecFor(columnName);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
@@ -120,19 +120,17 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
    */
   private void loadLookupTable()
       throws Exception {
-//    Map<PrimaryKey, GenericRow> snapshot;
-//    Map<PrimaryKey, GenericRow> replacement;
     DimensionTable snapshot;
     DimensionTable replacement;
     do {
       snapshot = _dimensionTable;
-      replacement = new DimensionTable();
-      populate(replacement);
+      replacement = createDimensionTable();
     } while (!UPDATER.compareAndSet(this, snapshot, replacement));
   }
 
-  private void populate(DimensionTable dimensionTable)
+  private DimensionTable createDimensionTable()
       throws Exception {
+    DimensionTable dimensionTable = new DimensionTable();
     Map<PrimaryKey, GenericRow> map = new HashMap<>();
     List<SegmentDataManager> segmentManagers = acquireAllSegments();
     try {
@@ -157,6 +155,7 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
         releaseSegment(segmentManager);
       }
     }
+    return dimensionTable;
   }
 
   public GenericRow lookupRowByPrimaryKey(PrimaryKey pk) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import javax.annotation.concurrent.ThreadSafe;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
@@ -48,6 +50,7 @@ import org.apache.pinot.spi.data.readers.PrimaryKey;
  */
 @ThreadSafe
 public class DimensionTableDataManager extends OfflineTableDataManager {
+
   // Storing singletons per table in a HashMap
   private static final Map<String, DimensionTableDataManager> INSTANCES = new ConcurrentHashMap<>();
 
@@ -73,25 +76,18 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
   }
 
   @SuppressWarnings("rawtypes")
-  private static final AtomicReferenceFieldUpdater<DimensionTableDataManager, Map> UPDATER =
-      AtomicReferenceFieldUpdater.newUpdater(DimensionTableDataManager.class, Map.class, "_lookupTable");
-  private volatile Map<PrimaryKey, GenericRow> _lookupTable = new HashMap<>();
-  private Schema _tableSchema;
-  private List<String> _primaryKeyColumns;
+  private static final AtomicReferenceFieldUpdater<DimensionTableDataManager, DimensionTable> UPDATER =
+      AtomicReferenceFieldUpdater.newUpdater(DimensionTableDataManager.class,
+          DimensionTable.class, "_dimensionTable");
+
+  private volatile DimensionTable _dimensionTable = new DimensionTable();
 
   @Override
   protected void doInit() {
     super.doInit();
-
     // dimension tables should always have schemas with primary keys
-    _tableSchema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
-    _primaryKeyColumns = _tableSchema.getPrimaryKeyColumns();
-  }
-
-  public void reloadPropertyStore() {
-    _propertyStore = _helixManager.getHelixPropertyStore();
-    _tableSchema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
-    _primaryKeyColumns = _tableSchema.getPrimaryKeyColumns();
+    Schema tableSchema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
+    _dimensionTable.populate(tableSchema, tableSchema.getPrimaryKeyColumns());
   }
 
   @Override
@@ -99,7 +95,6 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
       throws Exception {
     super.addSegment(indexDir, indexLoadingConfig);
     try {
-      reloadPropertyStore();
       loadLookupTable();
       _logger.info("Successfully added segment {} and loaded lookup table: {}", indexDir.getName(), getTableName());
     } catch (Exception e) {
@@ -111,7 +106,6 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
   public void removeSegment(String segmentName) {
     super.removeSegment(segmentName);
     try {
-      reloadPropertyStore();
       loadLookupTable();
       _logger.info("Successfully removed segment {} and reloaded lookup table: {}", segmentName, getTableName());
     } catch (Exception e) {
@@ -126,17 +120,20 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
    */
   private void loadLookupTable()
       throws Exception {
-    Map<PrimaryKey, GenericRow> snapshot;
-    Map<PrimaryKey, GenericRow> replacement;
+//    Map<PrimaryKey, GenericRow> snapshot;
+//    Map<PrimaryKey, GenericRow> replacement;
+    DimensionTable snapshot;
+    DimensionTable replacement;
     do {
-      snapshot = _lookupTable;
-      replacement = new HashMap<>(snapshot.size());
+      snapshot = _dimensionTable;
+      replacement = new DimensionTable();
       populate(replacement);
     } while (!UPDATER.compareAndSet(this, snapshot, replacement));
   }
 
-  private void populate(Map<PrimaryKey, GenericRow> map)
+  private void populate(DimensionTable dimensionTable)
       throws Exception {
+    Map<PrimaryKey, GenericRow> map = new HashMap<>();
     List<SegmentDataManager> segmentManagers = acquireAllSegments();
     try {
       for (SegmentDataManager segmentManager : segmentManagers) {
@@ -145,10 +142,16 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
             indexSegment.getSegmentMetadata().getIndexDir())) {
           while (reader.hasNext()) {
             GenericRow row = reader.next();
-            map.put(row.getPrimaryKey(_primaryKeyColumns), row);
+            map.put(row.getPrimaryKey(_dimensionTable.getPrimaryKeyColumns()), row);
           }
         }
       }
+
+      ZkHelixPropertyStore<ZNRecord> propertyStore = _helixManager.getHelixPropertyStore();
+      Schema tableSchema = ZKMetadataProvider.getTableSchema(propertyStore, _tableNameWithType);
+      List<String> primaryKeyColumns = tableSchema.getPrimaryKeyColumns();
+      dimensionTable.populate(map, tableSchema, primaryKeyColumns);
+
     } finally {
       for (SegmentDataManager segmentManager : segmentManagers) {
         releaseSegment(segmentManager);
@@ -157,14 +160,14 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
   }
 
   public GenericRow lookupRowByPrimaryKey(PrimaryKey pk) {
-    return _lookupTable.get(pk);
+    return _dimensionTable.get(pk);
   }
 
   public FieldSpec getColumnFieldSpec(String columnName) {
-    return _tableSchema.getFieldSpecFor(columnName);
+    return _dimensionTable.getFieldSpecFor(columnName);
   }
 
   public List<String> getPrimaryKeyColumns() {
-    return _primaryKeyColumns;
+    return _dimensionTable.getPrimaryKeyColumns();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
@@ -88,11 +88,18 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
     _primaryKeyColumns = _tableSchema.getPrimaryKeyColumns();
   }
 
+  public void reloadPropertyStore() {
+    _propertyStore = _helixManager.getHelixPropertyStore();
+    _tableSchema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
+    _primaryKeyColumns = _tableSchema.getPrimaryKeyColumns();
+  }
+
   @Override
   public void addSegment(File indexDir, IndexLoadingConfig indexLoadingConfig)
       throws Exception {
     super.addSegment(indexDir, indexLoadingConfig);
     try {
+      reloadPropertyStore();
       loadLookupTable();
       _logger.info("Successfully added segment {} and loaded lookup table: {}", indexDir.getName(), getTableName());
     } catch (Exception e) {
@@ -104,6 +111,7 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
   public void removeSegment(String segmentName) {
     super.removeSegment(segmentName);
     try {
+      reloadPropertyStore();
       loadLookupTable();
       _logger.info("Successfully removed segment {} and reloaded lookup table: {}", segmentName, getTableName());
     } catch (Exception e) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
@@ -100,7 +100,22 @@ public class DimensionTableDataManagerTest {
     return propertyStore;
   }
 
-  private DimensionTableDataManager makeTestableManager() {
+  private ZkHelixPropertyStore mockPropertyStoreWithNewColumn() {
+    String baseballTeamsSchemaStr =
+        "{\"schemaName\":\"dimBaseballTeams\",\"dimensionFieldSpecs\":[{\"name\":\"teamID\",\"dataType\":\"STRING\"},"
+            + "{\"name\":\"teamName\",\"dataType\":\"STRING\"}, {\"name\":\"teamCity\",\"dataType\":\"STRING\"}],"
+            + "\"primaryKeyColumns\":[\"teamID\"]}";
+    ZNRecord zkSchemaRec = new ZNRecord("dimBaseballTeams");
+    zkSchemaRec.setSimpleField("schemaJSON", baseballTeamsSchemaStr);
+
+    ZkHelixPropertyStore propertyStore = mock(ZkHelixPropertyStore.class);
+    when(propertyStore.get("/SCHEMAS/dimBaseballTeams", null, AccessOption.PERSISTENT)).
+        thenReturn(zkSchemaRec);
+
+    return propertyStore;
+  }
+
+  private DimensionTableDataManager makeTestableManager(HelixManager helixManager) {
     DimensionTableDataManager tableDataManager = DimensionTableDataManager.createInstanceByTableName(TABLE_NAME);
     TableDataManagerConfig config;
     {
@@ -109,7 +124,7 @@ public class DimensionTableDataManagerTest {
       when(config.getDataDir()).thenReturn(INDEX_DIR.getAbsolutePath());
     }
     tableDataManager.init(config, "dummyInstance", mockPropertyStore(),
-        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class), null);
+        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), helixManager, null);
     tableDataManager.start();
 
     return tableDataManager;
@@ -118,7 +133,7 @@ public class DimensionTableDataManagerTest {
   @Test
   public void instantiationTests()
       throws Exception {
-    DimensionTableDataManager mgr = makeTestableManager();
+    DimensionTableDataManager mgr = makeTestableManager(mock(HelixManager.class));
     Assert.assertEquals(mgr.getTableName(), TABLE_NAME);
 
     // fetch the same instance via static method
@@ -144,7 +159,7 @@ public class DimensionTableDataManagerTest {
   @Test
   public void lookupTests()
       throws Exception {
-    DimensionTableDataManager mgr = makeTestableManager();
+    DimensionTableDataManager mgr = makeTestableManager(mock(HelixManager.class));
 
     // try fetching data BEFORE loading segment
     GenericRow resp = mgr.lookupRowByPrimaryKey(new PrimaryKey(new String[]{"SF"}));
@@ -176,5 +191,34 @@ public class DimensionTableDataManagerTest {
     // confirm table is cleaned up
     resp = mgr.lookupRowByPrimaryKey(new PrimaryKey(new String[]{"SF"}));
     Assert.assertNull(resp, "Response should be null if no segment is loaded");
+  }
+
+  @Test
+  public void onRefreshDimensionTable()
+      throws Exception {
+    HelixManager helixManager = mock(HelixManager.class);
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mockPropertyStoreWithNewColumn();
+    when(helixManager.getHelixPropertyStore()).thenReturn(propertyStore);
+
+    DimensionTableDataManager mgr = makeTestableManager(helixManager);
+
+    mgr.addSegment(_indexDir, _indexLoadingConfig);
+
+    // Confirm table is loaded and available for lookup
+    GenericRow resp = mgr.lookupRowByPrimaryKey(new PrimaryKey(new String[]{"SF"}));
+    Assert.assertNotNull(resp, "Should return response after segment load");
+    Assert.assertEquals(resp.getValue("teamName"), "San Francisco Giants");
+
+    // WHEN
+    // Update ZK metadata to add new column and refresh segment
+
+    mgr.addSegment(_indexDir, _indexLoadingConfig);
+
+    // THEN
+    FieldSpec teamCitySpec = mgr.getColumnFieldSpec("teamCity");
+    Assert.assertNotNull(teamCitySpec, "Should return spec for existing column");
+    Assert.assertEquals(teamCitySpec.getDataType(), FieldSpec.DataType.STRING,
+        "Should return correct data type for teamCity column");
+
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
@@ -133,7 +133,10 @@ public class DimensionTableDataManagerTest {
   @Test
   public void instantiationTests()
       throws Exception {
-    DimensionTableDataManager mgr = makeTestableManager(mock(HelixManager.class));
+    HelixManager helixManager = mock(HelixManager.class);
+    ZkHelixPropertyStore propertyStore = mockPropertyStore();
+    when(helixManager.getHelixPropertyStore()).thenReturn(propertyStore);
+    DimensionTableDataManager mgr = makeTestableManager(helixManager);
     Assert.assertEquals(mgr.getTableName(), TABLE_NAME);
 
     // fetch the same instance via static method
@@ -159,7 +162,10 @@ public class DimensionTableDataManagerTest {
   @Test
   public void lookupTests()
       throws Exception {
-    DimensionTableDataManager mgr = makeTestableManager(mock(HelixManager.class));
+    HelixManager helixManager = mock(HelixManager.class);
+    ZkHelixPropertyStore propertyStore = mockPropertyStore();
+    when(helixManager.getHelixPropertyStore()).thenReturn(propertyStore);
+    DimensionTableDataManager mgr = makeTestableManager(helixManager);
 
     // try fetching data BEFORE loading segment
     GenericRow resp = mgr.lookupRowByPrimaryKey(new PrimaryKey(new String[]{"SF"}));


### PR DESCRIPTION
This PR fixes a problem where if you update a dimension table (e.g. by adding a new column and then uploading a new CSV file), the new column can't be read by the lookup function. Below is the type of error you'll see:

```
[
  {
    "message": "QueryExecutionError:\norg.apache.pinot.spi.exception.BadQueryRequestException: Caught exception while initializing transform function: lookup\n\tat org.apache.pinot.core.operator.transform.function.TransformFunctionFactory.get(TransformFunctionFactory.java:244)\n\tat org.apache.pinot.core.operator.transform.function.TransformFunctionFactory.get(TransformFunctionFactory.java:239)\n\tat org.apache.pinot.core.operator.transform.TransformOperator.<init>(TransformOperator.java:59)\n\tat org.apache.pinot.core.plan.TransformPlanNode.run(TransformPlanNode.java:71)\n...\nCaused by: java.lang.IllegalArgumentException: Column does not exist in dimension table: courses_OFFLINE:startLocation\n\tat shaded.com.google.common.base.Preconditions.checkArgument(Preconditions.java:383)\n\tat org.apache.pinot.core.operator.transform.function.LookupTransformFunction.init(LookupTransformFunction.java:125)\n\tat org.apache.pinot.core.operator.transform.function.TransformFunctionFactory.get(TransformFunctionFactory.java:242)\n\t... 20 more",
    "errorCode": 200
  }
]
```

The reason that happens is that `_propertyStore` and `_tableSchema` in `DimensionTableDataManager` don't get refreshed when the `addSegment` function gets called on the refreshing of the dimension table segment.

This PR refreshes those fields along with the cached lookup table.


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
