### PR TITLE
Support NOT LIKE and NOT BETWEEN

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -42,7 +42,9 @@ import org.apache.calcite.sql.SqlNumericLiteral;
 import org.apache.calcite.sql.SqlOrderBy;
 import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlSelectKeyword;
+import org.apache.calcite.sql.fun.SqlBetweenOperator;
 import org.apache.calcite.sql.fun.SqlCase;
+import org.apache.calcite.sql.fun.SqlLikeOperator;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.parser.babel.SqlBabelParserImpl;
@@ -55,6 +57,7 @@ import org.apache.pinot.common.request.ExpressionType;
 import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.utils.request.RequestUtils;
+import org.apache.pinot.pql.parsers.pql2.ast.FilterKind;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.utils.Pairs;
 import org.apache.pinot.sql.parsers.rewriter.QueryRewriter;
@@ -152,7 +155,7 @@ public class CalciteSqlParser {
       if (isAggregateExpression(selectExpression)) {
         aggregateExprCount++;
       } else if (hasGroupByClause && expressionOutsideGroupByList(selectExpression, groupByExprs)) {
-          throw new SqlCompilationException(
+        throw new SqlCompilationException(
             "'" + RequestUtils.prettyPrint(selectExpression) + "' should appear in GROUP BY clause.");
       }
     }
@@ -686,19 +689,21 @@ public class CalciteSqlParser {
 
   private static Expression compileFunctionExpression(SqlBasicCall functionNode) {
     SqlKind functionKind = functionNode.getKind();
+    boolean negated = false;
     String functionName;
     switch (functionKind) {
       case AND:
         return compileAndExpression(functionNode);
       case OR:
         return compileOrExpression(functionNode);
-      case COUNT:
-        SqlLiteral functionQuantifier = functionNode.getFunctionQuantifier();
-        if (functionQuantifier != null && functionQuantifier.toValue().equalsIgnoreCase("DISTINCT")) {
-          functionName = AggregationFunctionType.DISTINCTCOUNT.name();
-        } else {
-          functionName = AggregationFunctionType.COUNT.name();
-        }
+      // BETWEEN and LIKE might be negated (NOT BETWEEN, NOT LIKE)
+      case BETWEEN:
+        negated = ((SqlBetweenOperator) functionNode.getOperator()).isNegated();
+        functionName = SqlKind.BETWEEN.name();
+        break;
+      case LIKE:
+        negated = ((SqlLikeOperator) functionNode.getOperator()).isNegated();
+        functionName = SqlKind.LIKE.name();
         break;
       case OTHER:
       case OTHER_FUNCTION:
@@ -740,7 +745,16 @@ public class CalciteSqlParser {
     validateFunction(functionName, operands);
     Expression functionExpression = RequestUtils.getFunctionExpression(functionName);
     functionExpression.getFunctionCall().setOperands(operands);
-    return functionExpression;
+    if (negated) {
+      Expression negatedFunctionExpression = RequestUtils.getFunctionExpression(FilterKind.NOT.name());
+      // Do not use `Collections.singletonList()` because we might modify the operand later
+      List<Expression> negatedFunctionOperands = new ArrayList<>(1);
+      negatedFunctionOperands.add(functionExpression);
+      negatedFunctionExpression.getFunctionCall().setOperands(negatedFunctionOperands);
+      return negatedFunctionExpression;
+    } else {
+      return functionExpression;
+    }
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
@@ -180,7 +180,7 @@ public class FilterOperatorUtils {
           return 4;
         }
         if (filterOperator instanceof NotFilterOperator) {
-          return getPriority((NotFilterOperator) ((NotFilterOperator) filterOperator).getChildFilterOperator());
+          return getPriority(((NotFilterOperator) filterOperator).getChildFilterOperator());
         }
         if (filterOperator instanceof ScanBasedFilterOperator) {
           return getScanBasedFilterPriority((ScanBasedFilterOperator) filterOperator, 5, debugOptions);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/NotFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/NotFilterOperator.java
@@ -58,7 +58,7 @@ public class NotFilterOperator extends BaseFilterOperator {
     return new FilterBlock(new NotDocIdSet(_filterOperator.nextBlock().getBlockDocIdSet(), _numDocs));
   }
 
-  public Operator getChildFilterOperator() {
+  public BaseFilterOperator getChildFilterOperator() {
     return _filterOperator;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
@@ -241,15 +241,6 @@ public abstract class BaseQueriesTest {
     return brokerResponse;
   }
 
-  /**
-   * Run optimized SQL query on multiple index segments.
-   * <p>Use this to test the whole flow from server to broker.
-   * <p>The result should be equivalent to querying 4 identical index segments.
-   */
-  protected BrokerResponseNative getBrokerResponseForOptimizedSqlQuery(String sqlQuery, @Nullable Schema schema) {
-    return getBrokerResponseForOptimizedSqlQuery(sqlQuery, null, schema, PLAN_MAKER);
-  }
-
   protected BrokerResponseNative getBrokerResponseForOptimizedSqlQuery(String sqlQuery, @Nullable TableConfig config,
       @Nullable Schema schema) {
     return getBrokerResponseForOptimizedSqlQuery(sqlQuery, config, schema, PLAN_MAKER);


### PR DESCRIPTION
Calcite treats `NOT LIKE` and `NOT BETWEEN` as `FilterKind.LIKE` and `FilterKind.BETWEEN`, but with a `negated` flag set within the `SqlOperator`. This PR captures that flag and construct the `NOT` function accordingly while parsing the query.