### PR TITLE
Canonicalize the function name for SQL parser

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -39,7 +39,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
-import org.apache.calcite.sql.SqlKind;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.broker.api.RequestStatistics;
 import org.apache.pinot.broker.api.RequesterIdentity;
@@ -50,7 +49,6 @@ import org.apache.pinot.broker.routing.RoutingTable;
 import org.apache.pinot.broker.routing.timeboundary.TimeBoundaryInfo;
 import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.exception.QueryException;
-import org.apache.pinot.common.function.TransformFunctionType;
 import org.apache.pinot.common.metrics.BrokerGauge;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
@@ -76,7 +74,6 @@ import org.apache.pinot.common.response.broker.QueryProcessingException;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.request.RequestUtils;
-import org.apache.pinot.core.operator.transform.function.TransformFunctionFactory;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.optimizer.QueryOptimizer;
 import org.apache.pinot.core.requesthandler.PinotQueryParserFactory;
@@ -104,7 +101,8 @@ import org.slf4j.LoggerFactory;
 @ThreadSafe
 public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(BaseBrokerRequestHandler.class);
-  private static final String IN_SUBQUERY = "inSubquery";
+  private static final String IN_SUBQUERY = "insubquery";
+  private static final String IN_ID_SET = "inidset";
   private static final Expression FALSE = RequestUtils.getLiteralExpression(false);
   private static final Expression TRUE = RequestUtils.getLiteralExpression(true);
   private static final Expression STAR = RequestUtils.getIdentifierExpression("*");
@@ -975,7 +973,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       }
 
       String serializedIdSet = (String) response.getAggregationResults().get(0).getValue();
-      expression.setValue(TransformFunctionType.INIDSET.name());
+      expression.setValue(IN_ID_SET);
       children.set(1,
           new TransformExpressionTree(TransformExpressionTree.ExpressionType.LITERAL, serializedIdSet, null));
     } else {
@@ -1013,7 +1011,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       return;
     }
     List<Expression> operands = function.getOperands();
