### PR TITLE
Add support for pushFileNamePattern in pushJobSpec

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentMetadataPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentMetadataPushJobRunner.java
@@ -94,8 +94,7 @@ public class HadoopSegmentMetadataPushJobRunner implements IngestionJobRunner, S
 
     try {
       Map<String, String> segmentUriToTarPathMap = SegmentPushUtils
-          .getSegmentUriToTarPathMap(outputDirURI, _spec.getPushJobSpec().getSegmentUriPrefix(),
-              _spec.getPushJobSpec().getSegmentUriSuffix(), segmentsToPush.toArray(new String[0]));
+          .getSegmentUriToTarPathMap(outputDirURI, _spec.getPushJobSpec(), segmentsToPush.toArray(new String[0]));
       SegmentPushUtils
           .sendSegmentUriAndMetadata(_spec, PinotFSFactory.create(outputDirURI.getScheme()), segmentUriToTarPathMap);
     } catch (Exception e) {

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentMetadataPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentMetadataPushJobRunner.java
@@ -120,8 +120,7 @@ public class SparkSegmentMetadataPushJobRunner implements IngestionJobRunner, Se
           }
           try {
             Map<String, String> segmentUriToTarPathMap = SegmentPushUtils
-                .getSegmentUriToTarPathMap(finalOutputDirURI, _spec.getPushJobSpec().getSegmentUriPrefix(),
-                    _spec.getPushJobSpec().getSegmentUriSuffix(), new String[]{segmentTarPath});
+                .getSegmentUriToTarPathMap(finalOutputDirURI, _spec.getPushJobSpec(), new String[]{segmentTarPath});
             SegmentPushUtils.sendSegmentUriAndMetadata(_spec, PinotFSFactory.create(finalOutputDirURI.getScheme()),
                 segmentUriToTarPathMap);
           } catch (RetriableOperationException | AttemptsExceededException e) {

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentMetadataPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentMetadataPushJobRunner.java
@@ -60,7 +60,7 @@ public class SegmentMetadataPushJobRunner implements IngestionJobRunner {
       PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
     }
 
-    //Get outputFS for writing output Pinot segments
+    //Get outputFS for list of available Pinot segments
     URI outputDirURI;
     try {
       outputDirURI = new URI(_spec.getOutputDirURI());
@@ -79,9 +79,8 @@ public class SegmentMetadataPushJobRunner implements IngestionJobRunner {
     } catch (IOException e) {
       throw new RuntimeException("Unable to list all files under outputDirURI - '" + outputDirURI + "'");
     }
-    Map<String, String> segmentUriToTarPathMap = SegmentPushUtils
-        .getSegmentUriToTarPathMap(outputDirURI, _spec.getPushJobSpec().getSegmentUriPrefix(),
-            _spec.getPushJobSpec().getSegmentUriSuffix(), files);
+    Map<String, String> segmentUriToTarPathMap =
+        SegmentPushUtils.getSegmentUriToTarPathMap(outputDirURI, _spec.getPushJobSpec(), files);
     try {
       SegmentPushUtils.sendSegmentUriAndMetadata(_spec, outputDirFS, segmentUriToTarPathMap);
     } catch (Exception e) {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutor.java
@@ -189,9 +189,8 @@ public class SegmentGenerationAndPushTaskExecutor extends BaseTaskExecutor {
         break;
       case METADATA:
         try {
-          Map<String, String> segmentUriToTarPathMap = SegmentPushUtils
-              .getSegmentUriToTarPathMap(outputSegmentDirURI, pushJobSpec.getSegmentUriPrefix(),
-                  pushJobSpec.getSegmentUriSuffix(), new String[]{outputSegmentTarURI.toString()});
+          Map<String, String> segmentUriToTarPathMap = SegmentPushUtils.getSegmentUriToTarPathMap(outputSegmentDirURI,
+              pushJobSpec, new String[] { outputSegmentTarURI.toString() });
           SegmentPushUtils.sendSegmentUriAndMetadata(spec, outputFileFS, segmentUriToTarPathMap);
         } catch (RetriableOperationException | AttemptsExceededException e) {
           throw new RuntimeException(e);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
@@ -234,9 +234,8 @@ public final class IngestionUtils {
             outputSegmentDirURI = URI.create(batchConfig.getOutputSegmentDirURI());
           }
           PinotFS outputFileFS = getOutputPinotFS(batchConfig, outputSegmentDirURI);
-          Map<String, String> segmentUriToTarPathMap = SegmentPushUtils
-              .getSegmentUriToTarPathMap(outputSegmentDirURI, segmentUploadSpec.getPushJobSpec().getSegmentUriPrefix(),
-                  segmentUploadSpec.getPushJobSpec().getSegmentUriSuffix(), new String[]{segmentTarURIs.toString()});
+          Map<String, String> segmentUriToTarPathMap = SegmentPushUtils.getSegmentUriToTarPathMap(outputSegmentDirURI,
+              segmentUploadSpec.getPushJobSpec(), new String[] { segmentTarURIs.toString() });
           SegmentPushUtils.sendSegmentUriAndMetadata(segmentUploadSpec, outputFileFS, segmentUriToTarPathMap);
         } catch (RetriableOperationException | AttemptsExceededException e) {
           throw new RuntimeException(String

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SegmentPushUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SegmentPushUtilsTest.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.utils;
+
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.util.Map;
+import org.apache.pinot.spi.ingestion.batch.spec.PushJobSpec;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class SegmentPushUtilsTest {
+  
+  @Test
+  public void testGetSegmentUriToTarPathMap() throws IOException {
+    URI outputDirURI = Files.createTempDirectory("test").toUri();
+    
+    String[] segmentFiles = new String[] {
+        outputDirURI.resolve("segment.tar.gz").toString(),
+        outputDirURI.resolve("stats_202201.tar.gz").toString(),
+        outputDirURI.resolve("/2022/segment.tar.gz").toString(),
+        outputDirURI.resolve("/2022/stats_202201.tar.gz").toString()
+    };
+    
+    PushJobSpec pushSpec = new PushJobSpec();
+    Map<String, String> result = SegmentPushUtils.getSegmentUriToTarPathMap(outputDirURI, pushSpec, segmentFiles);
+    assertEquals(result.size(), 4);
+    for (String segmentFile : segmentFiles) {
+      assertTrue(result.containsKey(segmentFile));
+      assertEquals(result.get(segmentFile), segmentFile);
+    }
+    
+    pushSpec.setPushFileNamePattern("glob:**/2022/*.tar.gz");
+    result = SegmentPushUtils.getSegmentUriToTarPathMap(outputDirURI, pushSpec, segmentFiles);
+    assertEquals(result.size(), 2);
+    assertEquals(result.get(segmentFiles[2]), segmentFiles[2]);
+    assertEquals(result.get(segmentFiles[3]), segmentFiles[3]);
+
+    pushSpec.setPushFileNamePattern("glob:**/stats_*.tar.gz");
+    result = SegmentPushUtils.getSegmentUriToTarPathMap(outputDirURI, pushSpec, segmentFiles);
+    assertEquals(result.size(), 2);
+    assertEquals(result.get(segmentFiles[1]), segmentFiles[1]);
+    assertEquals(result.get(segmentFiles[3]), segmentFiles[3]);
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/PushJobSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/PushJobSpec.java
@@ -48,6 +48,22 @@ public class PushJobSpec implements Serializable {
   private String _segmentUriPrefix;
   private String _segmentUriSuffix;
 
+  /**
+   * Segments to push file name pattern, supported glob pattern.
+   * Sample usage:
+   *    'glob:2022/*.tar.gz' will include all segments under _outputDirURI/2022/, but not sub directories;
+   *    'glob:**\/stats_*.tar.gz' will include all the segments starting with "stats_" under _outputDirURI recursively.
+   */
+  private String _pushFileNamePattern;
+
+  public String getPushFileNamePattern() {
+    return _pushFileNamePattern;
+  }
+  
+  public void setPushFileNamePattern(String pushFileNamePattern) {
+    _pushFileNamePattern = pushFileNamePattern;
+  }
+  
   public String getSegmentUriPrefix() {
     return _segmentUriPrefix;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
@@ -60,10 +60,11 @@ public class SegmentGenerationJobSpec implements Serializable {
   private String _excludeFileNamePattern;
 
   /**
-   * Root directory of output segments, expected to have scheme configured in PinotFS.
+   * Root directory of output segments, expected to have scheme configured in PinotFS. Note that this
+   * is the input directory for jobs that push segments to the Pinot cluster.
    */
   private String _outputDirURI;
-
+  
   /**
    * Segment creation job parallelism.
    */

--- a/pom.xml
+++ b/pom.xml
@@ -1822,6 +1822,7 @@
             <exclude>**/*.iml</exclude>
             <exclude>**/maven-eclipse.xml</exclude>
             <exclude>**/.settings/**</exclude>
+            <exclude>**/.project</exclude>
             <exclude>.externalToolBuilders/**</exclude>
 
             <!-- Docker and Kubernetes (not part of the distribution) -->
@@ -1834,8 +1835,11 @@
             <!-- Github template files -->
             <exclude>.github/*.md</exclude>
 
-	      <!-- MISC -->
-	      <exclude>**/.factorypath</exclude>
+            <!-- Test output -->
+            <exclude>**/test-output/**</exclude>
+            
+            <!-- MISC -->
+            <exclude>**/.factorypath</exclude>
           </excludes>
         </configuration>
       </plugin>


### PR DESCRIPTION
## Description
Support a new, optional pushFileNamePattern parameter in the pushJobSpec section of the job yaml. This will filter segments in the outputDir that are pushed to Pinot.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [X] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
Support for name-based filtering of segments being pushed to the Pinot cluster.

## Documentation
In the https://docs.pinot.apache.org/configuration-reference/job-specification#push-job-spec section, add:

```
pushFileNamePattern | segment name pattern for which segments to push, supported glob and regex patterns. E.g. 
'glob:stats_* will push all segment files under the outputDirURI whose names start with 'stats_'. 
'glob:*2022-01*' will push all the segment files under the outputDirURI whose names contain '2022-01'.
```
