### PR TITLE
Aggregation delay conversion to double

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
@@ -54,41 +54,47 @@ public class MaxAggregationFunction extends BaseSingleInputAggregationFunction<D
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    double max = aggregationResultHolder.getDoubleResult();
     BlockValSet blockValSet = blockValSetMap.get(_expression);
     switch (blockValSet.getValueType().getStoredType()) {
       case INT: {
         int[] values = blockValSet.getIntValuesSV();
+        int max = values[0];
         for (int i = 0; i < length & i < values.length; i++) {
           max = Math.max(values[i], max);
         }
+        aggregationResultHolder.setValue(Math.max(max, aggregationResultHolder.getDoubleResult()));
         break;
       }
       case LONG: {
         long[] values = blockValSet.getLongValuesSV();
+        long max = values[0];
         for (int i = 0; i < length & i < values.length; i++) {
           max = Math.max(values[i], max);
         }
+        aggregationResultHolder.setValue(Math.max(max, aggregationResultHolder.getDoubleResult()));
         break;
       }
       case FLOAT: {
         float[] values = blockValSet.getFloatValuesSV();
+        float max = values[0];
         for (int i = 0; i < length & i < values.length; i++) {
           max = Math.max(values[i], max);
         }
+        aggregationResultHolder.setValue(Math.max(max, aggregationResultHolder.getDoubleResult()));
         break;
       }
       case DOUBLE: {
         double[] values = blockValSet.getDoubleValuesSV();
+        double max = values[0];
         for (int i = 0; i < length & i < values.length; i++) {
           max = Math.max(values[i], max);
         }
+        aggregationResultHolder.setValue(Math.max(max, aggregationResultHolder.getDoubleResult()));
         break;
       }
       default:
-        throw new IllegalStateException();
+        throw new IllegalStateException("Cannot compute min for non-numeric type: " + blockValSet.getValueType());
     }
-    aggregationResultHolder.setValue(max);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxAggregationFunction.java
@@ -54,13 +54,39 @@ public class MaxAggregationFunction extends BaseSingleInputAggregationFunction<D
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    double[] valueArray = blockValSetMap.get(_expression).getDoubleValuesSV();
     double max = aggregationResultHolder.getDoubleResult();