-    if (StringUtils.remove(function.getOperator(), '_').equalsIgnoreCase(IN_SUBQUERY)) {
+    if (function.getOperator().equals(IN_SUBQUERY)) {
       Preconditions.checkState(operands.size() == 2, "IN_SUBQUERY requires 2 arguments: expression, subquery");
       Literal subqueryLiteral = operands.get(1).getLiteral();
       Preconditions.checkState(subqueryLiteral != null, "Second argument of IN_SUBQUERY must be a literal (subquery)");
@@ -1024,7 +1022,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         throw new RuntimeException("Caught exception while executing subquery: " + subquery);
       }
       String serializedIdSet = (String) response.getResultTable().getRows().get(0)[0];
-      function.setOperator(TransformFunctionType.INIDSET.name());
+      function.setOperator(IN_ID_SET);
       operands.set(1, RequestUtils.getLiteralExpression(serializedIdSet));
     } else {
       for (Expression operand : operands) {
@@ -1236,21 +1234,15 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   }
 
   private static void rejectGroovyQuery(Expression expression) {
-    Function functionCall = expression.getFunctionCall();
-    if (functionCall == null) {
+    Function function = expression.getFunctionCall();
+    if (function == null) {
       return;
     }
-
-    if (TransformFunctionFactory.canonicalize(functionCall.getOperator())
-        .equals(TransformFunctionType.GROOVY.getName())) {
+    if (function.getOperator().equals("groovy")) {
       throw new BadQueryRequestException("Groovy transform functions are disabled for queries");
     }
-
-    List<Expression> operands = functionCall.getOperands();
-    if (operands != null) {
-      for (Expression operandExpression : operands) {
-        rejectGroovyQuery(operandExpression);
-      }
+    for (Expression operandExpression : function.getOperands()) {
+      rejectGroovyQuery(operandExpression);
     }
   }
 
@@ -1258,26 +1250,24 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
    * Sets HyperLogLog log2m for DistinctCountHLL functions if not explicitly set for the given SQL expression.
    */
   private static void handleHLLLog2mOverride(Expression expression, int hllLog2mOverride) {
-    Function functionCall = expression.getFunctionCall();
-    if (functionCall == null) {
+    Function function = expression.getFunctionCall();
+    if (function == null) {
       return;
     }
-    switch (functionCall.getOperator().toUpperCase()) {
-      case "DISTINCTCOUNTHLL":
-      case "DISTINCTCOUNTHLLMV":
-      case "DISTINCTCOUNTRAWHLL":
-      case "DISTINCTCOUNTRAWHLLMV":
-        if (functionCall.getOperandsSize() == 1) {
-          functionCall.addToOperands(RequestUtils.getLiteralExpression(hllLog2mOverride));
+    switch (function.getOperator()) {
+      case "distinctcounthll":
+      case "distinctcounthllmv":
+      case "distinctcountrawhll":
+      case "distinctcountrawhllmv":
+        if (function.getOperandsSize() == 1) {
+          function.addToOperands(RequestUtils.getLiteralExpression(hllLog2mOverride));
         }
         return;
       default:
         break;
     }
-    if (functionCall.getOperandsSize() > 0) {
-      for (Expression operand : functionCall.getOperands()) {
-        handleHLLLog2mOverride(operand, hllLog2mOverride);
-      }
+    for (Expression operand : function.getOperands()) {
+      handleHLLLog2mOverride(operand, hllLog2mOverride);
     }
   }
 
@@ -1387,12 +1377,11 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     if (function == null) {
       return;
     }
-    if (StringUtils.remove(function.getOperator(), '_')
-        .equalsIgnoreCase(AggregationFunctionType.DISTINCTCOUNT.name())) {
+    if (function.getOperator().equals("distinctcount")) {
       List<Expression> operands = function.getOperands();
       if (operands.size() == 1 && operands.get(0).isSetIdentifier() && segmentPartitionedColumns.contains(
           operands.get(0).getIdentifier().getName())) {
-        function.setOperator(AggregationFunctionType.SEGMENTPARTITIONEDDISTINCTCOUNT.name());
+        function.setOperator("segmentpartitioneddistinctcount");
       }
     } else {
       for (Expression operand : function.getOperands()) {
@@ -1429,9 +1418,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     if (function == null) {
       return;
     }
-    if (StringUtils.remove(function.getOperator(), '_')
-        .equalsIgnoreCase(AggregationFunctionType.DISTINCTCOUNT.name())) {
-      function.setOperator(AggregationFunctionType.DISTINCTCOUNTBITMAP.name());
+    if (function.getOperator().equals("distinctcount")) {
+      function.setOperator("distinctcountbitmap");
     } else {
       for (Expression operand : function.getOperands()) {
         handleDistinctCountBitmapOverride(operand);
@@ -1525,7 +1513,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       computeResultsForLiteral(e.getLiteral(), columnNames, columnTypes, row);
     }
     if (e.getType() == ExpressionType.FUNCTION) {
-      if (e.getFunctionCall().getOperator().equalsIgnoreCase(SqlKind.AS.toString())) {
+      if (e.getFunctionCall().getOperator().equals("as")) {
         String columnName = e.getFunctionCall().getOperands().get(1).getIdentifier().getName();
         computeResultsForExpression(e.getFunctionCall().getOperands().get(0), columnNames, columnTypes, row);
         columnNames.set(columnNames.size() - 1, columnName);
@@ -1741,7 +1729,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     } else if (expressionType == ExpressionType.FUNCTION) {
       final Function functionCall = expression.getFunctionCall();
       switch (functionCall.getOperator()) {
-        case "AS":
+        case "as":
           fixColumnName(rawTableName, functionCall.getOperands().get(0), columnNameMap, aliasMap, isCaseInsensitive);
           final Expression rightAsExpr = functionCall.getOperands().get(1);
           if (rightAsExpr.isSetIdentifier()) {
@@ -1753,7 +1741,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
             }
           }
           break;
-        case "LOOKUP":
+        case "lookup":
           // LOOKUP function looks up another table's schema, skip the check for now.
           break;
         default:

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/DistinctCountRewriteTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/DistinctCountRewriteTest.java
@@ -53,10 +53,10 @@ public class DistinctCountRewriteTest {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
     BaseBrokerRequestHandler.handleSegmentPartitionedDistinctCountOverride(pinotQuery, ImmutableSet.of("col2", "col3"));
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(),
-        AggregationFunctionType.DISTINCTCOUNT.name());
+        AggregationFunctionType.DISTINCTCOUNT.name().toLowerCase());
     BaseBrokerRequestHandler.handleSegmentPartitionedDistinctCountOverride(pinotQuery,
         ImmutableSet.of("col1", "col2", "col3"));
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(),
-        AggregationFunctionType.SEGMENTPARTITIONEDDISTINCTCOUNT.name());
+        AggregationFunctionType.SEGMENTPARTITIONEDDISTINCTCOUNT.name().toLowerCase());
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SelectStarWithOtherColsRewriteTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SelectStarWithOtherColsRewriteTest.java
@@ -65,8 +65,9 @@ public class SelectStarWithOtherColsRewriteTest {
       countMap.put(col, countMap.getOrDefault(col, 0) + 1);
     }
     Assert.assertEquals(countMap.size(), 5, "More new selections than expected");
-    Assert.assertTrue(countMap.keySet().containsAll(COL_MAP.keySet().stream().filter(a -> !a.startsWith("$")).collect(
-        Collectors.toList())), "New selections contain virtual columns");
+    Assert.assertTrue(countMap.keySet()
+            .containsAll(COL_MAP.keySet().stream().filter(a -> !a.startsWith("$")).collect(Collectors.toList())),
+        "New selections contain virtual columns");
     countMap.forEach(
         (key, value) -> Assert.assertEquals((int) value, 1, key + " has more than one occurrences in new selection"));
   }
@@ -156,7 +157,7 @@ public class SelectStarWithOtherColsRewriteTest {
     BaseBrokerRequestHandler.updateColumnNames("baseballStats", pinotQuery, false, COL_MAP);
     List<Expression> newSelections = pinotQuery.getSelectList();
     Assert.assertTrue(newSelections.get(0).isSetFunctionCall());
-    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperator(), "AS");
+    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
         "playerID");
     Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "pid");
@@ -180,7 +181,7 @@ public class SelectStarWithOtherColsRewriteTest {
     BaseBrokerRequestHandler.updateColumnNames("baseballStats", pinotQuery, false, COL_MAP);
     List<Expression> newSelections = pinotQuery.getSelectList();
     Assert.assertTrue(newSelections.get(0).isSetFunctionCall());
-    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperator(), "SQRT");
+    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperator(), "sqrt");
     Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
         "homeRuns");
     //homeRuns is returned as well
@@ -203,7 +204,7 @@ public class SelectStarWithOtherColsRewriteTest {
     BaseBrokerRequestHandler.updateColumnNames("baseballStats", pinotQuery, false, COL_MAP);
     List<Expression> newSelections = pinotQuery.getSelectList();
     Assert.assertTrue(newSelections.get(0).isSetFunctionCall());
-    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperator(), "ADD");
+    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperator(), "add");
     Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
         "homeRuns");
     Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(),
@@ -252,11 +253,11 @@ public class SelectStarWithOtherColsRewriteTest {
     BaseBrokerRequestHandler.updateColumnNames("baseballStats", pinotQuery, false, COL_MAP);
     List<Expression> newSelections = pinotQuery.getSelectList();
     Assert.assertTrue(newSelections.get(0).isSetFunctionCall());
-    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperator(), "ABS");
+    Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperator(), "abs");
     Assert.assertEquals(newSelections.get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
         "homeRuns");
     Assert.assertTrue(newSelections.get(1).isSetFunctionCall());
-    Assert.assertEquals(newSelections.get(1).getFunctionCall().getOperator(), "SQRT");
+    Assert.assertEquals(newSelections.get(1).getFunctionCall().getOperator(), "sqrt");
     Assert.assertEquals(newSelections.get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
         "groundedIntoDoublePlays");
     Assert.assertEquals(newSelections.get(2).getIdentifier().getName(), "G_old");
@@ -266,7 +267,7 @@ public class SelectStarWithOtherColsRewriteTest {
     Assert.assertEquals(newSelections.get(6).getIdentifier().getName(), "playerStint");
     Assert.assertEquals(newSelections.get(7).getIdentifier().getName(), "$segmentName");
     Assert.assertEquals(newSelections.get(8).getIdentifier().getName(), "$hostName");
-    Assert.assertEquals(newSelections.get(9).getFunctionCall().getOperator(), "AS");
+    Assert.assertEquals(newSelections.get(9).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(newSelections.get(9).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
         "playerStint");
     Assert.assertEquals(newSelections.get(9).getFunctionCall().getOperands().get(1).getIdentifier().getName(),

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -108,10 +108,10 @@ public enum TransformFunctionType {
   // Geo indexing
   GEOTOH3("geoToH3");
 
-  private static final Set<String> NAMES = Arrays.stream(values())
-      .flatMap(func -> Stream.of(func.getName(), StringUtils.remove(func.getName(), '_').toUpperCase(),
-          func.getName().toUpperCase(), func.getName().toLowerCase(), func.name(), func.name().toLowerCase()))
-      .collect(Collectors.toSet());
+  private static final Set<String> NAMES = Arrays.stream(values()).flatMap(
+      func -> Stream.of(func.getName(), StringUtils.remove(func.getName(), '_').toUpperCase(),
+          StringUtils.remove(func.getName(), '_').toLowerCase(), func.getName().toUpperCase(),
+          func.getName().toLowerCase(), func.name(), func.name().toLowerCase())).collect(Collectors.toSet());
 
   private final String _name;
 

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/OutputColumnAstNode.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/OutputColumnAstNode.java
@@ -74,7 +74,7 @@ public class OutputColumnAstNode extends BaseAstNode {
         Expression functionExpr;
         if (node.getName().equalsIgnoreCase("count")) {
           // COUNT aggregation function always works on '*'
-          functionExpr = RequestUtils.getFunctionExpression(node.getName());
+          functionExpr = RequestUtils.getFunctionExpression("count");
           functionExpr.getFunctionCall().addToOperands(RequestUtils.createIdentifierExpression("*"));
         } else {
           functionExpr = RequestUtils.getExpression(astNode);

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -20,7 +20,7 @@ package org.apache.pinot.sql.parsers;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -50,11 +50,11 @@ import org.apache.calcite.sql.parser.SqlParser;
 import org.apache.calcite.sql.parser.babel.SqlBabelParserImpl;
 import org.apache.calcite.sql.validate.SqlConformanceEnum;
 import org.apache.commons.collections.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.request.DataSource;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
 import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.Identifier;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.pql.parsers.pql2.ast.FilterKind;
@@ -187,7 +187,7 @@ public class CalciteSqlParser {
     List<Expression> selectList = pinotQuery.getSelectList();
     if (selectList.size() == 1) {
       Function function = selectList.get(0).getFunctionCall();
-      if (function != null && function.getOperator().equalsIgnoreCase(AggregationFunctionType.DISTINCT.getName())) {
+      if (function != null && function.getOperator().equals("distinct")) {
         if (CollectionUtils.isNotEmpty(pinotQuery.getGroupByList())) {
           // TODO: Explore if DISTINCT should be supported with GROUP BY
           throw new IllegalStateException("DISTINCT with GROUP BY is currently not supported");
@@ -231,16 +231,15 @@ public class CalciteSqlParser {
     if (expr.getType() == ExpressionType.LITERAL || isAggregateExpression(expr) || groupByExprs.contains(expr)) {
       return false;
     }
-
-    final Function funcExpr = expr.getFunctionCall();
+    Function function = expr.getFunctionCall();
     // function expression
-    if (funcExpr != null) {
+    if (function != null) {
       // for Alias function, check the actual value
-      if (funcExpr.getOperator().equalsIgnoreCase(SqlKind.AS.toString())) {
-        return expressionOutsideGroupByList(funcExpr.getOperands().get(0), groupByExprs);
+      if (function.getOperator().equals("as")) {
+        return expressionOutsideGroupByList(function.getOperands().get(0), groupByExprs);
       }
       // Expression is invalid if any of its children is invalid
-      return funcExpr.getOperands().stream().anyMatch(e -> expressionOutsideGroupByList(e, groupByExprs));
+      return function.getOperands().stream().anyMatch(e -> expressionOutsideGroupByList(e, groupByExprs));
     }
     return true;
   }
@@ -264,7 +263,8 @@ public class CalciteSqlParser {
   }
 
   public static boolean isAsFunction(Expression expression) {
-    return expression.getFunctionCall() != null && expression.getFunctionCall().getOperator().equalsIgnoreCase("AS");
+    Function function = expression.getFunctionCall();
+    return function != null && function.getOperator().equals("as");
   }
 
   /**
@@ -277,15 +277,17 @@ public class CalciteSqlParser {
   public static Set<String> extractIdentifiers(List<Expression> expressions, boolean excludeAs) {
     Set<String> identifiers = new HashSet<>();
     for (Expression expression : expressions) {
-      if (expression.getIdentifier() != null) {
-        identifiers.add(expression.getIdentifier().getName());
-      } else if (expression.getFunctionCall() != null) {
-        if (excludeAs && expression.getFunctionCall().getOperator().equalsIgnoreCase("AS")) {
-          identifiers.addAll(
-              extractIdentifiers(Arrays.asList(expression.getFunctionCall().getOperands().get(0)), true));
-          continue;
+      Identifier identifier = expression.getIdentifier();
+      if (identifier != null) {
+        identifiers.add(identifier.getName());
+        continue;
+      }
+      Function function = expression.getFunctionCall();
+      if (function != null) {
+        if (excludeAs && function.getOperator().equals("as")) {
+          identifiers.addAll(extractIdentifiers(Collections.singletonList(function.getOperands().get(0)), true));
         } else {
-          identifiers.addAll(extractIdentifiers(expression.getFunctionCall().getOperands(), excludeAs));
+          identifiers.addAll(extractIdentifiers(function.getOperands(), excludeAs));
         }
       }
     }
@@ -556,19 +558,14 @@ public class CalciteSqlParser {
   }
 
   private static Expression convertOrderBy(SqlNode node) {
-    final SqlKind kind = node.getKind();
     Expression expression;
-    switch (kind) {
-      case DESCENDING:
-        SqlBasicCall basicCall = (SqlBasicCall) node;
-        expression = RequestUtils.getFunctionExpression("DESC");
-        expression.getFunctionCall().addToOperands(toExpression(basicCall.getOperandList().get(0)));
-        break;
-      case IDENTIFIER:
-      default:
-        expression = RequestUtils.getFunctionExpression("ASC");
-        expression.getFunctionCall().addToOperands(toExpression(node));
-        break;
+    if (node.getKind() == SqlKind.DESCENDING) {
+      SqlBasicCall basicCall = (SqlBasicCall) node;
+      expression = RequestUtils.getFunctionExpression("desc");
+      expression.getFunctionCall().addToOperands(toExpression(basicCall.getOperandList().get(0)));
+    } else {
+      expression = RequestUtils.getFunctionExpression("asc");
+      expression.getFunctionCall().addToOperands(toExpression(node));
     }
     return expression;
   }
@@ -581,8 +578,7 @@ public class CalciteSqlParser {
    * @return DISTINCT function expression
    */
   private static Expression convertDistinctAndSelectListToFunctionExpression(SqlNodeList selectList) {
-    String functionName = AggregationFunctionType.DISTINCT.getName();
-    Expression functionExpression = RequestUtils.getFunctionExpression(functionName);
+    Expression functionExpression = RequestUtils.getFunctionExpression("distinct");
     for (SqlNode node : selectList) {
       Expression columnExpression = toExpression(node);
       if (columnExpression.getType() == ExpressionType.IDENTIFIER && columnExpression.getIdentifier().getName()
@@ -591,9 +587,7 @@ public class CalciteSqlParser {
             "Syntax error: Pinot currently does not support DISTINCT with *. Please specify each column name after "
                 + "DISTINCT keyword");
       } else if (columnExpression.getType() == ExpressionType.FUNCTION) {
-        Function functionCall = columnExpression.getFunctionCall();
-        String function = functionCall.getOperator();
-        if (AggregationFunctionType.isAggregationFunction(function)) {
+        if (AggregationFunctionType.isAggregationFunction(columnExpression.getFunctionCall().getOperator())) {
           throw new SqlCompilationException(
               "Syntax error: Use of DISTINCT with aggregation functions is not supported");
         }
@@ -639,7 +633,7 @@ public class CalciteSqlParser {
             return leftExpr;
           }
         }
-        final Expression asFuncExpr = RequestUtils.getFunctionExpression(SqlKind.AS.toString());
+        Expression asFuncExpr = RequestUtils.getFunctionExpression("as");
         asFuncExpr.getFunctionCall().addToOperands(leftExpr);
         asFuncExpr.getFunctionCall().addToOperands(rightExpr);
         return asFuncExpr;
@@ -653,7 +647,7 @@ public class CalciteSqlParser {
         SqlNodeList whenOperands = caseSqlNode.getWhenOperands();
         SqlNodeList thenOperands = caseSqlNode.getThenOperands();
         SqlNode elseOperand = caseSqlNode.getElseOperand();
-        Expression caseFuncExpr = RequestUtils.getFunctionExpression(SqlKind.CASE.name());
+        Expression caseFuncExpr = RequestUtils.getFunctionExpression("case");
         for (SqlNode whenSqlNode : whenOperands.getList()) {
           Expression whenExpression = toExpression(whenSqlNode);
           if (isAggregateExpression(whenExpression)) {
@@ -690,7 +684,7 @@ public class CalciteSqlParser {
   private static Expression compileFunctionExpression(SqlBasicCall functionNode) {
     SqlKind functionKind = functionNode.getKind();
     boolean negated = false;
-    String functionName;
+    String canonicalName;
     switch (functionKind) {
       case AND:
         return compileAndExpression(functionNode);
@@ -699,35 +693,36 @@ public class CalciteSqlParser {
       // BETWEEN and LIKE might be negated (NOT BETWEEN, NOT LIKE)
       case BETWEEN:
         negated = ((SqlBetweenOperator) functionNode.getOperator()).isNegated();
-        functionName = SqlKind.BETWEEN.name();
+        canonicalName = SqlKind.BETWEEN.name();
         break;
       case LIKE:
         negated = ((SqlLikeOperator) functionNode.getOperator()).isNegated();
-        functionName = SqlKind.LIKE.name();
+        canonicalName = SqlKind.LIKE.name();
         break;
       case OTHER:
       case OTHER_FUNCTION:
       case DOT:
-        functionName = functionNode.getOperator().getName().toUpperCase();
+        String functionName = functionNode.getOperator().getName();
         if (functionName.equals("ITEM") || functionName.equals("DOT")) {
           // Calcite parses path expression such as "data[0][1].a.b[0]" into a chain of ITEM and/or DOT
           // functions. Collapse this chain into an identifier.
-          StringBuffer path = new StringBuffer();
-          compilePathExpression(functionName, functionNode, path);
-          return RequestUtils.getIdentifierExpression(path.toString());
+          StringBuilder pathBuilder = new StringBuilder();
+          compilePathExpression(functionNode, pathBuilder);
+          return RequestUtils.getIdentifierExpression(pathBuilder.toString());
         }
+        canonicalName = RequestUtils.canonicalizeFunctionNamePreservingSpecialKey(functionName);
         if ((functionNode.getFunctionQuantifier() != null) && ("DISTINCT".equals(
             functionNode.getFunctionQuantifier().toString()))) {
-          if (AggregationFunctionType.COUNT.name().equals(functionName)) {
-            functionName = AggregationFunctionType.DISTINCTCOUNT.name();
-          } else if (AggregationFunctionType.isAggregationFunction(functionName)) {
+          if (canonicalName.equals("count")) {
+            canonicalName = "distinctcount";
+          } else if (AggregationFunctionType.isAggregationFunction(canonicalName)) {
             // Aggregation function(other than COUNT) on DISTINCT is not supported, e.g. SUM(DISTINCT colA).
             throw new SqlCompilationException("Function '" + functionName + "' on DISTINCT is not supported.");
           }
         }
         break;
       default:
-        functionName = functionKind.name();
+        canonicalName = RequestUtils.canonicalizeFunctionNamePreservingSpecialKey(functionKind.name());
         break;
     }
     // When there is no argument, set an empty list as the operands
@@ -742,8 +737,8 @@ public class CalciteSqlParser {
         operands.add(toExpression(childNode));
       }
     }
-    validateFunction(functionName, operands);
-    Expression functionExpression = RequestUtils.getFunctionExpression(functionName);
+    validateFunction(canonicalName, operands);
+    Expression functionExpression = RequestUtils.getFunctionExpression(canonicalName);
     functionExpression.getFunctionCall().setOperands(operands);
     if (negated) {
       Expression negatedFunctionExpression = RequestUtils.getFunctionExpression(FilterKind.NOT.name());
@@ -773,22 +768,22 @@ public class CalciteSqlParser {
    *                              ├── LITERAL (1)
    *                              └── IDENTIFIER (jsoncolumn.data)
    *
-   * @param functionName Name of the function ("DOT" or "ITEM")
    * @param functionNode Root node of the DOT and/or ITEM operator function chain.
-   * @param path String representation of path represented by DOT and/or ITEM function chain.
+   * @param pathBuilder StringBuilder representation of path represented by DOT and/or ITEM function chain.
    */
-  private static void compilePathExpression(String functionName, SqlBasicCall functionNode, StringBuffer path) {
+  private static void compilePathExpression(SqlBasicCall functionNode, StringBuilder pathBuilder) {
     List<SqlNode> operands = functionNode.getOperandList();
 
     // Compile first operand of the function (either an identifier or another DOT and/or ITEM function).
-    SqlKind kind0 = operands.get(0).getKind();
+    SqlNode operand0 = operands.get(0);
+    SqlKind kind0 = operand0.getKind();
     if (kind0 == SqlKind.IDENTIFIER) {
-      path.append(operands.get(0).toString());
+      pathBuilder.append(operand0);
     } else if (kind0 == SqlKind.DOT || kind0 == SqlKind.OTHER_FUNCTION) {
-      SqlBasicCall function0 = (SqlBasicCall) operands.get(0);
+      SqlBasicCall function0 = (SqlBasicCall) operand0;
       String name0 = function0.getOperator().getName();
       if (name0.equals("ITEM") || name0.equals("DOT")) {
-        compilePathExpression(name0, function0, path);
+        compilePathExpression(function0, pathBuilder);
       } else {
         throw new SqlCompilationException("SELECT list item has bad path expression.");
       }
@@ -797,26 +792,19 @@ public class CalciteSqlParser {
     }
 
     // Compile second operand of the function (either an identifier or literal).
-    SqlKind kind1 = operands.get(1).getKind();
+    SqlNode operand1 = operands.get(1);
+    SqlKind kind1 = operand1.getKind();
     if (kind1 == SqlKind.IDENTIFIER) {
-      path.append(".").append(((SqlIdentifier) operands.get(1)).getSimple());
+      pathBuilder.append('.').append(((SqlIdentifier) operand1).getSimple());
     } else if (kind1 == SqlKind.LITERAL) {
-      path.append("[").append(((SqlLiteral) operands.get(1)).toValue()).append("]");
+      pathBuilder.append('[').append(((SqlLiteral) operand1).toValue()).append(']');
     } else {
       throw new SqlCompilationException("SELECT list item has bad path expression.");
     }
   }
 
-  public static String canonicalize(String functionName) {
-    return StringUtils.remove(functionName, '_').toLowerCase();
-  }
-
-  public static boolean isSameFunction(String function1, String function2) {
-    return canonicalize(function1).equals(canonicalize(function2));
-  }
-
-  private static void validateFunction(String functionName, List<Expression> operands) {
-    switch (canonicalize(functionName)) {
+  private static void validateFunction(String canonicalName, List<Expression> operands) {
+    switch (canonicalName) {
       case "jsonextractscalar":
         validateJsonExtractScalarFunction(operands);
         break;
@@ -871,7 +859,7 @@ public class CalciteSqlParser {
         operands.add(toExpression(childNode));
       }
     }
-    Expression andExpression = RequestUtils.getFunctionExpression(SqlKind.AND.name());
+    Expression andExpression = RequestUtils.getFunctionExpression(FilterKind.AND.name());
     andExpression.getFunctionCall().setOperands(operands);
     return andExpression;
   }
@@ -889,7 +877,7 @@ public class CalciteSqlParser {
         operands.add(toExpression(childNode));
       }
     }
-    Expression andExpression = RequestUtils.getFunctionExpression(SqlKind.OR.name());
+    Expression andExpression = RequestUtils.getFunctionExpression(FilterKind.OR.name());
     andExpression.getFunctionCall().setOperands(operands);
     return andExpression;
   }
@@ -899,9 +887,9 @@ public class CalciteSqlParser {
       return true;
     }
     if (e.getType() == ExpressionType.FUNCTION) {
-      Function functionCall = e.getFunctionCall();
-      if (functionCall.getOperator().equalsIgnoreCase(SqlKind.AS.toString())) {
-        return isLiteralOnlyExpression(functionCall.getOperands().get(0));
+      Function function = e.getFunctionCall();
+      if (function.getOperator().equals("as")) {
+        return isLiteralOnlyExpression(function.getOperands().get(0));
       }
       return false;
     }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/AliasApplier.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/AliasApplier.java
@@ -23,7 +23,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.apache.calcite.sql.SqlKind;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.Identifier;
@@ -51,7 +50,7 @@ public class AliasApplier implements QueryRewriter {
       if (functionCall == null) {
         continue;
       }
-      if (functionCall.getOperator().equalsIgnoreCase(SqlKind.AS.toString())) {
+      if (functionCall.getOperator().equals("as")) {
         Expression identifierExpr = functionCall.getOperands().get(1);
         aliasMap.put(identifierExpr.getIdentifier(), functionCall.getOperands().get(0));
       }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/NonAggregationGroupByToDistinctQueryRewriter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/NonAggregationGroupByToDistinctQueryRewriter.java
@@ -57,7 +57,7 @@ public class NonAggregationGroupByToDistinctQueryRewriter implements QueryRewrit
       Set<String> selectIdentifiers = CalciteSqlParser.extractIdentifiers(pinotQuery.getSelectList(), true);
       Set<String> groupByIdentifiers = CalciteSqlParser.extractIdentifiers(pinotQuery.getGroupByList(), true);
       if (groupByIdentifiers.containsAll(selectIdentifiers)) {
-        Expression distinctExpression = RequestUtils.getFunctionExpression("DISTINCT");
+        Expression distinctExpression = RequestUtils.getFunctionExpression("distinct");
         for (Expression select : pinotQuery.getSelectList()) {
           distinctExpression.getFunctionCall().addToOperands(select);
         }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/OrdinalsUpdater.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/OrdinalsUpdater.java
@@ -20,7 +20,6 @@ package org.apache.pinot.sql.parsers.rewriter;
 
 import java.util.Arrays;
 import java.util.List;
-import org.apache.calcite.sql.SqlKind;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.sql.parsers.SqlCompilationException;
@@ -54,7 +53,7 @@ public class OrdinalsUpdater implements QueryRewriter {
     if (ordinal > 0 && ordinal <= selectList.size()) {
       final Expression expression = selectList.get(ordinal - 1);
       // If the expression has AS, return the left operand.
-      if (expression.isSetFunctionCall() && expression.getFunctionCall().getOperator().equals(SqlKind.AS.name())) {
+      if (expression.isSetFunctionCall() && expression.getFunctionCall().getOperator().equals("as")) {
         return expression.getFunctionCall().getOperands().get(0);
       }
       return expression;

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriter.java
@@ -20,7 +20,6 @@ package org.apache.pinot.sql.parsers.rewriter;
 
 import java.util.Arrays;
 import java.util.List;
-import org.apache.calcite.sql.SqlKind;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.PinotQuery;
@@ -50,12 +49,11 @@ public class PredicateComparisonRewriter implements QueryRewriter {
   private static Expression updateComparisonPredicate(Expression expression) {
     Function function = expression.getFunctionCall();
     if (function != null) {
-      String operator = function.getOperator().toUpperCase();
       FilterKind filterKind;
       try {
-        filterKind = FilterKind.valueOf(operator);
+        filterKind = FilterKind.valueOf(function.getOperator());
       } catch (Exception e) {
-        throw new SqlCompilationException("Unsupported filter kind: " + operator);
+        throw new SqlCompilationException("Unsupported filter kind: " + function.getOperator());
       }
       List<Expression> operands = function.getOperands();
       switch (filterKind) {
@@ -84,7 +82,7 @@ public class PredicateComparisonRewriter implements QueryRewriter {
 
           // Handle predicate like 'a > b' -> 'a - b > 0'
           if (!secondOperand.isSetLiteral()) {
-            Expression minusExpression = RequestUtils.getFunctionExpression(SqlKind.MINUS.name());
+            Expression minusExpression = RequestUtils.getFunctionExpression("minus");
             minusExpression.getFunctionCall().setOperands(Arrays.asList(firstOperand, secondOperand));
             operands.set(0, minusExpression);
             operands.set(1, RequestUtils.getLiteralExpression(0));

--- a/pinot-common/src/test/java/org/apache/pinot/pql/parsers/Pql2CompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/pql/parsers/Pql2CompilerTest.java
@@ -246,8 +246,8 @@ public class Pql2CompilerTest {
     } catch (Pql2CompilationException e) {
       // Expected
       Assert.assertTrue(e.getMessage().startsWith("1:30: "),
-          "Compilation exception should contain line and character for error message. Error message is " + e
-              .getMessage());
+          "Compilation exception should contain line and character for error message. Error message is "
+              + e.getMessage());
       return;
     }
 
@@ -271,8 +271,8 @@ public class Pql2CompilerTest {
     Assert.assertEquals(brokerRequest.getPinotQuery().getQueryOptionsSize(), 0);
     Assert.assertNull(brokerRequest.getPinotQuery().getQueryOptions());
 
-    brokerRequest = COMPILER
-        .compileToBrokerRequest("select * from vegetables where name != 'Brussels sprouts' OPTION (delicious=yes)");
+    brokerRequest = COMPILER.compileToBrokerRequest(
+        "select * from vegetables where name != 'Brussels sprouts' OPTION (delicious=yes)");
     Assert.assertEquals(brokerRequest.getQueryOptionsSize(), 1);
     Assert.assertTrue(brokerRequest.getQueryOptions().containsKey("delicious"));
     Assert.assertEquals(brokerRequest.getQueryOptions().get("delicious"), "yes");
@@ -374,12 +374,11 @@ public class Pql2CompilerTest {
     // Test PinotQuery
     selectFunctionList = brokerRequest.getPinotQuery().getSelectList();
     Assert.assertEquals(selectFunctionList.size(), 1);
-    Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperator(), "SUM");
+    Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperator(), "sum");
     Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperands().size(), 1);
 
-    Assert
-        .assertEquals(selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-            "ADD");
+    Assert.assertEquals(
+        selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "add");
     Assert.assertEquals(
         selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().size(), 2);
     Assert.assertEquals(
@@ -390,7 +389,7 @@ public class Pql2CompilerTest {
             .getLiteral().getStringValue(), "bar");
     groupbyList = brokerRequest.getPinotQuery().getGroupByList();
     Assert.assertEquals(groupbyList.size(), 1);
-    Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperator(), "SUB");
+    Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperator(), "sub");
     Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperands().size(), 2);
     Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperands().get(0).getLiteral().getStringValue(), "foo");
     Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "bar");

--- a/pinot-common/src/test/java/org/apache/pinot/request/BrokerRequestSerializationTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/request/BrokerRequestSerializationTest.java
@@ -34,6 +34,7 @@ import org.apache.pinot.common.request.QueryType;
 import org.apache.pinot.common.request.Selection;
 import org.apache.pinot.common.request.SelectionSort;
 import org.apache.pinot.common.utils.request.RequestUtils;
+import org.apache.pinot.pql.parsers.pql2.ast.FilterKind;
 import org.apache.pinot.pql.parsers.pql2.ast.OrderByAstNode;
 import org.apache.pinot.pql.parsers.pql2.ast.StringLiteralAstNode;
 import org.apache.thrift.TException;
@@ -147,15 +148,15 @@ public class BrokerRequestSerializationTest {
     pinotQuery.addToOrderByList(ascExpr);
 
     //Populate FilterQuery
-    Expression filter = RequestUtils.getFunctionExpression(FilterOperator.AND.name());
+    Expression filter = RequestUtils.getFunctionExpression(FilterKind.AND.name());
 
-    Expression filterExpr1 = RequestUtils.getFunctionExpression(FilterOperator.EQUALITY.name());
+    Expression filterExpr1 = RequestUtils.getFunctionExpression(FilterKind.EQUALS.name());
     filterExpr1.getFunctionCall().addToOperands(RequestUtils.createIdentifierExpression("dummy1"));
     filterExpr1.getFunctionCall()
         .addToOperands(RequestUtils.createLiteralExpression(new StringLiteralAstNode("dummy1")));
     filter.getFunctionCall().addToOperands(filterExpr1);
 
-    Expression filterExpr2 = RequestUtils.getFunctionExpression(FilterOperator.EQUALITY.name());
+    Expression filterExpr2 = RequestUtils.getFunctionExpression(FilterKind.EQUALS.name());
     filterExpr2.getFunctionCall().addToOperands(RequestUtils.createIdentifierExpression("dummy2"));
     filterExpr2.getFunctionCall()
         .addToOperands(RequestUtils.createLiteralExpression(new StringLiteralAstNode("dummy2")));

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -24,7 +24,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
-import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNumericLiteral;
 import org.apache.calcite.sql.parser.SqlParseException;
 import org.apache.pinot.common.request.AggregationInfo;
@@ -39,6 +38,7 @@ import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.utils.request.FilterQueryTree;
 import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.pql.parsers.PinotQuery2BrokerRequestConverter;
+import org.apache.pinot.pql.parsers.pql2.ast.FilterKind;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.sql.parsers.rewriter.CompileTimeFunctionsInvoker;
 import org.testng.Assert;
@@ -54,52 +54,87 @@ public class CalciteSqlCompilerTest {
   private static final long ONE_HOUR_IN_MS = TimeUnit.HOURS.toMillis(1);
 
   @Test
+  public void testCanonicalFunctionName() {
+    Expression expression = CalciteSqlParser.compileToExpression("dIsTiNcT_cOuNt(AbC)");
+    Function function = expression.getFunctionCall();
+    Assert.assertEquals(function.getOperator(), AggregationFunctionType.DISTINCTCOUNT.name().toLowerCase());
+    Assert.assertEquals(function.getOperands().size(), 1);
+    Assert.assertEquals(function.getOperands().get(0).getIdentifier().getName(), "AbC");
+
+    expression = CalciteSqlParser.compileToExpression("ReGeXpLiKe(AbC)");
+    function = expression.getFunctionCall();
+    Assert.assertEquals(function.getOperator(), FilterKind.REGEXP_LIKE.name());
+    Assert.assertEquals(function.getOperands().size(), 1);
+    Assert.assertEquals(function.getOperands().get(0).getIdentifier().getName(), "AbC");
+
+    expression = CalciteSqlParser.compileToExpression("aBc > DeF");
+    function = expression.getFunctionCall();
+    Assert.assertEquals(function.getOperator(), FilterKind.GREATER_THAN.name());
+    Assert.assertEquals(function.getOperands().size(), 2);
+    Assert.assertEquals(function.getOperands().get(0).getIdentifier().getName(), "aBc");
+    Assert.assertEquals(function.getOperands().get(1).getIdentifier().getName(), "DeF");
+  }
+
+  @Test
   public void testCaseWhenStatements() {
+    //@formatter:off
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
-        "SELECT OrderID, Quantity,\n" + "CASE\n" + "    WHEN Quantity > 30 THEN 'The quantity is greater than 30'\n"
-            + "    WHEN Quantity = 30 THEN 'The quantity is 30'\n" + "    ELSE 'The quantity is under 30'\n"
-            + "END AS QuantityText\n" + "FROM OrderDetails");
+        "SELECT OrderID, Quantity,\n"
+            + "CASE\n"
+            + "    WHEN Quantity > 30 THEN 'The quantity is greater than 30'\n"
+            + "    WHEN Quantity = 30 THEN 'The quantity is 30'\n"
+            + "    ELSE 'The quantity is under 30'\n"
+            + "END AS QuantityText\n"
+            + "FROM OrderDetails");
+    //@formatter:on
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getIdentifier().getName(), "OrderID");
     Assert.assertEquals(pinotQuery.getSelectList().get(1).getIdentifier().getName(), "Quantity");
     Function asFunc = pinotQuery.getSelectList().get(2).getFunctionCall();
-    Assert.assertEquals(asFunc.getOperator(), SqlKind.AS.name());
+    Assert.assertEquals(asFunc.getOperator(), "as");
     Function caseFunc = asFunc.getOperands().get(0).getFunctionCall();
-    Assert.assertEquals(caseFunc.getOperator(), SqlKind.CASE.name());
+    Assert.assertEquals(caseFunc.getOperator(), "case");
     Assert.assertEquals(caseFunc.getOperandsSize(), 5);
     Function greatThanFunc = caseFunc.getOperands().get(0).getFunctionCall();
-    Assert.assertEquals(greatThanFunc.getOperator(), SqlKind.GREATER_THAN.name());
+    Assert.assertEquals(greatThanFunc.getOperator(), FilterKind.GREATER_THAN.name());
     Assert.assertEquals(greatThanFunc.getOperands().get(0).getIdentifier().getName(), "Quantity");
     Assert.assertEquals(greatThanFunc.getOperands().get(1).getLiteral().getFieldValue(), 30L);
     Function equalsFunc = caseFunc.getOperands().get(1).getFunctionCall();
-    Assert.assertEquals(equalsFunc.getOperator(), SqlKind.EQUALS.name());
+    Assert.assertEquals(equalsFunc.getOperator(), FilterKind.EQUALS.name());
     Assert.assertEquals(equalsFunc.getOperands().get(0).getIdentifier().getName(), "Quantity");
     Assert.assertEquals(equalsFunc.getOperands().get(1).getLiteral().getFieldValue(), 30L);
     Assert.assertEquals(caseFunc.getOperands().get(2).getLiteral().getFieldValue(), "The quantity is greater than 30");
     Assert.assertEquals(caseFunc.getOperands().get(3).getLiteral().getFieldValue(), "The quantity is 30");
     Assert.assertEquals(caseFunc.getOperands().get(4).getLiteral().getFieldValue(), "The quantity is under 30");
 
+    //@formatter:off
     pinotQuery = CalciteSqlParser.compileToPinotQuery(
-        "SELECT Quantity,\n" + "SUM(CASE\n" + "    WHEN Quantity > 30 THEN 3\n" + "    WHEN Quantity > 20 THEN 2\n"
-            + "    WHEN Quantity > 10 THEN 1\n" + "    ELSE 0\n" + "END) AS new_sum_quant\n" + "FROM OrderDetails "
-            + "GROUP BY Quantity");
+        "SELECT Quantity,\n"
+            + "SUM(CASE\n"
+            + "    WHEN Quantity > 30 THEN 3\n"
+            + "    WHEN Quantity > 20 THEN 2\n"
+            + "    WHEN Quantity > 10 THEN 1\n"
+            + "    ELSE 0\n"
+            + "END) AS new_sum_quant\n"
+            + "FROM OrderDetails GROUP BY Quantity");
+    //@formatter:on
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getIdentifier().getName(), "Quantity");
     asFunc = pinotQuery.getSelectList().get(1).getFunctionCall();
-    Assert.assertEquals(asFunc.getOperator(), SqlKind.AS.name());
+    Assert.assertEquals(asFunc.getOperator(), "as");
     Function sumFunc = asFunc.getOperands().get(0).getFunctionCall();
-    Assert.assertEquals(sumFunc.getOperator(), SqlKind.SUM.name());
+    Assert.assertEquals(sumFunc.getOperator(), "sum");
     caseFunc = sumFunc.getOperands().get(0).getFunctionCall();
-    Assert.assertEquals(caseFunc.getOperator(), SqlKind.CASE.name());
+    Assert.assertEquals(caseFunc.getOperator(), "case");
     Assert.assertEquals(caseFunc.getOperandsSize(), 7);
     greatThanFunc = caseFunc.getOperands().get(0).getFunctionCall();
-    Assert.assertEquals(greatThanFunc.getOperator(), SqlKind.GREATER_THAN.name());
+    Assert.assertEquals(greatThanFunc.getOperator(), FilterKind.GREATER_THAN.name());
     Assert.assertEquals(greatThanFunc.getOperands().get(0).getIdentifier().getName(), "Quantity");
     Assert.assertEquals(greatThanFunc.getOperands().get(1).getLiteral().getFieldValue(), 30L);
     greatThanFunc = caseFunc.getOperands().get(1).getFunctionCall();
-    Assert.assertEquals(greatThanFunc.getOperator(), SqlKind.GREATER_THAN.name());
+    Assert.assertEquals(greatThanFunc.getOperator(), FilterKind.GREATER_THAN.name());
     Assert.assertEquals(greatThanFunc.getOperands().get(0).getIdentifier().getName(), "Quantity");
     Assert.assertEquals(greatThanFunc.getOperands().get(1).getLiteral().getFieldValue(), 20L);
     greatThanFunc = caseFunc.getOperands().get(2).getFunctionCall();
-    Assert.assertEquals(greatThanFunc.getOperator(), SqlKind.GREATER_THAN.name());
+    Assert.assertEquals(greatThanFunc.getOperator(), FilterKind.GREATER_THAN.name());
     Assert.assertEquals(greatThanFunc.getOperands().get(0).getIdentifier().getName(), "Quantity");
     Assert.assertEquals(greatThanFunc.getOperands().get(1).getLiteral().getFieldValue(), 10L);
     Assert.assertEquals(caseFunc.getOperands().get(3).getLiteral().getFieldValue(), 3L);
@@ -112,10 +147,16 @@ public class CalciteSqlCompilerTest {
   public void testInvalidCaseWhenStatements() {
     // Not support Aggregation functions in case statements.
     try {
-      CalciteSqlParser.compileToPinotQuery("SELECT OrderID, Quantity,\n" + "CASE\n"
-          + "    WHEN sum(Quantity) > 30 THEN 'The quantity is greater than 30'\n"
-          + "    WHEN sum(Quantity) = 30 THEN 'The quantity is 30'\n" + "    ELSE 'The quantity is under 30'\n"
-          + "END AS QuantityText\n" + "FROM OrderDetails");
+      //@formatter:off
+      CalciteSqlParser.compileToPinotQuery(
+          "SELECT OrderID, Quantity,\n"
+              + "CASE\n"
+              + "    WHEN sum(Quantity) > 30 THEN 'The quantity is greater than 30'\n"
+              + "    WHEN sum(Quantity) = 30 THEN 'The quantity is 30'\n"
+              + "    ELSE 'The quantity is under 30'\n"
+              + "END AS QuantityText\n"
+              + "FROM OrderDetails");
+      //@formatter:on
     } catch (SqlCompilationException e) {
       Assert.assertEquals(e.getMessage(),
           "Aggregation functions inside WHEN Clause is not supported - SUM(`Quantity`) > 30");
@@ -152,27 +193,27 @@ public class CalciteSqlCompilerTest {
   public void testFilterClauses() {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where a > 1.5");
     Function func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), SqlKind.GREATER_THAN.name());
+    Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN.name());
     Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "a");
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getDoubleValue(), 1.5);
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where b < 100");
     func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), SqlKind.LESS_THAN.name());
+    Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN.name());
     Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "b");
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 100L);
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where c >= 10");
     func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), SqlKind.GREATER_THAN_OR_EQUAL.name());
+    Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN_OR_EQUAL.name());
     Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "c");
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 10L);
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where d <= 50");
     func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), SqlKind.LESS_THAN_OR_EQUAL.name());
+    Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
     Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "d");
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 50L);
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where e BETWEEN 70 AND 80");
     func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), SqlKind.BETWEEN.name());
+    Assert.assertEquals(func.getOperator(), FilterKind.BETWEEN.name());
     Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "e");
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 70L);
     Assert.assertEquals(func.getOperands().get(2).getLiteral().getLongValue(), 80L);
@@ -183,7 +224,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getStringValue(), "^U.*");
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where g IN (12, 13, 15.2, 17)");
     func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), SqlKind.IN.name());
+    Assert.assertEquals(func.getOperator(), FilterKind.IN.name());
     Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "g");
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 12L);
     Assert.assertEquals(func.getOperands().get(2).getLiteral().getLongValue(), 13L);
@@ -195,8 +236,8 @@ public class CalciteSqlCompilerTest {
   public void testFilterClausesWithRightExpression() {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where a > b");
     Function func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), SqlKind.GREATER_THAN.name());
-    Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "MINUS");
+    Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN.name());
+    Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "minus");
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
         "a");
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(),
@@ -204,8 +245,8 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where 0 < a-b");
     func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), SqlKind.GREATER_THAN.name());
-    Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "MINUS");
+    Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN.name());
+    Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "minus");
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
         "a");
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(),
@@ -214,12 +255,12 @@ public class CalciteSqlCompilerTest {
 
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where b < 100 + c");
     func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), SqlKind.LESS_THAN.name());
-    Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "MINUS");
+    Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN.name());
+    Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "minus");
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
         "b");
     Assert.assertEquals(
-        func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "PLUS");
+        func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "plus");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
             .getLiteral().getLongValue(), 100L);
