### PR TITLE
Support identifying Gzipped files by checking GZIP MAGIC_HEADER.

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-json/src/test/java/org/apache/pinot/plugin/inputformat/json/GzippedJSONRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/test/java/org/apache/pinot/plugin/inputformat/json/GzippedJSONRecordReaderTest.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.json;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.GZIPOutputStream;
+import org.apache.pinot.spi.utils.JsonUtils;
+
+
+/**
+ * Unit test for {@link JSONRecordReader} for a Gzipped JSON file.
+ * Relies on the {@link JSONRecordReaderTest} for actual tests, by simply overriding
+ * the JSON file generation to generate a gzipped JSON file.
+ */
+public class GzippedJSONRecordReaderTest extends JSONRecordReaderTest {
+  private final File _dateFile = new File(_tempDir, "data.json");
+
+  protected void writeRecordsToFile(List<Map<String, Object>> recordsToWrite)
+      throws Exception {
+    try (Writer writer = new OutputStreamWriter(new GZIPOutputStream(new FileOutputStream(_dateFile)),
+        StandardCharsets.UTF_8)) {
+      for (Map<String, Object> r : recordsToWrite) {
+        ObjectNode jsonRecord = JsonUtils.newObjectNode();
+        for (String key : r.keySet()) {
+          jsonRecord.set(key, JsonUtils.objectToJsonNode(r.get(key)));
+        }
+        writer.write(jsonRecord.toString());
+      }
+    }
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderUtils.java
@@ -36,8 +36,6 @@ public class RecordReaderUtils {
   private RecordReaderUtils() {
   }
 
-  public static final String GZIP_FILE_EXTENSION = ".gz";
-
   public static BufferedReader getBufferedReader(File dataFile)
       throws IOException {
     return new BufferedReader(new InputStreamReader(getInputStream(dataFile), StandardCharsets.UTF_8));
@@ -50,9 +48,12 @@ public class RecordReaderUtils {
 
   public static InputStream getInputStream(File dataFile)
       throws IOException {
-    if (dataFile.getName().endsWith(GZIP_FILE_EXTENSION)) {
-      return new GZIPInputStream(new FileInputStream(dataFile));
-    } else {
+    FileInputStream fileInputStream = new FileInputStream(dataFile);
+    try {
+      return new GZIPInputStream(fileInputStream);
+    } catch (Exception e) {
+      // NOTE: Cannot reuse the input stream because it might already be read.
+      fileInputStream.close();
       return new FileInputStream(dataFile);
     }
   }


### PR DESCRIPTION
The current record reader relies on file extension to be `.gz`, which may
not always be the case. Implemented the following:

- Util method that actually relies on `GZIPInputStream.GZIP_MAGIC` to identify
  a gzipped file.

- Use the above method in RecordReader initialization.

- Added unit test for JSONRecordReader using Gzipped JSON.

Addresses the TODO in https://github.com/apache/pinot/pull/6321.

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
