### PR TITLE
Add support for IS NULL and NOT IS NULL in transform functions

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -55,6 +55,8 @@ public enum TransformFunctionType {
   LESS_THAN("less_than"),
   LESS_THAN_OR_EQUAL("less_than_or_equal"),
   IN("in"),
+  IS_NULL("is_null"),
+  IS_NOT_NULL("is_not_null"),
 
   AND("and"),
   OR("or"),

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -55,6 +55,7 @@ public enum TransformFunctionType {
   LESS_THAN("less_than"),
   LESS_THAN_OR_EQUAL("less_than_or_equal"),
   IN("in"),
+
   IS_NULL("is_null"),
   IS_NOT_NULL("is_not_null"),
 

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -610,6 +610,20 @@ public class CalciteSqlParser {
         return RequestUtils.getIdentifierExpression(node.toString());
       case LITERAL:
         return RequestUtils.getLiteralExpression((SqlLiteral) node);
+      case IS_NULL:
+        SqlBasicCall isNullSQLNode = (SqlBasicCall) node;
+        List<SqlNode> isNullOperands = isNullSQLNode.getOperandList();
+        Expression isNullLeftExpr = toExpression(isNullOperands.get(0));
+        final Expression isNullExpr = RequestUtils.getFunctionExpression("IS_NULL");
+        isNullExpr.getFunctionCall().addToOperands(isNullLeftExpr);
+        return isNullExpr;
+      case IS_NOT_NULL:
+        SqlBasicCall isNotNullSQLNode = (SqlBasicCall) node;
+        List<SqlNode> isNotNullOperands = isNotNullSQLNode.getOperandList();
+        Expression isNotNullLeftExpr = toExpression(isNotNullOperands.get(0));
+        final Expression isNotNullExpr = RequestUtils.getFunctionExpression("IS_NOT_NULL");
+        isNotNullExpr.getFunctionCall().addToOperands(isNotNullLeftExpr);
+        return isNotNullExpr;
       case AS:
         SqlBasicCall asFuncSqlNode = (SqlBasicCall) node;
         List<SqlNode> operands = asFuncSqlNode.getOperandList();

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -611,19 +611,9 @@ public class CalciteSqlParser {
       case LITERAL:
         return RequestUtils.getLiteralExpression((SqlLiteral) node);
       case IS_NULL:
-        SqlBasicCall isNullSQLNode = (SqlBasicCall) node;
-        List<SqlNode> isNullOperands = isNullSQLNode.getOperandList();
-        Expression isNullLeftExpr = toExpression(isNullOperands.get(0));
-        final Expression isNullExpr = RequestUtils.getFunctionExpression("IS_NULL");
-        isNullExpr.getFunctionCall().addToOperands(isNullLeftExpr);
-        return isNullExpr;
+        return compileNullCheckExpression((SqlBasicCall) node, "IS_NULL");
       case IS_NOT_NULL:
-        SqlBasicCall isNotNullSQLNode = (SqlBasicCall) node;
-        List<SqlNode> isNotNullOperands = isNotNullSQLNode.getOperandList();
-        Expression isNotNullLeftExpr = toExpression(isNotNullOperands.get(0));
-        final Expression isNotNullExpr = RequestUtils.getFunctionExpression("IS_NOT_NULL");
-        isNotNullExpr.getFunctionCall().addToOperands(isNotNullLeftExpr);
-        return isNotNullExpr;
+        return compileNullCheckExpression((SqlBasicCall) node, "IS_NOT_NULL");
       case AS:
         SqlBasicCall asFuncSqlNode = (SqlBasicCall) node;
         List<SqlNode> operands = asFuncSqlNode.getOperandList();
@@ -693,6 +683,14 @@ public class CalciteSqlParser {
           return compileFunctionExpression((SqlBasicCall) node);
         }
     }
+  }
+
+  private static Expression compileNullCheckExpression(SqlBasicCall node, String nullCheckType) {
+    List<SqlNode> nullCheckOperands = node.getOperandList();
+    Expression nullCheckLeftExpr = toExpression(nullCheckOperands.get(0));
+    final Expression nullCheckExpr = RequestUtils.getFunctionExpression(nullCheckType);
+    nullCheckExpr.getFunctionCall().addToOperands(nullCheckLeftExpr);
+    return nullCheckExpr;
   }
 
   private static Expression compileFunctionExpression(SqlBasicCall functionNode) {

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -610,10 +610,6 @@ public class CalciteSqlParser {
         return RequestUtils.getIdentifierExpression(node.toString());
       case LITERAL:
         return RequestUtils.getLiteralExpression((SqlLiteral) node);
-      case IS_NULL:
-        return compileNullCheckExpression((SqlBasicCall) node, "IS_NULL");
-      case IS_NOT_NULL:
-        return compileNullCheckExpression((SqlBasicCall) node, "IS_NOT_NULL");
       case AS:
         SqlBasicCall asFuncSqlNode = (SqlBasicCall) node;
         List<SqlNode> operands = asFuncSqlNode.getOperandList();
@@ -683,14 +679,6 @@ public class CalciteSqlParser {
           return compileFunctionExpression((SqlBasicCall) node);
         }
     }
-  }
-
-  private static Expression compileNullCheckExpression(SqlBasicCall node, String nullCheckType) {
-    List<SqlNode> nullCheckOperands = node.getOperandList();
-    Expression nullCheckLeftExpr = toExpression(nullCheckOperands.get(0));
-    final Expression nullCheckExpr = RequestUtils.getFunctionExpression(nullCheckType);
-    nullCheckExpr.getFunctionCall().addToOperands(nullCheckLeftExpr);
-    return nullCheckExpr;
   }
 
   private static Expression compileFunctionExpression(SqlBasicCall functionNode) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IdentifierTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IdentifierTransformFunction.java
@@ -45,6 +45,10 @@ public class IdentifierTransformFunction implements TransformFunction, PushDownT
         _dictionary != null);
   }
 
