### PR TITLE
Automatically update broker resource on broker changes

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.utils.helix;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -45,9 +46,12 @@ import org.apache.helix.model.HelixConfigScope.ConfigScopeProperty;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.utils.config.TagNameUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.BrokerResourceStateModel;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
 import org.apache.pinot.spi.utils.retry.RetryPolicy;
 import org.slf4j.Logger;
@@ -186,6 +190,52 @@ public class HelixHelper {
   }
 
   /**
+   * Updates broker resource ideal state for the given broker with the given broker tags. Optional {@code tablesAdded}
+   * and {@code tablesRemoved} can be provided to track the tables added/removed during the update.
+   */
+  public static void updateBrokerResource(HelixManager helixManager, String brokerId, List<String> brokerTags,
+      @Nullable List<String> tablesAdded, @Nullable List<String> tablesRemoved) {
+    Preconditions.checkArgument(brokerId.startsWith(CommonConstants.Helix.PREFIX_OF_BROKER_INSTANCE),
+        "Invalid broker id: %s", brokerId);
+    for (String brokerTag : brokerTags) {
+      Preconditions.checkArgument(TagNameUtils.isBrokerTag(brokerTag), "Invalid broker tag: %s", brokerTag);
+    }
+
+    Set<String> tablesForBrokerTag;
+    int numBrokerTags = brokerTags.size();
+    if (numBrokerTags == 0) {
+      tablesForBrokerTag = Collections.emptySet();
+    } else if (numBrokerTags == 1) {
+      tablesForBrokerTag = getTablesForBrokerTag(helixManager, brokerTags.get(0));
+    } else {
+      tablesForBrokerTag = getTablesForBrokerTags(helixManager, brokerTags);
+    }
+
+    updateIdealState(helixManager, BROKER_RESOURCE, idealState -> {
+      if (tablesAdded != null) {
+        tablesAdded.clear();
+      }
+      if (tablesRemoved != null) {
+        tablesRemoved.clear();
+      }
+      for (Map.Entry<String, Map<String, String>> entry : idealState.getRecord().getMapFields().entrySet()) {
+        String tableNameWithType = entry.getKey();
+        Map<String, String> brokerAssignment = entry.getValue();
+        if (tablesForBrokerTag.contains(tableNameWithType)) {
+          if (brokerAssignment.put(brokerId, BrokerResourceStateModel.ONLINE) == null && tablesAdded != null) {
+            tablesAdded.add(tableNameWithType);
+          }
+        } else {
+          if (brokerAssignment.remove(brokerId) != null && tablesRemoved != null) {
+            tablesRemoved.add(tableNameWithType);
+          }
+        }
+      }
+      return idealState;
+    });
+  }
+
+  /**
    * Returns all instances for the given cluster.
    *
    * @param helixAdmin The HelixAdmin object used to interact with the Helix cluster
@@ -320,8 +370,8 @@ public class HelixHelper {
 
     // Removing partitions from ideal state
     LOGGER.info("Trying to remove resource {} from idealstate", resourceTag);
-    HelixHelper
-        .updateIdealState(helixManager, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE, updater, DEFAULT_RETRY_POLICY);
+    HelixHelper.updateIdealState(helixManager, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE, updater,
+        DEFAULT_RETRY_POLICY);
   }
 
   /**
@@ -495,12 +545,12 @@ public class HelixHelper {
       TableType tableType) {
     Set<String> serverInstancesWithType = new HashSet<>();
     if (tableType == null || tableType == TableType.OFFLINE) {
-      serverInstancesWithType
-          .addAll(HelixHelper.getInstancesWithTag(instanceConfigs, TagNameUtils.getOfflineTagForTenant(tenant)));
+      serverInstancesWithType.addAll(
+          HelixHelper.getInstancesWithTag(instanceConfigs, TagNameUtils.getOfflineTagForTenant(tenant)));
     }
     if (tableType == null || tableType == TableType.REALTIME) {
-      serverInstancesWithType
-          .addAll(HelixHelper.getInstancesWithTag(instanceConfigs, TagNameUtils.getRealtimeTagForTenant(tenant)));
+      serverInstancesWithType.addAll(
+          HelixHelper.getInstancesWithTag(instanceConfigs, TagNameUtils.getRealtimeTagForTenant(tenant)));
     }
     return serverInstancesWithType;
   }
@@ -519,6 +569,28 @@ public class HelixHelper {
     return new HashSet<>(getInstancesConfigsWithTag(instanceConfigs, TagNameUtils.getBrokerTagForTenant(tenant)));
   }
 
+  public static Set<String> getTablesForBrokerTag(HelixManager helixManager, String brokerTag) {
+    Set<String> tablesForBrokerTag = new HashSet<>();
+    List<TableConfig> tableConfigs = ZKMetadataProvider.getAllTableConfigs(helixManager.getHelixPropertyStore());
+    for (TableConfig tableConfig : tableConfigs) {
+      if (TagNameUtils.getBrokerTagForTenant(tableConfig.getTenantConfig().getBroker()).equals(brokerTag)) {
+        tablesForBrokerTag.add(tableConfig.getTableName());
+      }
+    }
+    return tablesForBrokerTag;
+  }
+
+  public static Set<String> getTablesForBrokerTags(HelixManager helixManager, List<String> brokerTags) {
+    Set<String> tablesForBrokerTags = new HashSet<>();
+    List<TableConfig> tableConfigs = ZKMetadataProvider.getAllTableConfigs(helixManager.getHelixPropertyStore());
+    for (TableConfig tableConfig : tableConfigs) {
+      if (brokerTags.contains(TagNameUtils.getBrokerTagForTenant(tableConfig.getTenantConfig().getBroker()))) {
+        tablesForBrokerTags.add(tableConfig.getTableName());
+      }
+    }
+    return tablesForBrokerTags;
+  }
+
   /**
    * Returns the instance config for a specific instance.
    */
