### PR TITLE
Set numGroupLimitReached properly in a few places

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,7 @@ kubernetes/examples/helm/charts/
 .env.development.local
 .env.test.local
 .env.production.local
-
+.java-version
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/ConcurrentIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/ConcurrentIndexedTable.java
@@ -77,6 +77,7 @@ public class ConcurrentIndexedTable extends IndexedTable {
       addOrUpdateRecord(key, record);
       if (_lookupMap.size() >= _resultSize) {
         _noMoreNewRecords.set(true);
+        _groupLimitReached.set(true);
       }
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
@@ -24,6 +24,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
@@ -45,6 +47,7 @@ public abstract class IndexedTable extends BaseTable {
   protected final int _trimSize;
   protected final int _trimThreshold;
 
+  protected final AtomicBoolean _groupLimitReached = new AtomicBoolean();
   protected Collection<Record> _topRecords;
   private int _numResizes;
   private long _resizeTimeNs;
@@ -172,5 +175,9 @@ public abstract class IndexedTable extends BaseTable {
 
   public long getResizeTimeMs() {
     return TimeUnit.NANOSECONDS.toMillis(_resizeTimeNs);
+  }
+
+  public boolean IsNumGroupsLimitReached() {
+    return _groupLimitReached.get();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
@@ -178,6 +178,6 @@ public abstract class IndexedTable extends BaseTable {
   }
 
   public boolean IsNumGroupsLimitReached() {
-    return _groupLimitReached.get();
+    return _groupLimitReached.get() || _tableResizer.is_groupLimitReached();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
@@ -177,6 +177,6 @@ public abstract class IndexedTable extends BaseTable {
   }
 
   public boolean isNumGroupsLimitReached() {
-    return _groupLimitReached.get() || _tableResizer.isNumGroupsLimitReached();
+    return _groupLimitReached.get() || (_tableResizer != null && _tableResizer.isNumGroupsLimitReached());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
@@ -177,7 +177,7 @@ public abstract class IndexedTable extends BaseTable {
     return TimeUnit.NANOSECONDS.toMillis(_resizeTimeNs);
   }
 
-  public boolean IsNumGroupsLimitReached() {
-    return _groupLimitReached.get() || _tableResizer.is_groupLimitReached();
+  public boolean isNumGroupsLimitReached() {
+    return _groupLimitReached.get() || _tableResizer.isNumGroupsLimitReached();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/SimpleIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/SimpleIndexedTable.java
@@ -49,6 +49,7 @@ public class SimpleIndexedTable extends IndexedTable {
       if (_lookupMap.size() < _resultSize) {
         addOrUpdateRecord(key, record);
       } else {
+        _groupLimitReached.set(true);
         updateExistingRecord(key, record);
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
@@ -324,6 +324,10 @@ public class TableResizer {
     return getIntermediateRecord(new Key(keys), new Record(values));
   }
 
+  public boolean is_groupLimitReached() {
+    return _groupLimitReached;
+  }
+
   /**
    * Extractor for the order-by value from a Record.
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
@@ -54,6 +54,7 @@ public class TableResizer {
   private final int _numOrderByExpressions;
   private final OrderByValueExtractor[] _orderByValueExtractors;
   private final Comparator<IntermediateRecord> _intermediateRecordComparator;
+  private boolean _groupLimitReached = false;
 
   public TableResizer(DataSchema dataSchema, QueryContext queryContext) {
     _dataSchema = dataSchema;
@@ -138,6 +139,9 @@ public class TableResizer {
     if (numRecordsToEvict <= 0) {
       return;
     }
+
+    _groupLimitReached = true;
+
     if (numRecordsToEvict <= size) {
       // Fewer records to evict than retain, make a heap of records to evict
       IntermediateRecord[] recordsToEvict =

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
@@ -324,7 +324,7 @@ public class TableResizer {
     return getIntermediateRecord(new Key(keys), new Record(values));
   }
 
-  public boolean is_groupLimitReached() {
+  public boolean isNumGroupsLimitReached() {
     return _groupLimitReached;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
@@ -219,9 +219,9 @@ public class GroupByCombineOperator extends BaseCombineOperator {
     }
     // TODO: this value should be set in the inner-segment operators. Setting it here might cause false positive as we
     //       are comparing number of groups across segments with the groups limit for each segment.
-    if (_resultsMap.size() >= _innerSegmentNumGroupsLimit ||
-            _groupLimitReached.get() ||
-            aggregationGroupByTrimmingService.isTrimApplied()) {
+    if (_resultsMap.size() >= _innerSegmentNumGroupsLimit
+            || _groupLimitReached.get()
+            || aggregationGroupByTrimmingService.isTrimApplied()) {
       mergedBlock.setNumGroupsLimitReached(true);
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.response.ProcessingException;
@@ -71,6 +72,7 @@ public class GroupByCombineOperator extends BaseCombineOperator {
   // We use a CountDownLatch to track if all Futures are finished by the query timeout, and cancel the unfinished
   // _futures (try to interrupt the execution if it already started).
   private final CountDownLatch _operatorLatch;
+  private final AtomicBoolean _groupLimitReached = new AtomicBoolean();
 
   public GroupByCombineOperator(List<Operator> operators, QueryContext queryContext, ExecutorService executorService) {
     super(operators, overrideMaxExecutionThreads(queryContext, operators.size()), executorService);
@@ -140,6 +142,8 @@ public class GroupByCombineOperator extends BaseCombineOperator {
                   for (int i = 0; i < _numAggregationFunctions; i++) {
                     value[i] = aggregationGroupByResult.getResultForKey(groupKey, i);
                   }
+                } else {
+                  _groupLimitReached.set(true);
                 }
               } else {
                 for (int i = 0; i < _numAggregationFunctions; i++) {
@@ -215,7 +219,9 @@ public class GroupByCombineOperator extends BaseCombineOperator {
     }
     // TODO: this value should be set in the inner-segment operators. Setting it here might cause false positive as we
     //       are comparing number of groups across segments with the groups limit for each segment.
-    if (_resultsMap.size() >= _innerSegmentNumGroupsLimit) {
+    if (_resultsMap.size() >= _innerSegmentNumGroupsLimit ||
+            _groupLimitReached.get() ||
+            aggregationGroupByTrimmingService.isTrimApplied()) {
       mergedBlock.setNumGroupsLimitReached(true);
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByOrderByCombineOperator.java
@@ -243,7 +243,7 @@ public class GroupByOrderByCombineOperator extends BaseCombineOperator {
 
     mergedBlock.setNumResizes(indexedTable.getNumResizes());
     mergedBlock.setResizeTimeMs(indexedTable.getResizeTimeMs());
-    if (_indexedTable.IsNumGroupsLimitReached()) {
+    if (_indexedTable.isNumGroupsLimitReached()) {
       mergedBlock.setNumGroupsLimitReached(true);
     }
     return mergedBlock;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByOrderByCombineOperator.java
@@ -243,7 +243,9 @@ public class GroupByOrderByCombineOperator extends BaseCombineOperator {
 
     mergedBlock.setNumResizes(indexedTable.getNumResizes());
     mergedBlock.setResizeTimeMs(indexedTable.getResizeTimeMs());
-    // TODO - set numGroupsLimitReached
+    if (_indexedTable.IsNumGroupsLimitReached()) {
+      mergedBlock.setNumGroupsLimitReached(true);
+    }
     return mergedBlock;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/AggregationGroupByTrimmingService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/AggregationGroupByTrimmingService.java
@@ -51,6 +51,8 @@ public class AggregationGroupByTrimmingService {
   private final int _trimSize;
   private final int _trimThreshold;
 
+  private boolean _trimApplied = false;
+
   public AggregationGroupByTrimmingService(QueryContext queryContext) {
     _aggregationFunctions = queryContext.getAggregationFunctions();
     List<ExpressionContext> groupByExpressions = queryContext.getGroupByExpressions();
@@ -77,6 +79,8 @@ public class AggregationGroupByTrimmingService {
 
     int numGroups = intermediateResultsMap.size();
     if (numGroups > _trimThreshold) {
+      _trimApplied = true;
+
       // Trim the result only if number of groups is larger than the threshold
 
       Sorter[] sorters = new Sorter[numAggregationFunctions];
@@ -360,5 +364,9 @@ public class AggregationGroupByTrimmingService {
     public void dumpToGroupByResults(LinkedList<GroupByResult> dest, int numGroupByExpressions) {
       throw new UnsupportedOperationException();
     }
+  }
+
+  public boolean isTrimApplied() {
+    return _trimApplied;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -245,6 +245,9 @@ public class GroupByDataTableReducer implements DataTableReducer {
         resultRows.add(resultRow);
       }
       brokerResponseNative.setResultTable(new ResultTable(resultDataSchema, resultRows));
+      if (indexedTable.IsNumGroupsLimitReached()) {
+        brokerResponseNative.setNumGroupsLimitReached(true);
+      }
     } else {
       // PQL query with SQL group-by mode and response format
       // NOTE: For PQL query, keep the order of columns as is (group-by expressions followed by aggregations), no need

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -245,7 +245,7 @@ public class GroupByDataTableReducer implements DataTableReducer {
         resultRows.add(resultRow);
       }
       brokerResponseNative.setResultTable(new ResultTable(resultDataSchema, resultRows));
-      if (indexedTable.IsNumGroupsLimitReached()) {
+      if (indexedTable.isNumGroupsLimitReached()) {
         brokerResponseNative.setNumGroupsLimitReached(true);
       }
     } else {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
@@ -108,7 +108,7 @@ public class IndexedTableTest {
         future.get(10, TimeUnit.SECONDS);
       }
 
-      Assert.assertTrue(indexedTable.IsNumGroupsLimitReached());
+      Assert.assertTrue(indexedTable.isNumGroupsLimitReached());
       indexedTable.finish(false);
       Assert.assertEquals(indexedTable.size(), 5);
       checkEvicted(indexedTable, "c", "f");

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
@@ -277,12 +277,15 @@ public class IndexedTableTest {
   @Test
   public void testUpsertOrderByWithTrim() {
     QueryContext queryContext =
-            QueryContextConverterUtils.getQueryContextFromSQL("SELECT key, count(*) FROM testTable GROUP BY key ORDER BY 2 DESC");
+            QueryContextConverterUtils.getQueryContextFromSQL(
+                    "SELECT key, count(*) FROM testTable GROUP BY key ORDER BY 2 DESC"
+            );
     DataSchema dataSchema = new DataSchema(new String[]{"key", "count(*)"}, new ColumnDataType[]{
             ColumnDataType.INT, ColumnDataType.LONG
     });
 
-    IndexedTable indexedTable = new ConcurrentIndexedTable(dataSchema, queryContext, TRIM_SIZE, TRIM_SIZE, TRIM_THRESHOLD);
+    IndexedTable indexedTable =
+            new ConcurrentIndexedTable(dataSchema, queryContext, TRIM_SIZE, TRIM_SIZE, TRIM_THRESHOLD);
     for (int i = 1; i <= 21; i++) {
       indexedTable.upsert(getRecord(new Object[]{i, new Long(i + 10)}));
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
@@ -274,6 +274,21 @@ public class IndexedTableTest {
     Assert.assertTrue(indexedTable.isNumGroupsLimitReached());
   }
 
+  @Test
+  public void testUpsertOrderByWithTrim() {
+    QueryContext queryContext =
+            QueryContextConverterUtils.getQueryContextFromSQL("SELECT key, count(*) FROM testTable GROUP BY key ORDER BY 2 DESC");
+    DataSchema dataSchema = new DataSchema(new String[]{"key", "count(*)"}, new ColumnDataType[]{
+            ColumnDataType.INT, ColumnDataType.LONG
+    });
+
+    IndexedTable indexedTable = new ConcurrentIndexedTable(dataSchema, queryContext, TRIM_SIZE, TRIM_SIZE, TRIM_THRESHOLD);
+    for (int i = 1; i <= 21; i++) {
+      indexedTable.upsert(getRecord(new Object[]{i, new Long(i + 10)}));
+    }
+    Assert.assertTrue(indexedTable.isNumGroupsLimitReached());
+  }
+
   private void testNoMoreNewRecordsInTable(IndexedTable indexedTable) {
     // Insert 7 records. Check that last 2 never made it.
     indexedTable.upsert(getRecord(new Object[]{"a", 1, 10d, 10d, 100d}));

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
@@ -266,7 +266,8 @@ public class IndexedTableTest {
             ColumnDataType.INT, ColumnDataType.DOUBLE
     });
 
-    IndexedTable indexedTable = new ConcurrentIndexedTable(dataSchema, queryContext, TRIM_SIZE, TRIM_SIZE, TRIM_THRESHOLD);
+    IndexedTable indexedTable =
+            new ConcurrentIndexedTable(dataSchema, queryContext, TRIM_SIZE, TRIM_SIZE, TRIM_THRESHOLD);
     for (int i = 1; i <= 11; i++) {
       indexedTable.upsert(getRecord(new Object[]{i, 10d}));
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/IndexedTableTest.java
@@ -108,6 +108,7 @@ public class IndexedTableTest {
         future.get(10, TimeUnit.SECONDS);
       }
 
+      Assert.assertTrue(indexedTable.IsNumGroupsLimitReached());
       indexedTable.finish(false);
       Assert.assertEquals(indexedTable.size(), 5);
       checkEvicted(indexedTable, "c", "f");


### PR DESCRIPTION
## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
This patch correctly sets the `numGroupsLimitReached` flag in a few places where query operators trim results. There might be more places where results "trimming" occurs without settings this flag, but it's a start.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