+  public String getColumnName() {
+    return _columnName;
+  }
+
   @Override
   public String getName() {
     throw new UnsupportedOperationException();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
@@ -1,7 +1,24 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.operator.transform.function;
 
 import com.google.common.base.Preconditions;
-import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
@@ -77,7 +77,7 @@ public class IsNotNullTransformFunction extends BaseTransformFunction {
 
     int[] docIds = projectionBlock.getDocIds();
 
-    if (!_nullValueVectorIterator.hasNext() || (docIds.length > 0 && _nullValueVectorIterator.next() > docIds[0])) {
+    if (!_nullValueVectorIterator.hasNext() || (length > 0 && _nullValueVectorIterator.peekNext() > docIds[0])) {
       _nullValueVectorIterator = _nullValueVectorReader.getNullBitmap().getIntIterator();
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
@@ -34,7 +34,6 @@ public class IsNotNullTransformFunction extends BaseTransformFunction {
 
   private int[] _results;
   private PeekableIntIterator _nullValueVectorIterator;
-  private NullValueVectorReader _nullValueVectorReader;
 
   @Override
   public String getName() {
@@ -51,9 +50,9 @@ public class IsNotNullTransformFunction extends BaseTransformFunction {
           "Only column names are supported in IS_NOT_NULL. Support for functions is planned for future release");
     }
     String columnName = ((IdentifierTransformFunction) transformFunction).getColumnName();
-    _nullValueVectorReader = dataSourceMap.get(columnName).getNullValueVector();
-    if (_nullValueVectorReader != null) {
-      _nullValueVectorIterator = _nullValueVectorReader.getNullBitmap().getIntIterator();
+    NullValueVectorReader nullValueVectorReader = dataSourceMap.get(columnName).getNullValueVector();
+    if (nullValueVectorReader != null) {
+      _nullValueVectorIterator = nullValueVectorReader.getNullBitmap().getIntIterator();
     } else {
       _nullValueVectorIterator = null;
     }
@@ -75,9 +74,6 @@ public class IsNotNullTransformFunction extends BaseTransformFunction {
 
     Arrays.fill(_results, 1);
     if (_nullValueVectorIterator != null) {
-      if (!_nullValueVectorIterator.hasNext() || (length > 0 && _nullValueVectorIterator.peekNext() > docIds[0])) {
-        _nullValueVectorIterator = _nullValueVectorReader.getNullBitmap().getIntIterator();
-      }
       int currentDocIdIndex = 0;
       while (_nullValueVectorIterator.hasNext() & currentDocIdIndex < length) {
         _nullValueVectorIterator.advanceIfNeeded(docIds[currentDocIdIndex]);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
@@ -33,7 +33,7 @@ import org.roaringbitmap.PeekableIntIterator;
 public class IsNotNullTransformFunction extends BaseTransformFunction {
   public static final String FUNCTION_NAME = "IS_NOT_NULL";
 
-  private TransformFunction _leftTransformFunction;
+  private TransformFunction _transformFunction;
   private int[] _results;
   private Map<String, DataSource> _dataSourceMap = new HashMap<>();
   private PeekableIntIterator _nullValueVectorIterator;
@@ -48,13 +48,13 @@ public class IsNotNullTransformFunction extends BaseTransformFunction {
   public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
     Preconditions.checkArgument(arguments.size() == 1,
         "Exact 1 argument is required for IS_NOT_NULL operator function");
-    _leftTransformFunction = arguments.get(0);
-    if (!(_leftTransformFunction instanceof IdentifierTransformFunction)) {
+    _transformFunction = arguments.get(0);
+    if (!(_transformFunction instanceof IdentifierTransformFunction)) {
       throw new IllegalArgumentException(
           "Only column names are supported in IS_NOT_NULL. Support for functions is planned for future release");
     }
     _dataSourceMap = dataSourceMap;
-    String columnName = ((IdentifierTransformFunction) _leftTransformFunction).getColumnName();
+    String columnName = ((IdentifierTransformFunction) _transformFunction).getColumnName();
     _nullValueVectorReader = _dataSourceMap.get(columnName).getNullValueVector();
     if (_nullValueVectorReader != null) {
       _nullValueVectorIterator = _nullValueVectorReader.getNullBitmap().getIntIterator();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
@@ -73,12 +73,11 @@ public class IsNotNullTransformFunction extends BaseTransformFunction {
 
     int[] docIds = projectionBlock.getDocIds();
 
-    if (!_nullValueVectorIterator.hasNext() || (length > 0 && _nullValueVectorIterator.peekNext() > docIds[0])) {
-      _nullValueVectorIterator = _nullValueVectorReader.getNullBitmap().getIntIterator();
-    }
-
     Arrays.fill(_results, 1);
     if (_nullValueVectorIterator != null) {
+      if (!_nullValueVectorIterator.hasNext() || (length > 0 && _nullValueVectorIterator.peekNext() > docIds[0])) {
+        _nullValueVectorIterator = _nullValueVectorReader.getNullBitmap().getIntIterator();
+      }
       int currentDocIdIndex = 0;
       while (_nullValueVectorIterator.hasNext() & currentDocIdIndex < length) {
         _nullValueVectorIterator.advanceIfNeeded(docIds[currentDocIdIndex]);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
@@ -1,0 +1,69 @@
+package org.apache.pinot.core.operator.transform.function;
+
+import com.google.common.base.Preconditions;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+
+
+public class IsNotNullTransformFunction extends BaseTransformFunction {
+  public static final String FUNCTION_NAME = "IS_NOT_NULL";
+
+  private TransformFunction _leftTransformFunction;
+  private int[] _results;
+  private Map<String, DataSource> _dataSourceMap = new HashMap<>();
+
+  @Override
+  public String getName() {
+    return FUNCTION_NAME;
+  }
+
+  @Override
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
+    Preconditions.checkArgument(arguments.size() == 1,
+        "Exact 1 argument is required for IS_NOT_NULL operator function");
+    _leftTransformFunction = arguments.get(0);
+    if (!(_leftTransformFunction instanceof IdentifierTransformFunction)) {
+      throw new IllegalArgumentException(
+          "Only column names are supported in IS_NOT_NULL. Support for functions is planned for future release");
+    }
+    _dataSourceMap = dataSourceMap;
+  }
+
+  @Override
+  public TransformResultMetadata getResultMetadata() {
+    return BOOLEAN_SV_NO_DICTIONARY_METADATA;
+  }
+
+  @Override
+  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+    if (_results == null || _results.length < length) {
+      _results = new int[length];
+    }
+
+    int[] docIds = projectionBlock.getDocIds();
+    String columnName = ((IdentifierTransformFunction) _leftTransformFunction).getColumnName();
+    NullValueVectorReader nullValueVector = _dataSourceMap.get(columnName).getNullValueVector();
+
+    if (nullValueVector != null) {
+      for (int idx = 0; idx < length; idx++) {
+        int docId = docIds[idx];
+        if (nullValueVector.isNull(docId)) {
+          _results[idx] = 0;
+        } else {
+          _results[idx] = 1;
+        }
+      }
+    } else {
+      Arrays.fill(_results, 1);
+    }
+
+    return _results;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
@@ -37,6 +37,7 @@ public class IsNotNullTransformFunction extends BaseTransformFunction {
   private int[] _results;
   private Map<String, DataSource> _dataSourceMap = new HashMap<>();
   private PeekableIntIterator _nullValueVectorIterator;
+  private NullValueVectorReader _nullValueVectorReader;
 
   @Override
   public String getName() {
@@ -54,9 +55,9 @@ public class IsNotNullTransformFunction extends BaseTransformFunction {
     }
     _dataSourceMap = dataSourceMap;
     String columnName = ((IdentifierTransformFunction) _leftTransformFunction).getColumnName();
-    NullValueVectorReader nullValueVector = _dataSourceMap.get(columnName).getNullValueVector();
-    if (nullValueVector != null) {
-      _nullValueVectorIterator = nullValueVector.getNullBitmap().getIntIterator();
+    _nullValueVectorReader = _dataSourceMap.get(columnName).getNullValueVector();
+    if (_nullValueVectorReader != null) {
+      _nullValueVectorIterator = _nullValueVectorReader.getNullBitmap().getIntIterator();
     } else {
       _nullValueVectorIterator = null;
     }
@@ -76,8 +77,11 @@ public class IsNotNullTransformFunction extends BaseTransformFunction {
 
     int[] docIds = projectionBlock.getDocIds();
 
-    Arrays.fill(_results, 1);
+    if (!_nullValueVectorIterator.hasNext() || (docIds.length > 0 && _nullValueVectorIterator.next() > docIds[0])) {
+      _nullValueVectorIterator = _nullValueVectorReader.getNullBitmap().getIntIterator();
+    }
 
+    Arrays.fill(_results, 1);
     if (_nullValueVectorIterator != null) {
       int currentDocIdIndex = 0;
       while (_nullValueVectorIterator.hasNext() & currentDocIdIndex < length) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.operator.transform.function;
 
 import com.google.common.base.Preconditions;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.TransformFunctionType;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.operator.transform.function;
 
 import com.google.common.base.Preconditions;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
@@ -38,7 +38,7 @@ public class IsNullTransformFunction extends BaseTransformFunction {
 
   @Override
   public String getName() {
-    return TransformFunctionType.IS_NOT_NULL.getName();
+    return TransformFunctionType.IS_NULL.getName();
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
@@ -34,7 +34,6 @@ public class IsNullTransformFunction extends BaseTransformFunction {
 
   private int[] _results;
   private PeekableIntIterator _nullValueVectorIterator;
-  private NullValueVectorReader _nullValueVectorReader;
 
   @Override
   public String getName() {
@@ -50,9 +49,9 @@ public class IsNullTransformFunction extends BaseTransformFunction {
           "Only column names are supported in IS_NULL. Support for functions is planned for future release");
     }
     String columnName = ((IdentifierTransformFunction) transformFunction).getColumnName();
-    _nullValueVectorReader = dataSourceMap.get(columnName).getNullValueVector();
-    if (_nullValueVectorReader != null) {
-      _nullValueVectorIterator = _nullValueVectorReader.getNullBitmap().getIntIterator();
+    NullValueVectorReader nullValueVectorReader = dataSourceMap.get(columnName).getNullValueVector();
+    if (nullValueVectorReader != null) {
+      _nullValueVectorIterator = nullValueVectorReader.getNullBitmap().getIntIterator();
     } else {
       _nullValueVectorIterator = null;
     }
@@ -74,9 +73,6 @@ public class IsNullTransformFunction extends BaseTransformFunction {
 
     Arrays.fill(_results, 0);
     if (_nullValueVectorIterator != null) {
-      if (!_nullValueVectorIterator.hasNext() || (length > 0 && _nullValueVectorIterator.peekNext() > docIds[0])) {
-        _nullValueVectorIterator = _nullValueVectorReader.getNullBitmap().getIntIterator();
-      }
       int currentDocIdIndex = 0;
       while (_nullValueVectorIterator.hasNext() & currentDocIdIndex < length) {
         _nullValueVectorIterator.advanceIfNeeded(docIds[currentDocIdIndex]);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.function.TransformFunctionType;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.segment.spi.datasource.DataSource;
@@ -31,30 +32,26 @@ import org.roaringbitmap.PeekableIntIterator;
 
 
 public class IsNullTransformFunction extends BaseTransformFunction {
-  public static final String FUNCTION_NAME = "IS_NULL";
 
-  private TransformFunction _transformFunction;
   private int[] _results;
-  private Map<String, DataSource> _dataSourceMap = new HashMap<>();
   private PeekableIntIterator _nullValueVectorIterator;
   private NullValueVectorReader _nullValueVectorReader;
 
   @Override
   public String getName() {
-    return FUNCTION_NAME;
+    return TransformFunctionType.IS_NOT_NULL.getName();
   }
 
   @Override
   public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
     Preconditions.checkArgument(arguments.size() == 1, "Exact 1 argument is required for IS_NULL operator function");
-    _transformFunction = arguments.get(0);
-    if (!(_transformFunction instanceof IdentifierTransformFunction)) {
+    TransformFunction transformFunction = arguments.get(0);
+    if (!(transformFunction instanceof IdentifierTransformFunction)) {
       throw new IllegalArgumentException(
           "Only column names are supported in IS_NULL. Support for functions is planned for future release");
     }
-    _dataSourceMap = dataSourceMap;
-    String columnName = ((IdentifierTransformFunction) _transformFunction).getColumnName();
-    _nullValueVectorReader = _dataSourceMap.get(columnName).getNullValueVector();
+    String columnName = ((IdentifierTransformFunction) transformFunction).getColumnName();
+    _nullValueVectorReader = dataSourceMap.get(columnName).getNullValueVector();
     if (_nullValueVectorReader != null) {
       _nullValueVectorIterator = _nullValueVectorReader.getNullBitmap().getIntIterator();
     } else {
@@ -76,12 +73,11 @@ public class IsNullTransformFunction extends BaseTransformFunction {
 
     int[] docIds = projectionBlock.getDocIds();
 
-    if (!_nullValueVectorIterator.hasNext() || (length > 0 && _nullValueVectorIterator.peekNext() > docIds[0])) {
-      _nullValueVectorIterator = _nullValueVectorReader.getNullBitmap().getIntIterator();
-    }
-
     Arrays.fill(_results, 0);
     if (_nullValueVectorIterator != null) {
+      if (!_nullValueVectorIterator.hasNext() || (length > 0 && _nullValueVectorIterator.peekNext() > docIds[0])) {
+        _nullValueVectorIterator = _nullValueVectorReader.getNullBitmap().getIntIterator();
+      }
       int currentDocIdIndex = 0;
       while (_nullValueVectorIterator.hasNext() & currentDocIdIndex < length) {
         _nullValueVectorIterator.advanceIfNeeded(docIds[currentDocIdIndex]);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
@@ -70,13 +70,11 @@ public class IsNullTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-    if (_results == null || _results.length < length) {
-      _results = new int[length];
-    }
+    _results = new int[length];
 
     int[] docIds = projectionBlock.getDocIds();
 
-    if (!_nullValueVectorIterator.hasNext() || (docIds.length > 0 && _nullValueVectorIterator.next() > docIds[0])) {
+    if (!_nullValueVectorIterator.hasNext() || (length > 0 && _nullValueVectorIterator.peekNext() > docIds[0])) {
       _nullValueVectorIterator = _nullValueVectorReader.getNullBitmap().getIntIterator();
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.operator.transform.function;
 
 import com.google.common.base.Preconditions;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.TransformFunctionType;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
@@ -1,0 +1,65 @@
+package org.apache.pinot.core.operator.transform.function;
+
+import com.google.common.base.Preconditions;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+
+
+public class IsNullTransformFunction extends BaseTransformFunction {
+  public static final String FUNCTION_NAME = "IS_NULL";
+
+  private TransformFunction _leftTransformFunction;
+  private int[] _results;
+  private Map<String, DataSource> _dataSourceMap = new HashMap<>();
+
+  @Override
+  public String getName() {
+    return FUNCTION_NAME;
+  }
+
+  @Override
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
+    Preconditions.checkArgument(arguments.size() == 1, "Exact 1 argument is required for IS_NULL operator function");
+    _leftTransformFunction = arguments.get(0);
+    if (!(_leftTransformFunction instanceof IdentifierTransformFunction)) {
+      throw new IllegalArgumentException(
+          "Only column names are supported in IS_NULL. Support for functions is planned for future release");
+    }
+    _dataSourceMap = dataSourceMap;
+  }
+
+  @Override
+  public TransformResultMetadata getResultMetadata() {
+    return BOOLEAN_SV_NO_DICTIONARY_METADATA;
+  }
+
+  @Override
+  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+    if (_results == null || _results.length < length) {
+      _results = new int[length];
+    }
+
+    int[] docIds = projectionBlock.getDocIds();
+    String columnName = ((IdentifierTransformFunction) _leftTransformFunction).getColumnName();
+    NullValueVectorReader nullValueVector = _dataSourceMap.get(columnName).getNullValueVector();
+
+    if (nullValueVector != null) {
+      for (int idx = 0; idx < length; idx++) {
+        int docId = docIds[idx];
+        if (nullValueVector.isNull(docId)) {
+          _results[idx] = 1;
+        } else {
+          _results[idx] = 0;
+        }
+      }
+    }
+
+    return _results;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -165,6 +165,9 @@ public class TransformFunctionFactory {
           // tuple selection
           put(canonicalize(TransformFunctionType.LEAST.getName().toLowerCase()), LeastTransformFunction.class);
           put(canonicalize(TransformFunctionType.GREATEST.getName().toLowerCase()), GreatestTransformFunction.class);
+          put(canonicalize(TransformFunctionType.IS_NULL.getName().toLowerCase()), IsNullTransformFunction.class);
+          put(canonicalize(TransformFunctionType.IS_NOT_NULL.getName().toLowerCase()),
+              IsNotNullTransformFunction.class);
         }
       };
 
@@ -235,10 +238,9 @@ public class TransformFunctionFactory {
           if (functionInfo == null) {
             if (FunctionRegistry.containsFunction(functionName)) {
               throw new BadQueryRequestException(
-                String.format("Unsupported function: %s with %d parameters", functionName, numArguments));
+                  String.format("Unsupported function: %s with %d parameters", functionName, numArguments));
             } else {
-              throw new BadQueryRequestException(
-                String.format("Unsupported function: %s not found", functionName));
+              throw new BadQueryRequestException(String.format("Unsupported function: %s not found", functionName));
             }
           }
           transformFunction = new ScalarTransformFunctionWrapper(functionInfo);
@@ -259,8 +261,7 @@ public class TransformFunctionFactory {
         String columnName = expression.getIdentifier();
         return new IdentifierTransformFunction(columnName, dataSourceMap.get(columnName));
       case LITERAL:
-        return queryContext == null
-            ? new LiteralTransformFunction(expression.getLiteral())
+        return queryContext == null ? new LiteralTransformFunction(expression.getLiteral())
             : queryContext.getOrComputeSharedValue(LiteralTransformFunction.class, expression.getLiteral(),
                 LiteralTransformFunction::new);
       default:

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -165,6 +165,8 @@ public class TransformFunctionFactory {
           // tuple selection
           put(canonicalize(TransformFunctionType.LEAST.getName().toLowerCase()), LeastTransformFunction.class);
           put(canonicalize(TransformFunctionType.GREATEST.getName().toLowerCase()), GreatestTransformFunction.class);
+
+          // null handling
           put(canonicalize(TransformFunctionType.IS_NULL.getName().toLowerCase()), IsNullTransformFunction.class);
           put(canonicalize(TransformFunctionType.IS_NOT_NULL.getName().toLowerCase()),
               IsNotNullTransformFunction.class);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/NullHandlingTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/NullHandlingTransformFunctionTest.java
@@ -183,7 +183,7 @@ public class NullHandlingTransformFunctionTest {
         expectedValues[i] = 1;
       }
     }
-    testTransformFunction(transformFunction, expectedValues);
+    testTransformFunction(expression, expectedValues);
   }
 
   @Test
@@ -211,15 +211,15 @@ public class NullHandlingTransformFunctionTest {
         expectedValues[i] = 0;
       }
     }
-    testTransformFunction(transformFunction, expectedValues);
+    testTransformFunction(expression, expectedValues);
   }
 
-  protected void testTransformFunction(TransformFunction transformFunction, int[] expectedValues) {
-    int[] intValues = transformFunction.transformToIntValuesSV(_projectionBlock);
-    long[] longValues = transformFunction.transformToLongValuesSV(_projectionBlock);
-    float[] floatValues = transformFunction.transformToFloatValuesSV(_projectionBlock);
-    double[] doubleValues = transformFunction.transformToDoubleValuesSV(_projectionBlock);
-    String[] stringValues = transformFunction.transformToStringValuesSV(_projectionBlock);
+  protected void testTransformFunction(ExpressionContext expression, int[] expectedValues) throws Exception {
+    int[] intValues = getTransformFunctionInstance(expression).transformToIntValuesSV(_projectionBlock);
+    long[] longValues = getTransformFunctionInstance(expression).transformToLongValuesSV(_projectionBlock);
+    float[] floatValues = getTransformFunctionInstance(expression).transformToFloatValuesSV(_projectionBlock);
+    double[] doubleValues = getTransformFunctionInstance(expression).transformToDoubleValuesSV(_projectionBlock);
+    String[] stringValues = getTransformFunctionInstance(expression).transformToStringValuesSV(_projectionBlock);
     for (int i = 0; i < NUM_ROWS; i++) {
       Assert.assertEquals(intValues[i], expectedValues[i]);
       Assert.assertEquals(longValues[i], expectedValues[i]);
@@ -227,5 +227,9 @@ public class NullHandlingTransformFunctionTest {
       Assert.assertEquals(doubleValues[i], (double) expectedValues[i]);
       Assert.assertEquals(stringValues[i], Integer.toString(expectedValues[i]));
     }
+  }
+
+  private TransformFunction getTransformFunctionInstance(ExpressionContext expression) {
+    return TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/NullHandlingTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/NullHandlingTransformFunctionTest.java
@@ -1,0 +1,231 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import java.io.File;
+import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.core.operator.DocIdSetOperator;
+import org.apache.pinot.core.operator.ProjectionOperator;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+import org.apache.pinot.core.operator.filter.MatchAllFilterOperator;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.TimeGranularitySpec;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class NullHandlingTransformFunctionTest {
+  private static final String SEGMENT_NAME = "testSegmentWithNulls";
+  private static final String INDEX_DIR_PATH = FileUtils.getTempDirectoryPath() + File.separator + SEGMENT_NAME;
+  private static final Random RANDOM = new Random();
+
+  protected static final int NUM_ROWS = 1000;
+  protected static final String INT_SV_COLUMN = "intSV";
+  protected static final String LONG_SV_COLUMN = "longSV";
+  protected static final String FLOAT_SV_COLUMN = "floatSV";
+  protected static final String DOUBLE_SV_COLUMN = "doubleSV";
+  protected static final String STRING_SV_COLUMN = "stringSV";
+  protected static final String INT_MV_COLUMN = "intMV";
+  protected static final String BYTES_SV_COLUMN = "bytesSV";
+  protected static final String TIMESTAMP_COLUMN = "timestampColumn";
+  protected static final String TIME_COLUMN = "timeColumn";
+  protected final long[] _timeValues = new long[NUM_ROWS];
+
+  protected final int[] _intSVValues = new int[NUM_ROWS];
+  protected final long[] _longSVValues = new long[NUM_ROWS];
+  protected final float[] _floatSVValues = new float[NUM_ROWS];
+  protected final double[] _doubleSVValues = new double[NUM_ROWS];
+  protected final String[] _stringSVValues = new String[NUM_ROWS];
+  protected final byte[][] _bytesSVValues = new byte[NUM_ROWS][];
+
+  protected Map<String, DataSource> _dataSourceMap;
+  protected ProjectionBlock _projectionBlock;
+  protected static final int NULL_VALUE_MOD = 10;
+
+  @BeforeClass
+  public void setup()
+      throws Exception {
+    FileUtils.deleteQuietly(new File(INDEX_DIR_PATH));
+    DecimalFormat df = new DecimalFormat("0", DecimalFormatSymbols.getInstance(Locale.ENGLISH));
+    df.setMaximumFractionDigits(340); // 340 = DecimalFormat.DOUBLE_FRACTION_DIGITS
+    long currentTimeMs = System.currentTimeMillis();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      _intSVValues[i] = RANDOM.nextInt();
+      _longSVValues[i] = RANDOM.nextLong();
+      _floatSVValues[i] = _intSVValues[i] * RANDOM.nextFloat();
+      _doubleSVValues[i] = _intSVValues[i] * RANDOM.nextDouble();
+      _stringSVValues[i] = df.format(_intSVValues[i] * RANDOM.nextDouble());
+      _bytesSVValues[i] = RandomStringUtils.randomAlphanumeric(26).getBytes();
+
+      _timeValues[i] = currentTimeMs - RANDOM.nextInt(365 * 24 * 3600) * 1000L;
+    }
+
+    List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      Map<String, Object> map = new HashMap<>();
+      if (i % NULL_VALUE_MOD != 0) {
+        map.put(INT_SV_COLUMN, _intSVValues[i]);
+        map.put(LONG_SV_COLUMN, _longSVValues[i]);
+        map.put(FLOAT_SV_COLUMN, _floatSVValues[i]);
+        map.put(DOUBLE_SV_COLUMN, _doubleSVValues[i]);
+        map.put(STRING_SV_COLUMN, _stringSVValues[i]);
+        map.put(BYTES_SV_COLUMN, _bytesSVValues[i]);
+      } else {
+        map.put(INT_SV_COLUMN, null);
+        map.put(LONG_SV_COLUMN, null);
+        map.put(FLOAT_SV_COLUMN, null);
+        map.put(DOUBLE_SV_COLUMN, null);
+        map.put(STRING_SV_COLUMN, null);
+        map.put(BYTES_SV_COLUMN, null);
+      }
+      map.put(TIMESTAMP_COLUMN, _timeValues[i]);
+      map.put(TIME_COLUMN, _timeValues[i]);
+      GenericRow row = new GenericRow();
+      row.init(map);
+      rows.add(row);
+    }
+
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(INT_SV_COLUMN, FieldSpec.DataType.INT)
+        .addSingleValueDimension(LONG_SV_COLUMN, FieldSpec.DataType.LONG)
+        .addSingleValueDimension(FLOAT_SV_COLUMN, FieldSpec.DataType.FLOAT)
+        .addSingleValueDimension(DOUBLE_SV_COLUMN, FieldSpec.DataType.DOUBLE)
+        .addSingleValueDimension(STRING_SV_COLUMN, FieldSpec.DataType.STRING)
+        .addSingleValueDimension(BYTES_SV_COLUMN, FieldSpec.DataType.BYTES)
+        .addMultiValueDimension(INT_MV_COLUMN, FieldSpec.DataType.INT)
+        .addDateTime(TIMESTAMP_COLUMN, FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+        .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, TIME_COLUMN), null).build();
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName("testWithNulls").setNullHandlingEnabled(true)
+            .setTimeColumnName(TIME_COLUMN).build();
+
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setOutDir(INDEX_DIR_PATH);
+    config.setSegmentName(SEGMENT_NAME);
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(config, new GenericRowRecordReader(rows));
+    driver.build();
+
+    IndexSegment indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR_PATH, SEGMENT_NAME), ReadMode.heap);
+    Set<String> columnNames = indexSegment.getPhysicalColumnNames();
+    _dataSourceMap = new HashMap<>(columnNames.size());
+    for (String columnName : columnNames) {
+      _dataSourceMap.put(columnName, indexSegment.getDataSource(columnName));
+    }
+
+    _projectionBlock = new ProjectionOperator(_dataSourceMap,
+        new DocIdSetOperator(new MatchAllFilterOperator(NUM_ROWS), DocIdSetPlanNode.MAX_DOC_PER_CALL)).nextBlock();
+  }
+
+  @Test
+  public void testIsNullTransformFunction()
+      throws Exception {
+    testIsNullTransformFunction(INT_SV_COLUMN);
+    testIsNullTransformFunction(LONG_SV_COLUMN);
+    testIsNullTransformFunction(FLOAT_SV_COLUMN);
+    testIsNullTransformFunction(DOUBLE_SV_COLUMN);
+    testIsNullTransformFunction(STRING_SV_COLUMN);
+    testIsNullTransformFunction(BYTES_SV_COLUMN);
+  }
+
+  public void testIsNullTransformFunction(String columnName)
+      throws Exception {
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(String.format("%s IS NULL", columnName));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof IsNullTransformFunction);
+    Assert.assertEquals(transformFunction.getName(), IsNullTransformFunction.FUNCTION_NAME);
+    int[] expectedValues = new int[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      if (i % NULL_VALUE_MOD == 0) {
+        expectedValues[i] = 1;
+      }
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test(enabled = false)
+  public void testIsNotNullTransformFunction()
+      throws Exception {
+    testIsNotNullTransformFunction(INT_SV_COLUMN);
+    testIsNotNullTransformFunction(LONG_SV_COLUMN);
+    testIsNotNullTransformFunction(FLOAT_SV_COLUMN);
+    testIsNotNullTransformFunction(DOUBLE_SV_COLUMN);
+    testIsNotNullTransformFunction(STRING_SV_COLUMN);
+    testIsNotNullTransformFunction(BYTES_SV_COLUMN);
+  }
+
+  public void testIsNotNullTransformFunction(String columnName)
+      throws Exception {
+    ExpressionContext expression =
+        RequestContextUtils.getExpressionFromSQL(String.format("%s IS NOT NULL", columnName));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof IsNotNullTransformFunction);
+    Assert.assertEquals(transformFunction.getName(), IsNotNullTransformFunction.FUNCTION_NAME);
+    int[] expectedValues = new int[NUM_ROWS];
+    Arrays.fill(expectedValues, 1);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      if (i % NULL_VALUE_MOD == 0) {
+        expectedValues[i] = 0;
+      }
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  protected void testTransformFunction(TransformFunction transformFunction, int[] expectedValues) {
+    int[] intValues = transformFunction.transformToIntValuesSV(_projectionBlock);
+    long[] longValues = transformFunction.transformToLongValuesSV(_projectionBlock);
+    float[] floatValues = transformFunction.transformToFloatValuesSV(_projectionBlock);
+    double[] doubleValues = transformFunction.transformToDoubleValuesSV(_projectionBlock);
+    String[] stringValues = transformFunction.transformToStringValuesSV(_projectionBlock);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      Assert.assertEquals(intValues[i], expectedValues[i]);
+      Assert.assertEquals(longValues[i], expectedValues[i]);
+      Assert.assertEquals(floatValues[i], (float) expectedValues[i]);
+      Assert.assertEquals(doubleValues[i], (double) expectedValues[i]);
+      Assert.assertEquals(stringValues[i], Integer.toString(expectedValues[i]));
+    }
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/NullHandlingTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/NullHandlingTransformFunctionTest.java
@@ -70,8 +70,8 @@ public class NullHandlingTransformFunctionTest {
   protected static final String FLOAT_SV_COLUMN = "floatSV";
   protected static final String DOUBLE_SV_COLUMN = "doubleSV";
   protected static final String STRING_SV_COLUMN = "stringSV";
-  protected static final String INT_MV_COLUMN = "intMV";
   protected static final String BYTES_SV_COLUMN = "bytesSV";
+
   protected static final String TIMESTAMP_COLUMN = "timestampColumn";
   protected static final String TIME_COLUMN = "timeColumn";
   protected final long[] _timeValues = new long[NUM_ROWS];
@@ -136,7 +136,6 @@ public class NullHandlingTransformFunctionTest {
         .addSingleValueDimension(DOUBLE_SV_COLUMN, FieldSpec.DataType.DOUBLE)
         .addSingleValueDimension(STRING_SV_COLUMN, FieldSpec.DataType.STRING)
         .addSingleValueDimension(BYTES_SV_COLUMN, FieldSpec.DataType.BYTES)
-        .addMultiValueDimension(INT_MV_COLUMN, FieldSpec.DataType.INT)
         .addDateTime(TIMESTAMP_COLUMN, FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
         .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.MILLISECONDS, TIME_COLUMN), null).build();
     TableConfig tableConfig =

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/NullHandlingTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/NullHandlingTransformFunctionTest.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.pinot.common.function.TransformFunctionType;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.core.operator.DocIdSetOperator;
@@ -176,7 +177,7 @@ public class NullHandlingTransformFunctionTest {
     ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(String.format("%s IS NULL", columnName));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof IsNullTransformFunction);
-    Assert.assertEquals(transformFunction.getName(), IsNullTransformFunction.FUNCTION_NAME);
+    Assert.assertEquals(transformFunction.getName(), TransformFunctionType.IS_NULL.getName());
     int[] expectedValues = new int[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
       if (i % NULL_VALUE_MOD == 0) {
@@ -203,7 +204,7 @@ public class NullHandlingTransformFunctionTest {
         RequestContextUtils.getExpressionFromSQL(String.format("%s IS NOT NULL", columnName));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof IsNotNullTransformFunction);
-    Assert.assertEquals(transformFunction.getName(), IsNotNullTransformFunction.FUNCTION_NAME);
+    Assert.assertEquals(transformFunction.getName(), TransformFunctionType.IS_NOT_NULL.getName());
     int[] expectedValues = new int[NUM_ROWS];
     Arrays.fill(expectedValues, 1);
     for (int i = 0; i < NUM_ROWS; i++) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/NullHandlingTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/NullHandlingTransformFunctionTest.java
@@ -186,7 +186,7 @@ public class NullHandlingTransformFunctionTest {
     testTransformFunction(transformFunction, expectedValues);
   }
 
-  @Test(enabled = false)
+  @Test
   public void testIsNotNullTransformFunction()
       throws Exception {
     testIsNotNullTransformFunction(INT_SV_COLUMN);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
@@ -155,4 +155,18 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
     String query = "SELECT count(*) FROM " + getTableName() + " where description IS NOT NULL AND salary IS NOT NULL";
     testQuery(query, Collections.singletonList(query));
   }
+
+  @Test
+  public void testCaseWithNullSalary()
+      throws Exception {
+    String query = "SELECT CASE WHEN salary IS NULL THEN 1 ELSE 0 END FROM " + getTableName();
+    testSqlQuery(query, Collections.singletonList(query));
+  }
+
+  @Test
+  public void testCaseWithNotNullDescription()
+      throws Exception {
+    String query = "SELECT CASE WHEN description IS NOT NULL THEN 1 ELSE 0 END FROM " + getTableName();
+    testSqlQuery(query, Collections.singletonList(query));
+  }
 }


### PR DESCRIPTION
This PR addresses the issue #8251 . Currently, Pinot supports `IS NULL` syntax in filter expressions such as `WHERE` clause. But it doesn't support as part of SELECT expressions such as `CASE WHEN col IS NULL THEN a ELSE b`

The PR adds support for such expressions by utilising the `NullValueVectorReader` to get the docIds which are null.

The implementation has two requirements/limitations - 

* `nullHandlingEnabled` should be set to `true`  since native NULL values are not supported in  Pinot and requires a null value bitmap index.

* Only column names can be provided as the first argument for expressions. The support for functions is still not there. 
 e.g. `colA IS NULL` is supported but `LOWER(colA) IS NULL` is not supported.
 
 
 Currently Pending  - 
 * Documentation

