### PR TITLE
Put Netty Channel handlers and Tls context creation logic at same place

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/TlsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/TlsUtils.java
@@ -353,10 +353,10 @@ public final class TlsUtils {
     SslContextBuilder sslContextBuilder =
         SslContextBuilder.forClient().sslProvider(SslProvider.valueOf(tlsConfig.getSslProvider()));
     if (tlsConfig.getKeyStorePath() != null) {
-      sslContextBuilder.keyManager(TlsUtils.createKeyManagerFactory(tlsConfig));
+      sslContextBuilder.keyManager(createKeyManagerFactory(tlsConfig));
     }
     if (tlsConfig.getTrustStorePath() != null) {
-      sslContextBuilder.trustManager(TlsUtils.createTrustManagerFactory(tlsConfig));
+      sslContextBuilder.trustManager(createTrustManagerFactory(tlsConfig));
     }
     try {
       return sslContextBuilder.build();
@@ -374,10 +374,10 @@ public final class TlsUtils {
     if (tlsConfig.getKeyStorePath() == null) {
       throw new IllegalArgumentException("Must provide key store path for secured server");
     }
-    SslContextBuilder sslContextBuilder = SslContextBuilder.forServer(TlsUtils.createKeyManagerFactory(tlsConfig))
+    SslContextBuilder sslContextBuilder = SslContextBuilder.forServer(createKeyManagerFactory(tlsConfig))
         .sslProvider(SslProvider.valueOf(tlsConfig.getSslProvider()));
     if (tlsConfig.getTrustStorePath() != null) {
-      sslContextBuilder.trustManager(TlsUtils.createTrustManagerFactory(tlsConfig));
+      sslContextBuilder.trustManager(createTrustManagerFactory(tlsConfig));
     }
     if (tlsConfig.isClientAuthEnabled()) {
       sslContextBuilder.clientAuth(ClientAuth.REQUIRE);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/TlsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/TlsUtils.java
@@ -19,6 +19,10 @@
 package org.apache.pinot.common.utils;
 
 import com.google.common.base.Preconditions;
+import io.netty.handler.ssl.ClientAuth;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.SslProvider;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetAddress;
@@ -337,6 +341,51 @@ public final class TlsUtils {
     public Socket createSocket(String host, int port)
         throws IOException {
       return _sslSocketFactory.createSocket(host, port);
+    }
+  }
+
+  /**
+   * Builds client side SslContext based on a given TlsConfig.
+   *
+   * @param tlsConfig TLS config
+   */
+  public static SslContext buildClientContext(TlsConfig tlsConfig) {
+    SslContextBuilder sslContextBuilder =
+        SslContextBuilder.forClient().sslProvider(SslProvider.valueOf(tlsConfig.getSslProvider()));
+    if (tlsConfig.getKeyStorePath() != null) {
+      sslContextBuilder.keyManager(TlsUtils.createKeyManagerFactory(tlsConfig));
+    }
+    if (tlsConfig.getTrustStorePath() != null) {
+      sslContextBuilder.trustManager(TlsUtils.createTrustManagerFactory(tlsConfig));
+    }
+    try {
+      return sslContextBuilder.build();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Builds server side SslContext based on a given TlsConfig.
+   *
+   * @param tlsConfig TLS config
+   */
+  public static SslContext buildServerContext(TlsConfig tlsConfig) {
+    if (tlsConfig.getKeyStorePath() == null) {
+      throw new IllegalArgumentException("Must provide key store path for secured server");
+    }
+    SslContextBuilder sslContextBuilder = SslContextBuilder.forServer(TlsUtils.createKeyManagerFactory(tlsConfig))
+        .sslProvider(SslProvider.valueOf(tlsConfig.getSslProvider()));
+    if (tlsConfig.getTrustStorePath() != null) {
+      sslContextBuilder.trustManager(TlsUtils.createTrustManagerFactory(tlsConfig));
+    }
+    if (tlsConfig.isClientAuthEnabled()) {
+      sslContextBuilder.clientAuth(ClientAuth.REQUIRE);
+    }
+    try {
+      return sslContextBuilder.build();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ChannelHandlerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ChannelHandlerFactory.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.transport;
+
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
+import io.netty.handler.codec.LengthFieldPrepender;
+import org.apache.pinot.common.config.TlsConfig;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.utils.TlsUtils;
+import org.apache.pinot.core.query.scheduler.QueryScheduler;
+import org.apache.pinot.server.access.AccessControl;
+
+
+/**
+ * The {@code ChannelHandlerFactory} provides all kinds of Netty ChannelHandlers
+ */
+public class ChannelHandlerFactory {
+
+  public static final String SSL = "ssl";
+
+  private ChannelHandlerFactory() {
+  }
+
+  /**
+   * The {@code getLengthFieldBasedFrameDecoder} return a decoder ChannelHandler that splits the received ByteBuffers
+   * dynamically by the value of the length field in the message
+   */
+  public static ChannelHandler getLengthFieldBasedFrameDecoder() {
+    return new LengthFieldBasedFrameDecoder(Integer.MAX_VALUE, 0, Integer.BYTES, 0, Integer.BYTES);
+  }
+
+  /**
+   * The {@code getLengthFieldPrepender} return an encoder ChannelHandler that prepends the length of the message.
+   */
+  public static ChannelHandler getLengthFieldPrepender() {
+    return new LengthFieldPrepender(Integer.BYTES);
+  }
+
+  /**
+   * The {@code getClientTlsHandler} return a Client side Tls handler that encrypt and decrypt everything.
+   */
+  public static ChannelHandler getClientTlsHandler(TlsConfig tlsConfig, SocketChannel ch) {
+    return TlsUtils.buildClientContext(tlsConfig).newHandler(ch.alloc());
+  }
+
+  /**
+   * The {@code getServerTlsHandler} return a Server side Tls handler that encrypt and decrypt everything.
+   */
+  public static ChannelHandler getServerTlsHandler(TlsConfig tlsConfig, SocketChannel ch) {
+    return TlsUtils.buildServerContext(tlsConfig).newHandler(ch.alloc());
+  }
+
+  /**
+   * The {@code getDataTableHandler} return a {@code DataTableHandler} Netty inbound handler on Pinot Broker side to
+   * handle the serialized data table responses sent from Pinot Server.
+   */
+  public static ChannelHandler getDataTableHandler(QueryRouter queryRouter, ServerRoutingInstance serverRoutingInstance,
+      BrokerMetrics brokerMetrics) {
+    return new DataTableHandler(queryRouter, serverRoutingInstance, brokerMetrics);
+  }
+
+  /**
+   * The {@code getInstanceRequestHandler} return a {@code InstanceRequestHandler} Netty inbound handler on Pinot
+   * Server side to handle the serialized instance requests sent from Pinot Broker.
+   */
+  public static ChannelHandler getInstanceRequestHandler(QueryScheduler queryScheduler, ServerMetrics serverMetrics,
+      AccessControl accessControl) {
+    return new InstanceRequestHandler(queryScheduler, serverMetrics, accessControl);
+  }
+}


### PR DESCRIPTION
## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->

Netty Channel handlers creation logic and Tls context creation logic are scattered at different places, which makes code hard to read.

Please note that the method `initChannel` is called for every new connection that is opened, anything that requires unique state should be constructed inside this method. Thus we should use the factory pattern to get a new object for all the handlers whenever `initChannel` is called.


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
