### PR TITLE
adding a get children API for ZookeeperResource

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestURLBuilder.java
@@ -398,4 +398,12 @@ public class ControllerRequestURLBuilder {
   public String forZkPut() {
     return StringUtil.join("/", _baseUrl, "zk/put");
   }
+
+  public String forZkGet(String path) {
+    return StringUtil.join("/", _baseUrl, "zk/get", "?path=" + path);
+  }
+
+  public String forZkGetChildren(String path) {
+    return StringUtil.join("/", _baseUrl, "zk/getChildren", "?path=" + path);
+  }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1540,7 +1540,8 @@ public class PinotHelixResourceManager {
   }
 
   public List<ZNRecord> getZKChildren(String path) {
-    return _helixDataAccessor.getBaseDataAccessor().getChildren(path, null, -1, 1, 1);
+    return _helixDataAccessor.getBaseDataAccessor().getChildren(path, null, -1,
+        CommonConstants.Helix.ZkClient.RETRY_COUNT, CommonConstants.Helix.ZkClient.RETRY_INTERVAL_MS);
   }
 
   public List<String> getZKChildNames(String path) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1539,7 +1539,11 @@ public class PinotHelixResourceManager {
     return _helixDataAccessor.getBaseDataAccessor().get(path, null, -1);
   }
 
-  public List<String> getZKChildren(String path) {
+  public List<ZNRecord> getZKChildren(String path) {
+    return _helixDataAccessor.getBaseDataAccessor().getChildren(path, null, -1, 1, 1);
+  }
+
+  public List<String> getZKChildNames(String path) {
     return _helixDataAccessor.getBaseDataAccessor().getChildNames(path, -1);
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/ZookeeperResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/ZookeeperResourceTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.controller.api;
+package org.apache.pinot.controller.api.resources;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -26,9 +26,6 @@ import java.util.Map;
 import org.apache.helix.ZNRecord;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.controller.ControllerTestUtils;
-import org.codehaus.jackson.map.DeserializationConfig;
-import org.codehaus.jackson.map.ObjectMapper;
-import org.codehaus.jackson.map.SerializationConfig;
 import org.codehaus.jackson.type.TypeReference;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -36,16 +33,6 @@ import org.testng.annotations.Test;
 
 
 public class ZookeeperResourceTest {
-  private static final ObjectMapper MAPPER = new ObjectMapper();
-
-  static {
-    MAPPER.configure(SerializationConfig.Feature.INDENT_OUTPUT, true);
-    MAPPER.configure(SerializationConfig.Feature.AUTO_DETECT_FIELDS, true);
-    MAPPER.configure(SerializationConfig.Feature.CAN_OVERRIDE_ACCESS_MODIFIERS, true);
-    MAPPER.configure(DeserializationConfig.Feature.AUTO_DETECT_FIELDS, true);
-    MAPPER.configure(DeserializationConfig.Feature.AUTO_DETECT_SETTERS, true);
-    MAPPER.configure(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES, true);
-  }
 
   @BeforeClass
   public void setUp()
@@ -77,7 +64,7 @@ public class ZookeeperResourceTest {
     String urlGet = ControllerTestUtils.getControllerRequestURLBuilder().forZkGet(path1);
     result = ControllerTestUtils.sendGetRequest(urlGet);
 
-    ZNRecord znRecord = MAPPER.readValue(result.getBytes(StandardCharsets.UTF_8), ZNRecord.class);
+    ZNRecord znRecord = ZookeeperResource.MAPPER.readValue(result.getBytes(StandardCharsets.UTF_8), ZNRecord.class);
     Assert.assertEquals(znRecord.getId(), "QuickStartCluster");
     Assert.assertEquals(znRecord.getSimpleField("key"), "value");
 
@@ -85,7 +72,7 @@ public class ZookeeperResourceTest {
     urlGet = ControllerTestUtils.getControllerRequestURLBuilder().forZkGetChildren(path);
     result = ControllerTestUtils.sendGetRequest(urlGet);
 
-    List<ZNRecord> recordList = MAPPER.readValue(result.getBytes(StandardCharsets.UTF_8),
+    List<ZNRecord> recordList = ZookeeperResource.MAPPER.readValue(result.getBytes(StandardCharsets.UTF_8),
         new TypeReference<List<ZNRecord>>() { });
     Assert.assertEquals(recordList.size(), 1);
     Assert.assertEquals(recordList.get(0), znRecord);
@@ -128,7 +115,7 @@ public class ZookeeperResourceTest {
     urlGet = ControllerTestUtils.getControllerRequestURLBuilder().forZkGetChildren(path);
     result = ControllerTestUtils.sendGetRequest(urlGet);
 
-    recordList = MAPPER.readValue(result.getBytes(StandardCharsets.UTF_8),
+    recordList = ZookeeperResource.MAPPER.readValue(result.getBytes(StandardCharsets.UTF_8),
         new TypeReference<List<ZNRecord>>() { });
     Assert.assertEquals(recordList.size(), 2);
   }


### PR DESCRIPTION
It is not efficient to run `/zk/ls` then `/zk/get` for each of the ZNRecord inside a folder. 

Since helix accessor already supports getChildren. This PR enables it via Pinot controller's ZookeeperResource by adding a `zk/getChildren` API.
