### PR TITLE
Always handle null time values

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -337,26 +337,11 @@ public class TableConfigSerDeTest {
       assertEquals(tunerConfigToCompare.getName(), name);
       assertEquals(tunerConfigToCompare.getTunerProperties(), props);
     }
-    {
-      // disable handling null value in time column
-      TableConfig tableConfig = tableConfigBuilder.setTimeColumnName("timeColumn").build();
-      checkNullTimeValueHandling(JsonUtils.stringToObject(tableConfig.toJsonString(), TableConfig.class), false);
-      checkNullTimeValueHandling(TableConfigUtils.fromZNRecord(TableConfigUtils.toZNRecord(tableConfig)), false);
-
-      // enable handling null value in time column
-      tableConfig = tableConfigBuilder.setAllowNullTimeValue(true).setTimeColumnName("timeColumn").build();
-      checkNullTimeValueHandling(JsonUtils.stringToObject(tableConfig.toJsonString(), TableConfig.class), true);
-      checkNullTimeValueHandling(TableConfigUtils.fromZNRecord(TableConfigUtils.toZNRecord(tableConfig)), true);
-    }
   }
 
   private void checkSegmentsValidationAndRetentionConfig(TableConfig tableConfig) {
     // TODO validate other fields of SegmentsValidationAndRetentionConfig.
     assertEquals(tableConfig.getValidationConfig().getPeerSegmentDownloadScheme(), CommonConstants.HTTP_PROTOCOL);
-  }
-
-  private void checkNullTimeValueHandling(TableConfig tableConfig, boolean expected) {
-    assertEquals(tableConfig.getValidationConfig().isAllowNullTimeValue(), expected);
   }
 
   private void checkDefaultTableConfig(TableConfig tableConfig) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/geospatial/transform/GeoFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/geospatial/transform/GeoFunctionTest.java
@@ -59,9 +59,10 @@ public abstract class GeoFunctionTest {
   protected static final String STRING_SV_COLUMN = "stringSV";
   protected static final String LONG_SV_COLUMN = "longSV";
   protected static final String STRING_SV_COLUMN2 = "stringSV2";
+
+  private static final String RAW_TABLE_NAME = "testTable";
   private static final String SEGMENT_NAME = "testSegment";
   private static final String INDEX_DIR_PATH = FileUtils.getTempDirectoryPath() + File.separator + SEGMENT_NAME;
-  protected static final String TIME_COLUMN = "time";
 
   private static final double DELTA = 0.00001;
 
@@ -81,9 +82,9 @@ public abstract class GeoFunctionTest {
       throws Exception {
     assertIntFunction(
         String.format("%s(ST_GeomFromText(%s),ST_GeomFromText(%s))", functionName, STRING_SV_COLUMN, STRING_SV_COLUMN2),
-        new int[]{result ? 1 : 0}, Arrays
-            .asList(new Column(STRING_SV_COLUMN, FieldSpec.DataType.STRING, new String[]{leftWkt}),
-                new Column(STRING_SV_COLUMN2, FieldSpec.DataType.STRING, new String[]{rightWkt})));
+        new int[]{result ? 1 : 0},
+        Arrays.asList(new Column(STRING_SV_COLUMN, FieldSpec.DataType.STRING, new String[]{leftWkt}),
+            new Column(STRING_SV_COLUMN2, FieldSpec.DataType.STRING, new String[]{rightWkt})));
   }
 
   protected void assertLongFunction(String function, long[] expectedValues, List<Column> columns)
@@ -151,8 +152,7 @@ public abstract class GeoFunctionTest {
       rows.add(row);
     }
 
-    TableConfig tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName(TIME_COLUMN).build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
     config.setOutDir(INDEX_DIR_PATH);
     config.setSegmentName(SEGMENT_NAME);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -227,11 +227,6 @@ public final class TableConfigUtils {
       }
     }
 
