### PR TITLE
Adding broker level config for disabling Pinot queries with Groovy

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1213,7 +1213,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     }
 
     if (TransformFunctionFactory.canonicalize(functionCall.getOperator())
-        .contains(TransformFunctionType.GROOVY.getName())) {
+        .equals(TransformFunctionType.GROOVY.getName())) {
       throw new BadQueryRequestException("Groovy transform functions are disabled for queries");
     }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -76,6 +76,7 @@ import org.apache.pinot.common.response.broker.QueryProcessingException;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.request.RequestUtils;
+import org.apache.pinot.core.operator.transform.function.TransformFunctionFactory;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.optimizer.QueryOptimizer;
 import org.apache.pinot.core.requesthandler.PinotQueryParserFactory;
@@ -1211,7 +1212,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       return;
     }
 
-    if (functionCall.getOperator().toLowerCase().contains(TransformFunctionType.GROOVY.getName())) {
+    if (TransformFunctionFactory.canonicalize(functionCall.getOperator())
+        .contains(TransformFunctionType.GROOVY.getName())) {
       throw new BadQueryRequestException("Groovy transform functions are disabled for queries");
     }
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
@@ -188,6 +188,8 @@ public class QueryValidationTest {
     testRejectGroovyQuery(
         "SELECT GROOVY('{\"returnType\":\"INT\",\"isSingleValue\":true}', 'arg0 + arg1', colA, colB) FROM foo", true);
     testRejectGroovyQuery(
+        "SELECT groo_vy('{\"returnType\":\"INT\",\"isSingleValue\":true}', 'arg0 + arg1', colA, colB) FROM foo", true);
+    testRejectGroovyQuery(
         "SELECT foo FROM bar WHERE GROOVY('{\"returnType\":\"STRING\",\"isSingleValue\":true}', 'arg0 + arg1', colA,"
             + " colB) = 'foobarval'", true);
     testRejectGroovyQuery(

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
@@ -191,8 +191,8 @@ public class QueryValidationTest {
         "SELECT foo FROM bar WHERE GROOVY('{\"returnType\":\"STRING\",\"isSingleValue\":true}', 'arg0 + arg1', colA,"
             + " colB) = 'foobarval'", true);
     testDisabledGroovyException(
-        "SELECT COUNT(colA) FROM bar GROUP BY GROOVY('{\"returnType\":\"STRING\",\"isSingleValue\":true}', 'arg0 + arg1', colA,"
-            + " colB)", true);
+        "SELECT COUNT(colA) FROM bar GROUP BY GROOVY('{\"returnType\":\"STRING\",\"isSingleValue\":true}', "
+            + "'arg0 + arg1', colA, colB)", true);
     testDisabledGroovyException(
         "SELECT foo FROM bar HAVING GROOVY('{\"returnType\":\"STRING\",\"isSingleValue\":true}', 'arg0 + arg1', colA,"
             + " colB) = 'foobarval'", true);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
@@ -182,29 +182,29 @@ public class QueryValidationTest {
   }
 
   @Test
-  public void testDisabledGroovyOverride() {
-    testDisabledGroovyException(
+  public void testRejectGroovyQuery() {
+    testRejectGroovyQuery(
         "SELECT groovy('{\"returnType\":\"INT\",\"isSingleValue\":true}', 'arg0 + arg1', colA, colB) FROM foo", true);
-    testDisabledGroovyException(
+    testRejectGroovyQuery(
         "SELECT GROOVY('{\"returnType\":\"INT\",\"isSingleValue\":true}', 'arg0 + arg1', colA, colB) FROM foo", true);
-    testDisabledGroovyException(
+    testRejectGroovyQuery(
         "SELECT foo FROM bar WHERE GROOVY('{\"returnType\":\"STRING\",\"isSingleValue\":true}', 'arg0 + arg1', colA,"
             + " colB) = 'foobarval'", true);
-    testDisabledGroovyException(
+    testRejectGroovyQuery(
         "SELECT COUNT(colA) FROM bar GROUP BY GROOVY('{\"returnType\":\"STRING\",\"isSingleValue\":true}', "
             + "'arg0 + arg1', colA, colB)", true);
-    testDisabledGroovyException(
+    testRejectGroovyQuery(
         "SELECT foo FROM bar HAVING GROOVY('{\"returnType\":\"STRING\",\"isSingleValue\":true}', 'arg0 + arg1', colA,"
             + " colB) = 'foobarval'", true);
 
-    testDisabledGroovyException("SELECT foo FROM bar", false);
+    testRejectGroovyQuery("SELECT foo FROM bar", false);
   }
 
-  private void testDisabledGroovyException(String query, boolean queryContainsGroovy) {
+  private void testRejectGroovyQuery(String query, boolean queryContainsGroovy) {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
 
     try {
-      BaseBrokerRequestHandler.handleDisableGroovyOverride(pinotQuery);
+      BaseBrokerRequestHandler.rejectGroovyQuery(pinotQuery);
       if (queryContainsGroovy) {
         Assert.fail("Query should have failed since groovy was found in query: " + pinotQuery);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -131,7 +131,6 @@ public class TransformFunctionFactory {
           put(canonicalize(TransformFunctionType.AND.getName().toLowerCase()), AndOperatorTransformFunction.class);
           put(canonicalize(TransformFunctionType.OR.getName().toLowerCase()), OrOperatorTransformFunction.class);
 
-
           // geo functions
           // geo constructors
           put(canonicalize(TransformFunctionType.ST_GEOG_FROM_TEXT.getName().toLowerCase()),
@@ -269,7 +268,13 @@ public class TransformFunctionFactory {
     }
   }
 
-  private static String canonicalize(String functionName) {
+  /**
+   * Converts the transform function name into its canonical form
+   *
+   * @param functionName Name of the transform function
+   * @return canonicalized transform function name
+   */
+  public static String canonicalize(String functionName) {
     return StringUtils.remove(functionName, '_').toLowerCase();
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -228,6 +228,8 @@ public class CommonConstants {
     //Set to true to load all services tagged and compiled with hk2-metadata-generator. Default to False
     public static final String BROKER_SERVICE_AUTO_DISCOVERY = "pinot.broker.service.auto.discovery";
 
+    public static final String DISABLE_GROOVY = "pinot.broker.disable.groovy";
+
     public static class Request {
       public static final String PQL = "pql";
       public static final String SQL = "sql";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -228,7 +228,7 @@ public class CommonConstants {
     //Set to true to load all services tagged and compiled with hk2-metadata-generator. Default to False
     public static final String BROKER_SERVICE_AUTO_DISCOVERY = "pinot.broker.service.auto.discovery";
 
-    public static final String DISABLE_GROOVY = "pinot.broker.disable.groovy";
+    public static final String DISABLE_GROOVY = "pinot.broker.disable.query.groovy";
 
     public static class Request {
       public static final String PQL = "pql";


### PR DESCRIPTION
## Description
This change adds a broker config for disabling Groovy in Pinot queries as it is a security risk. See Github issue https://github.com/apache/pinot/issues/7966. By default, Groovy is allowed for backwards compatibility to not break existing use cases which currently use Groovy.

### Testing
Added unit tests and tested config with quick-start config override.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
* [x] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

Introduced new config for disabling Groovy in queries: `pinot.broker.disable.groovy`. If not defined, defaults to `false`.

