### PR TITLE
make github action trigger on multi_stage_query_engine branch

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -30,7 +30,8 @@ on:
       - "**.md"
   pull_request:
     branches:
-      - '*master'
+      - master
+      - multi_stage_query_engine
     paths-ignore:
       - "docs/**"
       - "licenses/**"


### PR DESCRIPTION
Enable Github action run on `master` branches and on the multi_stage_query_engine branch.

This works to make sure branch development like multi-stage query engine also gets full testing on all PRs open against that branch 