@@ -229,12 +270,12 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where b -(100+c)< 0");
     func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), SqlKind.LESS_THAN.name());
-    Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "MINUS");
+    Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN.name());
+    Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "minus");
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
         "b");
     Assert.assertEquals(
-        func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "PLUS");
+        func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "plus");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
             .getLiteral().getLongValue(), 100L);
@@ -246,24 +287,24 @@ public class CalciteSqlCompilerTest {
     pinotQuery =
         CalciteSqlParser.compileToPinotQuery("select * from vegetables where foo1(bar1(a-b)) <= foo2(bar2(c+d))");
     func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), SqlKind.LESS_THAN_OR_EQUAL.name());
-    Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "MINUS");
+    Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
+    Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "minus");
     Assert.assertEquals(
-        func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "FOO1");
+        func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "foo1");
     Assert.assertEquals(
-        func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "FOO2");
-    Assert.assertEquals(
-        func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
-            .getFunctionCall().getOperator(), "BAR1");
-    Assert.assertEquals(
-        func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
-            .getFunctionCall().getOperator(), "BAR2");
+        func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "foo2");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
-            .getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "MINUS");
+            .getFunctionCall().getOperator(), "bar1");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
-            .getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "PLUS");
+            .getFunctionCall().getOperator(), "bar2");
+    Assert.assertEquals(
+        func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
+            .getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "minus");
+    Assert.assertEquals(
+        func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
+            .getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "plus");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
@@ -284,24 +325,24 @@ public class CalciteSqlCompilerTest {
     pinotQuery =
         CalciteSqlParser.compileToPinotQuery("select * from vegetables where foo1(bar1(a-b)) - foo2(bar2(c+d)) <= 0");
     func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), SqlKind.LESS_THAN_OR_EQUAL.name());
