### PR TITLE
Fix bug when importing files with the same name in different directories

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
@@ -239,6 +239,7 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
 
     //copy input path to local
     File localInputDataFile = createLocalInputDateFile(inputFileURI, localInputTempDir);
+    System.out.println("localInputDataFile = " + localInputDataFile);
 
     _inputDirFS.copyToLocalFile(inputFileURI, localInputDataFile);
 
@@ -294,8 +295,7 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
 
   private File createLocalInputDateFile(URI inputFileURI, File localInputTempDir) {
     String inputFileURIPath = inputFileURI.getPath();
-    String fileNameFriendlyPath = inputFileURIPath.substring(0,
-        inputFileURIPath.lastIndexOf(File.separator)).replaceAll("\\W+", "-");
+    String fileNameFriendlyPath = UUID.randomUUID().toString();
     File localInputFileDir = new File(localInputTempDir, fileNameFriendlyPath);
     return new File(localInputFileDir, new File(inputFileURIPath).getName());
   }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
@@ -238,7 +238,8 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
     FileUtils.forceMkdir(localOutputTempDir);
 
     //copy input path to local
-    File localInputDataFile = new File(localInputTempDir, new File(inputFileURI.getPath()).getName());
+    File localInputDataFile = createLocalInputDateFile(inputFileURI, localInputTempDir);
+
     _inputDirFS.copyToLocalFile(inputFileURI, localInputDataFile);
 
     //create task spec
@@ -289,5 +290,13 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
         FileUtils.deleteQuietly(localInputDataFile);
       }
     });
+  }
+
+  private File createLocalInputDateFile(URI inputFileURI, File localInputTempDir) {
+    String inputFileURIPath = inputFileURI.getPath();
+    String fileNameFriendlyPath = inputFileURIPath.substring(0,
+        inputFileURIPath.lastIndexOf(File.separator)).replaceAll("\\W+", "-");
+    File localInputFileDir = new File(localInputTempDir, fileNameFriendlyPath);
+    return new File(localInputFileDir, new File(inputFileURIPath).getName());
   }
 }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
@@ -239,8 +239,6 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
 
     //copy input path to local
     File localInputDataFile = createLocalInputDateFile(inputFileURI, localInputTempDir);
-    System.out.println("localInputDataFile = " + localInputDataFile);
-
     _inputDirFS.copyToLocalFile(inputFileURI, localInputDataFile);
 
     //create task spec

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
@@ -293,8 +293,7 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
 
   private File createLocalInputDateFile(URI inputFileURI, File localInputTempDir) {
     String inputFileURIPath = inputFileURI.getPath();
-    String fileNameFriendlyPath = UUID.randomUUID().toString();
-    File localInputFileDir = new File(localInputTempDir, fileNameFriendlyPath);
+    File localInputFileDir = new File(localInputTempDir, UUID.randomUUID().toString());
     return new File(localInputFileDir, new File(inputFileURIPath).getName());
   }
 }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/test/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunnerTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/test/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunnerTest.java
