### PR TITLE
Streamlining

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionDefinitionRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionDefinitionRegistry.java
@@ -29,20 +29,10 @@ public class FunctionDefinitionRegistry {
   }
 
   public static boolean isAggFunc(String functionName) {
-    try {
-      AggregationFunctionType.getAggregationFunctionType(functionName);
-      return true;
-    } catch (IllegalArgumentException e) {
-      return false;
-    }
+    return AggregationFunctionType.isAggregationFunction(functionName);
   }
 
   public static boolean isTransformFunc(String functionName) {
-    try {
-      TransformFunctionType.getTransformFunctionType(functionName);
-      return true;
-    } catch (IllegalArgumentException e) {
-      return false;
-    }
+    return TransformFunctionType.isTransformFunction(functionName);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -18,6 +18,11 @@
  */
 package org.apache.pinot.common.function;
 
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+
 public enum TransformFunctionType {
   // Aggregation functions for single-valued columns
   ADD("add"),
@@ -101,10 +106,18 @@ public enum TransformFunctionType {
   // Geo indexing
   GEOTOH3("geoToH3");
 
+  private static final Set<String> NAMES = Arrays.stream(values()).map(TransformFunctionType::name)
+      .collect(Collectors.toSet());
+
   private final String _name;
 
   TransformFunctionType(String name) {
     _name = name;
+  }
+
+  public static boolean isTransformFunction(String functionName) {
+    String upperCaseFunctionName = functionName.toUpperCase();
+    return NAMES.contains(upperCaseFunctionName);
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.function;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 public enum TransformFunctionType {
@@ -106,7 +107,9 @@ public enum TransformFunctionType {
   // Geo indexing
   GEOTOH3("geoToH3");
 
-  private static final Set<String> NAMES = Arrays.stream(values()).map(TransformFunctionType::name)
+  private static final Set<String> NAMES = Arrays.stream(values())
+      .flatMap(func -> Stream.of(func.getName(), func.getName().replace("_", "").toUpperCase(),
+          func.getName().toUpperCase(), func.getName().toLowerCase(), func.name(), func.name().toLowerCase()))
       .collect(Collectors.toSet());
 
   private final String _name;
@@ -116,8 +119,14 @@ public enum TransformFunctionType {
   }
 
   public static boolean isTransformFunction(String functionName) {
-    String upperCaseFunctionName = functionName.toUpperCase();
-    return NAMES.contains(upperCaseFunctionName);
+    if (NAMES.contains(functionName)) {
+      return true;
+    }
+    // scalar functions
+    if (FunctionRegistry.containsFunction(functionName)) {
+      return true;
+    }
+    return NAMES.contains(functionName.toUpperCase().replace("_", ""));
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -247,10 +247,8 @@ public class CalciteSqlParser {
     Function functionCall = expression.getFunctionCall();
     if (functionCall != null) {
       String operator = functionCall.getOperator();
-      try {
-        AggregationFunctionType.getAggregationFunctionType(operator);
+      if (AggregationFunctionType.isAggregationFunction(operator)) {
         return true;
-      } catch (IllegalArgumentException e) {
       }
       if (functionCall.getOperandsSize() > 0) {
         for (Expression operand : functionCall.getOperands()) {

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionDefinitionRegistryTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionDefinitionRegistryTest.java
@@ -34,6 +34,8 @@ public class FunctionDefinitionRegistryTest {
     assertTrue(FunctionDefinitionRegistry.isAggFunc("percentilerawestmv"));
     assertTrue(FunctionDefinitionRegistry.isAggFunc("percentile_raw_est_mv"));
     assertTrue(FunctionDefinitionRegistry.isAggFunc("PERCENTILE_RAW_EST_MV"));
+    assertTrue(FunctionDefinitionRegistry.isAggFunc("PERCENTILEEST90"));
+    assertTrue(FunctionDefinitionRegistry.isAggFunc("percentileest90"));
     assertFalse(FunctionDefinitionRegistry.isAggFunc("toEpochSeconds"));
   }
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionDefinitionRegistryTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionDefinitionRegistryTest.java
@@ -29,12 +29,27 @@ public class FunctionDefinitionRegistryTest {
   @Test
   public void testIsAggFunc() {
     assertTrue(FunctionDefinitionRegistry.isAggFunc("count"));
+    assertTrue(FunctionDefinitionRegistry.isAggFunc("percentileRawEstMV"));
+    assertTrue(FunctionDefinitionRegistry.isAggFunc("PERCENTILERAWESTMV"));
+    assertTrue(FunctionDefinitionRegistry.isAggFunc("percentilerawestmv"));
+    assertTrue(FunctionDefinitionRegistry.isAggFunc("percentile_raw_est_mv"));
+    assertTrue(FunctionDefinitionRegistry.isAggFunc("PERCENTILE_RAW_EST_MV"));
     assertFalse(FunctionDefinitionRegistry.isAggFunc("toEpochSeconds"));
   }
 
   @Test
   public void testIsTransformFunc() {
     assertTrue(FunctionDefinitionRegistry.isTransformFunc("toEpochSeconds"));
+    assertTrue(FunctionDefinitionRegistry.isTransformFunc("json_extract_scalar"));
+    assertTrue(FunctionDefinitionRegistry.isTransformFunc("jsonextractscalar"));
+    assertTrue(FunctionDefinitionRegistry.isTransformFunc("JSON_EXTRACT_SCALAR"));
+    assertTrue(FunctionDefinitionRegistry.isTransformFunc("JSONEXTRACTSCALAR"));
+    assertTrue(FunctionDefinitionRegistry.isTransformFunc("jsonExtractScalar"));
+    assertTrue(FunctionDefinitionRegistry.isTransformFunc("ST_AsText"));
+    assertTrue(FunctionDefinitionRegistry.isTransformFunc("STAsText"));
+    assertTrue(FunctionDefinitionRegistry.isTransformFunc("stastext"));
+    assertTrue(FunctionDefinitionRegistry.isTransformFunc("ST_ASTEXT"));
+    assertTrue(FunctionDefinitionRegistry.isTransformFunc("STASTEXT"));
     assertFalse(FunctionDefinitionRegistry.isTransformFunc("foo_bar"));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
@@ -101,8 +101,9 @@ public class CaseTransformFunction extends BaseTransformFunction {
     for (int i = 0; i < numThenStatements; i++) {
       TransformFunction thenStatement = _elseThenStatements.get(i + 1);
       TransformResultMetadata thenStatementResultMetadata = thenStatement.getResultMetadata();
-      Preconditions.checkState(thenStatementResultMetadata.isSingleValue(),
-          String.format("Unsupported multi-value expression in the THEN clause of index: %d", i));
+      if (!thenStatementResultMetadata.isSingleValue()) {
+        throw new IllegalStateException("Unsupported multi-value expression in the THEN clause of index: " + i);
+      }
       DataType thenStatementDataType = thenStatementResultMetadata.getDataType();
 
       // Upcast the data type to cover all the data types in THEN and ELSE clauses if they don't match

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
-import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
@@ -185,16 +184,17 @@ public class CaseTransformFunction extends BaseTransformFunction {
    * index(1 to N) of matched WHEN clause, 0 means nothing matched, so go to ELSE.
    */
   private int[] getSelectedArray(ProjectionBlock projectionBlock) {
-    if (_selectedResults == null) {
-      _selectedResults = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    int numDocs = projectionBlock.getNumDocs();
+    if (_selectedResults == null || _selectedResults.length < numDocs) {
+      _selectedResults = new int[numDocs];
     } else {
-      Arrays.fill(_selectedResults, 0);
+      Arrays.fill(_selectedResults, 0, numDocs, 0);
     }
     int numWhenStatements = _whenStatements.size();
     for (int i = 0; i < numWhenStatements; i++) {
       TransformFunction whenStatement = _whenStatements.get(i);
       int[] conditions = whenStatement.transformToIntValuesSV(projectionBlock);
-      for (int j = 0; j < conditions.length; j++) {
+      for (int j = 0; j < numDocs & j < conditions.length; j++) {
         if (_selectedResults[j] == 0 && conditions[j] == 1) {
           _selectedResults[j] = i + 1;
         }
@@ -209,8 +209,8 @@ public class CaseTransformFunction extends BaseTransformFunction {
       return super.transformToIntValuesSV(projectionBlock);
     }
     int[] selected = getSelectedArray(projectionBlock);
-    if (_intResults == null) {
-      _intResults = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    if (_intResults == null || _intResults.length < projectionBlock.getNumDocs()) {
+      _intResults = new int[projectionBlock.getNumDocs()];
     }
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
@@ -232,8 +232,8 @@ public class CaseTransformFunction extends BaseTransformFunction {
       return super.transformToLongValuesSV(projectionBlock);
     }
     int[] selected = getSelectedArray(projectionBlock);
-    if (_longResults == null) {
-      _longResults = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    if (_longResults == null || _longResults.length < projectionBlock.getNumDocs()) {
+      _longResults = new long[projectionBlock.getNumDocs()];
     }
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
@@ -255,8 +255,8 @@ public class CaseTransformFunction extends BaseTransformFunction {
       return super.transformToFloatValuesSV(projectionBlock);
     }
     int[] selected = getSelectedArray(projectionBlock);
-    if (_floatResults == null) {
-      _floatResults = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    if (_floatResults == null || _floatResults.length < projectionBlock.getNumDocs()) {
+      _floatResults = new float[projectionBlock.getNumDocs()];
     }
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
@@ -278,8 +278,8 @@ public class CaseTransformFunction extends BaseTransformFunction {
       return super.transformToDoubleValuesSV(projectionBlock);
     }
     int[] selected = getSelectedArray(projectionBlock);
-    if (_doubleResults == null) {
-      _doubleResults = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    if (_doubleResults == null || _doubleResults.length < projectionBlock.getNumDocs()) {
+      _doubleResults = new double[projectionBlock.getNumDocs()];
     }
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
@@ -301,8 +301,8 @@ public class CaseTransformFunction extends BaseTransformFunction {
       return super.transformToStringValuesSV(projectionBlock);
     }
     int[] selected = getSelectedArray(projectionBlock);
-    if (_stringResults == null) {
-      _stringResults = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    if (_stringResults == null || _selectedResults.length < projectionBlock.getNumDocs()) {
+      _stringResults = new String[projectionBlock.getNumDocs()];
     }
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
@@ -324,8 +324,8 @@ public class CaseTransformFunction extends BaseTransformFunction {
       return super.transformToBytesValuesSV(projectionBlock);
     }
     int[] selected = getSelectedArray(projectionBlock);
-    if (_bytesResults == null) {
-      _bytesResults = new byte[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+    if (_bytesResults == null || _bytesResults.length < projectionBlock.getNumDocs()) {
+      _bytesResults = new byte[projectionBlock.getNumDocs()][];
     }
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LogicalOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LogicalOperatorTransformFunction.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
-import com.google.common.base.Preconditions;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -41,14 +40,16 @@ public abstract class LogicalOperatorTransformFunction extends BaseTransformFunc
   public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
     _arguments = arguments;
     int numArguments = arguments.size();
-    Preconditions.checkState(numArguments > 1, String
-        .format("Expect more than 1 argument for logical operator [%s], args [%s].", getName(),
-            Arrays.toString(arguments.toArray())));
+    if (numArguments <= 1) {
+      throw new IllegalArgumentException("Expect more than 1 argument for logical operator [" + getName() + "], args ["
+          + Arrays.toString(arguments.toArray()) + "].");
+    }
     for (int i = 0; i < numArguments; i++) {
       TransformResultMetadata argumentMetadata = arguments.get(i).getResultMetadata();
-      Preconditions
-          .checkState(argumentMetadata.isSingleValue() && argumentMetadata.getDataType().getStoredType().isNumeric(),
-              String.format("Unsupported argument of index: %d, expecting single-valued boolean/number", i));
+      if (!(argumentMetadata.isSingleValue() && argumentMetadata.getDataType().getStoredType().isNumeric())) {
+        throw new IllegalArgumentException(
+            "Unsupported argument of index: " + i + ", expecting single-valued boolean/number");
+      }
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
@@ -54,13 +54,39 @@ public class MaxAggregationFunction extends BaseSingleInputAggregationFunction<D
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    double[] valueArray = blockValSetMap.get(_expression).getDoubleValuesSV();
     double max = aggregationResultHolder.getDoubleResult();
-    for (int i = 0; i < length; i++) {
-      double value = valueArray[i];
-      if (value > max) {
-        max = value;
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    switch (blockValSet.getValueType().getStoredType()) {
+      case INT: {
+        int[] values = blockValSet.getIntValuesSV();
+        for (int i = 0; i < length & i < values.length; i++) {
+          max = Math.max(values[i], max);
+        }
+        break;
       }
+      case LONG: {
+        long[] values = blockValSet.getLongValuesSV();
+        for (int i = 0; i < length & i < values.length; i++) {
+          max = Math.max(values[i], max);
+        }
+        break;
+      }
+      case FLOAT: {
+        float[] values = blockValSet.getFloatValuesSV();
+        for (int i = 0; i < length & i < values.length; i++) {
+          max = Math.max(values[i], max);
+        }
+        break;
+      }
+      case DOUBLE: {
+        double[] values = blockValSet.getDoubleValuesSV();
+        for (int i = 0; i < length & i < values.length; i++) {
+          max = Math.max(values[i], max);
+        }
+        break;
+      }
+      default:
+        throw new IllegalStateException();
     }
     aggregationResultHolder.setValue(max);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
@@ -54,10 +54,39 @@ public class SumAggregationFunction extends BaseSingleInputAggregationFunction<D
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    double[] valueArray = blockValSetMap.get(_expression).getDoubleValuesSV();
     double sum = aggregationResultHolder.getDoubleResult();
-    for (int i = 0; i < length; i++) {
-      sum += valueArray[i];
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    switch (blockValSet.getValueType().getStoredType()) {
+      case INT: {
+        int[] values = blockValSet.getIntValuesSV();
+        for (int i = 0; i < length & i < values.length; i++) {
+          sum += values[i];
+        }
+        break;
+      }
+      case LONG: {
+        long[] values = blockValSet.getLongValuesSV();
+        for (int i = 0; i < length & i < values.length; i++) {
+          sum += values[i];
+        }
+        break;
+      }
+      case FLOAT: {
+        float[] values = blockValSet.getFloatValuesSV();
+        for (int i = 0; i < length & i < values.length; i++) {
+          sum += values[i];
+        }
+        break;
+      }
+      case DOUBLE: {
+        double[] values = blockValSet.getDoubleValuesSV();
+        for (int i = 0; i < length & i < values.length; i++) {
+          sum += values[i];
+        }
+        break;
+      }
+      default:
+        throw new IllegalStateException();
     }
     aggregationResultHolder.setValue(sum);
   }

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkFilteredAggregations.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkFilteredAggregations.java
@@ -128,6 +128,7 @@ public class BenchmarkFilteredAggregations extends BaseQueriesTest {
     }
 
     FileUtils.deleteQuietly(INDEX_DIR);
+    EXECUTOR_SERVICE.shutdownNow();
   }
 
   private List<GenericRow> createTestData(int numRows) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.lang3.StringUtils;
 
 
 /**
@@ -92,6 +91,13 @@ public enum AggregationFunctionType {
     if (NAMES.contains(functionName)) {
       return true;
     }
+    if (functionName.regionMatches(true, 0, "percentile", 0, 10)) {
+      try {
+        getAggregationFunctionType(functionName);
+        return true;
+      } catch (Exception ignore) {
+      }
+    }
     String upperCaseFunctionName = functionName.replace("_", "").toUpperCase();
     return NAMES.contains(upperCaseFunctionName);
   }
@@ -101,9 +107,8 @@ public enum AggregationFunctionType {
    * <p>NOTE: Underscores in the function name are ignored.
    */
   public static AggregationFunctionType getAggregationFunctionType(String functionName) {
-    String upperCaseFunctionName = StringUtils.remove(functionName, '_').toUpperCase();
-    if (upperCaseFunctionName.startsWith("PERCENTILE")) {
-      String remainingFunctionName = upperCaseFunctionName.substring(10);
+    if (functionName.regionMatches(true, 0, "percentile", 0, 10)) {
+      String remainingFunctionName = functionName.replace("_", "").substring(10).toUpperCase();
       if (remainingFunctionName.isEmpty() || remainingFunctionName.matches("\\d+")) {
         return PERCENTILE;
       } else if (remainingFunctionName.equals("EST") || remainingFunctionName.matches("EST\\d+")) {
@@ -129,7 +134,7 @@ public enum AggregationFunctionType {
       }
     } else {
       try {
-        return AggregationFunctionType.valueOf(upperCaseFunctionName);
+        return AggregationFunctionType.valueOf(functionName.replace("_", "").toUpperCase());
       } catch (IllegalArgumentException e) {
         throw new IllegalArgumentException("Invalid aggregation function name: " + functionName);
       }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.segment.spi;
 
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 
 
@@ -71,6 +74,9 @@ public enum AggregationFunctionType {
   PERCENTILERAWTDIGESTMV("percentileRawTDigestMV"),
   DISTINCT("distinct");
 
+  private static final Set<String> NAMES = Arrays.stream(values()).map(AggregationFunctionType::name)
+      .collect(Collectors.toSet());
+
   private final String _name;
 
   AggregationFunctionType(String name) {
@@ -79,6 +85,11 @@ public enum AggregationFunctionType {
 
   public String getName() {
     return _name;
+  }
+
+  public static boolean isAggregationFunction(String functionName) {
+    String upperCaseFunctionName = StringUtils.remove(functionName, '_').toUpperCase();
+    return NAMES.contains(upperCaseFunctionName);
   }
 
   /**

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
@@ -21,6 +21,7 @@ package org.apache.pinot.segment.spi;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 
 
@@ -74,8 +75,8 @@ public enum AggregationFunctionType {
   PERCENTILERAWTDIGESTMV("percentileRawTDigestMV"),
   DISTINCT("distinct");
 
-  private static final Set<String> NAMES = Arrays.stream(values()).map(AggregationFunctionType::name)
-      .collect(Collectors.toSet());
+  private static final Set<String> NAMES = Arrays.stream(values()).flatMap(func -> Stream.of(func.name(),
+      func.getName(), func.getName().toLowerCase())).collect(Collectors.toSet());
 
   private final String _name;
 
@@ -88,7 +89,10 @@ public enum AggregationFunctionType {
   }
 
   public static boolean isAggregationFunction(String functionName) {
-    String upperCaseFunctionName = StringUtils.remove(functionName, '_').toUpperCase();
+    if (NAMES.contains(functionName)) {
+      return true;
+    }
+    String upperCaseFunctionName = functionName.replace("_", "").toUpperCase();
     return NAMES.contains(upperCaseFunctionName);
   }
 


### PR DESCRIPTION
This addresses many inefficiencies which show up in a benchmark of the query engine
* delaying conversion of `int[]` to `double[]` speeds up reading blocks from storage, reduces the size of arrays stored in the `DataBlockCache`
* Don't detect function types by throwing exceptions
* Size `TransformFunction` results properly.
* Don't eagerly format error messages in function init

master
```
Benchmark                                                                            (_intBaseValue)  (_numRows)  Mode  Cnt        Score         Error   Units
BenchmarkFilteredAggregations.testFilteredAggregations                                             0     1500000  avgt    5    14603.463 ±    2802.292   us/op
BenchmarkFilteredAggregations.testFilteredAggregations:·gc.alloc.rate                              0     1500000  avgt    5       20.648 ±       3.821  MB/sec
BenchmarkFilteredAggregations.testFilteredAggregations:·gc.alloc.rate.norm                         0     1500000  avgt    5   473834.895 ±    4343.609    B/op
BenchmarkFilteredAggregations.testFilteredAggregations:·gc.churn.G1_Eden_Space                     0     1500000  avgt    5       35.002 ±     301.381  MB/sec
BenchmarkFilteredAggregations.testFilteredAggregations:·gc.churn.G1_Eden_Space.norm                0     1500000  avgt    5   785693.566 ± 6765058.556    B/op
BenchmarkFilteredAggregations.testFilteredAggregations:·gc.churn.G1_Old_Gen                        0     1500000  avgt    5        7.788 ±      67.060  MB/sec
BenchmarkFilteredAggregations.testFilteredAggregations:·gc.churn.G1_Old_Gen.norm                   0     1500000  avgt    5   174822.896 ± 1505277.856    B/op
BenchmarkFilteredAggregations.testFilteredAggregations:·gc.count                                   0     1500000  avgt    5        1.000                counts
BenchmarkFilteredAggregations.testFilteredAggregations:·gc.time                                    0     1500000  avgt    5        4.000                    ms
BenchmarkFilteredAggregations.testNonFilteredAggregations                                          0     1500000  avgt    5    31641.121 ±    2374.442   us/op
BenchmarkFilteredAggregations.testNonFilteredAggregations:·gc.alloc.rate                           0     1500000  avgt    5       23.624 ±       1.729  MB/sec
BenchmarkFilteredAggregations.testNonFilteredAggregations:·gc.alloc.rate.norm                      0     1500000  avgt    5  1171658.220 ±   20300.958    B/op
BenchmarkFilteredAggregations.testNonFilteredAggregations:·gc.count                                0     1500000  avgt    5          ≈ 0                counts
```

branch
```
Benchmark                                                                      (_intBaseValue)  (_numRows)  Mode  Cnt       Score         Error   Units
BenchmarkFilteredAggregations.testFilteredAggregations                                       0     1500000  avgt    5   14581.370 ±    1927.876   us/op
BenchmarkFilteredAggregations.testFilteredAggregations:·gc.alloc.rate                        0     1500000  avgt    5      13.738 ±      13.321  MB/sec
BenchmarkFilteredAggregations.testFilteredAggregations:·gc.alloc.rate.norm                   0     1500000  avgt    5  313800.088 ±  289751.441    B/op
BenchmarkFilteredAggregations.testFilteredAggregations:·gc.count                             0     1500000  avgt    5         ≈ 0                counts
BenchmarkFilteredAggregations.testNonFilteredAggregations                                    0     1500000  avgt    5   28648.469 ±    3463.714   us/op
BenchmarkFilteredAggregations.testNonFilteredAggregations:·gc.alloc.rate                     0     1500000  avgt    5      16.622 ±      26.714  MB/sec
BenchmarkFilteredAggregations.testNonFilteredAggregations:·gc.alloc.rate.norm                0     1500000  avgt    5  748228.779 ± 1208200.361    B/op
BenchmarkFilteredAggregations.testNonFilteredAggregations:·gc.count                          0     1500000  avgt    5         ≈ 0                counts
```

master
```
Benchmark                                                  (_intBaseValue)  (_numRows)  Mode  Cnt      Score      Error  Units
BenchmarkFilteredAggregations.testFilteredAggregations                   0     1500000  avgt    5  14759.558 ±  783.314  us/op
BenchmarkFilteredAggregations.testNonFilteredAggregations                0     1500000  avgt    5  32208.800 ± 1346.069  us/op
```

branch
```
Benchmark                                                  (_intBaseValue)  (_numRows)  Mode  Cnt      Score      Error  Units
BenchmarkFilteredAggregations.testFilteredAggregations                   0     1500000  avgt    5  14066.896 ± 2505.217  us/op
BenchmarkFilteredAggregations.testNonFilteredAggregations                0     1500000  avgt    5  28785.087 ± 4468.296  us/op
```