@@ -535,9 +607,9 @@ public class HelixHelper {
     // NOTE: Use HelixDataAccessor.setProperty() instead of HelixAdmin.setInstanceConfig() because the latter explicitly
     // forbids instance host/port modification
     HelixDataAccessor helixDataAccessor = helixManager.getHelixDataAccessor();
-    Preconditions.checkState(helixDataAccessor
-            .setProperty(helixDataAccessor.keyBuilder().instanceConfig(instanceConfig.getId()), instanceConfig),
-        "Failed to update instance config for instance: " + instanceConfig.getId());
+    Preconditions.checkState(
+        helixDataAccessor.setProperty(helixDataAccessor.keyBuilder().instanceConfig(instanceConfig.getId()),
+            instanceConfig), "Failed to update instance config for instance: " + instanceConfig.getId());
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -61,7 +61,12 @@ public class ControllerRequestURLBuilder {
   }
 
   public String forInstanceUpdateTags(String instanceName, List<String> tags) {
-    return StringUtil.join("/", _baseUrl, "instances", instanceName, "updateTags?tags=" + StringUtils.join(tags, ","));
+    return forInstanceUpdateTags(instanceName, tags, false);
+  }
+
+  public String forInstanceUpdateTags(String instanceName, List<String> tags, boolean updateBrokerResource) {
+    return StringUtil.join("/", _baseUrl, "instances", instanceName,
+        "updateTags?tags=" + StringUtils.join(tags, ",") + "&updateBrokerResource=" + updateBrokerResource);
   }
 
   public String forInstanceList() {
@@ -353,9 +358,9 @@ public class ControllerRequestURLBuilder {
 
   public String forIngestFromFile(String tableNameWithType, String batchConfigMapStr)
       throws UnsupportedEncodingException {
-    return String
-        .format("%s?tableNameWithType=%s&batchConfigMapStr=%s", StringUtil.join("/", _baseUrl, "ingestFromFile"),
-            tableNameWithType, URLEncoder.encode(batchConfigMapStr, StandardCharsets.UTF_8.toString()));
+    return String.format("%s?tableNameWithType=%s&batchConfigMapStr=%s",
+        StringUtil.join("/", _baseUrl, "ingestFromFile"), tableNameWithType,
+        URLEncoder.encode(batchConfigMapStr, StandardCharsets.UTF_8.toString()));
   }
 
   public String forIngestFromFile(String tableNameWithType, Map<String, String> batchConfigMap)

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
@@ -205,7 +205,7 @@ public class PinotHelixResourceManagerTest {
     // Add new instance.
     Instance instance = new Instance("localhost", biggerRandomNumber, InstanceType.SERVER,
         Collections.singletonList(UNTAGGED_SERVER_INSTANCE), null, 0, 0, false);
-    ControllerTestUtils.getHelixResourceManager().addInstance(instance);
+    ControllerTestUtils.getHelixResourceManager().addInstance(instance, false);
 
     List<String> allInstances = ControllerTestUtils.getHelixResourceManager().getAllInstances();
     Assert.assertTrue(allInstances.contains(instanceName));

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
@@ -18,7 +18,20 @@
  */
 package org.apache.pinot.integration.tests;
 
+import java.util.Collections;
+import java.util.Map;
+import org.apache.helix.model.IdealState;
+import org.apache.pinot.broker.broker.helix.HelixBrokerStarter;
+import org.apache.pinot.common.utils.helix.HelixHelper;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.BrokerResourceStateModel;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.fail;
 
 
 /**
@@ -41,6 +54,49 @@ public class MultiNodesOfflineClusterIntegrationTest extends OfflineClusterInteg
   @Override
   protected void startServers() {
     startServers(NUM_SERVERS);
+  }
+
+  @Test
+  public void testUpdateBrokerResource()
+      throws Exception {
+    // Add a new broker to the cluster
+    Map<String, Object> properties = getDefaultBrokerConfiguration().toMap();
+    properties.put(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, getHelixClusterName());
+    properties.put(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER, getZkUrl());
+    int port = NetUtils.findOpenPort(DEFAULT_BROKER_PORT);
+    properties.put(CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT, port);
+    properties.put(CommonConstants.Broker.CONFIG_OF_DELAY_SHUTDOWN_TIME_MS, 0);
+
+    HelixBrokerStarter brokerStarter = new HelixBrokerStarter();
+    brokerStarter.init(new PinotConfiguration(properties));
+    brokerStarter.start();
+
+    // Check if broker is added to all the tables in broker resource
+    String brokerId = brokerStarter.getInstanceId();
+    IdealState brokerResource = HelixHelper.getBrokerIdealStates(_helixAdmin, getHelixClusterName());
+    for (Map<String, String> brokerAssignment : brokerResource.getRecord().getMapFields().values()) {
+      assertEquals(brokerAssignment.get(brokerId), BrokerResourceStateModel.ONLINE);
+    }
+
+    // Stop and drop the broker
+    brokerStarter.stop();
+    try {
+      sendDeleteRequest(_controllerRequestURLBuilder.forInstance(brokerId));
+      fail("Dropping instance should fail because it is still in the broker resource");
+    } catch (Exception e) {
+      // Expected
+    }
+    // Untag the broker and update the broker resource so that it is removed from the broker resource
+    sendPutRequest(_controllerRequestURLBuilder.forInstanceUpdateTags(brokerId, Collections.emptyList(), true));
+    // Check if broker is removed from all the tables in broker resource
+    brokerResource = HelixHelper.getBrokerIdealStates(_helixAdmin, getHelixClusterName());
+    for (Map<String, String> brokerAssignment : brokerResource.getRecord().getMapFields().values()) {
+      assertFalse(brokerAssignment.containsKey(brokerId));
+    }
+    // Dropping instance should success
+    sendDeleteRequest(_controllerRequestURLBuilder.forInstance(brokerId));
+    // Check if broker is dropped from the cluster
+    assertFalse(_helixAdmin.getInstancesInCluster(getHelixClusterName()).contains(brokerId));
   }
 
   @Test(enabled = false)


### PR DESCRIPTION
## Description
Fix #7578 

Currently, when a new broker joins the cluster, or the tags for a broker is changed, broker resource won't be updated automatically. Users need to either rebuild broker resource for each table in that broker tenant, or wait for the periodic task to fix the broker resource. Before that, the changes for the broker won't be reflected.

This PR makes the following enhancements:
- Add a boolean flag `updateBrokerResource` to create/update instance rest APIs to automatically update the broker resource when enabled (disabled by default to keep the current behavior because updating broker resource can be costly for large cluster)
- Add a rest API to update the broker resource for a specified broker
- For single-tenant cluster, when broker joins the cluster for the first time as `DefaultTenant`, automatically update the broker resource so that it can build the routing tables properly.

## Release Notes
Add an optional boolean query parameter `updateBrokerResource` to the following rest APIs:
- `POST /instances`: Add an instance
- `PUT /instances/{instanceName}`: Update an instance
- `PUT /instances/{instanceName}/updateTags`: Update the tags for an instance

Add a rest API to update the broker resource for a specified broker:
- `POST /instances/{instanceName}/updateBrokerResource`

For single-tenant cluster, when broker joins the cluster for the first time as `DefaultTenant`, automatically update the broker resource so that it can build the routing tables properly