@@ -20,7 +20,6 @@ package org.apache.pinot.plugin.ingestion.batch.standalone;
 
 import com.google.common.collect.Lists;
 import java.io.File;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collections;

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/test/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunnerTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/test/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunnerTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.plugin.ingestion.batch.standalone;
 
 import com.google.common.collect.Lists;
 import java.io.File;
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Collections;
@@ -138,5 +139,89 @@ public class SegmentGenerationJobRunnerTest {
     Assert.assertTrue(newSegmentFile.length() > 0);
 
     // FUTURE - validate contents of file?
+  }
+
+  @Test
+  public void testInputFilesWithSameNameInDifferentDirectories()
+      throws Exception {
+    File testDir = Files.createTempDirectory("testSegmentGeneration-").toFile();
+    testDir.delete();
+    testDir.mkdirs();
+
+    File inputDir = new File(testDir, "input");
+    File inputSubDir1 = new File(inputDir, "2009");
+    File inputSubDir2 = new File(inputDir, "2010");
+    inputSubDir1.mkdirs();
+    inputSubDir2.mkdirs();
+
+    File inputFile1 = new File(inputSubDir1, "input.csv");
+    FileUtils.writeLines(inputFile1, Lists.newArrayList("col1,col2", "value1,1", "value2,2"));
+
+    File inputFile2 = new File(inputSubDir2, "input.csv");
+    FileUtils.writeLines(inputFile2, Lists.newArrayList("col1,col2", "value3,3", "value4,4"));
+
+    File outputDir = new File(testDir, "output");
+
+    // Set up schema file.
+    final String schemaName = "mySchema";
+    File schemaFile = new File(testDir, "schema");
+    Schema schema = new SchemaBuilder()
+        .setSchemaName(schemaName)
+        .addSingleValueDimension("col1", DataType.STRING)
+        .addMetric("col2", DataType.INT)
+        .build();
+    FileUtils.write(schemaFile, schema.toPrettyJsonString(), StandardCharsets.UTF_8);
+
+    // Set up table config file.
+    File tableConfigFile = new File(testDir, "tableConfig");
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("myTable")
+        .setSchemaName(schemaName)
+        .setNumReplicas(1)
+        .build();
+    FileUtils.write(tableConfigFile, tableConfig.toJsonString(), StandardCharsets.UTF_8);
+
+    SegmentGenerationJobSpec jobSpec = new SegmentGenerationJobSpec();
+    jobSpec.setJobType("SegmentCreation");
+    jobSpec.setInputDirURI(inputDir.toURI().toString());
+    jobSpec.setOutputDirURI(outputDir.toURI().toString());
+    jobSpec.setOverwriteOutput(true);
+
+    RecordReaderSpec recordReaderSpec = new RecordReaderSpec();
+    recordReaderSpec.setDataFormat("csv");
+    recordReaderSpec.setClassName(CSVRecordReader.class.getName());
+    recordReaderSpec.setConfigClassName(CSVRecordReaderConfig.class.getName());
+    jobSpec.setRecordReaderSpec(recordReaderSpec);
+
+    TableSpec tableSpec = new TableSpec();
+    tableSpec.setTableName("myTable");
+    tableSpec.setSchemaURI(schemaFile.toURI().toString());
+    tableSpec.setTableConfigURI(tableConfigFile.toURI().toString());
+    jobSpec.setTableSpec(tableSpec);
+
+    ExecutionFrameworkSpec efSpec = new ExecutionFrameworkSpec();
+    efSpec.setName("standalone");
+    efSpec.setSegmentGenerationJobRunnerClassName(SegmentGenerationJobRunner.class.getName());
+    jobSpec.setExecutionFrameworkSpec(efSpec);
+
+    PinotFSSpec pfsSpec = new PinotFSSpec();
+    pfsSpec.setScheme("file");
+    pfsSpec.setClassName(LocalPinotFS.class.getName());
+    jobSpec.setPinotFSSpecs(Collections.singletonList(pfsSpec));
+
+    SegmentGenerationJobRunner jobRunner = new SegmentGenerationJobRunner(jobSpec);
+    jobRunner.run();
+
+    // Check that both segment files are created
+
+    File newSegmentFile2009 = new File(outputDir, "2009/myTable_OFFLINE_0.tar.gz");
+    Assert.assertTrue(newSegmentFile2009.exists());
+    Assert.assertTrue(newSegmentFile2009.isFile());
+    Assert.assertTrue(newSegmentFile2009.length() > 0);
+
+    File newSegmentFile2010 = new File(outputDir, "2010/myTable_OFFLINE_0.tar.gz");
+    Assert.assertTrue(newSegmentFile2010.exists());
+    Assert.assertTrue(newSegmentFile2010.isFile());
+    Assert.assertTrue(newSegmentFile2010.length() > 0);
   }
 }


### PR DESCRIPTION
At the moment if you try to batch import files that have the same name, but are in different directories e.g.

```
input/2009/movies.csv
input/2010/movies.csv
```

You'll get the following exception:

```
2022/03/11 10:22:18.046 ERROR [SegmentGenerationJobRunner] [pool-2-thread-1] Failed to generate Pinot segment for file - file:/home/markhneedham/projects/pinot-recipes/recipes/import-data-files-different-directories/input/2000_2009/movies.csv
java.lang.IllegalStateException: Input path {} does not exist. [/tmp/pinot-4214a741-1111-4b31-b7f2-452833954e6a/input/movies.csv]
	at com.google.common.base.Preconditions.checkState(Preconditions.java:518) ~[guava-20.0.jar:?]
	at org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig.setInputFilePath(SegmentGeneratorConfig.java:420) ~[classes/:?]
	at org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationTaskRunner.run(SegmentGenerationTaskRunner.java:112) ~[classes/:?]
	at org.apache.pinot.plugin.ingestion.batch.standalone.SegmentGenerationJobRunner.lambda$submitSegmentGenTask$1(SegmentGenerationJobRunner.java:266) ~[classes/:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
2022/03/11 10:22:18.055 ERROR [SegmentGenerationJobRunner] [pool-2-thread-1] Failed to generate Pinot segment for file - file:/home/markhneedham/projects/pinot-recipes/recipes/import-data-files-different-directories/input/2010_2019/movies.csv
java.lang.IllegalStateException: Input path {} does not exist. [/tmp/pinot-4214a741-1111-4b31-b7f2-452833954e6a/input/movies.csv]
	at com.google.common.base.Preconditions.checkState(Preconditions.java:518) ~[guava-20.0.jar:?]
	at org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig.setInputFilePath(SegmentGeneratorConfig.java:420) ~[classes/:?]
	at org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationTaskRunner.run(SegmentGenerationTaskRunner.java:112) ~[classes/:?]
	at org.apache.pinot.plugin.ingestion.batch.standalone.SegmentGenerationJobRunner.lambda$submitSegmentGenTask$1(SegmentGenerationJobRunner.java:266) ~[classes/:?]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:834) [?:?]
```

When the CSV files are extracted locally they are extracted into `/tmpdir/filename`. The problem is that if we have multiple files with the same name we get a collision, which shows with the file being deleted or I guess it could be possible that one file gets overridden by another one.

So this PR tries to fix the problem by extracting the input files to:

```
/tmpdir/-input-2009/movies.csv
/tmpdir/-input-2010/movies.csv
```

Instead of having them both extracted to:

```
/tmpdir/movies.csv
```

Maybe there's a better way to generate the directory name under `/tmpdir`? Happy to change if so!