### PR TITLE
reuse regex matcher in dictionary based LIKE queries

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/RegexpLikePredicate.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/RegexpLikePredicate.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.common.request.context.predicate;
 
 import java.util.Objects;
+import java.util.regex.Pattern;
 import org.apache.pinot.common.request.context.ExpressionContext;
 
 
@@ -28,6 +29,7 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 public class RegexpLikePredicate implements Predicate {
   private final ExpressionContext _lhs;
   private final String _value;
+  private Pattern _pattern = null;
 
   public RegexpLikePredicate(ExpressionContext lhs, String value) {
     _lhs = lhs;
@@ -46,6 +48,13 @@ public class RegexpLikePredicate implements Predicate {
 
   public String getValue() {
     return _value;
+  }
+
+  public Pattern getPattern() {
+    if (_pattern == null) {
+      _pattern = Pattern.compile(_value, Pattern.UNICODE_CASE | Pattern.CASE_INSENSITIVE);
+    }
+    return _pattern;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RegexpLikePredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RegexpLikePredicateEvaluatorFactory.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.operator.filter.predicate;
 import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.ints.IntList;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.pinot.common.request.context.predicate.RegexpLikePredicate;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
@@ -64,6 +65,7 @@ public class RegexpLikePredicateEvaluatorFactory {
   private static final int PATTERN_FLAG = Pattern.UNICODE_CASE | Pattern.CASE_INSENSITIVE;
 
   private static final class DictionaryBasedRegexpLikePredicateEvaluator extends BaseDictionaryBasedPredicateEvaluator {
+    private final Matcher _matcher;
     final Pattern _pattern;
     final Dictionary _dictionary;
     int[] _matchingDictIds;
@@ -72,11 +74,12 @@ public class RegexpLikePredicateEvaluatorFactory {
       super(regexpLikePredicate);
       _pattern = Pattern.compile(regexpLikePredicate.getValue(), PATTERN_FLAG);
       _dictionary = dictionary;
+      _matcher = _pattern.matcher("");
     }
 
     @Override
     public boolean applySV(int dictId) {
-      return _pattern.matcher(_dictionary.getStringValue(dictId)).find();
+      return _matcher.reset(_dictionary.getStringValue(dictId)).find();
     }
 
     @Override


### PR DESCRIPTION
The profile below was taken from one of our customer's deployments - very high allocation rates are observed in no-index LIKE queries, because of matcher construction.
<img width="1596" alt="Screenshot 2022-02-28 at 18 27 57" src="https://user-images.githubusercontent.com/16439049/156040801-956865d0-96b0-49fc-a74b-64f80cda5886.png">

This PR simply reuses the `Matcher` as it will never be used across threads at the segment level.

This decreases allocation significantly (2.5x) and may slightly increase average query time.

before:

```
Benchmark                                                (_numRows)                                                                (_query)  (_scenario)  Mode  Cnt           Score            Error   Units
BenchmarkQueries.query                                      1500000  SELECT RAW_INT_COL FROM MyTable WHERE NO_INDEX_STRING_COL LIKE '%foo%'   EXP(0.001)  avgt    5         919.018 ±         14.737   ms/op
BenchmarkQueries.query:·gc.alloc.rate                       1500000  SELECT RAW_INT_COL FROM MyTable WHERE NO_INDEX_STRING_COL LIKE '%foo%'   EXP(0.001)  avgt    5         656.552 ±       1412.756  MB/sec
BenchmarkQueries.query:·gc.alloc.rate.norm                  1500000  SELECT RAW_INT_COL FROM MyTable WHERE NO_INDEX_STRING_COL LIKE '%foo%'   EXP(0.001)  avgt    5   806583564.800 ± 1735530730.138    B/op
BenchmarkQueries.query                                      1500000  SELECT RAW_INT_COL FROM MyTable WHERE NO_INDEX_STRING_COL LIKE '%foo%'     EXP(0.5)  avgt    5         758.236 ±         18.678   ms/op
BenchmarkQueries.query:·gc.alloc.rate                       1500000  SELECT RAW_INT_COL FROM MyTable WHERE NO_INDEX_STRING_COL LIKE '%foo%'     EXP(0.5)  avgt    5         762.000 ±       1639.664  MB/sec
BenchmarkQueries.query:·gc.alloc.rate.norm                  1500000  SELECT RAW_INT_COL FROM MyTable WHERE NO_INDEX_STRING_COL LIKE '%foo%'     EXP(0.5)  avgt    5   806583100.000 ± 1735530900.622    B/op
BenchmarkQueries.query                                      1500000  SELECT RAW_INT_COL FROM MyTable WHERE NO_INDEX_STRING_COL LIKE '%foo%'   EXP(0.999)  avgt    5         799.468 ±         17.653   ms/op
BenchmarkQueries.query:·gc.alloc.rate                       1500000  SELECT RAW_INT_COL FROM MyTable WHERE NO_INDEX_STRING_COL LIKE '%foo%'   EXP(0.999)  avgt    5         733.147 ±       1577.529  MB/sec
BenchmarkQueries.query:·gc.alloc.rate.norm                  1500000  SELECT RAW_INT_COL FROM MyTable WHERE NO_INDEX_STRING_COL LIKE '%foo%'   EXP(0.999)  avgt    5   806583204.000 ± 1735531021.166    B/op
```

after:
```
Benchmark                                            (_numRows)                                                                (_query)  (_scenario)  Mode  Cnt          Score            Error   Units
BenchmarkQueries.query                                  1500000  SELECT RAW_INT_COL FROM MyTable WHERE NO_INDEX_STRING_COL LIKE '%foo%'   EXP(0.001)  avgt    5        863.085 ±         31.335   ms/op
BenchmarkQueries.query:·gc.alloc.rate                   1500000  SELECT RAW_INT_COL FROM MyTable WHERE NO_INDEX_STRING_COL LIKE '%foo%'   EXP(0.001)  avgt    5        279.607 ±        601.640  MB/sec
BenchmarkQueries.query:·gc.alloc.rate.norm              1500000  SELECT RAW_INT_COL FROM MyTable WHERE NO_INDEX_STRING_COL LIKE '%foo%'   EXP(0.001)  avgt    5  326550961.600 ±  702576606.964    B/op
BenchmarkQueries.query                                  1500000  SELECT RAW_INT_COL FROM MyTable WHERE NO_INDEX_STRING_COL LIKE '%foo%'     EXP(0.5)  avgt    5        759.623 ±         77.455   ms/op
BenchmarkQueries.query:·gc.alloc.rate                   1500000  SELECT RAW_INT_COL FROM MyTable WHERE NO_INDEX_STRING_COL LIKE '%foo%'     EXP(0.5)  avgt    5        307.396 ±        661.675  MB/sec
BenchmarkQueries.query:·gc.alloc.rate.norm              1500000  SELECT RAW_INT_COL FROM MyTable WHERE NO_INDEX_STRING_COL LIKE '%foo%'     EXP(0.5)  avgt    5  326583524.000 ±  702294555.871    B/op
BenchmarkQueries.query                                  1500000  SELECT RAW_INT_COL FROM MyTable WHERE NO_INDEX_STRING_COL LIKE '%foo%'   EXP(0.999)  avgt    5        753.004 ±         79.038   ms/op
BenchmarkQueries.query:·gc.alloc.rate                   1500000  SELECT RAW_INT_COL FROM MyTable WHERE NO_INDEX_STRING_COL LIKE '%foo%'   EXP(0.999)  avgt    5        308.145 ±        663.030  MB/sec
BenchmarkQueries.query:·gc.alloc.rate.norm              1500000  SELECT RAW_INT_COL FROM MyTable WHERE NO_INDEX_STRING_COL LIKE '%foo%'   EXP(0.999)  avgt    5  326583459.200 ±  702294795.237    B/op
```