-    for (int i = 0; i < length; i++) {
-      double value = valueArray[i];
-      if (value > max) {
-        max = value;
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    switch (blockValSet.getValueType().getStoredType()) {
+      case INT: {
+        int[] values = blockValSet.getIntValuesSV();
+        for (int i = 0; i < length & i < values.length; i++) {
+          max = Math.max(values[i], max);
+        }
+        break;
       }
+      case LONG: {
+        long[] values = blockValSet.getLongValuesSV();
+        for (int i = 0; i < length & i < values.length; i++) {
+          max = Math.max(values[i], max);
+        }
+        break;
+      }
+      case FLOAT: {
+        float[] values = blockValSet.getFloatValuesSV();
+        for (int i = 0; i < length & i < values.length; i++) {
+          max = Math.max(values[i], max);
+        }
+        break;
+      }
+      case DOUBLE: {
+        double[] values = blockValSet.getDoubleValuesSV();
+        for (int i = 0; i < length & i < values.length; i++) {
+          max = Math.max(values[i], max);
+        }
+        break;
+      }
+      default:
+        throw new IllegalStateException();
     }
     aggregationResultHolder.setValue(max);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinAggregationFunction.java
@@ -54,15 +54,47 @@ public class MinAggregationFunction extends BaseSingleInputAggregationFunction<D
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    double[] valueArray = blockValSetMap.get(_expression).getDoubleValuesSV();
-    double min = aggregationResultHolder.getDoubleResult();
-    for (int i = 0; i < length; i++) {
-      double value = valueArray[i];
-      if (value < min) {
-        min = value;
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    switch (blockValSet.getValueType().getStoredType()) {
+      case INT: {
+        int[] values = blockValSet.getIntValuesSV();
+        int min = values[0];
+        for (int i = 0; i < length & i < values.length; i++) {
+          min = Math.min(values[i], min);
+        }
+        aggregationResultHolder.setValue(Math.min(min, aggregationResultHolder.getDoubleResult()));
+        break;
       }
+      case LONG: {
+        long[] values = blockValSet.getLongValuesSV();
+        long min = values[0];
+        for (int i = 0; i < length & i < values.length; i++) {
+          min = Math.min(values[i], min);
+        }
+        aggregationResultHolder.setValue(Math.min(min, aggregationResultHolder.getDoubleResult()));
+        break;
+      }
+      case FLOAT: {
+        float[] values = blockValSet.getFloatValuesSV();
+        float min = values[0];
+        for (int i = 0; i < length & i < values.length; i++) {
+          min = Math.min(values[i], min);
+        }
+        aggregationResultHolder.setValue(Math.min(min, aggregationResultHolder.getDoubleResult()));
+        break;
+      }
+      case DOUBLE: {
+        double[] values = blockValSet.getDoubleValuesSV();
+        double min = values[0];
+        for (int i = 0; i < length & i < values.length; i++) {
+          min = Math.min(values[i], min);
+        }
+        aggregationResultHolder.setValue(Math.min(min, aggregationResultHolder.getDoubleResult()));
+        break;
+      }
+      default:
+        throw new IllegalStateException("Cannot compute min for non-numeric type: " + blockValSet.getValueType());
     }
-    aggregationResultHolder.setValue(min);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
@@ -86,7 +86,7 @@ public class SumAggregationFunction extends BaseSingleInputAggregationFunction<D
         break;
       }
       default:
-        throw new IllegalStateException();
+        throw new IllegalStateException("Cannot compute min for non-numeric type: " + blockValSet.getValueType());
     }
     aggregationResultHolder.setValue(sum);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
@@ -54,10 +54,39 @@ public class SumAggregationFunction extends BaseSingleInputAggregationFunction<D
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    double[] valueArray = blockValSetMap.get(_expression).getDoubleValuesSV();
     double sum = aggregationResultHolder.getDoubleResult();
-    for (int i = 0; i < length; i++) {
-      sum += valueArray[i];
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    switch (blockValSet.getValueType().getStoredType()) {
+      case INT: {
+        int[] values = blockValSet.getIntValuesSV();
+        for (int i = 0; i < length & i < values.length; i++) {
+          sum += values[i];
+        }
+        break;
+      }
+      case LONG: {
+        long[] values = blockValSet.getLongValuesSV();
+        for (int i = 0; i < length & i < values.length; i++) {
+          sum += values[i];
+        }
+        break;
+      }
+      case FLOAT: {
+        float[] values = blockValSet.getFloatValuesSV();
+        for (int i = 0; i < length & i < values.length; i++) {
+          sum += values[i];
+        }
+        break;
+      }
+      case DOUBLE: {
+        double[] values = blockValSet.getDoubleValuesSV();
+        for (int i = 0; i < length & i < values.length; i++) {
+          sum += values[i];
+        }
+        break;
+      }
+      default:
+        throw new IllegalStateException();
     }
     aggregationResultHolder.setValue(sum);
   }


### PR DESCRIPTION
Aggregation function aggregate as `double` to avoid numeric overflow, but converting blocks to `double[]` too soon has two drawbacks:
* `double[]` are larger than `float[]` and `int[]` and this may result in twice the footprint on heap when these arrays are retained by the `DataBlockCache`
* If the values are read directly from a `ForwardIndexReader`, reading `int`/`long`/`float` values as `double` prevents autovectorization, resulting in a performance penalty.

## Avoiding Premature Type Conversion 

Type conversion slows down bulk reads in `ForwardIndexReader` - e.g. compare reading `long` contiguous values as `long` and as `double` (this benchmark is in the project and can be run by anyone):

```
Benchmark                                                     (_blockSize)  (_numBlocks)  Mode  Cnt      Score      Error  Units
BenchmarkFixedByteSVForwardIndexReader.readDoublesBatch              10000          1000  avgt    5  33931.164 ± 4052.520  us/op
BenchmarkFixedByteSVForwardIndexReader.readLongsBatch                10000          1000  avgt    5  14003.773 ± 1625.357  us/op
```

The root cause is that when values are read into an array from disk, the endianness needs to be swapped. Hotspot has an efficient implementation of this operation `Copy::conjoint_swap` which can't be used when type conversion also needs to be performed, so reading `long` values as `long`s is more efficient than reading `long`s as `double`s, despite the same amount of data being copied. This can be see by profiling the benchmark:


```
....[Hottest Regions]...............................................................................
 62.36%           libjvm.so  Copy::conjoint_swap (21 bytes) 
 30.25%         c2, level 4  org.apache.pinot.perf.BenchmarkFixedByteSVForwardIndexReader::readLongsBatch, version 1447 (101 bytes) 
 
 ....[Hottest Regions]...............................................................................
 81.73%         c2, level 4  org.apache.pinot.perf.BenchmarkFixedByteSVForwardIndexReader::readDoublesBatch, version 1428 (78 bytes) 
```

This means that a simple sum over a raw column is more efficient when the type conversion is delayed. This can be seen (in a benchmark to be contributed in another PR) when computing a sum over a raw INT column:

master
```
Benchmark               (_intBaseValue)  (_numRows)                              (_query)  Mode  Cnt      Score     Error  Units
BenchmarkQueries.query                0     1500000  SELECT SUM(RAW_INT_COL) FROM MyTable  avgt    5  17719.453 ± 171.739  us/op
```

branch
```
Benchmark               (_intBaseValue)  (_numRows)                              (_query)  Mode  Cnt      Score     Error  Units
BenchmarkQueries.query                0     1500000  SELECT SUM(RAW_INT_COL) FROM MyTable  avgt    5  15475.992 ± 537.057  us/op
```