### PR TITLE
add copy recursive API to pinotFS

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/PinotFSSegmentUploaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/PinotFSSegmentUploaderTest.java
@@ -114,7 +114,7 @@ public class PinotFSSegmentUploaderTest {
     }
 
     @Override
-    public boolean copy(URI srcUri, URI dstUri)
+    public boolean copyDir(URI srcUri, URI dstUri)
         throws IOException {
       return false;
     }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PeerDownloadLLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PeerDownloadLLCRealtimeClusterIntegrationTest.java
@@ -288,7 +288,7 @@ public class PeerDownloadLLCRealtimeClusterIntegrationTest extends RealtimeClust
     }
 
     @Override
-    public boolean copy(URI srcUri, URI dstUri)
+    public boolean copyDir(URI srcUri, URI dstUri)
         throws IOException {
       try {
         return _localPinotFS.copyDir(new URI(_basePath + srcUri.getPath()), new URI(_basePath + dstUri.getPath()));

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PeerDownloadLLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PeerDownloadLLCRealtimeClusterIntegrationTest.java
@@ -291,7 +291,7 @@ public class PeerDownloadLLCRealtimeClusterIntegrationTest extends RealtimeClust
     public boolean copy(URI srcUri, URI dstUri)
         throws IOException {
       try {
-        return _localPinotFS.copy(new URI(_basePath + srcUri.getPath()), new URI(_basePath + dstUri.getPath()));
+        return _localPinotFS.copyDir(new URI(_basePath + srcUri.getPath()), new URI(_basePath + dstUri.getPath()));
       } catch (URISyntaxException e) {
         throw new IllegalArgumentException(e.getMessage());
       }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
@@ -343,7 +343,7 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
       if (stagingDirURI != null) {
         LOGGER.info("Trying to copy segment tars from staging directory: [{}] to output directory [{}]", stagingDirURI,
             outputDirURI);
-        outputDirFS.copy(stagingDirURI, outputDirURI);
+        outputDirFS.copyDir(stagingDirURI, outputDirURI);
       }
     } finally {
       if (stagingDirURI != null) {

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
@@ -265,7 +265,7 @@ public class ADLSGen2PinotFS extends BasePinotFS {
    * @return true if move succeeds else false.
    */
   @Override
-  public boolean copy(URI srcUri, URI dstUri)
+  public boolean copyDir(URI srcUri, URI dstUri)
       throws IOException {
     LOGGER.debug("copy is called with srcUri='{}', dstUri='{}'", srcUri, dstUri);
     // If src and dst are the same, do nothing.

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/AzurePinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/AzurePinotFS.java
@@ -107,8 +107,12 @@ public class AzurePinotFS extends BasePinotFS {
   }
 
   @Override
-  public boolean copy(URI srcUri, URI dstUri)
+  public boolean copyDir(URI srcUri, URI dstUri)
       throws IOException {
+    if (isDirectory(srcUri)) {
+      throw new UnsupportedOperationException("Azure FS doesn't support directory recursive copy!");
+    }
+
     if (exists(dstUri)) {
       delete(dstUri, true);
     }
@@ -126,9 +130,8 @@ public class AzurePinotFS extends BasePinotFS {
       inputStream.close();
       outputStream.close();
     } catch (IOException e) {
-      LOGGER
-          .error("Exception encountered during copy, input: '{}', output: '{}'.", srcUri.toString(), dstUri.toString(),
-              e);
+      LOGGER.error("Exception encountered during copy, input: '{}', output: '{}'.", srcUri, dstUri, e);
+      return false;
     }
     return true;
   }

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/AzurePinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/AzurePinotFS.java
@@ -109,6 +109,7 @@ public class AzurePinotFS extends BasePinotFS {
   @Override
   public boolean copyDir(URI srcUri, URI dstUri)
       throws IOException {
+    // TODO: support directory copy.
     if (isDirectory(srcUri)) {
       throw new UnsupportedOperationException("Azure FS doesn't support directory recursive copy!");
     }

--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
@@ -122,14 +122,14 @@ public class GcsPinotFS extends BasePinotFS {
     GcsUri srcGcsUri = new GcsUri(srcUri);
     GcsUri dstGcsUri = new GcsUri(dstUri);
     if (copy(srcGcsUri, dstGcsUri)) {
-      // Only delete if all files were successfully moved
+      // Only delete if all files were successfully copied
       return delete(srcGcsUri, true);
     }
     return false;
   }
 
   @Override
-  public boolean copy(URI srcUri, URI dstUri)
+  public boolean copyDir(URI srcUri, URI dstUri)
       throws IOException {
     LOGGER.info("Copying uri {} to uri {}", srcUri, dstUri);
     return copy(new GcsUri(srcUri), new GcsUri(dstUri));
@@ -414,9 +414,11 @@ public class GcsPinotFS extends BasePinotFS {
     if (srcUri.equals(dstUri)) {
       return true;
     }
+    // copy directly if source is a single file.
     if (!existsDirectory(srcUri)) {
       return copyFile(srcUri, dstUri);
     }
+    // copy directory
     if (srcUri.hasSubpath(dstUri) || dstUri.hasSubpath(srcUri)) {
       throw new IOException(String.format("Cannot copy from or to a subdirectory: '%s' -> '%s'", srcUri, dstUri));
     }

--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/test/java/org/apache/pinot/plugin/filesystem/TestGcsPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/test/java/org/apache/pinot/plugin/filesystem/TestGcsPinotFS.java
@@ -211,7 +211,7 @@ public class TestGcsPinotFS {
 
     // Test copy directory -> directory
     GcsUri gcsDirectoryUriCopy = createTempDirectoryGcsUri();
-    _pinotFS.copy(gcsDirectoryUri.getUri(), gcsDirectoryUriCopy.getUri());
+    _pinotFS.copyDir(gcsDirectoryUri.getUri(), gcsDirectoryUriCopy.getUri());
 
     Set<GcsUri> expectedElementsCopy = new HashSet<>();
     String directoryName = Paths.get(gcsDirectoryUri.getPath()).getFileName().toString();

--- a/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
@@ -115,7 +115,7 @@ public class HadoopPinotFS extends BasePinotFS {
           }
         } else if (sourceFile.isDirectory()) {
           try {
-            copy(sourceFilePath.toUri(), new Path(target, sourceFilePath.getName()).toUri());
+            copyDir(sourceFilePath.toUri(), new Path(target, sourceFilePath.getName()).toUri());
           } catch (FileNotFoundException e) {
             LOGGER.warn("Not found directory {}, skipping copying it...", sourceFilePath, e);
           }

--- a/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
@@ -97,7 +97,7 @@ public class HadoopPinotFS extends BasePinotFS {
    * need to create a new configuration and filesystem. Keeps files if copy/move is partial.
    */
   @Override
-  public boolean copy(URI srcUri, URI dstUri)
+  public boolean copyDir(URI srcUri, URI dstUri)
       throws IOException {
     Path source = new Path(srcUri);
     Path target = new Path(dstUri);

--- a/pinot-plugins/pinot-file-system/pinot-hdfs/src/test/java/org/apache/pinot/plugin/filesystem/HadoopPinotFSTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/src/test/java/org/apache/pinot/plugin/filesystem/HadoopPinotFSTest.java
@@ -42,7 +42,7 @@ public class HadoopPinotFSTest {
       hadoopFS.touch(new Path(baseURI.getPath(), "src/dir/2").toUri());
       String[] srcFiles = hadoopFS.listFiles(new Path(baseURI.getPath(), "src").toUri(), true);
       Assert.assertEquals(srcFiles.length, 3);
-      hadoopFS.copy(new Path(baseURI.getPath(), "src").toUri(), new Path(baseURI.getPath(), "dest").toUri());
+      hadoopFS.copyDir(new Path(baseURI.getPath(), "src").toUri(), new Path(baseURI.getPath(), "dest").toUri());
       Assert.assertTrue(hadoopFS.exists(new Path(baseURI.getPath(), "dest").toUri()));
       Assert.assertTrue(hadoopFS.exists(new Path(baseURI.getPath(), "dest/dir").toUri()));
       Assert.assertTrue(hadoopFS.exists(new Path(baseURI.getPath(), "dest/dir/1").toUri()));

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -363,7 +363,7 @@ public class S3PinotFS extends BasePinotFS {
   @Override
   public boolean doMove(URI srcUri, URI dstUri)
       throws IOException {
-    if (copy(srcUri, dstUri)) {
+    if (copyDir(srcUri, dstUri)) {
       return delete(srcUri, true);
     }
     return false;

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -370,7 +370,7 @@ public class S3PinotFS extends BasePinotFS {
   }
 
   @Override
-  public boolean copy(URI srcUri, URI dstUri)
+  public boolean copyDir(URI srcUri, URI dstUri)
       throws IOException {
     LOGGER.info("Copying uri {} to uri {}", srcUri, dstUri);
     Preconditions.checkState(exists(srcUri), "Source URI '%s' does not exist", srcUri);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/BasePinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/BasePinotFS.java
@@ -57,4 +57,11 @@ public abstract class BasePinotFS implements PinotFS {
     }
     return doMove(srcUri, dstUri);
   }
+
+  /**
+   * Actual move implementation for each PinotFS. It should not be directly called, instead use
+   * {@link PinotFS#move(URI, URI, boolean)}.
+   */
+  protected abstract boolean doMove(URI srcUri, URI dstUri)
+      throws IOException;
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/LocalPinotFS.java
@@ -83,9 +83,9 @@ public class LocalPinotFS extends BasePinotFS {
   }
 
   @Override
-  public boolean copy(URI srcUri, URI dstUri)
+  public boolean copyDir(URI srcUri, URI dstUri)
       throws IOException {
-    copy(toFile(srcUri), toFile(dstUri), false);
+    copy(toFile(srcUri), toFile(dstUri), true);
     return true;
   }
 
@@ -182,7 +182,7 @@ public class LocalPinotFS extends BasePinotFS {
         FileUtils.copyDirectory(srcFile, dstFile);
       } else {
         // Throws Exception on failure
-        throw new IOException(srcFile.getAbsolutePath() + " is a directory");
+        throw new IOException(srcFile.getAbsolutePath() + " is a directory and recursive copy is not enabled.");
       }
     } else {
       // Will create parent directories, throws Exception on failure

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
@@ -103,7 +103,7 @@ public interface PinotFS extends Closeable, Serializable {
   default boolean copy(URI srcUri, URI dstUri)
       throws IOException {
     if (isDirectory(srcUri)) {
-      throw new UnsupportedOperationException("Recursive copy not supported");
+      throw new IllegalArgumentException("Recursive copy not supported");
     }
     return copyDir(srcUri, dstUri);
   }
@@ -123,10 +123,8 @@ public interface PinotFS extends Closeable, Serializable {
    * @return true if copy is successful
    * @throws IOException on IO failure
    */
-  default boolean copyDir(URI srcUri, URI dstUri)
-      throws IOException {
-    throw new UnsupportedOperationException("Recursive copy not supported");
-  }
+  boolean copyDir(URI srcUri, URI dstUri)
+      throws IOException;
 
   /**
    * Checks whether the file or directory at the provided location exists.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
@@ -88,10 +88,25 @@ public interface PinotFS extends Closeable, Serializable {
       throws IOException;
 
   /**
-   * Does the actual behavior of move in each FS.
+   * Copies the file from the src to dst. The original file is retained. If the dst has parent directories
+   * that haven't been created, this method will create all the necessary parent directories. If dst already exists,
+   * this will overwrite the existing file in the path.
+   *
+   * Note: In Pinot we recommend the full paths of both src and dst be specified.
+   * For example, if a file /a/b/c is copied to a file /x/y/z, the directory /a/b still exists containing the file 'c'.
+   * The dst file /x/y/z will contain the contents of 'c'.
+   * @param srcUri URI of the original file
+   * @param dstUri URI of the final file location
+   * @return true if copy is successful
+   * @throws IOException on IO failure
    */
-  boolean doMove(URI srcUri, URI dstUri)
-      throws IOException;
+  default boolean copy(URI srcUri, URI dstUri)
+      throws IOException {
+    if (isDirectory(srcUri)) {
+      throw new UnsupportedOperationException("Recursive copy not supported");
+    }
+    return copyDir(srcUri, dstUri);
+  }
 
   /**
    * Copies the file or directory from the src to dst. The original file is retained. If the dst has parent directories
@@ -108,8 +123,10 @@ public interface PinotFS extends Closeable, Serializable {
    * @return true if copy is successful
    * @throws IOException on IO failure
    */
-  boolean copy(URI srcUri, URI dstUri)
-      throws IOException;
+  default boolean copyDir(URI srcUri, URI dstUri)
+      throws IOException {
+    throw new UnsupportedOperationException("Recursive copy not supported");
+  }
 
   /**
    * Checks whether the file or directory at the provided location exists.
@@ -162,6 +179,7 @@ public interface PinotFS extends Closeable, Serializable {
       throws Exception {
     throw new UnsupportedOperationException("Recursive copy not supported");
   }
+
   /**
    * The src file is on the local disk. Add it to filesystem at the given dst name and the source is kept intact
    * afterwards.

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java
@@ -205,11 +205,47 @@ public class LocalPinotFSTest {
       // Expected.
     }
 
+    // Check that directory only copy worked
+    try {
+      localPinotFS.copyDir(firstTempDir.toURI(), secondTempDir.toURI());
+      fail();
+    } catch (IOException e) {
+      // expected.
+    }
+    localPinotFS.copyDir(firstTempDir.toURI(), secondTempDir.toURI());
+    Assert.assertTrue(localPinotFS.exists(secondTempDir.toURI()));
+
+    // Copying directory with files to directory with files
+    File testFile = new File(firstTempDir, "testFile");
+    Assert.assertTrue(testFile.createNewFile(), "Could not create file " + testFile.getPath());
+    File newTestFile = new File(secondTempDir, "newTestFile");
+    Assert.assertTrue(newTestFile.createNewFile(), "Could not create file " + newTestFile.getPath());
+
+    localPinotFS.copyDir(firstTempDir.toURI(), secondTempDir.toURI());
+    Assert.assertEquals(localPinotFS.listFiles(secondTempDir.toURI(), false).length, 1);
+
+    // Copying directory with files under another directory.
+    File firstTempDirUnderSecondTempDir = new File(secondTempDir, firstTempDir.getName());
+    localPinotFS.copyDir(firstTempDir.toURI(), firstTempDirUnderSecondTempDir.toURI());
+    Assert.assertTrue(localPinotFS.exists(firstTempDirUnderSecondTempDir.toURI()));
+    // There're two files/directories under secondTempDir.
+    Assert.assertEquals(localPinotFS.listFiles(secondTempDir.toURI(), false).length, 2);
+    // The file under src directory also got copied under dst directory.
+    Assert.assertEquals(localPinotFS.listFiles(firstTempDirUnderSecondTempDir.toURI(), true).length, 1);
+
     // len of dir = exception
     try {
       localPinotFS.length(firstTempDir.toURI());
       fail();
     } catch (IllegalArgumentException e) {
+      // expected.
     }
+
+    Assert.assertTrue(testFile.exists());
+
+    localPinotFS.copyFromLocalFile(testFile, secondTestFileUri);
+    Assert.assertTrue(localPinotFS.exists(secondTestFileUri));
+    localPinotFS.copyToLocalFile(testFile.toURI(), new File(secondTestFileUri));
+    Assert.assertTrue(localPinotFS.exists(secondTestFileUri));
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java
@@ -209,7 +209,7 @@ public class LocalPinotFSTest {
     try {
       localPinotFS.copy(firstTempDir.toURI(), secondTempDir.toURI());
       fail();
-    } catch (UnsupportedOperationException e) {
+    } catch (IllegalArgumentException e) {
       // expected.
     }
 

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/LocalPinotFSTest.java
@@ -205,13 +205,15 @@ public class LocalPinotFSTest {
       // Expected.
     }
 
-    // Check that directory only copy worked
+    // Check that directory only copy doesn't work with default 'copy'
     try {
-      localPinotFS.copyDir(firstTempDir.toURI(), secondTempDir.toURI());
+      localPinotFS.copy(firstTempDir.toURI(), secondTempDir.toURI());
       fail();
-    } catch (IOException e) {
+    } catch (UnsupportedOperationException e) {
       // expected.
     }
+
+    // Copying directory works with 'copyDir'
     localPinotFS.copyDir(firstTempDir.toURI(), secondTempDir.toURI());
     Assert.assertTrue(localPinotFS.exists(secondTempDir.toURI()));
 

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSFactoryTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSFactoryTest.java
@@ -94,7 +94,7 @@ public class PinotFSFactoryTest {
     }
 
     @Override
-    public boolean copy(URI srcUri, URI dstUri)
+    public boolean copyDir(URI srcUri, URI dstUri)
         throws IOException {
       return true;
     }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSTest.java
@@ -114,7 +114,7 @@ public class PinotFSTest {
     }
 
     @Override
-    public boolean copy(URI srcUri, URI dstUri)
+    public boolean copyDir(URI srcUri, URI dstUri)
         throws IOException {
       return false;
     }


### PR DESCRIPTION
Description
===
After #8162, behavior for pinotFS.copy is different between cloud and local implementation. 

- LocalPinotFS.copy(srcUri, dstUri) throws exception if srcUri is a directory.
- S3PinotFS.copy(srcUri, dstUri) return true and a recursive copy happened if srcUri is a directory.

this basically means users who needs to do a recursive copying would need to know exactly what underlying implementation

Proposal
===

- make the current S3PintoFS.copy(srcUri, dstUri) to also throw exception when the URI is a folder. thus make it consistent with LocalFS
    - this is achieved via a default copy function that rejects directory URIs.
- move the current recursive copy implementation in S3 to a new API: `PinotFS.copyDir(srcUri, dstUri)`.