### PR TITLE
Add prefixesToRename config for renaming fields upon ingestion

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -279,12 +279,12 @@ public class TableConfigSerDeTest {
       List<Map<String, String>> batchConfigMaps = new ArrayList<>();
       batchConfigMaps.add(batchConfigMap);
       List<String> fieldsToUnnest = Arrays.asList("c1, c2");
-      List<String> prefixesToDropFromFields = new ArrayList<>();
+      Map<String, String> prefixesToRename = new HashMap();
       IngestionConfig ingestionConfig =
           new IngestionConfig(new BatchIngestionConfig(batchConfigMaps, "APPEND", "HOURLY"),
               new StreamIngestionConfig(streamConfigMaps), new FilterConfig("filterFunc(foo)"), transformConfigs,
               new ComplexTypeConfig(fieldsToUnnest, ".",
-                      ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE, prefixesToDropFromFields));
+                      ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE, prefixesToRename));
       TableConfig tableConfig = tableConfigBuilder.setIngestionConfig(ingestionConfig).build();
 
       checkIngestionConfig(tableConfig);

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -282,7 +282,8 @@ public class TableConfigSerDeTest {
       IngestionConfig ingestionConfig =
           new IngestionConfig(new BatchIngestionConfig(batchConfigMaps, "APPEND", "HOURLY"),
               new StreamIngestionConfig(streamConfigMaps), new FilterConfig("filterFunc(foo)"), transformConfigs,
-              new ComplexTypeConfig(fieldsToUnnest, ".", ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE));
+              new ComplexTypeConfig(fieldsToUnnest, ".",
+                      ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE, false));
       TableConfig tableConfig = tableConfigBuilder.setIngestionConfig(ingestionConfig).build();
 
       checkIngestionConfig(tableConfig);

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -279,11 +279,12 @@ public class TableConfigSerDeTest {
       List<Map<String, String>> batchConfigMaps = new ArrayList<>();
       batchConfigMaps.add(batchConfigMap);
       List<String> fieldsToUnnest = Arrays.asList("c1, c2");
+      List<String> prefixesToDropFromFields = new ArrayList<>();
       IngestionConfig ingestionConfig =
           new IngestionConfig(new BatchIngestionConfig(batchConfigMaps, "APPEND", "HOURLY"),
               new StreamIngestionConfig(streamConfigMaps), new FilterConfig("filterFunc(foo)"), transformConfigs,
               new ComplexTypeConfig(fieldsToUnnest, ".",
-                      ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE, false));
+                      ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE, prefixesToDropFromFields));
       TableConfig tableConfig = tableConfigBuilder.setIngestionConfig(ingestionConfig).build();
 
       checkIngestionConfig(tableConfig);

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -279,7 +279,7 @@ public class TableConfigSerDeTest {
       List<Map<String, String>> batchConfigMaps = new ArrayList<>();
       batchConfigMaps.add(batchConfigMap);
       List<String> fieldsToUnnest = Arrays.asList("c1, c2");
-      Map<String, String> prefixesToRename = new HashMap();
+      Map<String, String> prefixesToRename = new HashMap<>();
       IngestionConfig ingestionConfig =
           new IngestionConfig(new BatchIngestionConfig(batchConfigMaps, "APPEND", "HOURLY"),
               new StreamIngestionConfig(streamConfigMaps), new FilterConfig("filterFunc(foo)"), transformConfigs,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -300,14 +300,17 @@ public class ComplexTypeTransformer implements RecordTransformer {
    */
   @VisibleForTesting
   protected void renamePrefixes(GenericRow record) {
+    if (_prefixesToRename.isEmpty()) {
+      return;
+    }
     List<String> fields = new ArrayList<>(record.getFieldToValueMap().keySet());
-    for (String field : fields) {
-      for (String prefix : _prefixesToRename.keySet()) {
+    for (String prefix : _prefixesToRename.keySet()) {
+      for (String field : fields) {
         if (field.startsWith(prefix)) {
           Object value = record.removeValue(field);
           String remainingColumnName = field.substring(prefix.length());
           String newName = _prefixesToRename.get(prefix) + remainingColumnName;
-          if (record.getValue(newName) != null) {
+          if (newName.isEmpty() || record.getValue(newName) != null) {
             throw new RuntimeException(
                     String.format("Name conflict after attempting to rename field %s to %s", field, newName));
           }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.function.scalar.JsonFunctions;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -301,7 +300,7 @@ public class ComplexTypeTransformer implements RecordTransformer {
     if (_prefixesToRename.isEmpty()) {
       return;
     }
-    Set<String> fields = record.getFieldToValueMap().keySet();
+    List<String> fields = new ArrayList<>(record.getFieldToValueMap().keySet());
     for (Map.Entry<String, String> entry : _prefixesToRename.entrySet()) {
       for (String field : fields) {
         String prefix = entry.getKey();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -300,13 +300,17 @@ public class ComplexTypeTransformer implements RecordTransformer {
    */
   @VisibleForTesting
   protected void renamePrefixes(GenericRow record) {
-    List<String> columns = new ArrayList<>(record.getFieldToValueMap().keySet());
-    for (String column : columns) {
+    List<String> fields = new ArrayList<>(record.getFieldToValueMap().keySet());
+    for (String field : fields) {
       for (String prefix : _prefixesToRename.keySet()) {
-        if (column.startsWith(prefix)) {
-          Object value = record.removeValue(column);
-          String remainingColumnName = column.substring(prefix.length());
+        if (field.startsWith(prefix)) {
+          Object value = record.removeValue(field);
+          String remainingColumnName = field.substring(prefix.length());
           String newName = _prefixesToRename.get(prefix) + remainingColumnName;
+          if (record.getValue(newName) != null) {
+            throw new RuntimeException(
+                    String.format("Name conflict after attempting to rename field %s to %s", field, newName));
+          }
           record.putValue(newName, value);
         }
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
@@ -299,8 +299,8 @@ public final class IngestionUtils {
    * TableConfig and Schema
    * Fields for ingestion come from 2 places:
    * 1. The schema
-   * 2. The ingestion config in the table config. The ingestion config (e.g. filter) can have fields which are not in
-   * the schema.
+   * 2. The ingestion config in the table config. The ingestion config (e.g. filter, complexType) can have fields which
+   * are not in the schema.
    */
   public static Set<String> getFieldsForRecordExtractor(@Nullable IngestionConfig ingestionConfig, Schema schema) {
     Set<String> fieldsForRecordExtractor = new HashSet<>();
@@ -325,11 +325,6 @@ public final class IngestionUtils {
         : complexTypeConfig.getDelimiter();
     for (String field : fieldsToRead) {
       result.add(StringUtils.split(field, delimiter)[0]);
-    }
-    if (complexTypeConfig.getFieldsToUnnest() != null) {
-      for (String field : complexTypeConfig.getFieldsToUnnest()) {
-        result.add(StringUtils.split(field, delimiter)[0]);
-      }
     }
     return result;
   }
@@ -375,6 +370,10 @@ public final class IngestionUtils {
               .getColumnName()); // add the column itself too, so that if it is already transformed, we won't
           // transform again
         }
+      }
+      ComplexTypeConfig complexTypeConfig = ingestionConfig.getComplexTypeConfig();
+      if (complexTypeConfig != null && complexTypeConfig.getFieldsToUnnest() != null) {
+        fields.addAll(complexTypeConfig.getFieldsToUnnest());
       }
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
@@ -326,6 +326,11 @@ public final class IngestionUtils {
     for (String field : fieldsToRead) {
       result.add(StringUtils.split(field, delimiter)[0]);
     }
+    if (complexTypeConfig.getFieldsToUnnest() != null) {
+      for (String field : complexTypeConfig.getFieldsToUnnest()) {
+        result.add(StringUtils.split(field, delimiter)[0]);
+      }
+    }
     return result;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -51,6 +51,7 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.TierConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
 import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
@@ -345,6 +346,23 @@ public final class TableConfigUtils {
             throw new IllegalStateException(
                 "Arguments of a transform function '" + arguments + "' cannot contain the destination column '"
                     + columnName + "'");
+          }
+        }
+      }
+
+      // Complex configs
+      ComplexTypeConfig complexTypeConfig = ingestionConfig.getComplexTypeConfig();
+      if (complexTypeConfig != null && schema != null) {
+        Map<String, String> prefixesToRename = complexTypeConfig.getPrefixesToRename();
+        Set<String> fieldNames = schema.getFieldSpecMap().keySet();
+        if (prefixesToRename != null) {
+          for (String prefix : prefixesToRename.keySet()) {
+            for (String field : fieldNames) {
+              if (field.startsWith(prefix)) {
+                throw new IllegalStateException("Fields in the schema may not begin with any prefix specified in the "
+                        + "prefixesToRename config. Name conflict with field: " + field + " and prefix: " + prefix);
+              }
+            }
           }
         }
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -358,7 +358,7 @@ public final class TableConfigUtils {
         if (MapUtils.isNotEmpty(prefixesToRename)) {
           for (String prefix : prefixesToRename.keySet()) {
             for (String field : fieldNames) {
-              Preconditions.checkState(field.startsWith(prefix),
+              Preconditions.checkState(!field.startsWith(prefix),
                       "Fields in the schema may not begin with any prefix specified in the prefixesToRename"
                               + " config. Name conflict with field: " + field + " and prefix: " + prefix);
             }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -355,13 +355,12 @@ public final class TableConfigUtils {
       if (complexTypeConfig != null && schema != null) {
         Map<String, String> prefixesToRename = complexTypeConfig.getPrefixesToRename();
         Set<String> fieldNames = schema.getFieldSpecMap().keySet();
-        if (prefixesToRename != null) {
+        if (MapUtils.isNotEmpty(prefixesToRename)) {
           for (String prefix : prefixesToRename.keySet()) {
             for (String field : fieldNames) {
-              if (field.startsWith(prefix)) {
-                throw new IllegalStateException("Fields in the schema may not begin with any prefix specified in the "
-                        + "prefixesToRename config. Name conflict with field: " + field + " and prefix: " + prefix);
-              }
+              Preconditions.checkState(field.startsWith(prefix),
+                      "Fields in the schema may not begin with any prefix specified in the prefixesToRename"
+                              + " config. Name conflict with field: " + field + " and prefix: " + prefix);
             }
           }
         }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
@@ -299,7 +299,7 @@ public class ComplexTypeTransformerTest {
     //   "array":"[1,2]"
     // }
     transformer = new ComplexTypeTransformer(Arrays.asList(), ".",
-            ComplexTypeConfig.CollectionNotUnnestedToJson.ALL, Arrays.asList());
+            ComplexTypeConfig.CollectionNotUnnestedToJson.ALL, new HashMap<>());
     genericRow = new GenericRow();
     array = new Object[]{1, 2};
     genericRow.putValue("array", array);
@@ -345,16 +345,18 @@ public class ComplexTypeTransformerTest {
     map.put("array1", array1);
     genericRow.putValue("t", map);
     transformer = new ComplexTypeTransformer(Arrays.asList(), ".",
-            ComplexTypeConfig.CollectionNotUnnestedToJson.NONE, Arrays.asList());
+            ComplexTypeConfig.CollectionNotUnnestedToJson.NONE, new HashMap<>());
     transformer.transform(genericRow);
     Assert.assertTrue(ComplexTypeTransformer.isArray(genericRow.getValue("t.array1")));
   }
 
   @Test
-  public void testPrefixesToDropFromFields() {
-    List<String> prefixesToDropFromFields = Arrays.asList("map1.");
+  public void testPrefixesToRename() {
+    HashMap<String, String> prefixesToRename = new HashMap<>();
+    prefixesToRename.put("map1.", "");
+    prefixesToRename.put("map2", "test");
     ComplexTypeTransformer transformer = new ComplexTypeTransformer(new ArrayList<>(), ".",
-            DEFAULT_COLLECTION_TO_JSON_MODE, prefixesToDropFromFields);
+            DEFAULT_COLLECTION_TO_JSON_MODE, prefixesToRename);
 
     // test flatten root-level tuples
     GenericRow genericRow = new GenericRow();
@@ -375,6 +377,6 @@ public class ComplexTypeTransformerTest {
     Assert.assertEquals(genericRow.getValue("b"), "v");
     Assert.assertEquals(genericRow.getValue("im1.aa"), 2);
     Assert.assertEquals(genericRow.getValue("im1.bb"), "u");
-    Assert.assertEquals(genericRow.getValue("map2.c"), 3);
+    Assert.assertEquals(genericRow.getValue("test.c"), 3);
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
@@ -367,7 +367,7 @@ public class ComplexTypeTransformerTest {
     Assert.assertEquals(genericRow.getValue("b"), 2L);
     Assert.assertEquals(genericRow.getValue("test.c"), "u");
 
-    // name conflict
+    // name conflict where there becomes duplicate field names after renaming
     prefixesToRename = new HashMap<>();
     prefixesToRename.put("test.", "");
     transformer = new ComplexTypeTransformer(new ArrayList<>(), ".",
@@ -381,6 +381,32 @@ public class ComplexTypeTransformerTest {
     } catch (RuntimeException e) {
       // expected
     }
+
+    // name conflict where there becomes an empty field name after renaming
+    prefixesToRename = new HashMap<>();
+    prefixesToRename.put("test", "");
+    transformer = new ComplexTypeTransformer(new ArrayList<>(), ".",
+            DEFAULT_COLLECTION_TO_JSON_MODE, prefixesToRename);
+    genericRow = new GenericRow();
+    genericRow.putValue("a", 1L);
+    genericRow.putValue("test", 2L);
+    try {
+      transformer.renamePrefixes(genericRow);
+      Assert.fail("Should fail due to empty name after renaming");
+    } catch (RuntimeException e) {
+      // expected
+    }
+
+    // case where nothing gets renamed
+    prefixesToRename = new HashMap<>();
+    transformer = new ComplexTypeTransformer(new ArrayList<>(), ".",
+            DEFAULT_COLLECTION_TO_JSON_MODE, prefixesToRename);
+    genericRow = new GenericRow();
+    genericRow.putValue("a", 1L);
+    genericRow.putValue("test", 2L);
+    transformer.renamePrefixes(genericRow);
+    Assert.assertEquals(genericRow.getValue("a"), 1L);
+    Assert.assertEquals(genericRow.getValue("test"), 2L);
   }
 
   @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
@@ -296,7 +296,8 @@ public class ComplexTypeTransformerTest {
     // {
     //   "array":"[1,2]"
     // }
-    transformer = new ComplexTypeTransformer(Arrays.asList(), ".", ComplexTypeConfig.CollectionNotUnnestedToJson.ALL);
+    transformer = new ComplexTypeTransformer(Arrays.asList(), ".",
+            ComplexTypeConfig.CollectionNotUnnestedToJson.ALL, false);
     genericRow = new GenericRow();
     array = new Object[]{1, 2};
     genericRow.putValue("array", array);
@@ -341,7 +342,8 @@ public class ComplexTypeTransformerTest {
     array1[0] = ImmutableMap.of("b", "v1");
     map.put("array1", array1);
     genericRow.putValue("t", map);
-    transformer = new ComplexTypeTransformer(Arrays.asList(), ".", ComplexTypeConfig.CollectionNotUnnestedToJson.NONE);
+    transformer = new ComplexTypeTransformer(Arrays.asList(), ".",
+            ComplexTypeConfig.CollectionNotUnnestedToJson.NONE, false);
     transformer.transform(genericRow);
     Assert.assertTrue(ComplexTypeTransformer.isArray(genericRow.getValue("t.array1")));
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
@@ -351,6 +351,39 @@ public class ComplexTypeTransformerTest {
   }
 
   @Test
+  public void testRenamePrefixes() {
+    HashMap<String, String> prefixesToRename = new HashMap<>();
+    prefixesToRename.put("map1.", "");
+    prefixesToRename.put("map2", "test");
+    ComplexTypeTransformer transformer = new ComplexTypeTransformer(new ArrayList<>(), ".",
+            DEFAULT_COLLECTION_TO_JSON_MODE, prefixesToRename);
+
+    GenericRow genericRow = new GenericRow();
+    genericRow.putValue("a", 1L);
+    genericRow.putValue("map1.b", 2L);
+    genericRow.putValue("map2.c", "u");
+    transformer.renamePrefixes(genericRow);
+    Assert.assertEquals(genericRow.getValue("a"), 1L);
+    Assert.assertEquals(genericRow.getValue("b"), 2L);
+    Assert.assertEquals(genericRow.getValue("test.c"), "u");
+
+    // name conflict
+    prefixesToRename = new HashMap<>();
+    prefixesToRename.put("test.", "");
+    transformer = new ComplexTypeTransformer(new ArrayList<>(), ".",
+            DEFAULT_COLLECTION_TO_JSON_MODE, prefixesToRename);
+    genericRow = new GenericRow();
+    genericRow.putValue("a", 1L);
+    genericRow.putValue("test.a", 2L);
+    try {
+      transformer.renamePrefixes(genericRow);
+      Assert.fail("Should fail due to name conflict after renaming");
+    } catch (RuntimeException e) {
+      // expected
+    }
+  }
+
+  @Test
   public void testPrefixesToRename() {
     HashMap<String, String> prefixesToRename = new HashMap<>();
     prefixesToRename.put("map1.", "");

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/IngestionUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/IngestionUtilsTest.java
@@ -22,7 +22,9 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
@@ -213,9 +215,10 @@ public class IngestionUtilsTest {
     TransformConfig transformConfig = new TransformConfig("dateColumn", "toDateTime(timestampColumn, 'yyyy-MM-dd')");
     transformConfigs = Lists.newArrayList(transformConfig);
     List<String> fieldsToUnnest = Arrays.asList("before.test", "after.test");
-    List<String> prefixesToDropFromFields = Arrays.asList("before", "after");
+    Map<String, String> prefixesToRename = new HashMap<>();
+    prefixesToRename.put("before", "after");
     ComplexTypeConfig complexTypeConfigs = new ComplexTypeConfig(fieldsToUnnest, ".",
-            ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE, prefixesToDropFromFields);
+            ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE, prefixesToRename);
     FilterConfig filterConfig = new FilterConfig("Groovy({d1 == \"10\"}, d1)");
     ingestionConfig = new IngestionConfig(null, null, filterConfig, transformConfigs, complexTypeConfigs);
     extract = new ArrayList<>(IngestionUtils.getFieldsForRecordExtractor(ingestionConfig, schema));

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/IngestionUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/IngestionUtilsTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
 import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
@@ -201,5 +202,26 @@ public class IngestionUtilsTest {
     extract = new ArrayList<>(IngestionUtils.getFieldsForRecordExtractor(ingestionConfig, schema));
     Assert.assertEquals(extract.size(), 6);
     Assert.assertTrue(extract.containsAll(Lists.newArrayList("d1", "d2", "m1", "dateColumn", "xy", "timestampColumn")));
+
+    // filter + transform configs + schema fields  + schema transform + complex type configs
+    schema = new Schema.SchemaBuilder().addSingleValueDimension("d1", FieldSpec.DataType.STRING)
+            .addSingleValueDimension("d2", FieldSpec.DataType.STRING)
+            .addMetric("m1", FieldSpec.DataType.INT)
+            .addDateTime("dateColumn", FieldSpec.DataType.STRING, "1:DAYS:SIMPLE_DATE_FORMAT:yyyy-MM-dd", "1:DAYS")
+            .build();
+    schema.getFieldSpecFor("d2").setTransformFunction("reverse(xy)");
+    TransformConfig transformConfig = new TransformConfig("dateColumn", "toDateTime(timestampColumn, 'yyyy-MM-dd')");
+    transformConfigs = Lists.newArrayList(transformConfig);
+    List<String> fieldsToUnnest = Arrays.asList("before.test", "after.test");
+    List<String> prefixesToDropFromFields = Arrays.asList("before", "after");
+    ComplexTypeConfig complexTypeConfigs = new ComplexTypeConfig(fieldsToUnnest, ".",
+            ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE, prefixesToDropFromFields);
+    FilterConfig filterConfig = new FilterConfig("Groovy({d1 == \"10\"}, d1)");
+    ingestionConfig = new IngestionConfig(null, null, filterConfig, transformConfigs, complexTypeConfigs);
+    extract = new ArrayList<>(IngestionUtils.getFieldsForRecordExtractor(ingestionConfig, schema));
+    Assert.assertEquals(extract.size(), 8);
+    List<String> expectedColumns =
+            Lists.newArrayList("d1", "d2", "m1", "dateColumn", "xy", "timestampColumn", "before", "after");
+    Assert.assertTrue(extract.containsAll(expectedColumns));
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -39,6 +39,7 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.TierConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
 import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
@@ -413,6 +414,22 @@ public class TableConfigUtilsTest {
         new IngestionConfig(null, null, null, Lists.newArrayList(new TransformConfig("transformedCol", "reverse(x)"),
             new TransformConfig("myCol", "lower(transformedCol)")), null)).build();
     TableConfigUtils.validate(tableConfig, schema);
+
+    // invalid field name in schema with matching prefix from complexConfigType's prefixesToRename
+    HashMap<String, String> prefixesToRename = new HashMap<>();
+    prefixesToRename.put("after.", "");
+    ComplexTypeConfig complexConfig = new ComplexTypeConfig(null, ".", null, prefixesToRename);
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(
+            new IngestionConfig(null, null, null,
+                    null, complexConfig)).build();
+    schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+            .addMultiValueDimension("after.test", FieldSpec.DataType.STRING).build();
+    try {
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should fail due to name conflict from field name in schema with a prefix in prefixesToRename");
+    } catch (IllegalStateException e) {
+      // expected
+    }
   }
 
   @Test

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ComplexTypeConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ComplexTypeConfig.java
@@ -44,13 +44,18 @@ public class ComplexTypeConfig extends BaseJsonConfig {
   @JsonPropertyDescription("The mode of converting collection to JSON string")
   private final CollectionNotUnnestedToJson _collectionNotUnnestedToJson;
 
+  @JsonPropertyDescription("The leaf field name is kept if true instead of the full unnested delimiter joined name")
+  private final Boolean _useLeafFieldName;
+
   @JsonCreator
   public ComplexTypeConfig(@JsonProperty("fieldsToUnnest") @Nullable List<String> fieldsToUnnest,
       @JsonProperty("delimiter") @Nullable String delimiter,
-      @JsonProperty("collectionNotUnnestedToJson") @Nullable CollectionNotUnnestedToJson collectionNotUnnestedToJson) {
+      @JsonProperty("collectionNotUnnestedToJson") @Nullable CollectionNotUnnestedToJson collectionNotUnnestedToJson,
+                           @JsonProperty("useLeafFieldName") @Nullable Boolean useLeafFieldName) {
     _fieldsToUnnest = fieldsToUnnest;
     _delimiter = delimiter;
     _collectionNotUnnestedToJson = collectionNotUnnestedToJson;
+    _useLeafFieldName = useLeafFieldName;
   }
 
   @Nullable
@@ -66,5 +71,10 @@ public class ComplexTypeConfig extends BaseJsonConfig {
   @Nullable
   public CollectionNotUnnestedToJson getCollectionNotUnnestedToJson() {
     return _collectionNotUnnestedToJson;
+  }
+
+  @Nullable
+  public Boolean getUseLeafFieldName() {
+    return _useLeafFieldName;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ComplexTypeConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ComplexTypeConfig.java
@@ -52,7 +52,7 @@ public class ComplexTypeConfig extends BaseJsonConfig {
   public ComplexTypeConfig(@JsonProperty("fieldsToUnnest") @Nullable List<String> fieldsToUnnest,
       @JsonProperty("delimiter") @Nullable String delimiter,
       @JsonProperty("collectionNotUnnestedToJson") @Nullable CollectionNotUnnestedToJson collectionNotUnnestedToJson,
-                           @JsonProperty("prefixesToRename") @Nullable Map<String, String> prefixesToRename) {
+      @JsonProperty("prefixesToRename") @Nullable Map<String, String> prefixesToRename) {
     _fieldsToUnnest = fieldsToUnnest;
     _delimiter = delimiter;
     _collectionNotUnnestedToJson = collectionNotUnnestedToJson;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ComplexTypeConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ComplexTypeConfig.java
@@ -44,18 +44,18 @@ public class ComplexTypeConfig extends BaseJsonConfig {
   @JsonPropertyDescription("The mode of converting collection to JSON string")
   private final CollectionNotUnnestedToJson _collectionNotUnnestedToJson;
 
-  @JsonPropertyDescription("The leaf field name is kept if true instead of the full unnested delimiter joined name")
-  private final Boolean _useLeafFieldName;
+  @JsonPropertyDescription("The prefixes of fields to rename so the resulting field names don't have them")
+  private final List<String> _prefixesToDropFromFields;
 
   @JsonCreator
   public ComplexTypeConfig(@JsonProperty("fieldsToUnnest") @Nullable List<String> fieldsToUnnest,
       @JsonProperty("delimiter") @Nullable String delimiter,
       @JsonProperty("collectionNotUnnestedToJson") @Nullable CollectionNotUnnestedToJson collectionNotUnnestedToJson,
-                           @JsonProperty("useLeafFieldName") @Nullable Boolean useLeafFieldName) {
+                           @JsonProperty("prefixesToDropFromFields") @Nullable List<String> prefixesToDropFromFields) {
     _fieldsToUnnest = fieldsToUnnest;
     _delimiter = delimiter;
     _collectionNotUnnestedToJson = collectionNotUnnestedToJson;
-    _useLeafFieldName = useLeafFieldName;
+    _prefixesToDropFromFields = prefixesToDropFromFields;
   }
 
   @Nullable
@@ -74,7 +74,7 @@ public class ComplexTypeConfig extends BaseJsonConfig {
   }
 
   @Nullable
-  public Boolean getUseLeafFieldName() {
-    return _useLeafFieldName;
+  public List<String> getPrefixesToDropFromFields() {
+    return _prefixesToDropFromFields;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ComplexTypeConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ComplexTypeConfig.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.BaseJsonConfig;
 
@@ -45,17 +46,17 @@ public class ComplexTypeConfig extends BaseJsonConfig {
   private final CollectionNotUnnestedToJson _collectionNotUnnestedToJson;
 
   @JsonPropertyDescription("The prefixes of fields to rename so the resulting field names don't have them")
-  private final List<String> _prefixesToDropFromFields;
+  private final Map<String, String> _prefixesToRename;
 
   @JsonCreator
   public ComplexTypeConfig(@JsonProperty("fieldsToUnnest") @Nullable List<String> fieldsToUnnest,
       @JsonProperty("delimiter") @Nullable String delimiter,
       @JsonProperty("collectionNotUnnestedToJson") @Nullable CollectionNotUnnestedToJson collectionNotUnnestedToJson,
-                           @JsonProperty("prefixesToDropFromFields") @Nullable List<String> prefixesToDropFromFields) {
+                           @JsonProperty("prefixesToRename") @Nullable Map<String, String> prefixesToRename) {
     _fieldsToUnnest = fieldsToUnnest;
     _delimiter = delimiter;
     _collectionNotUnnestedToJson = collectionNotUnnestedToJson;
-    _prefixesToDropFromFields = prefixesToDropFromFields;
+    _prefixesToRename = prefixesToRename;
   }
 
   @Nullable
@@ -74,7 +75,7 @@ public class ComplexTypeConfig extends BaseJsonConfig {
   }
 
   @Nullable
-  public List<String> getPrefixesToDropFromFields() {
-    return _prefixesToDropFromFields;
+  public Map<String, String> getPrefixesToRename() {
+    return _prefixesToRename;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ComplexTypeConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/ComplexTypeConfig.java
@@ -45,7 +45,7 @@ public class ComplexTypeConfig extends BaseJsonConfig {
   @JsonPropertyDescription("The mode of converting collection to JSON string")
   private final CollectionNotUnnestedToJson _collectionNotUnnestedToJson;
 
-  @JsonPropertyDescription("The prefixes of fields to rename so the resulting field names don't have them")
+  @JsonPropertyDescription("Map of <prefix, replacement> so matching fields are renamed to start with the replacement")
   private final Map<String, String> _prefixesToRename;
 
   @JsonCreator


### PR DESCRIPTION
## Description
This change allows fields to be renamed upon ingestion to avoid duplication of columns/data. More specifically, the proposed change will enabling dropping specified prefixes of fields that are in the source data, so that the resulting field names do not have those prefixes. This addresses issue #8161

More details here in this design doc here - https://docs.google.com/document/d/1U_vQC0BiCCEcx49Tsp499V5F075iJ3fW9IrsD8sNdU0/edit?usp=sharing 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] No (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] No (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes

- Added `prefixesToRename` config to rename columns upon ingestion based on their prefixes

## Documentation

#