### PR TITLE
Disable quick-start-streaming test because Meetup RSVP stream is retired

### DIFF
--- a/.github/workflows/scripts/.pinot_quickstart.sh
+++ b/.github/workflows/scripts/.pinot_quickstart.sh
@@ -210,41 +210,42 @@ if [ "${PASS}" -eq 0 ]; then
 fi
 
 # Test quick-start-streaming
-bin/quick-start-streaming.sh &
-PID=$!
-
-PASS=0
-RES_1=0
-
-# Wait for 1 minute for table to be set up, then at most 5 minutes to reach the desired state
-sleep 60
-for i in $(seq 1 150)
-do
-  QUERY_RES=`curl -X POST --header 'Accept: application/json'  -d '{"sql":"select count(*) from meetupRsvp limit 1","trace":false}' http://localhost:8000/query/sql`
-  if [ $? -eq 0 ]; then
-    COUNT_STAR_RES=`echo "${QUERY_RES}" | jq '.resultTable.rows[0][0]'`
-    if [[ "${COUNT_STAR_RES}" =~ ^[0-9]+$ ]] && [ "${COUNT_STAR_RES}" -gt 0 ]; then
-      if [ "${RES_1}" -eq 0 ]; then
-        RES_1="${COUNT_STAR_RES}"
-        continue
-      elif [ "${COUNT_STAR_RES}" -gt "${RES_1}" ]; then
-        PASS=1
-        break
-      fi
-    fi
-  fi
-  sleep 2
-done
-
-cleanup "${PID}"
-if [ "${PASS}" -eq 0 ]; then
-  if [ "${RES_1}" -eq 0 ]; then
-    echo 'Streaming Quickstart test failed: Cannot get correct result for count star query.'
-    exit 1
-  fi
-  echo 'Streaming Quickstart test failed: Cannot get incremental counts for count star query.'
-  exit 1
-fi
+# TODO: Streaming test is disabled because Meetup RSVP stream is retired. Find a replacement and re-enable this test.
+#bin/quick-start-streaming.sh &
+#PID=$!
+#
+#PASS=0
+#RES_1=0
+#
+## Wait for 1 minute for table to be set up, then at most 5 minutes to reach the desired state
+#sleep 60
+#for i in $(seq 1 150)
+#do
+#  QUERY_RES=`curl -X POST --header 'Accept: application/json'  -d '{"sql":"select count(*) from meetupRsvp limit 1","trace":false}' http://localhost:8000/query/sql`
+#  if [ $? -eq 0 ]; then
+#    COUNT_STAR_RES=`echo "${QUERY_RES}" | jq '.resultTable.rows[0][0]'`
+#    if [[ "${COUNT_STAR_RES}" =~ ^[0-9]+$ ]] && [ "${COUNT_STAR_RES}" -gt 0 ]; then
+#      if [ "${RES_1}" -eq 0 ]; then
+#        RES_1="${COUNT_STAR_RES}"
+#        continue
+#      elif [ "${COUNT_STAR_RES}" -gt "${RES_1}" ]; then
+#        PASS=1
+#        break
+#      fi
+#    fi
+#  fi
+#  sleep 2
+#done
+#
+#cleanup "${PID}"
+#if [ "${PASS}" -eq 0 ]; then
+#  if [ "${RES_1}" -eq 0 ]; then
+#    echo 'Streaming Quickstart test failed: Cannot get correct result for count star query.'
+#    exit 1
+#  fi
+#  echo 'Streaming Quickstart test failed: Cannot get incremental counts for count star query.'
+#  exit 1
+#fi
 
 # Test quick-start-hybrid
 bin/quick-start-hybrid.sh &


### PR DESCRIPTION
TODO: Find a replacement for this stream, then re-enable this test.