### PR TITLE
Early terminate orderby when columns already sorted

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
@@ -217,8 +217,20 @@ public class SelectionOrderByOperator extends BaseOperator<IntermediateResultsBl
     DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[numExpressions];
     for (int i = 0; i < numExpressions; i++) {
       columnNames[i] = _expressions.get(i).toString();
+    }
+
+    int numOrderByExpressions = _orderByExpressions.size();
+    for (int i = 0; i < numOrderByExpressions; i++) {
       TransformResultMetadata expressionMetadata = _orderByExpressionMetadata[i];
       columnDataTypes[i] =
+          DataSchema.ColumnDataType.fromDataType(expressionMetadata.getDataType(), expressionMetadata.isSingleValue());
+    }
+
+    List<ExpressionContext> nonOrderByExpressions = _expressions.subList(numOrderByExpressions, numExpressions);
+    int numNonOrderByExpressions = nonOrderByExpressions.size();
+    for (int i = 0; i < numNonOrderByExpressions; i++) {
+      TransformResultMetadata expressionMetadata = _transformOperator.getResultMetadata(nonOrderByExpressions.get(i));
+      columnDataTypes[numOrderByExpressions + i] =
           DataSchema.ColumnDataType.fromDataType(expressionMetadata.getDataType(), expressionMetadata.isSingleValue());
     }
     DataSchema dataSchema = new DataSchema(columnNames, columnDataTypes);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