-    Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "MINUS");
+    Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
+    Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "minus");
     Assert.assertEquals(
-        func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "FOO1");
+        func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "foo1");
     Assert.assertEquals(
-        func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "FOO2");
-    Assert.assertEquals(
-        func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
-            .getFunctionCall().getOperator(), "BAR1");
-    Assert.assertEquals(
-        func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
-            .getFunctionCall().getOperator(), "BAR2");
+        func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "foo2");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
-            .getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "MINUS");
+            .getFunctionCall().getOperator(), "bar1");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
-            .getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "PLUS");
+            .getFunctionCall().getOperator(), "bar2");
+    Assert.assertEquals(
+        func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
+            .getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "minus");
+    Assert.assertEquals(
+        func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
+            .getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "plus");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
@@ -322,12 +363,12 @@ public class CalciteSqlCompilerTest {
 
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where c >= 10");
     func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), SqlKind.GREATER_THAN_OR_EQUAL.name());
+    Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN_OR_EQUAL.name());
     Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "c");
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 10L);
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where 10 <= c");
     func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), SqlKind.GREATER_THAN_OR_EQUAL.name());
+    Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN_OR_EQUAL.name());
     Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "c");
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 10L);
   }
@@ -361,7 +402,7 @@ public class CalciteSqlCompilerTest {
     PinotQuery pinotQuery =
         CalciteSqlParser.compileToPinotQuery("select * from vegetables where g IN (12, 13, 15.2, 17)");
     Function func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), SqlKind.IN.name());
+    Assert.assertEquals(func.getOperator(), FilterKind.IN.name());
     Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "g");
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 12L);
     Assert.assertEquals(func.getOperands().get(2).getLiteral().getLongValue(), 13L);
@@ -410,7 +451,7 @@ public class CalciteSqlCompilerTest {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
         "select sum(A) as sum_A, count(B) as count_B  from vegetables where g IN (12, 13, 15.2, 17)");
     Function func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), SqlKind.IN.name());
+    Assert.assertEquals(func.getOperator(), FilterKind.IN.name());
     Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "g");
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 12L);
     Assert.assertEquals(func.getOperands().get(2).getLiteral().getLongValue(), 13L);
@@ -420,8 +461,8 @@ public class CalciteSqlCompilerTest {
     BrokerRequest tempBrokerRequest = converter.convert(pinotQuery);
     Assert.assertEquals(tempBrokerRequest.getQuerySource().getTableName(), "vegetables");
     Assert.assertNull(tempBrokerRequest.getSelections());
-    Assert.assertEquals(tempBrokerRequest.getAggregationsInfo().get(0).getAggregationType(), "SUM");
-    Assert.assertEquals(tempBrokerRequest.getAggregationsInfo().get(1).getAggregationType(), "COUNT");
+    Assert.assertEquals(tempBrokerRequest.getAggregationsInfo().get(0).getAggregationType(), "sum");
+    Assert.assertEquals(tempBrokerRequest.getAggregationsInfo().get(1).getAggregationType(), "count");
     Assert.assertEquals(tempBrokerRequest.getFilterQuery().getColumn(), "g");
     Assert.assertEquals(tempBrokerRequest.getFilterQuery().getValue().size(), 4);
     Assert.assertEquals(tempBrokerRequest.getFilterQuery().getValue().get(0), "12");
@@ -494,7 +535,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(pinotQuery.getOrderByList().get(0).getType(), ExpressionType.FUNCTION);
     Assert.assertEquals(
         pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "SUM");
+        "sum");
     Assert.assertEquals(10, pinotQuery.getLimit());
 
     try {
@@ -510,7 +551,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(pinotQuery.getOrderByList().get(0).getType(), ExpressionType.FUNCTION);
     Assert.assertEquals(
         pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "SUM");
+        "sum");
     Assert.assertEquals(10, pinotQuery.getLimit());
 
     try {
@@ -527,13 +568,13 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(pinotQuery.getOrderByList().get(0).getType(), ExpressionType.FUNCTION);
     Assert.assertEquals(
         pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "SUM");
+        "sum");
     Assert.assertEquals(
         pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "rsvp_count");
     Assert.assertEquals(
         pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "COUNT");
+        "count");
     Assert.assertEquals(
         pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "*");
@@ -555,7 +596,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(pinotQuery.getOrderByList().get(0).getType(), ExpressionType.FUNCTION);
     Assert.assertEquals(
         pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "COUNT");
+        "count");
     Assert.assertEquals(10, pinotQuery.getLimit());
   }
 
@@ -741,10 +782,10 @@ public class CalciteSqlCompilerTest {
         "SELECT SUM(ADD(foo, 'bar')) FROM myTable GROUP BY sub(foo, bar), SUB(BAR, FOO)");
     selectFunctionList = pinotQuery.getSelectList();
     Assert.assertEquals(selectFunctionList.size(), 1);
-    Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperator(), "SUM");
+    Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperator(), "sum");
     Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperands().size(), 1);
     Assert.assertEquals(
-        selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "ADD");
+        selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "add");
     Assert.assertEquals(
         selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().size(), 2);
     Assert.assertEquals(
@@ -755,12 +796,12 @@ public class CalciteSqlCompilerTest {
             .getLiteral().getStringValue(), "bar");
     groupbyList = pinotQuery.getGroupByList();
     Assert.assertEquals(groupbyList.size(), 2);
-    Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperator(), "SUB");
+    Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperator(), "sub");
     Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperands().size(), 2);
     Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "foo");
     Assert.assertEquals(groupbyList.get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "bar");
 
-    Assert.assertEquals(groupbyList.get(1).getFunctionCall().getOperator(), "SUB");
+    Assert.assertEquals(groupbyList.get(1).getFunctionCall().getOperator(), "sub");
     Assert.assertEquals(groupbyList.get(1).getFunctionCall().getOperands().size(), 2);
     Assert.assertEquals(groupbyList.get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "BAR");
     Assert.assertEquals(groupbyList.get(1).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "FOO");
