### PR TITLE
add more testing for MV var-length columns, detect overflow scenarios

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/BaseChunkSVForwardIndexWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/BaseChunkSVForwardIndexWriter.java
@@ -69,15 +69,16 @@ public abstract class BaseChunkSVForwardIndexWriter implements Closeable {
    * @throws IOException if the file isn't found or can't be mapped
    */
   protected BaseChunkSVForwardIndexWriter(File file, ChunkCompressionType compressionType, int totalDocs,
-      int numDocsPerChunk, int chunkSize, int sizeOfEntry, int version, boolean fixed)
+      int numDocsPerChunk, long chunkSize, int sizeOfEntry, int version, boolean fixed)
       throws IOException {
     Preconditions.checkArgument(version == DEFAULT_VERSION || version == CURRENT_VERSION
         || (fixed && version == 4));
-    _chunkSize = chunkSize;
+    Preconditions.checkArgument(chunkSize <= Integer.MAX_VALUE, "chunk size limited to 2GB");
+    _chunkSize = (int) chunkSize;
     _chunkCompressor = ChunkCompressorFactory.getCompressor(compressionType);
     _headerEntryChunkOffsetSize = getHeaderEntryChunkOffsetSize(version);
     _dataOffset = writeHeader(compressionType, totalDocs, numDocsPerChunk, sizeOfEntry, version);
-    _chunkBuffer = ByteBuffer.allocateDirect(chunkSize);
+    _chunkBuffer = ByteBuffer.allocateDirect(_chunkSize);
     int maxCompressedChunkSize = _chunkCompressor.maxCompressedSize(_chunkSize); // may exceed original chunk size
     _compressedBuffer = ByteBuffer.allocateDirect(maxCompressedChunkSize);
     _dataFile = new RandomAccessFile(file, "rw").getChannel();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueVarByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueVarByteRawIndexCreator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.segment.creator.impl.fwd;
 
+import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
 import org.apache.pinot.segment.local.io.writer.impl.BaseChunkSVForwardIndexWriter;
@@ -76,6 +77,8 @@ public class MultiValueVarByteRawIndexCreator implements ForwardIndexCreator {
     //we will prepend the actual content with numElements and length array containing length of each element
     int maxLengthPrefixes = Integer.BYTES * maxNumberOfElements;
     int totalMaxLength = Integer.BYTES + maxRowLengthInBytes + maxLengthPrefixes;
+    Preconditions.checkArgument((maxLengthPrefixes | maxRowLengthInBytes | totalMaxLength | maxNumberOfElements) > 0,
+        "integer overflow detected");
     File file = new File(baseIndexDir,
         column + Indexes.RAW_MV_FORWARD_INDEX_FILE_EXTENSION);
     int numDocsPerChunk = Math.max(

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkSVForwardIndexWriterTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/io/writer/impl/VarByteChunkSVForwardIndexWriterTest.java
@@ -1,0 +1,183 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.io.writer.impl;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.SplittableRandom;
+import java.util.UUID;
+import java.util.stream.IntStream;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.segment.index.readers.forward.ChunkReaderContext;
+import org.apache.pinot.segment.local.segment.index.readers.forward.VarByteChunkSVForwardIndexReader;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertEquals;
+
+
+public class VarByteChunkSVForwardIndexWriterTest {
+
+  private static final File OUTPUT_DIR =
+      new File(FileUtils.getTempDirectory(), VarByteChunkSVForwardIndexWriterTest.class.getSimpleName());
+
+  @BeforeClass
+  public void setup()
+      throws Exception {
+    FileUtils.forceMkdir(OUTPUT_DIR);
+  }
+
+  @AfterClass
+  public void cleanup() {
+    FileUtils.deleteQuietly(OUTPUT_DIR);
+  }
+
+  @DataProvider
+  public static Object[][] params() {
+    int[] numDocsPerChunks = {1, 2, 20, 500, 1000};
+    int[] numbersOfDocs = {10, 1000};
+    int[][] entryLengths = {{1, 1}, {0, 10}, {0, 100}, {100, 100}, {900, 1000}};
+    int[] versions = {2, 3};
+    return Arrays.stream(ChunkCompressionType.values())
+        .flatMap(chunkCompressionType -> IntStream.of(versions).boxed().flatMap(
+            version -> IntStream.of(numbersOfDocs).boxed()
+                .flatMap(totalDocs -> IntStream.of(numDocsPerChunks).boxed().flatMap(
+                    numDocsPerChunk -> Arrays.stream(entryLengths).map(
+                        lengths -> new Object[]{
+                            chunkCompressionType, totalDocs, numDocsPerChunk,
+                            lengths, version
+                        })))))
+        .toArray(Object[][]::new);
+  }
+
+  @Test(dataProvider = "params")
+  public void testPutStrings(ChunkCompressionType compressionType, int totalDocs, int numDocsPerChunk,
+      int[] lengths, int version)
+      throws IOException {
+    String column = "testCol-" + UUID.randomUUID();
+    File file = new File(OUTPUT_DIR, column + V1Constants.Indexes.RAW_SV_FORWARD_INDEX_FILE_EXTENSION);
+    List<String[]> arrays = generateStringArrays(totalDocs, lengths, 50);
+    int maxEntryLengthInBytes =
+        arrays.stream().mapToInt(array -> Integer.BYTES + Arrays.stream(array).mapToInt(
+            str -> Integer.BYTES + str.getBytes(UTF_8).length).sum()).max().orElse(0);
+    try (
+        VarByteChunkSVForwardIndexWriter writer = new VarByteChunkSVForwardIndexWriter(file, compressionType, totalDocs,
+            numDocsPerChunk, maxEntryLengthInBytes, version)) {
+      for (String[] array : arrays) {
+        writer.putStrings(array);
+      }
+    }
+    try (VarByteChunkSVForwardIndexReader reader = new VarByteChunkSVForwardIndexReader(
+        PinotDataBuffer.loadBigEndianFile(file), FieldSpec.DataType.STRING);
+        ChunkReaderContext context = reader.createContext()) {
+      for (int i = 0; i < arrays.size(); i++) {
+        String[] array = arrays.get(i);
+        byte[] bytes = reader.getBytes(i, context);
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        assertEquals(buffer.getInt(), array.length);
+        int offset = Integer.BYTES * (array.length + 1);
+        for (String value : array) {
+          int length = buffer.getInt();
+          assertEquals(length, value.length());
+          assertEquals(new String(bytes, offset, length, UTF_8), value);
+          offset += length;
+        }
+      }
+    }
+  }
+
+  @Test(dataProvider = "params")
+  public void testPutBytes(ChunkCompressionType compressionType, int totalDocs, int numDocsPerChunk,
+      int[] lengths, int version)
+      throws IOException {
+    String column = "testCol-" + UUID.randomUUID();
+    File file = new File(OUTPUT_DIR, column + V1Constants.Indexes.RAW_SV_FORWARD_INDEX_FILE_EXTENSION);
+    List<String[]> arrays = generateStringArrays(totalDocs, lengths, 50);
+    int maxEntryLengthInBytes = arrays.stream()
+        .mapToInt(array -> Integer.BYTES
+            + Arrays.stream(array).mapToInt(str -> Integer.BYTES + str.getBytes(UTF_8).length).sum())
+        .max().orElse(0);
+    try (VarByteChunkSVForwardIndexWriter writer = new VarByteChunkSVForwardIndexWriter(file, compressionType,
+        totalDocs, numDocsPerChunk, maxEntryLengthInBytes, version)) {
+      for (String[] array : arrays) {
+        writer.putByteArrays(Arrays.stream(array).map(str -> str.getBytes(UTF_8)).toArray(byte[][]::new));
+      }
+    }
+    try (VarByteChunkSVForwardIndexReader reader = new VarByteChunkSVForwardIndexReader(
+        PinotDataBuffer.loadBigEndianFile(file), FieldSpec.DataType.BYTES);
+        ChunkReaderContext context = reader.createContext()) {
+      for (int i = 0; i < arrays.size(); i++) {
+        String[] array = arrays.get(i);
+        byte[] bytes = reader.getBytes(i, context);
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        assertEquals(buffer.getInt(), array.length);
+        int offset = Integer.BYTES * (array.length + 1);
+        for (String value : array) {
+          int length = buffer.getInt();
+          assertEquals(length, value.length());
+          assertEquals(new String(bytes, offset, length, UTF_8), value);
+          offset += length;
+        }
+      }
+    }
+  }
+
+  private static List<String[]> generateStringArrays(int count, int[] lengths, int maxElementCount) {
+    Iterator<String> strings = generateStrings(lengths[0], lengths[1]);
+    Random random = new Random();
+    List<String[]> stringArrays = new ArrayList<>(count);
+    for (int i = 0; i < count; i++) {
+      String[] array = new String[random.nextInt(maxElementCount)];
+      for (int j = 0; j < array.length; j++) {
+        array[j] = strings.next();
+      }
+      stringArrays.add(array);
+    }
+    return stringArrays;
+  }
+
+  private static Iterator<String> generateStrings(int minLength, int maxLength) {
+    SplittableRandom random = new SplittableRandom();
+    return IntStream.generate(() -> random.nextInt(minLength, maxLength + 1))
+        .mapToObj(length -> {
+          char[] string = new char[length];
+          Arrays.fill(string, 'b');
+          if (string.length > 0) {
+            string[0] = 'a';
+          }
+          if (string.length > 1) {
+            string[string.length - 1] = 'c';
+          }
+          return new String(string);
+        }).iterator();
+  }
+}


### PR DESCRIPTION
This addresses a bug report of a buffer overflow creating MV string raw forward index, with the following stack trace:

```
Start building IndexCreator!
Could not build segment
java.lang.IllegalArgumentException: newPosition > limit: (1048580 > 1048575)
	at java.nio.Buffer.createPositionException(Buffer.java:318) ~[?:?]
	at java.nio.Buffer.position(Buffer.java:293) ~[?:?]
	at java.nio.ByteBuffer.position(ByteBuffer.java:1094) ~[?:?]
	at java.nio.MappedByteBuffer.position(MappedByteBuffer.java:226) ~[?:?]
	at java.nio.MappedByteBuffer.position(MappedByteBuffer.java:67) ~[?:?]
	at org.apache.pinot.segment.local.io.writer.impl.VarByteChunkSVForwardIndexWriter.putStrings(VarByteChunkSVForwardIndexWriter.java:119) ~[pinot-all-0.10.0-SNAPSHOT-jar-with-dependencies.jar:0.10.0-SNAPSHOT-bb98ed89e7e2f06138139f58ec0ec6d4f9944a16]
	at org.apache.pinot.segment.local.segment.creator.impl.fwd.MultiValueVarByteRawIndexCreator.putStringMV(MultiValueVarByteRawIndexCreator.java:106) ~[pinot-all-0.10.0-SNAPSHOT-jar-with-dependencies.jar:0.10.0-SNAPSHOT-bb98ed89e7e2f06138139f58ec0ec6d4f9944a16]
	at org.apache.pinot.segment.local.segment.creator.impl.SegmentColumnarIndexCreator.indexRow(SegmentColumnarIndexCreator.java:543) ~[pinot-all-0.10.0-SNAPSHOT-jar-with-dependencies.jar:0.10.0-SNAPSHOT-bb98ed89e7e2f06138139f58ec0ec6d4f9944a16]
	at org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl.build(SegmentIndexCreationDriverImpl.java:244) ~[pinot-all-0.10.0-SNAPSHOT-jar-with-dependencies.jar:0.10.0-SNAPSHOT-bb98ed89e7e2f06138139f58ec0ec6d4f9944a16]
	at org.apache.pinot.segment.local.realtime.converter.RealtimeSegmentConverter.build(RealtimeSegmentConverter.java:131) ~[pinot-all-0.10.0-SNAPSHOT-jar-with-dependencies.jar:0.10.0-SNAPSHOT-bb98ed89e7e2f06138139f58ec0ec6d4f9944a16]
	at org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager.buildSegmentInternal(LLRealtimeSegmentDataManager.java:815) [pinot-all-0.10.0-SNAPSHOT-jar-with-dependencies.jar:0.10.0-SNAPSHOT-bb98ed89e7e2f06138139f58ec0ec6d4f9944a16]
	at org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager.buildSegmentForCommit(LLRealtimeSegmentDataManager.java:746) [pinot-all-0.10.0-SNAPSHOT-jar-with-dependencies.jar:0.10.0-SNAPSHOT-bb98ed89e7e2f06138139f58ec0ec6d4f9944a16]
	at org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager$PartitionConsumer.run(LLRealtimeSegmentDataManager.java:644) [pinot-all-0.10.0-SNAPSHOT-jar-with-dependencies.jar:0.10.0-SNAPSHOT-bb98ed89e7e2f06138139f58ec0ec6d4f9944a16]
	at java.lang.Thread.run(Thread.java:829) [?:?]
```

I have added extensive testing for the impacted components and could not find any buffer overflows, and have narrowed this down to an integer overflow such that the product of `Integer.BYTES + maxRowLengthInBytes + maxLengthPrefixes` and a fixed `numDocsPerChunk` overflows and is non-negative. Very large MV values is a limitation of the current implementation and I have added precondition checks to detect overflow unambiguously.