@@ -206,9 +206,9 @@ public class SelectionOrderByOperator extends BaseOperator<IntermediateResultsBl
 
   @Override
   protected IntermediateResultsBlock getNextBlock() {
-  if (isAllOrderByColumnsSorted()) {
-    return computeAllPreSorted();
-  } else if (_expressions.size() == _orderByExpressions.size()) {
+    if (isAllOrderByColumnsSorted()) {
+      return computeAllPreSorted();
+    } else if (_expressions.size() == _orderByExpressions.size()) {
       return computeAllOrdered();
     } else {
       return computePartiallyOrdered();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
@@ -216,23 +216,13 @@ public class SelectionOrderByOperator extends BaseOperator<IntermediateResultsBl
     String[] columnNames = new String[numExpressions];
     DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[numExpressions];
     for (int i = 0; i < numExpressions; i++) {
-      columnNames[i] = _expressions.get(i).toString();
-    }
-
-    int numOrderByExpressions = _orderByExpressions.size();
-    for (int i = 0; i < numOrderByExpressions; i++) {
-      TransformResultMetadata expressionMetadata = _orderByExpressionMetadata[i];
+      ExpressionContext expression = _expressions.get(i);
+      columnNames[i] = expression.toString();
+      TransformResultMetadata expressionMetadata = _transformOperator.getResultMetadata(expression);
       columnDataTypes[i] =
           DataSchema.ColumnDataType.fromDataType(expressionMetadata.getDataType(), expressionMetadata.isSingleValue());
     }
 
-    List<ExpressionContext> nonOrderByExpressions = _expressions.subList(numOrderByExpressions, numExpressions);
-    int numNonOrderByExpressions = nonOrderByExpressions.size();
-    for (int i = 0; i < numNonOrderByExpressions; i++) {
-      TransformResultMetadata expressionMetadata = _transformOperator.getResultMetadata(nonOrderByExpressions.get(i));
-      columnDataTypes[numOrderByExpressions + i] =
-          DataSchema.ColumnDataType.fromDataType(expressionMetadata.getDataType(), expressionMetadata.isSingleValue());
-    }
     DataSchema dataSchema = new DataSchema(columnNames, columnDataTypes);
 
     return new IntermediateResultsBlock(dataSchema, _rows);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
@@ -198,8 +198,7 @@ public class SelectionOrderByOperator extends BaseOperator<IntermediateResultsBl
     BlockValSet[] blockValSets = new BlockValSet[numExpressions];
     int numColumnsProjected = _transformOperator.getNumColumnsProjected();
     TransformBlock transformBlock;
-    while (_numDocsScanned < _numRowsToKeep
-           && (transformBlock = _transformOperator.nextBlock()) != null) {
+    while (_numDocsScanned < _numRowsToKeep && (transformBlock = _transformOperator.nextBlock()) != null) {
       for (int i = 0; i < numExpressions; i++) {
         ExpressionContext expression = _expressions.get(i);
         blockValSets[i] = transformBlock.getBlockValueSet(expression);

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
@@ -56,17 +56,17 @@ public class SelectionPlanNode implements PlanNode {
       if (orderByExpressions == null) {
         // Selection only
         TransformOperator transformOperator = new TransformPlanNode(_indexSegment, _queryContext, expressions,
-            Math.min(limit, DocIdSetPlanNode.MAX_DOC_PER_CALL)).run();
+              Math.min(limit + _queryContext.getOffset(), DocIdSetPlanNode.MAX_DOC_PER_CALL)).run();
         return new SelectionOnlyOperator(_indexSegment, _queryContext, expressions, transformOperator);
       } else {
         if (isAllOrderByColumnsSorted(orderByExpressions)) { // no sorting needed
           TransformOperator transformOperator =
-                  new TransformPlanNode(_indexSegment, _queryContext, expressions, DocIdSetPlanNode.MAX_DOC_PER_CALL).run();
+              new TransformPlanNode(_indexSegment, _queryContext, expressions, DocIdSetPlanNode.MAX_DOC_PER_CALL).run();
           return new SelectionOrderByOperator(_indexSegment, _queryContext, expressions, transformOperator, true);
         } else if (orderByExpressions.size() == expressions.size()) { // Selection order-by
           // All output expressions are ordered
           TransformOperator transformOperator =
-                  new TransformPlanNode(_indexSegment, _queryContext, expressions, DocIdSetPlanNode.MAX_DOC_PER_CALL).run();
+              new TransformPlanNode(_indexSegment, _queryContext, expressions, DocIdSetPlanNode.MAX_DOC_PER_CALL).run();
           return new SelectionOrderByOperator(_indexSegment, _queryContext, expressions, transformOperator, false);
         } else {
           // Not all output expressions are ordered, only fetch the order-by expressions and docId to avoid the

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
@@ -59,12 +59,15 @@ public class SelectionPlanNode implements PlanNode {
             Math.min(limit, DocIdSetPlanNode.MAX_DOC_PER_CALL)).run();
         return new SelectionOnlyOperator(_indexSegment, _queryContext, expressions, transformOperator);
       } else {
-        // Selection order-by
-        if (orderByExpressions.size() == expressions.size()) {
+        if (isAllOrderByColumnsSorted(orderByExpressions)) { // no sorting needed
+          TransformOperator transformOperator =
+                  new TransformPlanNode(_indexSegment, _queryContext, expressions, DocIdSetPlanNode.MAX_DOC_PER_CALL).run();
+          return new SelectionOrderByOperator(_indexSegment, _queryContext, expressions, transformOperator, true);
+        } else if (orderByExpressions.size() == expressions.size()) { // Selection order-by
           // All output expressions are ordered
           TransformOperator transformOperator =
-              new TransformPlanNode(_indexSegment, _queryContext, expressions, DocIdSetPlanNode.MAX_DOC_PER_CALL).run();
-          return new SelectionOrderByOperator(_indexSegment, _queryContext, expressions, transformOperator);
+                  new TransformPlanNode(_indexSegment, _queryContext, expressions, DocIdSetPlanNode.MAX_DOC_PER_CALL).run();
+          return new SelectionOrderByOperator(_indexSegment, _queryContext, expressions, transformOperator, false);
         } else {
           // Not all output expressions are ordered, only fetch the order-by expressions and docId to avoid the
           // unnecessary data fetch
@@ -74,9 +77,9 @@ public class SelectionPlanNode implements PlanNode {
           }
           expressionsToTransform.add(ExpressionContext.forIdentifier(BuiltInVirtualColumn.DOCID));
           TransformOperator transformOperator =
-              new TransformPlanNode(_indexSegment, _queryContext, expressionsToTransform,
-                  DocIdSetPlanNode.MAX_DOC_PER_CALL).run();
-          return new SelectionOrderByOperator(_indexSegment, _queryContext, expressions, transformOperator);
+                  new TransformPlanNode(_indexSegment, _queryContext, expressionsToTransform,
+                          DocIdSetPlanNode.MAX_DOC_PER_CALL).run();
+          return new SelectionOrderByOperator(_indexSegment, _queryContext, expressions, transformOperator, false);
         }
       }
     } else {
@@ -84,5 +87,32 @@ public class SelectionPlanNode implements PlanNode {
       TransformOperator transformOperator = new TransformPlanNode(_indexSegment, _queryContext, expressions, 0).run();
       return new EmptySelectionOperator(_indexSegment, expressions, transformOperator);
     }
+  }
+
+  /**
+   *  This function checks whether all columns in order by clause are pre-sorted.
+   *  This is used to optimize order by limit clauses.
+   *  For eg:
+   *  A query like "select * from table order by col1, col2 limit 10"
+   *  will take all the n matching rows and add it to a priority queue of size 10.
+   *  This is nlogk operation which can be quite expensive for a large n.
+   *  In the above example, if the docs in the segment are already sorted by col1 and col2 then there is no need for
+   *  sorting at all (only limit is needed).
+   * @return true is all columns in order by clause are sorted . False otherwise
+   */
+  private boolean isAllOrderByColumnsSorted(List<OrderByExpressionContext> orderByExpressions) {
+    int numOrderByExpressions = orderByExpressions.size();
+    for (int i = 0; i < numOrderByExpressions; i++) {
+      OrderByExpressionContext expressionContext = orderByExpressions.get(0);
+      if (!(expressionContext.getExpression().getType() == ExpressionContext.Type.IDENTIFIER)
+              || !expressionContext.isAsc()) {
+        return false;
+      }
+      String column = expressionContext.getExpression().getIdentifier();
+      if (!_indexSegment.getDataSource(column).getDataSourceMetadata().isSorted()) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
@@ -56,7 +56,7 @@ public class SelectionPlanNode implements PlanNode {
       if (orderByExpressions == null) {
         // Selection only
         TransformOperator transformOperator = new TransformPlanNode(_indexSegment, _queryContext, expressions,
-              Math.min(limit + _queryContext.getOffset(), DocIdSetPlanNode.MAX_DOC_PER_CALL)).run();
+            Math.min(limit + _queryContext.getOffset(), DocIdSetPlanNode.MAX_DOC_PER_CALL)).run();
         return new SelectionOnlyOperator(_indexSegment, _queryContext, expressions, transformOperator);
       } else {
         if (isAllOrderByColumnsSorted(orderByExpressions)) { // no sorting needed
@@ -77,8 +77,8 @@ public class SelectionPlanNode implements PlanNode {
           }
           expressionsToTransform.add(ExpressionContext.forIdentifier(BuiltInVirtualColumn.DOCID));
           TransformOperator transformOperator =
-                  new TransformPlanNode(_indexSegment, _queryContext, expressionsToTransform,
-                          DocIdSetPlanNode.MAX_DOC_PER_CALL).run();
+              new TransformPlanNode(_indexSegment, _queryContext, expressionsToTransform,
+                  DocIdSetPlanNode.MAX_DOC_PER_CALL).run();
           return new SelectionOrderByOperator(_indexSegment, _queryContext, expressions, transformOperator, false);
         }
       }
@@ -104,8 +104,8 @@ public class SelectionPlanNode implements PlanNode {
     int numOrderByExpressions = orderByExpressions.size();
     for (int i = 0; i < numOrderByExpressions; i++) {
       OrderByExpressionContext expressionContext = orderByExpressions.get(0);
-      if (!(expressionContext.getExpression().getType() == ExpressionContext.Type.IDENTIFIER)
-              || !expressionContext.isAsc()) {
+      if (!(expressionContext.getExpression().getType() == ExpressionContext.Type.IDENTIFIER) || !expressionContext
+          .isAsc()) {
         return false;
       }
       String column = expressionContext.getExpression().getIdentifier();

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/SelectionCombineOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/SelectionCombineOperatorTest.java
@@ -175,8 +175,8 @@ public class SelectionCombineOperatorTest {
     // Should early-terminate after processing the result of the first segment. Each thread should process at most 1
     // segment.
     long numDocsScanned = combineResult.getNumDocsScanned();
-    assertTrue(numDocsScanned >= NUM_RECORDS_PER_SEGMENT
-        && numDocsScanned <= CombineOperatorUtils.MAX_NUM_THREADS_PER_QUERY * NUM_RECORDS_PER_SEGMENT);
+    // result size is 10. Each thread scans atmost 10 docs
+    assertTrue(numDocsScanned <= 10 * CombineOperatorUtils.MAX_NUM_THREADS_PER_QUERY);
     assertEquals(combineResult.getNumEntriesScannedInFilter(), 0);
     assertEquals(combineResult.getNumEntriesScannedPostFilter(), numDocsScanned);
     assertEquals(combineResult.getNumSegmentsProcessed(), NUM_SEGMENTS);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionSingleValueQueriesTest.java
@@ -350,8 +350,8 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     ExecutionStatistics executionStatistics = selectionOrderByOperator.getExecutionStatistics();
     Assert.assertEquals(executionStatistics.getNumDocsScanned(), 10L);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 0L);
-    // 10 * (1 order-by columns + 1 docId column) + 10 * (10 non-order-by columns)
-    Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 120L);
+    // 10 * (1 order-by columns) + 10 * (10 non-order-by columns)
+    Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 110L);
     Assert.assertEquals(executionStatistics.getNumTotalDocs(), 30000L);
     DataSchema selectionDataSchema = resultsBlock.getDataSchema();
     Map<String, Integer> columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
@@ -374,7 +374,7 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     Assert.assertEquals(executionStatistics.getNumDocsScanned(), 10);
     Assert.assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 84134L);
     // 6129 * (2 order-by columns + 1 docId column) + 10 * (9 non-order-by columns)
-    Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 120);
+    Assert.assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 110);
     Assert.assertEquals(executionStatistics.getNumTotalDocs(), 30000L);
     selectionDataSchema = resultsBlock.getDataSchema();
     columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);


### PR DESCRIPTION
## Description
For a query like, Order by col1, col2 limit k will take all the n matching rows and add it to a priority queue of size k.
This is nlogk operation which can be quite expensive for a large n.
In the above example, if the docs are already sorted by col1, col2 then there is no need for any
sorting at all (only limit is needed). 

This PR basically tracks if left most columns are sorted and if they all are, then short circuits the nlogk loop.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ No]

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ No]

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ No]
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