@@ -770,12 +811,12 @@ public class CalciteSqlCompilerTest {
   public void testFilterUdf() {
     PinotQuery pinotQuery =
         CalciteSqlParser.compileToPinotQuery("select count(*) from baseballStats where DIV(numberOfGames,10) = 100");
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "COUNT");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "count");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "*");
-    Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "EQUALS");
+    Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), FilterKind.EQUALS.name());
     Assert.assertEquals(
-        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "DIV");
+        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "div");
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "numberOfGames");
@@ -787,13 +828,13 @@ public class CalciteSqlCompilerTest {
 
     pinotQuery = CalciteSqlParser.compileToPinotQuery(
         "SELECT count(*) FROM mytable WHERE timeConvert(DaysSinceEpoch,'DAYS','SECONDS') = 1394323200");
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "COUNT");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "count");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "*");
-    Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "EQUALS");
+    Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), FilterKind.EQUALS.name());
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "TIMECONVERT");
+        "timeconvert");
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "DaysSinceEpoch");
@@ -812,16 +853,16 @@ public class CalciteSqlCompilerTest {
   public void testSelectionTransformFunction() {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
         "  select mapKey(mapField,k1) from baseballStats where mapKey(mapField,k1) = 'v1'");
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "MAPKEY");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "mapkey");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "mapField");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "k1");
 
-    Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "EQUALS");
+    Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), FilterKind.EQUALS.name());
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "MAPKEY");
+        "mapkey");
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "mapField");
@@ -836,12 +877,12 @@ public class CalciteSqlCompilerTest {
   public void testTimeTransformFunction() {
     PinotQuery pinotQuery =
         CalciteSqlParser.compileToPinotQuery("  select hour(ts), d1, sum(m1) from baseballStats group by hour(ts), d1");
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "HOUR");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "hour");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "ts");
     Assert.assertEquals(pinotQuery.getSelectList().get(1).getIdentifier().getName(), "d1");
-    Assert.assertEquals(pinotQuery.getSelectList().get(2).getFunctionCall().getOperator(), "SUM");
-    Assert.assertEquals(pinotQuery.getGroupByList().get(0).getFunctionCall().getOperator(), "HOUR");
+    Assert.assertEquals(pinotQuery.getSelectList().get(2).getFunctionCall().getOperator(), "sum");
+    Assert.assertEquals(pinotQuery.getGroupByList().get(0).getFunctionCall().getOperator(), "hour");
     Assert.assertEquals(
         pinotQuery.getGroupByList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "ts");
     Assert.assertEquals(pinotQuery.getGroupByList().get(1).getIdentifier().getName(), "d1");
@@ -1042,7 +1083,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(distinctFunction.getOperands().size(), 1);
 
     Function add = distinctFunction.getOperands().get(0).getFunctionCall();
-    Assert.assertEquals(add.getOperator(), "ADD");
+    Assert.assertEquals(add.getOperator(), "add");
     Assert.assertEquals(add.getOperands().size(), 2);
     c1 = add.getOperands().get(0).getIdentifier();
     c2 = add.getOperands().get(1).getIdentifier();
@@ -1071,13 +1112,13 @@ public class CalciteSqlCompilerTest {
 
     // check for DISTINCT's first operand ADD(....)
     add = distinctFunction.getOperands().get(0).getFunctionCall();
-    Assert.assertEquals(add.getOperator(), "ADD");
+    Assert.assertEquals(add.getOperator(), "add");
     Assert.assertEquals(add.getOperands().size(), 2);
     Function div = add.getOperands().get(0).getFunctionCall();
     Function mul = add.getOperands().get(1).getFunctionCall();
 
     // check for ADD's first operand DIV(...)
-    Assert.assertEquals(div.getOperator(), "DIV");
+    Assert.assertEquals(div.getOperator(), "div");
     Assert.assertEquals(div.getOperands().size(), 2);
     c1 = div.getOperands().get(0).getIdentifier();
     c2 = div.getOperands().get(1).getIdentifier();
@@ -1085,7 +1126,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(c2.getName(), "col2");
 
     // check for ADD's second operand MUL(...)
-    Assert.assertEquals(mul.getOperator(), "MUL");
+    Assert.assertEquals(mul.getOperator(), "mul");
     Assert.assertEquals(mul.getOperands().size(), 2);
     c1 = mul.getOperands().get(0).getIdentifier();
     c2 = mul.getOperands().get(1).getIdentifier();
@@ -1094,7 +1135,7 @@ public class CalciteSqlCompilerTest {
 
     // check for DISTINCT's second operand SUB(...)
     Function sub = distinctFunction.getOperands().get(1).getFunctionCall();
-    Assert.assertEquals(sub.getOperator(), "SUB");
+    Assert.assertEquals(sub.getOperator(), "sub");
     Assert.assertEquals(sub.getOperands().size(), 2);
     c1 = sub.getOperands().get(0).getIdentifier();
     c2 = sub.getOperands().get(1).getIdentifier();
@@ -1125,13 +1166,13 @@ public class CalciteSqlCompilerTest {
 
     // check for DISTINCT's first operand ADD(....)
     add = distinctFunction.getOperands().get(0).getFunctionCall();
-    Assert.assertEquals(add.getOperator(), "ADD");
+    Assert.assertEquals(add.getOperator(), "add");
     Assert.assertEquals(add.getOperands().size(), 2);
     div = add.getOperands().get(0).getFunctionCall();
     mul = add.getOperands().get(1).getFunctionCall();
 
     // check for ADD's first operand DIV(...)
-    Assert.assertEquals(div.getOperator(), "DIV");
+    Assert.assertEquals(div.getOperator(), "div");
     Assert.assertEquals(div.getOperands().size(), 2);
     c1 = div.getOperands().get(0).getIdentifier();
     c2 = div.getOperands().get(1).getIdentifier();
@@ -1139,7 +1180,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(c2.getName(), "col2");
 
     // check for ADD's second operand MUL(...)
-    Assert.assertEquals(mul.getOperator(), "MUL");
+    Assert.assertEquals(mul.getOperator(), "mul");
     Assert.assertEquals(mul.getOperands().size(), 2);
     c1 = mul.getOperands().get(0).getIdentifier();
     c2 = mul.getOperands().get(1).getIdentifier();
@@ -1148,7 +1189,7 @@ public class CalciteSqlCompilerTest {
 
     // check for DISTINCT's second operand SUB(...)
     sub = distinctFunction.getOperands().get(1).getFunctionCall();
-    Assert.assertEquals(sub.getOperator(), "SUB");
+    Assert.assertEquals(sub.getOperator(), "sub");
     Assert.assertEquals(sub.getOperands().size(), 2);
     c1 = sub.getOperands().get(0).getIdentifier();
     c2 = sub.getOperands().get(1).getIdentifier();
@@ -1236,17 +1277,17 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(pinotQuery.getSelectListSize(), 3);
     Assert.assertEquals(pinotQuery.getGroupByListSize(), 1);
     Assert.assertEquals(pinotQuery.getOrderByListSize(), 2);
-    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperator(), "ASC");
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperator(), "asc");
     Assert.assertEquals(
         pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "COUNT");
+        "count");
     Assert.assertEquals(
         pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "*");
-    Assert.assertEquals(pinotQuery.getOrderByList().get(1).getFunctionCall().getOperator(), "DESC");
+    Assert.assertEquals(pinotQuery.getOrderByList().get(1).getFunctionCall().getOperator(), "desc");
     Assert.assertEquals(
         pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "SUM");
+        "sum");
     Assert.assertEquals(
         pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "rsvp_count");
@@ -1258,17 +1299,17 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(pinotQuery.getSelectListSize(), 3);
     Assert.assertEquals(pinotQuery.getGroupByListSize(), 1);
     Assert.assertEquals(pinotQuery.getOrderByListSize(), 2);
-    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperator(), "ASC");
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperator(), "asc");
     Assert.assertEquals(
         pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "COUNT");
+        "count");
     Assert.assertEquals(
         pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "*");
-    Assert.assertEquals(pinotQuery.getOrderByList().get(1).getFunctionCall().getOperator(), "DESC");
+    Assert.assertEquals(pinotQuery.getOrderByList().get(1).getFunctionCall().getOperator(), "desc");
     Assert.assertEquals(
         pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "SUM");
+        "sum");
     Assert.assertEquals(
         pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "rsvp_count");
@@ -1278,10 +1319,10 @@ public class CalciteSqlCompilerTest {
         + " limit 50";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 3);
-    Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "EQUALS");
+    Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), FilterKind.EQUALS.name());
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "DIVIDE");
+        "divide");
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "secondsSinceEpoch");
@@ -1291,7 +1332,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 18523);
     Assert.assertEquals(pinotQuery.getGroupByListSize(), 1);
-    Assert.assertEquals(pinotQuery.getGroupByList().get(0).getFunctionCall().getOperator(), "DIVIDE");
+    Assert.assertEquals(pinotQuery.getGroupByList().get(0).getFunctionCall().getOperator(), "divide");
     Assert.assertEquals(
         pinotQuery.getGroupByList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
         "secondsSinceEpoch");
@@ -1317,19 +1358,19 @@ public class CalciteSqlCompilerTest {
     sql = "SELECT C1 AS ALIAS_C1, C2 AS ALIAS_C2, ADD(C1, C2) FROM Foo";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 3);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), SqlKind.AS.toString());
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "C1");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "ALIAS_C1");
 
-    Assert.assertEquals(pinotQuery.getSelectList().get(1).getFunctionCall().getOperator(), SqlKind.AS.toString());
+    Assert.assertEquals(pinotQuery.getSelectList().get(1).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "C2");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(1).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "ALIAS_C2");
 
-    Assert.assertEquals(pinotQuery.getSelectList().get(2).getFunctionCall().getOperator(), "ADD");
+    Assert.assertEquals(pinotQuery.getSelectList().get(2).getFunctionCall().getOperator(), "add");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(2).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "C1");
     Assert.assertEquals(
@@ -1359,20 +1400,20 @@ public class CalciteSqlCompilerTest {
   public void testArithmeticOperator() {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select a,b+2,c*5,(d+5)*2 from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 4);
-    Assert.assertEquals(pinotQuery.getSelectList().get(1).getFunctionCall().getOperator(), "PLUS");
+    Assert.assertEquals(pinotQuery.getSelectList().get(1).getFunctionCall().getOperator(), "plus");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "b");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(1).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 2);
-    Assert.assertEquals(pinotQuery.getSelectList().get(2).getFunctionCall().getOperator(), "TIMES");
+    Assert.assertEquals(pinotQuery.getSelectList().get(2).getFunctionCall().getOperator(), "times");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(2).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "c");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(2).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 5);
-    Assert.assertEquals(pinotQuery.getSelectList().get(3).getFunctionCall().getOperator(), "TIMES");
+    Assert.assertEquals(pinotQuery.getSelectList().get(3).getFunctionCall().getOperator(), "times");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(3).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "PLUS");
+        "plus");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(3).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "d");
@@ -1384,10 +1425,10 @@ public class CalciteSqlCompilerTest {
 
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select a % 200 + b * 5  from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "PLUS");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "plus");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "MOD");
+        "mod");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "a");
@@ -1396,7 +1437,7 @@ public class CalciteSqlCompilerTest {
             .getLiteral().getLongValue(), 200);
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(),
-        "TIMES");
+        "times");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "b");
@@ -1417,52 +1458,52 @@ public class CalciteSqlCompilerTest {
         "select max(value) as max, min(value) as min, sum(value) as sum, count(*) as count, avg(value) as avg from "
             + "myTable where groups = 'foo'");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 5);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "AS");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "MAX");
+        "max");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "value");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "max");
-    Assert.assertEquals(pinotQuery.getSelectList().get(1).getFunctionCall().getOperator(), "AS");
+    Assert.assertEquals(pinotQuery.getSelectList().get(1).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "MIN");
+        "min");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "value");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(1).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "min");
-    Assert.assertEquals(pinotQuery.getSelectList().get(2).getFunctionCall().getOperator(), "AS");
+    Assert.assertEquals(pinotQuery.getSelectList().get(2).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(2).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "SUM");
+        "sum");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(2).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "value");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(2).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "sum");
-    Assert.assertEquals(pinotQuery.getSelectList().get(3).getFunctionCall().getOperator(), "AS");
+    Assert.assertEquals(pinotQuery.getSelectList().get(3).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(3).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "COUNT");
+        "count");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(3).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "*");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(3).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "count");
-    Assert.assertEquals(pinotQuery.getSelectList().get(4).getFunctionCall().getOperator(), "AS");
+    Assert.assertEquals(pinotQuery.getSelectList().get(4).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(4).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "AVG");
+        "avg");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(4).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "value");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(4).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "avg");
-    Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "EQUALS");
+    Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), FilterKind.EQUALS.name());
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(), "groups");
     Assert.assertEquals(
@@ -1563,62 +1604,71 @@ public class CalciteSqlCompilerTest {
   public void testCastTransformation() {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select CAST(25.65 AS int) from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
-    Assert.assertEquals("CAST", pinotQuery.getSelectList().get(0).getFunctionCall().getOperator());
-    Assert.assertEquals(25.65,
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getLiteral().getDoubleValue());
-    Assert.assertEquals("INTEGER",
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getStringValue());
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "cast");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getLiteral().getDoubleValue(), 25.65);
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getStringValue(),
+        "INTEGER");
 
     pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT CAST('20170825' AS LONG) from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
-    Assert.assertEquals("CAST", pinotQuery.getSelectList().get(0).getFunctionCall().getOperator());
-    Assert.assertEquals("20170825",
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getLiteral().getStringValue());
-    Assert.assertEquals("LONG",
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getStringValue());
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "cast");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getLiteral().getStringValue(),
+        "20170825");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getStringValue(), "LONG");
 
     pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT CAST(20170825.0 AS Float) from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
-    Assert.assertEquals("CAST", pinotQuery.getSelectList().get(0).getFunctionCall().getOperator());
-    Assert.assertEquals(20170825.0,
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getLiteral().getDoubleValue());
-    Assert.assertEquals("FLOAT",
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getStringValue());
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "cast");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getLiteral().getDoubleValue(),
+        20170825.0);
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getStringValue(),
+        "FLOAT");
 
     pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT CAST(20170825.0 AS dOuble) from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
