### PR TITLE
Upgrade protobuf as the current version has security vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
     To change kafka connector dependency, we only need to update this version number config.
     TODO: figure out a way to inject kafka dependency instead of explicitly setting the kafka module dependency -->
     <kafka.version>2.0</kafka.version>
-    <protobuf.version>3.12.0</protobuf.version>
+    <protobuf.version>3.19.2</protobuf.version>
     <grpc.version>1.41.0</grpc.version>
 
     <!-- Checkstyle violation prop.-->
@@ -1818,7 +1818,7 @@
 
             <!-- Test output -->
             <exclude>**/test-output/**</exclude>
-            
+
             <!-- MISC -->
             <exclude>**/.factorypath</exclude>
           </excludes>


### PR DESCRIPTION
Our internal build system failed after flagging a security vulenrability in protobuf version

com.google.protobuf:protobuf-java:3.17.1
Notes: Vulnerability found and is blocked -- vulnerability: An issue in protobuf-java allowed the interleaving of com.google.protobuf.UnknownFieldSet fields in such a way that would be processed out of order. A small malicious payload can occupy the parser for several minutes by creating large numbers of short-lived objects that cause frequent, repeated pauses. 

Upgrading to 3.19.2 

https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java