### PR TITLE
Optimize geometry serializer usage when literal is available

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/BaseBinaryGeoTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/BaseBinaryGeoTransformFunction.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.geospatial.transform.function;
+
+import com.google.common.base.Preconditions;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.core.operator.transform.function.BaseTransformFunction;
+import org.apache.pinot.core.operator.transform.function.LiteralTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TransformFunction;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.segment.local.utils.GeometrySerializer;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.utils.BytesUtils;
+import org.locationtech.jts.geom.Geometry;
+
+
+/**
+ * Base Binary geo transform functions that can take either one of the arguments as literal.
+ */
+public abstract class BaseBinaryGeoTransformFunction extends BaseTransformFunction {
+  private TransformFunction _firstArgument;
+  private TransformFunction _secondArgument;
+  private Geometry _firstLiteral;
+  private Geometry _secondLiteral;
+  private int[] _intResults;
+  private double[] _doubleResults;
+
+  @Override
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
+    Preconditions
+        .checkArgument(arguments.size() == 2, "2 arguments are required for transform function: %s", getName());
+    TransformFunction transformFunction = arguments.get(0);
+    Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
+        "First argument must be single-valued for transform function: %s", getName());
+    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
+            || transformFunction instanceof LiteralTransformFunction,
+        "The first argument must be of type BYTES , but was %s",
+            transformFunction.getResultMetadata().getDataType()
+        );
+    if (transformFunction instanceof LiteralTransformFunction) {
+      _firstLiteral = GeometrySerializer.deserialize(
+          BytesUtils.toBytes(((LiteralTransformFunction) transformFunction).getLiteral()));
+    } else {
+      _firstArgument = transformFunction;
+    }
+    transformFunction = arguments.get(1);
+    Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
+        "Second argument must be single-valued for transform function: %s", getName());
+    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
+            || transformFunction instanceof LiteralTransformFunction,
+        "The second argument must be of type BYTES , but was %s",
+            transformFunction.getResultMetadata().getDataType()
+        );
+    if (transformFunction instanceof LiteralTransformFunction) {
+      _secondLiteral = GeometrySerializer.deserialize(
+          BytesUtils.toBytes(((LiteralTransformFunction) transformFunction).getLiteral()));
+    } else {
+      _secondArgument = transformFunction;
+    }
+  }
+
+  @Override
+  public TransformResultMetadata getResultMetadata() {
+    return INT_SV_NO_DICTIONARY_METADATA;
+  }
+
+  @Override
+  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    if (_intResults == null) {
+      _intResults = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    }
+    final byte[][] firstValues;
+    final byte[][] secondValues;
+    if (_firstArgument != null) {
+      firstValues = _firstArgument.transformToBytesValuesSV(projectionBlock);
+    } else {
+      firstValues = null;
+    }
+    if (_secondArgument != null) {
+      secondValues = _secondArgument.transformToBytesValuesSV(projectionBlock);
+    } else {
+      secondValues = null;
+    }
+    for (int i = 0; i < projectionBlock.getNumDocs(); i++) {
+      Geometry firstGeometry = firstValues == null ? _firstLiteral : GeometrySerializer.deserialize(firstValues[i]);
+      Geometry secondGeometry = secondValues == null ? _secondLiteral : GeometrySerializer.deserialize(secondValues[i]);
+      _intResults[i] = transformGeometryToInt(firstGeometry, secondGeometry);
+    }
+    return _intResults;
+  }
+
+  @Override
+  public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
+    if (_doubleResults == null) {
+      _doubleResults = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    }
+    final byte[][] firstValues;
+    final byte[][] secondValues;
+    if (_firstArgument != null) {
+      firstValues = _firstArgument.transformToBytesValuesSV(projectionBlock);
+    } else {
+      firstValues = null;
+    }
+    if (_secondArgument != null) {
+      secondValues = _secondArgument.transformToBytesValuesSV(projectionBlock);
+    } else {
+      secondValues = null;
+    }
+    for (int i = 0; i < projectionBlock.getNumDocs(); i++) {
+      Geometry firstGeometry = firstValues == null ? _firstLiteral : GeometrySerializer.deserialize(firstValues[i]);
+      Geometry secondGeometry = secondValues == null ? _secondLiteral : GeometrySerializer.deserialize(secondValues[i]);
+      _doubleResults[i] = transformGeometryToDouble(firstGeometry, secondGeometry);
+    }
+    return _doubleResults;
+  }
+
+  public int transformGeometryToInt(Geometry firstGeometry, Geometry secondGeometry) {
+    throw new UnsupportedOperationException("Unsupported!");
+  }
+
+  public double transformGeometryToDouble(Geometry firstGeometry, Geometry secondGeometry) {
+    throw new UnsupportedOperationException("Unsupported!");
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/BaseBinaryGeoTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/BaseBinaryGeoTransformFunction.java
@@ -83,20 +83,24 @@ public abstract class BaseBinaryGeoTransformFunction extends BaseTransformFuncti
     if (_intResults == null) {
       _intResults = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
     }
-    byte[][] firstValues = _firstArgument != null ? _firstArgument.transformToBytesValuesSV(projectionBlock) : null;
-    byte[][] secondValues = _secondArgument != null ? _secondArgument.transformToBytesValuesSV(projectionBlock) : null;
-    if (firstValues == null && secondValues == null) {
+    byte[][] firstValues;
+    byte[][] secondValues;
+    if (_firstArgument == null && _secondArgument == null) {
       _intResults = new int[Math.min(projectionBlock.getNumDocs(), DocIdSetPlanNode.MAX_DOC_PER_CALL)];
       Arrays.fill(_intResults, transformGeometryToInt(_firstLiteral, _secondLiteral));
-    } else if (firstValues == null) {
+    } else if (_firstArgument == null) {
+      secondValues = _secondArgument.transformToBytesValuesSV(projectionBlock);
       for (int i = 0; i < projectionBlock.getNumDocs(); i++) {
         _intResults[i] = transformGeometryToInt(_firstLiteral, GeometrySerializer.deserialize(secondValues[i]));
       }
-    } else if (secondValues == null) {
+    } else if (_secondArgument == null) {
+      firstValues = _firstArgument.transformToBytesValuesSV(projectionBlock);
       for (int i = 0; i < projectionBlock.getNumDocs(); i++) {
         _intResults[i] = transformGeometryToInt(GeometrySerializer.deserialize(firstValues[i]), _secondLiteral);
       }
     } else {
+      firstValues = _firstArgument.transformToBytesValuesSV(projectionBlock);
+      secondValues = _secondArgument.transformToBytesValuesSV(projectionBlock);
       for (int i = 0; i < projectionBlock.getNumDocs(); i++) {
         _intResults[i] = transformGeometryToInt(GeometrySerializer.deserialize(firstValues[i]),
             GeometrySerializer.deserialize(secondValues[i]));
@@ -109,20 +113,24 @@ public abstract class BaseBinaryGeoTransformFunction extends BaseTransformFuncti
     if (_doubleResults == null) {
       _doubleResults = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
     }
-    byte[][] firstValues = _firstArgument != null ? _firstArgument.transformToBytesValuesSV(projectionBlock) : null;
-    byte[][] secondValues = _secondArgument != null ? _secondArgument.transformToBytesValuesSV(projectionBlock) : null;
-    if (firstValues == null && secondValues == null) {
+    byte[][] firstValues;
+    byte[][] secondValues;
+    if (_firstArgument == null && _secondArgument == null) {
       _doubleResults = new double[Math.min(projectionBlock.getNumDocs(), DocIdSetPlanNode.MAX_DOC_PER_CALL)];
       Arrays.fill(_doubleResults, transformGeometryToDouble(_firstLiteral, _secondLiteral));
-    } else if (firstValues == null) {
+    } else if (_firstArgument == null) {
+      secondValues = _secondArgument.transformToBytesValuesSV(projectionBlock);
       for (int i = 0; i < projectionBlock.getNumDocs(); i++) {
         _doubleResults[i] = transformGeometryToDouble(_firstLiteral, GeometrySerializer.deserialize(secondValues[i]));
       }
-    } else if (secondValues == null) {
+    } else if (_secondArgument == null) {
+      firstValues = _firstArgument.transformToBytesValuesSV(projectionBlock);
       for (int i = 0; i < projectionBlock.getNumDocs(); i++) {
         _doubleResults[i] = transformGeometryToDouble(GeometrySerializer.deserialize(firstValues[i]), _secondLiteral);
       }
     } else {
+      firstValues = _firstArgument.transformToBytesValuesSV(projectionBlock);
+      secondValues = _secondArgument.transformToBytesValuesSV(projectionBlock);
       for (int i = 0; i < projectionBlock.getNumDocs(); i++) {
         _doubleResults[i] = transformGeometryToDouble(GeometrySerializer.deserialize(firstValues[i]),
             GeometrySerializer.deserialize(secondValues[i]));

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StContainsFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StContainsFunction.java
@@ -18,20 +18,8 @@
  */
 package org.apache.pinot.core.geospatial.transform.function;
 
-import com.google.common.base.Preconditions;
-import java.util.List;
-import java.util.Map;
-import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
-import org.apache.pinot.core.operator.transform.function.BaseTransformFunction;
-import org.apache.pinot.core.operator.transform.function.LiteralTransformFunction;
-import org.apache.pinot.core.operator.transform.function.TransformFunction;
-import org.apache.pinot.core.plan.DocIdSetPlanNode;
-import org.apache.pinot.segment.local.utils.GeometrySerializer;
 import org.apache.pinot.segment.local.utils.GeometryUtils;
-import org.apache.pinot.segment.spi.datasource.DataSource;
-import org.apache.pinot.spi.data.FieldSpec;
-import org.apache.pinot.spi.utils.BytesUtils;
 import org.locationtech.jts.geom.Geometry;
 
 
@@ -40,51 +28,12 @@ import org.locationtech.jts.geom.Geometry;
  * second geometry lie in the exterior of the first geometry, and at least one point of the interior of the first
  * geometry lies in the interior of the second geometry.
  */
-public class StContainsFunction extends BaseTransformFunction {
+public class StContainsFunction extends BaseBinaryGeoTransformFunction {
   public static final String FUNCTION_NAME = "ST_Contains";
-  private TransformFunction _firstArgument;
-  private TransformFunction _secondArgument;
-  private Geometry _firstLiteral;
-  private Geometry _secondLiteral;
-  private int[] _results;
 
   @Override
   public String getName() {
     return FUNCTION_NAME;
-  }
-
-  @Override
-  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
-    Preconditions
-        .checkArgument(arguments.size() == 2, "2 arguments are required for transform function: %s", getName());
-    TransformFunction transformFunction = arguments.get(0);
-    Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
-        "First argument must be single-valued for transform function: %s", getName());
-    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
-            || transformFunction instanceof LiteralTransformFunction,
-        "The first argument must be of type BYTES , but was %s",
-            transformFunction.getResultMetadata().getDataType()
-        );
-    if (transformFunction instanceof LiteralTransformFunction) {
-      _firstLiteral = GeometrySerializer.deserialize(
-          BytesUtils.toBytes(((LiteralTransformFunction) transformFunction).getLiteral()));
-    } else {
-      _firstArgument = transformFunction;
-    }
-    transformFunction = arguments.get(1);
-    Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
-        "Second argument must be single-valued for transform function: %s", getName());
-    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
-            || transformFunction instanceof LiteralTransformFunction,
-        "The second argument must be of type BYTES , but was %s",
-            transformFunction.getResultMetadata().getDataType()
-        );
-    if (transformFunction instanceof LiteralTransformFunction) {
-      _secondLiteral = GeometrySerializer.deserialize(
-          BytesUtils.toBytes(((LiteralTransformFunction) transformFunction).getLiteral()));
-    } else {
-      _secondArgument = transformFunction;
-    }
   }
 
   @Override
@@ -93,26 +42,10 @@ public class StContainsFunction extends BaseTransformFunction {
   }
 
   @Override
-  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
-    if (_results == null) {
-      _results = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+  public int transformGeometryToInt(Geometry firstGeometry, Geometry secondGeometry) {
+    if (GeometryUtils.isGeography(firstGeometry) || GeometryUtils.isGeography(secondGeometry)) {
+      throw new RuntimeException(String.format("%s is available for Geometry objects only", FUNCTION_NAME));
     }
-    byte[][] firstValues = null;
-    byte[][] secondValues = null;
-    if (_firstArgument != null) {
-      firstValues = _firstArgument.transformToBytesValuesSV(projectionBlock);
-    }
-    if (_secondArgument != null) {
-      secondValues = _secondArgument.transformToBytesValuesSV(projectionBlock);
-    }
-    for (int i = 0; i < projectionBlock.getNumDocs(); i++) {
-      Geometry firstGeometry = firstValues == null ? _firstLiteral : GeometrySerializer.deserialize(firstValues[i]);
-      Geometry secondGeometry = secondValues == null ? _secondLiteral : GeometrySerializer.deserialize(secondValues[i]);
-      if (GeometryUtils.isGeography(firstGeometry) || GeometryUtils.isGeography(secondGeometry)) {
-        throw new RuntimeException(String.format("%s is available for Geometry objects only", FUNCTION_NAME));
-      }
-      _results[i] = firstGeometry.contains(secondGeometry) ? 1 : 0;
-    }
-    return _results;
+    return firstGeometry.contains(secondGeometry) ? 1 : 0;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StContainsFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StContainsFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.geospatial.transform.function;
 
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.segment.local.utils.GeometryUtils;
 import org.locationtech.jts.geom.Geometry;
@@ -39,6 +40,11 @@ public class StContainsFunction extends BaseBinaryGeoTransformFunction {
   @Override
   public TransformResultMetadata getResultMetadata() {
     return INT_SV_NO_DICTIONARY_METADATA;
+  }
+
+  @Override
+  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    return transformGeometryToIntValuesSV(projectionBlock);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StDistanceFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StDistanceFunction.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.geospatial.transform.function;
 
 import com.google.common.base.Preconditions;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.segment.local.utils.GeometryUtils;
 import org.locationtech.jts.geom.Geometry;
@@ -45,6 +46,11 @@ public class StDistanceFunction extends BaseBinaryGeoTransformFunction {
   @Override
   public TransformResultMetadata getResultMetadata() {
     return DOUBLE_SV_NO_DICTIONARY_METADATA;
+  }
+
+  @Override
+  public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
+    return transformGeometryToDoubleValuesSV(projectionBlock);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StDistanceFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StDistanceFunction.java
@@ -19,18 +19,8 @@
 package org.apache.pinot.core.geospatial.transform.function;
 
 import com.google.common.base.Preconditions;
-import java.util.List;
-import java.util.Map;
-import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
-import org.apache.pinot.core.operator.transform.function.BaseTransformFunction;
-import org.apache.pinot.core.operator.transform.function.LiteralTransformFunction;
-import org.apache.pinot.core.operator.transform.function.TransformFunction;
-import org.apache.pinot.core.plan.DocIdSetPlanNode;
-import org.apache.pinot.segment.local.utils.GeometrySerializer;
 import org.apache.pinot.segment.local.utils.GeometryUtils;
-import org.apache.pinot.segment.spi.datasource.DataSource;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
 
@@ -40,43 +30,16 @@ import org.locationtech.jts.geom.Point;
  * cartesian minimum distance (based on spatial ref) between two geometries in projected units. For geography, returns
  * the great-circle distance in meters between two SphericalGeography points. Note that g1, g2 shall have the same type.
  */
-public class StDistanceFunction extends BaseTransformFunction {
+public class StDistanceFunction extends BaseBinaryGeoTransformFunction {
   private static final float MIN_LATITUDE = -90;
   private static final float MAX_LATITUDE = 90;
   private static final float MIN_LONGITUDE = -180;
   private static final float MAX_LONGITUDE = 180;
   public static final String FUNCTION_NAME = "ST_Distance";
-  private TransformFunction _firstArgument;
-  private TransformFunction _secondArgument;
-  private double[] _results;
 
   @Override
   public String getName() {
     return FUNCTION_NAME;
-  }
-
-  @Override
-  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
-    Preconditions
-        .checkArgument(arguments.size() == 2, "2 arguments are required for transform function: %s", getName());
-    TransformFunction transformFunction = arguments.get(0);
-    Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
-        "First argument must be single-valued for transform function: %s", getName());
-    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
-        || transformFunction instanceof LiteralTransformFunction,
-        "The first argument must be of type BYTES , but was %s",
-            transformFunction.getResultMetadata().getDataType()
-        );
-    _firstArgument = transformFunction;
-    transformFunction = arguments.get(1);
-    Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
-        "Second argument must be single-valued for transform function: %s", getName());
-    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
-        || transformFunction instanceof LiteralTransformFunction,
-        "The second argument must be of type BYTES , but was %s",
-            transformFunction.getResultMetadata().getDataType()
-        );
-    _secondArgument = transformFunction;
   }
 
   @Override
@@ -85,26 +48,15 @@ public class StDistanceFunction extends BaseTransformFunction {
   }
 
   @Override
-  public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
-    if (_results == null) {
-      _results = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+  public double transformGeometryToDouble(Geometry firstGeometry, Geometry secondGeometry) {
+    if (GeometryUtils.isGeography(firstGeometry) != GeometryUtils.isGeography(secondGeometry)) {
+      throw new RuntimeException("The first and second arguments shall either all be geometry or all geography");
     }
-    byte[][] firstValues = _firstArgument.transformToBytesValuesSV(projectionBlock);
-    byte[][] secondValues = _secondArgument.transformToBytesValuesSV(projectionBlock);
-    for (int i = 0; i < projectionBlock.getNumDocs(); i++) {
-      Geometry firstGeometry = GeometrySerializer.deserialize(firstValues[i]);
-      Geometry secondGeometry = GeometrySerializer.deserialize(secondValues[i]);
-      if (GeometryUtils.isGeography(firstGeometry) != GeometryUtils.isGeography(secondGeometry)) {
-        throw new RuntimeException("The first and second arguments shall either all be geometry or all geography");
-      }
-      if (GeometryUtils.isGeography(firstGeometry)) {
-        _results[i] = sphericalDistance(firstGeometry, secondGeometry);
-      } else {
-        _results[i] =
-            firstGeometry.isEmpty() || secondGeometry.isEmpty() ? Double.NaN : firstGeometry.distance(secondGeometry);
-      }
+    if (GeometryUtils.isGeography(firstGeometry)) {
+      return sphericalDistance(firstGeometry, secondGeometry);
+    } else {
+      return firstGeometry.isEmpty() || secondGeometry.isEmpty() ? Double.NaN : firstGeometry.distance(secondGeometry);
     }
-    return _results;
   }
 
   private static void checkLatitude(double latitude) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StEqualsFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StEqualsFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.geospatial.transform.function;
 
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.locationtech.jts.geom.Geometry;
 
@@ -36,6 +37,11 @@ public class StEqualsFunction extends BaseBinaryGeoTransformFunction {
   @Override
   public TransformResultMetadata getResultMetadata() {
     return INT_SV_NO_DICTIONARY_METADATA;
+  }
+
+  @Override
+  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    return transformGeometryToIntValuesSV(projectionBlock);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StEqualsFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StEqualsFunction.java
@@ -18,57 +18,19 @@
  */
 package org.apache.pinot.core.geospatial.transform.function;
 
-import com.google.common.base.Preconditions;
-import java.util.List;
-import java.util.Map;
-import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
-import org.apache.pinot.core.operator.transform.function.BaseTransformFunction;
-import org.apache.pinot.core.operator.transform.function.LiteralTransformFunction;
-import org.apache.pinot.core.operator.transform.function.TransformFunction;
-import org.apache.pinot.core.plan.DocIdSetPlanNode;
-import org.apache.pinot.segment.local.utils.GeometrySerializer;
-import org.apache.pinot.segment.spi.datasource.DataSource;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.locationtech.jts.geom.Geometry;
 
 
 /**
  * Function that returns true if the given geometries represent the same geometry.
  */
-public class StEqualsFunction extends BaseTransformFunction {
+public class StEqualsFunction extends BaseBinaryGeoTransformFunction {
   public static final String FUNCTION_NAME = "ST_Equals";
-  private TransformFunction _firstArgument;
-  private TransformFunction _secondArgument;
-  private int[] _results;
 
   @Override
   public String getName() {
     return FUNCTION_NAME;
-  }
-
-  @Override
-  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
-    Preconditions
-        .checkArgument(arguments.size() == 2, "2 arguments are required for transform function: %s", getName());
-    TransformFunction transformFunction = arguments.get(0);
-    Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
-        "First argument must be single-valued for transform function: %s", getName());
-    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
-            || transformFunction instanceof LiteralTransformFunction,
-        String.format("The first argument must be of type BYTES , but was %s",
-            transformFunction.getResultMetadata().getDataType()
-        ));
-    _firstArgument = transformFunction;
-    transformFunction = arguments.get(1);
-    Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
-        "Second argument must be single-valued for transform function: %s", getName());
-    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
-            || transformFunction instanceof LiteralTransformFunction,
-        "The second argument must be of type BYTES , but was %s",
-            transformFunction.getResultMetadata().getDataType()
-        );
-    _secondArgument = transformFunction;
   }
 
   @Override
@@ -77,17 +39,7 @@ public class StEqualsFunction extends BaseTransformFunction {
   }
 
   @Override
-  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
-    if (_results == null) {
-      _results = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-    }
-    byte[][] firstValues = _firstArgument.transformToBytesValuesSV(projectionBlock);
-    byte[][] secondValues = _secondArgument.transformToBytesValuesSV(projectionBlock);
-    for (int i = 0; i < projectionBlock.getNumDocs(); i++) {
-      Geometry firstGeometry = GeometrySerializer.deserialize(firstValues[i]);
-      Geometry secondGeometry = GeometrySerializer.deserialize(secondValues[i]);
-      _results[i] = firstGeometry.equals(secondGeometry) ? 1 : 0;
-    }
-    return _results;
+  public int transformGeometryToInt(Geometry firstGeometry, Geometry secondGeometry) {
+    return firstGeometry.equals(secondGeometry) ? 1 : 0;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StWithinFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StWithinFunction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.geospatial.transform.function;
 
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.segment.local.utils.GeometryUtils;
 import org.locationtech.jts.geom.Geometry;
@@ -38,6 +39,11 @@ public class StWithinFunction extends BaseBinaryGeoTransformFunction {
   @Override
   public TransformResultMetadata getResultMetadata() {
     return INT_SV_NO_DICTIONARY_METADATA;
+  }
+
+  @Override
+  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    return transformGeometryToIntValuesSV(projectionBlock);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StWithinFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StWithinFunction.java
@@ -18,18 +18,8 @@
  */
 package org.apache.pinot.core.geospatial.transform.function;
 
-import com.google.common.base.Preconditions;
-import java.util.List;
-import java.util.Map;
-import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
-import org.apache.pinot.core.operator.transform.function.BaseTransformFunction;
-import org.apache.pinot.core.operator.transform.function.LiteralTransformFunction;
-import org.apache.pinot.core.operator.transform.function.TransformFunction;
-import org.apache.pinot.segment.local.utils.GeometrySerializer;
 import org.apache.pinot.segment.local.utils.GeometryUtils;
-import org.apache.pinot.segment.spi.datasource.DataSource;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.locationtech.jts.geom.Geometry;
 
 
@@ -37,37 +27,12 @@ import org.locationtech.jts.geom.Geometry;
  * Function that checks the containment of the two geo-spatial objects. It returns true if and only if
  * first geometry is completely inside second geometry.
  */
-public class StWithinFunction extends BaseTransformFunction {
+public class StWithinFunction extends BaseBinaryGeoTransformFunction {
   public static final String FUNCTION_NAME = "ST_Within";
-  private TransformFunction _firstArgument;
-  private TransformFunction _secondArgument;
-  private int[] _results;
 
   @Override
   public String getName() {
     return FUNCTION_NAME;
-  }
-
-  @Override
-  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
-    Preconditions
-        .checkArgument(arguments.size() == 2, "2 arguments are required for transform function: %s", getName());
-    TransformFunction transformFunction = arguments.get(0);
-    Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
-        "First argument must be single-valued for transform function: %s", getName());
-    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
-        || transformFunction instanceof LiteralTransformFunction,
-        "The first argument must be of type BYTES, but was %s",
-        transformFunction.getResultMetadata().getDataType());
-    _firstArgument = transformFunction;
-    transformFunction = arguments.get(1);
-    Preconditions.checkArgument(transformFunction.getResultMetadata().isSingleValue(),
-        "Second argument must be single-valued for transform function: %s", getName());
-    Preconditions.checkArgument(transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BYTES
-        || transformFunction instanceof LiteralTransformFunction,
-        "The second argument must be of types BYTES, but was %s",
-        transformFunction.getResultMetadata().getDataType());
-    _secondArgument = transformFunction;
   }
 
   @Override
@@ -76,20 +41,10 @@ public class StWithinFunction extends BaseTransformFunction {
   }
 
   @Override
-  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
-    if (_results == null) {
-      _results = new int[projectionBlock.getNumDocs()];
+  public int transformGeometryToInt(Geometry firstGeometry, Geometry secondGeometry) {
+    if (GeometryUtils.isGeography(firstGeometry) || GeometryUtils.isGeography(secondGeometry)) {
+      throw new RuntimeException(String.format("%s is available for Geometry objects only", FUNCTION_NAME));
     }
-    byte[][] firstValues = _firstArgument.transformToBytesValuesSV(projectionBlock);
-    byte[][] secondValues = _secondArgument.transformToBytesValuesSV(projectionBlock);
-    for (int i = 0; i < projectionBlock.getNumDocs(); i++) {
-      Geometry firstGeometry = GeometrySerializer.deserialize(firstValues[i]);
-      Geometry secondGeometry = GeometrySerializer.deserialize(secondValues[i]);
-      if (GeometryUtils.isGeography(firstGeometry) || GeometryUtils.isGeography(secondGeometry)) {
-        throw new RuntimeException(String.format("%s is available for Geometry objects only", FUNCTION_NAME));
-      }
-      _results[i] = firstGeometry.within(secondGeometry) ? 1 : 0;
-    }
-    return _results;
+    return firstGeometry.within(secondGeometry) ? 1 : 0;
   }
 }


### PR DESCRIPTION
Cache the Literal converted Geometry instead of computing it each time the Geometry function is called. 

This 
- save memory for processing literal transform function (previously it was done via Array.fill)
- save compute from Geometry function

In general this should apply to any chained call to LiteralTransformFunction with block --> it should be considered as a fake array instead fo a real, replicated one. This is out of scope of this PR but something to keep in mind.