### PR TITLE
Add tlsPort into InstanceConfig so Pinot can start both HTTP and HTTPS ports

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -85,6 +85,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
   protected String _zkServers;
   protected String _hostname;
   protected int _port;
+  protected int _tlsPort;
   protected String _instanceId;
   private volatile boolean _isStarting = false;
   private volatile boolean _isShuttingDown = false;
@@ -125,6 +126,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
               : NetUtils.getHostAddress();
     }
     _port = _listenerConfigs.get(0).getPort();
+    _tlsPort = ListenerConfigUtil.findLastTlsPort(_listenerConfigs, -1);
 
     _instanceId = _brokerConf.getProperty(Helix.Instance.INSTANCE_ID_KEY);
     if (_instanceId != null) {
@@ -328,6 +330,9 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
   private void updateInstanceConfigAndBrokerResourceIfNeeded() {
     InstanceConfig instanceConfig = HelixHelper.getInstanceConfig(_participantHelixManager, _instanceId);
     boolean instanceConfigUpdated = HelixHelper.updateHostnamePort(instanceConfig, _hostname, _port);
+    if (_tlsPort > 0) {
+      HelixHelper.updateTlsPort(instanceConfig, _tlsPort);
+    }
     boolean shouldUpdateBrokerResource = false;
     String brokerTag = null;
     List<String> instanceTags = instanceConfig.getTags();

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/DynamicBrokerSelectorTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/DynamicBrokerSelectorTest.java
@@ -62,6 +62,11 @@ public class DynamicBrokerSelectorTest {
       }
 
       @Override
+      protected ExternalViewReader getEvReader(ZkClient zkClient, boolean preferTlsPort) {
+        return _mockExternalViewReader;
+      }
+
+      @Override
       protected ZkClient getZkClient(String zkServers) {
         return _mockZkClient;
       }

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/ExternalViewReaderTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/ExternalViewReaderTest.java
@@ -18,9 +18,11 @@
  */
 package org.apache.pinot.client;
 
+import com.google.common.collect.ImmutableMap;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -44,6 +46,37 @@ public class ExternalViewReaderTest {
 
   private ExternalViewReader _externalViewReaderUnderTest;
 
+  private final String _instanceConfigPlain = "{\n"
+      + "  \"id\": \"Broker_12.34.56.78_1234\",\n"
+      + "  \"simpleFields\": {\n"
+      + "    \"HELIX_ENABLED\": \"true\",\n"
+      + "    \"HELIX_ENABLED_TIMESTAMP\": \"1646486555646\",\n"
+      + "    \"HELIX_HOST\": \"first.pug-pinot-broker-headless\",\n"
+      + "    \"HELIX_PORT\": \"8099\"\n"
+      + "  },\n"
+      + "  \"mapFields\": {},\n"
+      + "  \"listFields\": {\n"
+      + "    \"TAG_LIST\": [\n"
+      + "      \"DefaultTenant_BROKER\"\n"
+      + "    ]\n"
+      + "  }\n"
+      + "}";
+  private final String _instanceConfigTls = "{\n"
+      + "  \"id\": \"Broker_12.34.56.78_1234\",\n"
+      + "  \"simpleFields\": {\n"
+      + "    \"HELIX_ENABLED\": \"true\",\n"
+      + "    \"HELIX_ENABLED_TIMESTAMP\": \"1646486555646\",\n"
+      + "    \"HELIX_HOST\": \"first.pug-pinot-broker-headless\",\n"
+      + "    \"HELIX_PORT\": \"8099\",\n"
+      + "    \"PINOT_TLS_PORT\": \"8090\""
+      + "  },\n"
+      + "  \"mapFields\": {},\n"
+      + "  \"listFields\": {\n"
+      + "    \"TAG_LIST\": [\n"
+      + "      \"DefaultTenant_BROKER\"\n"
+      + "    ]\n"
+      + "  }\n"
+      + "}";
   @BeforeMethod
   public void setUp()
       throws Exception {
@@ -111,5 +144,77 @@ public class ExternalViewReaderTest {
 
     // Verify the results
     assertEquals(expectedResult, result);
+  }
+
+  @Test
+  public void testGetBrokersMapByInstanceConfig() {
+    configureData(_instanceConfigPlain, true);
+    // Run the test
+    final Map<String, List<String>> result = _externalViewReaderUnderTest.getTableToBrokersMap();
+    final Map<String, List<String>> expectedResult = ImmutableMap.of("field1", Arrays.asList("first.pug-pinot-broker-headless:8099"));
+    // Verify the results
+    assertEquals(expectedResult, result);
+  }
+
+  private void configureData(String instanceConfigPlain, boolean preferTls) {
+    when(_mockZkClient.readData(ExternalViewReader.BROKER_EXTERNAL_VIEW_PATH, true))
+        .thenReturn("json".getBytes());
+    when(_mockZkClient.readData(ExternalViewReader.BROKER_INSTANCE_PATH + "/Broker_12.34.56.78_1234", true))
+        .thenReturn(instanceConfigPlain.getBytes(StandardCharsets.UTF_8));
+    _externalViewReaderUnderTest._preferTlsPort = preferTls;
+  }
+
+  @Test
+  public void testGetBrokerListByInstanceConfigDefault() {
+    configureData(_instanceConfigPlain, false);
+    final List<String> brokers = _externalViewReaderUnderTest.getLiveBrokers();
+    assertEquals(brokers, Arrays.asList("first.pug-pinot-broker-headless:8099"));
+  }
+
+  @Test
+  public void testGetBrokersMapByInstanceConfigTlsDefault() {
+    configureData(_instanceConfigTls, false);
+    final Map<String, List<String>> result = _externalViewReaderUnderTest.getTableToBrokersMap();
+    final Map<String, List<String>> expectedResult = ImmutableMap.of("field1", Arrays.asList("first.pug-pinot-broker-headless:8099"));
+    // Verify the results
+    assertEquals(expectedResult, result);
+  }
+  @Test
+  public void testGetBrokerListByInstanceConfigTlsDefault() {
+    configureData(_instanceConfigTls, false);
+    final List<String> brokers = _externalViewReaderUnderTest.getLiveBrokers();
+    assertEquals(brokers, Arrays.asList("first.pug-pinot-broker-headless:8099"));
+  }
+
+  @Test
+  public void testGetBrokersMapByInstanceConfigDefault() {
+    configureData(_instanceConfigPlain, false);
+    // Run the test
+    final Map<String, List<String>> result = _externalViewReaderUnderTest.getTableToBrokersMap();
+    final Map<String, List<String>> expectedResult = ImmutableMap.of("field1", Arrays.asList("first.pug-pinot-broker-headless:8099"));
+    // Verify the results
+    assertEquals(expectedResult, result);
+  }
+
+  @Test
+  public void testGetBrokerListByInstanceConfig() {
+    configureData(_instanceConfigPlain, true);
+    final List<String> brokers = _externalViewReaderUnderTest.getLiveBrokers();
+    assertEquals(brokers, Arrays.asList("first.pug-pinot-broker-headless:8099"));
+  }
+
+  @Test
+  public void testGetBrokersMapByInstanceConfigTls() {
+    configureData(_instanceConfigTls, true);
+    final Map<String, List<String>> result = _externalViewReaderUnderTest.getTableToBrokersMap();
+    final Map<String, List<String>> expectedResult = ImmutableMap.of("field1", Arrays.asList("first.pug-pinot-broker-headless:8090"));
+    // Verify the results
+    assertEquals(expectedResult, result);
+  }
+  @Test
+  public void testGetBrokerListByInstanceConfigTls() {
+    configureData(_instanceConfigTls, true);
+    final List<String> brokers = _externalViewReaderUnderTest.getLiveBrokers();
+    assertEquals(brokers, Arrays.asList("first.pug-pinot-broker-headless:8090"));
   }
 }

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/ExternalViewReaderTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/ExternalViewReaderTest.java
@@ -151,7 +151,8 @@ public class ExternalViewReaderTest {
     configureData(_instanceConfigPlain, true);
     // Run the test
     final Map<String, List<String>> result = _externalViewReaderUnderTest.getTableToBrokersMap();
-    final Map<String, List<String>> expectedResult = ImmutableMap.of("field1", Arrays.asList("first.pug-pinot-broker-headless:8099"));
+    final Map<String, List<String>> expectedResult = ImmutableMap.of("field1",
+        Arrays.asList("first.pug-pinot-broker-headless:8099"));
     // Verify the results
     assertEquals(expectedResult, result);
   }
@@ -175,7 +176,8 @@ public class ExternalViewReaderTest {
   public void testGetBrokersMapByInstanceConfigTlsDefault() {
     configureData(_instanceConfigTls, false);
     final Map<String, List<String>> result = _externalViewReaderUnderTest.getTableToBrokersMap();
-    final Map<String, List<String>> expectedResult = ImmutableMap.of("field1", Arrays.asList("first.pug-pinot-broker-headless:8099"));
+    final Map<String, List<String>> expectedResult = ImmutableMap.of("field1",
+        Arrays.asList("first.pug-pinot-broker-headless:8099"));
     // Verify the results
     assertEquals(expectedResult, result);
   }
@@ -191,7 +193,8 @@ public class ExternalViewReaderTest {
     configureData(_instanceConfigPlain, false);
     // Run the test
     final Map<String, List<String>> result = _externalViewReaderUnderTest.getTableToBrokersMap();
-    final Map<String, List<String>> expectedResult = ImmutableMap.of("field1", Arrays.asList("first.pug-pinot-broker-headless:8099"));
+    final Map<String, List<String>> expectedResult = ImmutableMap.of("field1",
+        Arrays.asList("first.pug-pinot-broker-headless:8099"));
     // Verify the results
     assertEquals(expectedResult, result);
   }
@@ -207,7 +210,8 @@ public class ExternalViewReaderTest {
   public void testGetBrokersMapByInstanceConfigTls() {
     configureData(_instanceConfigTls, true);
     final Map<String, List<String>> result = _externalViewReaderUnderTest.getTableToBrokersMap();
-    final Map<String, List<String>> expectedResult = ImmutableMap.of("field1", Arrays.asList("first.pug-pinot-broker-headless:8090"));
+    final Map<String, List<String>> expectedResult = ImmutableMap.of("field1",
+        Arrays.asList("first.pug-pinot-broker-headless:8090"));
     // Verify the results
     assertEquals(expectedResult, result);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/helix/ExtraInstanceConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/helix/ExtraInstanceConfig.java
@@ -44,6 +44,4 @@ public class ExtraInstanceConfig {
   public void setTlsPort(String tlsPort) {
     _proxy.getRecord().setSimpleField(PinotInstanceConfigProperty.PINOT_TLS_PORT.toString(), tlsPort);
   }
-
-
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/helix/ExtraInstanceConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/helix/ExtraInstanceConfig.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.common.helix;
+
+import org.apache.helix.model.InstanceConfig;
+
+
+/**
+ * Pinot extended Instance Config for pinot extra configuration like TlsPort, etc
+ */
+public class ExtraInstanceConfig {
+
+  private final InstanceConfig _proxy;
+
+  public enum PinotInstanceConfigProperty {
+    PINOT_TLS_PORT
+  }
+
+  public ExtraInstanceConfig(InstanceConfig proxy) {
+    _proxy = proxy;
+  }
+
+  public String getTlsPort() {
+    return _proxy.getRecord().getSimpleField(PinotInstanceConfigProperty.PINOT_TLS_PORT.toString());
+  }
+
+  public void setTlsPort(String tlsPort) {
+    _proxy.getRecord().setSimpleField(PinotInstanceConfigProperty.PINOT_TLS_PORT.toString(), tlsPort);
+  }
+
+
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -46,6 +46,7 @@ import org.apache.helix.model.HelixConfigScope.ConfigScopeProperty;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
+import org.apache.pinot.common.helix.ExtraInstanceConfig;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -632,6 +633,18 @@ public class HelixHelper {
       updated = true;
     }
     return updated;
+  }
+
+  /**
+   * Updates a tlsPort value into Pinot instance config so it can be retrieved later
+   * @param instanceConfig the instance config to update
+   * @param tlsPort the tlsPort number
+   * @return true if updated
+   */
+  public static boolean updateTlsPort(InstanceConfig instanceConfig, int tlsPort) {
+    ExtraInstanceConfig pinotInstanceConfig = new ExtraInstanceConfig(instanceConfig);
+    pinotInstanceConfig.setTlsPort(String.valueOf(tlsPort));
+    return true;
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -127,6 +127,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
   protected String _helixClusterName;
   protected String _hostname;
   protected int _port;
+  protected int _tlsPort;
   protected String _helixControllerInstanceId;
   protected String _helixParticipantInstanceId;
   protected boolean _isUpdateStateModel;
@@ -168,6 +169,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     inferHostnameIfNeeded(_config);
     _hostname = _config.getControllerHost();
     _port = _listenerConfigs.get(0).getPort();
+    _tlsPort = ListenerConfigUtil.findLastTlsPort(_listenerConfigs, 0);
     // NOTE: Use <hostname>_<port> as Helix controller instance id because ControllerLeaderLocator relies on this format
     //       to parse the leader controller's hostname and port
     // TODO: Use the same instance id for controller and participant when leadControllerResource is always enabled after
@@ -607,6 +609,9 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     InstanceConfig instanceConfig =
         HelixHelper.getInstanceConfig(_helixParticipantManager, _helixParticipantInstanceId);
     boolean updated = HelixHelper.updateHostnamePort(instanceConfig, _hostname, _port);
+    if (_tlsPort > 0) {
+      updated |= HelixHelper.updateTlsPort(instanceConfig, _tlsPort);
+    }
     updated |= HelixHelper
         .addDefaultTags(instanceConfig, () -> Collections.singletonList(CommonConstants.Helix.CONTROLLER_INSTANCE));
     if (updated) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/util/ListenerConfigUtilTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/util/ListenerConfigUtilTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.util;
 
+import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.core.transport.ListenerConfig;
@@ -170,6 +171,31 @@ public class ListenerConfigUtilTest {
     controllerConf.setProperty("controller.access.protocols.https.port", "");
 
     ListenerConfigUtil.buildControllerConfigs(controllerConf);
+  }
+
+  @Test
+  public void testFindLastTlsPort() {
+    List<ListenerConfig> configs = ImmutableList.of(
+        new ListenerConfig("conf1", "host1", 9000, "http", null),
+        new ListenerConfig("conf2", "host2", 9001, "https", null),
+        new ListenerConfig("conf3", "host3", 9002, "http", null),
+        new ListenerConfig("conf4", "host4", 9003, "https", null),
+        new ListenerConfig("conf5", "host5", 9004, "http", null)
+    );
+    int tlsPort = ListenerConfigUtil.findLastTlsPort(configs, -1);
+    Assert.assertEquals(tlsPort, 9003);
+  }
+
+  @Test
+  public void testFindLastTlsPortMissing() {
+    List<ListenerConfig> configs = ImmutableList.of(
+        new ListenerConfig("conf1", "host1", 9000, "http", null),
+        new ListenerConfig("conf2", "host2", 9001, "http", null),
+        new ListenerConfig("conf3", "host3", 9002, "http", null),
+        new ListenerConfig("conf4", "host4", 9004, "http", null)
+    );
+    int tlsPort = ListenerConfigUtil.findLastTlsPort(configs, -1);
+    Assert.assertEquals(tlsPort, -1);
   }
 
   private void assertLegacyListener(ListenerConfig legacyListener) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/ListenerConfigUtil.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/ListenerConfigUtil.java
@@ -50,6 +50,8 @@ import org.glassfish.jersey.internal.guava.ThreadFactoryBuilder;
 import org.glassfish.jersey.process.JerseyProcessingUncaughtExceptionHandler;
 import org.glassfish.jersey.server.ResourceConfig;
 
+import static org.apache.pinot.spi.utils.CommonConstants.HTTPS_PROTOCOL;
+
 
 /**
  * Utility class that generates Http {@link ListenerConfig} instances
@@ -237,6 +239,20 @@ public final class ListenerConfigUtil {
     }
 
     httpServer.addListener(listener);
+  }
+
+  /**
+   * Finds the last listener that has HTTPS protocol, and returns its port. If not found any TLS, return defaultValue
+   * @param configs the config to search
+   * @param defaultValue the default value if the TLS listener is not found
+   * @return the port number of last entry that has secure protocol. If not found then defaultValue
+   */
+  public static int findLastTlsPort(List<ListenerConfig> configs, int defaultValue) {
+    return configs.stream()
+        .filter(config -> config.getProtocol().equalsIgnoreCase(HTTPS_PROTOCOL))
+        .map(ListenerConfig::getPort)
+        .reduce((first, second) -> second)
+        .orElse(defaultValue);
   }
 
   private static SSLEngineConfigurator buildSSLEngineConfigurator(TlsConfig tlsConfig) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
@@ -28,9 +28,11 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.httpclient.methods.PostMethod;
 import org.apache.commons.io.FileUtils;
+import org.apache.helix.model.InstanceConfig;
 import org.apache.http.Header;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -45,7 +47,9 @@ import org.apache.pinot.client.ConnectionFactory;
 import org.apache.pinot.client.JsonAsyncHttpPinotClientTransportFactory;
 import org.apache.pinot.client.Request;
 import org.apache.pinot.client.ResultSetGroup;
+import org.apache.pinot.common.helix.ExtraInstanceConfig;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
+import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.integration.tests.access.CertBasedTlsChannelAccessControlFactory;
@@ -274,6 +278,17 @@ public class TlsIntegrationTest extends BaseClusterIntegrationTest {
     sendDeleteRequest(
         _controllerRequestURLBuilder.forTableDelete(TableNameBuilder.REALTIME.tableNameWithType(tableName)),
         AUTH_HEADER);
+  }
+
+  @Test
+  public void testUpdatedBrokerTlsPort() {
+
+    List<InstanceConfig> instanceConfigs = HelixHelper.getInstanceConfigs(_helixManager);
+    List<ExtraInstanceConfig> securedInstances =
+        instanceConfigs.stream().map(ExtraInstanceConfig::new)
+            .filter(pinotInstanceConfig -> pinotInstanceConfig.getTlsPort() != null)
+            .collect(Collectors.toList());
+    Assert.assertFalse(securedInstances.isEmpty());
   }
 
   @Test


### PR DESCRIPTION
## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
Introduced an `ExtraInstanceConfig` class for tlsport.
The extra port will be set by Controller and Broker into InstanceConfig `SimpleFields`.

Later the `DynamicBrokerSelector` can pick out the tlsPort if set the preference.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->
* Added and set the extra tlsPort value into Broker and Controller InstanceConfig.
* 
<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
