### PR TITLE
upgrade to RoaringBitmap 0.9.25

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -389,8 +389,8 @@ org.eclipse.jetty:jetty-util:9.4.39.v20210325
 org.javassist:javassist:3.19.0-GA
 org.lz4:lz4-java:1.7.1
 org.quartz-scheduler:quartz:2.3.2
-org.roaringbitmap:RoaringBitmap:0.9.23
-org.roaringbitmap:shims:0.9.23
+org.roaringbitmap:RoaringBitmap:0.9.25
+org.roaringbitmap:shims:0.9.25
 org.typelevel:macro-compat_2.12:1.1.1
 org.webjars:swagger-ui:3.23.11
 org.wildfly.openssl:wildfly-openssl:1.0.7.Final

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BitSlicedRangeIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BitSlicedRangeIndexReader.java
@@ -27,7 +27,6 @@ import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.index.reader.RangeIndexReader;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.roaringbitmap.RangeBitmap;
-import org.roaringbitmap.RoaringBitmap;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
@@ -109,11 +108,10 @@ public class BitSlicedRangeIndexReader implements RangeIndexReader<ImmutableRoar
   private ImmutableRoaringBitmap queryRangeBitmap(long min, long max, long columnMax) {
     RangeBitmap rangeBitmap = mapRangeBitmap();
     if (Long.compareUnsigned(max, columnMax) < 0) {
-      RoaringBitmap lte = rangeBitmap.lte(max);
       if (Long.compareUnsigned(min, 0) > 0) {
-        return rangeBitmap.gte(min, lte).toMutableRoaringBitmap();
+        return rangeBitmap.between(min, max).toMutableRoaringBitmap();
       }
-      return lte.toMutableRoaringBitmap();
+      return rangeBitmap.lte(max).toMutableRoaringBitmap();
     } else {
       if (Long.compareUnsigned(min, 0) > 0) {
         return rangeBitmap.gte(min).toMutableRoaringBitmap();

--- a/pom.xml
+++ b/pom.xml
@@ -436,7 +436,7 @@
       <dependency>
         <groupId>org.roaringbitmap</groupId>
         <artifactId>RoaringBitmap</artifactId>
-        <version>0.9.23</version>
+        <version>0.9.25</version>
       </dependency>
       <dependency>
         <groupId>com.101tec</groupId>


### PR DESCRIPTION
Picks up some performance improvements in `RangeBitmap`:

```
Benchmark                    (_dataType)  (_decile)  (_numDocs)                          (_scenario)  (_seed)  Mode  Cnt      Score     Error  Units
BenchmarkRangeIndex.queryV2         LONG          5    10000000                          NORMAL(0,1)       42  avgt    5   1506.798 ±  35.190  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000                NORMAL(10000000,1000)       42  avgt    5   5558.664 ± 125.293  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000                          EXP(0.0001)       42  avgt    5   8785.747 ± 649.172  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000                             EXP(0.5)       42  avgt    5   3226.282 ±  11.844  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000              UNIFORM(0,100000000000)       42  avgt    5  13849.725 ± 721.279  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000  UNIFORM(100000000000, 100000000100)       42  avgt    5   2097.835 ±  54.656  us/op
```

```
Benchmark                    (_dataType)  (_decile)  (_numDocs)                          (_scenario)  (_seed)  Mode  Cnt      Score      Error  Units
BenchmarkRangeIndex.queryV2         LONG          5    10000000                          NORMAL(0,1)       42  avgt    5   1071.426 ±   64.424  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000                NORMAL(10000000,1000)       42  avgt    5   4531.646 ±   66.475  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000                          EXP(0.0001)       42  avgt    5   6177.665 ±  110.414  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000                             EXP(0.5)       42  avgt    5   3113.483 ±   16.219  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000              UNIFORM(0,100000000000)       42  avgt    5  10834.696 ± 3089.046  us/op
BenchmarkRangeIndex.queryV2         LONG          5    10000000  UNIFORM(100000000000, 100000000100)       42  avgt    5   1868.769 ±   39.611  us/op
```

Also memory mapping a bitmap is now ~25% faster.