### PR TITLE
Allow subclass to customize what happens pre/post segment uploading

### DIFF
--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
  */
 public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExecutor {
   private static final Logger LOGGER = LoggerFactory.getLogger(BaseMultipleSegmentsConversionExecutor.class);
-  private static final String UPLOAD_CONTEXT_LINEAGE_ENTRY_ID = "lineageEntryId";
+  private static final String CUSTOM_SEGMENT_UPLOAD_CONTEXT_LINEAGE_ENTRY_ID = "lineageEntryId";
 
   protected MinionConf _minionConf;
 
@@ -92,46 +92,30 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
   protected void postProcess(PinotTaskConfig pinotTaskConfig) {
   }
 
-  protected Map<String, Object> preUploadSegments(PinotTaskConfig pinotTaskConfig,
-      List<SegmentConversionResult> segmentConversionResults)
+  protected void preUploadSegments(SegmentUploadContext context)
       throws Exception {
     // Update the segment lineage to indicate that the segment replacement is in progress.
-    Map<String, String> configs = pinotTaskConfig.getConfigs();
-    String replaceSegmentsString = configs.get(MinionConstants.ENABLE_REPLACE_SEGMENTS_KEY);
-    boolean replaceSegmentsEnabled = Boolean.parseBoolean(replaceSegmentsString);
-
-    Map<String, Object> uploadContext = new HashMap<>();
-    if (replaceSegmentsEnabled) {
-      String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
-      String inputSegmentNames = configs.get(MinionConstants.SEGMENT_NAME_KEY);
-      String uploadURL = configs.get(MinionConstants.UPLOAD_URL_KEY);
-      String authToken = configs.get(MinionConstants.AUTH_TOKEN);
+    if (context.isReplaceSegmentsEnabled()) {
       List<String> segmentsFrom =
-          Arrays.stream(StringUtils.split(inputSegmentNames, MinionConstants.SEGMENT_NAME_SEPARATOR)).map(String::trim)
-              .collect(Collectors.toList());
+          Arrays.stream(StringUtils.split(context.getInputSegmentNames(), MinionConstants.SEGMENT_NAME_SEPARATOR))
+              .map(String::trim).collect(Collectors.toList());
       List<String> segmentsTo =
-          segmentConversionResults.stream().map(SegmentConversionResult::getSegmentName).collect(Collectors.toList());
-      String lineageEntryId = SegmentConversionUtils.startSegmentReplace(tableNameWithType, uploadURL,
-          new StartReplaceSegmentsRequest(segmentsFrom, segmentsTo), authToken);
-      uploadContext.put(UPLOAD_CONTEXT_LINEAGE_ENTRY_ID, lineageEntryId);
+          context.getSegmentConversionResults().stream().map(SegmentConversionResult::getSegmentName)
+              .collect(Collectors.toList());
+      String lineageEntryId =
+          SegmentConversionUtils.startSegmentReplace(context.getTableNameWithType(), context.getUploadURL(),
+              new StartReplaceSegmentsRequest(segmentsFrom, segmentsTo), context.getAuthToken());
+      context.setCustomContext(CUSTOM_SEGMENT_UPLOAD_CONTEXT_LINEAGE_ENTRY_ID, lineageEntryId);
     }
-    return uploadContext;
   }
 
-  protected void postUploadSegments(PinotTaskConfig pinotTaskConfig, Map<String, Object> uploadContext)
+  protected void postUploadSegments(SegmentUploadContext context)
       throws Exception {
     // Update the segment lineage to indicate that the segment replacement is done.
-    Map<String, String> configs = pinotTaskConfig.getConfigs();
-    String replaceSegmentsString = configs.get(MinionConstants.ENABLE_REPLACE_SEGMENTS_KEY);
-    boolean replaceSegmentsEnabled = Boolean.parseBoolean(replaceSegmentsString);
-    if (replaceSegmentsEnabled) {
-      String lineageEntryId = (String) uploadContext.get(UPLOAD_CONTEXT_LINEAGE_ENTRY_ID);
-      String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
-      String uploadURL = configs.get(MinionConstants.UPLOAD_URL_KEY);
-      String authToken = configs.get(MinionConstants.AUTH_TOKEN);
-      SegmentConversionUtils
-          .endSegmentReplace(tableNameWithType, uploadURL, lineageEntryId, _minionConf.getEndReplaceSegmentsTimeoutMs(),
-              authToken);
+    if (context.isReplaceSegmentsEnabled()) {
+      String lineageEntryId = (String) context.getCustomContext(CUSTOM_SEGMENT_UPLOAD_CONTEXT_LINEAGE_ENTRY_ID);
+      SegmentConversionUtils.endSegmentReplace(context.getTableNameWithType(), context.getUploadURL(), lineageEntryId,
+          _minionConf.getEndReplaceSegmentsTimeoutMs(), context.getAuthToken());
     }
   }
 
@@ -212,7 +196,8 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
             taskType + " on table: " + tableNameWithType + ", segments: " + inputSegmentNames + " got cancelled");
       }
 
-      Map<String, Object> uploadContext = preUploadSegments(pinotTaskConfig, segmentConversionResults);
+      SegmentUploadContext segmentUploadContext = new SegmentUploadContext(pinotTaskConfig, segmentConversionResults);
+      preUploadSegments(segmentUploadContext);
 
       // Upload the tarred segments
       for (int i = 0; i < numOutputSegments; i++) {
@@ -246,7 +231,7 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
         }
       }
 
