### PR TITLE
allow to specify fixed segment name for SegmentProcessorFramework

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -100,6 +100,7 @@ public class MinionConstants {
     public static final String MAX_NUM_PARALLEL_BUCKETS = "maxNumParallelBuckets";
     public static final String SEGMENT_NAME_PREFIX_KEY = "segmentNamePrefix";
     public static final String SEGMENT_NAME_POSTFIX_KEY = "segmentNamePostfix";
+    public static final String FIXED_SEGMENT_NAME_KEY = "fixedSegmentName";
   }
 
   public static class MergeRollupTask extends MergeTask {

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentConfig.java
@@ -35,15 +35,18 @@ public class SegmentConfig {
   private final int _maxNumRecordsPerSegment;
   private final String _segmentNamePrefix;
   private final String _segmentNamePostfix;
+  private final String _fixedSegmentName;
 
   @JsonCreator
   private SegmentConfig(@JsonProperty(value = "maxNumRecordsPerSegment", required = true) int maxNumRecordsPerSegment,
       @JsonProperty("segmentNamePrefix") @Nullable String segmentNamePrefix,
-      @JsonProperty("segmentNamePostfix") @Nullable String segmentNamePostfix) {
+      @JsonProperty("segmentNamePostfix") @Nullable String segmentNamePostfix,
+      @JsonProperty("fixedSegmentName") @Nullable String fixedSegmentName) {
     Preconditions.checkState(maxNumRecordsPerSegment > 0, "Max num records per segment must be > 0");
     _maxNumRecordsPerSegment = maxNumRecordsPerSegment;
     _segmentNamePrefix = segmentNamePrefix;
     _segmentNamePostfix = segmentNamePostfix;
+    _fixedSegmentName = fixedSegmentName;
   }
 
   /**
@@ -63,6 +66,11 @@ public class SegmentConfig {
     return _segmentNamePostfix;
   }
 
+  @Nullable
+  public String getFixedSegmentName() {
+    return _fixedSegmentName;
+  }
+
   /**
    * Builder for SegmentConfig
    */
@@ -70,6 +78,7 @@ public class SegmentConfig {
     private int _maxNumRecordsPerSegment = DEFAULT_MAX_NUM_RECORDS_PER_SEGMENT;
     private String _segmentNamePrefix;
     private String _segmentNamePostfix;
+    private String _fixedSegmentName;
 
     public Builder setMaxNumRecordsPerSegment(int maxNumRecordsPerSegment) {
       _maxNumRecordsPerSegment = maxNumRecordsPerSegment;
@@ -86,15 +95,21 @@ public class SegmentConfig {
       return this;
     }
 
+    public Builder setFixedSegmentName(String fixedSegmentName) {
+      _fixedSegmentName = fixedSegmentName;
+      return this;
+    }
+
     public SegmentConfig build() {
       Preconditions.checkState(_maxNumRecordsPerSegment > 0, "Max num records per segment must be > 0");
-      return new SegmentConfig(_maxNumRecordsPerSegment, _segmentNamePrefix, _segmentNamePostfix);
+      return new SegmentConfig(_maxNumRecordsPerSegment, _segmentNamePrefix, _segmentNamePostfix, _fixedSegmentName);
     }
   }
 
   @Override
   public String toString() {
     return "SegmentConfig{" + "_maxNumRecordsPerSegment=" + _maxNumRecordsPerSegment + ", _segmentNamePrefix='"
-        + _segmentNamePrefix + '\'' + ", _segmentNamePostfix='" + _segmentNamePostfix + '\'' + '}';
+        + _segmentNamePrefix + '\'' + ", _segmentNamePostfix='" + _segmentNamePostfix + '\'' + ", _fixedSegmentName='"
+        + _fixedSegmentName + '\'' + '}';
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
@@ -117,13 +117,14 @@ public class SegmentProcessorFramework {
     Schema schema = _segmentProcessorConfig.getSchema();
     String segmentNamePrefix = _segmentProcessorConfig.getSegmentConfig().getSegmentNamePrefix();
     String segmentNamePostfix = _segmentProcessorConfig.getSegmentConfig().getSegmentNamePostfix();
+    String fixedSegmentName = _segmentProcessorConfig.getSegmentConfig().getFixedSegmentName();
     SegmentGeneratorConfig generatorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     generatorConfig.setOutDir(_segmentsOutputDir.getPath());
 
     if (tableConfig.getIndexingConfig().getSegmentNameGeneratorType() != null) {
-      generatorConfig.setSegmentNameGenerator(
-          SegmentNameGeneratorFactory
-              .createSegmentNameGenerator(tableConfig, schema, segmentNamePrefix, segmentNamePostfix, false));
+      generatorConfig.setSegmentNameGenerator(SegmentNameGeneratorFactory
+          .createSegmentNameGenerator(tableConfig, schema, segmentNamePrefix, segmentNamePostfix, fixedSegmentName,
+              false));
     } else {
       // SimpleSegmentNameGenerator is used by default.
       generatorConfig.setSegmentNamePrefix(segmentNamePrefix);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtils.java
@@ -143,6 +143,7 @@ public class MergeTaskUtils {
     }
     segmentConfigBuilder.setSegmentNamePrefix(taskConfig.get(MergeTask.SEGMENT_NAME_PREFIX_KEY));
     segmentConfigBuilder.setSegmentNamePostfix(taskConfig.get(MergeTask.SEGMENT_NAME_POSTFIX_KEY));
+    segmentConfigBuilder.setFixedSegmentName(taskConfig.get(MergeTask.FIXED_SEGMENT_NAME_KEY));
     return segmentConfigBuilder.build();
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtilsTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtilsTest.java
@@ -86,8 +86,9 @@ public class MergeTaskUtilsTest {
   @Test
   public void testGetPartitionerConfigs() {
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable")
-        .setSegmentPartitionConfig(new SegmentPartitionConfig(
-            Collections.singletonMap("memberId", new ColumnPartitionConfig("murmur", 10)))).build();
+        .setSegmentPartitionConfig(
+            new SegmentPartitionConfig(Collections.singletonMap("memberId", new ColumnPartitionConfig("murmur", 10))))
+        .build();
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("memberId", DataType.LONG).build();
     Map<String, String> taskConfig = Collections.emptyMap();
 
@@ -161,17 +162,21 @@ public class MergeTaskUtilsTest {
     taskConfig.put(MergeTask.MAX_NUM_RECORDS_PER_SEGMENT_KEY, "10000");
     taskConfig.put(MergeTask.SEGMENT_NAME_PREFIX_KEY, "myPrefix");
     taskConfig.put(MergeTask.SEGMENT_NAME_POSTFIX_KEY, "myPostfix");
+    taskConfig.put(MergeTask.FIXED_SEGMENT_NAME_KEY, "mySegment");
     SegmentConfig segmentConfig = MergeTaskUtils.getSegmentConfig(taskConfig);
     assertEquals(segmentConfig.getMaxNumRecordsPerSegment(), 10000);
     assertEquals(segmentConfig.getSegmentNamePrefix(), "myPrefix");
     assertEquals(segmentConfig.getSegmentNamePostfix(), "myPostfix");
+    assertEquals(segmentConfig.getSegmentNamePostfix(), "myPostfix");
+    assertEquals(segmentConfig.getFixedSegmentName(), "mySegment");
     assertEquals(segmentConfig.toString(),
         "SegmentConfig{_maxNumRecordsPerSegment=10000, _segmentNamePrefix='myPrefix', "
-            + "_segmentNamePostfix='myPostfix'}");
+            + "_segmentNamePostfix='myPostfix', _fixedSegmentName='mySegment'}");
 
     segmentConfig = MergeTaskUtils.getSegmentConfig(Collections.emptyMap());
     assertEquals(segmentConfig.getMaxNumRecordsPerSegment(), SegmentConfig.DEFAULT_MAX_NUM_RECORDS_PER_SEGMENT);
     assertNull(segmentConfig.getSegmentNamePrefix());
     assertNull(segmentConfig.getSegmentNamePostfix());
+    assertNull(segmentConfig.getFixedSegmentName());
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SegmentNameGeneratorFactory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SegmentNameGeneratorFactory.java
@@ -29,6 +29,7 @@ import org.apache.pinot.spi.utils.IngestionConfigUtils;
 
 
 public class SegmentNameGeneratorFactory {
+  public static final String FIXED_SEGMENT_NAME_GENERATOR = "fixed";
   public static final String SIMPLE_SEGMENT_NAME_GENERATOR = "simple";
   public static final String NORMALIZED_DATE_SEGMENT_NAME_GENERATOR = "normalizeddate";
 
@@ -39,7 +40,7 @@ public class SegmentNameGeneratorFactory {
    * Create the segment name generator given input configurations
    */
   public static SegmentNameGenerator createSegmentNameGenerator(TableConfig tableConfig, Schema schema,
-      @Nullable String prefix, @Nullable String postfix, boolean excludeSequenceId) {
+      @Nullable String prefix, @Nullable String postfix, @Nullable String fixedSegmentName, boolean excludeSequenceId) {
     String segmentNameGeneratorType = tableConfig.getIndexingConfig().getSegmentNameGeneratorType();
     if (segmentNameGeneratorType == null || segmentNameGeneratorType.isEmpty()) {
       segmentNameGeneratorType = SIMPLE_SEGMENT_NAME_GENERATOR;
@@ -47,6 +48,8 @@ public class SegmentNameGeneratorFactory {
 
     String tableName = tableConfig.getTableName();
     switch (segmentNameGeneratorType.toLowerCase()) {
+      case FIXED_SEGMENT_NAME_GENERATOR:
+        return new FixedSegmentNameGenerator(fixedSegmentName);
       case SIMPLE_SEGMENT_NAME_GENERATOR:
         if (prefix != null) {
           return new SimpleSegmentNameGenerator(prefix, postfix);


### PR DESCRIPTION
## Description
allow to specify segment name when using SegmentProcessorFramework, e.g. using the framework generate a single segment to replace existing one. 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