-    if (validationConfig.isAllowNullTimeValue()) {
-      Preconditions.checkState(timeColumnName != null && !timeColumnName.isEmpty(),
-          "'timeColumnName' should exist if null time value is allowed");
-    }
-
     validateRetentionConfig(tableConfig);
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
@@ -30,7 +30,6 @@ import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
@@ -114,8 +113,8 @@ public class RecordTransformerTest {
     Assert.assertFalse(genericRow.getFieldToValueMap().containsKey(GenericRow.SKIP_RECORD_KEY));
 
     // invalid function
-    tableConfig
-        .setIngestionConfig(new IngestionConfig(null, null, new FilterConfig("Groovy(svInt == 123)"), null, null));
+    tableConfig.setIngestionConfig(
+        new IngestionConfig(null, null, new FilterConfig("Groovy(svInt == 123)"), null, null));
     try {
       new FilterTransformer(tableConfig);
       Assert.fail("Should have failed constructing FilterTransformer");
@@ -189,98 +188,75 @@ public class RecordTransformerTest {
       validateNullValueTransformerResult(record);
     }
 
-    // test null value handling for time column disabled by default.
-    String columnInTimeType = "columnInTimeType";
-    String columnInDateTimeType = "columnInDateTimeType";
-    String dateTimeFormat = "5:MINUTES:EPOCH";
-    Schema schemaWithTimeColumn = new Schema.SchemaBuilder()
-        .addTime(new TimeGranularitySpec(DataType.LONG, TimeUnit.SECONDS, columnInTimeType), null)
-        .addDateTime(columnInDateTimeType, DataType.STRING, dateTimeFormat, "5:MINUTES").build();
-    // Set time column to be columnInTimeType, so the expected value is null.
-    // The value in columnInDateTimeType will be filled with default value based on data type.
+    String timeColumn = "timeColumn";
     TableConfig tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName("testTable").setTimeColumnName(columnInTimeType)
+        new TableConfigBuilder(TableType.REALTIME).setTableName("testTable").setTimeColumnName(timeColumn).build();
+
+    // Test null time value with valid default time in epoch
+    String epochFormat = "1:DAYS:EPOCH";
+    Schema schema =
+        new Schema.SchemaBuilder().addDateTime(timeColumn, DataType.LONG, epochFormat, "1:DAYS", 12345, null).build();
+    transformer = new NullValueTransformer(tableConfig, schema);
+    record = transformer.transform(new GenericRow());
+    assertNotNull(record);
+    assertTrue(record.isNullValue(timeColumn));
+    assertEquals(record.getValue(timeColumn), 12345L);
+
+    // Test null time value without default time in epoch
+    schema = new Schema.SchemaBuilder().addDateTime(timeColumn, DataType.LONG, epochFormat, "1:DAYS").build();
+    long startTimeMs = System.currentTimeMillis();
+    transformer = new NullValueTransformer(tableConfig, schema);
+    record = transformer.transform(new GenericRow());
+    long endTimeMs = System.currentTimeMillis();
+    assertNotNull(record);
+    assertTrue(record.isNullValue(timeColumn));
+    assertTrue((long) record.getValue(timeColumn) >= TimeUnit.MILLISECONDS.toDays(startTimeMs)
+        && (long) record.getValue(timeColumn) <= TimeUnit.MILLISECONDS.toDays(endTimeMs));
+
+    // Test null time value with invalid default time in epoch
+    schema = new Schema.SchemaBuilder().addDateTime(timeColumn, DataType.LONG, epochFormat, "1:DAYS", 0, null).build();
+    startTimeMs = System.currentTimeMillis();
+    transformer = new NullValueTransformer(tableConfig, schema);
+    record = transformer.transform(new GenericRow());
+    endTimeMs = System.currentTimeMillis();
+    assertNotNull(record);
+    assertTrue(record.isNullValue(timeColumn));
+    assertTrue((long) record.getValue(timeColumn) >= TimeUnit.MILLISECONDS.toDays(startTimeMs)
+        && (long) record.getValue(timeColumn) <= TimeUnit.MILLISECONDS.toDays(endTimeMs));
+
+    // Test null time value with valid default time in SDF
+    String sdfFormat = "1:DAYS:SIMPLE_DATE_FORMAT:yyyy-MM-dd";
+    schema =
+        new Schema.SchemaBuilder().addDateTime(timeColumn, DataType.STRING, sdfFormat, "1:DAYS", "2020-02-02", null)
             .build();
-    record = new GenericRow();
-    transformer = new NullValueTransformer(tableConfig, schemaWithTimeColumn);
-    record = transformer.transform(record);
+    transformer = new NullValueTransformer(tableConfig, schema);
+    record = transformer.transform(new GenericRow());
     assertNotNull(record);
-    assertNull(record.getValue(columnInTimeType));
-    assertFalse(record.isNullValue(columnInTimeType));
-    assertEquals(record.getValue(columnInDateTimeType), FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_STRING);
-    assertTrue(record.isNullValue(columnInDateTimeType));
-    // Set time column to be columnInDateTimeType, so the expected value is null.
-    // The value in columnInTimeType will be filled with default value based on data type.
-    tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName("testTable").setTimeColumnName(columnInDateTimeType)
-            .build();
-    record = new GenericRow();
-    transformer = new NullValueTransformer(tableConfig, schemaWithTimeColumn);
-    record = transformer.transform(record);
-    assertNotNull(record);
-    assertNull(record.getValue(columnInDateTimeType));
-    assertFalse(record.isNullValue(columnInDateTimeType));
-    assertEquals(record.getValue(columnInTimeType), FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_LONG);
-    assertTrue(record.isNullValue(columnInTimeType));
-    // columnInTimeType and columnInDateTimeType will be filled with default value based on data type if table config
-    // doesn't have time
-    // column specified
-    tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testTable").build();
-    record = new GenericRow();
-    transformer = new NullValueTransformer(tableConfig, schemaWithTimeColumn);
-    record = transformer.transform(record);
-    assertNotNull(record);
-    assertEquals(record.getValue(columnInDateTimeType), FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_STRING);
-    assertTrue(record.isNullValue(columnInDateTimeType));
-    assertEquals(record.getValue(columnInTimeType), FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_LONG);
-    assertTrue(record.isNullValue(columnInTimeType));
+    assertTrue(record.isNullValue(timeColumn));
+    assertEquals(record.getValue(timeColumn), "2020-02-02");
 
-    // test time column null handling enabled, with long type, epoch seconds unit.
-    long startTime = System.currentTimeMillis();
-    tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testTable").setAllowNullTimeValue(true)
-        .setTimeColumnName(columnInTimeType).build();
-    record = new GenericRow();
-    transformer = new NullValueTransformer(tableConfig, schemaWithTimeColumn);
-    record = transformer.transform(record);
+    // Test null time value without default time in SDF
+    schema = new Schema.SchemaBuilder().addDateTime(timeColumn, DataType.STRING, sdfFormat, "1:DAYS").build();
+    startTimeMs = System.currentTimeMillis();
+    transformer = new NullValueTransformer(tableConfig, schema);
+    record = transformer.transform(new GenericRow());
+    endTimeMs = System.currentTimeMillis();
     assertNotNull(record);
-    assertTrue(record.getValue(columnInTimeType) instanceof Long);
-    long endTime = System.currentTimeMillis();
-    assertTrue((long) record.getValue(columnInTimeType) >= TimeUnit.MILLISECONDS.toSeconds(startTime)
-        && (long) record.getValue(columnInTimeType) <= TimeUnit.MILLISECONDS.toSeconds(endTime));
-    assertTrue(record.isNullValue(columnInTimeType));
+    assertTrue(record.isNullValue(timeColumn));
+    DateTimeFormatSpec dateTimeFormatSpec = new DateTimeFormatSpec(sdfFormat);
+    assertTrue(((String) record.getValue(timeColumn)).compareTo(dateTimeFormatSpec.fromMillisToFormat(startTimeMs)) >= 0
+        && ((String) record.getValue(timeColumn)).compareTo(dateTimeFormatSpec.fromMillisToFormat(endTimeMs)) <= 0);
 
-    // test time column null handling enabled, with string type, 5 MINUTES as time granularity.
-    tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName("testTable").setAllowNullTimeValue(true)
-        .setTimeColumnName(columnInDateTimeType).build();
-    record = new GenericRow();
-    transformer = new NullValueTransformer(tableConfig, schemaWithTimeColumn);
-    record = transformer.transform(record);
+    // Test null time value with invalid default time in SDF
+    schema =
+        new Schema.SchemaBuilder().addDateTime(timeColumn, DataType.STRING, sdfFormat, "1:DAYS", 12345, null).build();
+    transformer = new NullValueTransformer(tableConfig, schema);
+    record = transformer.transform(new GenericRow());
     assertNotNull(record);
-    assertTrue(record.getValue(columnInDateTimeType) instanceof String);
-    long timeValue = Long.parseLong((String) record.getValue(columnInDateTimeType));
-    endTime = System.currentTimeMillis();
-    DateTimeFormatSpec dateTimeFormatSpec = new DateTimeFormatSpec(dateTimeFormat);
-    long startTimeValue = Long.parseLong(dateTimeFormatSpec.fromMillisToFormat(startTime));
-    long endTimeValue = Long.parseLong(dateTimeFormatSpec.fromMillisToFormat(endTime));
-    assertTrue(timeValue >= startTimeValue && timeValue <= endTimeValue);
-    assertTrue(record.isNullValue(columnInDateTimeType));
-
-    // test time column null handling enabled, with integer type, with a yyyyMMdd pattern.
-    dateTimeFormat = "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd";
-    schemaWithTimeColumn =
-        new Schema.SchemaBuilder().addDateTime(columnInDateTimeType, DataType.INT, dateTimeFormat, "5:MINUTES").build();
-    record = new GenericRow();
-    transformer = new NullValueTransformer(tableConfig, schemaWithTimeColumn);
-    record = transformer.transform(record);
-    assertNotNull(record);
-    assertTrue(record.getValue(columnInDateTimeType) instanceof Integer);
-    timeValue = (int) record.getValue(columnInDateTimeType);
-    endTime = System.currentTimeMillis();
-    dateTimeFormatSpec = new DateTimeFormatSpec(dateTimeFormat);
-    startTimeValue = Integer.parseInt(dateTimeFormatSpec.fromMillisToFormat(startTime));
-    endTimeValue = Integer.parseInt(dateTimeFormatSpec.fromMillisToFormat(endTime));
-    assertTrue(timeValue >= startTimeValue && timeValue <= endTimeValue);
-    assertTrue(record.isNullValue(columnInDateTimeType));
+    assertTrue(record.isNullValue(timeColumn));
+    dateTimeFormatSpec = new DateTimeFormatSpec(sdfFormat);
+    assertTrue(((String) record.getValue(timeColumn)).compareTo(dateTimeFormatSpec.fromMillisToFormat(startTimeMs)) >= 0
+        && ((String) record.getValue(timeColumn)).compareTo(dateTimeFormatSpec.fromMillisToFormat(endTimeMs)) <= 0);
   }
 
   private void validateNullValueTransformerResult(GenericRow record) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -172,18 +172,6 @@ public class TableConfigUtilsTest {
     tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
     TableConfigUtils.validate(tableConfig, schema);
-
-    // time column is missing, but null handling for time column is enabled
-    schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-        .addSingleValueDimension("dimField", FieldSpec.DataType.STRING).build();
-    tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setAllowNullTimeValue(true).build();
-    try {
-      TableConfigUtils.validate(tableConfig, schema);
-      Assert.fail("Should fail for timeColumnName not present");
-    } catch (IllegalStateException e) {
-      // expected
-    }
   }
 
   @Test

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -39,8 +39,6 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   private String _schemaName;
   private String _timeColumnName;
   private TimeUnit _timeType;
-  // Flag to indicate if null value in time column is allowed.
-  private boolean _allowNullTimeValue;
   private String _segmentAssignmentStrategy;
   private ReplicaGroupStrategyConfig _replicaGroupStrategyConfig;
   private CompletionConfig _completionConfig;
@@ -77,14 +75,6 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
 
   public void setTimeType(String timeType) {
     _timeType = TimeUtils.timeUnitFromString(timeType);
-  }
-
-  public boolean isAllowNullTimeValue() {
-    return _allowNullTimeValue;
-  }
-
-  public void setAllowNullTimeValue(boolean allowNullTimeValue) {
-    _allowNullTimeValue = allowNullTimeValue;
   }
 
   public String getRetentionTimeUnit() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -23,7 +23,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
@@ -723,8 +722,7 @@ public final class Schema implements Serializable {
    * the dateTimeFieldSpec,
    *    and configure a transform function for the conversion from incoming
    */
-  @VisibleForTesting
-  static DateTimeFieldSpec convertToDateTimeFieldSpec(TimeFieldSpec timeFieldSpec) {
+  public static DateTimeFieldSpec convertToDateTimeFieldSpec(TimeFieldSpec timeFieldSpec) {
     DateTimeFieldSpec dateTimeFieldSpec = new DateTimeFieldSpec();
     TimeGranularitySpec incomingGranularitySpec = timeFieldSpec.getIncomingGranularitySpec();
     TimeGranularitySpec outgoingGranularitySpec = timeFieldSpec.getOutgoingGranularitySpec();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -65,7 +65,6 @@ public class TableConfigBuilder {
   private String _numReplicas = DEFAULT_NUM_REPLICAS;
   private String _timeColumnName;
   private String _timeType;
-  private boolean _allowNullTimeValue;
   private String _retentionTimeUnit;
   private String _retentionTimeValue;
   private String _deletedSegmentsRetentionPeriod = DEFAULT_DELETED_SEGMENTS_RETENTION_PERIOD;
@@ -152,11 +151,6 @@ public class TableConfigBuilder {
 
   public TableConfigBuilder setTimeType(String timeType) {
     _timeType = timeType;
-    return this;
-  }
-
-  public TableConfigBuilder setAllowNullTimeValue(boolean allowNullTimeValue) {
-    _allowNullTimeValue = allowNullTimeValue;
     return this;
   }
 
@@ -372,7 +366,6 @@ public class TableConfigBuilder {
     SegmentsValidationAndRetentionConfig validationConfig = new SegmentsValidationAndRetentionConfig();
     validationConfig.setTimeColumnName(_timeColumnName);
     validationConfig.setTimeType(_timeType);
-    validationConfig.setAllowNullTimeValue(_allowNullTimeValue);
     validationConfig.setRetentionTimeUnit(_retentionTimeUnit);
     validationConfig.setRetentionTimeValue(_retentionTimeValue);
     validationConfig.setDeletedSegmentsRetentionPeriod(_deletedSegmentsRetentionPeriod);


### PR DESCRIPTION
In #7269 we added support for null time handling, but with 2 limitations:
- It is not enabled by default
- It does not support custom default value

This PR addressed these 2 limitations by checking if the default value complies with the time format and is in valid time range (1971-01-01 to 2071-01-01). If so, use the custom default value; if not, fall back to the current time.

## Release Notes
Removed config `allowNullTimeValue` from the `segmentsConfig`, and `null` time values are always filled with default values
