### PR TITLE
Return TIMESTAMP type for possible time functions

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
@@ -61,7 +61,13 @@ public class FunctionRegistry {
     for (Method method : methodSet) {
       ScalarFunction scalarFunction = method.getAnnotation(ScalarFunction.class);
       if (scalarFunction.enabled()) {
-        if (!scalarFunction.name().isEmpty()) {
+        // Annotated function names
+        String scalarFunctionNames = scalarFunction.names();
+        if (!scalarFunctionNames.isEmpty()) {
+          for (String name : scalarFunctionNames.split(",")) {
+            FunctionRegistry.registerFunction(name.trim(), method);
+          }
+        } else if (!scalarFunction.name().isEmpty()) {
           FunctionRegistry.registerFunction(scalarFunction.name(), method);
         } else {
           FunctionRegistry.registerFunction(method);

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
@@ -651,7 +651,8 @@ public class DateTimeFunctions {
    * @return truncated timeValue
    *
    */
-  @ScalarFunction
+  // This function name is registered by DateTruncTransformationFunction, so rename to dateTruncScalar.
+  @ScalarFunction(names = "dateTruncScalar", returnType = "TIMESTAMP")
   public static long dateTrunc(String unit, long timeValue, String inputTimeUnitStr, String timeZone,
       String outputTimeUnitStr) {
     TimeUnit inputTimeUnit = TimeUnit.valueOf(inputTimeUnitStr);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
@@ -487,7 +487,7 @@ public enum PinotDataType {
 
     @Override
     public Long toInternal(Object value) {
-      return ((Timestamp) value).getTime();
+      return value instanceof Timestamp ? ((Timestamp) value).getTime() : Long.parseLong(value.toString().trim());
     }
   },
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/annotations/ScalarFunction.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/annotations/ScalarFunction.java
@@ -46,5 +46,13 @@ public @interface ScalarFunction {
 
   boolean enabled() default true;
 
+  @Deprecated
   String name() default "";
+
+  // A comma-separated function names to register in FunctionRegistry
+  String names() default "";
+
+  String alias() default "";
+
+  String returnType() default "";
 }


### PR DESCRIPTION
## Description
1. Support ScalarFunction annotation for the return type
2. Infer time functions(DateTimeConversionTransformFunction/DateTruncTransformationFunction) return type to TIMESTAMP when this function:
- Operate on TIMESTAMP column/function
- Response is still in the MillsEpoch time unit

Some examples:

<img width="1204" alt="image" src="https://user-images.githubusercontent.com/1202120/155631190-9cc22e1e-275f-4f34-970c-eeb8f7e411e2.png">

<img width="1204" alt="image" src="https://user-images.githubusercontent.com/1202120/155631358-f56c7d44-7f2e-4758-a8e0-74f1f720899d.png">


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