-    Assert.assertEquals("CAST", pinotQuery.getSelectList().get(0).getFunctionCall().getOperator());
-    Assert.assertEquals(20170825.0,
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getLiteral().getDoubleValue());
-    Assert.assertEquals("DOUBLE",
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getStringValue());
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "cast");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getLiteral().getDoubleValue(),
+        20170825.0);
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getStringValue(),
+        "DOUBLE");
 
     pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT CAST(column1 AS STRING) from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
-    Assert.assertEquals("CAST", pinotQuery.getSelectList().get(0).getFunctionCall().getOperator());
-    Assert.assertEquals("column1",
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName());
-    Assert.assertEquals("STRING",
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getStringValue());
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "cast");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "column1");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getStringValue(),
+        "STRING");
 
     pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT CAST(column1 AS varchar) from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
-    Assert.assertEquals("CAST", pinotQuery.getSelectList().get(0).getFunctionCall().getOperator());
-    Assert.assertEquals("column1",
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName());
-    Assert.assertEquals("VARCHAR",
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getStringValue());
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "cast");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "column1");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getStringValue(),
+        "VARCHAR");
 
     pinotQuery = CalciteSqlParser.compileToPinotQuery(
         "SELECT SUM(CAST(CAST(ArrTime AS STRING) AS LONG)) FROM mytable WHERE DaysSinceEpoch <> 16312 AND Carrier = "
             + "'DL'");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
-    Assert.assertEquals("SUM", pinotQuery.getSelectList().get(0).getFunctionCall().getOperator());
-    Assert.assertEquals("CAST",
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator());
-    Assert.assertEquals("CAST",
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "sum");
+    Assert.assertEquals(
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "cast");
+    Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
-            .getFunctionCall().getOperator());
+            .getFunctionCall().getOperator(), "cast");
   }
 
   @Test
@@ -1626,42 +1676,42 @@ public class CalciteSqlCompilerTest {
     String query = "SELECT count(distinct bar) FROM foo";
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 1);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "DISTINCTCOUNT");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctcount");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
     query = "SELECT count(distinct bar) FROM foo GROUP BY city";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 1);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "DISTINCTCOUNT");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctcount");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
     query = "SELECT count(distinct bar), distinctCount(bar) FROM foo GROUP BY city";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 2);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "DISTINCTCOUNT");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctcount");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
-    Assert.assertEquals(pinotQuery.getSelectList().get(1).getFunctionCall().getOperator(), "DISTINCTCOUNT");
+    Assert.assertEquals(pinotQuery.getSelectList().get(1).getFunctionCall().getOperator(), "distinctcount");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
     query = "SELECT count(distinct bar), count(*), sum(a),min(a),max(b) FROM foo GROUP BY city";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 5);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "DISTINCTCOUNT");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctcount");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "bar");
 
     query = "SELECT count(distinct bar) AS distinct_bar, count(*), sum(a),min(a),max(b) FROM foo GROUP BY city";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getSelectList().size(), 5);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "AS");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "DISTINCTCOUNT");
+        "distinctcount");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "bar");
@@ -1677,7 +1727,7 @@ public class CalciteSqlCompilerTest {
       PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     } catch (Exception e) {
       Assert.assertTrue(e instanceof SqlCompilationException);
-      Assert.assertEquals(e.getMessage(), "Function 'SUM' on DISTINCT is not supported.");
+      Assert.assertEquals(e.getMessage(), "Function 'sum' on DISTINCT is not supported.");
     }
   }
 
@@ -1717,12 +1767,12 @@ public class CalciteSqlCompilerTest {
     query = "select a, b + 2, array_sum(c) as array_sum_c, count(*) from data group by a, 2, array_sum_c";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     Assert.assertEquals(pinotQuery.getGroupByList().get(0).getIdentifier().getName(), "a");
-    Assert.assertEquals(pinotQuery.getGroupByList().get(1).getFunctionCall().getOperator(), "PLUS");
+    Assert.assertEquals(pinotQuery.getGroupByList().get(1).getFunctionCall().getOperator(), "plus");
     Assert.assertEquals(
         pinotQuery.getGroupByList().get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "b");
     Assert.assertEquals(
         pinotQuery.getGroupByList().get(1).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 2L);
-    Assert.assertEquals(pinotQuery.getGroupByList().get(2).getFunctionCall().getOperator(), "ARRAY_SUM");
+    Assert.assertEquals(pinotQuery.getGroupByList().get(2).getFunctionCall().getOperator(), "arraysum");
     Assert.assertEquals(
         pinotQuery.getGroupByList().get(2).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "c");
 
@@ -1751,17 +1801,17 @@ public class CalciteSqlCompilerTest {
   public void testNoArgFunction() {
     String query = "SELECT noArgFunc() FROM foo ";
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "NOARGFUNC");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "noargfunc");
 
     query = "SELECT a FROM foo where time_col > noArgFunc()";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     Function greaterThan = pinotQuery.getFilterExpression().getFunctionCall();
     Function minus = greaterThan.getOperands().get(0).getFunctionCall();
-    Assert.assertEquals(minus.getOperands().get(1).getFunctionCall().getOperator(), "NOARGFUNC");
+    Assert.assertEquals(minus.getOperands().get(1).getFunctionCall().getOperator(), "noargfunc");
 
     query = "SELECT sum(a), noArgFunc() FROM foo group by noArgFunc()";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    Assert.assertEquals(pinotQuery.getGroupByList().get(0).getFunctionCall().getOperator(), "NOARGFUNC");
+    Assert.assertEquals(pinotQuery.getGroupByList().get(0).getFunctionCall().getOperator(), "noargfunc");
   }
 
   @Test
@@ -1872,7 +1922,7 @@ public class CalciteSqlCompilerTest {
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
     expression = pinotQuery.getFilterExpression();
     Assert.assertNotNull(expression.getFunctionCall());
-    Assert.assertEquals(expression.getFunctionCall().getOperator(), "TODATETIME");
+    Assert.assertEquals(expression.getFunctionCall().getOperator(), "todatetime");
     Assert.assertEquals(expression.getFunctionCall().getOperands().get(0).getIdentifier().getName(),
         "millisSinceEpoch");
 
@@ -1882,7 +1932,7 @@ public class CalciteSqlCompilerTest {
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
     expression = pinotQuery.getFilterExpression();
     Assert.assertNotNull(expression.getFunctionCall());
-    Assert.assertEquals(expression.getFunctionCall().getOperator(), "REVERSE");
+    Assert.assertEquals(expression.getFunctionCall().getOperator(), "reverse");
     Assert.assertEquals(expression.getFunctionCall().getOperands().get(0).getIdentifier().getName(), "playerName");
 
     expression = CalciteSqlParser.compileToExpression("reverse('playerName')");
@@ -1907,7 +1957,7 @@ public class CalciteSqlCompilerTest {
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
     expression = pinotQuery.getFilterExpression();
     Assert.assertNotNull(expression.getFunctionCall());
-    Assert.assertEquals(expression.getFunctionCall().getOperator(), "COUNT");
+    Assert.assertEquals(expression.getFunctionCall().getOperator(), "count");
     Assert.assertEquals(expression.getFunctionCall().getOperands().get(0).getIdentifier().getName(), "*");
   }
 
@@ -2025,13 +2075,13 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator().toUpperCase(), "DISTINCT");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "PLUS");
+        "plus");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "col1");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
-            .getFunctionCall().getOperator(), "TIMES");
+            .getFunctionCall().getOperator(), "times");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
             .getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col2");
@@ -2050,20 +2100,19 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator().toUpperCase(), "DISTINCT");
     Assert.assertEquals(
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator()
-            .toUpperCase(), "AS");
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
             .getIdentifier().getName(), "col3");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
-            .getFunctionCall().getOperator(), "PLUS");
+            .getFunctionCall().getOperator(), "plus");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col1");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
-            .getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "TIMES");
+            .getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "times");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
@@ -2098,11 +2147,11 @@ public class CalciteSqlCompilerTest {
       String query = "SELECT * FROM foo WHERE col1 > 0 AND (col2 > 0 AND col3 > 0) AND col4 > 0";
       PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
       Function functionCall = pinotQuery.getFilterExpression().getFunctionCall();
-      Assert.assertEquals(functionCall.getOperator(), SqlKind.AND.name());
+      Assert.assertEquals(functionCall.getOperator(), FilterKind.AND.name());
       List<Expression> operands = functionCall.getOperands();
       Assert.assertEquals(operands.size(), 4);
       for (Expression operand : operands) {
-        Assert.assertEquals(operand.getFunctionCall().getOperator(), SqlKind.GREATER_THAN.name());
+        Assert.assertEquals(operand.getFunctionCall().getOperator(), FilterKind.GREATER_THAN.name());
       }
 
       BrokerRequest brokerRequest = BROKER_REQUEST_CONVERTER.convert(pinotQuery);
@@ -2119,12 +2168,12 @@ public class CalciteSqlCompilerTest {
       String query = "SELECT * FROM foo WHERE col1 > 0 AND (col2 AND col3 > 0) AND col4";
       PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
       Function functionCall = pinotQuery.getFilterExpression().getFunctionCall();
-      Assert.assertEquals(functionCall.getOperator(), SqlKind.AND.name());
+      Assert.assertEquals(functionCall.getOperator(), FilterKind.AND.name());
       List<Expression> operands = functionCall.getOperands();
       Assert.assertEquals(operands.size(), 4);
-      Assert.assertEquals(operands.get(0).getFunctionCall().getOperator(), SqlKind.GREATER_THAN.name());
+      Assert.assertEquals(operands.get(0).getFunctionCall().getOperator(), FilterKind.GREATER_THAN.name());
       Assert.assertEquals(operands.get(1).getIdentifier().getName(), "col2");
-      Assert.assertEquals(operands.get(2).getFunctionCall().getOperator(), SqlKind.GREATER_THAN.name());
+      Assert.assertEquals(operands.get(2).getFunctionCall().getOperator(), FilterKind.GREATER_THAN.name());
       Assert.assertEquals(operands.get(3).getIdentifier().getName(), "col4");
 
       // NOTE: PQL does not support logical identifier
@@ -2134,11 +2183,11 @@ public class CalciteSqlCompilerTest {
       String query = "SELECT * FROM foo WHERE col1 <= 0 OR col2 <= 0 OR (col3 <= 0 OR col4 <= 0)";
       PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
       Function functionCall = pinotQuery.getFilterExpression().getFunctionCall();
-      Assert.assertEquals(functionCall.getOperator(), SqlKind.OR.name());
+      Assert.assertEquals(functionCall.getOperator(), FilterKind.OR.name());
       List<Expression> operands = functionCall.getOperands();
       Assert.assertEquals(operands.size(), 4);
       for (Expression operand : operands) {
-        Assert.assertEquals(operand.getFunctionCall().getOperator(), SqlKind.LESS_THAN_OR_EQUAL.name());
+        Assert.assertEquals(operand.getFunctionCall().getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
       }
 
       BrokerRequest brokerRequest = BROKER_REQUEST_CONVERTER.convert(pinotQuery);
@@ -2155,12 +2204,12 @@ public class CalciteSqlCompilerTest {
       String query = "SELECT * FROM foo WHERE col1 <= 0 OR col2 OR (col3 <= 0 OR col4)";
       PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
       Function functionCall = pinotQuery.getFilterExpression().getFunctionCall();
-      Assert.assertEquals(functionCall.getOperator(), SqlKind.OR.name());
+      Assert.assertEquals(functionCall.getOperator(), FilterKind.OR.name());
       List<Expression> operands = functionCall.getOperands();
       Assert.assertEquals(operands.size(), 4);
-      Assert.assertEquals(operands.get(0).getFunctionCall().getOperator(), SqlKind.LESS_THAN_OR_EQUAL.name());
+      Assert.assertEquals(operands.get(0).getFunctionCall().getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
       Assert.assertEquals(operands.get(1).getIdentifier().getName(), "col2");
-      Assert.assertEquals(operands.get(2).getFunctionCall().getOperator(), SqlKind.LESS_THAN_OR_EQUAL.name());
+      Assert.assertEquals(operands.get(2).getFunctionCall().getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
       Assert.assertEquals(operands.get(3).getIdentifier().getName(), "col4");
 
       // NOTE: PQL does not support logical identifier
@@ -2171,25 +2220,25 @@ public class CalciteSqlCompilerTest {
           + "(col3 <= 0 OR col4 <= 0) OR (col3 > 0 AND col4 > 0))))";
       PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
       Function functionCall = pinotQuery.getFilterExpression().getFunctionCall();
-      Assert.assertEquals(functionCall.getOperator(), SqlKind.AND.name());
+      Assert.assertEquals(functionCall.getOperator(), FilterKind.AND.name());
       List<Expression> operands = functionCall.getOperands();
       Assert.assertEquals(operands.size(), 4);
       for (int i = 0; i < 3; i++) {
-        Assert.assertEquals(operands.get(i).getFunctionCall().getOperator(), SqlKind.GREATER_THAN.name());
+        Assert.assertEquals(operands.get(i).getFunctionCall().getOperator(), FilterKind.GREATER_THAN.name());
       }
       functionCall = operands.get(3).getFunctionCall();
-      Assert.assertEquals(functionCall.getOperator(), SqlKind.OR.name());
+      Assert.assertEquals(functionCall.getOperator(), FilterKind.OR.name());
       operands = functionCall.getOperands();
       Assert.assertEquals(operands.size(), 5);
       for (int i = 0; i < 4; i++) {
-        Assert.assertEquals(operands.get(i).getFunctionCall().getOperator(), SqlKind.LESS_THAN_OR_EQUAL.name());
+        Assert.assertEquals(operands.get(i).getFunctionCall().getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
       }
       functionCall = operands.get(4).getFunctionCall();
-      Assert.assertEquals(functionCall.getOperator(), SqlKind.AND.name());
+      Assert.assertEquals(functionCall.getOperator(), FilterKind.AND.name());
       operands = functionCall.getOperands();
       Assert.assertEquals(operands.size(), 2);
       for (Expression operand : operands) {
-        Assert.assertEquals(operand.getFunctionCall().getOperator(), SqlKind.GREATER_THAN.name());
+        Assert.assertEquals(operand.getFunctionCall().getOperator(), FilterKind.GREATER_THAN.name());
       }
 
       BrokerRequest brokerRequest = BROKER_REQUEST_CONVERTER.convert(pinotQuery);
@@ -2223,10 +2272,10 @@ public class CalciteSqlCompilerTest {
       String query = "SELECT SUM(col1), col2 FROM foo WHERE true GROUP BY col2 HAVING SUM(col1) > 10";
       PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
       Function functionCall = pinotQuery.getHavingExpression().getFunctionCall();
-      Assert.assertEquals(functionCall.getOperator(), SqlKind.GREATER_THAN.name());
+      Assert.assertEquals(functionCall.getOperator(), FilterKind.GREATER_THAN.name());
       List<Expression> operands = functionCall.getOperands();
       Assert.assertEquals(operands.size(), 2);
-      Assert.assertEquals(operands.get(0).getFunctionCall().getOperator(), SqlKind.SUM.name());
+      Assert.assertEquals(operands.get(0).getFunctionCall().getOperator(), "sum");
       Assert.assertEquals(operands.get(1).getLiteral().getFieldValue().toString(), "10");
 
       // It should not throw exception when converting PinotQuery to BrokerRequest. Having clause won't be added to the
@@ -2242,11 +2291,11 @@ public class CalciteSqlCompilerTest {
               + "(col4) > 15";
       PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
       Function functionCall = pinotQuery.getHavingExpression().getFunctionCall();
-      Assert.assertEquals(functionCall.getOperator(), SqlKind.AND.name());
+      Assert.assertEquals(functionCall.getOperator(), FilterKind.AND.name());
       List<Expression> operands = functionCall.getOperands();
       Assert.assertEquals(operands.size(), 3);
       for (Expression operand : operands) {
-        Assert.assertEquals(operand.getFunctionCall().getOperator(), SqlKind.GREATER_THAN.name());
+        Assert.assertEquals(operand.getFunctionCall().getOperator(), FilterKind.GREATER_THAN.name());
       }
 
       // It should not throw exception when converting PinotQuery to BrokerRequest. Having clause won't be added to the
@@ -2265,11 +2314,11 @@ public class CalciteSqlCompilerTest {
       List<Expression> selectList = pinotQuery.getSelectList();
       Assert.assertEquals(selectList.size(), 1);
       Function functionCall = selectList.get(0).getFunctionCall();
-      Assert.assertEquals(functionCall.getOperator(), SqlKind.TIMES.name());
+      Assert.assertEquals(functionCall.getOperator(), "times");
       List<Expression> operands = functionCall.getOperands();
       Assert.assertEquals(operands.size(), 2);
       for (Expression operand : operands) {
-        Assert.assertEquals(operand.getFunctionCall().getOperator(), SqlKind.SUM.name());
+        Assert.assertEquals(operand.getFunctionCall().getOperator(), "sum");
       }
 
       // It should not throw exception when converting PinotQuery to BrokerRequest. SELECT clause will be ignored when
@@ -2283,15 +2332,15 @@ public class CalciteSqlCompilerTest {
       List<Expression> orderByList = pinotQuery.getOrderByList();
       Assert.assertEquals(orderByList.size(), 1);
       Function functionCall = orderByList.get(0).getFunctionCall();
-      Assert.assertEquals(functionCall.getOperator(), "ASC");
+      Assert.assertEquals(functionCall.getOperator(), "asc");
       List<Expression> operands = functionCall.getOperands();
       Assert.assertEquals(operands.size(), 1);
       functionCall = operands.get(0).getFunctionCall();
-      Assert.assertEquals(functionCall.getOperator(), SqlKind.MINUS.name());
+      Assert.assertEquals(functionCall.getOperator(), "minus");
       operands = functionCall.getOperands();
       Assert.assertEquals(operands.size(), 2);
       for (Expression operand : operands) {
-        Assert.assertEquals(operand.getFunctionCall().getOperator(), SqlKind.MAX.name());
+        Assert.assertEquals(operand.getFunctionCall().getOperator(), "max");
       }
 
       // It should not throw exception when converting PinotQuery to BrokerRequest. ORDER-BY clause will be ignored when
@@ -2304,20 +2353,20 @@ public class CalciteSqlCompilerTest {
       String query = "SELECT SUM(col1), col2 FROM foo GROUP BY col2 HAVING SUM(col1) + SUM(col3) > MAX(col4)";
       PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
       Function functionCall = pinotQuery.getHavingExpression().getFunctionCall();
-      Assert.assertEquals(functionCall.getOperator(), SqlKind.GREATER_THAN.name());
+      Assert.assertEquals(functionCall.getOperator(), FilterKind.GREATER_THAN.name());
       List<Expression> operands = functionCall.getOperands();
       Assert.assertEquals(operands.size(), 2);
       Assert.assertEquals(operands.get(1).getLiteral().getFieldValue().toString(), "0");
       functionCall = operands.get(0).getFunctionCall();
-      Assert.assertEquals(functionCall.getOperator(), SqlKind.MINUS.name());
+      Assert.assertEquals(functionCall.getOperator(), "minus");
       operands = functionCall.getOperands();
       Assert.assertEquals(operands.size(), 2);
-      Assert.assertEquals(operands.get(1).getFunctionCall().getOperator(), SqlKind.MAX.name());
+      Assert.assertEquals(operands.get(1).getFunctionCall().getOperator(), "max");
       functionCall = operands.get(0).getFunctionCall();
       operands = functionCall.getOperands();
       Assert.assertEquals(operands.size(), 2);
       for (Expression operand : operands) {
-        Assert.assertEquals(operand.getFunctionCall().getOperator(), SqlKind.SUM.name());
+        Assert.assertEquals(operand.getFunctionCall().getOperator(), "sum");
       }
 
       // It should not throw exception when converting PinotQuery to BrokerRequest. Having clause won't be added to the
@@ -2335,7 +2384,7 @@ public class CalciteSqlCompilerTest {
     sql = "SELECT sum(array_sum(a)) FROM Foo";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "sumMV");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "summv");
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().size(), 1);
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "a");
@@ -2343,7 +2392,7 @@ public class CalciteSqlCompilerTest {
     sql = "SELECT MIN(ARRAYMIN(a)) FROM Foo";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "minMV");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "minmv");
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().size(), 1);
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "a");
@@ -2351,7 +2400,7 @@ public class CalciteSqlCompilerTest {
     sql = "SELECT Max(ArrayMax(a)) FROM Foo";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "maxMV");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "maxmv");
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().size(), 1);
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "a");
@@ -2359,11 +2408,11 @@ public class CalciteSqlCompilerTest {
     sql = "SELECT Max(ArrayMax(a)) + 1 FROM Foo";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(sql);
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "PLUS");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "plus");
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().size(), 2);
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
-        "maxMV");
+        "maxmv");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().size(),
         1);
