### PR TITLE
Add commonly used math, string and date scalar functions in Pinot 

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/DateTimePatternHandler.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/DateTimePatternHandler.java
@@ -39,6 +39,14 @@ public class DateTimePatternHandler {
   }
 
   /**
+   * Converts the dateTimeString of passed pattern into a long of the millis since epoch
+   */
+  public static long parseDateTimeStringToEpochMillis(String dateTimeString, String pattern, String timezoneId) {
+    DateTimeFormatter dateTimeFormatter = getDateTimeFormatter(pattern, timezoneId);
+    return dateTimeFormatter.parseMillis(dateTimeString);
+  }
+
+  /**
    * Converts the millis representing seconds since epoch into a string of passed pattern
    */
   public static String parseEpochMillisToDateTimeString(long millis, String pattern) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -53,6 +53,7 @@ public enum TransformFunctionType {
   SIGN("sign"),
   ROUND_DECIMAL("round_decimal"),
   POWER("power"),
+  TRUNCATE("truncate"),
 
   LEAST("least"),
   GREATEST("greatest"),

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -46,6 +46,7 @@ public enum TransformFunctionType {
   EXP("exp"),
   FLOOR("floor"),
   LN("ln"),
+  LOG("log"),
   SQRT("sqrt"),
   LOG2("log2"),
   LOG10("log10"),

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -47,13 +47,13 @@ public enum TransformFunctionType {
   FLOOR("floor"),
   LN("ln"),
   LOG("log"),
-  SQRT("sqrt"),
   LOG2("log2"),
   LOG10("log10"),
   SIGN("sign"),
-  ROUND_DECIMAL("round_decimal"),
-  POWER("power"),
+  ROUND_DECIMAL("roundDecimal"),
   TRUNCATE("truncate"),
+  POWER("power"),
+  SQRT("sqrt"),
 
   LEAST("least"),
   GREATEST("greatest"),
@@ -133,7 +133,6 @@ public enum TransformFunctionType {
   // Geo indexing
   GEOTOH3("geoToH3"),
 
-
   //Trigonometry
   SIN("sin"),
   COS("cos"),
@@ -148,8 +147,6 @@ public enum TransformFunctionType {
   TANH("tanh"),
   DEGREES("degrees"),
   RADIANS("radians");
-
-
 
   private static final Set<String> NAMES = Arrays.stream(values()).flatMap(
       func -> func.getAliases().stream().flatMap(name -> Stream.of(name, StringUtils.remove(name, '_').toUpperCase(),

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -47,7 +47,8 @@ public enum TransformFunctionType {
   FLOOR("floor"),
   LN("ln"),
   SQRT("sqrt"),
-  LOG("log"),
+  LOG2("log2"),
+  LOG10("log10"),
   SIGN("sign"),
   ROUND_DECIMAL("round_decimal"),
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -51,6 +51,7 @@ public enum TransformFunctionType {
   LOG10("log10"),
   SIGN("sign"),
   ROUND_DECIMAL("round_decimal"),
+  POWER("power"),
 
   LEAST("least"),
   GREATEST("greatest"),

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -47,6 +47,9 @@ public enum TransformFunctionType {
   FLOOR("floor"),
   LN("ln"),
   SQRT("sqrt"),
+  LOG("log"),
+  SIGN("sign"),
+  ROUND_DECIMAL("round_decimal"),
 
   LEAST("least"),
   GREATEST("greatest"),
@@ -124,7 +127,25 @@ public enum TransformFunctionType {
   ST_WITHIN("ST_Within"),
 
   // Geo indexing
-  GEOTOH3("geoToH3");
+  GEOTOH3("geoToH3"),
+
+
+  //Trigonometry
+  SIN("sin"),
+  COS("cos"),
+  TAN("tan"),
+  COT("cot"),
+  ASIN("asin"),
+  ACOS("acos"),
+  ATAN("atan"),
+  ATAN2("atan2"),
+  SINH("sinh"),
+  COSH("cosh"),
+  TANH("tanh"),
+  DEGREES("degrees"),
+  RADIANS("radians");
+
+
 
   private static final Set<String> NAMES = Arrays.stream(values()).flatMap(
       func -> func.getAliases().stream().flatMap(name -> Stream.of(name, StringUtils.remove(name, '_').toUpperCase(),

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
@@ -133,4 +133,9 @@ public class ArithmeticFunctions {
   public static double roundDecimal(double a, int b) {
     return BigDecimal.valueOf(a).setScale(b, RoundingMode.HALF_UP).doubleValue();
   }
+
+  @ScalarFunction
+  public static double roundDecimal(double a) {
+    return BigDecimal.valueOf(a).setScale(0, RoundingMode.HALF_UP).doubleValue();
+  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
@@ -118,10 +118,14 @@ public class ArithmeticFunctions {
   }
 
   @ScalarFunction
-  public static double pi() { return Math.PI; }
+  public static double pi() {
+    return Math.PI;
+  }
 
   @ScalarFunction
-  public static double e() { return Math.E; }
+  public static double e() {
+    return Math.E;
+  }
 
   @ScalarFunction
   public static double power(double a, double b) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
@@ -123,7 +123,12 @@ public class ArithmeticFunctions {
   }
 
   @ScalarFunction
-  public static double log(double a) {
+  public static double log2(double a) {
+    return Math.log(a) / Math.log(2);
+  }
+
+  @ScalarFunction
+  public static double log10(double a) {
     return Math.log10(a);
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
@@ -103,6 +103,16 @@ public class ArithmeticFunctions {
   }
 
   @ScalarFunction
+  public static double log2(double a) {
+    return Math.log(a) / Math.log(2);
+  }
+
+  @ScalarFunction
+  public static double log10(double a) {
+    return Math.log10(a);
+  }
+
+  @ScalarFunction
   public static double sqrt(double a) {
     return Math.sqrt(a);
   }
@@ -115,16 +125,6 @@ public class ArithmeticFunctions {
   @ScalarFunction
   public static double power(double a, double b) {
     return Math.pow(a, b);
-  }
-
-  @ScalarFunction
-  public static double log2(double a) {
-    return Math.log(a) / Math.log(2);
-  }
-
-  @ScalarFunction
-  public static double log10(double a) {
-    return Math.log10(a);
   }
 
   //TODO: The function should ideally be named 'round'

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
@@ -97,7 +97,7 @@ public class ArithmeticFunctions {
     return Math.exp(a);
   }
 
-  @ScalarFunction
+  @ScalarFunction(names = {"ln", "log"})
   public static double ln(double a) {
     return Math.log(a);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
@@ -82,13 +82,8 @@ public class ArithmeticFunctions {
     return Math.abs(a);
   }
 
-  @ScalarFunction
+  @ScalarFunction(names = {"ceil", "ceiling"})
   public static double ceil(double a) {
-    return Math.ceil(a);
-  }
-
-  @ScalarFunction
-  public static double ceiling(double a) {
     return Math.ceil(a);
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
@@ -138,4 +138,14 @@ public class ArithmeticFunctions {
   public static double roundDecimal(double a) {
     return BigDecimal.valueOf(a).setScale(0, RoundingMode.HALF_UP).doubleValue();
   }
+
+  @ScalarFunction
+  public static double truncate(double a, int b) {
+    return BigDecimal.valueOf(a).setScale(b, RoundingMode.DOWN).doubleValue();
+  }
+
+  @ScalarFunction
+  public static double truncate(double a) {
+    return Math.signum(a) * Math.floor(Math.abs(a));
+  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
@@ -118,16 +118,6 @@ public class ArithmeticFunctions {
   }
 
   @ScalarFunction
-  public static double pi() {
-    return Math.PI;
-  }
-
-  @ScalarFunction
-  public static double e() {
-    return Math.E;
-  }
-
-  @ScalarFunction
   public static double power(double a, double b) {
     return Math.pow(a, b);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.common.function.scalar;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import org.apache.pinot.spi.annotations.ScalarFunction;
 
 
@@ -129,5 +131,10 @@ public class ArithmeticFunctions {
   @ScalarFunction
   public static double log(double a) {
     return Math.log10(a);
+  }
+
+  @ScalarFunction(names = {"round_decimal"})
+  public static double roundDecimal(double a, int b) {
+    return BigDecimal.valueOf(a).setScale(b, RoundingMode.HALF_UP).doubleValue();
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
@@ -137,7 +137,9 @@ public class ArithmeticFunctions {
     return Math.log10(a);
   }
 
-  @ScalarFunction(names = {"round_decimal"})
+  //TODO: The function should ideally be named 'round'
+  // but it is not possible because of existing DateTimeFunction with same name.
+  @ScalarFunction
   public static double roundDecimal(double a, int b) {
     return BigDecimal.valueOf(a).setScale(b, RoundingMode.HALF_UP).doubleValue();
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
@@ -122,26 +122,31 @@ public class ArithmeticFunctions {
     return Math.signum(a);
   }
 
-  @ScalarFunction
-  public static double power(double a, double b) {
-    return Math.pow(a, b);
+  @ScalarFunction(names = {"pow", "power"})
+  public static double power(double a, double exponent) {
+    return Math.pow(a, exponent);
   }
 
-  //TODO: The function should ideally be named 'round'
+
+  // Big Decimal Implementation has been used here to avoid overflows
+  // when multiplying by Math.pow(10, scale) for rounding
+  @ScalarFunction
+  public static double roundDecimal(double a, int scale) {
+    return BigDecimal.valueOf(a).setScale(scale, RoundingMode.HALF_UP).doubleValue();
+  }
+
+  // TODO: The function should ideally be named 'round'
   // but it is not possible because of existing DateTimeFunction with same name.
   @ScalarFunction
-  public static double roundDecimal(double a, int b) {
-    return BigDecimal.valueOf(a).setScale(b, RoundingMode.HALF_UP).doubleValue();
-  }
-
-  @ScalarFunction
   public static double roundDecimal(double a) {
-    return BigDecimal.valueOf(a).setScale(0, RoundingMode.HALF_UP).doubleValue();
+    return Math.round(a);
   }
 
+  // Big Decimal Implementation has been used here to avoid overflows
+  // when multiplying by Math.pow(10, scale) for rounding
   @ScalarFunction
-  public static double truncate(double a, int b) {
-    return BigDecimal.valueOf(a).setScale(b, RoundingMode.DOWN).doubleValue();
+  public static double truncate(double a, int scale) {
+    return BigDecimal.valueOf(a).setScale(scale, RoundingMode.DOWN).doubleValue();
   }
 
   @ScalarFunction

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
@@ -86,6 +86,11 @@ public class ArithmeticFunctions {
   }
 
   @ScalarFunction
+  public static double ceiling(double a) {
+    return Math.ceil(a);
+  }
+
+  @ScalarFunction
   public static double floor(double a) {
     return Math.floor(a);
   }
@@ -103,5 +108,26 @@ public class ArithmeticFunctions {
   @ScalarFunction
   public static double sqrt(double a) {
     return Math.sqrt(a);
+  }
+
+  @ScalarFunction
+  public static double sign(double a) {
+    return Math.signum(a);
+  }
+
+  @ScalarFunction
+  public static double pi() { return Math.PI; }
+
+  @ScalarFunction
+  public static double e() { return Math.E; }
+
+  @ScalarFunction
+  public static double power(double a, double b) {
+    return Math.pow(a, b);
+  }
+
+  @ScalarFunction
+  public static double log(double a) {
+    return Math.log10(a);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
@@ -274,9 +274,6 @@ public class DateTimeFunctions {
    */
   @ScalarFunction
   public static long fromDateTime(String dateTimeString, String pattern) {
-    if (StringUtils.isEmpty(dateTimeString)) {
-      return 0;
-    }
     return DateTimePatternHandler.parseDateTimeStringToEpochMillis(dateTimeString, pattern);
   }
 
@@ -285,9 +282,6 @@ public class DateTimeFunctions {
    */
   @ScalarFunction
   public static long fromDateTime(String dateTimeString, String pattern, String timeZoneId) {
-    if (StringUtils.isEmpty(dateTimeString)) {
-      return 0;
-    }
     return DateTimePatternHandler.parseDateTimeStringToEpochMillis(dateTimeString, pattern, timeZoneId);
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
@@ -732,28 +732,18 @@ public class DateTimeFunctions {
     }
   }
 
-  @ScalarFunction
+  @ScalarFunction(names = {"timestampAdd", "dateAdd"})
   public static long timestampAdd(String unit, int interval, long timestamp) {
     ISOChronology chronology = ISOChronology.getInstanceUTC();
     long millis = getTimestampField(chronology, unit).add(timestamp, interval);
     return millis;
   }
 
-  @ScalarFunction
+  @ScalarFunction(names = {"timestampDiff", "dateDiff"})
   public static long timestampDiff(String unit, long timestamp1, long timestamp2) {
     ISOChronology chronology = ISOChronology.getInstanceUTC();
     long millis = getTimestampField(chronology, unit).getDifferenceAsLong(timestamp1, timestamp2);
     return millis;
-  }
-
-  @ScalarFunction
-  public static long dateAdd(String unit, int interval, long date) {
-    return timestampAdd(unit, interval, date);
-  }
-
-  @ScalarFunction
-  public static long dateDiff(String unit, long date1, long date2) {
-    return timestampDiff(unit, date1, date2);
   }
 
   private static DateTimeField getTimestampField(ISOChronology chronology, String unit) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
@@ -30,10 +30,10 @@ import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.DateTimeGranularitySpec;
 import org.joda.time.DateTime;
+import org.joda.time.DateTimeField;
 import org.joda.time.DateTimeZone;
 import org.joda.time.chrono.ISOChronology;
 import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.DateTimeField;
 
 /**
  * Inbuilt date time related transform functions

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
@@ -21,7 +21,6 @@ package org.apache.pinot.common.function.scalar;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.function.DateTimePatternHandler;
 import org.apache.pinot.common.function.DateTimeUtils;
 import org.apache.pinot.common.function.TimeZoneKey;

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
@@ -751,7 +751,6 @@ public class DateTimeFunctions {
   @ScalarFunction(names = {"timestampDiff", "dateDiff"})
   public static long timestampDiff(String unit, long timestamp1, long timestamp2) {
     ISOChronology chronology = ISOChronology.getInstanceUTC();
-    long millis = DateTimeUtils.getTimestampField(chronology, unit).getDifferenceAsLong(timestamp2, timestamp1);
-    return millis;
+    return DateTimeUtils.getTimestampField(chronology, unit).getDifferenceAsLong(timestamp2, timestamp1);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
@@ -29,7 +29,6 @@ import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.DateTimeGranularitySpec;
 import org.joda.time.DateTime;
-import org.joda.time.DateTimeField;
 import org.joda.time.DateTimeZone;
 import org.joda.time.chrono.ISOChronology;
 import org.joda.time.format.DateTimeFormatter;

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
@@ -725,40 +725,33 @@ public class DateTimeFunctions {
     }
   }
 
+  /**
+   * Add a time period to the provided timestamp.
+   * e.g. timestampAdd('days', 10, NOW()) will add 10 days to the current timestamp and return the value
+   * @param unit the timeunit of the period to add. e.g. milliseconds, seconds, days, year
+   * @param interval value of the period to add.
+   * @param timestamp
+   * @return
+   */
   @ScalarFunction(names = {"timestampAdd", "dateAdd"})
-  public static long timestampAdd(String unit, int interval, long timestamp) {
+  public static long timestampAdd(String unit, long interval, long timestamp) {
     ISOChronology chronology = ISOChronology.getInstanceUTC();
-    long millis = getTimestampField(chronology, unit).add(timestamp, interval);
+    long millis = DateTimeUtils.getTimestampField(chronology, unit).add(timestamp, interval);
     return millis;
   }
 
+  /**
+   * Get difference between two timestamps and return the result in the specified timeunit.
+   * e.g. timestampDiff('days', ago('10D'), ago('2D')) will return 8 i.e. 8 days
+   * @param unit
+   * @param timestamp1
+   * @param timestamp2
+   * @return
+   */
   @ScalarFunction(names = {"timestampDiff", "dateDiff"})
   public static long timestampDiff(String unit, long timestamp1, long timestamp2) {
     ISOChronology chronology = ISOChronology.getInstanceUTC();
-    long millis = getTimestampField(chronology, unit).getDifferenceAsLong(timestamp1, timestamp2);
+    long millis = DateTimeUtils.getTimestampField(chronology, unit).getDifferenceAsLong(timestamp2, timestamp1);
     return millis;
-  }
-
-  private static DateTimeField getTimestampField(ISOChronology chronology, String unit) {
-    switch (unit.toLowerCase()) {
-      case "millisecond":
-        return chronology.millisOfSecond();
-      case "second":
-        return chronology.secondOfMinute();
-      case "minute":
-        return chronology.minuteOfHour();
-      case "hour":
-        return chronology.hourOfDay();
-      case "day":
-        return chronology.dayOfMonth();
-      case "week":
-        return chronology.weekOfWeekyear();
-      case "month":
-        return chronology.monthOfYear();
-      case "year":
-        return chronology.year();
-      default:
-        throw new UnsupportedOperationException("Timeunit " + unit + " is not supported by Pinot");
-    }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
@@ -274,7 +274,7 @@ public class DateTimeFunctions {
    */
   @ScalarFunction
   public static long fromDateTime(String dateTimeString, String pattern) {
-    if(StringUtils.isEmpty(dateTimeString)){
+    if (StringUtils.isEmpty(dateTimeString)) {
       return 0;
     }
     return DateTimePatternHandler.parseDateTimeStringToEpochMillis(dateTimeString, pattern);
@@ -285,7 +285,7 @@ public class DateTimeFunctions {
    */
   @ScalarFunction
   public static long fromDateTime(String dateTimeString, String pattern, String timeZoneId) {
-    if(StringUtils.isEmpty(dateTimeString)){
+    if (StringUtils.isEmpty(dateTimeString)) {
       return 0;
     }
     return DateTimePatternHandler.parseDateTimeStringToEpochMillis(dateTimeString, pattern, timeZoneId);
@@ -733,31 +733,30 @@ public class DateTimeFunctions {
   }
 
   @ScalarFunction
-  public static long timestampAdd(String unit, int interval, long timestamp){
+  public static long timestampAdd(String unit, int interval, long timestamp) {
     ISOChronology chronology = ISOChronology.getInstanceUTC();
     long millis = getTimestampField(chronology, unit).add(timestamp, interval);
     return millis;
   }
 
   @ScalarFunction
-  public static long timestampDiff(String unit, long timestamp1,  long timestamp2){
+  public static long timestampDiff(String unit, long timestamp1, long timestamp2) {
     ISOChronology chronology = ISOChronology.getInstanceUTC();
     long millis = getTimestampField(chronology, unit).getDifferenceAsLong(timestamp1, timestamp2);
     return millis;
   }
 
   @ScalarFunction
-  public static long dateAdd(String unit, int interval, long date){
+  public static long dateAdd(String unit, int interval, long date) {
     return timestampAdd(unit, interval, date);
   }
 
   @ScalarFunction
-  public static long dateDiff(String unit, long date1,  long date2){
+  public static long dateDiff(String unit, long date1, long date2) {
     return timestampDiff(unit, date1, date2);
   }
 
-  private static DateTimeField getTimestampField(ISOChronology chronology, String unit)
-  {
+  private static DateTimeField getTimestampField(ISOChronology chronology, String unit) {
     switch (unit.toLowerCase()) {
       case "millisecond":
         return chronology.millisOfSecond();
@@ -778,10 +777,5 @@ public class DateTimeFunctions {
       default:
         throw new UnsupportedOperationException("Timeunit " + unit + " is not supported by Pinot");
     }
-  }
-
-  public static void main(String[] args) {
-    long out = timestampAdd("DAY", 1, fromDateTime("2004-07-09 10:17:35", "yyyy-MM-dd HH:mm:ss"));
-    System.out.println(toDateTime(out, "yyyy-MM-dd HH:mm:ss"));
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -439,11 +439,22 @@ public class StringFunctions {
   /**
    * @param input
    * @param delimiter
+   * @param limit
+   * @return splits string on specified delimiter limiting the number of results till the specified limit
+   */
+  @ScalarFunction
+  public static String[] split(String input, String delimiter, int limit) {
+    return StringUtils.split(input, delimiter, limit);
+  }
+
+  /**
+   * @param input
+   * @param delimiter
    * @param index
    * @return splits string on specified delimiter and returns String at specified index from the split.
    */
   @ScalarFunction
-  public static String split(String input, String delimiter, int index) {
+  public static String splitPart(String input, String delimiter, int index) {
     String[] splitString = StringUtils.split(input, delimiter);
     if (index < splitString.length) {
       return splitString[index];

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -82,7 +82,7 @@ public class StringFunctions {
    */
   @ScalarFunction
   public static String substr(String input, int beginIndex) {
-    return input.substring(beginIndex);
+    return StringUtils.substring(input, beginIndex);
   }
 
   /**
@@ -100,7 +100,7 @@ public class StringFunctions {
     if (endIndex == -1) {
       return substr(input, beginIndex);
     }
-    return input.substring(beginIndex, endIndex);
+    return StringUtils.substring(input, beginIndex, endIndex);
   }
 
   /**
@@ -181,6 +181,24 @@ public class StringFunctions {
   @ScalarFunction
   public static String rtrim(String input) {
     return RTRIM.matcher(input).replaceAll("");
+  }
+
+  /**
+   * @param input
+   * @return trim spaces from right side of the string
+   */
+  @ScalarFunction
+  public static String leftSubStr(String input, int length) {
+    return StringUtils.left(input, length);
+  }
+
+  /**
+   * @param input
+   * @return trim spaces from right side of the string
+   */
+  @ScalarFunction
+  public static String rightSubStr(String input, int length) {
+    return StringUtils.right(input, length);
   }
 
   /**
@@ -293,7 +311,18 @@ public class StringFunctions {
    */
   @ScalarFunction
   public static boolean startsWith(String input, String prefix) {
-    return input.startsWith(prefix);
+    return StringUtils.startsWith(input, prefix);
+  }
+
+  /**
+   * @see String#startsWith(String)
+   * @param input
+   * @param suffix substring to check if it is the prefix
+   * @return true if string starts with prefix, false o.w.
+   */
+  @ScalarFunction
+  public static boolean endsWith(String input, String suffix) {
+    return StringUtils.endsWith(input, suffix);
   }
 
   /**
@@ -363,6 +392,16 @@ public class StringFunctions {
   }
 
   /**
+   * @see StandardCharsets#UTF_8#encode(String)
+   * @param input
+   * @return bytes
+   */
+  @ScalarFunction
+  public static byte[] toAscii(String input) {
+    return input.getBytes(StandardCharsets.US_ASCII);
+  }
+
+  /**
    * see Normalizer#normalize(String, Form)
    * @param input
    * @return transforms string with NFC normalization form.
@@ -394,6 +433,45 @@ public class StringFunctions {
   public static String[] split(String input, String delimiter) {
     return StringUtils.split(input, delimiter);
   }
+
+  /**
+   * see String#split(String)
+   * @param input
+   * @param delimiter
+   * @return splits string on specified delimiter and returns an array.
+   */
+  @ScalarFunction
+  public static String split(String input, String delimiter, int index) {
+    String[] splitString = StringUtils.split(input, delimiter);
+    if(index < splitString.length){
+      return splitString[index];
+    } else {
+      return "null";
+    }
+  }
+
+  /**
+   * see String#split(String)
+   * @param input
+   * @param times
+   * @return splits string on specified delimiter and returns an array.
+   */
+  @ScalarFunction
+  public static String repeat(String input, int times) {
+    return StringUtils.repeat(input, times);
+  }
+
+  /**
+   * see String#split(String)
+   * @param input
+   * @param times
+   * @return splits string on specified delimiter and returns an array.
+   */
+  @ScalarFunction
+  public static String repeat(String input, String sep, int times) {
+    return StringUtils.repeat(input, sep, times);
+  }
+
 
   /**
    * see String#replaceAll(String, String)

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -45,7 +45,7 @@ public class StringFunctions {
   private final static Pattern RTRIM = Pattern.compile("\\s+$");
 
   /**
-   * @see StringBuilder#reverse()
+   * @see StringUtils#reverse(String)
    * @param input
    * @return reversed input in from end to start
    */
@@ -184,8 +184,9 @@ public class StringFunctions {
   }
 
   /**
+   * @see StringUtils#left(String, int)
    * @param input
-   * @return trim spaces from right side of the string
+   * @return get substring starting from the first index and extending upto specified length.
    */
   @ScalarFunction
   public static String leftSubStr(String input, int length) {
@@ -193,8 +194,9 @@ public class StringFunctions {
   }
 
   /**
+   * @see StringUtils#right(String, int)
    * @param input
-   * @return trim spaces from right side of the string
+   * @return get substring ending at the last index with specified length
    */
   @ScalarFunction
   public static String rightSubStr(String input, int length) {
@@ -304,7 +306,7 @@ public class StringFunctions {
   }
 
   /**
-   * @see String#startsWith(String)
+   * @see StringUtils#startsWith(CharSequence, CharSequence)
    * @param input
    * @param prefix substring to check if it is the prefix
    * @return true if string starts with prefix, false o.w.
@@ -315,10 +317,10 @@ public class StringFunctions {
   }
 
   /**
-   * @see String#startsWith(String)
+   * @see StringUtils#endsWith(CharSequence, CharSequence)
    * @param input
    * @param suffix substring to check if it is the prefix
-   * @return true if string starts with prefix, false o.w.
+   * @return true if string ends with prefix, false o.w.
    */
   @ScalarFunction
   public static boolean endsWith(String input, String suffix) {
@@ -392,7 +394,7 @@ public class StringFunctions {
   }
 
   /**
-   * @see StandardCharsets#UTF_8#encode(String)
+   * @see StandardCharsets#US_ASCII#encode(String)
    * @param input
    * @return bytes
    */
@@ -402,7 +404,7 @@ public class StringFunctions {
   }
 
   /**
-   * see Normalizer#normalize(String, Form)
+   * @see Normalizer#normalize(CharSequence, Normalizer.Form)
    * @param input
    * @return transforms string with NFC normalization form.
    */
@@ -412,7 +414,7 @@ public class StringFunctions {
   }
 
   /**
-   * see Normalizer#normalize(String, Form)
+   * @see Normalizer#normalize(CharSequence, Normalizer.Form)
    * @param input
    * @param form
    * @return transforms string with the specified normalization form
@@ -424,7 +426,7 @@ public class StringFunctions {
   }
 
   /**
-   * see String#split(String)
+   * @see StringUtils#split(String, String)
    * @param input
    * @param delimiter
    * @return splits string on specified delimiter and returns an array.
@@ -435,15 +437,15 @@ public class StringFunctions {
   }
 
   /**
-   * see String#split(String)
    * @param input
    * @param delimiter
-   * @return splits string on specified delimiter and returns an array.
+   * @param index
+   * @return splits string on specified delimiter and returns String at specified index from the split.
    */
   @ScalarFunction
   public static String split(String input, String delimiter, int index) {
     String[] splitString = StringUtils.split(input, delimiter);
-    if(index < splitString.length){
+    if (index < splitString.length) {
       return splitString[index];
     } else {
       return "null";
@@ -451,10 +453,10 @@ public class StringFunctions {
   }
 
   /**
-   * see String#split(String)
+   * @see StringUtils#repeat(char, int)
    * @param input
    * @param times
-   * @return splits string on specified delimiter and returns an array.
+   * @return concatenate the string to itself specified number of times
    */
   @ScalarFunction
   public static String repeat(String input, int times) {
@@ -462,19 +464,18 @@ public class StringFunctions {
   }
 
   /**
-   * see String#split(String)
+   * @see StringUtils#repeat(String, String, int)
    * @param input
    * @param times
-   * @return splits string on specified delimiter and returns an array.
+   * @return concatenate the string to itself specified number of times with specified seperator
    */
   @ScalarFunction
   public static String repeat(String input, String sep, int times) {
     return StringUtils.repeat(input, sep, times);
   }
 
-
   /**
-   * see String#replaceAll(String, String)
+   * @see StringUtils#remove(String, String)
    * @param input
    * @param search
    * @return removes all instances of search from string
@@ -504,7 +505,7 @@ public class StringFunctions {
   }
 
   /**
-   * see String#contains(String)
+   * @see String#contains(CharSequence)
    * @param input
    * @param substring
    * @return returns true if substring present in main string else false.

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/TrigonometricFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/TrigonometricFunctions.java
@@ -4,7 +4,7 @@ import org.apache.pinot.spi.annotations.ScalarFunction;
 
 
 public class TrigonometricFunctions {
-  private TrigonometricFunctions(){
+  private TrigonometricFunctions() {
   }
 
   @ScalarFunction

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/TrigonometricFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/TrigonometricFunctions.java
@@ -1,0 +1,74 @@
+package org.apache.pinot.common.function.scalar;
+
+import org.apache.pinot.spi.annotations.ScalarFunction;
+
+
+public class TrigonometricFunctions {
+  private TrigonometricFunctions(){
+  }
+
+  @ScalarFunction
+  public static double sin(double a) {
+    return Math.sin(a);
+  }
+
+  @ScalarFunction
+  public static double cos(double a) {
+    return Math.cos(a);
+  }
+
+  @ScalarFunction
+  public static double tan(double a) {
+    return Math.tan(a);
+  }
+
+  @ScalarFunction
+  public static double cot(double a) {
+    return Math.sin(a);
+  }
+
+  @ScalarFunction
+  public static double asin(double a) {
+    return Math.asin(a);
+  }
+
+  @ScalarFunction
+  public static double acos(double a) {
+    return Math.acos(a);
+  }
+
+  @ScalarFunction
+  public static double atan(double a) {
+    return Math.atan(a);
+  }
+
+  @ScalarFunction
+  public static double atan2(double a, double b) {
+    return Math.atan2(a, b);
+  }
+
+  @ScalarFunction
+  public static double sinh(double a) {
+    return Math.sinh(a);
+  }
+
+  @ScalarFunction
+  public static double cosh(double a) {
+    return Math.cosh(a);
+  }
+
+  @ScalarFunction
+  public static double tanh(double a) {
+    return Math.tanh(a);
+  }
+
+  @ScalarFunction
+  public static double degrees(double a) {
+    return Math.toDegrees(a);
+  }
+
+  @ScalarFunction
+  public static double radian(double a) {
+    return Math.toRadians(a);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/TrigonometricFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/TrigonometricFunctions.java
@@ -42,7 +42,7 @@ public class TrigonometricFunctions {
 
   @ScalarFunction
   public static double cot(double a) {
-    return Math.sin(a);
+    return 1.0/tan(a);
   }
 
   @ScalarFunction

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/TrigonometricFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/TrigonometricFunctions.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.common.function.scalar;
 
 import org.apache.pinot.spi.annotations.ScalarFunction;
@@ -68,7 +86,7 @@ public class TrigonometricFunctions {
   }
 
   @ScalarFunction
-  public static double radian(double a) {
+  public static double radians(double a) {
     return Math.toRadians(a);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/TrigonometricFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/TrigonometricFunctions.java
@@ -42,7 +42,7 @@ public class TrigonometricFunctions {
 
   @ScalarFunction
   public static double cot(double a) {
-    return 1.0/tan(a);
+    return 1.0 / tan(a);
   }
 
   @ScalarFunction

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
@@ -40,7 +40,7 @@ import org.apache.pinot.spi.utils.BytesUtils;
  */
 public class LiteralTransformFunction implements TransformFunction {
   private final String _literal;
-  private DataType _dataType;
+  private final DataType _dataType;
   private final int _intLiteral;
   private final long _longLiteral;
   private final float _floatLiteral;
@@ -57,36 +57,17 @@ public class LiteralTransformFunction implements TransformFunction {
   public LiteralTransformFunction(String literal) {
     _literal = literal;
     _dataType = inferLiteralDataType(literal);
-    double mathLiteral;
     if (_dataType.isNumeric()) {
       BigDecimal bigDecimal = new BigDecimal(_literal);
       _intLiteral = bigDecimal.intValue();
       _longLiteral = bigDecimal.longValue();
       _floatLiteral = bigDecimal.floatValue();
       _doubleLiteral = bigDecimal.doubleValue();
-    } else if ((mathLiteral = getMathConstant(literal)) != 0) {
-      BigDecimal bigDecimal = new BigDecimal(mathLiteral);
-      _intLiteral = bigDecimal.intValue();
-      _longLiteral = bigDecimal.longValue();
-      _floatLiteral = bigDecimal.floatValue();
-      _doubleLiteral = bigDecimal.doubleValue();
-      _dataType = DataType.DOUBLE;
     } else {
       _intLiteral = 0;
       _longLiteral = 0L;
       _floatLiteral = 0F;
       _doubleLiteral = 0D;
-    }
-  }
-
-  static double getMathConstant(String literal) {
-    switch (literal.toUpperCase()) {
-      case "E":
-        return Math.E;
-      case "PI":
-        return Math.PI;
-      default:
-        return 0D;
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
@@ -40,7 +40,7 @@ import org.apache.pinot.spi.utils.BytesUtils;
  */
 public class LiteralTransformFunction implements TransformFunction {
   private final String _literal;
-  private final DataType _dataType;
+  private DataType _dataType;
   private final int _intLiteral;
   private final long _longLiteral;
   private final float _floatLiteral;
@@ -57,17 +57,36 @@ public class LiteralTransformFunction implements TransformFunction {
   public LiteralTransformFunction(String literal) {
     _literal = literal;
     _dataType = inferLiteralDataType(literal);
+    double mathLiteral;
     if (_dataType.isNumeric()) {
       BigDecimal bigDecimal = new BigDecimal(_literal);
       _intLiteral = bigDecimal.intValue();
       _longLiteral = bigDecimal.longValue();
       _floatLiteral = bigDecimal.floatValue();
       _doubleLiteral = bigDecimal.doubleValue();
+    } else if ((mathLiteral = getMathConstant(literal)) != 0) {
+      BigDecimal bigDecimal = new BigDecimal(mathLiteral);
+      _intLiteral = bigDecimal.intValue();
+      _longLiteral = bigDecimal.longValue();
+      _floatLiteral = bigDecimal.floatValue();
+      _doubleLiteral = bigDecimal.doubleValue();
+      _dataType = DataType.DOUBLE;
     } else {
       _intLiteral = 0;
       _longLiteral = 0L;
       _floatLiteral = 0F;
       _doubleLiteral = 0D;
+    }
+  }
+
+  static double getMathConstant(String literal) {
+    switch (literal.toUpperCase()) {
+      case "E":
+        return Math.E;
+      case "PI":
+        return Math.PI;
+      default:
+        return 0D;
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunction.java
@@ -23,7 +23,7 @@ public class PowerTransformFunction extends BaseTransformFunction {
   @Override
   public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
     // Check that there are more than 1 arguments
-    if (arguments.size() == 2) {
+    if (arguments.size() != 2) {
       throw new IllegalArgumentException("Exactly 2 arguments are required for power transform function");
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunction.java
@@ -31,7 +31,7 @@ public class PowerTransformFunction extends BaseTransformFunction {
   private TransformFunction _leftTransformFunction;
   private TransformFunction _rightTransformFunction;
   private double _exponent;
-  private boolean _hasLiteralArg;
+  private boolean _fixedExponent;
 
   @Override
   public String getName() {
@@ -45,12 +45,12 @@ public class PowerTransformFunction extends BaseTransformFunction {
       throw new IllegalArgumentException("Exactly 2 arguments are required for power transform function");
     }
 
-    _hasLiteralArg = false;
+    _fixedExponent = false;
     _leftTransformFunction = arguments.get(0);
     _rightTransformFunction = arguments.get(1);
     if (_rightTransformFunction instanceof LiteralTransformFunction) {
       _exponent = Double.parseDouble(((LiteralTransformFunction) _rightTransformFunction).getLiteral());
-      _hasLiteralArg = true;
+      _fixedExponent = true;
     }
     Preconditions.checkArgument(
         _leftTransformFunction.getResultMetadata().isSingleValue() || _rightTransformFunction.getResultMetadata()
@@ -71,7 +71,7 @@ public class PowerTransformFunction extends BaseTransformFunction {
     }
 
     double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
-    if (_hasLiteralArg) {
+    if (_fixedExponent) {
       for (int i = 0; i < length; i++) {
         _doubleValuesSV[i] = Math.pow(leftValues[i], _exponent);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunction.java
@@ -1,8 +1,6 @@
 package org.apache.pinot.core.operator.transform.function;
 
 import com.google.common.base.Preconditions;
-import java.math.BigDecimal;
-import java.math.RoundingMode;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
@@ -11,10 +9,8 @@ import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 
 
-//TODO: The function should ideally be named 'round'
-// but it is not possible because of existing DateTimeFunction with same name.
-public class RoundDecimalTransformFunction extends BaseTransformFunction {
-  public static final String FUNCTION_NAME = "roundDecimal";
+public class PowerTransformFunction extends BaseTransformFunction {
+  public static final String FUNCTION_NAME = "power";
   private double[] _result;
   private TransformFunction _leftTransformFunction;
   private TransformFunction _rightTransformFunction;
@@ -28,7 +24,7 @@ public class RoundDecimalTransformFunction extends BaseTransformFunction {
   public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
     // Check that there are more than 1 arguments
     if (arguments.size() == 2) {
-      throw new IllegalArgumentException("Exactly 2 arguments are required for roundDecimal transform function");
+      throw new IllegalArgumentException("Exactly 2 arguments are required for power transform function");
     }
 
     _leftTransformFunction = arguments.get(0);
@@ -51,11 +47,10 @@ public class RoundDecimalTransformFunction extends BaseTransformFunction {
 
     int length = projectionBlock.getNumDocs();
     double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
-    int[] rightValues = _rightTransformFunction.transformToIntValuesSV(projectionBlock);
+    double[] rightValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _result[i] = BigDecimal.valueOf(leftValues[i]).setScale(rightValues[i], RoundingMode.HALF_UP).doubleValue();
+      _result[i] = Math.pow(leftValues[i], rightValues[i]);
     }
-
     return _result;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunction.java
@@ -31,6 +31,7 @@ public class PowerTransformFunction extends BaseTransformFunction {
   private TransformFunction _leftTransformFunction;
   private TransformFunction _rightTransformFunction;
   private double _exponent;
+  private boolean _hasLiteralArg;
 
   @Override
   public String getName() {
@@ -44,12 +45,12 @@ public class PowerTransformFunction extends BaseTransformFunction {
       throw new IllegalArgumentException("Exactly 2 arguments are required for power transform function");
     }
 
+    _hasLiteralArg = false;
     _leftTransformFunction = arguments.get(0);
     _rightTransformFunction = arguments.get(1);
     if (_rightTransformFunction instanceof LiteralTransformFunction) {
       _exponent = Double.parseDouble(((LiteralTransformFunction) _rightTransformFunction).getLiteral());
-    } else {
-      _exponent = Double.NaN;
+      _hasLiteralArg = true;
     }
     Preconditions.checkArgument(
         _leftTransformFunction.getResultMetadata().isSingleValue() || _rightTransformFunction.getResultMetadata()
@@ -70,7 +71,7 @@ public class PowerTransformFunction extends BaseTransformFunction {
     }
 
     double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
-    if (!Double.isNaN(_exponent)) {
+    if (_hasLiteralArg) {
       for (int i = 0; i < length; i++) {
         _doubleValuesSV[i] = Math.pow(leftValues[i], _exponent);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunction.java
@@ -32,6 +32,7 @@ public class PowerTransformFunction extends BaseTransformFunction {
   private double[] _result;
   private TransformFunction _leftTransformFunction;
   private TransformFunction _rightTransformFunction;
+  private Double _exponent;
 
   @Override
   public String getName() {
@@ -47,6 +48,11 @@ public class PowerTransformFunction extends BaseTransformFunction {
 
     _leftTransformFunction = arguments.get(0);
     _rightTransformFunction = arguments.get(1);
+    if (_rightTransformFunction instanceof LiteralTransformFunction) {
+      _exponent = Double.parseDouble(((LiteralTransformFunction) _rightTransformFunction).getLiteral());
+    } else {
+      _exponent = null;
+    }
     Preconditions.checkArgument(
         _leftTransformFunction.getResultMetadata().isSingleValue() || _rightTransformFunction.getResultMetadata()
             .isSingleValue(), "Argument must be single-valued for transform function: %s", getName());
@@ -65,9 +71,15 @@ public class PowerTransformFunction extends BaseTransformFunction {
 
     int length = projectionBlock.getNumDocs();
     double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
-    double[] rightValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
-    for (int i = 0; i < length; i++) {
-      _result[i] = Math.pow(leftValues[i], rightValues[i]);
+    if (_exponent != null) {
+      for (int i = 0; i < length; i++) {
+        _result[i] = Math.pow(leftValues[i], _exponent);
+      }
+    } else {
+      double[] rightValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
+      for (int i = 0; i < length; i++) {
+        _result[i] = Math.pow(leftValues[i], rightValues[i]);
+      }
     }
     return _result;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunction.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
-import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 
 
@@ -65,11 +64,12 @@ public class PowerTransformFunction extends BaseTransformFunction {
 
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
-    if (_result == null) {
-      _result = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    int length = projectionBlock.getNumDocs();
+
+    if (_result == null || _result.length < length) {
+      _result = new double[length];
     }
 
-    int length = projectionBlock.getNumDocs();
     double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
     if (_exponent != null) {
       for (int i = 0; i < length; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunction.java
@@ -28,10 +28,9 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
 
 public class PowerTransformFunction extends BaseTransformFunction {
   public static final String FUNCTION_NAME = "power";
-  private double[] _result;
   private TransformFunction _leftTransformFunction;
   private TransformFunction _rightTransformFunction;
-  private Double _exponent;
+  private double _exponent;
 
   @Override
   public String getName() {
@@ -50,7 +49,7 @@ public class PowerTransformFunction extends BaseTransformFunction {
     if (_rightTransformFunction instanceof LiteralTransformFunction) {
       _exponent = Double.parseDouble(((LiteralTransformFunction) _rightTransformFunction).getLiteral());
     } else {
-      _exponent = null;
+      _exponent = Double.NaN;
     }
     Preconditions.checkArgument(
         _leftTransformFunction.getResultMetadata().isSingleValue() || _rightTransformFunction.getResultMetadata()
@@ -66,21 +65,21 @@ public class PowerTransformFunction extends BaseTransformFunction {
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
 
-    if (_result == null || _result.length < length) {
-      _result = new double[length];
+    if (_doubleValuesSV == null || _doubleValuesSV.length < length) {
+      _doubleValuesSV = new double[length];
     }
 
     double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
-    if (_exponent != null) {
+    if (!Double.isNaN(_exponent)) {
       for (int i = 0; i < length; i++) {
-        _result[i] = Math.pow(leftValues[i], _exponent);
+        _doubleValuesSV[i] = Math.pow(leftValues[i], _exponent);
       }
     } else {
       double[] rightValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
       for (int i = 0; i < length; i++) {
-        _result[i] = Math.pow(leftValues[i], rightValues[i]);
+        _doubleValuesSV[i] = Math.pow(leftValues[i], rightValues[i]);
       }
     }
-    return _result;
+    return _doubleValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.operator.transform.function;
 
 import com.google.common.base.Preconditions;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
@@ -26,13 +26,19 @@ public class RoundDecimalTransformFunction extends BaseTransformFunction {
 
   @Override
   public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
-    // Check that there are more than 1 arguments
-    if (arguments.size() != 2) {
-      throw new IllegalArgumentException("Exactly 2 arguments are required for roundDecimal transform function");
+    int numArguments = arguments.size();
+    // Check that there are more than 2 arguments or no arguments
+    if (numArguments < 1 || numArguments > 2) {
+      throw new IllegalArgumentException("roundDecimal transform function supports either 1 or 2 arguments. Num arguments provided: " + numArguments);
     }
 
     _leftTransformFunction = arguments.get(0);
-    _rightTransformFunction = arguments.get(1);
+    if(numArguments > 1) {
+      _rightTransformFunction = arguments.get(1);
+    } else {
+      _rightTransformFunction = new LiteralTransformFunction("0");
+    }
+
     Preconditions.checkArgument(
         _leftTransformFunction.getResultMetadata().isSingleValue() || _rightTransformFunction.getResultMetadata()
             .isSingleValue(), "Argument must be single-valued for transform function: %s", getName());

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
@@ -27,7 +27,7 @@ public class RoundDecimalTransformFunction extends BaseTransformFunction {
   @Override
   public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
     // Check that there are more than 1 arguments
-    if (arguments.size() == 2) {
+    if (arguments.size() != 2) {
       throw new IllegalArgumentException("Exactly 2 arguments are required for roundDecimal transform function");
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
@@ -36,7 +36,7 @@ public class RoundDecimalTransformFunction extends BaseTransformFunction {
   private double[] _result;
   private TransformFunction _leftTransformFunction;
   private TransformFunction _rightTransformFunction;
-  private Integer _scale;
+  private int _scale;
 
   @Override
   public String getName() {
@@ -58,7 +58,7 @@ public class RoundDecimalTransformFunction extends BaseTransformFunction {
       if (_rightTransformFunction instanceof LiteralTransformFunction) {
         _scale = Integer.parseInt(((LiteralTransformFunction) _rightTransformFunction).getLiteral());
       } else {
-        _scale = null;
+        _scale = Integer.MIN_VALUE;
       }
       Preconditions.checkArgument(
           _rightTransformFunction.getResultMetadata().isSingleValue() && isIntegralResultDatatype(
@@ -66,7 +66,7 @@ public class RoundDecimalTransformFunction extends BaseTransformFunction {
           "Argument must be single-valued with type INT or LONG for transform function: %s", getName());
     } else {
       _rightTransformFunction = null;
-      _scale = null;
+      _scale = Integer.MIN_VALUE;
     }
 
     Preconditions.checkArgument(_leftTransformFunction.getResultMetadata().isSingleValue(),
@@ -92,7 +92,7 @@ public class RoundDecimalTransformFunction extends BaseTransformFunction {
     }
 
     double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
-    if (_scale != null) {
+    if (_scale != Integer.MIN_VALUE) {
       for (int i = 0; i < length; i++) {
         _result[i] = BigDecimal.valueOf(leftValues[i]).setScale(_scale, RoundingMode.HALF_UP).doubleValue();
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
@@ -36,7 +36,7 @@ public class RoundDecimalTransformFunction extends BaseTransformFunction {
   private TransformFunction _leftTransformFunction;
   private TransformFunction _rightTransformFunction;
   private int _scale;
-  private boolean _hasLiteralArg;
+  private boolean _fixedScale;
 
   @Override
   public String getName() {
@@ -52,13 +52,13 @@ public class RoundDecimalTransformFunction extends BaseTransformFunction {
           "roundDecimal transform function supports either 1 or 2 arguments. Num arguments provided: " + numArguments);
     }
 
-    _hasLiteralArg = false;
+    _fixedScale = false;
     _leftTransformFunction = arguments.get(0);
     if (numArguments > 1) {
       _rightTransformFunction = arguments.get(1);
       if (_rightTransformFunction instanceof LiteralTransformFunction) {
         _scale = Integer.parseInt(((LiteralTransformFunction) _rightTransformFunction).getLiteral());
-        _hasLiteralArg = true;
+        _fixedScale = true;
       }
       Preconditions.checkArgument(
           _rightTransformFunction.getResultMetadata().isSingleValue() && isIntegralResultDatatype(
@@ -91,7 +91,7 @@ public class RoundDecimalTransformFunction extends BaseTransformFunction {
     }
 
     double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
-    if (_hasLiteralArg) {
+    if (_fixedScale) {
       for (int i = 0; i < length; i++) {
         _doubleValuesSV[i] = BigDecimal.valueOf(leftValues[i])
             .setScale(_scale, RoundingMode.HALF_UP).doubleValue();
@@ -104,8 +104,7 @@ public class RoundDecimalTransformFunction extends BaseTransformFunction {
       }
     } else {
       for (int i = 0; i < length; i++) {
-        _doubleValuesSV[i] = BigDecimal.valueOf(leftValues[i])
-            .setScale(0, RoundingMode.HALF_UP).doubleValue();
+        _doubleValuesSV[i] = (double) Math.round(leftValues[i]);
       }
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
@@ -1,0 +1,62 @@
+package org.apache.pinot.core.operator.transform.function;
+
+import com.google.common.base.Preconditions;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+
+
+//TODO: The function should ideally be named 'round'
+// but it is not possible because of existing DateTimeFunction with same name.
+public class RoundDecimalTransformFunction extends BaseTransformFunction {
+  public static final String FUNCTION_NAME = "roundDecimal";
+  private double[] _result;
+  private TransformFunction _leftTransformFunction;
+  private TransformFunction _rightTransformFunction;
+
+  @Override
+  public String getName() {
+    return FUNCTION_NAME;
+  }
+
+  @Override
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
+    // Check that there are more than 1 arguments
+    if (arguments.size() == 2) {
+      throw new IllegalArgumentException("Exactly 2 arguments are required for roundDecimal transform function");
+    }
+
+    _leftTransformFunction = arguments.get(0);
+    _rightTransformFunction = arguments.get(1);
+    Preconditions.checkArgument(
+        _leftTransformFunction.getResultMetadata().isSingleValue() || _rightTransformFunction.getResultMetadata()
+            .isSingleValue(), "Argument must be single-valued for transform function: %s", getName());
+  }
+
+  @Override
+  public TransformResultMetadata getResultMetadata() {
+    return DOUBLE_SV_NO_DICTIONARY_METADATA;
+  }
+
+  @Override
+  public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
+    if (_result == null) {
+      _result = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    }
+
+    int length = projectionBlock.getNumDocs();
+    double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
+    int[] rightValues = _rightTransformFunction.transformToIntValuesSV(projectionBlock);
+    for (int i = 0; i < length; i++) {
+      _result[i] = Math.atan2(leftValues[i], rightValues[i]);
+      BigDecimal.valueOf(leftValues[i]).setScale(rightValues[i], RoundingMode.HALF_UP).doubleValue();
+    }
+
+    return _result;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
@@ -29,11 +29,12 @@ public class RoundDecimalTransformFunction extends BaseTransformFunction {
     int numArguments = arguments.size();
     // Check that there are more than 2 arguments or no arguments
     if (numArguments < 1 || numArguments > 2) {
-      throw new IllegalArgumentException("roundDecimal transform function supports either 1 or 2 arguments. Num arguments provided: " + numArguments);
+      throw new IllegalArgumentException(
+          "roundDecimal transform function supports either 1 or 2 arguments. Num arguments provided: " + numArguments);
     }
 
     _leftTransformFunction = arguments.get(0);
-    if(numArguments > 1) {
+    if (numArguments > 1) {
       _rightTransformFunction = arguments.get(1);
     } else {
       _rightTransformFunction = new LiteralTransformFunction("0");

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
-import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.spi.data.FieldSpec;
 
@@ -37,6 +36,7 @@ public class RoundDecimalTransformFunction extends BaseTransformFunction {
   private double[] _result;
   private TransformFunction _leftTransformFunction;
   private TransformFunction _rightTransformFunction;
+  private Integer _scale;
 
   @Override
   public String getName() {
@@ -55,18 +55,25 @@ public class RoundDecimalTransformFunction extends BaseTransformFunction {
     _leftTransformFunction = arguments.get(0);
     if (numArguments > 1) {
       _rightTransformFunction = arguments.get(1);
-      Preconditions.checkArgument(_rightTransformFunction.getResultMetadata().isSingleValue()
-              && isArgumentDataTypeValid(_rightTransformFunction),
-          "Argument must be single-valued with type INT for transform function: %s", getName());
+      if (_rightTransformFunction instanceof LiteralTransformFunction) {
+        _scale = Integer.parseInt(((LiteralTransformFunction) _rightTransformFunction).getLiteral());
+      } else {
+        _scale = null;
+      }
+      Preconditions.checkArgument(
+          _rightTransformFunction.getResultMetadata().isSingleValue() && isIntegralResultDatatype(
+              _rightTransformFunction),
+          "Argument must be single-valued with type INT or LONG for transform function: %s", getName());
     } else {
       _rightTransformFunction = null;
+      _scale = null;
     }
 
     Preconditions.checkArgument(_leftTransformFunction.getResultMetadata().isSingleValue(),
         "Argument must be single-valued for transform function: %s", getName());
   }
 
-  private boolean isArgumentDataTypeValid(TransformFunction transformFunction) {
+  private boolean isIntegralResultDatatype(TransformFunction transformFunction) {
     return transformFunction.getResultMetadata().getDataType().getStoredType() == FieldSpec.DataType.INT
         || transformFunction.getResultMetadata().getDataType().getStoredType() == FieldSpec.DataType.LONG;
   }
@@ -78,13 +85,18 @@ public class RoundDecimalTransformFunction extends BaseTransformFunction {
 
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
-    if (_result == null) {
-      _result = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    int length = projectionBlock.getNumDocs();
+
+    if (_result == null || _result.length < length) {
+      _result = new double[length];
     }
 
-    int length = projectionBlock.getNumDocs();
     double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
-    if (_rightTransformFunction != null) {
+    if (_scale != null) {
+      for (int i = 0; i < length; i++) {
+        _result[i] = BigDecimal.valueOf(leftValues[i]).setScale(_scale, RoundingMode.HALF_UP).doubleValue();
+      }
+    } else if (_rightTransformFunction != null) {
       int[] rightValues = _rightTransformFunction.transformToIntValuesSV(projectionBlock);
       for (int i = 0; i < length; i++) {
         _result[i] = BigDecimal.valueOf(leftValues[i]).setScale(rightValues[i], RoundingMode.HALF_UP).doubleValue();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
@@ -33,7 +33,6 @@ import org.apache.pinot.spi.data.FieldSpec;
 // but it is not possible because of existing DateTimeFunction with same name.
 public class RoundDecimalTransformFunction extends BaseTransformFunction {
   public static final String FUNCTION_NAME = "roundDecimal";
-  private double[] _result;
   private TransformFunction _leftTransformFunction;
   private TransformFunction _rightTransformFunction;
   private int _scale;
@@ -87,26 +86,26 @@ public class RoundDecimalTransformFunction extends BaseTransformFunction {
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
 
-    if (_result == null || _result.length < length) {
-      _result = new double[length];
+    if (_doubleValuesSV == null || _doubleValuesSV.length < length) {
+      _doubleValuesSV = new double[length];
     }
 
     double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
     if (_scale != Integer.MIN_VALUE) {
       for (int i = 0; i < length; i++) {
-        _result[i] = BigDecimal.valueOf(leftValues[i]).setScale(_scale, RoundingMode.HALF_UP).doubleValue();
+        _doubleValuesSV[i] = BigDecimal.valueOf(leftValues[i]).setScale(_scale, RoundingMode.HALF_UP).doubleValue();
       }
     } else if (_rightTransformFunction != null) {
       int[] rightValues = _rightTransformFunction.transformToIntValuesSV(projectionBlock);
       for (int i = 0; i < length; i++) {
-        _result[i] = BigDecimal.valueOf(leftValues[i]).setScale(rightValues[i], RoundingMode.HALF_UP).doubleValue();
+        _doubleValuesSV[i] = BigDecimal.valueOf(leftValues[i]).setScale(rightValues[i], RoundingMode.HALF_UP).doubleValue();
       }
     } else {
       for (int i = 0; i < length; i++) {
-        _result[i] = BigDecimal.valueOf(leftValues[i]).setScale(0, RoundingMode.HALF_UP).doubleValue();
+        _doubleValuesSV[i] = BigDecimal.valueOf(leftValues[i]).setScale(0, RoundingMode.HALF_UP).doubleValue();
       }
     }
 
-    return _result;
+    return _doubleValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
-import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 
 
@@ -55,12 +54,14 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
 
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
-    if (_results == null) {
-      _results = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    int length = projectionBlock.getNumDocs();
+
+    if (_results == null || _results.length < length) {
+      _results = new double[length];
     }
 
     double[] values = _transformFunction.transformToDoubleValuesSV(projectionBlock);
-    applyMathOperator(values, projectionBlock.getNumDocs());
+    applyMathOperator(values, length);
     return _results;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
@@ -164,7 +164,7 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
 
   public static class Log2TransformFunction extends SingleParamMathTransformFunction {
     public static final String FUNCTION_NAME = "log2";
-    public static final double LOG_BASE = Math.log(2);
+    public static final double LOG_BASE = 0.6931471805599453d;
 
     @Override
     public String getName() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
@@ -164,6 +164,7 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
 
   public static class Log2TransformFunction extends SingleParamMathTransformFunction {
     public static final String FUNCTION_NAME = "log2";
+    public static final double LOG_BASE = Math.log(2);
 
     @Override
     public String getName() {
@@ -173,9 +174,8 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
     @Override
     protected void applyMathOperator(double[] values, int length) {
       for (int i = 0; i < length; i++) {
-        _results[i] = Math.log(values[i]) / Math.log(2);
+        _results[i] = Math.log(values[i]) / LOG_BASE;
       }
-      ;
     }
   }
 
@@ -192,7 +192,6 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
       for (int i = 0; i < length; i++) {
         _results[i] = Math.log10(values[i]);
       }
-      ;
     }
   }
 
@@ -209,7 +208,6 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
       for (int i = 0; i < length; i++) {
         _results[i] = Math.signum(values[i]);
       }
-      ;
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
@@ -37,8 +37,8 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
 
   @Override
   public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
-    Preconditions
-        .checkArgument(arguments.size() == 1, "Exactly 1 argument is required for transform function: %s", getName());
+    Preconditions.checkArgument(arguments.size() == 1, "Exactly 1 argument is required for transform function: %s",
+        getName());
     TransformFunction transformFunction = arguments.get(0);
     Preconditions.checkArgument(!(transformFunction instanceof LiteralTransformFunction),
         "Argument cannot be literal for transform function: %s", getName());
@@ -172,7 +172,10 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
 
     @Override
     protected void applyMathOperator(double[] values, int length) {
-      for(int i = 0; i < length; i++) { _results[i] =  Math.log(values[i]) / Math.log(2) ; };
+      for (int i = 0; i < length; i++) {
+        _results[i] = Math.log(values[i]) / Math.log(2);
+      }
+      ;
     }
   }
 
@@ -186,7 +189,10 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
 
     @Override
     protected void applyMathOperator(double[] values, int length) {
-      for(int i = 0; i < length; i++) { _results[i] =  Math.log10(values[i]); };
+      for (int i = 0; i < length; i++) {
+        _results[i] = Math.log10(values[i]);
+      }
+      ;
     }
   }
 
@@ -200,8 +206,10 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
 
     @Override
     protected void applyMathOperator(double[] values, int length) {
-      for(int i = 0; i < length; i++) { _results[i] =  Math.signum(values[i]); };
+      for (int i = 0; i < length; i++) {
+        _results[i] = Math.signum(values[i]);
+      }
+      ;
     }
   }
-
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
@@ -162,8 +162,22 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
     }
   }
 
-  public static class LogTransformFunction extends SingleParamMathTransformFunction {
-    public static final String FUNCTION_NAME = "log";
+  public static class Log2TransformFunction extends SingleParamMathTransformFunction {
+    public static final String FUNCTION_NAME = "log2";
+
+    @Override
+    public String getName() {
+      return FUNCTION_NAME;
+    }
+
+    @Override
+    protected void applyMathOperator(double[] values, int length) {
+      for(int i = 0; i < length; i++) { _results[i] =  Math.log(values[i]) / Math.log(2) ; };
+    }
+  }
+
+  public static class Log10TransformFunction extends SingleParamMathTransformFunction {
+    public static final String FUNCTION_NAME = "log10";
 
     @Override
     public String getName() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
@@ -161,4 +161,33 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
       }
     }
   }
+
+  public static class LogTransformFunction extends SingleParamMathTransformFunction {
+    public static final String FUNCTION_NAME = "log";
+
+    @Override
+    public String getName() {
+      return FUNCTION_NAME;
+    }
+
+    @Override
+    protected void applyMathOperator(double[] values, int length) {
+      for(int i = 0; i < length; i++) { _results[i] =  Math.log10(values[i]); };
+    }
+  }
+
+  public static class SignTransformFunction extends SingleParamMathTransformFunction {
+    public static final String FUNCTION_NAME = "sign";
+
+    @Override
+    public String getName() {
+      return FUNCTION_NAME;
+    }
+
+    @Override
+    protected void applyMathOperator(double[] values, int length) {
+      for(int i = 0; i < length; i++) { _results[i] =  Math.signum(values[i]); };
+    }
+  }
+
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
@@ -147,22 +147,6 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
     }
   }
 
-  public static class SqrtTransformFunction extends SingleParamMathTransformFunction {
-    public static final String FUNCTION_NAME = "sqrt";
-
-    @Override
-    public String getName() {
-      return FUNCTION_NAME;
-    }
-
-    @Override
-    protected void applyMathOperator(double[] values, int length) {
-      for (int i = 0; i < length; i++) {
-        _results[i] = Math.sqrt(values[i]);
-      }
-    }
-  }
-
   public static class Log2TransformFunction extends SingleParamMathTransformFunction {
     public static final String FUNCTION_NAME = "log2";
     public static final double LOG_BASE = Math.log(2.0);
@@ -192,6 +176,22 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
     protected void applyMathOperator(double[] values, int length) {
       for (int i = 0; i < length; i++) {
         _results[i] = Math.log10(values[i]);
+      }
+    }
+  }
+
+  public static class SqrtTransformFunction extends SingleParamMathTransformFunction {
+    public static final String FUNCTION_NAME = "sqrt";
+
+    @Override
+    public String getName() {
+      return FUNCTION_NAME;
+    }
+
+    @Override
+    protected void applyMathOperator(double[] values, int length) {
+      for (int i = 0; i < length; i++) {
+        _results[i] = Math.sqrt(values[i]);
       }
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
@@ -165,7 +165,7 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
 
   public static class Log2TransformFunction extends SingleParamMathTransformFunction {
     public static final String FUNCTION_NAME = "log2";
-    public static final double LOG_BASE = 0.6931471805599453d;
+    public static final double LOG_BASE = Math.log(2.0);
 
     @Override
     public String getName() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -105,6 +105,7 @@ public class TransformFunctionFactory {
     typeToImplementation.put(TransformFunctionType.SQRT, SqrtTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.ROUND_DECIMAL, RoundDecimalTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.SIGN, SignTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.POWER, PowerTransformFunction.class);
 
     typeToImplementation.put(TransformFunctionType.CAST, CastTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.JSONEXTRACTSCALAR,

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -100,6 +100,7 @@ public class TransformFunctionFactory {
     typeToImplementation.put(TransformFunctionType.EXP, ExpTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.FLOOR, FloorTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.LN, LnTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.LOG, LnTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.LOG2, Log2TransformFunction.class);
     typeToImplementation.put(TransformFunctionType.LOG10, Log10TransformFunction.class);
     typeToImplementation.put(TransformFunctionType.SQRT, SqrtTransformFunction.class);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -52,10 +52,23 @@ import org.apache.pinot.core.operator.transform.function.SingleParamMathTransfor
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.FloorTransformFunction;
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.LnTransformFunction;
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.SqrtTransformFunction;
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.LogTransformFunction;
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.SignTransformFunction;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
-
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.SinTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.CosTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.TanTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.AsinTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.AcosTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.AtanTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.Atan2TransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.SinhTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.CoshTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.TanhTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.DegreesTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.RadiansTransformFunction;
 
 /**
  * Factory class for transformation functions.
@@ -86,7 +99,9 @@ public class TransformFunctionFactory {
     typeToImplementation.put(TransformFunctionType.EXP, ExpTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.FLOOR, FloorTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.LN, LnTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.LOG, LogTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.SQRT, SqrtTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.ROUND_DECIMAL, RoundDecimalTransformFunction.class);
 
     typeToImplementation.put(TransformFunctionType.CAST, CastTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.JSONEXTRACTSCALAR,
@@ -185,6 +200,20 @@ public class TransformFunctionFactory {
     typeToImplementation.put(TransformFunctionType.IS_NULL, IsNullTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.IS_NOT_NULL,
         IsNotNullTransformFunction.class);
+
+    // Trignometric functions
+    typeToImplementation.put(TransformFunctionType.SIN, SinTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.COS, CosTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.TAN, TanTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.ASIN, AsinTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.ACOS, AcosTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.ATAN, AtanTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.ATAN2, Atan2TransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.SINH, SinhTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.COSH, CoshTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.TANH, TanhTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.DEGREES, DegreesTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.RADIANS, RadiansTransformFunction.class);
 
     Map<String, Class<? extends TransformFunction>> registry = new HashMap<>(typeToImplementation.size());
     for (Map.Entry<TransformFunctionType, Class<? extends TransformFunction>> entry : typeToImplementation.entrySet()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -52,7 +52,8 @@ import org.apache.pinot.core.operator.transform.function.SingleParamMathTransfor
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.FloorTransformFunction;
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.LnTransformFunction;
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.SqrtTransformFunction;
-import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.LogTransformFunction;
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.Log2TransformFunction;
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.Log10TransformFunction;
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.SignTransformFunction;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.datasource.DataSource;
@@ -99,7 +100,8 @@ public class TransformFunctionFactory {
     typeToImplementation.put(TransformFunctionType.EXP, ExpTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.FLOOR, FloorTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.LN, LnTransformFunction.class);
-    typeToImplementation.put(TransformFunctionType.LOG, LogTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.LOG2, Log2TransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.LOG10, Log10TransformFunction.class);
     typeToImplementation.put(TransformFunctionType.SQRT, SqrtTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.ROUND_DECIMAL, RoundDecimalTransformFunction.class);
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -104,9 +104,10 @@ public class TransformFunctionFactory {
     typeToImplementation.put(TransformFunctionType.LOG2, Log2TransformFunction.class);
     typeToImplementation.put(TransformFunctionType.LOG10, Log10TransformFunction.class);
     typeToImplementation.put(TransformFunctionType.SQRT, SqrtTransformFunction.class);
-    typeToImplementation.put(TransformFunctionType.ROUND_DECIMAL, RoundDecimalTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.SIGN, SignTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.POWER, PowerTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.ROUND_DECIMAL, RoundDecimalTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.TRUNCATE, TruncateDecimalTransformFunction.class);
 
     typeToImplementation.put(TransformFunctionType.CAST, CastTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.JSONEXTRACTSCALAR,

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -51,25 +51,25 @@ import org.apache.pinot.core.operator.transform.function.SingleParamMathTransfor
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.ExpTransformFunction;
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.FloorTransformFunction;
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.LnTransformFunction;
-import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.SqrtTransformFunction;
-import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.Log2TransformFunction;
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.Log10TransformFunction;
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.Log2TransformFunction;
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.SignTransformFunction;
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.SqrtTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.AcosTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.AsinTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.Atan2TransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.AtanTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.CosTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.CoshTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.DegreesTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.RadiansTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.SinTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.SinhTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.TanTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.TanhTransformFunction;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
-import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.SinTransformFunction;
-import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.CosTransformFunction;
-import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.TanTransformFunction;
-import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.AsinTransformFunction;
-import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.AcosTransformFunction;
-import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.AtanTransformFunction;
-import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.Atan2TransformFunction;
-import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.SinhTransformFunction;
-import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.CoshTransformFunction;
-import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.TanhTransformFunction;
-import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.DegreesTransformFunction;
-import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.RadiansTransformFunction;
 
 /**
  * Factory class for transformation functions.
@@ -104,6 +104,7 @@ public class TransformFunctionFactory {
     typeToImplementation.put(TransformFunctionType.LOG10, Log10TransformFunction.class);
     typeToImplementation.put(TransformFunctionType.SQRT, SqrtTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.ROUND_DECIMAL, RoundDecimalTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.SIGN, SignTransformFunction.class);
 
     typeToImplementation.put(TransformFunctionType.CAST, CastTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.JSONEXTRACTSCALAR,

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TrigonometricTransformFunctions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TrigonometricTransformFunctions.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.operator.transform.function;
 
 import com.google.common.base.Preconditions;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TrigonometricTransformFunctions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TrigonometricTransformFunctions.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
-import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 
 
@@ -60,11 +59,12 @@ public class TrigonometricTransformFunctions {
 
     @Override
     public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
-      if (_result == null) {
-        _result = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      int length = projectionBlock.getNumDocs();
+
+      if (_result == null || _result.length < length) {
+        _result = new double[length];
       }
 
-      int length = projectionBlock.getNumDocs();
       double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
       double[] rightValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
       for (int i = 0; i < length; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TrigonometricTransformFunctions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TrigonometricTransformFunctions.java
@@ -1,0 +1,151 @@
+package org.apache.pinot.core.operator.transform.function;
+
+import java.lang.Override;
+import java.lang.String;
+
+public class TrigonometricTransformFunctions {
+
+  public static class DegreesTransformFunction extends SingleParamMathTransformFunction {
+    @Override
+    public String getName() {
+      return "degrees";
+    }
+
+    @Override
+    protected void applyMathOperator(double[] values, int length) {
+      for(int i = 0; i < length; i++) { _results[i] =  Math.toDegrees(values[i]); };
+    }
+  }
+
+  public static class AcosTransformFunction extends SingleParamMathTransformFunction {
+    @Override
+    public String getName() {
+      return "acos";
+    }
+
+    @Override
+    protected void applyMathOperator(double[] values, int length) {
+      for(int i = 0; i < length; i++) { _results[i] =  Math.acos(values[i]); };
+    }
+  }
+
+  public static class TanTransformFunction extends SingleParamMathTransformFunction {
+    @Override
+    public String getName() {
+      return "tan";
+    }
+
+    @Override
+    protected void applyMathOperator(double[] values, int length) {
+      for(int i = 0; i < length; i++) { _results[i] =  Math.tan(values[i]); };
+    }
+  }
+
+  public static class SinhTransformFunction extends SingleParamMathTransformFunction {
+    @Override
+    public String getName() {
+      return "sinh";
+    }
+
+    @Override
+    protected void applyMathOperator(double[] values, int length) {
+      for(int i = 0; i < length; i++) { _results[i] =  Math.sinh(values[i]); };
+    }
+  }
+
+  public static class CotTransformFunction extends SingleParamMathTransformFunction {
+    @Override
+    public String getName() {
+      return "cot";
+    }
+
+    @Override
+    protected void applyMathOperator(double[] values, int length) {
+      for(int i = 0; i < length; i++) { _results[i] =  1.0/Math.tan(values[i]); };
+    }
+  }
+
+  public static class AtanTransformFunction extends SingleParamMathTransformFunction {
+    @Override
+    public String getName() {
+      return "atan";
+    }
+
+    @Override
+    protected void applyMathOperator(double[] values, int length) {
+      for(int i = 0; i < length; i++) { _results[i] =  Math.atan(values[i]); };
+    }
+  }
+
+  public static class CosTransformFunction extends SingleParamMathTransformFunction {
+    @Override
+    public String getName() {
+      return "cos";
+    }
+
+    @Override
+    protected void applyMathOperator(double[] values, int length) {
+      for(int i = 0; i < length; i++) { _results[i] =  Math.cos(values[i]); };
+    }
+  }
+
+  public static class AsinTransformFunction extends SingleParamMathTransformFunction {
+    @Override
+    public String getName() {
+      return "asin";
+    }
+
+    @Override
+    protected void applyMathOperator(double[] values, int length) {
+      for(int i = 0; i < length; i++) { _results[i] =  Math.asin(values[i]); };
+    }
+  }
+
+  public static class CoshTransformFunction extends SingleParamMathTransformFunction {
+    @Override
+    public String getName() {
+      return "cosh";
+    }
+
+    @Override
+    protected void applyMathOperator(double[] values, int length) {
+      for(int i = 0; i < length; i++) { _results[i] =  Math.cosh(values[i]); };
+    }
+  }
+
+  public static class SinTransformFunction extends SingleParamMathTransformFunction {
+    @Override
+    public String getName() {
+      return "sin";
+    }
+
+    @Override
+    protected void applyMathOperator(double[] values, int length) {
+      for(int i = 0; i < length; i++) { _results[i] =  Math.sin(values[i]); };
+    }
+  }
+
+  public static class TanhTransformFunction extends SingleParamMathTransformFunction {
+    @Override
+    public String getName() {
+      return "tanh";
+    }
+
+    @Override
+    protected void applyMathOperator(double[] values, int length) {
+      for(int i = 0; i < length; i++) { _results[i] =  Math.tanh(values[i]); };
+    }
+  }
+
+  public static class RadiansTransformFunction extends SingleParamMathTransformFunction {
+    @Override
+    public String getName() {
+      return "radians";
+    }
+
+    @Override
+    protected void applyMathOperator(double[] values, int length) {
+      for(int i = 0; i < length; i++) { _results[i] =  Math.toRadians(values[i]); };
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TrigonometricTransformFunctions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TrigonometricTransformFunctions.java
@@ -1,17 +1,12 @@
 package org.apache.pinot.core.operator.transform.function;
 
 import com.google.common.base.Preconditions;
-import java.lang.Override;
-import java.lang.String;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.segment.spi.datasource.DataSource;
-import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class TrigonometricTransformFunctions {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TrigonometricTransformFunctions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TrigonometricTransformFunctions.java
@@ -1,151 +1,268 @@
 package org.apache.pinot.core.operator.transform.function;
 
+import com.google.common.base.Preconditions;
 import java.lang.Override;
 import java.lang.String;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.spi.data.FieldSpec;
+
 
 public class TrigonometricTransformFunctions {
+  public static class Atan2TransformFunction extends BaseTransformFunction {
+    public static final String FUNCTION_NAME = "atan2";
+    private double[] _result;
+    private TransformFunction _leftTransformFunction;
+    private TransformFunction _rightTransformFunction;
 
-  public static class DegreesTransformFunction extends SingleParamMathTransformFunction {
     @Override
     public String getName() {
-      return "degrees";
+      return FUNCTION_NAME;
+    }
+
+    @Override
+    public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
+      // Check that there are more than 1 arguments
+      if (arguments.size() == 2) {
+        throw new IllegalArgumentException("Exactly 2 arguments are required for Atan2 transform function");
+      }
+
+      _leftTransformFunction = arguments.get(0);
+      _rightTransformFunction = arguments.get(1);
+      Preconditions.checkArgument(
+          _leftTransformFunction.getResultMetadata().isSingleValue() || _rightTransformFunction.getResultMetadata()
+              .isSingleValue(), "Argument must be single-valued for transform function: %s", getName());
+    }
+
+    @Override
+    public TransformResultMetadata getResultMetadata() {
+      return DOUBLE_SV_NO_DICTIONARY_METADATA;
+    }
+
+    @Override
+    public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
+      if (_result == null) {
+        _result = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      }
+
+      int length = projectionBlock.getNumDocs();
+      double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
+      double[] rightValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
+      for (int i = 0; i < length; i++) {
+        _result[i] = Math.atan2(leftValues[i], rightValues[i]);
+      }
+
+      return _result;
+    }
+  }
+
+  public static class DegreesTransformFunction extends SingleParamMathTransformFunction {
+    public static final String FUNCTION_NAME = "degrees";
+
+    @Override
+    public String getName() {
+      return FUNCTION_NAME;
     }
 
     @Override
     protected void applyMathOperator(double[] values, int length) {
-      for(int i = 0; i < length; i++) { _results[i] =  Math.toDegrees(values[i]); };
+      for (int i = 0; i < length; i++) {
+        _results[i] = Math.toDegrees(values[i]);
+      }
+      ;
     }
   }
 
   public static class AcosTransformFunction extends SingleParamMathTransformFunction {
+    public static final String FUNCTION_NAME = "acos";
+
     @Override
     public String getName() {
-      return "acos";
+      return FUNCTION_NAME;
     }
 
     @Override
     protected void applyMathOperator(double[] values, int length) {
-      for(int i = 0; i < length; i++) { _results[i] =  Math.acos(values[i]); };
+      for (int i = 0; i < length; i++) {
+        _results[i] = Math.acos(values[i]);
+      }
+      ;
     }
   }
 
   public static class TanTransformFunction extends SingleParamMathTransformFunction {
+    public static final String FUNCTION_NAME = "tan";
+
     @Override
     public String getName() {
-      return "tan";
+      return FUNCTION_NAME;
     }
 
     @Override
     protected void applyMathOperator(double[] values, int length) {
-      for(int i = 0; i < length; i++) { _results[i] =  Math.tan(values[i]); };
+      for (int i = 0; i < length; i++) {
+        _results[i] = Math.tan(values[i]);
+      }
+      ;
     }
   }
 
   public static class SinhTransformFunction extends SingleParamMathTransformFunction {
+    public static final String FUNCTION_NAME = "sinh";
+
     @Override
     public String getName() {
-      return "sinh";
+      return FUNCTION_NAME;
     }
 
     @Override
     protected void applyMathOperator(double[] values, int length) {
-      for(int i = 0; i < length; i++) { _results[i] =  Math.sinh(values[i]); };
+      for (int i = 0; i < length; i++) {
+        _results[i] = Math.sinh(values[i]);
+      }
+      ;
     }
   }
 
   public static class CotTransformFunction extends SingleParamMathTransformFunction {
+    public static final String FUNCTION_NAME = "cot";
+
     @Override
     public String getName() {
-      return "cot";
+      return FUNCTION_NAME;
     }
 
     @Override
     protected void applyMathOperator(double[] values, int length) {
-      for(int i = 0; i < length; i++) { _results[i] =  1.0/Math.tan(values[i]); };
+      for (int i = 0; i < length; i++) {
+        _results[i] = 1.0 / Math.tan(values[i]);
+      }
+      ;
     }
   }
 
   public static class AtanTransformFunction extends SingleParamMathTransformFunction {
+    public static final String FUNCTION_NAME = "atan";
+
     @Override
     public String getName() {
-      return "atan";
+      return FUNCTION_NAME;
     }
 
     @Override
     protected void applyMathOperator(double[] values, int length) {
-      for(int i = 0; i < length; i++) { _results[i] =  Math.atan(values[i]); };
+      for (int i = 0; i < length; i++) {
+        _results[i] = Math.atan(values[i]);
+      }
+      ;
     }
   }
 
   public static class CosTransformFunction extends SingleParamMathTransformFunction {
+    public static final String FUNCTION_NAME = "cos";
+
     @Override
     public String getName() {
-      return "cos";
+      return FUNCTION_NAME;
     }
 
     @Override
     protected void applyMathOperator(double[] values, int length) {
-      for(int i = 0; i < length; i++) { _results[i] =  Math.cos(values[i]); };
+      for (int i = 0; i < length; i++) {
+        _results[i] = Math.cos(values[i]);
+      }
+      ;
     }
   }
 
   public static class AsinTransformFunction extends SingleParamMathTransformFunction {
+    public static final String FUNCTION_NAME = "asin";
+
     @Override
     public String getName() {
-      return "asin";
+      return FUNCTION_NAME;
     }
 
     @Override
     protected void applyMathOperator(double[] values, int length) {
-      for(int i = 0; i < length; i++) { _results[i] =  Math.asin(values[i]); };
+      for (int i = 0; i < length; i++) {
+        _results[i] = Math.asin(values[i]);
+      }
+      ;
     }
   }
 
   public static class CoshTransformFunction extends SingleParamMathTransformFunction {
+    public static final String FUNCTION_NAME = "cosh";
+
     @Override
     public String getName() {
-      return "cosh";
+      return FUNCTION_NAME;
     }
 
     @Override
     protected void applyMathOperator(double[] values, int length) {
-      for(int i = 0; i < length; i++) { _results[i] =  Math.cosh(values[i]); };
+      for (int i = 0; i < length; i++) {
+        _results[i] = Math.cosh(values[i]);
+      }
+      ;
     }
   }
 
   public static class SinTransformFunction extends SingleParamMathTransformFunction {
+    public static final String FUNCTION_NAME = "sin";
+
     @Override
     public String getName() {
-      return "sin";
+      return FUNCTION_NAME;
     }
 
     @Override
     protected void applyMathOperator(double[] values, int length) {
-      for(int i = 0; i < length; i++) { _results[i] =  Math.sin(values[i]); };
+      for (int i = 0; i < length; i++) {
+        _results[i] = Math.sin(values[i]);
+      }
+      ;
     }
   }
 
   public static class TanhTransformFunction extends SingleParamMathTransformFunction {
+    public static final String FUNCTION_NAME = "tanh";
+
     @Override
     public String getName() {
-      return "tanh";
+      return FUNCTION_NAME;
     }
 
     @Override
     protected void applyMathOperator(double[] values, int length) {
-      for(int i = 0; i < length; i++) { _results[i] =  Math.tanh(values[i]); };
+      for (int i = 0; i < length; i++) {
+        _results[i] = Math.tanh(values[i]);
+      }
+      ;
     }
   }
 
   public static class RadiansTransformFunction extends SingleParamMathTransformFunction {
+    public static final String FUNCTION_NAME = "radians";
+
     @Override
     public String getName() {
-      return "radians";
+      return FUNCTION_NAME;
     }
 
     @Override
     protected void applyMathOperator(double[] values, int length) {
-      for(int i = 0; i < length; i++) { _results[i] =  Math.toRadians(values[i]); };
+      for (int i = 0; i < length; i++) {
+        _results[i] = Math.toRadians(values[i]);
+      }
+      ;
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TrigonometricTransformFunctions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TrigonometricTransformFunctions.java
@@ -88,7 +88,6 @@ public class TrigonometricTransformFunctions {
       for (int i = 0; i < length; i++) {
         _results[i] = Math.toDegrees(values[i]);
       }
-      ;
     }
   }
 
@@ -105,7 +104,6 @@ public class TrigonometricTransformFunctions {
       for (int i = 0; i < length; i++) {
         _results[i] = Math.acos(values[i]);
       }
-      ;
     }
   }
 
@@ -122,7 +120,6 @@ public class TrigonometricTransformFunctions {
       for (int i = 0; i < length; i++) {
         _results[i] = Math.tan(values[i]);
       }
-      ;
     }
   }
 
@@ -139,7 +136,6 @@ public class TrigonometricTransformFunctions {
       for (int i = 0; i < length; i++) {
         _results[i] = Math.sinh(values[i]);
       }
-      ;
     }
   }
 
@@ -156,7 +152,6 @@ public class TrigonometricTransformFunctions {
       for (int i = 0; i < length; i++) {
         _results[i] = 1.0 / Math.tan(values[i]);
       }
-      ;
     }
   }
 
@@ -173,7 +168,6 @@ public class TrigonometricTransformFunctions {
       for (int i = 0; i < length; i++) {
         _results[i] = Math.atan(values[i]);
       }
-      ;
     }
   }
 
@@ -190,7 +184,6 @@ public class TrigonometricTransformFunctions {
       for (int i = 0; i < length; i++) {
         _results[i] = Math.cos(values[i]);
       }
-      ;
     }
   }
 
@@ -207,7 +200,6 @@ public class TrigonometricTransformFunctions {
       for (int i = 0; i < length; i++) {
         _results[i] = Math.asin(values[i]);
       }
-      ;
     }
   }
 
@@ -224,7 +216,6 @@ public class TrigonometricTransformFunctions {
       for (int i = 0; i < length; i++) {
         _results[i] = Math.cosh(values[i]);
       }
-      ;
     }
   }
 
@@ -241,7 +232,6 @@ public class TrigonometricTransformFunctions {
       for (int i = 0; i < length; i++) {
         _results[i] = Math.sin(values[i]);
       }
-      ;
     }
   }
 
@@ -258,7 +248,6 @@ public class TrigonometricTransformFunctions {
       for (int i = 0; i < length; i++) {
         _results[i] = Math.tanh(values[i]);
       }
-      ;
     }
   }
 
@@ -275,7 +264,6 @@ public class TrigonometricTransformFunctions {
       for (int i = 0; i < length; i++) {
         _results[i] = Math.toRadians(values[i]);
       }
-      ;
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TrigonometricTransformFunctions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TrigonometricTransformFunctions.java
@@ -24,7 +24,7 @@ public class TrigonometricTransformFunctions {
     @Override
     public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
       // Check that there are more than 1 arguments
-      if (arguments.size() == 2) {
+      if (arguments.size() != 2) {
         throw new IllegalArgumentException("Exactly 2 arguments are required for Atan2 transform function");
       }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TrigonometricTransformFunctions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TrigonometricTransformFunctions.java
@@ -29,7 +29,6 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
 public class TrigonometricTransformFunctions {
   public static class Atan2TransformFunction extends BaseTransformFunction {
     public static final String FUNCTION_NAME = "atan2";
-    private double[] _result;
     private TransformFunction _leftTransformFunction;
     private TransformFunction _rightTransformFunction;
 
@@ -61,17 +60,17 @@ public class TrigonometricTransformFunctions {
     public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
       int length = projectionBlock.getNumDocs();
 
-      if (_result == null || _result.length < length) {
-        _result = new double[length];
+      if (_doubleValuesSV == null || _doubleValuesSV.length < length) {
+        _doubleValuesSV = new double[length];
       }
 
       double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
       double[] rightValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
       for (int i = 0; i < length; i++) {
-        _result[i] = Math.atan2(leftValues[i], rightValues[i]);
+        _doubleValuesSV[i] = Math.atan2(leftValues[i], rightValues[i]);
       }
 
-      return _result;
+      return _doubleValuesSV;
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TruncateDecimalTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TruncateDecimalTransformFunction.java
@@ -34,7 +34,7 @@ public class TruncateDecimalTransformFunction extends BaseTransformFunction {
   private double[] _result;
   private TransformFunction _leftTransformFunction;
   private TransformFunction _rightTransformFunction;
-  private Integer _scale;
+  private int _scale;
 
   @Override
   public String getName() {
@@ -56,7 +56,7 @@ public class TruncateDecimalTransformFunction extends BaseTransformFunction {
       if (_rightTransformFunction instanceof LiteralTransformFunction) {
         _scale = Integer.parseInt(((LiteralTransformFunction) _rightTransformFunction).getLiteral());
       } else {
-        _scale = null;
+        _scale = Integer.MIN_VALUE;
       }
       Preconditions.checkArgument(
           _rightTransformFunction.getResultMetadata().isSingleValue() && isIntegralResultDatatype(
@@ -64,7 +64,7 @@ public class TruncateDecimalTransformFunction extends BaseTransformFunction {
           getName());
     } else {
       _rightTransformFunction = null;
-      _scale = null;
+      _scale = Integer.MIN_VALUE;
     }
 
     Preconditions.checkArgument(_leftTransformFunction.getResultMetadata().isSingleValue(),
@@ -90,7 +90,7 @@ public class TruncateDecimalTransformFunction extends BaseTransformFunction {
     }
 
     double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
-    if (_scale != null) {
+    if (_scale != Integer.MIN_VALUE) {
       for (int i = 0; i < length; i++) {
         _result[i] = BigDecimal.valueOf(leftValues[i]).setScale(_scale, RoundingMode.DOWN).doubleValue();
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TruncateDecimalTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TruncateDecimalTransformFunction.java
@@ -34,7 +34,7 @@ public class TruncateDecimalTransformFunction extends BaseTransformFunction {
   private TransformFunction _leftTransformFunction;
   private TransformFunction _rightTransformFunction;
   private int _scale;
-  private boolean _hasLiteralArg;
+  private boolean _fixedScale;
 
   @Override
   public String getName() {
@@ -50,13 +50,13 @@ public class TruncateDecimalTransformFunction extends BaseTransformFunction {
           "truncate transform function supports either 1 or 2 arguments. Num arguments provided: " + numArguments);
     }
 
-    _hasLiteralArg = false;
+    _fixedScale = false;
     _leftTransformFunction = arguments.get(0);
     if (numArguments > 1) {
       _rightTransformFunction = arguments.get(1);
       if (_rightTransformFunction instanceof LiteralTransformFunction) {
         _scale = Integer.parseInt(((LiteralTransformFunction) _rightTransformFunction).getLiteral());
-        _hasLiteralArg = true;
+        _fixedScale = true;
       }
       Preconditions.checkArgument(
           _rightTransformFunction.getResultMetadata().isSingleValue() && isIntegralResultDatatype(
@@ -89,7 +89,7 @@ public class TruncateDecimalTransformFunction extends BaseTransformFunction {
     }
 
     double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
-    if (_hasLiteralArg) {
+    if (_fixedScale) {
       for (int i = 0; i < length; i++) {
         _doubleValuesSV[i] = BigDecimal.valueOf(leftValues[i])
             .setScale(_scale, RoundingMode.DOWN).doubleValue();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TruncateDecimalTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TruncateDecimalTransformFunction.java
@@ -31,7 +31,6 @@ import org.apache.pinot.spi.data.FieldSpec;
 
 public class TruncateDecimalTransformFunction extends BaseTransformFunction {
   public static final String FUNCTION_NAME = "truncate";
-  private double[] _result;
   private TransformFunction _leftTransformFunction;
   private TransformFunction _rightTransformFunction;
   private int _scale;
@@ -85,26 +84,26 @@ public class TruncateDecimalTransformFunction extends BaseTransformFunction {
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
 
-    if (_result == null || _result.length < length) {
-      _result = new double[length];
+    if (_doubleValuesSV == null || _doubleValuesSV.length < length) {
+      _doubleValuesSV = new double[length];
     }
 
     double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
     if (_scale != Integer.MIN_VALUE) {
       for (int i = 0; i < length; i++) {
-        _result[i] = BigDecimal.valueOf(leftValues[i]).setScale(_scale, RoundingMode.DOWN).doubleValue();
+        _doubleValuesSV[i] = BigDecimal.valueOf(leftValues[i]).setScale(_scale, RoundingMode.DOWN).doubleValue();
       }
     } else if (_rightTransformFunction != null) {
       int[] rightValues = _rightTransformFunction.transformToIntValuesSV(projectionBlock);
       for (int i = 0; i < length; i++) {
-        _result[i] = BigDecimal.valueOf(leftValues[i]).setScale(rightValues[i], RoundingMode.DOWN).doubleValue();
+        _doubleValuesSV[i] = BigDecimal.valueOf(leftValues[i]).setScale(rightValues[i], RoundingMode.DOWN).doubleValue();
       }
     } else {
       for (int i = 0; i < length; i++) {
-        _result[i] = Math.signum(leftValues[i]) * Math.floor(Math.abs(leftValues[i]));
+        _doubleValuesSV[i] = Math.signum(leftValues[i]) * Math.floor(Math.abs(leftValues[i]));
       }
     }
 
-    return _result;
+    return _doubleValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TruncateDecimalTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TruncateDecimalTransformFunction.java
@@ -19,16 +19,19 @@
 package org.apache.pinot.core.operator.transform.function;
 
 import com.google.common.base.Preconditions;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.spi.data.FieldSpec;
 
 
-public class PowerTransformFunction extends BaseTransformFunction {
-  public static final String FUNCTION_NAME = "power";
+public class TruncateDecimalTransformFunction extends BaseTransformFunction {
+  public static final String FUNCTION_NAME = "truncate";
   private double[] _result;
   private TransformFunction _leftTransformFunction;
   private TransformFunction _rightTransformFunction;
@@ -40,16 +43,30 @@ public class PowerTransformFunction extends BaseTransformFunction {
 
   @Override
   public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
-    // Check that there are more than 1 arguments
-    if (arguments.size() != 2) {
-      throw new IllegalArgumentException("Exactly 2 arguments are required for power transform function");
+    int numArguments = arguments.size();
+    // Check that there are more than 2 arguments or no arguments
+    if (numArguments < 1 || numArguments > 2) {
+      throw new IllegalArgumentException(
+          "truncate transform function supports either 1 or 2 arguments. Num arguments provided: " + numArguments);
     }
 
     _leftTransformFunction = arguments.get(0);
-    _rightTransformFunction = arguments.get(1);
-    Preconditions.checkArgument(
-        _leftTransformFunction.getResultMetadata().isSingleValue() || _rightTransformFunction.getResultMetadata()
-            .isSingleValue(), "Argument must be single-valued for transform function: %s", getName());
+    if (numArguments > 1) {
+      _rightTransformFunction = arguments.get(1);
+      Preconditions.checkArgument(_rightTransformFunction.getResultMetadata().isSingleValue()
+              && isArgumentDataTypeValid(_rightTransformFunction),
+          "Argument must be single-valued with type INT for transform function: %s", getName());
+    } else {
+      _rightTransformFunction = null;
+    }
+
+    Preconditions.checkArgument(_leftTransformFunction.getResultMetadata().isSingleValue(),
+        "Argument must be single-valued for transform function: %s", getName());
+  }
+
+  private boolean isArgumentDataTypeValid(TransformFunction transformFunction) {
+    return transformFunction.getResultMetadata().getDataType().getStoredType() == FieldSpec.DataType.INT
+        || transformFunction.getResultMetadata().getDataType().getStoredType() == FieldSpec.DataType.LONG;
   }
 
   @Override
@@ -65,10 +82,17 @@ public class PowerTransformFunction extends BaseTransformFunction {
 
     int length = projectionBlock.getNumDocs();
     double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
-    double[] rightValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
-    for (int i = 0; i < length; i++) {
-      _result[i] = Math.pow(leftValues[i], rightValues[i]);
+    if (_rightTransformFunction != null) {
+      int[] rightValues = _rightTransformFunction.transformToIntValuesSV(projectionBlock);
+      for (int i = 0; i < length; i++) {
+        _result[i] = BigDecimal.valueOf(leftValues[i]).setScale(rightValues[i], RoundingMode.DOWN).doubleValue();
+      }
+    } else {
+      for (int i = 0; i < length; i++) {
+        _result[i] = Math.signum(leftValues[i]) * Math.floor(Math.abs(leftValues[i]));
+      }
     }
+
     return _result;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/ArithmeticFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/ArithmeticFunctionsTest.java
@@ -81,6 +81,22 @@ public class ArithmeticFunctionsTest {
     inputs.add(new Object[]{"least(a, b)", Lists.newArrayList("a", "b"), row5, 5.0});
     inputs.add(new Object[]{"greatest(a, b)", Lists.newArrayList("a", "b"), row5, 9.0});
 
+    GenericRow row6 = new GenericRow();
+    row6.putValue("a", 9.5);
+    inputs.add(new Object[]{"floor(a)", Lists.newArrayList("a"), row6, 9.0});
+    inputs.add(new Object[]{"ceil(a)", Lists.newArrayList("a"), row6, 10.0});
+    inputs.add(new Object[]{"exp(a)", Lists.newArrayList("a"), row6, Math.exp(9.5)});
+    inputs.add(new Object[]{"sqrt(a)", Lists.newArrayList("a"), row6, Math.sqrt(9.5)});
+    inputs.add(new Object[]{"ln(a)", Lists.newArrayList("a"), row6, Math.log(9.5)});
+    inputs.add(new Object[]{"log10(a)", Lists.newArrayList("a"), row6, Math.log10(9.5)});
+    inputs.add(new Object[]{"log2(a)", Lists.newArrayList("a"), row6, Math.log(9.5) / Math.log(2.0)});
+
+    GenericRow row7 = new GenericRow();
+    row7.putValue("a", -9.5);
+    inputs.add(new Object[]{"sign(a)", Lists.newArrayList("a"), row6, 1.0});
+    inputs.add(new Object[]{"sign(a)", Lists.newArrayList("a"), row7, -1.0});
+
+
     return inputs.toArray(new Object[0][]);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/ArithmeticFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/ArithmeticFunctionsTest.java
@@ -96,7 +96,6 @@ public class ArithmeticFunctionsTest {
     inputs.add(new Object[]{"sign(a)", Lists.newArrayList("a"), row6, 1.0});
     inputs.add(new Object[]{"sign(a)", Lists.newArrayList("a"), row7, -1.0});
 
-
     return inputs.toArray(new Object[0][]);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
@@ -81,9 +81,8 @@ public class DateTimeFunctionsTest {
     // toEpochSeconds w/ bucketing (with underscore in function name)
     GenericRow row12 = new GenericRow();
     row12.putValue("timestamp", 1578685189000L);
-    inputs.add(new Object[]{
-        "to_epoch_seconds_bucket(\"timestamp\", 10)", Lists.newArrayList("timestamp"), row12, 157868518L
-    });
+    inputs.add(
+        new Object[]{"to_epoch_seconds_bucket(\"timestamp\", 10)", Lists.newArrayList("timestamp"), row12, 157868518L});
 
     // toEpochMinutes
     GenericRow row20 = new GenericRow();
@@ -141,9 +140,8 @@ public class DateTimeFunctionsTest {
     // fromEpochDays w/ bucketing
     GenericRow row51 = new GenericRow();
     row51.putValue("sevenDaysSinceEpoch", 2000);
-    inputs.add(new Object[]{
-        "fromEpochDaysBucket(sevenDaysSinceEpoch, 7)", Lists.newArrayList("sevenDaysSinceEpoch"), row51, 1209600000000L
-    });
+    inputs.add(new Object[]{"fromEpochDaysBucket(sevenDaysSinceEpoch, 7)", Lists.newArrayList(
+        "sevenDaysSinceEpoch"), row51, 1209600000000L});
 
     // fromEpochHours
     GenericRow row60 = new GenericRow();
@@ -154,53 +152,44 @@ public class DateTimeFunctionsTest {
     // fromEpochHours w/ bucketing
     GenericRow row61 = new GenericRow();
     row61.putValue("twoHoursSinceEpoch", 168000);
-    inputs.add(new Object[]{
-        "fromEpochHoursBucket(twoHoursSinceEpoch, 2)", Lists.newArrayList("twoHoursSinceEpoch"), row61, 1209600000000L
-    });
+    inputs.add(new Object[]{"fromEpochHoursBucket(twoHoursSinceEpoch, 2)", Lists.newArrayList(
+        "twoHoursSinceEpoch"), row61, 1209600000000L});
 
     // fromEpochMinutes
     GenericRow row70 = new GenericRow();
     row70.putValue("minutesSinceEpoch", 20160000);
-    inputs.add(new Object[]{
-        "fromEpochMinutes(minutesSinceEpoch)", Lists.newArrayList("minutesSinceEpoch"), row70, 1209600000000L
-    });
+    inputs.add(new Object[]{"fromEpochMinutes(minutesSinceEpoch)", Lists.newArrayList(
+        "minutesSinceEpoch"), row70, 1209600000000L});
 
     // fromEpochMinutes w/ bucketing
     GenericRow row71 = new GenericRow();
     row71.putValue("fifteenMinutesSinceEpoch", 1344000);
-    inputs.add(new Object[]{
-        "fromEpochMinutesBucket(fifteenMinutesSinceEpoch, 15)", Lists.newArrayList(
-        "fifteenMinutesSinceEpoch"), row71, 1209600000000L
-    });
+    inputs.add(new Object[]{"fromEpochMinutesBucket(fifteenMinutesSinceEpoch, 15)", Lists.newArrayList(
+        "fifteenMinutesSinceEpoch"), row71, 1209600000000L});
 
     // fromEpochSeconds
     GenericRow row80 = new GenericRow();
     row80.putValue("secondsSinceEpoch", 1209600000L);
-    inputs.add(new Object[]{
-        "fromEpochSeconds(secondsSinceEpoch)", Lists.newArrayList("secondsSinceEpoch"), row80, 1209600000000L
-    });
+    inputs.add(new Object[]{"fromEpochSeconds(secondsSinceEpoch)", Lists.newArrayList(
+        "secondsSinceEpoch"), row80, 1209600000000L});
 
     // fromEpochSeconds w/ bucketing
     GenericRow row81 = new GenericRow();
     row81.putValue("tenSecondsSinceEpoch", 120960000L);
-    inputs.add(new Object[]{
-        "fromEpochSecondsBucket(tenSecondsSinceEpoch, 10)", Lists.newArrayList(
-        "tenSecondsSinceEpoch"), row81, 1209600000000L
-    });
+    inputs.add(new Object[]{"fromEpochSecondsBucket(tenSecondsSinceEpoch, 10)", Lists.newArrayList(
+        "tenSecondsSinceEpoch"), row81, 1209600000000L});
 
     // nested
     GenericRow row90 = new GenericRow();
     row90.putValue("hoursSinceEpoch", 336000);
-    inputs.add(new Object[]{
-        "toEpochDays(fromEpochHours(hoursSinceEpoch))", Lists.newArrayList("hoursSinceEpoch"), row90, 14000L
-    });
+    inputs.add(new Object[]{"toEpochDays(fromEpochHours(hoursSinceEpoch))", Lists.newArrayList(
+        "hoursSinceEpoch"), row90, 14000L});
 
     GenericRow row91 = new GenericRow();
     row91.putValue("fifteenSecondsSinceEpoch", 80640000L);
-    inputs.add(new Object[]{
-        "toEpochMinutesBucket(fromEpochSecondsBucket(fifteenSecondsSinceEpoch, 15), 10)", Lists.newArrayList(
-        "fifteenSecondsSinceEpoch"), row91, 2016000L
-    });
+    inputs.add(
+        new Object[]{"toEpochMinutesBucket(fromEpochSecondsBucket(fifteenSecondsSinceEpoch, 15), 10)", Lists.newArrayList(
+            "fifteenSecondsSinceEpoch"), row91, 2016000L});
 
     // toDateTime simple
     GenericRow row100 = new GenericRow();
@@ -210,26 +199,21 @@ public class DateTimeFunctionsTest {
     // toDateTime complex
     GenericRow row101 = new GenericRow();
     row101.putValue("dateTime", 1234567890000L);
-    inputs.add(new Object[]{
-        "toDateTime(dateTime, 'MM/yyyy/dd HH:mm:ss')", Lists.newArrayList("dateTime"), row101, "02/2009/13 23:31:30"
-    });
+    inputs.add(new Object[]{"toDateTime(dateTime, 'MM/yyyy/dd HH:mm:ss')", Lists.newArrayList(
+        "dateTime"), row101, "02/2009/13 23:31:30"});
 
     // toDateTime with timezone
     GenericRow row102 = new GenericRow();
     row102.putValue("dateTime", 7897897890000L);
-    inputs.add(new Object[]{
-        "toDateTime(dateTime, 'EEE MMM dd HH:mm:ss ZZZ yyyy')", Lists.newArrayList(
-        "dateTime"), row102, "Mon Apr 10 20:31:30 UTC 2220"
-    });
+    inputs.add(new Object[]{"toDateTime(dateTime, 'EEE MMM dd HH:mm:ss ZZZ yyyy')", Lists.newArrayList(
+        "dateTime"), row102, "Mon Apr 10 20:31:30 UTC 2220"});
 
     // toDateTime with timezone conversion
     GenericRow row103 = new GenericRow();
     row103.putValue("dateTime", 1633740369000L);
     row103.putValue("tz", "America/Los_Angeles");
-    inputs.add(new Object[]{
-        "toDateTime(dateTime, 'yyyy-MM-dd ZZZ', tz)", Lists.newArrayList("dateTime",
-        "tz"), row103, "2021-10-08 America/Los_Angeles"
-    });
+    inputs.add(new Object[]{"toDateTime(dateTime, 'yyyy-MM-dd ZZZ', tz)", Lists.newArrayList("dateTime",
+        "tz"), row103, "2021-10-08 America/Los_Angeles"});
 
     // fromDateTime simple
     GenericRow row110 = new GenericRow();
@@ -240,16 +224,14 @@ public class DateTimeFunctionsTest {
     // fromDateTime complex
     GenericRow row111 = new GenericRow();
     row111.putValue("dateTime", "02/2009/13 15:31:30");
-    inputs.add(new Object[]{
-        "fromDateTime(dateTime, 'MM/yyyy/dd HH:mm:ss')", Lists.newArrayList("dateTime"), row111, 1234539090000L
-    });
+    inputs.add(new Object[]{"fromDateTime(dateTime, 'MM/yyyy/dd HH:mm:ss')", Lists.newArrayList(
+        "dateTime"), row111, 1234539090000L});
 
     // fromDateTime with timezone
     GenericRow row112 = new GenericRow();
     row112.putValue("dateTime", "Mon Aug 24 12:36:46 America/Los_Angeles 2009");
-    inputs.add(new Object[]{
-        "fromDateTime(dateTime, 'EEE MMM dd HH:mm:ss ZZZ yyyy')", Lists.newArrayList("dateTime"), row112, 1251142606000L
-    });
+    inputs.add(new Object[]{"fromDateTime(dateTime, 'EEE MMM dd HH:mm:ss ZZZ yyyy')", Lists.newArrayList(
+        "dateTime"), row112, 1251142606000L});
 
     // fromDateTime with null
     GenericRow row113 = new GenericRow();
@@ -533,6 +515,48 @@ public class DateTimeFunctionsTest {
     testDateTimeConvert("20180418T01:00:00", "1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMdd''T''HH:mm:ss",
         "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Los_Angeles)", "1:DAYS",
         "2018-04-17 00:00:00.000");
+  }
+
+  @Test
+  private void testTimestampAdd() {
+    long currentTimestamp = System.currentTimeMillis();
+    long timestampHalfHourBack = currentTimestamp - (30 * 60 * 1000);
+    long timestamp10DaysAgo = currentTimestamp - (10 * 86400 * 1000);
+
+    GenericRow row = new GenericRow();
+    row.putValue("timeCol", timestamp10DaysAgo);
+
+    List<String> arguments = Collections.singletonList("timeCol");
+
+    testFunction("timestampAdd(DAY, 10, timeCol)", arguments, row, currentTimestamp);
+
+    row.putValue("timeCol", timestampHalfHourBack);
+    testFunction("timestampAdd(MINUTE, 30, timeCol)", arguments, row, currentTimestamp);
+
+    row.putValue("timeCol", timestamp10DaysAgo);
+    testFunction("timestampAdd(MINUTE, 14370, timeCol)", arguments, row, timestampHalfHourBack);
+  }
+
+  @Test
+  private void testTimestampDiff() {
+    long currentTimestamp = System.currentTimeMillis();
+    long timestampHalfHourBack = currentTimestamp - (30 * 60 * 1000);
+    long timestamp10DaysAgo = currentTimestamp - (10 * 86400 * 1000);
+
+    GenericRow row = new GenericRow();
+    row.putValue("timeCol", currentTimestamp);
+
+    row.putValue("timeCol2", timestamp10DaysAgo);
+    List<String> arguments = new ArrayList<>();
+    arguments.add("timeCol2");
+    arguments.add("timeCol");
+    testFunction("timestampDiff(DAY, timeCol2, timeCol)", arguments, row, 10L);
+
+    row.putValue("timeCol2", timestampHalfHourBack);
+    testFunction("timestampDiff(MINUTE, timeCol2, timeCol)", arguments, row, 30L);
+
+    row.putValue("timeCol2", timestampHalfHourBack);
+    testFunction("timestampDiff(SECOND, timeCol2, timeCol)", arguments, row, 1800L);
   }
 
   private void testDateTimeConvert(Object timeValue, String inputFormatStr, String outputFormatStr,

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
@@ -188,8 +188,8 @@ public class DateTimeFunctionsTest {
     GenericRow row91 = new GenericRow();
     row91.putValue("fifteenSecondsSinceEpoch", 80640000L);
     inputs.add(
-        new Object[]{"toEpochMinutesBucket(fromEpochSecondsBucket(fifteenSecondsSinceEpoch, 15), 10)", Lists.newArrayList(
-            "fifteenSecondsSinceEpoch"), row91, 2016000L});
+        new Object[]{"toEpochMinutesBucket(fromEpochSecondsBucket(fifteenSecondsSinceEpoch, 15), 10)",
+            Lists.newArrayList("fifteenSecondsSinceEpoch"), row91, 2016000L});
 
     // toDateTime simple
     GenericRow row100 = new GenericRow();

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunctionTest.java
@@ -1,0 +1,58 @@
+package org.apache.pinot.core.operator.transform.function;
+
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class PowerTransformFunctionTest extends BaseTransformFunctionTest {
+
+  @Test
+  public void testPowerTransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpressionFromSQL(String.format("power(%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof PowerTransformFunction);
+    Assert.assertEquals(transformFunction.getName(), PowerTransformFunction.FUNCTION_NAME);
+    double[] expectedValues = new double[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.pow((double) _intSVValues[i] , (double) _longSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("power(%s,%s)", LONG_SV_COLUMN, FLOAT_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof PowerTransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.pow((double) _longSVValues[i] , (double) _floatSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression =
+        RequestContextUtils.getExpressionFromSQL(String.format("power(%s,%s)", FLOAT_SV_COLUMN, DOUBLE_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof PowerTransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.pow((double) _floatSVValues[i] , _doubleSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression =
+        RequestContextUtils.getExpressionFromSQL(String.format("power(%s,%s)", DOUBLE_SV_COLUMN, STRING_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof PowerTransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.pow(_doubleSVValues[i] , Double.parseDouble(_stringSVValues[i]));
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("power(%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof PowerTransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.pow(Double.parseDouble(_stringSVValues[i]) , (double) _intSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunctionTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.operator.transform.function;
 
 import org.apache.pinot.common.request.context.ExpressionContext;

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunctionTest.java
@@ -75,4 +75,19 @@ public class PowerTransformFunctionTest extends BaseTransformFunctionTest {
     }
     testTransformFunction(transformFunction, expectedValues);
   }
+
+  @Test
+  public void testPowerTransformFunctionWithLiteralExponents() {
+    Double exponent = 2.5;
+    ExpressionContext expression =
+        RequestContextUtils.getExpressionFromSQL(String.format("power(%s, %f)", INT_SV_COLUMN, exponent));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof PowerTransformFunction);
+    Assert.assertEquals(transformFunction.getName(), PowerTransformFunction.FUNCTION_NAME);
+    double[] expectedValues = new double[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.pow((double) _intSVValues[i], exponent);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunctionTest.java
@@ -17,15 +17,16 @@ public class PowerTransformFunctionTest extends BaseTransformFunctionTest {
     Assert.assertEquals(transformFunction.getName(), PowerTransformFunction.FUNCTION_NAME);
     double[] expectedValues = new double[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Math.pow((double) _intSVValues[i] , (double) _longSVValues[i]);
+      expectedValues[i] = Math.pow((double) _intSVValues[i], (double) _longSVValues[i]);
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpressionFromSQL(String.format("power(%s,%s)", LONG_SV_COLUMN, FLOAT_SV_COLUMN));
+    expression =
+        RequestContextUtils.getExpressionFromSQL(String.format("power(%s,%s)", LONG_SV_COLUMN, FLOAT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof PowerTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Math.pow((double) _longSVValues[i] , (double) _floatSVValues[i]);
+      expectedValues[i] = Math.pow((double) _longSVValues[i], (double) _floatSVValues[i]);
     }
     testTransformFunction(transformFunction, expectedValues);
 
@@ -34,7 +35,7 @@ public class PowerTransformFunctionTest extends BaseTransformFunctionTest {
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof PowerTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Math.pow((double) _floatSVValues[i] , _doubleSVValues[i]);
+      expectedValues[i] = Math.pow((double) _floatSVValues[i], _doubleSVValues[i]);
     }
     testTransformFunction(transformFunction, expectedValues);
 
@@ -43,15 +44,16 @@ public class PowerTransformFunctionTest extends BaseTransformFunctionTest {
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof PowerTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Math.pow(_doubleSVValues[i] , Double.parseDouble(_stringSVValues[i]));
+      expectedValues[i] = Math.pow(_doubleSVValues[i], Double.parseDouble(_stringSVValues[i]));
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpressionFromSQL(String.format("power(%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN));
+    expression =
+        RequestContextUtils.getExpressionFromSQL(String.format("power(%s,%s)", STRING_SV_COLUMN, INT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof PowerTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Math.pow(Double.parseDouble(_stringSVValues[i]) , (double) _intSVValues[i]);
+      expectedValues[i] = Math.pow(Double.parseDouble(_stringSVValues[i]), (double) _intSVValues[i]);
     }
     testTransformFunction(transformFunction, expectedValues);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunctionTest.java
@@ -27,7 +27,6 @@ public class RoundDecimalTransformFunctionTest extends BaseTransformFunctionTest
     }
     testTransformFunction(transformFunction, expectedValues);
 
-
     expression = RequestContextUtils.getExpressionFromSQL(String.format("round_decimal(%s, -2)", DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof RoundDecimalTransformFunction);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunctionTest.java
@@ -1,0 +1,51 @@
+package org.apache.pinot.core.operator.transform.function;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class RoundDecimalTransformFunctionTest extends BaseTransformFunctionTest {
+
+  @Test
+  public void testRoundDecimalTransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpressionFromSQL(String.format("round_decimal(%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof RoundDecimalTransformFunction);
+    Assert.assertEquals(transformFunction.getName(), RoundDecimalTransformFunction.FUNCTION_NAME);
+    double[] expectedValues = new double[NUM_ROWS];
+
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("round_decimal(%s,2)", DOUBLE_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof RoundDecimalTransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = round(_doubleSVValues[i], 2);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("round_decimal(%s, -2)", DOUBLE_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof RoundDecimalTransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = round(_doubleSVValues[i], -2);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("round_decimal(%s)", DOUBLE_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof RoundDecimalTransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = round(_doubleSVValues[i], 0);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  public Double round(double a, int b) {
+    return BigDecimal.valueOf(a).setScale(b, RoundingMode.HALF_UP).doubleValue();
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
@@ -417,6 +417,34 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   }
 
   @Test
+  public void testStringStartsWithTransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpressionFromSQL(String.format("starts_with(%s, 'A')", STRING_ALPHANUM_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "startsWith");
+    int[] expectedValues = new int[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = StringUtils.startsWith(_stringAlphaNumericSVValues[i], "A") ? 1 : 0;
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testStringEndsWithTransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpressionFromSQL(String.format("ends_with(%s, 'A')", STRING_ALPHANUM_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "endsWith");
+    int[] expectedValues = new int[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = StringUtils.endsWith(_stringAlphaNumericSVValues[i], "A") ? 1 : 0;
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
   public void testStringNormalizeTransformFunction() {
     ExpressionContext expression =
         RequestContextUtils.getExpressionFromSQL(String.format("normalize(%s)", STRING_ALPHANUM_SV_COLUMN));

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
@@ -138,8 +138,8 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   public void testStringPadTransformFunction() {
     int padLength = 50;
     String padString = "#";
-    ExpressionContext expression = RequestContextUtils
-        .getExpressionFromSQL(String.format("lpad(%s, %d, '%s')", STRING_ALPHANUM_SV_COLUMN, padLength, padString));
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(
+        String.format("lpad(%s, %d, '%s')", STRING_ALPHANUM_SV_COLUMN, padLength, padString));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "lpad");
@@ -149,8 +149,8 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils
-        .getExpressionFromSQL(String.format("rpad(%s, %d, '%s')", STRING_ALPHANUM_SV_COLUMN, padLength, padString));
+    expression = RequestContextUtils.getExpressionFromSQL(
+        String.format("rpad(%s, %d, '%s')", STRING_ALPHANUM_SV_COLUMN, padLength, padString));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "rpad");
@@ -177,8 +177,8 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     assertEquals(transformFunction.getName(), "rtrim");
     testTransformFunction(transformFunction, _stringAlphaNumericSVValues);
 
-    expression = RequestContextUtils
-        .getExpressionFromSQL(String.format("trim(rpad(lpad(%s, 50, ' '), 100, ' '))", STRING_ALPHANUM_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(
+        String.format("trim(rpad(lpad(%s, 50, ' '), 100, ' '))", STRING_ALPHANUM_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "trim");
@@ -274,6 +274,76 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
       expectedValues[i] = StringUtils.split(_stringAlphaNumericSVValues[i], ",");
     }
     testTransformFunctionMV(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(
+        String.format("split(%s, ',', %s)", STRING_ALPHANUM_SV_COLUMN, INT_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "split");
+    expectedValues = new String[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = StringUtils.split(_stringAlphaNumericSVValues[i], ",", _intSVValues[i]);
+    }
+    testTransformFunctionMV(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testStringSplitPartTransformFunction() {
+    int index = 2;
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(
+        String.format("split_part(%s, ',', %d)", STRING_ALPHANUM_SV_COLUMN, index));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "splitPart");
+    String[] expectedValues = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      String[] splitString = StringUtils.split(_stringAlphaNumericSVValues[i], ",");
+      if (splitString.length > index) {
+        expectedValues[i] = splitString[i];
+      } else {
+        expectedValues[i] = "null";
+      }
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testStringRepeatTransformFunction() {
+    int timesToRepeat = 21;
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(
+        String.format("repeat(%s, %d)", STRING_ALPHANUM_SV_COLUMN, timesToRepeat));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "repeat");
+    String[] expectedValues = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = StringUtils.repeat(_stringAlphaNumericSVValues[i], timesToRepeat);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    String seperator = "::";
+    expression = RequestContextUtils.getExpressionFromSQL(
+        String.format("repeat(%s, '%s', %d)", STRING_ALPHANUM_SV_COLUMN, seperator, timesToRepeat));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "repeat");
+    expectedValues = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = StringUtils.repeat(_stringAlphaNumericSVValues[i], seperator, timesToRepeat);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    timesToRepeat = -1;
+    expression = RequestContextUtils.getExpressionFromSQL(
+        String.format("repeat(%s, '%s', %d)", STRING_ALPHANUM_SV_COLUMN, seperator, timesToRepeat));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "repeat");
+    expectedValues = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = "";
+    }
+    testTransformFunction(transformFunction, expectedValues);
   }
 
   @Test
@@ -642,8 +712,8 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
 
   @Test
   public void testArrayUnionIntTransformFunction() {
-    ExpressionContext expression = RequestContextUtils
-        .getExpressionFromSQL(String.format("array_union_int(%s, %s)", INT_MV_COLUMN, INT_MV_COLUMN));
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(
+        String.format("array_union_int(%s, %s)", INT_MV_COLUMN, INT_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arrayUnionInt");
@@ -658,8 +728,8 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
 
   @Test
   public void testUnionStringTransformFunction() {
-    ExpressionContext expression = RequestContextUtils
-        .getExpressionFromSQL(String.format("array_union_string(%s, %s)", STRING_MV_COLUMN, STRING_MV_COLUMN));
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(
+        String.format("array_union_string(%s, %s)", STRING_MV_COLUMN, STRING_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arrayUnionString");
@@ -674,8 +744,8 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
 
   @Test
   public void testArrayConcatIntTransformFunction() {
-    ExpressionContext expression = RequestContextUtils
-        .getExpressionFromSQL(String.format("array_concat_int(%s, %s)", INT_MV_COLUMN, INT_MV_COLUMN));
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(
+        String.format("array_concat_int(%s, %s)", INT_MV_COLUMN, INT_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arrayConcatInt");
@@ -691,8 +761,8 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
 
   @Test
   public void testConcatStringTransformFunction() {
-    ExpressionContext expression = RequestContextUtils
-        .getExpressionFromSQL(String.format("array_concat_string(%s, %s)", STRING_MV_COLUMN, STRING_MV_COLUMN));
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(
+        String.format("array_concat_string(%s, %s)", STRING_MV_COLUMN, STRING_MV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "arrayConcatString");

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunctionTest.java
@@ -25,11 +25,10 @@ import org.apache.pinot.core.operator.transform.function.SingleParamMathTransfor
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.ExpTransformFunction;
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.FloorTransformFunction;
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.LnTransformFunction;
-import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.SqrtTransformFunction;
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.Log10TransformFunction;
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.Log2TransformFunction;
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.SignTransformFunction;
-
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.SqrtTransformFunction;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunctionTest.java
@@ -26,6 +26,10 @@ import org.apache.pinot.core.operator.transform.function.SingleParamMathTransfor
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.FloorTransformFunction;
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.LnTransformFunction;
 import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.SqrtTransformFunction;
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.Log10TransformFunction;
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.Log2TransformFunction;
+import org.apache.pinot.core.operator.transform.function.SingleParamMathTransformFunction.SignTransformFunction;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -298,6 +302,141 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     Assert.assertTrue(transformFunction instanceof SqrtTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedValues[i] = Math.sqrt(Double.parseDouble(_stringSVValues[i]));
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testLog10TransformFunction() {
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(String.format("log10(%s)", INT_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof Log10TransformFunction);
+    Assert.assertEquals(transformFunction.getName(), Log10TransformFunction.FUNCTION_NAME);
+    double[] expectedValues = new double[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.log10(_intSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("log10(%s)", LONG_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof Log10TransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.log10(_longSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("log10(%s)", FLOAT_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof Log10TransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.log10(_floatSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("log10(%s)", DOUBLE_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof Log10TransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.log10(_doubleSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("log10(%s)", STRING_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof Log10TransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.log10(Double.parseDouble(_stringSVValues[i]));
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testLog2TransformFunction() {
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(String.format("log2(%s)", INT_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof Log2TransformFunction);
+    Assert.assertEquals(transformFunction.getName(), Log2TransformFunction.FUNCTION_NAME);
+    double[] expectedValues = new double[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.log(_intSVValues[i]) / Math.log(2);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("log2(%s)", LONG_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof Log2TransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.log(_longSVValues[i]) / Math.log(2);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("log2(%s)", FLOAT_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof Log2TransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.log(_floatSVValues[i]) / Math.log(2);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("log2(%s)", DOUBLE_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof Log2TransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.log(_doubleSVValues[i]) / Math.log(2);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("log2(%s)", STRING_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof Log2TransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.log(Double.parseDouble(_stringSVValues[i])) / Math.log(2);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testSignTransformFunction() {
+    ExpressionContext expression = RequestContextUtils.getExpressionFromSQL(String.format("sign(%s)", INT_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof SignTransformFunction);
+    Assert.assertEquals(transformFunction.getName(), SignTransformFunction.FUNCTION_NAME);
+    double[] expectedValues = new double[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.signum(_intSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("sign(%s)", LONG_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof SignTransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.signum(_longSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("sign(%s)", FLOAT_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof SignTransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.signum(_floatSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("sign(%s)", DOUBLE_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof SignTransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.signum(_doubleSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("sign(%s)", STRING_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof SignTransformFunction);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.signum(Double.parseDouble(_stringSVValues[i]));
     }
     testTransformFunction(transformFunction, expectedValues);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TrigonometricFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TrigonometricFunctionsTest.java
@@ -1,0 +1,145 @@
+package org.apache.pinot.core.operator.transform.function;
+
+import java.util.function.DoubleUnaryOperator;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.AcosTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.AsinTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.Atan2TransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.AtanTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.CosTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.CoshTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.DegreesTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.RadiansTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.SinTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.SinhTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.TanTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.TanhTransformFunction;
+
+
+public class TrigonometricFunctionsTest extends BaseTransformFunctionTest {
+
+  @Test
+  public void testSinTransformFunction() {
+    testTrigonometricTransformFunction(SinTransformFunction.class, "sin", Math::sin);
+  }
+
+  @Test
+  public void testCosTransformFunction() {
+    testTrigonometricTransformFunction(CosTransformFunction.class, "cos", Math::cos);
+  }
+
+  @Test
+  public void testTanTransformFunction() {
+    testTrigonometricTransformFunction(TanTransformFunction.class, "tan", Math::tan);
+  }
+
+  @Test
+  public void testAsinTransformFunction() {
+    testTrigonometricTransformFunction(AsinTransformFunction.class, "asin", Math::asin);
+  }
+
+  @Test
+  public void testACosTransformFunction() {
+    testTrigonometricTransformFunction(AcosTransformFunction.class, "acos", Math::acos);
+  }
+
+  @Test
+  public void testAtanTransformFunction() {
+    testTrigonometricTransformFunction(AtanTransformFunction.class, "atan", Math::atan);
+  }
+
+  @Test
+  public void testSinHTransformFunction() {
+    testTrigonometricTransformFunction(SinhTransformFunction.class, "sinh", Math::sinh);
+  }
+
+  @Test
+  public void testCosHTransformFunction() {
+    testTrigonometricTransformFunction(CoshTransformFunction.class, "cosh", Math::cosh);
+  }
+
+  @Test
+  public void testTanHTransformFunction() {
+    testTrigonometricTransformFunction(TanhTransformFunction.class, "tanh", Math::tanh);
+  }
+
+  @Test
+  public void testDegreesTransformFunction() {
+    testTrigonometricTransformFunction(DegreesTransformFunction.class, "degrees", Math::toDegrees);
+  }
+
+  @Test
+  public void testRadiansTransformFunction() {
+    testTrigonometricTransformFunction(RadiansTransformFunction.class, "radians", Math::toRadians);
+  }
+
+  @Test
+  public void testAtan2TransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpressionFromSQL(String.format("atan2(%s, %s)", DOUBLE_SV_COLUMN, FLOAT_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof Atan2TransformFunction);
+    Assert.assertEquals(transformFunction.getName(), Atan2TransformFunction.FUNCTION_NAME);
+    double[] expectedValues = new double[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.atan2(_doubleSVValues[i], _floatSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  public void testTrigonometricTransformFunction(Class<?> clazz, String sqlFunction, DoubleUnaryOperator op) {
+    ExpressionContext expression =
+        RequestContextUtils.getExpressionFromSQL(String.format("%s(%s)", sqlFunction, INT_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(clazz.isInstance(transformFunction));
+    Assert.assertEquals(transformFunction.getName(), sqlFunction);
+    double[] expectedValues = new double[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = op.applyAsDouble(_intSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("%s(%s)", sqlFunction, LONG_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(clazz.isInstance(transformFunction));
+    Assert.assertEquals(transformFunction.getName(), sqlFunction);
+    expectedValues = new double[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = op.applyAsDouble(_longSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("%s(%s)", sqlFunction, FLOAT_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(clazz.isInstance(transformFunction));
+    Assert.assertEquals(transformFunction.getName(), sqlFunction);
+    expectedValues = new double[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = op.applyAsDouble(_floatSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("%s(%s)", sqlFunction, DOUBLE_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(clazz.isInstance(transformFunction));
+    Assert.assertEquals(transformFunction.getName(), sqlFunction);
+    expectedValues = new double[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = op.applyAsDouble(_doubleSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("%s(%s)", sqlFunction, STRING_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(clazz.isInstance(transformFunction));
+    Assert.assertEquals(transformFunction.getName(), sqlFunction);
+    expectedValues = new double[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = op.applyAsDouble(Double.parseDouble(_stringSVValues[i]));
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TrigonometricFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TrigonometricFunctionsTest.java
@@ -21,8 +21,6 @@ package org.apache.pinot.core.operator.transform.function;
 import java.util.function.DoubleUnaryOperator;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.AcosTransformFunction;
 import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.AsinTransformFunction;
 import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.Atan2TransformFunction;
@@ -35,6 +33,8 @@ import org.apache.pinot.core.operator.transform.function.TrigonometricTransformF
 import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.SinhTransformFunction;
 import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.TanTransformFunction;
 import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.TanhTransformFunction;
+import org.testng.Assert;
+import org.testng.annotations.Test;
 
 
 public class TrigonometricFunctionsTest extends BaseTransformFunctionTest {

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TrigonometricFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TrigonometricFunctionsTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.core.operator.transform.function;
 
 import java.util.function.DoubleUnaryOperator;

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TruncateDecimalTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TruncateDecimalTransformFunctionTest.java
@@ -26,43 +26,43 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
-public class RoundDecimalTransformFunctionTest extends BaseTransformFunctionTest {
+public class TruncateDecimalTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test
   public void testRoundDecimalTransformFunction() {
     ExpressionContext expression =
-        RequestContextUtils.getExpressionFromSQL(String.format("round_decimal(%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN));
+        RequestContextUtils.getExpressionFromSQL(String.format("truncate(%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-    Assert.assertTrue(transformFunction instanceof RoundDecimalTransformFunction);
-    Assert.assertEquals(transformFunction.getName(), RoundDecimalTransformFunction.FUNCTION_NAME);
+    Assert.assertTrue(transformFunction instanceof TruncateDecimalTransformFunction);
+    Assert.assertEquals(transformFunction.getName(), TruncateDecimalTransformFunction.FUNCTION_NAME);
     double[] expectedValues = new double[NUM_ROWS];
 
-    expression = RequestContextUtils.getExpressionFromSQL(String.format("round_decimal(%s,2)", DOUBLE_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("truncate(%s,2)", DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-    Assert.assertTrue(transformFunction instanceof RoundDecimalTransformFunction);
+    Assert.assertTrue(transformFunction instanceof TruncateDecimalTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = round(_doubleSVValues[i], 2);
+      expectedValues[i] = truncate(_doubleSVValues[i], 2);
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpressionFromSQL(String.format("round_decimal(%s, -2)", DOUBLE_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("truncate(%s, -2)", DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-    Assert.assertTrue(transformFunction instanceof RoundDecimalTransformFunction);
+    Assert.assertTrue(transformFunction instanceof TruncateDecimalTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = round(_doubleSVValues[i], -2);
+      expectedValues[i] = truncate(_doubleSVValues[i], -2);
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression = RequestContextUtils.getExpressionFromSQL(String.format("round_decimal(%s)", DOUBLE_SV_COLUMN));
+    expression = RequestContextUtils.getExpressionFromSQL(String.format("truncate(%s)", DOUBLE_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-    Assert.assertTrue(transformFunction instanceof RoundDecimalTransformFunction);
+    Assert.assertTrue(transformFunction instanceof TruncateDecimalTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = round(_doubleSVValues[i], 0);
+      expectedValues[i] = truncate(_doubleSVValues[i], 0);
     }
     testTransformFunction(transformFunction, expectedValues);
   }
 
-  public Double round(double a, int b) {
-    return BigDecimal.valueOf(a).setScale(b, RoundingMode.HALF_UP).doubleValue();
+  public Double truncate(double a, int b) {
+    return BigDecimal.valueOf(a).setScale(b, RoundingMode.DOWN).doubleValue();
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TruncateDecimalTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TruncateDecimalTransformFunctionTest.java
@@ -29,7 +29,7 @@ import org.testng.annotations.Test;
 public class TruncateDecimalTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test
-  public void testRoundDecimalTransformFunction() {
+  public void testTruncateDecimalTransformFunction() {
     ExpressionContext expression =
         RequestContextUtils.getExpressionFromSQL(String.format("truncate(%s,%s)", INT_SV_COLUMN, LONG_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);


### PR DESCRIPTION
There are some functions which are missing from Pinot currently which are part of standard SQL. We can still do some of these operations (except for trignometric ones) by writing composite SQL expressions using existing functions. This however leads to complex queries and it is better we support these functions directly in Pinot.

For better performance, Transform function classes have also been added for the new Math functions. The classes have the same function name as scalar and will be given first preference when function is used.

This also helps in providing better support for third party tools such as Tableau.