### PR TITLE
Handle authentication in pulsar pinot connector

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarConfig.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarConfig.java
@@ -35,18 +35,29 @@ import org.apache.pulsar.client.api.MessageId;
 public class PulsarConfig {
   public static final String STREAM_TYPE = "pulsar";
   public static final String BOOTSTRAP_SERVERS = "bootstrap.servers";
-
+  public static final String AUTHENTICATION_TOKEN = "authenticationToken";
+  public static final String TLS_TRUST_CERTS_FILE_PATH = "tlsTrustCertsFilePath";
+  
   private String _pulsarTopicName;
   private String _subscriberId;
   private String _bootstrapServers;
   private MessageId _initialMessageId;
-
+  private String _authenticationToken;
+  private String _tlsTrustCertsFilePath;
+  
   public PulsarConfig(StreamConfig streamConfig, String subscriberId) {
     Map<String, String> streamConfigMap = streamConfig.getStreamConfigsMap();
     _pulsarTopicName = streamConfig.getTopicName();
     _bootstrapServers =
         streamConfigMap.get(StreamConfigProperties.constructStreamProperty(STREAM_TYPE, BOOTSTRAP_SERVERS));
     _subscriberId = subscriberId;
+
+    String authenticationTokenKey = StreamConfigProperties.constructStreamProperty(STREAM_TYPE, AUTHENTICATION_TOKEN);
+    _authenticationToken = streamConfigMap.get(authenticationTokenKey);
+
+    String tlsTrustCertsFilePathKey = StreamConfigProperties.
+            constructStreamProperty(STREAM_TYPE, TLS_TRUST_CERTS_FILE_PATH);
+    _tlsTrustCertsFilePath = streamConfigMap.get(tlsTrustCertsFilePathKey);
 
     Preconditions.checkNotNull(_bootstrapServers, "No brokers provided in the config");
 
@@ -79,5 +90,13 @@ public class PulsarConfig {
 
   public MessageId getInitialMessageId() {
     return _initialMessageId;
+  }
+
+  public String getAuthenticationToken() {
+    return _authenticationToken;
+  }
+
+  public String getTlsTrustCertsFilePath() {
+    return _tlsTrustCertsFilePath;
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarPartitionLevelConnectionHandler.java
@@ -21,6 +21,8 @@ package org.apache.pinot.plugin.stream.pulsar;
 import java.io.IOException;
 import java.util.List;
 import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Reader;
 import org.slf4j.Logger;
@@ -50,7 +52,11 @@ public class PulsarPartitionLevelConnectionHandler {
     _topic = _config.getPulsarTopicName();
 
     try {
-      _pulsarClient = PulsarClient.builder().serviceUrl(_config.getBootstrapServers()).build();
+      Authentication authentication = AuthenticationFactory.token(_config.getAuthenticationToken());
+      _pulsarClient = PulsarClient.builder().serviceUrl(_config.getBootstrapServers())
+              .tlsTrustCertsFilePath(_config.getTlsTrustCertsFilePath())
+              .authentication(authentication)
+              .build();
 
       _reader = _pulsarClient.newReader().topic(getPartitionedTopicName(partition))
           .startMessageId(_config.getInitialMessageId()).create();

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarPartitionLevelConnectionHandler.java
@@ -53,14 +53,13 @@ public class PulsarPartitionLevelConnectionHandler {
     _topic = _config.getPulsarTopicName();
 
     try {
-      Authentication authentication = AuthenticationFactory.token(_config.getAuthenticationToken());
-
       ClientBuilder pulsarClientBuilder = PulsarClient.builder().serviceUrl(_config.getBootstrapServers());
       if (_config.getTlsTrustCertsFilePath() != null) {
         pulsarClientBuilder.tlsTrustCertsFilePath(_config.getTlsTrustCertsFilePath());
       }
 
       if (_config.getAuthenticationToken() != null) {
+        Authentication authentication = AuthenticationFactory.token(_config.getAuthenticationToken());
         pulsarClientBuilder.authentication(authentication);
       }
 

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarPartitionLevelConnectionHandler.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
+import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Reader;
 import org.slf4j.Logger;
@@ -53,10 +54,17 @@ public class PulsarPartitionLevelConnectionHandler {
 
     try {
       Authentication authentication = AuthenticationFactory.token(_config.getAuthenticationToken());
-      _pulsarClient = PulsarClient.builder().serviceUrl(_config.getBootstrapServers())
-              .tlsTrustCertsFilePath(_config.getTlsTrustCertsFilePath())
-              .authentication(authentication)
-              .build();
+
+      ClientBuilder pulsarClientBuilder = PulsarClient.builder().serviceUrl(_config.getBootstrapServers());
+      if (_config.getTlsTrustCertsFilePath() != null) {
+        pulsarClientBuilder.tlsTrustCertsFilePath(_config.getTlsTrustCertsFilePath());
+      }
+
+      if (_config.getAuthenticationToken() != null) {
+        pulsarClientBuilder.authentication(authentication);
+      }
+
+      _pulsarClient = pulsarClientBuilder.build();
 
       _reader = _pulsarClient.newReader().topic(getPartitionedTopicName(partition))
           .startMessageId(_config.getInitialMessageId()).create();

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamLevelConsumerManager.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamLevelConsumerManager.java
@@ -78,15 +78,14 @@ public class PulsarStreamLevelConsumerManager {
 
       // Create the consumer
       try {
-        Authentication authentication = AuthenticationFactory.token(
-                pulsarStreamLevelStreamConfig.getAuthenticationToken());
-
         ClientBuilder pulsarClientBuilder = PulsarClient.builder().serviceUrl(pulsarStreamLevelStreamConfig.getBootstrapServers());
         if (pulsarStreamLevelStreamConfig.getTlsTrustCertsFilePath() != null) {
           pulsarClientBuilder.tlsTrustCertsFilePath(pulsarStreamLevelStreamConfig.getTlsTrustCertsFilePath());
         }
 
         if (pulsarStreamLevelStreamConfig.getAuthenticationToken() != null) {
+          Authentication authentication = AuthenticationFactory.token(
+                  pulsarStreamLevelStreamConfig.getAuthenticationToken());
           pulsarClientBuilder.authentication(authentication);
         }
 

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamLevelConsumerManager.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamLevelConsumerManager.java
@@ -25,6 +25,8 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.apache.pulsar.client.api.Authentication;
+import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Reader;
@@ -75,7 +77,12 @@ public class PulsarStreamLevelConsumerManager {
 
       // Create the consumer
       try {
-        _pulsarClient = PulsarClient.builder().serviceUrl(pulsarStreamLevelStreamConfig.getBootstrapServers()).build();
+        Authentication authentication = AuthenticationFactory.token(
+                pulsarStreamLevelStreamConfig.getAuthenticationToken());
+        _pulsarClient = PulsarClient.builder().serviceUrl(pulsarStreamLevelStreamConfig.getBootstrapServers())
+                .tlsTrustCertsFilePath(pulsarStreamLevelStreamConfig.getTlsTrustCertsFilePath())
+                .authentication(authentication)
+                .build();
 
         _reader = _pulsarClient.newReader().topic(pulsarStreamLevelStreamConfig.getPulsarTopicName())
             .startMessageId(pulsarStreamLevelStreamConfig.getInitialMessageId()).create();

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamLevelConsumerManager.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamLevelConsumerManager.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
+import org.apache.pulsar.client.api.ClientBuilder;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Reader;
@@ -79,10 +80,17 @@ public class PulsarStreamLevelConsumerManager {
       try {
         Authentication authentication = AuthenticationFactory.token(
                 pulsarStreamLevelStreamConfig.getAuthenticationToken());
-        _pulsarClient = PulsarClient.builder().serviceUrl(pulsarStreamLevelStreamConfig.getBootstrapServers())
-                .tlsTrustCertsFilePath(pulsarStreamLevelStreamConfig.getTlsTrustCertsFilePath())
-                .authentication(authentication)
-                .build();
+
+        ClientBuilder pulsarClientBuilder = PulsarClient.builder().serviceUrl(pulsarStreamLevelStreamConfig.getBootstrapServers());
+        if (pulsarStreamLevelStreamConfig.getTlsTrustCertsFilePath() != null) {
+          pulsarClientBuilder.tlsTrustCertsFilePath(pulsarStreamLevelStreamConfig.getTlsTrustCertsFilePath());
+        }
+
+        if (pulsarStreamLevelStreamConfig.getAuthenticationToken() != null) {
+          pulsarClientBuilder.authentication(authentication);
+        }
+
+        _pulsarClient = pulsarClientBuilder.build();
 
         _reader = _pulsarClient.newReader().topic(pulsarStreamLevelStreamConfig.getPulsarTopicName())
             .startMessageId(pulsarStreamLevelStreamConfig.getInitialMessageId()).create();


### PR DESCRIPTION
## Description
This PR modify the Pulsar connector to handle authentication.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* No

Does this PR fix a zero-downtime upgrade introduced earlier?
* No

Does this PR otherwise need attention when creating release notes? :
- New configuration options

## Release Notes
2 optionals parameters are added to streamConfigs to handle authentication :
- `stream.pulsar.authenticationToken`
- `stream.pulsar.tlsTrustCertsFilePath`

## Documentation
The Pulsar connector can be used with a secured Apache Pulsar server using an authentication token and a TLS certificate. These parameters are optionals to handle unsecured Apache Pulsar servers.
- `stream.pulsar.authenticationToken`
- `stream.pulsar.tlsTrustCertsFilePath`
