### PR TITLE
Support rewriting transform to derived column

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -249,8 +249,7 @@ public class TableConfigSerDeTest {
     {
       // with upsert config
       UpsertConfig upsertConfig =
-          new UpsertConfig(UpsertConfig.Mode.FULL, null, null, "comparison",
-              UpsertConfig.HashFunction.NONE);
+          new UpsertConfig(UpsertConfig.Mode.FULL, null, null, "comparison", UpsertConfig.HashFunction.NONE);
 
       TableConfig tableConfig = tableConfigBuilder.setUpsertConfig(upsertConfig).build();
 
@@ -269,7 +268,7 @@ public class TableConfigSerDeTest {
     {
       // With ingestion config
       List<TransformConfig> transformConfigs =
-          Lists.newArrayList(new TransformConfig("bar", "func(moo)"), new TransformConfig("zoo", "myfunc()"));
+          Lists.newArrayList(new TransformConfig("bar", "func(moo)"), new TransformConfig("zoo", "myfunc()", true));
       Map<String, String> batchConfigMap = new HashMap<>();
       batchConfigMap.put("batchType", "s3");
       Map<String, String> streamConfigMap = new HashMap<>();
@@ -456,8 +455,10 @@ public class TableConfigSerDeTest {
     assertEquals(transformConfigs.size(), 2);
     assertEquals(transformConfigs.get(0).getColumnName(), "bar");
     assertEquals(transformConfigs.get(0).getTransformFunction(), "func(moo)");
+    assertFalse(transformConfigs.get(0).isEnableQueryRewrite());
     assertEquals(transformConfigs.get(1).getColumnName(), "zoo");
     assertEquals(transformConfigs.get(1).getTransformFunction(), "myfunc()");
+    assertTrue(transformConfigs.get(1).isEnableQueryRewrite());
     assertNotNull(ingestionConfig.getBatchIngestionConfig());
     assertNotNull(ingestionConfig.getBatchIngestionConfig().getBatchConfigMaps());
     assertEquals(ingestionConfig.getBatchIngestionConfig().getBatchConfigMaps().size(), 1);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/TransformConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/TransformConfig.java
@@ -35,11 +35,20 @@ public class TransformConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Transformation function string")
   private final String _transformFunction;
 
+  @JsonPropertyDescription("Whether to automatically rewrite query with this transform to column")
+  private final boolean _enableQueryRewrite;
+
   @JsonCreator
   public TransformConfig(@JsonProperty("columnName") String columnName,
-      @JsonProperty("transformFunction") String transformFunction) {
+      @JsonProperty("transformFunction") String transformFunction,
+      @JsonProperty("enableQueryRewrite") boolean enableQueryRewrite) {
     _columnName = columnName;
     _transformFunction = transformFunction;
+    _enableQueryRewrite = enableQueryRewrite;
+  }
+
+  public TransformConfig(String columnName, String transformFunction) {
+    this(columnName, transformFunction, false);
   }
 
   public String getColumnName() {
@@ -48,5 +57,9 @@ public class TransformConfig extends BaseJsonConfig {
 
   public String getTransformFunction() {
     return _transformFunction;
+  }
+
+  public boolean isEnableQueryRewrite() {
+    return _enableQueryRewrite;
   }
 }


### PR DESCRIPTION
## Description
Allow broker to automatically rewrite query with transform to derived column if exists

## Release Notes
Add a new config `enableQueryRewrite` to `TransformConfig` to enable the rewrite