@@ -2520,7 +2569,7 @@ public class CalciteSqlCompilerTest {
         () -> CalciteSqlParser.compileToPinotQuery("SELECT col1, count(*) from foo"));
 
     Assert.expectThrows(SqlCompilationException.class,
-       () -> CalciteSqlParser.compileToPinotQuery("SELECT UPPER(col1), count(*) from foo"));
+        () -> CalciteSqlParser.compileToPinotQuery("SELECT UPPER(col1), count(*) from foo"));
 
     Assert.expectThrows(SqlCompilationException.class,
         () -> CalciteSqlParser.compileToPinotQuery("SELECT UPPER(col1), avg(col2) from foo"));

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/NonAggregationGroupByToDistinctQueryRewriterTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/NonAggregationGroupByToDistinctQueryRewriterTest.java
@@ -32,7 +32,7 @@ public class NonAggregationGroupByToDistinctQueryRewriterTest {
   public void testQuery1() {
     final PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT A FROM myTable GROUP BY A");
     QUERY_REWRITER.rewrite(pinotQuery);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "DISTINCT");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinct");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "A");
   }
@@ -43,7 +43,7 @@ public class NonAggregationGroupByToDistinctQueryRewriterTest {
     final PinotQuery pinotQuery =
         CalciteSqlParser.compileToPinotQuery("SELECT col1+col2*5 FROM foo GROUP BY col1, col2");
     QUERY_REWRITER.rewrite(pinotQuery);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "DISTINCT");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinct");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "col1");
@@ -61,7 +61,7 @@ public class NonAggregationGroupByToDistinctQueryRewriterTest {
     final PinotQuery pinotQuery =
         CalciteSqlParser.compileToPinotQuery("SELECT col1, col2 FROM foo GROUP BY col1, col2 ");
     QUERY_REWRITER.rewrite(pinotQuery);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "DISTINCT");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinct");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col1");
     Assert.assertEquals(
@@ -73,9 +73,9 @@ public class NonAggregationGroupByToDistinctQueryRewriterTest {
   public void testQuery4() {
     final PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT col1 as col2 FROM foo GROUP BY col1");
     QUERY_REWRITER.rewrite(pinotQuery);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "DISTINCT");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinct");
     Assert.assertEquals(
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "AS");
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "col1");
@@ -91,9 +91,9 @@ public class NonAggregationGroupByToDistinctQueryRewriterTest {
     final PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
         "SELECT col1 as a, col2 as b, concat(col3, col4, '') as c FROM foo GROUP BY a,b,c");
     QUERY_REWRITER.rewrite(pinotQuery);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "DISTINCT");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinct");
     Assert.assertEquals(
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "AS");
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "col1");
@@ -101,7 +101,7 @@ public class NonAggregationGroupByToDistinctQueryRewriterTest {
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
             .getIdentifier().getName(), "a");
     Assert.assertEquals(
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "AS");
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "col2");
@@ -109,10 +109,10 @@ public class NonAggregationGroupByToDistinctQueryRewriterTest {
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(1)
             .getIdentifier().getName(), "b");
     Assert.assertEquals(
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(2).getFunctionCall().getOperator(), "AS");
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(2).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(2).getFunctionCall().getOperands().get(0)
-            .getFunctionCall().getOperator(), "CONCAT");
+            .getFunctionCall().getOperator(), "concat");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(2).getFunctionCall().getOperands().get(0)
             .getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col3");
@@ -134,9 +134,9 @@ public class NonAggregationGroupByToDistinctQueryRewriterTest {
     final PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
         "SELECT col1 as a, col2 as b, concat(col3, col4, '') as c FROM foo GROUP BY col1, col2, col3, col4");
     QUERY_REWRITER.rewrite(pinotQuery);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "DISTINCT");
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinct");
     Assert.assertEquals(
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "AS");
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "col1");
@@ -144,7 +144,7 @@ public class NonAggregationGroupByToDistinctQueryRewriterTest {
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
             .getIdentifier().getName(), "a");
     Assert.assertEquals(
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "AS");
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "col2");
@@ -152,10 +152,10 @@ public class NonAggregationGroupByToDistinctQueryRewriterTest {
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(1)
             .getIdentifier().getName(), "b");
     Assert.assertEquals(
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(2).getFunctionCall().getOperator(), "AS");
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(2).getFunctionCall().getOperator(), "as");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(2).getFunctionCall().getOperands().get(0)
-            .getFunctionCall().getOperator(), "CONCAT");
+            .getFunctionCall().getOperator(), "concat");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(2).getFunctionCall().getOperands().get(0)
             .getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col3");

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -71,8 +71,7 @@ public class FilterPlanNode implements PlanNode {
     _numDocs = _indexSegment.getSegmentMetadata().getTotalDocs();
   }
 
