### PR TITLE
Fixed broken HashCode partitioning

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/HashCodePartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/HashCodePartitionFunction.java
@@ -37,7 +37,8 @@ public class HashCodePartitionFunction implements PartitionFunction {
   }
 
   @Override
-  public int getPartition(Object value) {
+  public int getPartition(Object valueIn) {
+    String value = valueIn instanceof String ? (String) valueIn : valueIn.toString();
     return Math.abs(value.hashCode()) % _numPartitions;
   }
 

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
@@ -174,8 +174,16 @@ public class PartitionFunctionTest {
 
       testBasicProperties(partitionFunction, functionName, expectedNumPartitions);
 
+      // Test Integer values
       for (int j = 0; j < 1000; j++) {
         Integer value = random.nextInt();
+        assertEquals(partitionFunction.getPartition(value),
+            Math.abs(value.toString().hashCode()) % expectedNumPartitions);
+      }
+
+      // Test Double values represented as String.
+      for (int j = 0; j < 1000; j++) {
+        String value = String.valueOf(random.nextDouble());
         assertEquals(partitionFunction.getPartition(value), Math.abs(value.hashCode()) % expectedNumPartitions);
       }
     }


### PR DESCRIPTION
## Description
HashCodePartitionFunction is producing different partitionId for same value of different type.
HashCode generated [here](https://github.com/apache/pinot/blob/master/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/AbstractColumnStatisticsCollector.java#L157) is different than hashcode generated [here](https://github.com/apache/pinot/blob/master/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/PartitionSegmentPruner.java#L215) for exact same value(In pruner, toString() is called before invoking getPartitionId on value.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] No

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] No

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] No