-      postUploadSegments(pinotTaskConfig, uploadContext);
+      postUploadSegments(segmentUploadContext);
 
       String outputSegmentNames = segmentConversionResults.stream().map(SegmentConversionResult::getSegmentName)
           .collect(Collectors.joining(","));
@@ -258,6 +243,71 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
       return segmentConversionResults;
     } finally {
       FileUtils.deleteQuietly(tempDataDir);
+    }
+  }
+
+  // SegmentUploadContext holds the info to conduct certain actions
+  // before and after uploading multiple segments.
+  protected static class SegmentUploadContext {
+    private final PinotTaskConfig _pinotTaskConfig;
+    private final List<SegmentConversionResult> _segmentConversionResults;
+
+    private final String _tableNameWithType;
+    private final String _uploadURL;
+    private final String _authToken;
+    private final String _inputSegmentNames;
+    private final boolean _replaceSegmentsEnabled;
+    private final Map<String, Object> _customMap;
+
+    public SegmentUploadContext(PinotTaskConfig pinotTaskConfig,
+        List<SegmentConversionResult> segmentConversionResults) {
+      _pinotTaskConfig = pinotTaskConfig;
+      _segmentConversionResults = segmentConversionResults;
+
+      Map<String, String> configs = pinotTaskConfig.getConfigs();
+      _tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
+      _uploadURL = configs.get(MinionConstants.UPLOAD_URL_KEY);
+      _authToken = configs.get(MinionConstants.AUTH_TOKEN);
+      _inputSegmentNames = configs.get(MinionConstants.SEGMENT_NAME_KEY);
+      String replaceSegmentsString = configs.get(MinionConstants.ENABLE_REPLACE_SEGMENTS_KEY);
+      _replaceSegmentsEnabled = Boolean.parseBoolean(replaceSegmentsString);
+      _customMap = new HashMap<>();
+    }
+
+    public PinotTaskConfig getPinotTaskConfig() {
+      return _pinotTaskConfig;
+    }
+
+    public List<SegmentConversionResult> getSegmentConversionResults() {
+      return _segmentConversionResults;
+    }
+
+    public String getTableNameWithType() {
+      return _tableNameWithType;
+    }
+
+    public String getUploadURL() {
+      return _uploadURL;
+    }
+
+    public String getAuthToken() {
+      return _authToken;
+    }
+
+    public String getInputSegmentNames() {
+      return _inputSegmentNames;
+    }
+
+    public boolean isReplaceSegmentsEnabled() {
+      return _replaceSegmentsEnabled;
+    }
+
+    public Object getCustomContext(String key) {
+      return _customMap.get(key);
+    }
+
+    public void setCustomContext(String key, Object value) {
+      _customMap.put(key, value);
     }
   }
 }


### PR DESCRIPTION
## Description
Added pre/postUploadSegments() methods for BaseMultipleSegmentsConversionExecutor, so that subclass can customize what happens before/after segment uploading, e.g. RT2OFF task should use segment lineage against the dest offline table instead of the src realtime table, but MergeRollup uses segment lineage against a single table that is both src/dest table.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
