### PR TITLE
Fix bug in GrpcBrokerRequestHandler: exceptions are suppressed

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/StreamingReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/StreamingReduceService.java
@@ -116,7 +116,7 @@ public class StreamingReduceService extends BaseReduceService {
     // and https://stackoverflow.com/questions/23301598/transform-java-future-into-a-completablefuture
     // Future created via ExecutorService.submit() can be created by CompletableFuture.supplyAsync()
     for (Map.Entry<ServerRoutingInstance, Iterator<Server.ServerResponse>> entry : serverResponseMap.entrySet()) {
-      futures[cnt++] = CompletableFuture.supplyAsync(() -> {
+      futures[cnt++] = CompletableFuture.runAsync(() -> {
         Iterator<Server.ServerResponse> streamingResponses = entry.getValue();
         try {
           while (streamingResponses.hasNext()) {
@@ -129,7 +129,6 @@ public class StreamingReduceService extends BaseReduceService {
               aggregator.aggregate(entry.getKey(), dataTable);
             }
           }
-          return null;
         } catch (Exception e) {
           LOGGER.error("Unable to process streaming response. Failure occurred!", e);
           throw new RuntimeException("Unable to process streaming response. Failure occurred!", e);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/StreamingReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/StreamingReduceService.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -87,7 +88,7 @@ public class StreamingReduceService extends BaseReduceService {
     streamingReducer.init(dataTableReducerContext);
 
     try {
-      processIterativeServerResponse(streamingReducer, serverResponseMap, reduceTimeOutMs,
+      processIterativeServerResponse(streamingReducer, _reduceExecutorService, serverResponseMap, reduceTimeOutMs,
           aggregator);
     } catch (Exception e) {
       LOGGER.error("Unable to process streaming query response!", e);
@@ -105,7 +106,7 @@ public class StreamingReduceService extends BaseReduceService {
   }
 
   @VisibleForTesting
-  static void processIterativeServerResponse(StreamingReducer reducer,
+  static void processIterativeServerResponse(StreamingReducer reducer, ExecutorService executorService,
       Map<ServerRoutingInstance, Iterator<Server.ServerResponse>> serverResponseMap, long reduceTimeOutMs,
       ExecutionStatsAggregator aggregator)
       throws Exception {
@@ -133,7 +134,7 @@ public class StreamingReduceService extends BaseReduceService {
           LOGGER.error("Unable to process streaming response. Failure occurred!", e);
           throw new RuntimeException("Unable to process streaming response. Failure occurred!", e);
         }
-      });
+      }, executorService);
     }
     CompletableFuture<Void> syncWaitPoint = CompletableFuture.allOf(futures);
     try {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/StreamingReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/StreamingReduceService.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.reduce;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
@@ -25,6 +26,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.common.metrics.BrokerMetrics;
@@ -105,12 +108,13 @@ public class StreamingReduceService extends BaseReduceService {
     return brokerResponseNative;
   }
 
-  private static void processIterativeServerResponse(StreamingReducer reducer, ExecutorService executorService,
+  @VisibleForTesting
+  static void processIterativeServerResponse(StreamingReducer reducer, ExecutorService executorService,
       Map<ServerRoutingInstance, Iterator<Server.ServerResponse>> serverResponseMap, long reduceTimeOutMs,
-      ExecutionStatsAggregator aggregator) throws Exception {
+      ExecutionStatsAggregator aggregator) throws ExecutionException {
     int cnt = 0;
-    Future[] futures = new Future[serverResponseMap.size()];
-    // based on consensus on https://stackoverflow.com/questions/19348248/waiting-on-a-list-of-future
+    Future<Void>[] futures = new Future[serverResponseMap.size()];
+    // based on ideas from on https://stackoverflow.com/questions/19348248/waiting-on-a-list-of-future
     // mostly because we need to handle and transfer the exception in threads into caller thread.
     ExecutorCompletionService<Void> countDownHelper = new ExecutorCompletionService<>(executorService);
     for (Map.Entry<ServerRoutingInstance, Iterator<Server.ServerResponse>> entry: serverResponseMap.entrySet()) {
@@ -119,7 +123,6 @@ public class StreamingReduceService extends BaseReduceService {
         try {
           while (streamingResponses.hasNext()) {
             Server.ServerResponse streamingResponse = streamingResponses.next();
-            LOGGER.info("Streaming Response is {}", streamingResponse.toString());
             DataTable dataTable = DataTableFactory.getDataTable(streamingResponse.getPayload().asReadOnlyByteBuffer());
             // null dataSchema is a metadata-only block.
             if (dataTable.getDataSchema() != null) {
@@ -137,7 +140,12 @@ public class StreamingReduceService extends BaseReduceService {
     }
     for (int received = 0; received < futures.length; received++) {
       try {
-        countDownHelper.take().get();
+        Future<Void> rpcCallHandle = countDownHelper.poll(reduceTimeOutMs, TimeUnit.MILLISECONDS);
+        if (rpcCallHandle == null) {
+          throw new TimeoutException("Failed to complete gRPC call within " + reduceTimeOutMs + "ms.");
+        }
+        // below will force the thread exception thrown into current thread
+        rpcCallHandle.get(reduceTimeOutMs, TimeUnit.MILLISECONDS);
       } catch (Exception ex) {
         for (Future future : futures) {
           if (!future.isDone()) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/reduce/StreamingReduceServiceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/reduce/StreamingReduceServiceTest.java
@@ -19,10 +19,8 @@
 package org.apache.pinot.core.query.reduce;
 
 import com.google.common.collect.ImmutableMap;
-import io.grpc.StatusRuntimeException;
 import java.util.Iterator;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/reduce/StreamingReduceServiceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/reduce/StreamingReduceServiceTest.java
@@ -54,7 +54,7 @@ public class StreamingReduceServiceTest {
     // here we hope to verify deeper to make sure the thrown exception is nested inside the exception
     assertTrue(verifyException(() -> {
           StreamingReduceService.processIterativeServerResponse(mock(StreamingReducer.class),
-              threadPoolService, ImmutableMap.of(routingInstance, mockedResponse),
+              ImmutableMap.of(routingInstance, mockedResponse),
               1000,
               mock(BaseReduceService.ExecutionStatsAggregator.class));
           return null;
@@ -83,7 +83,7 @@ public class StreamingReduceServiceTest {
     // here we hope to verify deeper to make sure the thrown exception is nested inside the exception
     assertTrue(verifyException(() -> {
           StreamingReduceService.processIterativeServerResponse(mock(StreamingReducer.class),
-              threadPoolService, ImmutableMap.of(routingInstance, mockedResponse),
+              ImmutableMap.of(routingInstance, mockedResponse),
               10,
               mock(BaseReduceService.ExecutionStatsAggregator.class));
           return null;
@@ -99,7 +99,7 @@ public class StreamingReduceServiceTest {
     try {
       verifyTarget.call();
     } catch (Exception ex) {
-      for (Throwable child = ex.getCause();
+      for (Throwable child = ex;
           child != null && child.getCause() != child && !exceptionVerified;
           child = child.getCause()) {
         if (verifyCause.apply(child)) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/reduce/StreamingReduceServiceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/reduce/StreamingReduceServiceTest.java
@@ -54,6 +54,7 @@ public class StreamingReduceServiceTest {
     // here we hope to verify deeper to make sure the thrown exception is nested inside the exception
     assertTrue(verifyException(() -> {
           StreamingReduceService.processIterativeServerResponse(mock(StreamingReducer.class),
+              threadPoolService,
               ImmutableMap.of(routingInstance, mockedResponse),
               1000,
               mock(BaseReduceService.ExecutionStatsAggregator.class));
@@ -83,6 +84,7 @@ public class StreamingReduceServiceTest {
     // here we hope to verify deeper to make sure the thrown exception is nested inside the exception
     assertTrue(verifyException(() -> {
           StreamingReduceService.processIterativeServerResponse(mock(StreamingReducer.class),
+              threadPoolService,
               ImmutableMap.of(routingInstance, mockedResponse),
               10,
               mock(BaseReduceService.ExecutionStatsAggregator.class));

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/reduce/StreamingReduceServiceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/reduce/StreamingReduceServiceTest.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.reduce;
+
+import com.google.common.collect.ImmutableMap;
+import io.grpc.StatusRuntimeException;
+import java.util.Iterator;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Function;
+import org.apache.pinot.common.proto.Server;
+import org.apache.pinot.core.transport.ServerRoutingInstance;
+import org.apache.pinot.spi.config.table.TableType;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
+
+
+public class StreamingReduceServiceTest {
+
+  @Test
+  public void testThreadExceptionTransfer() {
+    // simulate a thread exception in gRPC call and verify that the thread can transfer the exception
+    Iterator<Server.ServerResponse> mockedResponse = (Iterator<Server.ServerResponse>) mock(Iterator.class);
+    when(mockedResponse.hasNext()).thenReturn(true);
+    final String exceptionMessage = "Some exception";
+    final RuntimeException innerException = new RuntimeException(exceptionMessage);
+    when(mockedResponse.next()).thenThrow(innerException);
+    final ExecutorService threadPoolService = Executors.newFixedThreadPool(1);
+    final ServerRoutingInstance routingInstance =
+        new ServerRoutingInstance("localhost", 9527, TableType.OFFLINE, false);
+    // supposedly we can use TestNG's annotation like @Test(expectedExceptions = { IOException.class }) to verify
+    // here we hope to verify deeper to make sure the thrown exception is nested inside the exception
+    assertTrue(verifyException(() -> {
+          StreamingReduceService.processIterativeServerResponse(mock(StreamingReducer.class),
+              threadPoolService, ImmutableMap.of(routingInstance, mockedResponse),
+              1000,
+              mock(BaseReduceService.ExecutionStatsAggregator.class));
+          return null;
+        }, (cause) -> cause.getMessage().contains(exceptionMessage))
+    );
+  }
+
+  @Test
+  public void testExecutionTimeout()
+      throws Exception {
+    // simulate a thread timeout in gRPC call and verify that the thread can transfer the exception
+    Iterator<Server.ServerResponse> mockedResponse = (Iterator<Server.ServerResponse>) mock(Iterator.class);
+    when(mockedResponse.hasNext()).thenReturn(true);
+    when(mockedResponse.next()).then(new Answer<Void>() {
+      @Override
+      public Void answer(InvocationOnMock invocationOnMock)
+          throws Throwable {
+        Thread.sleep(1000);
+        return null;
+      }
+    });
+    final ExecutorService threadPoolService = Executors.newFixedThreadPool(1);
+    final ServerRoutingInstance routingInstance =
+        new ServerRoutingInstance("localhost", 9527, TableType.OFFLINE, false);
+    // supposedly we can use TestNG's annotation like @Test(expectedExceptions = { IOException.class }) to verify
+    // here we hope to verify deeper to make sure the thrown exception is nested inside the exception
+    assertTrue(verifyException(() -> {
+          StreamingReduceService.processIterativeServerResponse(mock(StreamingReducer.class),
+              threadPoolService, ImmutableMap.of(routingInstance, mockedResponse),
+              10,
+              mock(BaseReduceService.ExecutionStatsAggregator.class));
+          return null;
+        },
+        (cause) -> cause instanceof TimeoutException));
+  }
+
+  private static boolean verifyException(Callable<Void> verifyTarget, Function<Throwable, Boolean> verifyCause) {
+    boolean exceptionVerified = false;
+    if (verifyTarget == null || verifyCause == null) {
+      throw new RuntimeException("verifyException method needs two non-null lambdas");
+    }
+    try {
+      verifyTarget.call();
+    } catch (Exception ex) {
+      for (Throwable child = ex.getCause();
+          child != null && child.getCause() != child && !exceptionVerified;
+          child = child.getCause()) {
+        if (verifyCause.apply(child)) {
+          exceptionVerified = true;
+        }
+      }
+    }
+    return exceptionVerified;
+  }
+}


### PR DESCRIPTION
## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
In our `GrpcBrokerRequestHandler` if there is an exception in gRPC calls, the exceptions are suppressed and there is no trace or error handling. The handler will consider all calls "success".

This is because gRPC calls are done inside ExecutorService, mostly via a ThreadPool. The Exceptions thrown inside a thread will "stay" inside that thread; when the Future.get() of that thread is called, the Exception will trigger an `ExecutionException` with the thread exception as cause.

In our code because we use CountDownLatch to help parallelize the gRPC call, we did not call the Future.get() to trigger the exception.

## Fix
Following https://stackoverflow.com/questions/19348248/waiting-on-a-list-of-future we rewrite to use the `ExecutorCompletionService<T>` to help out.

** We may need to look everywhere for CountDownLatch for potential similar problems**

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? No

## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->
Fixed a bug where `GrpcBrokerRequestHandler` will ignore all gRPC exceptions.

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
