### PR TITLE
Resolve dependency convergence issue between pinot-core and pinot-adls on kqueue

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
@@ -50,6 +50,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-transport-native-unix-common</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-kqueue</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>
@@ -57,6 +61,12 @@
       <artifactId>azure-identity</artifactId>
       <version>1.2.2</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-transport-native-kqueue</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
   <dependencyManagement>


### PR DESCRIPTION
## Description
Resolve dependency convergence issue between pinot-core and pinot-adls on kqueue

```
➜  incubator-pinot git:(fix_kqueque_convergence) mvn dependency:tree | grep netty-transport-native-kqueue
[INFO] +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:provided
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:provided
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:provided
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:provided
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:provided
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:provided
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:provided
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:provided
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
[INFO] |  |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
[INFO] |  |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:provided
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
[INFO] |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
[INFO] |  |  +- io.netty:netty-transport-native-kqueue:jar:osx-x86_64:4.1.60.Final:compile
```

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] No (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)