### PR TITLE
Fix segment replace test

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
@@ -451,12 +451,19 @@ public class PinotHelixResourceManagerTest {
 
   @Test
   public void testSegmentReplacement()
-      throws IOException {
+      throws Exception {
     // Create broker tenant on 1 Brokers
     Tenant brokerTenant = new Tenant(TenantRole.BROKER, BROKER_TENANT_NAME, 1, 0, 0);
     PinotResourceManagerResponse response =
         ControllerTestUtils.getHelixResourceManager().createBrokerTenant(brokerTenant);
     Assert.assertTrue(response.isSuccessful());
+
+    testSegmentReplacementRegular();
+    testSegmentReplacementForRefresh();
+  }
+
+  private void testSegmentReplacementRegular()
+      throws IOException {
 
     // Create the table
     TableConfig tableConfig =
@@ -666,14 +673,8 @@ public class PinotHelixResourceManagerTest {
     Assert.assertEquals(segmentLineage.getLineageEntry(lineageEntryId4).getState(), LineageEntryState.COMPLETED);
   }
 
-  @Test
-  public void testSegmentReplacementForRefresh()
+  private void testSegmentReplacementForRefresh()
       throws IOException, InterruptedException {
-    // Create broker tenant on 1 Brokers
-    Tenant brokerTenant = new Tenant(TenantRole.BROKER, BROKER_TENANT_NAME, 1, 0, 0);
-    PinotResourceManagerResponse response =
-        ControllerTestUtils.getHelixResourceManager().createBrokerTenant(brokerTenant);
-    Assert.assertTrue(response.isSuccessful());
 
     // Create the table
     TableConfig tableConfig =
@@ -893,6 +894,7 @@ public class PinotHelixResourceManagerTest {
     do {
       if (ControllerTestUtils.getHelixResourceManager().getSegmentsFor(tableNameWithType, false).size()
           == expectedNumSegmentsAfterDelete) {
+        System.out.println("segment deleted after " + (System.currentTimeMillis() - endTimeMs + timeOutInMillis));
         return;
       } else {
         Thread.sleep(500L);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
@@ -96,7 +96,7 @@ public class PinotHelixResourceManagerTest {
 
   private static final int CONNECTION_TIMEOUT_IN_MILLISECOND = 10_000;
   private static final int MAXIMUM_NUMBER_OF_CONTROLLER_INSTANCES = 10;
-  private static final long TIMEOUT_IN_MS = 10_000L;
+  private static final long TIMEOUT_IN_MS = 60_000L;
 
   @BeforeClass
   public void setUp()
@@ -894,7 +894,6 @@ public class PinotHelixResourceManagerTest {
     do {
       if (ControllerTestUtils.getHelixResourceManager().getSegmentsFor(tableNameWithType, false).size()
           == expectedNumSegmentsAfterDelete) {
-        System.out.println("segment deleted after " + (System.currentTimeMillis() - endTimeMs + timeOutInMillis));
         return;
       } else {
         Thread.sleep(500L);


### PR DESCRIPTION
recently there were many instability in `PinotHelixResourceManagerTest.testSegmentReplacementForRefresh` where it stuck at `waitForSegmentsToDelete`. 
e.g. 2 completely different/irrelevant PR failed on this:
https://github.com/apache/pinot/runs/5194729499?check_suite_focus=true
https://github.com/apache/pinot/runs/5161381187?check_suite_focus=true


This PR moves it to the stateless test so it doesn't run together with other statefuls tests. also simplified the logic to run them sequentially  