-  public FilterPlanNode(IndexSegment indexSegment, QueryContext queryContext,
-      FilterContext filterContext) {
+  public FilterPlanNode(IndexSegment indexSegment, QueryContext queryContext, FilterContext filterContext) {
     this(indexSegment, queryContext);
 
     _filterContext = filterContext;
@@ -120,7 +119,8 @@ public class FilterPlanNode implements PlanNode {
     if (predicate.getType() != Predicate.Type.RANGE) {
       return false;
     }
-    if (!function.getFunctionName().equalsIgnoreCase(StDistanceFunction.FUNCTION_NAME)) {
+    String functionName = function.getFunctionName();
+    if (!functionName.equals("st_distance") && !functionName.equals("stdistance")) {
       return false;
     }
     List<ExpressionContext> arguments = function.getArguments();
@@ -221,8 +221,8 @@ public class FilterPlanNode implements PlanNode {
               return FilterOperatorUtils.getLeafFilterOperator(predicateEvaluator, dataSource, _numDocs);
             case JSON_MATCH:
               JsonIndexReader jsonIndex = dataSource.getJsonIndex();
-              Preconditions
-                  .checkState(jsonIndex != null, "Cannot apply JSON_MATCH on column: %s without json index", column);
+              Preconditions.checkState(jsonIndex != null, "Cannot apply JSON_MATCH on column: %s without json index",
+                  column);
               return new JsonMatchFilterOperator(jsonIndex, (JsonMatchPredicate) predicate, _numDocs);
             case IS_NULL:
               NullValueVectorReader nullValueVector = dataSource.getNullValueVector();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
@@ -78,9 +78,9 @@ import org.apache.pinot.sql.parsers.CalciteSqlParser;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class DistinctCountThetaSketchAggregationFunction
     extends BaseSingleInputAggregationFunction<List<Sketch>, Comparable> {
-  private static final String SET_UNION = "SET_UNION";
-  private static final String SET_INTERSECT = "SET_INTERSECT";
-  private static final String SET_DIFF = "SET_DIFF";
+  private static final String SET_UNION = "setunion";
+  private static final String SET_INTERSECT = "setintersect";
+  private static final String SET_DIFF = "setdiff";
   private static final String DEFAULT_SKETCH_IDENTIFIER = "$0";
   private static final Sketch EMPTY_SKETCH = new UpdateSketchBuilder().build().compact();
 
@@ -142,8 +142,8 @@ public class DistinctCountThetaSketchAggregationFunction
       Preconditions.checkArgument(postAggregationExpression.getType() == ExpressionContext.Type.LITERAL,
           "Last argument of DISTINCT_COUNT_THETA_SKETCH aggregation function must be literal (post-aggregation "
               + "expression)");
-      _postAggregationExpression = RequestContextUtils
-          .getExpression(CalciteSqlParser.compileToExpression(postAggregationExpression.getLiteral()));
+      _postAggregationExpression = RequestContextUtils.getExpression(
+          CalciteSqlParser.compileToExpression(postAggregationExpression.getLiteral()));
 
       // Validate the post-aggregation expression
       _includeDefaultSketch = validatePostAggregationExpression(_postAggregationExpression, _filterEvaluators.size());
@@ -1048,8 +1048,8 @@ public class DistinctCountThetaSketchAggregationFunction
 
     if (expression.getType() == ExpressionContext.Type.IDENTIFIER) {
       int sketchId = extractSketchId(expression.getIdentifier());
-      Preconditions
-          .checkArgument(sketchId <= numFilters, "Sketch id: %s exceeds number of filters: %s", sketchId, numFilters);
+      Preconditions.checkArgument(sketchId <= numFilters, "Sketch id: %s exceeds number of filters: %s", sketchId,
+          numFilters);
       return sketchId == 0;
     }
 
@@ -1058,12 +1058,11 @@ public class DistinctCountThetaSketchAggregationFunction
     List<ExpressionContext> arguments = function.getArguments();
     int numArguments = arguments.size();
     boolean includeDefaultSketch = false;
-    switch (functionName.toUpperCase()) {
+    switch (functionName) {
       case SET_UNION:
       case SET_INTERSECT:
-        Preconditions
-            .checkArgument(numArguments >= 2, "SET_UNION and SET_INTERSECT should have at least 2 arguments, got: %s",
-                numArguments);
+        Preconditions.checkArgument(numArguments >= 2,
+            "SET_UNION and SET_INTERSECT should have at least 2 arguments, got: %s", numArguments);
         for (ExpressionContext argument : arguments) {
           includeDefaultSketch |= validatePostAggregationExpression(argument, numFilters);
         }
@@ -1084,8 +1083,8 @@ public class DistinctCountThetaSketchAggregationFunction
    * Extracts the sketch id from the identifier (e.g. $0 -> 0, $1 -> 1).
    */
   private static int extractSketchId(String identifier) {
-    Preconditions
-        .checkArgument(identifier.charAt(0) == '$', "Invalid identifier: %s, expecting $0, $1, etc.", identifier);
+    Preconditions.checkArgument(identifier.charAt(0) == '$', "Invalid identifier: %s, expecting $0, $1, etc.",
+        identifier);
     int sketchId = Integer.parseInt(identifier.substring(1));
     Preconditions.checkArgument(sketchId >= 0, "Invalid identifier: %s, expecting $0, $1, etc.", identifier);
     return sketchId;
@@ -1267,7 +1266,7 @@ public class DistinctCountThetaSketchAggregationFunction
     FunctionContext function = expression.getFunction();
     String functionName = function.getFunctionName();
     List<ExpressionContext> arguments = function.getArguments();
-    switch (functionName.toUpperCase()) {
+    switch (functionName) {
       case SET_UNION:
         Union union = _setOperationBuilder.buildUnion();
         for (ExpressionContext argument : arguments) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/statement/JsonStatementOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/statement/JsonStatementOptimizer.java
@@ -265,7 +265,7 @@ public class JsonStatementOptimizer implements StatementOptimizer {
    * @return a Function with "AS" operator that wraps another function.
    */
   private static Function getAliasFunction(String alias, Function function) {
-    Function aliasFunction = new Function("AS");
+    Function aliasFunction = new Function("as");
 
     List<Expression> operands = new ArrayList<>();
     Expression expression = new Expression(ExpressionType.FUNCTION);
@@ -287,7 +287,7 @@ public class JsonStatementOptimizer implements StatementOptimizer {
    * @return a Function with JSON_EXTRACT_SCALAR operator created using parts of fully qualified identifier name.
    */
   private static Function getJsonExtractFunction(String[] parts, DataSchema.ColumnDataType dataType) {
-    Function jsonExtractScalarFunction = new Function("JSON_EXTRACT_SCALAR");
+    Function jsonExtractScalarFunction = new Function("jsonextractscalar");
     List<Expression> operands = new ArrayList<>();
     operands.add(RequestUtils.createIdentifierExpression(parts[0]));
     operands.add(RequestUtils.createLiteralExpression(new StringLiteralAstNode(getJsonPath(parts, false))));
@@ -333,7 +333,7 @@ public class JsonStatementOptimizer implements StatementOptimizer {
               String[] parts = getIdentifierParts(left.getIdentifier());
               if (parts.length > 1 && isValidJSONColumn(parts[0], schema)) {
                 if (isIndexedJSONColumn(parts[0], tableConfig)) {
-                  Function jsonMatchFunction = new Function("JSON_MATCH");
+                  Function jsonMatchFunction = new Function(FilterKind.JSON_MATCH.name());
 
                   List<Expression> jsonMatchFunctionOperands = new ArrayList<>();
                   jsonMatchFunctionOperands.add(RequestUtils.createIdentifierExpression(parts[0]));
@@ -360,7 +360,7 @@ public class JsonStatementOptimizer implements StatementOptimizer {
               String[] parts = getIdentifierParts(operand.getIdentifier());
               if (parts.length > 1 && isValidJSONColumn(parts[0], schema)) {
                 if (isIndexedJSONColumn(parts[0], tableConfig)) {
-                  Function jsonMatchFunction = new Function("JSON_MATCH");
+                  Function jsonMatchFunction = new Function(FilterKind.JSON_MATCH.name());
 
                   List<Expression> jsonMatchFunctionOperands = new ArrayList<>();
                   jsonMatchFunctionOperands.add(RequestUtils.createIdentifierExpression(parts[0]));
@@ -409,11 +409,11 @@ public class JsonStatementOptimizer implements StatementOptimizer {
 
     // column name followed by all other JSON path expression
     if (dotIndex != -1) {
-      return new String[] {name.substring(0, dotIndex), name.substring(dotIndex)};
+      return new String[]{name.substring(0, dotIndex), name.substring(dotIndex)};
     }
 
     // column name without any JSON path expression
-    return new String[] {name};
+    return new String[]{name};
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/statement/StringPredicateFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/statement/StringPredicateFilterOptimizer.java
@@ -18,18 +18,15 @@
  */
 package org.apache.pinot.core.query.optimizer.statement;
 
-import java.lang.reflect.Method;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import javax.annotation.Nullable;
-import org.apache.pinot.common.function.scalar.StringFunctions;
+import org.apache.pinot.common.function.FunctionInfo;
+import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
 import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.pql.parsers.pql2.ast.FilterKind;
-import org.apache.pinot.spi.annotations.ScalarFunction;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
@@ -47,9 +44,8 @@ import org.apache.pinot.spi.data.Schema;
  * rewrite phase with optimizer phase to avoid such issues altogether.
  */
 public class StringPredicateFilterOptimizer implements StatementOptimizer {
-  private static final String MINUS_OPERATOR_NAME = "MINUS";
-  private static final String STRCMP_OPERATOR_NAME = "STRCMP";
-  private static final Set<String> STRING_OUTPUT_FUNCTIONS = getStringOutputFunctionList();
+  private static final String MINUS_OPERATOR_NAME = "minus";
+  private static final String STRCMP_OPERATOR_NAME = "strcmp";
 
   @Override
   public void optimize(PinotQuery query, @Nullable TableConfig tableConfig, @Nullable Schema schema) {
@@ -105,8 +101,8 @@ public class StringPredicateFilterOptimizer implements StatementOptimizer {
     Function function = expression.getFunctionCall();
     String operator = function.getOperator();
     List<Expression> operands = function.getOperands();
-    if (operator.equals(MINUS_OPERATOR_NAME) && operands.size() == 2 && isString(operands.get(0), schema)
-        && isString(operands.get(1), schema)) {
+    if (operator.equals(MINUS_OPERATOR_NAME) && operands.size() == 2 && isString(operands.get(0), schema) && isString(
+        operands.get(1), schema)) {
       function.setOperator(STRCMP_OPERATOR_NAME);
     }
   }
@@ -122,26 +118,14 @@ public class StringPredicateFilterOptimizer implements StatementOptimizer {
       return fieldSpec != null && fieldSpec.getDataType() == FieldSpec.DataType.STRING;
     }
 
-    // Check if the function returns STRING as output.
-    return (expressionType == ExpressionType.FUNCTION && STRING_OUTPUT_FUNCTIONS
-        .contains(expression.getFunctionCall().getOperator().toUpperCase()));
-  }
-
-  /** List of string functions that return STRING output. */
-  private static Set<String> getStringOutputFunctionList() {
-    Set<String> set = new HashSet<>();
-    Method[] methods = StringFunctions.class.getDeclaredMethods();
-    for (Method method : methods) {
-      if (method.getReturnType() == String.class) {
-        if (method.isAnnotationPresent(ScalarFunction.class)) {
-          ScalarFunction annotation = method.getAnnotation(ScalarFunction.class);
-          for (String name : annotation.names()) {
-            set.add(name.toUpperCase());
-          }
-        }
-        set.add(method.getName().toUpperCase());
-      }
+    if (expressionType == ExpressionType.FUNCTION) {
+      // Check if the function returns STRING as output.
+      Function function = expression.getFunctionCall();
+      FunctionInfo functionInfo =
+          FunctionRegistry.getFunctionInfo(function.getOperator(), function.getOperands().size());
+      return functionInfo != null && functionInfo.getMethod().getReturnType() == String.class;
     }
-    return set;
+
+    return false;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/StUnionQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/StUnionQueriesTest.java
@@ -206,14 +206,14 @@ public class StUnionQueriesTest extends BaseQueriesTest {
     BrokerResponseNative brokerResponse = getBrokerResponseForSqlQuery(query);
     ResultTable resultTable = brokerResponse.getResultTable();
     DataSchema expectedDataSchema = new DataSchema(new String[]{
-        "st_as_text(st_union(pointColumn))",
-        "st_as_binary(st_union(pointColumn))",
-        "to_geometry(st_union(pointColumn))",
-        "to_spherical_geography(st_union(pointColumn))",
-        "st_geom_from_text(st_as_text(st_union(pointColumn)))",
-        "st_geog_from_text(st_as_text(st_union(pointColumn)))",
-        "st_geom_from_wkb(st_as_binary(st_union(pointColumn)))",
-        "st_geog_from_wkb(st_as_binary(st_union(pointColumn)))"
+        "stastext(stunion(pointColumn))",
+        "stasbinary(stunion(pointColumn))",
+        "togeometry(stunion(pointColumn))",
+        "tosphericalgeography(stunion(pointColumn))",
+        "stgeomfromtext(stastext(stunion(pointColumn)))",
+        "stgeogfromtext(stastext(stunion(pointColumn)))",
+        "stgeomfromwkb(stasbinary(stunion(pointColumn)))",
+        "stgeogfromwkb(stasbinary(stunion(pointColumn)))"
     }, new ColumnDataType[]{
         ColumnDataType.STRING,
         ColumnDataType.BYTES,

--- a/pinot-core/src/test/java/org/apache/pinot/queries/SumPrecisionQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/SumPrecisionQueriesTest.java
@@ -151,9 +151,8 @@ public class SumPrecisionQueriesTest extends BaseQueriesTest {
 
   @Test
   public void testAggregationOnly() {
-    String query =
-        "SELECT SUM_PRECISION(intColumn), SUM_PRECISION(longColumn), SUM_PRECISION(floatColumn), SUM_PRECISION"
-            + "(doubleColumn), SUM_PRECISION(stringColumn), SUM_PRECISION(bytesColumn) FROM testTable";
+    String query = "SELECT SUM_PRECISION(intColumn), SUM_PRECISION(longColumn), SUM_PRECISION(floatColumn), "
+        + "SUM_PRECISION(doubleColumn), SUM_PRECISION(stringColumn), SUM_PRECISION(bytesColumn) FROM testTable";
 
     // Inner segment
     Operator operator = getOperatorForSqlQuery(query);
@@ -190,10 +189,9 @@ public class SumPrecisionQueriesTest extends BaseQueriesTest {
 
   @Test
   public void testAggregationWithPrecision() {
-    String query =
-        "SELECT SUM_PRECISION(intColumn, 6), SUM_PRECISION(longColumn, 6), SUM_PRECISION(floatColumn, 6), "
-            + "SUM_PRECISION(doubleColumn, 6), SUM_PRECISION(stringColumn, 6), SUM_PRECISION(bytesColumn, 6) FROM "
-            + "testTable";
+    String query = "SELECT SUM_PRECISION(intColumn, 6), SUM_PRECISION(longColumn, 6), SUM_PRECISION(floatColumn, 6), "
+        + "SUM_PRECISION(doubleColumn, 6), SUM_PRECISION(stringColumn, 6), SUM_PRECISION(bytesColumn, 6) "
+        + "FROM testTable";
 
     // Inner segment
     Operator operator = getOperatorForSqlQuery(query);
@@ -231,10 +229,9 @@ public class SumPrecisionQueriesTest extends BaseQueriesTest {
 
   @Test
   public void testAggregationWithPrecisionAndScale() {
-    String query =
-        "SELECT SUM_PRECISION(intColumn, 10, 3), SUM_PRECISION(longColumn, 10, 3), SUM_PRECISION(floatColumn, 10, 3),"
-            + " SUM_PRECISION(doubleColumn, 10, 3), SUM_PRECISION(stringColumn, 10, 3), SUM_PRECISION(bytesColumn, "
-            + "10, 3) FROM testTable";
+    String query = "SELECT SUM_PRECISION(intColumn, 10, 3), SUM_PRECISION(longColumn, 10, 3), "
+        + "SUM_PRECISION(floatColumn, 10, 3), SUM_PRECISION(doubleColumn, 10, 3), SUM_PRECISION(stringColumn, 10, 3), "
+        + "SUM_PRECISION(bytesColumn, 10, 3) FROM testTable";
 
     // Inner segment
     Operator operator = getOperatorForSqlQuery(query);
@@ -285,8 +282,8 @@ public class SumPrecisionQueriesTest extends BaseQueriesTest {
     // Inter segment
     BrokerResponseNative brokerResponse = getBrokerResponseForSqlQuery(query);
     ResultTable resultTable = brokerResponse.getResultTable();
-    DataSchema expectedDataSchema = new DataSchema(new String[]{"times(sum_precision(intColumn),'2')"},
-        new ColumnDataType[]{ColumnDataType.DOUBLE});
+    DataSchema expectedDataSchema =
+        new DataSchema(new String[]{"times(sumprecision(intColumn),'2')"}, new ColumnDataType[]{ColumnDataType.DOUBLE});
     assertEquals(resultTable.getDataSchema(), expectedDataSchema);
     List<Object[]> rows = resultTable.getRows();
     assertEquals(rows.size(), 1);


### PR DESCRIPTION
Canonicalize the function name to be lower case without underscore when parsing the expression