### PR TITLE
prune unselected THEN statements in CaseTransformFunction

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
-import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
@@ -58,6 +57,8 @@ public class CaseTransformFunction extends BaseTransformFunction {
 
   private List<TransformFunction> _whenStatements = new ArrayList<>();
   private List<TransformFunction> _elseThenStatements = new ArrayList<>();
+  private boolean[] _selections;
+  private int _numSelections;
   private TransformResultMetadata _resultMetadata;
   private int[] _selectedResults;
   private int[] _intResults;
@@ -89,6 +90,7 @@ public class CaseTransformFunction extends BaseTransformFunction {
     for (int i = numWhenStatements; i < numWhenStatements * 2; i++) {
       _elseThenStatements.add(arguments.get(i));
     }
+    _selections = new boolean[_elseThenStatements.size()];
     _resultMetadata = calculateResultMetadata();
   }
 
@@ -102,8 +104,9 @@ public class CaseTransformFunction extends BaseTransformFunction {
     for (int i = 0; i < numThenStatements; i++) {
       TransformFunction thenStatement = _elseThenStatements.get(i + 1);
       TransformResultMetadata thenStatementResultMetadata = thenStatement.getResultMetadata();
-      Preconditions.checkState(thenStatementResultMetadata.isSingleValue(),
-          String.format("Unsupported multi-value expression in the THEN clause of index: %d", i));
+      if (!thenStatementResultMetadata.isSingleValue()) {
+        throw new IllegalStateException("Unsupported multi-value expression in the THEN clause of index: " + i);
+      }
       DataType thenStatementDataType = thenStatementResultMetadata.getDataType();
 
       // Upcast the data type to cover all the data types in THEN and ELSE clauses if they don't match
@@ -185,21 +188,29 @@ public class CaseTransformFunction extends BaseTransformFunction {
    * index(1 to N) of matched WHEN clause, 0 means nothing matched, so go to ELSE.
    */
   private int[] getSelectedArray(ProjectionBlock projectionBlock) {
-    if (_selectedResults == null) {
-      _selectedResults = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    int numDocs = projectionBlock.getNumDocs();
+    if (_selectedResults == null || _selectedResults.length < numDocs) {
+      _selectedResults = new int[numDocs];
     } else {
-      Arrays.fill(_selectedResults, 0);
+      Arrays.fill(_selectedResults, 0, numDocs, 0);
+      Arrays.fill(_selections, false);
     }
     int numWhenStatements = _whenStatements.size();
-    for (int i = 0; i < numWhenStatements; i++) {
+    for (int i = numWhenStatements - 1; i >= 0; i--) {
       TransformFunction whenStatement = _whenStatements.get(i);
       int[] conditions = whenStatement.transformToIntValuesSV(projectionBlock);
-      for (int j = 0; j < conditions.length; j++) {
-        if (_selectedResults[j] == 0 && conditions[j] == 1) {
-          _selectedResults[j] = i + 1;
-        }
+      for (int j = 0; j < numDocs & j < conditions.length; j++) {
+        _selectedResults[j] = Math.max(conditions[j] * (i + 1), _selectedResults[j]);
+        _selections[_selectedResults[j]] = true;
       }
     }
+    int numSelections = 0;
+    for (boolean selection : _selections) {
+      if (selection) {
+        numSelections++;
+      }
+    }
+    _numSelections = numSelections;
     return _selectedResults;
   }
 
@@ -209,17 +220,23 @@ public class CaseTransformFunction extends BaseTransformFunction {
       return super.transformToIntValuesSV(projectionBlock);
     }
     int[] selected = getSelectedArray(projectionBlock);
-    if (_intResults == null) {
-      _intResults = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    int numDocs = projectionBlock.getNumDocs();
+    if (_intResults == null || _intResults.length < numDocs) {
+      _intResults = new int[numDocs];
     }
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
-      TransformFunction transformFunction = _elseThenStatements.get(i);
-      int[] intValues = transformFunction.transformToIntValuesSV(projectionBlock);
-      int numDocs = projectionBlock.getNumDocs();
-      for (int j = 0; j < numDocs; j++) {
-        if (selected[j] == i) {
-          _intResults[j] = intValues[j];
+      if (_selections[i]) {
+        TransformFunction transformFunction = _elseThenStatements.get(i);
+        int[] intValues = transformFunction.transformToIntValuesSV(projectionBlock);
+        if (_numSelections == 1) {
+          System.arraycopy(intValues, 0, _intResults, 0, numDocs);
+        } else {
+          for (int j = 0; j < numDocs; j++) {
+            if (selected[j] == i) {
+              _intResults[j] = intValues[j];
+            }
+          }
         }
       }
     }
@@ -232,17 +249,23 @@ public class CaseTransformFunction extends BaseTransformFunction {
       return super.transformToLongValuesSV(projectionBlock);
     }
     int[] selected = getSelectedArray(projectionBlock);
-    if (_longResults == null) {
-      _longResults = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    int numDocs = projectionBlock.getNumDocs();
+    if (_longResults == null || _longResults.length < numDocs) {
+      _longResults = new long[numDocs];
     }
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
-      TransformFunction transformFunction = _elseThenStatements.get(i);
-      long[] longValues = transformFunction.transformToLongValuesSV(projectionBlock);
-      int numDocs = projectionBlock.getNumDocs();
-      for (int j = 0; j < numDocs; j++) {
-        if (selected[j] == i) {
-          _longResults[j] = longValues[j];
+      if (_selections[i]) {
+        TransformFunction transformFunction = _elseThenStatements.get(i);
+        long[] longValues = transformFunction.transformToLongValuesSV(projectionBlock);
+        if (_numSelections == 1) {
+          System.arraycopy(longValues, 0, _longResults, 0, numDocs);
+        } else {
+          for (int j = 0; j < numDocs; j++) {
+            if (selected[j] == i) {
+              _longResults[j] = longValues[j];
+            }
+          }
         }
       }
     }
@@ -255,17 +278,23 @@ public class CaseTransformFunction extends BaseTransformFunction {
       return super.transformToFloatValuesSV(projectionBlock);
     }
     int[] selected = getSelectedArray(projectionBlock);
-    if (_floatResults == null) {
-      _floatResults = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    int numDocs = projectionBlock.getNumDocs();
+    if (_floatResults == null || _floatResults.length < numDocs) {
+      _floatResults = new float[numDocs];
     }
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
-      TransformFunction transformFunction = _elseThenStatements.get(i);
-      float[] floatValues = transformFunction.transformToFloatValuesSV(projectionBlock);
-      int numDocs = projectionBlock.getNumDocs();
-      for (int j = 0; j < numDocs; j++) {
-        if (selected[j] == i) {
-          _floatResults[j] = floatValues[j];
+      if (_selections[i]) {
+        TransformFunction transformFunction = _elseThenStatements.get(i);
+        float[] floatValues = transformFunction.transformToFloatValuesSV(projectionBlock);
+        if (_numSelections == 1) {
+          System.arraycopy(floatValues, 0, _floatResults, 0, numDocs);
+        } else {
+          for (int j = 0; j < numDocs; j++) {
+            if (selected[j] == i) {
+              _floatResults[j] = floatValues[j];
+            }
+          }
         }
       }
     }
@@ -278,17 +307,23 @@ public class CaseTransformFunction extends BaseTransformFunction {
       return super.transformToDoubleValuesSV(projectionBlock);
     }
     int[] selected = getSelectedArray(projectionBlock);
-    if (_doubleResults == null) {
-      _doubleResults = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    int numDocs = projectionBlock.getNumDocs();
+    if (_doubleResults == null || _doubleResults.length < numDocs) {
+      _doubleResults = new double[numDocs];
     }
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
-      TransformFunction transformFunction = _elseThenStatements.get(i);
-      double[] doubleValues = transformFunction.transformToDoubleValuesSV(projectionBlock);
-      int numDocs = projectionBlock.getNumDocs();
-      for (int j = 0; j < numDocs; j++) {
-        if (selected[j] == i) {
-          _doubleResults[j] = doubleValues[j];
+      if (_selections[i]) {
+        TransformFunction transformFunction = _elseThenStatements.get(i);
+        double[] doubleValues = transformFunction.transformToDoubleValuesSV(projectionBlock);
+        if (_numSelections == 1) {
+          System.arraycopy(doubleValues, 0, _doubleResults, 0, numDocs);
+        } else {
+          for (int j = 0; j < numDocs; j++) {
+            if (selected[j] == i) {
+              _doubleResults[j] = doubleValues[j];
+            }
+          }
         }
       }
     }
@@ -301,17 +336,23 @@ public class CaseTransformFunction extends BaseTransformFunction {
       return super.transformToStringValuesSV(projectionBlock);
     }
     int[] selected = getSelectedArray(projectionBlock);
-    if (_stringResults == null) {
-      _stringResults = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    int numDocs = projectionBlock.getNumDocs();
+    if (_stringResults == null || _selectedResults.length < numDocs) {
+      _stringResults = new String[numDocs];
     }
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
-      TransformFunction transformFunction = _elseThenStatements.get(i);
-      String[] stringValues = transformFunction.transformToStringValuesSV(projectionBlock);
-      int numDocs = projectionBlock.getNumDocs();
-      for (int j = 0; j < numDocs; j++) {
-        if (selected[j] == i) {
-          _stringResults[j] = stringValues[j];
+      if (_selections[i]) {
+        TransformFunction transformFunction = _elseThenStatements.get(i);
+        String[] stringValues = transformFunction.transformToStringValuesSV(projectionBlock);
+        if (_numSelections == 1) {
+          System.arraycopy(stringValues, 0, _stringResults, 0, numDocs);
+        } else {
+          for (int j = 0; j < numDocs; j++) {
+            if (selected[j] == i) {
+              _stringResults[j] = stringValues[j];
+            }
+          }
         }
       }
     }
@@ -324,17 +365,23 @@ public class CaseTransformFunction extends BaseTransformFunction {
       return super.transformToBytesValuesSV(projectionBlock);
     }
     int[] selected = getSelectedArray(projectionBlock);
-    if (_bytesResults == null) {
-      _bytesResults = new byte[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+    int numDocs = projectionBlock.getNumDocs();
+    if (_bytesResults == null || _bytesResults.length < numDocs) {
+      _bytesResults = new byte[numDocs][];
     }
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
-      TransformFunction transformFunction = _elseThenStatements.get(i);
-      byte[][] bytesValues = transformFunction.transformToBytesValuesSV(projectionBlock);
-      int numDocs = projectionBlock.getNumDocs();
-      for (int j = 0; j < numDocs; j++) {
-        if (selected[j] == i) {
-          _bytesResults[j] = bytesValues[j];
+      if (_selections[i]) {
+        TransformFunction transformFunction = _elseThenStatements.get(i);
+        byte[][] bytesValues = transformFunction.transformToBytesValuesSV(projectionBlock);
+        if (_numSelections == 1) {
+          System.arraycopy(bytesValues, 0, _byteValuesSV, 0, numDocs);
+        } else {
+          for (int j = 0; j < numDocs; j++) {
+            if (selected[j] == i) {
+              _bytesResults[j] = bytesValues[j];
+            }
+          }
         }
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LogicalOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LogicalOperatorTransformFunction.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
-import com.google.common.base.Preconditions;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -41,14 +40,16 @@ public abstract class LogicalOperatorTransformFunction extends BaseTransformFunc
   public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
     _arguments = arguments;
     int numArguments = arguments.size();
-    Preconditions.checkState(numArguments > 1, String
-        .format("Expect more than 1 argument for logical operator [%s], args [%s].", getName(),
-            Arrays.toString(arguments.toArray())));
+    if (numArguments <= 1) {
+      throw new IllegalArgumentException("Expect more than 1 argument for logical operator [" + getName() + "], args ["
+          + Arrays.toString(arguments.toArray()) + "].");
+    }
     for (int i = 0; i < numArguments; i++) {
       TransformResultMetadata argumentMetadata = arguments.get(i).getResultMetadata();
-      Preconditions
-          .checkState(argumentMetadata.isSingleValue() && argumentMetadata.getDataType().getStoredType().isNumeric(),
-              String.format("Unsupported argument of index: %d, expecting single-valued boolean/number", i));
+      if (!(argumentMetadata.isSingleValue() && argumentMetadata.getDataType().getStoredType().isNumeric())) {
+        throw new IllegalArgumentException(
+            "Unsupported argument of index: " + i + ", expecting single-valued boolean/number");
+      }
     }
   }
 


### PR DESCRIPTION
This PR prunes evaluation of THEN cases when they are not selected at the block level. This can happen when e.g. the conditions are applied to the values of a sorted column, or if a CASE holding is very rare and the THEN statement is a fallback.

This also includes some reductions in allocations in `LiteralTransformFunction` and `LogicalOperatorTransformFunction`, which are often used with CASE statements.

This speeds up query evaluation even when there are no branches to prune because selecting the cases is slightly more efficient, and some unnecessary allocations are removed:

master
```
Benchmark               (_intBaseValue)  (_numRows)                                                                                                                                                                                                                                                         (_query)  Mode  Cnt      Score      Error  Units
BenchmarkQueries.query                0     1500000  SELECT SUM(CASE WHEN (INT_COL > 123 AND INT_COL < 599999) THEN INT_COL ELSE 0 END) AS total_sum,MAX(CASE WHEN (INT_COL > 123 AND INT_COL < 599999) THEN INT_COL ELSE 0 END) AS total_avg FROM MyTable WHERE NO_INDEX_INT_COL > 5 AND NO_INDEX_INT_COL < 1499999  avgt    5  52684.909 ± 8678.865  us/op

```

branch
```
Benchmark               (_intBaseValue)  (_numRows)                                                                                                                                                                                                                                                         (_query)  Mode  Cnt      Score      Error  Units
BenchmarkQueries.query                0     1500000  SELECT SUM(CASE WHEN (INT_COL > 123 AND INT_COL < 599999) THEN INT_COL ELSE 0 END) AS total_sum,MAX(CASE WHEN (INT_COL > 123 AND INT_COL < 599999) THEN INT_COL ELSE 0 END) AS total_avg FROM MyTable WHERE NO_INDEX_INT_COL > 5 AND NO_INDEX_INT_COL < 1499999  avgt    5  49619.396 ± 1900.814  us/op
```