### PR TITLE
Allow ingesting Avro complex types into JSON column.

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/queries/JsonIngestionFromAvroQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/JsonIngestionFromAvroQueriesTest.java
@@ -1,0 +1,244 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import com.google.common.collect.Lists;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
+import org.apache.pinot.plugin.inputformat.avro.AvroRecordReader;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.utils.Pair;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.apache.avro.Schema.*;
+
+
+/**
+ * Test if ComplexType (RECORD, ARRAY, MAP, and UNION) field from an AVRO file can be ingested into a JSON column in
+ * a Pinot segment. This class tests. Ingestion from ENUM (symbol) and FIXED (binary) is not supported.
+ */
+public class JsonIngestionFromAvroQueriesTest extends BaseQueriesTest {
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "JsonIngestionFromAvroTest");
+  private static final File AVRO_DATA_FILE = new File(INDEX_DIR, "JsonIngestionFromAvroTest.avro");
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String SEGMENT_NAME = "testSegment";
+
+  private static final String INT_COLUMN = "intColumn";
+  private static final String JSON_COLUMN = "jsonColumn";
+  private static final String STRING_COLUMN = "stringColumn";
+  private static final Schema SCHEMA =
+      new Schema.SchemaBuilder().addSingleValueDimension(INT_COLUMN, FieldSpec.DataType.INT)
+          .addSingleValueDimension(JSON_COLUMN, FieldSpec.DataType.JSON)
+          .addSingleValueDimension(STRING_COLUMN, FieldSpec.DataType.STRING).build();
+  private static final TableConfig TABLE_CONFIG =
+      new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+
+  private IndexSegment _indexSegment;
+  private List<IndexSegment> _indexSegments;
+
+  @Override
+  protected String getFilter() {
+    return "";
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
+  }
+
+  /** @return {@link GenericRow} representing a row in Pinot table. */
+  private static GenericRow createTableRecord(int intValue, String stringValue, Object jsonValue) {
+    GenericRow record = new GenericRow();
+    record.putValue(INT_COLUMN, intValue);
+    record.putValue(STRING_COLUMN, stringValue);
+    record.putValue(JSON_COLUMN, jsonValue);
+
+    return record;
+  }
+
+  private static Map<String, String> createMapField(Pair<String, String>[] pairs) {
+    Map<String, String> map = new HashMap<>();
+    for (Pair<String, String> pair : pairs) {
+      map.put(pair.getFirst(), pair.getSecond());
+    }
+    return map;
+  }
+
+  private static org.apache.avro.Schema createRecordSchema() {
+    List<org.apache.avro.Schema.Field> fields = new ArrayList<>();
+    fields.add(new org.apache.avro.Schema.Field("id", create(Type.INT)));
+    fields.add(new org.apache.avro.Schema.Field("name", create(Type.STRING)));
+    return createRecord("record", "doc", JsonIngestionFromAvroQueriesTest.class.getCanonicalName(), false, fields);
+  }
+
+  public static GenericData.Record createRecordField(String k1, int v1, String k2, String v2) {
+    GenericData.Record record = new GenericData.Record(createRecordSchema());
+    record.put(k1, v1);
+    record.put(k2, v2);
+    return record;
+  }
+
+  protected void createInputFile()
+      throws IOException {
+    INDEX_DIR.mkdir();
+    org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord("eventsRecord", null, null, false);
+    List<Field> fields = Arrays
+        .asList(new Field(INT_COLUMN, createUnion(Lists.newArrayList(create(Type.INT), create(Type.NULL))), null, null),
+            new Field(STRING_COLUMN, createUnion(Lists.newArrayList(create(Type.STRING), create(Type.NULL))), null,
+                null), new Field(JSON_COLUMN,
+                createUnion(createArray(create(Type.STRING)), createMap(create(Type.STRING)), createRecordSchema(),
+                    create(Type.NULL))));
+    avroSchema.setFields(fields);
+    List<GenericRow> inputRecords = new ArrayList<>();
+    // insert ARRAY
+    inputRecords.add(createTableRecord(1, "daffy duck", Arrays.asList("this", "is", "a", "test")));
+
+    // insert MAP
+    inputRecords
+        .add(createTableRecord(2, "mickey mouse", createMapField(new Pair[]{new Pair("a", "1"), new Pair("b", "2")})));
+    inputRecords
+        .add(createTableRecord(3, "donald duck", createMapField(new Pair[]{new Pair("a", "1"), new Pair("b", "2")})));
+    inputRecords.add(
+        createTableRecord(4, "scrooge mcduck", createMapField(new Pair[]{new Pair("a", "1"), new Pair("b", "2")})));
+
+    // insert RECORD
+    inputRecords.add(createTableRecord(5, "minney mouse", createRecordField("id", 1, "name", "minney")));
+
+    try (DataFileWriter<GenericData.Record> fileWriter = new DataFileWriter<>(new GenericDatumWriter<>(avroSchema))) {
+      fileWriter.create(avroSchema, AVRO_DATA_FILE);
+      for (GenericRow inputRecord : inputRecords) {
+        GenericData.Record record = new GenericData.Record(avroSchema);
+        record.put(INT_COLUMN, inputRecord.getValue(INT_COLUMN));
+        record.put(STRING_COLUMN, inputRecord.getValue(STRING_COLUMN));
+        record.put(JSON_COLUMN, inputRecord.getValue(JSON_COLUMN));
+        fileWriter.append(record);
+      }
+    }
+  }
+
+  protected RecordReader createRecordReader(Set<String> fieldsToRead)
+      throws IOException {
+    AvroRecordReader avroRecordReader = new AvroRecordReader();
+    avroRecordReader.init(AVRO_DATA_FILE, fieldsToRead, null);
+    return avroRecordReader;
+  }
+
+  /** Create an AVRO file and then ingest it into Pinot while creating a JsonIndex. */
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteDirectory(INDEX_DIR);
+    createInputFile();
+
+    List<String> jsonIndexColumns = new ArrayList<>();
+    jsonIndexColumns.add("jsonColumn");
+    TABLE_CONFIG.getIndexingConfig().setJsonIndexColumns(jsonIndexColumns);
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE_CONFIG, SCHEMA);
+    segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
+    segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
+    segmentGeneratorConfig.setOutDir(INDEX_DIR.getPath());
+    segmentGeneratorConfig.setInputFilePath(AVRO_DATA_FILE.getPath());
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(segmentGeneratorConfig, createRecordReader(Set.of(INT_COLUMN, STRING_COLUMN, JSON_COLUMN)));
+    driver.build();
+
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
+    indexLoadingConfig.setTableConfig(TABLE_CONFIG);
+    indexLoadingConfig.setJsonIndexColumns(new HashSet<String>(jsonIndexColumns));
+    indexLoadingConfig.setReadMode(ReadMode.mmap);
+
+    ImmutableSegment immutableSegment =
+        ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), indexLoadingConfig);
+    _indexSegment = immutableSegment;
+    _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
+  }
+
+  /** Verify that we can query the JSON column that ingested ComplexType data from an AVRO file (see setUp). */
+  @Test
+  public void testSimpleSelectOnJsonColumn() {
+    try {
+      Operator operator = getOperatorForSqlQuery("select intColumn, stringColumn, jsonColumn FROM testTable limit 100");
+      IntermediateResultsBlock block = (IntermediateResultsBlock) operator.nextBlock();
+      Collection<Object[]> rows = block.getSelectionResult();
+      Assert.assertEquals(block.getDataSchema().getColumnDataType(0), DataSchema.ColumnDataType.INT);
+      Assert.assertEquals(block.getDataSchema().getColumnDataType(1), DataSchema.ColumnDataType.STRING);
+      Assert.assertEquals(block.getDataSchema().getColumnDataType(2), DataSchema.ColumnDataType.JSON);
+
+      List<String> expecteds = Arrays
+          .asList("[1, daffy duck, [\"this\",\"is\",\"a\",\"test\"]]", "[2, mickey mouse, {\"a\":\"1\",\"b\":\"2\"}]",
+              "[3, donald duck, {\"a\":\"1\",\"b\":\"2\"}]", "[4, scrooge mcduck, {\"a\":\"1\",\"b\":\"2\"}]",
+              "[5, minney mouse, {\"name\":\"minney\",\"id\":1}]");
+      int index = 0;
+
+      Iterator<Object[]> iterator = rows.iterator();
+      while (iterator.hasNext()) {
+        Object[] row = iterator.next();
+        System.out.println(Arrays.toString(row));
+        Assert.assertEquals(Arrays.toString(row), expecteds.get(index++));
+      }
+    } catch (IllegalStateException ise) {
+      Assert.assertTrue(true);
+    }
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    _indexSegment.destroy();
+    FileUtils.deleteDirectory(INDEX_DIR);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/JsonIngestionFromAvroQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/JsonIngestionFromAvroQueriesTest.java
@@ -124,14 +124,14 @@ public class JsonIngestionFromAvroQueriesTest extends BaseQueriesTest {
     return createRecord("record", "doc", JsonIngestionFromAvroQueriesTest.class.getCanonicalName(), false, fields);
   }
 
-  public static GenericData.Record createRecordField(String k1, int v1, String k2, String v2) {
+  private static GenericData.Record createRecordField(String k1, int v1, String k2, String v2) {
     GenericData.Record record = new GenericData.Record(createRecordSchema());
     record.put(k1, v1);
     record.put(k2, v2);
     return record;
   }
 
-  protected void createInputFile()
+  private static void createInputFile()
       throws IOException {
     INDEX_DIR.mkdir();
     org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord("eventsRecord", null, null, false);
@@ -169,10 +169,14 @@ public class JsonIngestionFromAvroQueriesTest extends BaseQueriesTest {
     }
   }
 
-  protected RecordReader createRecordReader(Set<String> fieldsToRead)
+  private static RecordReader createRecordReader()
       throws IOException {
+    Set<String> set = new HashSet<>();
+    set.add(INT_COLUMN);
+    set.add(STRING_COLUMN);
+    set.add(JSON_COLUMN);
     AvroRecordReader avroRecordReader = new AvroRecordReader();
-    avroRecordReader.init(AVRO_DATA_FILE, fieldsToRead, null);
+    avroRecordReader.init(AVRO_DATA_FILE, set, null);
     return avroRecordReader;
   }
 
@@ -193,7 +197,7 @@ public class JsonIngestionFromAvroQueriesTest extends BaseQueriesTest {
     segmentGeneratorConfig.setInputFilePath(AVRO_DATA_FILE.getPath());
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-    driver.init(segmentGeneratorConfig, createRecordReader(Set.of(INT_COLUMN, STRING_COLUMN, JSON_COLUMN)));
+    driver.init(segmentGeneratorConfig, createRecordReader());
     driver.build();
 
     IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroIngestionSchemaValidator.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroIngestionSchemaValidator.java
@@ -100,7 +100,7 @@ public class AvroIngestionSchemaValidator implements IngestionSchemaValidator {
       String avroColumnName = avroColumnField.schema().getName();
       org.apache.avro.Schema avroColumnSchema = avroColumnField.schema();
       org.apache.avro.Schema.Type avroColumnType = avroColumnSchema.getType();
-      if (avroColumnType == org.apache.avro.Schema.Type.UNION) {
+      if (avroColumnType == org.apache.avro.Schema.Type.UNION && fieldSpec.getDataType() != FieldSpec.DataType.JSON) {
         org.apache.avro.Schema nonNullSchema = null;
         for (org.apache.avro.Schema childFieldSchema : avroColumnSchema.getTypes()) {
           if (childFieldSchema.getType() != org.apache.avro.Schema.Type.NULL) {
@@ -124,13 +124,16 @@ public class AvroIngestionSchemaValidator implements IngestionSchemaValidator {
               "The Pinot column: %s is 'single-value' column but the column: %s from input %s is 'multi-value' column.",
               columnName, avroColumnName, getInputSchemaType()));
         }
-        FieldSpec.DataType dataTypeForSVColumn = AvroUtils.extractFieldDataType(avroColumnField);
-        // check data type mismatch
-        if (fieldSpec.getDataType() != dataTypeForSVColumn) {
-          _dataTypeMismatch.addMismatchReason(String
-              .format("The Pinot column: (%s: %s) doesn't match with the column (%s: %s) in input %s schema.",
-                  columnName, fieldSpec.getDataType().name(), avroColumnName, avroColumnType.name(),
-                  getInputSchemaType()));
+
+        if (fieldSpec.getDataType() != FieldSpec.DataType.JSON) {
+          FieldSpec.DataType dataTypeForSVColumn = AvroUtils.extractFieldDataType(avroColumnField);
+          // check data type mismatch
+          if (fieldSpec.getDataType() != dataTypeForSVColumn) {
+            _dataTypeMismatch.addMismatchReason(String
+                .format("The Pinot column: (%s: %s) doesn't match with the column (%s: %s) in input %s schema.",
+                    columnName, fieldSpec.getDataType().name(), avroColumnName, avroColumnType.name(),
+                    getInputSchemaType()));
+          }
         }
       } else {
         // check single-value multi-value mismatch

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroSchemaUtil.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroSchemaUtil.java
@@ -50,6 +50,11 @@ public class AvroSchemaUtil {
         return DataType.STRING;
       case BYTES:
         return DataType.BYTES;
+      case MAP:
+      case ARRAY:
+      case RECORD:
+      case UNION:
+        return DataType.JSON;
       default:
         throw new UnsupportedOperationException("Unsupported Avro type: " + avroType);
     }
@@ -94,6 +99,9 @@ public class AvroSchemaUtil {
         return jsonSchema;
       case BYTES:
         jsonSchema.set("type", convertStringsToJsonArray("null", "bytes"));
+        return jsonSchema;
+      case JSON:
+        jsonSchema.set("type", convertStringsToJsonArray("null", "json"));
         return jsonSchema;
       default:
         throw new UnsupportedOperationException();

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractorTest.java
@@ -73,8 +73,12 @@ public class AvroRecordExtractorTest extends AbstractRecordExtractorTest {
             new Field("firstName", createUnion(Lists.newArrayList(create(Type.STRING), create(Type.NULL))), null, null),
             new Field("lastName", createUnion(Lists.newArrayList(create(Type.STRING), create(Type.NULL))), null, null),
             new Field("bids", createUnion(Lists.newArrayList(createArray(create(Type.INT)), create(Type.NULL))), null,
-                null), new Field("campaignInfo", create(Type.STRING), null, null),
-            new Field("cost", create(Type.DOUBLE), null, null), new Field("timestamp", create(Type.LONG), null, null));
+                null),
+            new Field("campaignInfo", create(Type.STRING), null, null),
+            new Field("cost", create(Type.DOUBLE), null, null),
+            new Field("timestamp", create(Type.LONG), null, null),
+            new Field("xarray", createArray(create(Type.STRING))),
+            new Field("xmap", createMap(create(Type.STRING))));
 
     avroSchema.setFields(fields);
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformer.java
@@ -60,7 +60,10 @@ public class DataTypeTransformer implements RecordTransformer {
           continue;
         }
         PinotDataType dest = entry.getValue();
-        value = standardize(column, value, dest.isSingleValue());
+        if (dest != PinotDataType.JSON) {
+          value = standardize(column, value, dest.isSingleValue());
+        }
+
         // NOTE: The standardized value could be null for empty Collection/Map/Object[].
         if (value == null) {
           record.putValue(column, null);

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/AbstractRecordExtractorTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/AbstractRecordExtractorTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.avro.generic.GenericData;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.utils.Pair;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -59,6 +60,14 @@ public abstract class AbstractRecordExtractorTest {
     _recordReaderNoIncludeList = createRecordReader(null);
   }
 
+  private static Map<String, String> createMap(Pair<String, String>[] entries) {
+    Map<String, String> map = new HashMap<>();
+    for (Pair<String, String> entry : entries) {
+      map.put(entry.getFirst(), entry.getSecond());
+    }
+    return map;
+  }
+
   protected List<Map<String, Object>> getInputRecords() {
     Integer[] userID = new Integer[]{1, 2, null, 4};
     String[] firstName = new String[]{null, "John", "Ringo", "George"};
@@ -67,6 +76,14 @@ public abstract class AbstractRecordExtractorTest {
     String[] campaignInfo = new String[]{"yesterday", "blackbird", "here comes the sun", "hey jude"};
     double[] cost = new double[]{10000, 20000, 30000, 25000};
     long[] timestamp = new long[]{1570863600000L, 1571036400000L, 1571900400000L, 1574000000000L};
+    List[] arrays = new List[]{Arrays.asList("a", "b", "c"), Arrays.asList("d", "e"), Arrays.asList("w", "x", "y",
+        "z"), Collections.singletonList("a")};
+    Map<String, String>[] maps = new Map[]{
+        createMap(new Pair[]{new Pair<>("a", "1"), new Pair<>("b", "2")}),
+        createMap(new Pair[]{new Pair<>("a", "3"), new Pair<>("b", "4")}),
+        createMap(new Pair[]{new Pair<>("a", "5"), new Pair<>("b", "6")}),
+        createMap(new Pair[]{new Pair<>("a", "7"), new Pair<>("b", "8")})
+    };
 
     List<Map<String, Object>> inputRecords = new ArrayList<>(4);
     for (int i = 0; i < 4; i++) {
@@ -78,13 +95,16 @@ public abstract class AbstractRecordExtractorTest {
       record.put("campaignInfo", campaignInfo[i]);
       record.put("cost", cost[i]);
       record.put("timestamp", timestamp[i]);
+      record.put("xarray", arrays[i]);
+      record.put("xmap", maps[i]);
       inputRecords.add(record);
     }
     return inputRecords;
   }
 
   protected Set<String> getSourceFields() {
-    return Sets.newHashSet("user_id", "firstName", "lastName", "bids", "campaignInfo", "cost", "timestamp");
+    return Sets.newHashSet("user_id", "firstName", "lastName", "bids", "campaignInfo", "cost", "timestamp", "xarray",
+        "xmap");
   }
 
   @AfterClass


### PR DESCRIPTION
## Description
Handle Avro complex types (RECORD, ARRAY, MAP, and UNION) so that we can ingest Avro complex type data into a JSON column.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
