### PR TITLE
Add support for Kinesis datasource in Github Events recipe

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
@@ -39,6 +39,7 @@
     <aws.version>2.14.28</aws.version>
     <easymock.version>4.2</easymock.version>
     <reactive.version>1.0.2</reactive.version>
+    <localstack-utils.version>0.2.19</localstack-utils.version>
   </properties>
 
   <dependencyManagement>
@@ -183,6 +184,18 @@
       <artifactId>easymock</artifactId>
       <version>${easymock.version}</version>
       <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>cloud.localstack</groupId>
+      <artifactId>localstack-utils</artifactId>
+      <version>${localstack-utils.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>software.amazon.awssdk</groupId>
+          <artifactId>*</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
   </dependencies>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/server/KinesisDataProducer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/server/KinesisDataProducer.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.plugin.stream.kinesis.server;
 
 import java.net.URI;

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/server/KinesisDataProducer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/server/KinesisDataProducer.java
@@ -54,7 +54,8 @@ public class KinesisDataProducer implements StreamDataProducer {
         localStackKinesisEndpoint = props.getProperty(ENDPOINT, DEFAULT_ENDPOINT);
         _kinesisClient = KinesisClient.builder().httpClient(new ApacheSdkHttpService().createHttpClientBuilder()
                 .buildWithDefaults(
-                    AttributeMap.builder().put(SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES, Boolean.TRUE).build()))
+                    AttributeMap.builder().put(
+                        SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES, Boolean.TRUE).build()))
             .credentialsProvider(getLocalAWSCredentials(props)).region(Region.of(props.getProperty(REGION)))
             .endpointOverride(new URI(localStackKinesisEndpoint)).build();
       } else {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/server/KinesisDataProducer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/server/KinesisDataProducer.java
@@ -1,0 +1,68 @@
+package org.apache.pinot.plugin.stream.kinesis.server;
+
+import java.net.URI;
+import java.util.Properties;
+import java.util.UUID;
+import org.apache.pinot.spi.stream.StreamDataProducer;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.SdkBytes;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.apache.ApacheSdkHttpService;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.kinesis.KinesisClient;
+import software.amazon.awssdk.services.kinesis.model.PutRecordRequest;
+import software.amazon.awssdk.services.kinesis.model.PutRecordResponse;
+import software.amazon.awssdk.utils.AttributeMap;
+
+
+public class KinesisDataProducer implements StreamDataProducer {
+  public static final String ENDPOINT = "endpoint";
+  public static final String REGION = "region";
+  public static final String ACCESS = "access";
+  public static final String SECRET = "secret";
+  public static final String DEFAULT_PORT = "4566";
+
+  private KinesisClient _kinesisClient;
+  private String _localStackKinesisEndpoint = "http://localhost:%s";
+
+  @Override
+  public void init(Properties props) {
+    try {
+      _localStackKinesisEndpoint = String.format(_localStackKinesisEndpoint, props.getProperty("port", DEFAULT_PORT));
+      _kinesisClient = KinesisClient.builder().httpClient(new ApacheSdkHttpService().createHttpClientBuilder().buildWithDefaults(
+              AttributeMap.builder().put(SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES, Boolean.TRUE).build())).credentialsProvider(getLocalAWSCredentials(props)).region(Region.of(props.getProperty(
+              REGION)))
+          .endpointOverride(new URI(_localStackKinesisEndpoint)).build();
+    } catch (Exception e){
+      _kinesisClient = null;
+    }
+  }
+
+  @Override
+  public void produce(String topic, byte[] payload) {
+    PutRecordRequest putRecordRequest =
+        PutRecordRequest.builder().streamName(topic).data(SdkBytes.fromByteArray(payload))
+            .partitionKey(UUID.randomUUID().toString()).build();
+    PutRecordResponse putRecordResponse = _kinesisClient.putRecord(putRecordRequest);
+  }
+
+  @Override
+  public void produce(String topic, byte[] key, byte[] payload) {
+    PutRecordRequest putRecordRequest =
+        PutRecordRequest.builder().streamName(topic).data(SdkBytes.fromByteArray(payload))
+            .partitionKey(new String(key)).build();
+    PutRecordResponse putRecordResponse = _kinesisClient.putRecord(putRecordRequest);
+  }
+
+  @Override
+  public void close() {
+    _kinesisClient.close();
+  }
+
+  private AwsCredentialsProvider getLocalAWSCredentials(Properties props) {
+    return StaticCredentialsProvider.create(AwsBasicCredentials.create(props.getProperty(ACCESS), props.getProperty(
+        SECRET)));
+  }
+}

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/server/KinesisDataProducer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/server/KinesisDataProducer.java
@@ -50,14 +50,14 @@ public class KinesisDataProducer implements StreamDataProducer {
   public void init(Properties props) {
     try {
       if (props.containsKey(ENDPOINT)) {
-        String localStackKinesisEndpoint;
-        localStackKinesisEndpoint = props.getProperty(ENDPOINT, DEFAULT_ENDPOINT);
+        String kinesisEndpoint;
+        kinesisEndpoint = props.getProperty(ENDPOINT, DEFAULT_ENDPOINT);
         _kinesisClient = KinesisClient.builder().httpClient(new ApacheSdkHttpService().createHttpClientBuilder()
                 .buildWithDefaults(
                     AttributeMap.builder().put(
                         SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES, Boolean.TRUE).build()))
             .credentialsProvider(getLocalAWSCredentials(props)).region(Region.of(props.getProperty(REGION)))
-            .endpointOverride(new URI(localStackKinesisEndpoint)).build();
+            .endpointOverride(new URI(kinesisEndpoint)).build();
       } else {
         _kinesisClient = KinesisClient.builder().credentialsProvider(DefaultCredentialsProvider.create())
             .region(Region.of(props.getProperty(REGION))).build();

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/server/KinesisDataProducer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/server/KinesisDataProducer.java
@@ -31,9 +31,9 @@ public class KinesisDataProducer implements StreamDataProducer {
   @Override
   public void init(Properties props) {
     try {
-      if (props.containsKey("endpoint")) {
+      if (props.containsKey(ENDPOINT)) {
         String localStackKinesisEndpoint;
-        localStackKinesisEndpoint = props.getProperty("endpoint", DEFAULT_ENDPOINT);
+        localStackKinesisEndpoint = props.getProperty(ENDPOINT, DEFAULT_ENDPOINT);
         _kinesisClient = KinesisClient.builder().httpClient(new ApacheSdkHttpService().createHttpClientBuilder()
                 .buildWithDefaults(
                     AttributeMap.builder().put(SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES, Boolean.TRUE).build()))

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/server/KinesisDataServerStartable.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/server/KinesisDataServerStartable.java
@@ -20,16 +20,12 @@ package org.apache.pinot.plugin.stream.kinesis.server;
 
 import cloud.localstack.Localstack;
 import cloud.localstack.ServiceName;
-import cloud.localstack.docker.annotation.IEnvironmentVariableProvider;
 import cloud.localstack.docker.annotation.LocalstackDockerConfiguration;
-import cloud.localstack.docker.annotation.LocalstackDockerProperties;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
-import org.apache.groovy.util.SystemUtil;
 import org.apache.pinot.spi.stream.StreamDataServerStartable;
-import cloud.localstack.docker.annotation.LocalstackDockerAnnotationProcessor;
 import org.apache.pinot.spi.utils.NetUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,11 +60,13 @@ public class KinesisDataServerStartable implements StreamDataServerStartable {
     _serverProperties = props;
     final Map<String, String> environmentVariables = new HashMap<>();
     environmentVariables.put("SERVICES", ServiceName.KINESIS);
-    _dockerConfig = LocalstackDockerConfiguration.builder().portEdge(_serverProperties.getProperty("port", DEFAULT_PORT))
-        .portElasticSearch(String.valueOf(NetUtils.findOpenPort(4571))).imageTag("0.12.15")
-        .environmentVariables(environmentVariables).build();
+    _dockerConfig =
+        LocalstackDockerConfiguration.builder().portEdge(_serverProperties.getProperty("port", DEFAULT_PORT))
+            .portElasticSearch(String.valueOf(NetUtils.findOpenPort(4571))).imageTag("0.12.15")
+            .environmentVariables(environmentVariables).build();
 
-    _localStackKinesisEndpoint = String.format(_localStackKinesisEndpoint, _serverProperties.getProperty("port", DEFAULT_PORT));
+    _localStackKinesisEndpoint =
+        String.format(_localStackKinesisEndpoint, _serverProperties.getProperty("port", DEFAULT_PORT));
   }
 
   @Override

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/server/KinesisDataServerStartable.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/server/KinesisDataServerStartable.java
@@ -1,0 +1,104 @@
+package org.apache.pinot.plugin.stream.kinesis.server;
+
+import cloud.localstack.Localstack;
+import cloud.localstack.ServiceName;
+import cloud.localstack.docker.annotation.IEnvironmentVariableProvider;
+import cloud.localstack.docker.annotation.LocalstackDockerConfiguration;
+import cloud.localstack.docker.annotation.LocalstackDockerProperties;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.groovy.util.SystemUtil;
+import org.apache.pinot.spi.stream.StreamDataServerStartable;
+import cloud.localstack.docker.annotation.LocalstackDockerAnnotationProcessor;
+import org.apache.pinot.spi.utils.NetUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.http.SdkHttpConfigurationOption;
+import software.amazon.awssdk.http.apache.ApacheSdkHttpService;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.kinesis.KinesisClient;
+import software.amazon.awssdk.services.kinesis.model.CreateStreamRequest;
+import software.amazon.awssdk.services.kinesis.model.DescribeStreamRequest;
+import software.amazon.awssdk.utils.AttributeMap;
+
+
+public class KinesisDataServerStartable implements StreamDataServerStartable {
+  private static final Logger LOGGER = LoggerFactory.getLogger(KinesisDataServerStartable.class);
+
+  public static final String NUM_SHARDS_PROPERTY = "numShards";
+  public static final String DEFAULT_REGION = "us-east-1";
+  public static final String DEFAULT_ACCESS_KEY = "access";
+  public static final String DEFAULT_SECRET_KEY = "secret";
+  public static final String DEFAULT_PORT = "4566";
+
+  private final Localstack _localstackDocker = Localstack.INSTANCE;
+  LocalstackDockerConfiguration _dockerConfig;
+  Properties _serverProperties;
+  private String _localStackKinesisEndpoint = "http://localhost:%s";
+
+  @Override
+  public void init(Properties props) {
+    _serverProperties = props;
+    final Map<String, String> environmentVariables = new HashMap<>();
+    environmentVariables.put("SERVICES", ServiceName.KINESIS);
+    _dockerConfig = LocalstackDockerConfiguration.builder().portEdge(_serverProperties.getProperty("port", DEFAULT_PORT))
+        .portElasticSearch(String.valueOf(NetUtils.findOpenPort(4571))).imageTag("0.12.15")
+        .environmentVariables(environmentVariables).build();
+
+    _localStackKinesisEndpoint = String.format(_localStackKinesisEndpoint, _serverProperties.getProperty("port", DEFAULT_PORT));
+  }
+
+  @Override
+  public void start() {
+    _localstackDocker.startup(_dockerConfig);
+  }
+
+  @Override
+  public void stop() {
+    _localstackDocker.stop();
+  }
+
+  @Override
+  public void createTopic(String topic, Properties topicProps) {
+    try {
+      KinesisClient kinesisClient = KinesisClient.builder().httpClient(
+              new ApacheSdkHttpService().createHttpClientBuilder().buildWithDefaults(
+                  AttributeMap.builder().put(SdkHttpConfigurationOption.TRUST_ALL_CERTIFICATES, Boolean.TRUE).build()))
+          .credentialsProvider(getLocalAWSCredentials()).region(Region.of(DEFAULT_REGION))
+          .endpointOverride(new URI(_localStackKinesisEndpoint)).build();
+
+      kinesisClient.createStream(
+          CreateStreamRequest.builder().streamName(topic).shardCount((Integer) topicProps.get(NUM_SHARDS_PROPERTY))
+              .build());
+
+      String kinesisStreamStatus =
+          kinesisClient.describeStream(DescribeStreamRequest.builder().streamName(topic).build()).streamDescription()
+              .streamStatusAsString();
+
+      while (!kinesisStreamStatus.contentEquals("ACTIVE")) {
+        Thread.sleep(5000L);
+        kinesisStreamStatus =
+            kinesisClient.describeStream(DescribeStreamRequest.builder().streamName(topic).build()).streamDescription()
+                .streamStatusAsString();
+      }
+
+      LOGGER.info("Kinesis stream created successfully: " + topic);
+    } catch (Exception e) {
+      LOGGER.warn("Error occurred while creating topic: " + topic, e);
+    }
+  }
+
+  @Override
+  public int getPort() {
+    return _localstackDocker.getEdgePort();
+  }
+
+  private AwsCredentialsProvider getLocalAWSCredentials() {
+    return StaticCredentialsProvider.create(AwsBasicCredentials.create(DEFAULT_ACCESS_KEY, DEFAULT_SECRET_KEY));
+  }
+}

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/server/KinesisDataServerStartable.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/server/KinesisDataServerStartable.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.plugin.stream.kinesis.server;
 
 import cloud.localstack.Localstack;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/GitHubEventsQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/GitHubEventsQuickstart.java
@@ -24,14 +24,19 @@ import java.io.File;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
+import java.util.Properties;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.spi.stream.StreamDataProvider;
 import org.apache.pinot.spi.stream.StreamDataServerStartable;
+import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.tools.Quickstart.Color;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 import org.apache.pinot.tools.streams.githubevents.PullRequestMergedEventsStream;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
+import org.apache.pinot.tools.utils.KinesisStarterUtils;
+import org.apache.pinot.tools.utils.StreamSourceType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,15 +45,16 @@ import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
 
 /**
  * Sets up a demo Pinot cluster with 1 zookeeper, 1 controller, 1 broker and 1 server
- * Sets up a demo Kafka cluster, and creates a topic pullRequestMergedEvents
+ * Sets up a demo Kafka/Kinesis cluster, and creates a topic pullRequestMergedEvents
  * Creates a realtime table pullRequestMergedEvents
  * Starts the {@link PullRequestMergedEventsStream} to publish pullRequestMergedEvents into the topic
  */
 public class GitHubEventsQuickstart extends QuickStartBase {
   private static final Logger LOGGER = LoggerFactory.getLogger(GitHubEventsQuickstart.class);
-  private StreamDataServerStartable _kafkaStarter;
+  private StreamDataServerStartable _serverStarter;
   private ZkStarter.ZookeeperInstance _zookeeperInstance;
   private String _personalAccessToken;
+  private StreamSourceType _sourceType;
 
   public GitHubEventsQuickstart() {
   }
@@ -56,16 +62,45 @@ public class GitHubEventsQuickstart extends QuickStartBase {
   private void startKafka() {
     _zookeeperInstance = ZkStarter.startLocalZkServer();
     try {
-      _kafkaStarter = StreamDataProvider.getServerDataStartable(KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME,
+      _serverStarter = StreamDataProvider.getServerDataStartable(KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME,
           KafkaStarterUtils.getDefaultKafkaConfiguration(_zookeeperInstance));
     } catch (Exception e) {
       throw new RuntimeException("Failed to start " + KafkaStarterUtils.KAFKA_SERVER_STARTABLE_CLASS_NAME, e);
     }
-    _kafkaStarter.start();
-    _kafkaStarter.createTopic("pullRequestMergedEvents", KafkaStarterUtils.getTopicCreationProps(2));
+    _serverStarter.start();
+    _serverStarter.createTopic("pullRequestMergedEvents", KafkaStarterUtils.getTopicCreationProps(2));
   }
 
-  private void execute(String personalAccessToken)
+  private void startKinesis() {
+    try {
+
+      Properties serverProperties = new Properties();
+      serverProperties.put(KinesisStarterUtils.PORT, 4566);
+      _serverStarter =
+          StreamDataProvider.getServerDataStartable(KinesisStarterUtils.KINESIS_SERVER_STARTABLE_CLASS_NAME,
+              serverProperties);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to start " + KinesisStarterUtils.KINESIS_SERVER_STARTABLE_CLASS_NAME, e);
+    }
+    _serverStarter.start();
+
+    Properties topicProperties = new Properties();
+    topicProperties.put(KinesisStarterUtils.NUM_SHARDS, 3);
+    _serverStarter.createTopic("pullRequestMergedEvents", topicProperties);
+  }
+
+  private void startServer() {
+    switch (_sourceType) {
+      case KAFKA:
+        startKafka();
+        break;
+      case KINESIS:
+        startKinesis();
+        break;
+    }
+  }
+
+  private void execute(String personalAccessToken, StreamSourceType streamSourceType)
       throws Exception {
     final File quickStartDataDir =
         new File(new File("githubEvents-" + System.currentTimeMillis()), "pullRequestMergedEvents");
@@ -81,8 +116,9 @@ public class GitHubEventsQuickstart extends QuickStartBase {
     URL resource = classLoader.getResource("examples/stream/githubEvents/pullRequestMergedEvents_schema.json");
     Preconditions.checkNotNull(resource);
     FileUtils.copyURLToFile(resource, schemaFile);
-    resource =
-        classLoader.getResource("examples/stream/githubEvents/pullRequestMergedEvents_realtime_table_config.json");
+    String tableConfigFilePath;
+    tableConfigFilePath = getTableConfigFilePath();
+    resource = classLoader.getResource(tableConfigFilePath);
     Preconditions.checkNotNull(resource);
     FileUtils.copyURLToFile(resource, tableConfigFile);
 
@@ -92,8 +128,8 @@ public class GitHubEventsQuickstart extends QuickStartBase {
     final QuickstartRunner runner =
         new QuickstartRunner(Lists.newArrayList(request), 1, 1, 1, 0, tempDir, getConfigOverrides());
 
-    printStatus(Color.CYAN, "***** Starting Kafka *****");
-    startKafka();
+    printStatus(Color.CYAN, String.format("***** Starting %s *****", streamSourceType));
+    startServer();
 
     printStatus(Color.CYAN, "***** Starting zookeeper, controller, server and broker *****");
     runner.startAll();
@@ -101,10 +137,11 @@ public class GitHubEventsQuickstart extends QuickStartBase {
     printStatus(Color.CYAN, "***** Adding pullRequestMergedEvents table *****");
     runner.bootstrapTable();
 
-    printStatus(Color.CYAN, "***** Starting pullRequestMergedEvents data stream and publishing to Kafka *****");
+    printStatus(Color.CYAN,
+        String.format("***** Starting pullRequestMergedEvents data stream and publishing to %s *****", _sourceType));
     final PullRequestMergedEventsStream pullRequestMergedEventsStream =
-        new PullRequestMergedEventsStream(schemaFile.getAbsolutePath(), "pullRequestMergedEvents",
-            personalAccessToken, PullRequestMergedEventsStream.getKafkaStreamDataProducer());
+        new PullRequestMergedEventsStream(schemaFile.getAbsolutePath(), "pullRequestMergedEvents", personalAccessToken,
+            PullRequestMergedEventsStream.getStreamDataProducer(_sourceType));
     pullRequestMergedEventsStream.execute();
     printStatus(Color.CYAN, "***** Waiting for 10 seconds for a few events to get populated *****");
     Thread.sleep(10000);
@@ -113,7 +150,7 @@ public class GitHubEventsQuickstart extends QuickStartBase {
       try {
         printStatus(Color.GREEN, "***** Shutting down GitHubEventsQuickStart *****");
         runner.stop();
-        _kafkaStarter.stop();
+        _serverStarter.stop();
         ZkStarter.stopLocalZkServer(_zookeeperInstance);
         FileUtils.deleteDirectory(quickStartDataDir);
       } catch (Exception e) {
@@ -156,6 +193,21 @@ public class GitHubEventsQuickstart extends QuickStartBase {
     printStatus(Color.GREEN, "You can always go to http://localhost:9000 to play around in the query console");
   }
 
+  private String getTableConfigFilePath() {
+    String tableConfigFilePath;
+    switch (_sourceType) {
+      case KAFKA:
+        tableConfigFilePath = "examples/stream/githubEvents/pullRequestMergedEvents_realtime_table_config.json";
+        break;
+      case KINESIS:
+        tableConfigFilePath = "examples/stream/githubEvents/pullRequestMergedEvents_kinesis_realtime_table_config.json";
+        break;
+      default:
+        tableConfigFilePath = "examples/stream/githubEvents/pullRequestMergedEvents_realtime_table_config.json";
+    }
+    return tableConfigFilePath;
+  }
+
   @Override
   public List<String> types() {
     return Arrays.asList("GITHUB-EVENTS", "GITHUB_EVENTS");
@@ -164,11 +216,16 @@ public class GitHubEventsQuickstart extends QuickStartBase {
   @Override
   public void execute()
       throws Exception {
-    execute(_personalAccessToken);
+    execute(_personalAccessToken, _sourceType);
   }
 
   public GitHubEventsQuickstart setPersonalAccessToken(String personalAccessToken) {
     _personalAccessToken = personalAccessToken;
+    return this;
+  }
+
+  public GitHubEventsQuickstart setSourceType(String sourceType) {
+    _sourceType = StreamSourceType.valueOf(sourceType.toUpperCase());
     return this;
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/GitHubEventsQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/GitHubEventsQuickstart.java
@@ -87,7 +87,7 @@ public class GitHubEventsQuickstart extends QuickStartBase {
     _serverStarter.createTopic("pullRequestMergedEvents", topicProperties);
   }
 
-  private void startServer() {
+  private void startStreamServer() {
     switch (_sourceType) {
       case KINESIS:
         startKinesis();
@@ -115,8 +115,7 @@ public class GitHubEventsQuickstart extends QuickStartBase {
     URL resource = classLoader.getResource("examples/stream/githubEvents/pullRequestMergedEvents_schema.json");
     Preconditions.checkNotNull(resource);
     FileUtils.copyURLToFile(resource, schemaFile);
-    String tableConfigFilePath;
-    tableConfigFilePath = getTableConfigFilePath();
+    String tableConfigFilePath = getTableConfigFilePath();
     resource = classLoader.getResource(tableConfigFilePath);
     Preconditions.checkNotNull(resource);
     FileUtils.copyURLToFile(resource, tableConfigFile);
@@ -128,7 +127,7 @@ public class GitHubEventsQuickstart extends QuickStartBase {
         new QuickstartRunner(Lists.newArrayList(request), 1, 1, 1, 0, tempDir, getConfigOverrides());
 
     printStatus(Color.CYAN, String.format("***** Starting %s *****", streamSourceType));
-    startServer();
+    startStreamServer();
 
     printStatus(Color.CYAN, "***** Starting zookeeper, controller, server and broker *****");
     runner.startAll();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/GitHubEventsQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/GitHubEventsQuickstart.java
@@ -24,13 +24,11 @@ import java.io.File;
 import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Locale;
 import java.util.Properties;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.spi.stream.StreamDataProvider;
 import org.apache.pinot.spi.stream.StreamDataServerStartable;
-import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.tools.Quickstart.Color;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 import org.apache.pinot.tools.streams.githubevents.PullRequestMergedEventsStream;
@@ -91,11 +89,12 @@ public class GitHubEventsQuickstart extends QuickStartBase {
 
   private void startServer() {
     switch (_sourceType) {
-      case KAFKA:
-        startKafka();
-        break;
       case KINESIS:
         startKinesis();
+        break;
+      case KAFKA:
+      default:
+        startKafka();
         break;
     }
   }
@@ -196,14 +195,15 @@ public class GitHubEventsQuickstart extends QuickStartBase {
   private String getTableConfigFilePath() {
     String tableConfigFilePath;
     switch (_sourceType) {
-      case KAFKA:
-        tableConfigFilePath = "examples/stream/githubEvents/pullRequestMergedEvents_realtime_table_config.json";
-        break;
       case KINESIS:
-        tableConfigFilePath = "examples/stream/githubEvents/pullRequestMergedEvents_kinesis_realtime_table_config.json";
+        tableConfigFilePath =
+            "examples/stream/githubEvents/pullRequestMergedEvents_kinesis_realtime_table_config.json";
         break;
+      case KAFKA:
       default:
-        tableConfigFilePath = "examples/stream/githubEvents/pullRequestMergedEvents_realtime_table_config.json";
+        tableConfigFilePath =
+            "examples/stream/githubEvents/pullRequestMergedEvents_realtime_table_config.json";
+        break;
     }
     return tableConfigFilePath;
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/GitHubEventsQuickStartCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/GitHubEventsQuickStartCommand.java
@@ -33,11 +33,18 @@ public class GitHubEventsQuickStartCommand extends AbstractBaseAdminCommand impl
   @CommandLine.Option(names = {"-personalAccessToken"}, required = true, description = "GitHub personal access token.")
   private String _personalAccessToken;
 
+  @CommandLine.Option(names = {"-sourceType"}, defaultValue = "Kafka", description = "Stream DataSource to use for ingesting data. Supported values - Kafka,Kinesis")
+  private String _sourceType;
+
   @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, help = true, description = "Print this message.")
   private boolean _help = false;
 
   public void setPersonalAccessToken(String personalAccessToken) {
     _personalAccessToken = personalAccessToken;
+  }
+
+  public void setSourceType(String sourceType) {
+    _sourceType = sourceType;
   }
 
   @Override
@@ -52,7 +59,7 @@ public class GitHubEventsQuickStartCommand extends AbstractBaseAdminCommand impl
 
   @Override
   public String toString() {
-    return ("GitHubEventsQuickStart -personalAccessToken " + _personalAccessToken);
+    return ("GitHubEventsQuickStart -personalAccessToken " + _personalAccessToken + " -sourceType" + _sourceType);
   }
 
   @Override
@@ -68,7 +75,7 @@ public class GitHubEventsQuickStartCommand extends AbstractBaseAdminCommand impl
   public boolean execute()
       throws Exception {
     PluginManager.get().init();
-    new GitHubEventsQuickstart().setPersonalAccessToken(_personalAccessToken).execute();
+    new GitHubEventsQuickstart().setPersonalAccessToken(_personalAccessToken).setSourceType(_sourceType).execute();
     return true;
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/GitHubEventsQuickStartCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/GitHubEventsQuickStartCommand.java
@@ -33,7 +33,8 @@ public class GitHubEventsQuickStartCommand extends AbstractBaseAdminCommand impl
   @CommandLine.Option(names = {"-personalAccessToken"}, required = true, description = "GitHub personal access token.")
   private String _personalAccessToken;
 
-  @CommandLine.Option(names = {"-sourceType"}, defaultValue = "Kafka", description = "Stream DataSource to use for ingesting data. Supported values - Kafka,Kinesis")
+  @CommandLine.Option(names = {"-sourceType"}, defaultValue = "Kafka",
+      description = "Stream DataSource to use for ingesting data. Supported values - Kafka,Kinesis")
   private String _sourceType;
 
   @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, help = true, description = "Print this message.")

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StreamGitHubEventsCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StreamGitHubEventsCommand.java
@@ -23,7 +23,6 @@ import org.apache.pinot.spi.stream.StreamDataProducer;
 import org.apache.pinot.tools.Command;
 import org.apache.pinot.tools.streams.githubevents.PullRequestMergedEventsStream;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
-import org.apache.pinot.tools.utils.KinesisStarterUtils;
 import org.apache.pinot.tools.utils.StreamSourceType;
 import picocli.CommandLine;
 
@@ -39,13 +38,16 @@ public class StreamGitHubEventsCommand extends AbstractBaseAdminCommand implemen
   @CommandLine.Option(names = {"-personalAccessToken"}, required = true, description = "GitHub personal access token.")
   private String _personalAccessToken;
 
-  @CommandLine.Option(names = {"-sourceType"}, defaultValue = "Kafka", description = "Stream DataSource to use for ingesting data. Supported values - Kafka,Kinesis")
+  @CommandLine.Option(names = {"-sourceType"}, defaultValue = "Kafka",
+      description = "Stream DataSource to use for ingesting data. Supported values - Kafka,Kinesis")
   private String _sourceType;
 
-  @CommandLine.Option(names = {"-kafkaBrokerList"}, description = "Kafka broker list of the kafka cluster to produce events.")
+  @CommandLine.Option(names = {"-kafkaBrokerList"},
+      description = "Kafka broker list of the kafka cluster to produce events.")
   private String _kafkaBrokerList = KafkaStarterUtils.DEFAULT_KAFKA_BROKER;
 
-  @CommandLine.Option(names = {"-kinesisEndpoint"}, description = "Endpoint of locastack or any other Kinesis cluster when not using AWS.")
+  @CommandLine.Option(names = {"-kinesisEndpoint"},
+      description = "Endpoint of locastack or any other Kinesis cluster when not using AWS.")
   private String _kinesisEndpoint = null;
 
   @CommandLine.Option(names = {"-awsRegion"}, description = "AWS Region in which Kinesis is located")
@@ -54,7 +56,8 @@ public class StreamGitHubEventsCommand extends AbstractBaseAdminCommand implemen
   @CommandLine.Option(names = {"-topic"}, required = true, description = "Name of kafka topic to publish events.")
   private String _topic;
 
-  @CommandLine.Option(names = {"-eventType"}, description = "Type of GitHub event. Supported types - pullRequestMergedEvent")
+  @CommandLine.Option(names = {"-eventType"},
+      description = "Type of GitHub event. Supported types - pullRequestMergedEvent")
   private String _eventType = PULL_REQUEST_MERGED_EVENT_TYPE;
 
   @CommandLine.Option(names = {"-schemaFile"}, description = "Path to schema file. "
@@ -117,15 +120,16 @@ public class StreamGitHubEventsCommand extends AbstractBaseAdminCommand implemen
       StreamDataProducer streamDataProducer;
       switch (StreamSourceType.valueOf(_sourceType.toUpperCase())) {
         case KINESIS:
-          streamDataProducer = PullRequestMergedEventsStream.getKinesisStreamDataProducer(_kinesisEndpoint, _awsRegion);
+          streamDataProducer =
+              PullRequestMergedEventsStream.getKinesisStreamDataProducer(_kinesisEndpoint, _awsRegion);
           break;
         case KAFKA:
         default:
           streamDataProducer = PullRequestMergedEventsStream.getKafkaStreamDataProducer(_kafkaBrokerList);
+          break;
       }
       PullRequestMergedEventsStream pullRequestMergedEventsStream =
-          new PullRequestMergedEventsStream(_schemaFile, _topic, _personalAccessToken,
-              streamDataProducer);
+          new PullRequestMergedEventsStream(_schemaFile, _topic, _personalAccessToken, streamDataProducer);
       pullRequestMergedEventsStream.execute();
     } else {
       throw new UnsupportedOperationException("Event type " + _eventType + " is unsupported");

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StreamGitHubEventsCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StreamGitHubEventsCommand.java
@@ -53,6 +53,14 @@ public class StreamGitHubEventsCommand extends AbstractBaseAdminCommand implemen
   @CommandLine.Option(names = {"-awsRegion"}, description = "AWS Region in which Kinesis is located")
   private String _awsRegion = "us-east-1";
 
+  @CommandLine.Option(names = {"-awsAccessKey"},
+      description = "AccessKey for AWS Account.")
+  private String _accessKey;
+
+  @CommandLine.Option(names = {"-awsSecretKey"},
+      description = "SecretKey for AWS Account")
+  private String _secretKey;
+
   @CommandLine.Option(names = {"-topic"}, required = true,
       description = "Name of kafka-topic/kinesis-stream to publish events.")
   private String _topic;
@@ -122,7 +130,7 @@ public class StreamGitHubEventsCommand extends AbstractBaseAdminCommand implemen
       switch (StreamSourceType.valueOf(_sourceType.toUpperCase())) {
         case KINESIS:
           streamDataProducer =
-              PullRequestMergedEventsStream.getKinesisStreamDataProducer(_kinesisEndpoint, _awsRegion);
+              PullRequestMergedEventsStream.getKinesisStreamDataProducer(_kinesisEndpoint, _awsRegion, _accessKey, _secretKey);
           break;
         case KAFKA:
         default:

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StreamGitHubEventsCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StreamGitHubEventsCommand.java
@@ -28,7 +28,7 @@ import picocli.CommandLine;
 
 
 /**
- * Command to stream GitHub events into a kafka topic
+ * Command to stream GitHub events into a kafka topic or kinesis stream
  */
 @CommandLine.Command(name = "StreamGitHubEvents")
 public class StreamGitHubEventsCommand extends AbstractBaseAdminCommand implements Command {
@@ -47,13 +47,14 @@ public class StreamGitHubEventsCommand extends AbstractBaseAdminCommand implemen
   private String _kafkaBrokerList = KafkaStarterUtils.DEFAULT_KAFKA_BROKER;
 
   @CommandLine.Option(names = {"-kinesisEndpoint"},
-      description = "Endpoint of locastack or any other Kinesis cluster when not using AWS.")
+      description = "Endpoint of localstack or any other Kinesis cluster when not using AWS.")
   private String _kinesisEndpoint = null;
 
   @CommandLine.Option(names = {"-awsRegion"}, description = "AWS Region in which Kinesis is located")
   private String _awsRegion = "us-east-1";
 
-  @CommandLine.Option(names = {"-topic"}, required = true, description = "Name of kafka topic to publish events.")
+  @CommandLine.Option(names = {"-topic"}, required = true,
+      description = "Name of kafka-topic/kinesis-stream to publish events.")
   private String _topic;
 
   @CommandLine.Option(names = {"-eventType"},

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StreamGitHubEventsCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StreamGitHubEventsCommand.java
@@ -19,9 +19,12 @@
 package org.apache.pinot.tools.admin.command;
 
 import org.apache.pinot.spi.plugin.PluginManager;
+import org.apache.pinot.spi.stream.StreamDataProducer;
 import org.apache.pinot.tools.Command;
 import org.apache.pinot.tools.streams.githubevents.PullRequestMergedEventsStream;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
+import org.apache.pinot.tools.utils.KinesisStarterUtils;
+import org.apache.pinot.tools.utils.StreamSourceType;
 import picocli.CommandLine;
 
 
@@ -36,15 +39,22 @@ public class StreamGitHubEventsCommand extends AbstractBaseAdminCommand implemen
   @CommandLine.Option(names = {"-personalAccessToken"}, required = true, description = "GitHub personal access token.")
   private String _personalAccessToken;
 
-  @CommandLine.Option(names = {"-kafkaBrokerList"},
-      description = "Kafka broker list of the kafka cluster to produce events.")
+  @CommandLine.Option(names = {"-sourceType"}, defaultValue = "Kafka", description = "Stream DataSource to use for ingesting data. Supported values - Kafka,Kinesis")
+  private String _sourceType;
+
+  @CommandLine.Option(names = {"-kafkaBrokerList"}, description = "Kafka broker list of the kafka cluster to produce events.")
   private String _kafkaBrokerList = KafkaStarterUtils.DEFAULT_KAFKA_BROKER;
+
+  @CommandLine.Option(names = {"-kinesisEndpoint"}, description = "Endpoint of locastack or any other Kinesis cluster when not using AWS.")
+  private String _kinesisEndpoint = null;
+
+  @CommandLine.Option(names = {"-awsRegion"}, description = "AWS Region in which Kinesis is located")
+  private String _awsRegion = "us-east-1";
 
   @CommandLine.Option(names = {"-topic"}, required = true, description = "Name of kafka topic to publish events.")
   private String _topic;
 
-  @CommandLine.Option(names = {"-eventType"},
-      description = "Type of GitHub event. Supported types - pullRequestMergedEvent")
+  @CommandLine.Option(names = {"-eventType"}, description = "Type of GitHub event. Supported types - pullRequestMergedEvent")
   private String _eventType = PULL_REQUEST_MERGED_EVENT_TYPE;
 
   @CommandLine.Option(names = {"-schemaFile"}, description = "Path to schema file. "
@@ -96,7 +106,7 @@ public class StreamGitHubEventsCommand extends AbstractBaseAdminCommand implemen
 
   @Override
   public String description() {
-    return "Streams GitHubEvents into a Kafka topic";
+    return "Streams GitHubEvents into a Kafka topic or Kinesis Stream";
   }
 
   @Override
@@ -104,9 +114,18 @@ public class StreamGitHubEventsCommand extends AbstractBaseAdminCommand implemen
       throws Exception {
     PluginManager.get().init();
     if (PULL_REQUEST_MERGED_EVENT_TYPE.equals(_eventType)) {
+      StreamDataProducer streamDataProducer;
+      switch (StreamSourceType.valueOf(_sourceType.toUpperCase())) {
+        case KINESIS:
+          streamDataProducer = PullRequestMergedEventsStream.getKinesisStreamDataProducer(_kinesisEndpoint, _awsRegion);
+          break;
+        case KAFKA:
+        default:
+          streamDataProducer = PullRequestMergedEventsStream.getKafkaStreamDataProducer(_kafkaBrokerList);
+      }
       PullRequestMergedEventsStream pullRequestMergedEventsStream =
           new PullRequestMergedEventsStream(_schemaFile, _topic, _personalAccessToken,
-              PullRequestMergedEventsStream.getKafkaStreamDataProducer(_kafkaBrokerList));
+              streamDataProducer);
       pullRequestMergedEventsStream.execute();
     } else {
       throw new UnsupportedOperationException("Event type " + _eventType + " is unsupported");

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StreamGitHubEventsCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StreamGitHubEventsCommand.java
@@ -38,35 +38,28 @@ public class StreamGitHubEventsCommand extends AbstractBaseAdminCommand implemen
   @CommandLine.Option(names = {"-personalAccessToken"}, required = true, description = "GitHub personal access token.")
   private String _personalAccessToken;
 
-  @CommandLine.Option(names = {"-sourceType"}, defaultValue = "Kafka",
-      description = "Stream DataSource to use for ingesting data. Supported values - Kafka,Kinesis")
+  @CommandLine.Option(names = {"-sourceType"}, defaultValue = "Kafka", description = "Stream DataSource to use for ingesting data. Supported values - Kafka,Kinesis")
   private String _sourceType;
 
-  @CommandLine.Option(names = {"-kafkaBrokerList"},
-      description = "Kafka broker list of the kafka cluster to produce events.")
+  @CommandLine.Option(names = {"-kafkaBrokerList"}, description = "Kafka broker list of the kafka cluster to produce events.")
   private String _kafkaBrokerList = KafkaStarterUtils.DEFAULT_KAFKA_BROKER;
 
-  @CommandLine.Option(names = {"-kinesisEndpoint"},
-      description = "Endpoint of localstack or any other Kinesis cluster when not using AWS.")
+  @CommandLine.Option(names = {"-kinesisEndpoint"}, description = "Endpoint of localstack or any other Kinesis cluster when not using AWS.")
   private String _kinesisEndpoint = null;
 
   @CommandLine.Option(names = {"-awsRegion"}, description = "AWS Region in which Kinesis is located")
   private String _awsRegion = "us-east-1";
 
-  @CommandLine.Option(names = {"-awsAccessKey"},
-      description = "AccessKey for AWS Account.")
+  @CommandLine.Option(names = {"-awsAccessKey"}, description = "AccessKey for AWS Account.")
   private String _accessKey;
 
-  @CommandLine.Option(names = {"-awsSecretKey"},
-      description = "SecretKey for AWS Account")
+  @CommandLine.Option(names = {"-awsSecretKey"}, description = "SecretKey for AWS Account")
   private String _secretKey;
 
-  @CommandLine.Option(names = {"-topic"}, required = true,
-      description = "Name of kafka-topic/kinesis-stream to publish events.")
+  @CommandLine.Option(names = {"-topic"}, required = true, description = "Name of kafka-topic/kinesis-stream to publish events.")
   private String _topic;
 
-  @CommandLine.Option(names = {"-eventType"},
-      description = "Type of GitHub event. Supported types - pullRequestMergedEvent")
+  @CommandLine.Option(names = {"-eventType"}, description = "Type of GitHub event. Supported types - pullRequestMergedEvent")
   private String _eventType = PULL_REQUEST_MERGED_EVENT_TYPE;
 
   @CommandLine.Option(names = {"-schemaFile"}, description = "Path to schema file. "
@@ -130,7 +123,8 @@ public class StreamGitHubEventsCommand extends AbstractBaseAdminCommand implemen
       switch (StreamSourceType.valueOf(_sourceType.toUpperCase())) {
         case KINESIS:
           streamDataProducer =
-              PullRequestMergedEventsStream.getKinesisStreamDataProducer(_kinesisEndpoint, _awsRegion, _accessKey, _secretKey);
+              PullRequestMergedEventsStream.getKinesisStreamDataProducer(_kinesisEndpoint, _awsRegion, _accessKey,
+                  _secretKey);
           break;
         case KAFKA:
         default:

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StreamGitHubEventsCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StreamGitHubEventsCommand.java
@@ -38,13 +38,16 @@ public class StreamGitHubEventsCommand extends AbstractBaseAdminCommand implemen
   @CommandLine.Option(names = {"-personalAccessToken"}, required = true, description = "GitHub personal access token.")
   private String _personalAccessToken;
 
-  @CommandLine.Option(names = {"-sourceType"}, defaultValue = "Kafka", description = "Stream DataSource to use for ingesting data. Supported values - Kafka,Kinesis")
+  @CommandLine.Option(names = {"-sourceType"}, defaultValue = "Kafka",
+      description = "Stream DataSource to use for ingesting data. Supported values - Kafka,Kinesis")
   private String _sourceType;
 
-  @CommandLine.Option(names = {"-kafkaBrokerList"}, description = "Kafka broker list of the kafka cluster to produce events.")
+  @CommandLine.Option(names = {"-kafkaBrokerList"},
+      description = "Kafka broker list of the kafka cluster to produce events.")
   private String _kafkaBrokerList = KafkaStarterUtils.DEFAULT_KAFKA_BROKER;
 
-  @CommandLine.Option(names = {"-kinesisEndpoint"}, description = "Endpoint of localstack or any other Kinesis cluster when not using AWS.")
+  @CommandLine.Option(names = {"-kinesisEndpoint"},
+      description = "Endpoint of localstack or any other Kinesis cluster when not using AWS.")
   private String _kinesisEndpoint = null;
 
   @CommandLine.Option(names = {"-awsRegion"}, description = "AWS Region in which Kinesis is located")
@@ -56,10 +59,12 @@ public class StreamGitHubEventsCommand extends AbstractBaseAdminCommand implemen
   @CommandLine.Option(names = {"-awsSecretKey"}, description = "SecretKey for AWS Account")
   private String _secretKey;
 
-  @CommandLine.Option(names = {"-topic"}, required = true, description = "Name of kafka-topic/kinesis-stream to publish events.")
+  @CommandLine.Option(names = {"-topic"}, required = true,
+      description = "Name of kafka-topic/kinesis-stream to publish events.")
   private String _topic;
 
-  @CommandLine.Option(names = {"-eventType"}, description = "Type of GitHub event. Supported types - pullRequestMergedEvent")
+  @CommandLine.Option(names = {"-eventType"},
+      description = "Type of GitHub event. Supported types - pullRequestMergedEvent")
   private String _eventType = PULL_REQUEST_MERGED_EVENT_TYPE;
 
   @CommandLine.Option(names = {"-schemaFile"}, description = "Path to schema file. "

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/streams/githubevents/PullRequestMergedEventsStream.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/streams/githubevents/PullRequestMergedEventsStream.java
@@ -108,7 +108,7 @@ public class PullRequestMergedEventsStream {
 
     properties.put("access", "access");
     properties.put("secret", "secret");
-    if(StringUtils.isNotEmpty(endpoint)) {
+    if (StringUtils.isNotEmpty(endpoint)) {
       properties.put("endpoint", endpoint);
     }
     properties.put("region", region);
@@ -117,14 +117,18 @@ public class PullRequestMergedEventsStream {
 
   public static StreamDataProducer getKinesisStreamDataProducer()
       throws Exception {
-   return getKinesisStreamDataProducer("http://localhost:4566", "us-east-1");
+    return getKinesisStreamDataProducer("http://localhost:4566", "us-east-1");
   }
 
-  public static StreamDataProducer getStreamDataProducer(StreamSourceType streamSourceType) throws Exception {
-    switch (streamSourceType){
-      case KAFKA: return getKafkaStreamDataProducer();
-      case KINESIS: return getKinesisStreamDataProducer();
-      default: throw new RuntimeException("Invalid streamSourceType specified: " + streamSourceType);
+  public static StreamDataProducer getStreamDataProducer(StreamSourceType streamSourceType)
+      throws Exception {
+    switch (streamSourceType) {
+      case KAFKA:
+        return getKafkaStreamDataProducer();
+      case KINESIS:
+        return getKinesisStreamDataProducer();
+      default:
+        throw new RuntimeException("Invalid streamSourceType specified: " + streamSourceType);
     }
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/streams/githubevents/PullRequestMergedEventsStream.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/streams/githubevents/PullRequestMergedEventsStream.java
@@ -30,6 +30,7 @@ import java.util.concurrent.Executors;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.plugin.inputformat.avro.AvroUtils;
 import org.apache.pinot.spi.stream.StreamDataProducer;
 import org.apache.pinot.spi.stream.StreamDataProvider;
@@ -101,15 +102,22 @@ public class PullRequestMergedEventsStream {
     return StreamDataProvider.getStreamDataProducer(KafkaStarterUtils.KAFKA_PRODUCER_CLASS_NAME, properties);
   }
 
-  public static StreamDataProducer getKinesisStreamDataProducer()
+  public static StreamDataProducer getKinesisStreamDataProducer(String endpoint, String region)
       throws Exception {
     Properties properties = new Properties();
 
     properties.put("access", "access");
     properties.put("secret", "secret");
-    properties.put("port", "4566");
-    properties.put("region", "us-east-1");
+    if(StringUtils.isNotEmpty(endpoint)) {
+      properties.put("endpoint", endpoint);
+    }
+    properties.put("region", region);
     return StreamDataProvider.getStreamDataProducer(KinesisStarterUtils.KINESIS_PRODUCER_CLASS_NAME, properties);
+  }
+
+  public static StreamDataProducer getKinesisStreamDataProducer()
+      throws Exception {
+   return getKinesisStreamDataProducer("http://localhost:4566", "us-east-1");
   }
 
   public static StreamDataProducer getStreamDataProducer(StreamSourceType streamSourceType) throws Exception {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/streams/githubevents/PullRequestMergedEventsStream.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/streams/githubevents/PullRequestMergedEventsStream.java
@@ -36,6 +36,8 @@ import org.apache.pinot.spi.stream.StreamDataProvider;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.tools.Quickstart;
 import org.apache.pinot.tools.utils.KafkaStarterUtils;
+import org.apache.pinot.tools.utils.KinesisStarterUtils;
+import org.apache.pinot.tools.utils.StreamSourceType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,6 +99,25 @@ public class PullRequestMergedEventsStream {
     properties.put("serializer.class", "kafka.serializer.DefaultEncoder");
     properties.put("request.required.acks", "1");
     return StreamDataProvider.getStreamDataProducer(KafkaStarterUtils.KAFKA_PRODUCER_CLASS_NAME, properties);
+  }
+
+  public static StreamDataProducer getKinesisStreamDataProducer()
+      throws Exception {
+    Properties properties = new Properties();
+
+    properties.put("access", "access");
+    properties.put("secret", "secret");
+    properties.put("port", "4566");
+    properties.put("region", "us-east-1");
+    return StreamDataProvider.getStreamDataProducer(KinesisStarterUtils.KINESIS_PRODUCER_CLASS_NAME, properties);
+  }
+
+  public static StreamDataProducer getStreamDataProducer(StreamSourceType streamSourceType) throws Exception {
+    switch (streamSourceType){
+      case KAFKA: return getKafkaStreamDataProducer();
+      case KINESIS: return getKinesisStreamDataProducer();
+      default: throw new RuntimeException("Invalid streamSourceType specified: " + streamSourceType);
+    }
   }
 
   public static void main(String[] args)

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/streams/githubevents/PullRequestMergedEventsStream.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/streams/githubevents/PullRequestMergedEventsStream.java
@@ -102,12 +102,15 @@ public class PullRequestMergedEventsStream {
     return StreamDataProvider.getStreamDataProducer(KafkaStarterUtils.KAFKA_PRODUCER_CLASS_NAME, properties);
   }
 
-  public static StreamDataProducer getKinesisStreamDataProducer(String endpoint, String region)
+  public static StreamDataProducer getKinesisStreamDataProducer(String endpoint, String region, String access, String secret)
       throws Exception {
     Properties properties = new Properties();
 
-    properties.put("access", "access");
-    properties.put("secret", "secret");
+    if(StringUtils.isNotEmpty(access) && StringUtils.isNotEmpty(secret)) {
+      properties.put("access", access);
+      properties.put("secret", secret);
+    }
+
     if (StringUtils.isNotEmpty(endpoint)) {
       properties.put("endpoint", endpoint);
     }
@@ -117,7 +120,7 @@ public class PullRequestMergedEventsStream {
 
   public static StreamDataProducer getKinesisStreamDataProducer()
       throws Exception {
-    return getKinesisStreamDataProducer("http://localhost:4566", "us-east-1");
+    return getKinesisStreamDataProducer("http://localhost:4566", "us-east-1", "access", "secret");
   }
 
   public static StreamDataProducer getStreamDataProducer(StreamSourceType streamSourceType)

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/streams/githubevents/PullRequestMergedEventsStream.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/streams/githubevents/PullRequestMergedEventsStream.java
@@ -102,11 +102,12 @@ public class PullRequestMergedEventsStream {
     return StreamDataProvider.getStreamDataProducer(KafkaStarterUtils.KAFKA_PRODUCER_CLASS_NAME, properties);
   }
 
-  public static StreamDataProducer getKinesisStreamDataProducer(String endpoint, String region, String access, String secret)
+  public static StreamDataProducer getKinesisStreamDataProducer(String endpoint, String region, String access,
+      String secret)
       throws Exception {
     Properties properties = new Properties();
 
-    if(StringUtils.isNotEmpty(access) && StringUtils.isNotEmpty(secret)) {
+    if (StringUtils.isNotEmpty(access) && StringUtils.isNotEmpty(secret)) {
       properties.put("access", access);
       properties.put("secret", secret);
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/KinesisStarterUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/KinesisStarterUtils.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.tools.utils;
 
 import java.util.Properties;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/KinesisStarterUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/KinesisStarterUtils.java
@@ -22,21 +22,23 @@ import java.util.Properties;
 import org.apache.pinot.spi.stream.StreamDataProvider;
 import org.apache.pinot.spi.stream.StreamDataServerStartable;
 
+
 public class KinesisStarterUtils {
-  private KinesisStarterUtils(){}
+  private KinesisStarterUtils() {
+  }
 
   public static final String DEFAULT_KINESIS_PORT = "4566";
-  public static final String DEFAULT_KINESIS_ENDPOINT = "http://localhost:"+DEFAULT_KINESIS_PORT;
+  public static final String DEFAULT_KINESIS_ENDPOINT = "http://localhost:" + DEFAULT_KINESIS_PORT;
 
   public static final String KINESIS_SERVER_STARTABLE_CLASS_NAME =
       getKinesisConnectorPackageName() + ".server.KinesisDataServerStartable";
-  public static final String KINESIS_PRODUCER_CLASS_NAME = getKinesisConnectorPackageName() + ".server.KinesisDataProducer";
+  public static final String KINESIS_PRODUCER_CLASS_NAME =
+      getKinesisConnectorPackageName() + ".server.KinesisDataProducer";
   public static final String KINESIS_STREAM_CONSUMER_FACTORY_CLASS_NAME =
       getKinesisConnectorPackageName() + ".KinesisConsumerFactory";
 
   public static final String PORT = "port";
   public static final String NUM_SHARDS = "numShards";
-
 
   private static String getKinesisConnectorPackageName() {
     return "org.apache.pinot.plugin.stream.kinesis";

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/KinesisStarterUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/KinesisStarterUtils.java
@@ -1,14 +1,8 @@
 package org.apache.pinot.tools.utils;
 
-import java.util.Optional;
 import java.util.Properties;
-import java.util.ServiceLoader;
-import java.util.stream.StreamSupport;
-import org.apache.pinot.spi.stream.StreamConsumerFactory;
 import org.apache.pinot.spi.stream.StreamDataProvider;
 import org.apache.pinot.spi.stream.StreamDataServerStartable;
-import org.apache.pinot.spi.utils.NetUtils;
-
 
 public class KinesisStarterUtils {
   private KinesisStarterUtils(){}
@@ -30,9 +24,9 @@ public class KinesisStarterUtils {
     return "org.apache.pinot.plugin.stream.kinesis";
   }
 
-  public static Properties getTopicCreationProps(int numKafkaPartitions) {
+  public static Properties getTopicCreationProps(int numKinesisShards) {
     Properties topicProps = new Properties();
-    topicProps.put(NUM_SHARDS, numKafkaPartitions);
+    topicProps.put(NUM_SHARDS, numKinesisShards);
     return topicProps;
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/KinesisStarterUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/KinesisStarterUtils.java
@@ -1,0 +1,52 @@
+package org.apache.pinot.tools.utils;
+
+import java.util.Optional;
+import java.util.Properties;
+import java.util.ServiceLoader;
+import java.util.stream.StreamSupport;
+import org.apache.pinot.spi.stream.StreamConsumerFactory;
+import org.apache.pinot.spi.stream.StreamDataProvider;
+import org.apache.pinot.spi.stream.StreamDataServerStartable;
+import org.apache.pinot.spi.utils.NetUtils;
+
+
+public class KinesisStarterUtils {
+  private KinesisStarterUtils(){}
+
+  public static final String DEFAULT_KINESIS_PORT = "4566";
+  public static final String DEFAULT_KINESIS_ENDPOINT = "http://localhost:"+DEFAULT_KINESIS_PORT;
+
+  public static final String KINESIS_SERVER_STARTABLE_CLASS_NAME =
+      getKinesisConnectorPackageName() + ".server.KinesisDataServerStartable";
+  public static final String KINESIS_PRODUCER_CLASS_NAME = getKinesisConnectorPackageName() + ".server.KinesisDataProducer";
+  public static final String KINESIS_STREAM_CONSUMER_FACTORY_CLASS_NAME =
+      getKinesisConnectorPackageName() + ".KinesisConsumerFactory";
+
+  public static final String PORT = "port";
+  public static final String NUM_SHARDS = "numShards";
+
+
+  private static String getKinesisConnectorPackageName() {
+    return "org.apache.pinot.plugin.stream.kinesis";
+  }
+
+  public static Properties getTopicCreationProps(int numKafkaPartitions) {
+    Properties topicProps = new Properties();
+    topicProps.put(NUM_SHARDS, numKafkaPartitions);
+    return topicProps;
+  }
+
+  public static StreamDataServerStartable startServer(final int port, final Properties baseConf) {
+    StreamDataServerStartable kinesisStarter;
+    Properties configuration = new Properties(baseConf);
+    int kinesisPort = port;
+    try {
+      configuration.put(KinesisStarterUtils.PORT, kinesisPort);
+      kinesisStarter = StreamDataProvider.getServerDataStartable(KINESIS_SERVER_STARTABLE_CLASS_NAME, configuration);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to start " + KINESIS_SERVER_STARTABLE_CLASS_NAME, e);
+    }
+    kinesisStarter.start();
+    return kinesisStarter;
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/StreamSourceType.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/StreamSourceType.java
@@ -1,0 +1,6 @@
+package org.apache.pinot.tools.utils;
+
+public enum StreamSourceType {
+  KAFKA,
+  KINESIS;
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/StreamSourceType.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/StreamSourceType.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.tools.utils;
 
 public enum StreamSourceType {

--- a/pinot-tools/src/main/resources/examples/stream/githubEvents/pullRequestMergedEvents_kinesis_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/githubEvents/pullRequestMergedEvents_kinesis_realtime_table_config.json
@@ -1,0 +1,39 @@
+{
+  "tableName": "pullRequestMergedEvents",
+  "tableType": "REALTIME",
+  "segmentsConfig": {
+    "timeColumnName": "mergedTimeMillis",
+    "retentionTimeUnit": "DAYS",
+    "retentionTimeValue": "60",
+    "schemaName": "pullRequestMergedEvents",
+    "replication": "1",
+    "replicasPerPartition": "1"
+  },
+  "tenants": {},
+  "tableIndexConfig": {
+    "loadMode": "MMAP",
+    "invertedIndexColumns": [
+      "organization",
+      "repo"
+    ],
+    "streamConfigs": {
+      "streamType": "kinesis",
+      "stream.kinesis.consumer.type": "lowlevel",
+      "stream.kinesis.topic.name": "pullRequestMergedEvents",
+      "stream.kinesis.decoder.class.name": "org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder",
+      "stream.kinesis.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kinesis.KinesisConsumerFactory",
+      "realtime.segment.flush.threshold.time": "12h",
+      "realtime.segment.flush.threshold.size": "100000",
+      "stream.kinesis.consumer.prop.auto.offset.reset": "smallest",
+      "region": "us-east-1",
+      "shardIteratorType": "TRIM_HORIZON",
+      "endpoint" : "http://localhost:4566",
+      "accessKey" : "access",
+      "secretKey": "secret"
+    }
+  },
+  "metadata": {
+    "customConfigs": {}
+  }
+}
+


### PR DESCRIPTION
This source is useful for people who quickly want to test Pinot with Kinesis. 
It starts a localstack Kinesis docker machine which can be used exactly the same as AWS Kinesis.
Rest of the code remains same.