### PR TITLE
Add dateTimeConvert scalar function

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
@@ -25,9 +25,13 @@ import org.apache.pinot.common.function.DateTimePatternHandler;
 import org.apache.pinot.common.function.DateTimeUtils;
 import org.apache.pinot.common.function.TimeZoneKey;
 import org.apache.pinot.spi.annotations.ScalarFunction;
+import org.apache.pinot.spi.data.DateTimeFieldSpec;
+import org.apache.pinot.spi.data.DateTimeFormatSpec;
+import org.apache.pinot.spi.data.DateTimeGranularitySpec;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeField;
 import org.joda.time.DateTimeZone;
+import org.joda.time.chrono.ISOChronology;
+import org.joda.time.format.DateTimeFormatter;
 
 
 /**
@@ -604,18 +608,20 @@ public class DateTimeFunctions {
   }
 
   /**
-   * The sql compatible date_trunc function for epoch time
+   * The sql compatible date_trunc function for epoch time.
+   *
    * @param unit truncate to unit (millisecond, second, minute, hour, day, week, month, quarter, year)
    * @param timeValue value to truncate
    * @return truncated timeValue in TimeUnit.MILLISECONDS
    */
   @ScalarFunction
   public long dateTrunc(String unit, long timeValue) {
-    return dateTrunc(unit, timeValue, TimeUnit.MILLISECONDS.name());
+    return dateTrunc(unit, timeValue, TimeUnit.MILLISECONDS, ISOChronology.getInstanceUTC(), TimeUnit.MILLISECONDS);
   }
 
   /**
    * The sql compatible date_trunc function for epoch time.
+   *
    * @param unit truncate to unit (millisecond, second, minute, hour, day, week, month, quarter, year)
    * @param timeValue value to truncate
    * @param inputTimeUnitStr TimeUnit of value, expressed in Java's joda TimeUnit
@@ -623,12 +629,13 @@ public class DateTimeFunctions {
    */
   @ScalarFunction
   public static long dateTrunc(String unit, long timeValue, String inputTimeUnitStr) {
-    return dateTrunc(unit, timeValue, inputTimeUnitStr, TimeZoneKey.UTC_KEY.getId(), inputTimeUnitStr);
+    TimeUnit inputTimeUnit = TimeUnit.valueOf(inputTimeUnitStr);
+    return dateTrunc(unit, timeValue, inputTimeUnit, ISOChronology.getInstanceUTC(), inputTimeUnit);
   }
 
   /**
-   *
    * The sql compatible date_trunc function for epoch time.
+   *
    * @param unit truncate to unit (millisecond, second, minute, hour, day, week, month, quarter, year)
    * @param timeValue value to truncate
    * @param inputTimeUnitStr TimeUnit of value, expressed in Java's joda TimeUnit
@@ -637,12 +644,14 @@ public class DateTimeFunctions {
    */
   @ScalarFunction
   public static long dateTrunc(String unit, long timeValue, String inputTimeUnitStr, String timeZone) {
-    return dateTrunc(unit, timeValue, inputTimeUnitStr, timeZone, inputTimeUnitStr);
+    TimeUnit inputTimeUnit = TimeUnit.valueOf(inputTimeUnitStr);
+    return dateTrunc(unit, timeValue, inputTimeUnit, DateTimeUtils.getChronology(TimeZoneKey.getTimeZoneKey(timeZone)),
+        inputTimeUnit);
   }
 
   /**
-   *
    * The sql compatible date_trunc function for epoch time.
+   *
    * @param unit truncate to unit (millisecond, second, minute, hour, day, week, month, quarter, year)
    * @param timeValue value to truncate
    * @param inputTimeUnitStr TimeUnit of value, expressed in Java's joda TimeUnit
@@ -654,12 +663,56 @@ public class DateTimeFunctions {
   @ScalarFunction
   public static long dateTrunc(String unit, long timeValue, String inputTimeUnitStr, String timeZone,
       String outputTimeUnitStr) {
-    TimeUnit inputTimeUnit = TimeUnit.valueOf(inputTimeUnitStr);
-    TimeUnit outputTimeUnit = TimeUnit.valueOf(outputTimeUnitStr);
-    TimeZoneKey timeZoneKey = TimeZoneKey.getTimeZoneKey(timeZone);
+    return dateTrunc(unit, timeValue, TimeUnit.valueOf(inputTimeUnitStr),
+        DateTimeUtils.getChronology(TimeZoneKey.getTimeZoneKey(timeZone)), TimeUnit.valueOf(outputTimeUnitStr));
+  }
 
-    DateTimeField dateTimeField = DateTimeUtils.getTimestampField(DateTimeUtils.getChronology(timeZoneKey), unit);
-    return outputTimeUnit.convert(dateTimeField.roundFloor(TimeUnit.MILLISECONDS.convert(timeValue, inputTimeUnit)),
-        TimeUnit.MILLISECONDS);
+  private static long dateTrunc(String unit, long timeValue, TimeUnit inputTimeUnit, ISOChronology chronology,
+      TimeUnit outputTimeUnit) {
+    return outputTimeUnit.convert(DateTimeUtils.getTimestampField(chronology, unit)
+        .roundFloor(TimeUnit.MILLISECONDS.convert(timeValue, inputTimeUnit)), TimeUnit.MILLISECONDS);
+  }
+
+  /**
+   * Equivalent to {@code DateTimeConversionTransformFunction}. Both input and output are string type to support simple
+   * date format.
+   */
+  @ScalarFunction
+  public static String dateTimeConvert(String timeValueStr, String inputFormatStr, String outputFormatStr,
+      String outputGranularityStr) {
+    long timeValueMs = new DateTimeFormatSpec(inputFormatStr).fromFormatToMillis(timeValueStr);
+    DateTimeFormatSpec outputFormat = new DateTimeFormatSpec(outputFormatStr);
+    DateTimeGranularitySpec granularitySpec = new DateTimeGranularitySpec(outputGranularityStr);
+    if (outputFormat.getTimeFormat() == DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT) {
+      DateTimeFormatter outputFormatter = outputFormat.getDateTimeFormatter();
+      DateTime dateTime = new DateTime(timeValueMs, outputFormatter.getZone());
+      int size = granularitySpec.getSize();
+      switch (granularitySpec.getTimeUnit()) {
+        case MILLISECONDS:
+          dateTime = dateTime.withMillisOfSecond((dateTime.getMillisOfSecond() / size) * size);
+          break;
+        case SECONDS:
+          dateTime = dateTime.withSecondOfMinute((dateTime.getSecondOfMinute() / size) * size).secondOfMinute()
+              .roundFloorCopy();
+          break;
+        case MINUTES:
+          dateTime =
+              dateTime.withMinuteOfHour((dateTime.getMinuteOfHour() / size) * size).minuteOfHour().roundFloorCopy();
+          break;
+        case HOURS:
+          dateTime = dateTime.withHourOfDay((dateTime.getHourOfDay() / size) * size).hourOfDay().roundFloorCopy();
+          break;
+        case DAYS:
+          dateTime = dateTime.withDayOfMonth((dateTime.getDayOfMonth() / size) * size).dayOfMonth().roundFloorCopy();
+          break;
+        default:
+          break;
+      }
+      return outputFormatter.print(dateTime);
+    } else {
+      long granularityMs = granularitySpec.granularityToMillis();
+      long roundedTimeValueMs = timeValueMs / granularityMs * granularityMs;
+      return new DateTimeFormatSpec(outputFormatStr).fromMillisToFormat(roundedTimeValueMs);
+    }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
@@ -99,8 +99,8 @@ public class DateTimeFunctionsTest {
     // toEpochMinutes w/ bucketing
     GenericRow row22 = new GenericRow();
     row22.putValue("timestamp", 1578685189000L);
-    inputs
-        .add(new Object[]{"toEpochMinutesBucket(\"timestamp\", 15)", Lists.newArrayList("timestamp"), row22, 1754094L});
+    inputs.add(
+        new Object[]{"toEpochMinutesBucket(\"timestamp\", 15)", Lists.newArrayList("timestamp"), row22, 1754094L});
 
     // toEpochHours
     GenericRow row30 = new GenericRow();
@@ -169,8 +169,8 @@ public class DateTimeFunctionsTest {
     GenericRow row71 = new GenericRow();
     row71.putValue("fifteenMinutesSinceEpoch", 1344000);
     inputs.add(new Object[]{
-        "fromEpochMinutesBucket(fifteenMinutesSinceEpoch, 15)", Lists.newArrayList("fifteenMinutesSinceEpoch"), row71,
-        1209600000000L
+        "fromEpochMinutesBucket(fifteenMinutesSinceEpoch, 15)", Lists.newArrayList(
+        "fifteenMinutesSinceEpoch"), row71, 1209600000000L
     });
 
     // fromEpochSeconds
@@ -184,8 +184,8 @@ public class DateTimeFunctionsTest {
     GenericRow row81 = new GenericRow();
     row81.putValue("tenSecondsSinceEpoch", 120960000L);
     inputs.add(new Object[]{
-        "fromEpochSecondsBucket(tenSecondsSinceEpoch, 10)", Lists.newArrayList("tenSecondsSinceEpoch"), row81,
-        1209600000000L
+        "fromEpochSecondsBucket(tenSecondsSinceEpoch, 10)", Lists.newArrayList(
+        "tenSecondsSinceEpoch"), row81, 1209600000000L
     });
 
     // nested
@@ -198,8 +198,8 @@ public class DateTimeFunctionsTest {
     GenericRow row91 = new GenericRow();
     row91.putValue("fifteenSecondsSinceEpoch", 80640000L);
     inputs.add(new Object[]{
-        "toEpochMinutesBucket(fromEpochSecondsBucket(fifteenSecondsSinceEpoch, 15), 10)",
-        Lists.newArrayList("fifteenSecondsSinceEpoch"), row91, 2016000L
+        "toEpochMinutesBucket(fromEpochSecondsBucket(fifteenSecondsSinceEpoch, 15), 10)", Lists.newArrayList(
+        "fifteenSecondsSinceEpoch"), row91, 2016000L
     });
 
     // toDateTime simple
@@ -218,22 +218,24 @@ public class DateTimeFunctionsTest {
     GenericRow row102 = new GenericRow();
     row102.putValue("dateTime", 7897897890000L);
     inputs.add(new Object[]{
-        "toDateTime(dateTime, 'EEE MMM dd HH:mm:ss ZZZ yyyy')", Lists.newArrayList("dateTime"), row102,
-        "Mon Apr 10 20:31:30 UTC 2220"
+        "toDateTime(dateTime, 'EEE MMM dd HH:mm:ss ZZZ yyyy')", Lists.newArrayList(
+        "dateTime"), row102, "Mon Apr 10 20:31:30 UTC 2220"
     });
 
     // toDateTime with timezone conversion
     GenericRow row103 = new GenericRow();
     row103.putValue("dateTime", 1633740369000L);
     row103.putValue("tz", "America/Los_Angeles");
-    inputs.add(new Object[]{"toDateTime(dateTime, 'yyyy-MM-dd ZZZ', tz)",
-            Lists.newArrayList("dateTime", "tz"), row103, "2021-10-08 America/Los_Angeles"});
+    inputs.add(new Object[]{
+        "toDateTime(dateTime, 'yyyy-MM-dd ZZZ', tz)", Lists.newArrayList("dateTime",
+        "tz"), row103, "2021-10-08 America/Los_Angeles"
+    });
 
     // fromDateTime simple
     GenericRow row110 = new GenericRow();
     row110.putValue("dateTime", "19730216");
-    inputs
-        .add(new Object[]{"fromDateTime(dateTime, 'yyyyMMdd')", Lists.newArrayList("dateTime"), row110, 98668800000L});
+    inputs.add(
+        new Object[]{"fromDateTime(dateTime, 'yyyyMMdd')", Lists.newArrayList("dateTime"), row110, 98668800000L});
 
     // fromDateTime complex
     GenericRow row111 = new GenericRow();
@@ -403,5 +405,122 @@ public class DateTimeFunctionsTest {
   private static long iso8601ToUtcEpochMillis(String iso8601) {
     DateTimeFormatter formatter = ISODateTimeFormat.dateTimeParser().withOffsetParsed();
     return formatter.parseDateTime(iso8601).getMillis();
+  }
+
+  @Test
+  public void testDateTimeConvert() {
+    // EPOCH to EPOCH
+    // Test bucketing to 15 minutes
+    testDateTimeConvert(1505898960000L/* 20170920T02:16:00 */, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS:EPOCH",
+        "15:MINUTES", 1505898900000L/* 20170920T02:15:00 */);
+    // Test input which should create no change
+    testDateTimeConvert(1505898960000L/* 20170920T02:16:00 */, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS:EPOCH",
+        "1:MILLISECONDS", 1505898960000L/* 20170920T02:16:00 */);
+    // Test conversion from millis to hours
+    testDateTimeConvert(1505902560000L/* 20170920T03:16:00 */, "1:MILLISECONDS:EPOCH", "1:HOURS:EPOCH", "1:HOURS",
+        418306L/* 20170920T03:00:00 */);
+    // Test conversion from 5 minutes to hours
+    testDateTimeConvert(5019675L/* 20170920T03:15:00 */, "5:MINUTES:EPOCH", "1:HOURS:EPOCH", "1:HOURS",
+        418306L/* 20170920T03:00:00 */);
+    // Test conversion from 5 minutes to millis and bucketing to hours
+    testDateTimeConvert(5019675L/* 20170920T03:15:00 */, "5:MINUTES:EPOCH", "1:MILLISECONDS:EPOCH", "1:HOURS",
+        1505901600000L/* 20170920T03:00:00 */);
+
+    // EPOCH to SDF
+    // Test conversion from millis since epoch to simple date format (UTC)
+    testDateTimeConvert(1505985360000L/* 20170921T02:16:00 */, "1:MILLISECONDS:EPOCH",
+        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", "1:DAYS", "20170921");
+    // Test conversion from millis since epoch to simple date format (Pacific timezone)
+    testDateTimeConvert(1505962800000L/* 20170920T20:00:00 */, "1:MILLISECONDS:EPOCH",
+        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd tz(America/Los_Angeles)", "1:DAYS", "20170920");
+    // Test conversion from millis since epoch to simple date format (IST)
+    testDateTimeConvert(1505962800000L/* 20170920T20:00:00 */, "1:MILLISECONDS:EPOCH",
+        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd tz(IST)", "1:DAYS", "20170921");
+    // Test conversion from millis since epoch to simple date format (Pacific timezone)
+    testDateTimeConvert(1505962800000L/* 20170920T20:00:00 */, "1:MILLISECONDS:EPOCH",
+        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMddHH tz(America/Los_Angeles)", "1:HOURS", "2017092020");
+    // Test conversion from millis since epoch to simple date format (East Coast timezone)
+    testDateTimeConvert(1505970000000L/* 20170920T22:00:00 */, "1:MILLISECONDS:EPOCH",
+        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMddHH tz(America/New_York)", "1:HOURS", "2017092101");
+    // Test conversion from millis since epoch to simple date format (America/Denver timezone with 15 second
+    // granularity)
+    testDateTimeConvert(1523560632000L/* 20180412T19:17:12 */, "1:MILLISECONDS:EPOCH",
+        "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)", "15:SECONDS",
+        "2018-04-12 13:17:00.000");
+    // Test conversion from millis since epoch to simple date format (America/Denver timezone with 3 minute granularity)
+    testDateTimeConvert(1523561708000L/* 20180412T19:35:08 */, "1:MILLISECONDS:EPOCH",
+        "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)", "3:MINUTES",
+        "2018-04-12 13:33:00.000");
+    // Test conversion from millis since epoch to simple date format (America/Denver timezone with 12 hour granularity)
+    testDateTimeConvert(1523430205000L/* 20180411T07:03:25 */, "1:MILLISECONDS:EPOCH",
+        "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)", "12:HOURS",
+        "2018-04-11 00:00:00.000");
+    // Test conversion from millis since epoch to simple date format (America/Denver timezone with 5 day granularity)
+    testDateTimeConvert(1522230205000L/* 20180328T09:43:25 */, "1:MILLISECONDS:EPOCH",
+        "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)", "5:DAYS",
+        "2018-03-25 00:00:00.000");
+    // Test conversion from millis since epoch to simple date format (America/Los_Angeles timezone with 1 day
+    // granularity)
+    testDateTimeConvert(1524013200000L/* 20180418T01:00:00 */, "1:MILLISECONDS:EPOCH",
+        "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Los_Angeles)", "1:DAYS",
+        "2018-04-17 00:00:00.000");
+
+    // SDF to EPOCH
+    // Test conversion from simple date format to millis since epoch
+    testDateTimeConvert("20170921", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", "1:MILLISECONDS:EPOCH", "1:DAYS",
+        1505952000000L/* 20170921T00:00:00 */);
+    // Test conversion from simple date format (East Coast timezone) to millis since epoch
+    testDateTimeConvert("20170921", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd tz(America/New_York)", "1:MILLISECONDS:EPOCH",
+        "1:DAYS", 1505952000000L/* 20170921T00:00:00 */);
+    // Test conversion from simple date format (East Coast timezone) to millis since epoch
+    testDateTimeConvert("2017092000", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMddHH tz(America/New_York)",
+        "1:MILLISECONDS:EPOCH", "1:HOURS", 1505880000000L/* 20170920T00:00:00 Eastern */);
+    // Test conversion from simple date format with special characters to millis since epoch
+    testDateTimeConvert("2017092000 America/Los_Angeles", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMddHH ZZZ",
+        "1:MILLISECONDS:EPOCH", "1:HOURS", 1505890800000L/* 20170920T00:00:00 UTC */);
+    // Test conversion from simple date format with special characters to millis since epoch
+    testDateTimeConvert("8/7/2017 12 PM", "1:HOURS:SIMPLE_DATE_FORMAT:M/d/yyyy h a", "1:MILLISECONDS:EPOCH", "1:HOURS",
+        1502107200000L/* 20170807T12:00:00 UTC */);
+    // Test conversion from simple date format with special characters to millis since epoch, with bucketing
+    testDateTimeConvert("8/7/2017 12:00:01 PM", "1:SECONDS:SIMPLE_DATE_FORMAT:M/d/yyyy h:mm:ss a",
+        "1:MILLISECONDS:EPOCH", "1:HOURS", 1502107200000L/* 20170807T12:00:00 UTC */);
+    // Test conversion from simple date format with special characters to millis since epoch, without bucketing
+    testDateTimeConvert("8/7/2017 12:00:01 PM", "1:DAYS:SIMPLE_DATE_FORMAT:M/d/yyyy h:mm:ss a", "1:MILLISECONDS:EPOCH",
+        "1:MILLISECONDS", 1502107201000L/* 20170807T12:00:01 UTC */);
+
+    // SDF to SDF
+    // Test conversion from simple date format to another simple date format
+    testDateTimeConvert("8/7/2017 12:45:50 AM", "1:DAYS:SIMPLE_DATE_FORMAT:M/d/yyyy h:mm:ss a",
+        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", "1:MILLISECONDS", "20170807");
+    // Test conversion from simple date format with timezone to another simple date format
+    testDateTimeConvert("20170921 Asia/Kolkata", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd ZZZ",
+        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", "1:MILLISECONDS", "20170920");
+    // Test conversion from simple date format with timezone to another simple date format with timezone
+    testDateTimeConvert("20170921 Asia/Kolkata", "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd ZZZ",
+        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd tz(America/Chicago)", "1:MILLISECONDS", "20170920");
+    // Test conversion from simple date format to another simple date format (America/Denver timezone with 15 second
+    // granularity)
+    testDateTimeConvert("20180412T19:17:12", "1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMdd''T''HH:mm:ss",
+        "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Denver)", "15:SECONDS",
+        "2018-04-12 13:17:00.000");
+    // Test conversion from simple date format to another simple date format (America/Denver timezone with 5 day
+    // granularity)
+    testDateTimeConvert("20180328T09:43:25", "1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMdd''T''HH:mm:ss",
+        "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss" + ".SSS tz(America/Denver)", "5:DAYS",
+        "2018-03-25 00:00:00.000");
+    // Test conversion from simple date format to another simple date format (America/Los_Angeles timezone with 1 day
+    // granularity)
+    testDateTimeConvert("20180418T01:00:00", "1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMdd''T''HH:mm:ss",
+        "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Los_Angeles)", "1:DAYS",
+        "2018-04-17 00:00:00.000");
+  }
+
+  private void testDateTimeConvert(Object timeValue, String inputFormatStr, String outputFormatStr,
+      String outputGranularityStr, Object expectedResult) {
+    GenericRow row = new GenericRow();
+    row.putValue("timeCol", timeValue);
+    List<String> arguments = Collections.singletonList("timeCol");
+    testFunction(String.format("dateTimeConvert(timeCol, '%s', '%s', '%s')", inputFormatStr, outputFormatStr,
+        outputGranularityStr), arguments, row, expectedResult.toString());
   }
 }


### PR DESCRIPTION
Add the `dateTimeConvert` scalar function which is equivalent to the `DateTimeConversionTransformFunction` so that it can be used for ingestion transform and post aggregation