### PR TITLE
Allocation free `DataBlockCache` lookups

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataBlockCache.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataBlockCache.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nonnull;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.segment.spi.evaluator.TransformEvaluator;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -65,10 +64,9 @@ public class DataBlockCache {
   public void initNewBlock(int[] docIds, int length) {
     _docIds = docIds;
     _length = length;
-
     _columnDictIdLoaded.clear();
-    for (Set<String> column : _columnValueLoaded.values()) {
-      column.clear();
+    for (Set<String> columns : _columnValueLoaded.values()) {
+      columns.clear();
     }
     _columnNumValuesLoaded.clear();
   }
@@ -412,7 +410,7 @@ public class DataBlockCache {
    * @return Array of string values
    */
   public String[][] getStringValuesForMVColumn(String column) {
-    String[][] stringValues = (String[][]) getValues(FieldSpec.DataType.STRING, column);
+    String[][] stringValues = getValues(FieldSpec.DataType.STRING, column);
     if (markLoaded(FieldSpec.DataType.STRING, column)) {
       if (stringValues == null) {
         stringValues = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
@@ -456,11 +454,12 @@ public class DataBlockCache {
     return _columnValueLoaded.computeIfAbsent(dataType, k -> new HashSet<>()).add(column);
   }
 
-  private <T> T getValues(@Nonnull FieldSpec.DataType dataType, @Nonnull String column) {
+  @SuppressWarnings("unchecked")
+  private <T> T getValues(FieldSpec.DataType dataType, String column) {
     return (T) _valuesMap.computeIfAbsent(dataType, k -> new HashMap<>()).get(column);
   }
 
-  private void putValues(@Nonnull FieldSpec.DataType dataType, @Nonnull String column, @Nonnull Object values) {
+  private void putValues(FieldSpec.DataType dataType, String column, Object values) {
     _valuesMap.get(dataType).put(column, values);
   }
 }


### PR DESCRIPTION
`ColumnTypePair` show up just behind `int[]`/`double[]` in allocation profiles of query execution.
<img width="693" alt="Screenshot 2022-02-06 at 21 48 53" src="https://user-images.githubusercontent.com/16439049/152702760-e63a7454-b10d-4791-873c-033c5cf5743e.png">

This changes avoids allocating these by using the `DataType` as a first level lookup into an `EnumMap` (a small array behind the scenes) to a `Set<String>` which is the set of columns for that data type. This reduces allocation rate and improves performance (does not regress) for a range of queries:

master
```
Benchmark                                                (_intBaseValue)  (_numRows)                                                                                                                                                                                                                                                         (_query)  Mode  Cnt        Score         Error   Units
BenchmarkQueries.query                                                 0     1500000                                                                                                                                                                                                                             SELECT SUM(RAW_INT_COL) FROM MyTable  avgt    5    17463.734 ±     355.827   us/op
BenchmarkQueries.query:·gc.alloc.rate.norm                             0     1500000                                                                                                                                                                                                                             SELECT SUM(RAW_INT_COL) FROM MyTable  avgt    5   608548.162 ± 1016513.369    B/op
BenchmarkQueries.query                                                 0     1500000                                                        SELECT SUM(INT_COL) FILTER(WHERE INT_COL > 123 AND INT_COL < 599999),MAX(INT_COL) FILTER(WHERE INT_COL > 123 AND INT_COL < 599999) FROM MyTable WHERE NO_INDEX_INT_COL > 5 AND NO_INDEX_INT_COL < 1499999  avgt    5    23784.153 ±    1163.643   us/op
BenchmarkQueries.query:·gc.alloc.rate.norm                             0     1500000                                                        SELECT SUM(INT_COL) FILTER(WHERE INT_COL > 123 AND INT_COL < 599999),MAX(INT_COL) FILTER(WHERE INT_COL > 123 AND INT_COL < 599999) FROM MyTable WHERE NO_INDEX_INT_COL > 5 AND NO_INDEX_INT_COL < 1499999  avgt    5   426997.395 ±  420169.858    B/op
BenchmarkQueries.query                                                 0     1500000  SELECT SUM(CASE WHEN (INT_COL > 123 AND INT_COL < 599999) THEN INT_COL ELSE 0 END) AS total_sum,MAX(CASE WHEN (INT_COL > 123 AND INT_COL < 599999) THEN INT_COL ELSE 0 END) AS total_avg FROM MyTable WHERE NO_INDEX_INT_COL > 5 AND NO_INDEX_INT_COL < 1499999  avgt    5    52328.177 ±    2807.010   us/op
BenchmarkQueries.query:·gc.alloc.rate.norm                             0     1500000  SELECT SUM(CASE WHEN (INT_COL > 123 AND INT_COL < 599999) THEN INT_COL ELSE 0 END) AS total_sum,MAX(CASE WHEN (INT_COL > 123 AND INT_COL < 599999) THEN INT_COL ELSE 0 END) AS total_avg FROM MyTable WHERE NO_INDEX_INT_COL > 5 AND NO_INDEX_INT_COL < 1499999  avgt    5   998184.088 ± 1572072.289    B/op
```

branch
```
Benchmark                                                (_intBaseValue)  (_numRows)                                                                                                                                                                                                                                                         (_query)  Mode  Cnt       Score         Error   Units
BenchmarkQueries.query                                                 0     1500000                                                                                                                                                                                                                             SELECT SUM(RAW_INT_COL) FROM MyTable  avgt    5   17374.187 ±     334.140   us/op
BenchmarkQueries.query:·gc.alloc.rate.norm                             0     1500000                                                                                                                                                                                                                             SELECT SUM(RAW_INT_COL) FROM MyTable  avgt    5  603245.214 ± 1004990.185    B/op
BenchmarkQueries.query                                                 0     1500000                                                        SELECT SUM(INT_COL) FILTER(WHERE INT_COL > 123 AND INT_COL < 599999),MAX(INT_COL) FILTER(WHERE INT_COL > 123 AND INT_COL < 599999) FROM MyTable WHERE NO_INDEX_INT_COL > 5 AND NO_INDEX_INT_COL < 1499999  avgt    5   23116.649 ±     753.629   us/op
BenchmarkQueries.query:·gc.alloc.rate.norm                             0     1500000                                                        SELECT SUM(INT_COL) FILTER(WHERE INT_COL > 123 AND INT_COL < 599999),MAX(INT_COL) FILTER(WHERE INT_COL > 123 AND INT_COL < 599999) FROM MyTable WHERE NO_INDEX_INT_COL > 5 AND NO_INDEX_INT_COL < 1499999  avgt    5  422940.704 ±  411258.808    B/op
BenchmarkQueries.query                                                 0     1500000  SELECT SUM(CASE WHEN (INT_COL > 123 AND INT_COL < 599999) THEN INT_COL ELSE 0 END) AS total_sum,MAX(CASE WHEN (INT_COL > 123 AND INT_COL < 599999) THEN INT_COL ELSE 0 END) AS total_avg FROM MyTable WHERE NO_INDEX_INT_COL > 5 AND NO_INDEX_INT_COL < 1499999  avgt    5   52473.093 ±    3630.290   us/op
BenchmarkQueries.query:·gc.alloc.rate.norm                             0     1500000  SELECT SUM(CASE WHEN (INT_COL > 123 AND INT_COL < 599999) THEN INT_COL ELSE 0 END) AS total_sum,MAX(CASE WHEN (INT_COL > 123 AND INT_COL < 599999) THEN INT_COL ELSE 0 END) AS total_avg FROM MyTable WHERE NO_INDEX_INT_COL > 5 AND NO_INDEX_INT_COL < 1499999  avgt    5  973148.139 ± 1518881.578    B/op
```