### PR TITLE
Enable service discovery in controller too

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -26,6 +26,7 @@ import java.util.List;
 import org.apache.pinot.broker.requesthandler.BrokerRequestHandler;
 import org.apache.pinot.broker.routing.RoutingManager;
 import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.core.api.ServiceAutoDiscoveryFeature;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -51,7 +52,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     packages(RESOURCE_PACKAGE);
     property(PINOT_CONFIGURATION, brokerConf);
     if (brokerConf.getProperty(CommonConstants.Broker.BROKER_SERVICE_AUTO_DISCOVERY, false)) {
-      register(BrokerServiceAutoDiscoveryFeature.class);
+      register(ServiceAutoDiscoveryFeature.class);
     }
     register(new AbstractBinder() {
       @Override

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
@@ -28,6 +28,7 @@ import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AuthenticationFilter;
+import org.apache.pinot.core.api.ServiceAutoDiscoveryFeature;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -57,6 +58,9 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     packages(_controllerResourcePackages);
     // TODO See ControllerResponseFilter
 //    register(new LoggingFeature());
+    if (conf.getProperty(CommonConstants.Controller.CONTROLLER_SERVICE_AUTO_DISCOVERY, false)) {
+      register(ServiceAutoDiscoveryFeature.class);
+    }
     register(JacksonFeature.class);
     register(MultiPartFeature.class);
     registerClasses(io.swagger.jaxrs.listing.ApiListingResource.class);

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -179,6 +179,10 @@
       <groupId>org.glassfish.grizzly</groupId>
       <artifactId>grizzly-http-server</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.glassfish.hk2</groupId>
+      <artifactId>hk2-locator</artifactId>
+    </dependency>
 
     <!-- test -->
     <dependency>

--- a/pinot-core/src/main/java/org/apache/pinot/core/api/ServiceAutoDiscoveryFeature.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/api/ServiceAutoDiscoveryFeature.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.broker.broker;
+package org.apache.pinot.core.api;
 
 import java.io.IOException;
 import javax.inject.Inject;
@@ -30,6 +30,7 @@ import org.glassfish.hk2.utilities.ClasspathDescriptorFileFinder;
 import org.glassfish.hk2.utilities.DuplicatePostProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
 
 /**
  * Auto scan and discovery classes annotated with Service tags. This enables the feature similar to Spring's
@@ -68,8 +69,8 @@ import org.slf4j.LoggerFactory;
  * pinot-integration-tests/src/main/java/org/apache/pinot/broker/integration/tests/BrokerTestAutoLoadedService.java
  * </code>
  */
-public class BrokerServiceAutoDiscoveryFeature implements Feature {
-    private static final Logger LOGGER = LoggerFactory.getLogger(BrokerServiceAutoDiscoveryFeature.class);
+public class ServiceAutoDiscoveryFeature implements Feature {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ServiceAutoDiscoveryFeature.class);
 
     @Inject
     ServiceLocator _serviceLocator;

--- a/pinot-integration-tests/src/main/java/org/apache/pinot/broker/api/resources/BrokerEchoWithAutoDiscovery.java
+++ b/pinot-integration-tests/src/main/java/org/apache/pinot/broker/api/resources/BrokerEchoWithAutoDiscovery.java
@@ -26,7 +26,7 @@ import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
-import org.apache.pinot.broker.integration.tests.BrokerTestAutoLoadedService;
+import org.apache.pinot.core.api.AutoLoadedServiceForTest;
 
 /**
  * This class is a typical "echo" service that will return whatever string you call GET with a path.
@@ -35,9 +35,9 @@ import org.apache.pinot.broker.integration.tests.BrokerTestAutoLoadedService;
  */
 @Api(tags = "Test")
 @Path("/test")
-public class EchoWithAutoDiscovery {
+public class BrokerEchoWithAutoDiscovery {
     @Inject
-    public BrokerTestAutoLoadedService _injectedService;
+    public AutoLoadedServiceForTest _injectedService;
     @GET
     @Path("/echo/{table}")
     @Produces(MediaType.TEXT_PLAIN)

--- a/pinot-integration-tests/src/main/java/org/apache/pinot/controller/api/resources/ControllerEchoWithAutoDiscovery.java
+++ b/pinot-integration-tests/src/main/java/org/apache/pinot/controller/api/resources/ControllerEchoWithAutoDiscovery.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.controller.api.resources;
+
+import io.swagger.annotations.Api;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import org.apache.pinot.core.api.AutoLoadedServiceForTest;
+
+
+/**
+ * This class is a typical "echo" service that will return whatever string you call GET with a path.
+ * It is both an integration test and a demonstration of how to dynamically add an endpoint to broker,
+ * create auto-service discovery
+ */
+@Api(tags = "Test")
+@Path("/test")
+public class ControllerEchoWithAutoDiscovery {
+    @Inject
+    public AutoLoadedServiceForTest _injectedService;
+    @GET
+    @Path("/echo/{table}")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String echo(@PathParam("table") String table) {
+        return _injectedService.echo(table);
+    }
+}

--- a/pinot-integration-tests/src/main/java/org/apache/pinot/core/api/AutoLoadedServiceForTest.java
+++ b/pinot-integration-tests/src/main/java/org/apache/pinot/core/api/AutoLoadedServiceForTest.java
@@ -16,14 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.broker.integration.tests;
+package org.apache.pinot.core.api;
 
 import javax.inject.Singleton;
 import org.jvnet.hk2.annotations.Service;
 
 @Service
 @Singleton
-public class BrokerTestAutoLoadedService {
+public class AutoLoadedServiceForTest {
     public String echo(String echoText) {
         return echoText;
     }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerServiceDiscoveryIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerServiceDiscoveryIntegrationTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.integration.tests;
 
+import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -27,10 +28,11 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+
 /**
  * Integration test that starts one broker with auto-discovered echo service and test it
  */
-public class BrokerServiceDiscoveryIntegrationTest extends BaseClusterIntegrationTestSet {
+public class ControllerServiceDiscoveryIntegrationTest extends BaseClusterIntegrationTestSet {
   private static final String TENANT_NAME = "TestTenant";
 
   @Override
@@ -43,10 +45,10 @@ public class BrokerServiceDiscoveryIntegrationTest extends BaseClusterIntegratio
     return TENANT_NAME;
   }
 
-  protected PinotConfiguration getDefaultBrokerConfiguration() {
-    PinotConfiguration config = new PinotConfiguration();
-    config.setProperty(CommonConstants.Broker.BROKER_SERVICE_AUTO_DISCOVERY, true);
-    return config;
+  public Map<String, Object> getDefaultControllerConfiguration() {
+    Map<String, Object> retVal = super.getDefaultControllerConfiguration();
+    retVal.put(CommonConstants.Controller.CONTROLLER_SERVICE_AUTO_DISCOVERY, true);
+    return retVal;
   }
 
   @BeforeClass
@@ -59,8 +61,8 @@ public class BrokerServiceDiscoveryIntegrationTest extends BaseClusterIntegratio
     startController();
     startBrokers(1);
     startServers(1);
-  }
 
+  }
   @AfterClass
   public void tearDown()
           throws Exception {
@@ -73,9 +75,9 @@ public class BrokerServiceDiscoveryIntegrationTest extends BaseClusterIntegratio
   }
 
   @Test
-  public void testBrokerExtraEndpointsAutoLoaded()
+  public void testControllerExtraEndpointsAutoLoaded()
       throws Exception {
-    String response = sendGetRequest(_brokerBaseApiUrl + "/test/echo/doge");
+    String response = sendGetRequest(_controllerBaseApiUrl + "/test/echo/doge");
     Assert.assertEquals(response, "doge");
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerServiceDiscoveryIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerServiceDiscoveryIntegrationTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.integration.tests;
 
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
@@ -44,10 +45,18 @@ public class ControllerServiceDiscoveryIntegrationTest extends BaseClusterIntegr
     return TENANT_NAME;
   }
 
+  @Override
   public Map<String, Object> getDefaultControllerConfiguration() {
     Map<String, Object> retVal = super.getDefaultControllerConfiguration();
     retVal.put(CommonConstants.Controller.CONTROLLER_SERVICE_AUTO_DISCOVERY, true);
     return retVal;
+  }
+
+  @Override
+  protected PinotConfiguration getDefaultBrokerConfiguration() {
+    PinotConfiguration config = new PinotConfiguration();
+    config.setProperty(CommonConstants.Broker.BROKER_SERVICE_AUTO_DISCOVERY, true);
+    return config;
   }
 
   @BeforeClass
@@ -77,6 +86,8 @@ public class ControllerServiceDiscoveryIntegrationTest extends BaseClusterIntegr
   public void testControllerExtraEndpointsAutoLoaded()
       throws Exception {
     String response = sendGetRequest(_controllerBaseApiUrl + "/test/echo/doge");
+    Assert.assertEquals(response, "doge");
+    response = sendGetRequest(_brokerBaseApiUrl + "/test/echo/doge");
     Assert.assertEquals(response, "doge");
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerServiceDiscoveryIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerServiceDiscoveryIntegrationTest.java
@@ -69,7 +69,6 @@ public class ControllerServiceDiscoveryIntegrationTest extends BaseClusterIntegr
     startController();
     startBrokers(1);
     startServers(1);
-
   }
   @AfterClass
   public void tearDown()

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerServiceDiscoveryIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerServiceDiscoveryIntegrationTest.java
@@ -20,7 +20,6 @@ package org.apache.pinot.integration.tests;
 
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -442,6 +442,8 @@ public class CommonConstants {
     public static final String CONFIG_OF_INSTANCE_ID = "pinot.controller.instance.id";
     public static final String CONFIG_OF_CONTROLLER_QUERY_REWRITER_CLASS_NAMES =
         "pinot.controller.query.rewriter.class.names";
+    //Set to true to load all services tagged and compiled with hk2-metadata-generator. Default to False
+    public static final String CONTROLLER_SERVICE_AUTO_DISCOVERY = "pinot.controller.service.auto.discovery";
   }
 
   public static class Minion {


### PR DESCRIPTION
## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->

**Enable controller service auto-discovery in Jersey framework.**
Also refactored the Broker's ServiceAutoDiscoveryFeature into a shared class for Pinot

### Background
This is following https://github.com/apache/pinot/pull/8107 to enable the service auto-creation in controller too.
It is found out that we may need to hook in new services in Pinot Controllers too.

The context can be found in previous PR, I will copy/paste the same text here for reference:

1. Main idea is behind [mkyong's article in detail in here](https://mkyong.com/webservices/jax-rs/jersey-and-hk2-dependency-injection-auto-scanning/)
2. Added a property boolean named `pinot.controller.service.auto.discovery` to enable this behavior

Steps needed to make a class auto-created in PinotController:
1. Add `hk2-metadata-generator` module as a dependency in your JAR file
2. Tag your class with `@org.jvnet.hk2.annotations.Service` tag 
3. Set `pinot.controller.service.auto.discovery=true` in your Controller's property config
4. Make sure your JAR file is loaded in class path(of coz)
5. (Optional) inject your class instance to other places


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

- New configuration options: `pinot.controller.service.auto.discovery` so Jersey services can be created automatically and then later injected to Endpoints.

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
