### PR TITLE
Timestamp type index

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1859,6 +1859,9 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         return actualAlias;
       }
     }
+    if (columnName.charAt(0) == '$') {
+      return columnName;
+    }
     throw new BadQueryRequestException("Unknown columnName '" + columnName + "' found in the query");
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -39,6 +39,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.broker.api.RequestStatistics;
 import org.apache.pinot.broker.api.RequesterIdentity;
@@ -85,6 +86,7 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.TimestampIndexGranularity;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
@@ -381,10 +383,12 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       offlineBrokerRequest = getOfflineBrokerRequest(serverBrokerRequest);
       PinotQuery offlinePinotQuery = offlineBrokerRequest.getPinotQuery();
       handleExpressionOverride(offlinePinotQuery, _tableCache.getExpressionOverrideMap(offlineTableName));
+      handleTimestampIndexOverride(offlinePinotQuery, offlineTableConfig);
       _queryOptimizer.optimize(offlinePinotQuery, offlineTableConfig, schema);
       realtimeBrokerRequest = getRealtimeBrokerRequest(serverBrokerRequest);
       PinotQuery realtimePinotQuery = realtimeBrokerRequest.getPinotQuery();
       handleExpressionOverride(realtimePinotQuery, _tableCache.getExpressionOverrideMap(realtimeTableName));
+      handleTimestampIndexOverride(realtimePinotQuery, realtimeTableConfig);
       _queryOptimizer.optimize(realtimePinotQuery, realtimeTableConfig, schema);
       requestStatistics.setFanoutType(RequestStatistics.FanoutType.HYBRID);
       requestStatistics.setOfflineServerTenant(getServerTenant(offlineTableName));
@@ -393,6 +397,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       // OFFLINE only
       setTableName(serverBrokerRequest, offlineTableName);
       handleExpressionOverride(pinotQuery, _tableCache.getExpressionOverrideMap(offlineTableName));
+      handleTimestampIndexOverride(pinotQuery, offlineTableConfig);
       _queryOptimizer.optimize(pinotQuery, offlineTableConfig, schema);
       offlineBrokerRequest = serverBrokerRequest;
       requestStatistics.setFanoutType(RequestStatistics.FanoutType.OFFLINE);
@@ -401,6 +406,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       // REALTIME only
       setTableName(serverBrokerRequest, realtimeTableName);
       handleExpressionOverride(pinotQuery, _tableCache.getExpressionOverrideMap(realtimeTableName));
+      handleTimestampIndexOverride(pinotQuery, realtimeTableConfig);
       _queryOptimizer.optimize(pinotQuery, realtimeTableConfig, schema);
       realtimeBrokerRequest = serverBrokerRequest;
       requestStatistics.setFanoutType(RequestStatistics.FanoutType.REALTIME);
@@ -561,6 +567,64 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     logBrokerResponse(requestId, query, requestStatistics, brokerRequest, numUnavailableSegments, serverStats,
         brokerResponse, totalTimeMs);
     return brokerResponse;
+  }
+
+  private void handleTimestampIndexOverride(PinotQuery pinotQuery, @Nullable TableConfig tableConfig) {
+    if (tableConfig == null || tableConfig.getFieldConfigList() == null) {
+      return;
+    }
+
+    Set<String> timestampIndexColumns = _tableCache.getTimestampIndexColumns(tableConfig.getTableName());
+    if (timestampIndexColumns.isEmpty()) {
+      return;
+    }
+    for (Expression expression : pinotQuery.getSelectList()) {
+      setTimestampIndexExpressionOverrideHints(expression, timestampIndexColumns, pinotQuery);
+    }
+    setTimestampIndexExpressionOverrideHints(pinotQuery.getFilterExpression(), timestampIndexColumns, pinotQuery);
+    setTimestampIndexExpressionOverrideHints(pinotQuery.getHavingExpression(), timestampIndexColumns, pinotQuery);
+    List<Expression> groupByList = pinotQuery.getGroupByList();
+    if (CollectionUtils.isNotEmpty(groupByList)) {
+      groupByList.forEach(
+          expression -> setTimestampIndexExpressionOverrideHints(expression, timestampIndexColumns, pinotQuery));
+    }
+    List<Expression> orderByList = pinotQuery.getOrderByList();
+    if (CollectionUtils.isNotEmpty(orderByList)) {
+      orderByList.forEach(
+          expression -> setTimestampIndexExpressionOverrideHints(expression, timestampIndexColumns, pinotQuery));
+    }
+  }
+
+  private void setTimestampIndexExpressionOverrideHints(@Nullable Expression expression,
+      Set<String> timestampIndexColumns,
+      PinotQuery pinotQuery) {
+    if (expression == null || expression.getFunctionCall() == null) {
+      return;
+    }
+    Function function = expression.getFunctionCall();
+    switch (function.getOperator()) {
+      case "datetrunc":
+        String granularString = function.getOperands().get(0).getLiteral().getStringValue();
+        Expression timeExpression = function.getOperands().get(1);
+        if (((function.getOperandsSize() == 2)
+            || (function.getOperandsSize() == 3
+            && "MILLISECONDS".equalsIgnoreCase(function.getOperands().get(2).getLiteral().getStringValue())))
+            && TimestampIndexGranularity.isValidTimeGranularity(granularString)
+            && timeExpression.getIdentifier() != null) {
+          String timeColumn = timeExpression.getIdentifier().getName();
+          String timeColumnWithGranularity = TimestampIndexGranularity.getColumnNameWithGranularity(timeColumn,
+              TimestampIndexGranularity.valueOf(granularString));
+          if (timestampIndexColumns.contains(timeColumnWithGranularity)) {
+            pinotQuery.putToExpressionOverrideHints(expression,
+                RequestUtils.getIdentifierExpression(timeColumnWithGranularity));
+          }
+        }
+        break;
+      default:
+        break;
+    }
+    function.getOperands()
+        .forEach(operand -> setTimestampIndexExpressionOverrideHints(operand, timestampIndexColumns, pinotQuery));
   }
 
   /** Set EXPLAIN PLAN query to route to only one segment on one server. */

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -575,7 +575,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     }
 
     Set<String> timestampIndexColumns = _tableCache.getTimestampIndexColumns(tableConfig.getTableName());
-    if (timestampIndexColumns.isEmpty()) {
+    if (CollectionUtils.isEmpty(timestampIndexColumns)) {
       return;
     }
     for (Expression expression : pinotQuery.getSelectList()) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/config/provider/TableCache.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/provider/TableCache.java
@@ -266,23 +266,6 @@ public class TableCache implements PinotConfigProvider {
       _tableNameMap.put(tableNameWithType, tableNameWithType);
       _tableNameMap.put(rawTableName, rawTableName);
     }
-    addOverrideHintsColumns(tableConfig, schemaName, _caseInsensitive);
-  }
-
-  private void addOverrideHintsColumns(TableConfig tableConfig, String schemaName, boolean caseInsensitive) {
-    SchemaInfo schemaInfo =
-        (schemaName == null) ? _schemaInfoMap.get(TableNameBuilder.extractRawTableName(tableConfig.getTableName()))
-            : _schemaInfoMap.get(schemaName);
-    if (schemaInfo == null) {
-      return;
-    }
-    TimestampIndexGranularity.extractTimestampIndexGranularityColumnNames(tableConfig).forEach(column -> {
-      if (caseInsensitive) {
-        schemaInfo._columnNameMap.put(column.toLowerCase(), column);
-      } else {
-        schemaInfo._columnNameMap.put(column, column);
-      }
-    });
   }
 
   private void removeTableConfig(String path) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
@@ -622,7 +622,7 @@ public class DateTimeFunctions {
    * @return truncated timeValue in TimeUnit.MILLISECONDS
    */
   @ScalarFunction
-  public long dateTrunc(String unit, long timeValue) {
+  public static long dateTrunc(String unit, long timeValue) {
     return dateTrunc(unit, timeValue, TimeUnit.MILLISECONDS, ISOChronology.getInstanceUTC(), TimeUnit.MILLISECONDS);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
@@ -28,7 +28,9 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.segment.local.function.FunctionEvaluator;
 import org.apache.pinot.segment.local.function.FunctionEvaluatorFactory;
+import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TimestampIndexGranularity;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
@@ -62,6 +64,19 @@ public class ExpressionTransformer implements RecordTransformer {
         FunctionEvaluator functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec);
         if (functionEvaluator != null) {
           expressionEvaluators.put(fieldName, functionEvaluator);
+        }
+      }
+    }
+    // For fields with Timestamp indexes, also generate the corresponding values during record transformation.
+    if (tableConfig.getFieldConfigList() != null) {
+      for (FieldConfig fieldConfig : tableConfig.getFieldConfigList()) {
+        if (fieldConfig.getIndexTypes().contains(FieldConfig.IndexType.TIMESTAMP)) {
+          for (TimestampIndexGranularity granularity : fieldConfig.getTimestampConfig().getGranularities()) {
+            expressionEvaluators.put(
+                TimestampIndexGranularity.getColumnNameWithGranularity(fieldConfig.getName(), granularity),
+                FunctionEvaluatorFactory.getExpressionEvaluator(
+                    String.format("dateTrunc(\'" + granularity + "\', " + fieldConfig.getName() + ")")));
+          }
         }
       }
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.segment.local.segment.index.column.PhysicalColumnIndexContainer;
 import org.apache.pinot.segment.local.segment.index.loader.columnminmaxvalue.ColumnMinMaxValueGeneratorMode;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
 import org.apache.pinot.segment.spi.index.creator.H3IndexConfig;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderRegistry;
@@ -39,6 +40,7 @@ import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TimestampIndexGranularity;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.ReadMode;
@@ -66,6 +68,7 @@ public class IndexLoadingConfig {
   private Set<String> _varLengthDictionaryColumns = new HashSet<>();
   private Set<String> _onHeapDictionaryColumns = new HashSet<>();
   private Map<String, BloomFilterConfig> _bloomFilterConfigs = new HashMap<>();
+  private Map<String, List<TimestampIndexGranularity>> _timestampIndexConfigs = new HashMap<>();
   private boolean _enableDynamicStarTreeCreation;
   private List<StarTreeIndexConfig> _starTreeIndexConfigs;
   private boolean _enableDefaultStarTree;
@@ -150,6 +153,14 @@ public class IndexLoadingConfig {
     extractTextIndexColumnsFromTableConfig(tableConfig);
     extractFSTIndexColumnsFromTableConfig(tableConfig);
     extractH3IndexConfigsFromTableConfig(tableConfig);
+    _timestampIndexConfigs.putAll(SegmentGeneratorConfig.extractTimestampIndexConfigsFromTableConfig(tableConfig));
+
+    // Apply range index for all Timestamp column with granularities columns.
+    for (String timestampColumn : _timestampIndexConfigs.keySet()) {
+      for (TimestampIndexGranularity granularity : _timestampIndexConfigs.get(timestampColumn)) {
+        _rangeIndexColumns.add(TimestampIndexGranularity.getColumnNameWithGranularity(timestampColumn, granularity));
+      }
+    }
 
     Map<String, String> noDictionaryConfig = indexingConfig.getNoDictionaryConfig();
     if (noDictionaryConfig != null) {
@@ -318,6 +329,10 @@ public class IndexLoadingConfig {
     return _h3IndexConfigs;
   }
 
+  public Map<String, List<TimestampIndexGranularity>> getTimestampIndexConfigs() {
+    return _timestampIndexConfigs;
+  }
+
   public Map<String, Map<String, String>> getColumnProperties() {
     return _columnProperties;
   }
@@ -376,6 +391,11 @@ public class IndexLoadingConfig {
   @VisibleForTesting
   public void setBloomFilterConfigs(Map<String, BloomFilterConfig> bloomFilterConfigs) {
     _bloomFilterConfigs = bloomFilterConfigs;
+  }
+
+  @VisibleForTesting
+  public void setTimestampIndexColumns(Map<String, List<TimestampIndexGranularity>> timestampIndexConfigs) {
+    _timestampIndexConfigs = timestampIndexConfigs;
   }
 
   @VisibleForTesting

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -742,6 +742,10 @@ public final class TableConfigUtils {
               Preconditions.checkState(fieldConfigColSpec.getDataType().getStoredType() == DataType.STRING,
                   "TEXT Index is only supported for string columns");
               break;
+            case TIMESTAMP:
+              Preconditions.checkState(fieldConfigColSpec.getDataType() == DataType.TIMESTAMP,
+                  "TIMESTAMP Index is only supported for timestamp columns");
+              break;
             default:
               break;
           }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -696,7 +696,7 @@ public class TableConfigUtilsTest {
         .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
 
     try {
-      FieldConfig fieldConfig = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null);
+      FieldConfig fieldConfig = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -225,12 +225,8 @@ public class SegmentGeneratorConfig implements Serializable {
     if (timestampColumnWithGranularityFieldSpecs.isEmpty()) {
       return schema;
     }
-    Schema newSchema = new Schema.SchemaBuilder()
-        .setSchemaName(schema.getSchemaName())
-        .setPrimaryKeyColumns(schema.getPrimaryKeyColumns())
-        .build();
+    Schema newSchema = schema.clone();
     timestampColumnWithGranularityFieldSpecs.forEach(fieldSpec -> newSchema.addField(fieldSpec));
-    schema.getAllFieldSpecs().forEach(fieldSpec -> newSchema.addField(fieldSpec));
     return newSchema;
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/SegmentMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/SegmentMetadataImpl.java
@@ -50,6 +50,7 @@ import org.apache.pinot.segment.spi.creator.SegmentVersion;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2Constants;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2Metadata;
 import org.apache.pinot.segment.spi.store.SegmentDirectoryPaths;
+import org.apache.pinot.spi.config.table.TimestampIndexGranularity;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -269,7 +270,13 @@ public class SegmentMetadataImpl implements SegmentMetadata {
   private static void addPhysicalColumns(List src, Collection<String> dest) {
     for (Object o : src) {
       String column = o.toString();
-      if (!column.isEmpty() && column.charAt(0) != '$' && !dest.contains(column)) {
+      if (!column.isEmpty() && !dest.contains(column)) {
+        if (column.charAt(0) == '$') {
+          // Skip virtual columns starting with '$', but keep time column with granularity as physical column.
+          if (!TimestampIndexGranularity.isValidTimeColumnWithGranularityName(column)) {
+            continue;
+          }
+        }
         dest.add(column);
       }
     }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfigTest.java
@@ -18,13 +18,21 @@
  */
 package org.apache.pinot.segment.spi.creator;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.TimestampConfig;
+import org.apache.pinot.spi.config.table.TimestampIndexGranularity;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -95,5 +103,64 @@ public class SegmentGeneratorConfigTest {
     assertNull(segmentGeneratorConfig.getSegmentTimeUnit());
     assertNotNull(segmentGeneratorConfig.getDateTimeFormatSpec());
     assertEquals(segmentGeneratorConfig.getDateTimeFormatSpec().getSDFPattern(), "yyyyMMdd");
+  }
+
+  @Test
+  public void testExtractTimestampIndexConfigsFromTableConfig() {
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("t1").setFieldConfigList(
+        ImmutableList.of(new FieldConfig("f1", FieldConfig.EncodingType.DICTIONARY, null,
+                ImmutableList.of(FieldConfig.IndexType.TIMESTAMP), FieldConfig.CompressionCodec.ZSTANDARD,
+                new TimestampConfig(ImmutableList.of(TimestampIndexGranularity.DAY)), ImmutableMap.of()),
+            new FieldConfig("f2", FieldConfig.EncodingType.DICTIONARY, null,
+                ImmutableList.of(FieldConfig.IndexType.TIMESTAMP), FieldConfig.CompressionCodec.LZ4,
+                new TimestampConfig(ImmutableList.of(TimestampIndexGranularity.WEEK)), ImmutableMap.of()),
+            new FieldConfig("f3", FieldConfig.EncodingType.DICTIONARY, null,
+                ImmutableList.of(FieldConfig.IndexType.TIMESTAMP), FieldConfig.CompressionCodec.PASS_THROUGH,
+                new TimestampConfig(ImmutableList.of(TimestampIndexGranularity.MONTH)), ImmutableMap.of()))).build();
+    Map<String, List<TimestampIndexGranularity>> timestampIndexGranularityMap =
+        SegmentGeneratorConfig.extractTimestampIndexConfigsFromTableConfig(tableConfig);
+    Assert.assertEquals(3, timestampIndexGranularityMap.size());
+    Assert.assertTrue(timestampIndexGranularityMap.containsKey("f1"));
+    Assert.assertTrue(timestampIndexGranularityMap.get("f1").contains(TimestampIndexGranularity.DAY));
+    Assert.assertTrue(timestampIndexGranularityMap.containsKey("f2"));
+    Assert.assertTrue(timestampIndexGranularityMap.get("f2").contains(TimestampIndexGranularity.WEEK));
+    Assert.assertTrue(timestampIndexGranularityMap.containsKey("f3"));
+    Assert.assertTrue(timestampIndexGranularityMap.get("f3").contains(TimestampIndexGranularity.MONTH));
+  }
+
+  @Test
+  public void testUpdateSchemaWithTimestampIndexes() {
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("t1").setFieldConfigList(
+        ImmutableList.of(new FieldConfig("f1", FieldConfig.EncodingType.DICTIONARY, null,
+                ImmutableList.of(FieldConfig.IndexType.TIMESTAMP), FieldConfig.CompressionCodec.ZSTANDARD,
+                new TimestampConfig(ImmutableList.of(TimestampIndexGranularity.DAY)), ImmutableMap.of()),
+            new FieldConfig("f2", FieldConfig.EncodingType.DICTIONARY, null,
+                ImmutableList.of(FieldConfig.IndexType.TIMESTAMP), FieldConfig.CompressionCodec.LZ4,
+                new TimestampConfig(ImmutableList.of(TimestampIndexGranularity.WEEK)), ImmutableMap.of()),
+            new FieldConfig("f3", FieldConfig.EncodingType.DICTIONARY, null,
+                ImmutableList.of(FieldConfig.IndexType.TIMESTAMP), FieldConfig.CompressionCodec.PASS_THROUGH,
+                new TimestampConfig(ImmutableList.of(TimestampIndexGranularity.MONTH)), ImmutableMap.of()))).build();
+    Map<String, List<TimestampIndexGranularity>> timestampIndexGranularityMap =
+        SegmentGeneratorConfig.extractTimestampIndexConfigsFromTableConfig(tableConfig);
+    Schema schema = new Schema.SchemaBuilder()
+        .addDateTime("f1", FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:SECONDS")
+        .addDateTime("f2", FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:SECONDS")
+        .addDateTime("f3", FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:SECONDS")
+        .build();
+
+    // No update when no timestampIndexGranularityMap
+    Assert.assertEquals(schema, SegmentGeneratorConfig.updateSchemaWithTimestampIndexes(schema, ImmutableMap.of()));
+
+    Schema updatedSchema =
+        SegmentGeneratorConfig.updateSchemaWithTimestampIndexes(schema, timestampIndexGranularityMap);
+    Assert.assertEquals(6, updatedSchema.getAllFieldSpecs().size());
+    Assert.assertTrue(updatedSchema.hasColumn("$f1$DAY"));
+    Assert.assertTrue(updatedSchema.hasColumn("$f2$WEEK"));
+    Assert.assertTrue(updatedSchema.hasColumn("$f3$MONTH"));
+    Assert.assertTrue(timestampIndexGranularityMap.get("f1").contains(TimestampIndexGranularity.DAY));
+    Assert.assertTrue(timestampIndexGranularityMap.containsKey("f2"));
+    Assert.assertTrue(timestampIndexGranularityMap.get("f2").contains(TimestampIndexGranularity.WEEK));
+    Assert.assertTrue(timestampIndexGranularityMap.containsKey("f3"));
+    Assert.assertTrue(timestampIndexGranularityMap.get("f3").contains(TimestampIndexGranularity.MONTH));
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -50,16 +50,17 @@ public class FieldConfig extends BaseJsonConfig {
   private final List<IndexType> _indexTypes;
   private final CompressionCodec _compressionCodec;
   private final Map<String, String> _properties;
+  private final TimestampConfig _timestampConfig;
 
   @Deprecated
   public FieldConfig(String name, EncodingType encodingType, IndexType indexType, CompressionCodec compressionCodec,
       Map<String, String> properties) {
-    this(name, encodingType, indexType, null, compressionCodec, properties);
+    this(name, encodingType, indexType, null, compressionCodec, null, properties);
   }
 
   public FieldConfig(String name, EncodingType encodingType, List<IndexType> indexTypes,
       CompressionCodec compressionCodec, Map<String, String> properties) {
-    this(name, encodingType, null, indexTypes, compressionCodec, properties);
+    this(name, encodingType, null, indexTypes, compressionCodec, null, properties);
   }
 
   @JsonCreator
@@ -68,6 +69,7 @@ public class FieldConfig extends BaseJsonConfig {
       @JsonProperty(value = "indexType") @Nullable IndexType indexType,
       @JsonProperty(value = "indexTypes") @Nullable List<IndexType> indexTypes,
       @JsonProperty(value = "compressionCodec") @Nullable CompressionCodec compressionCodec,
+      @JsonProperty(value = "timestampConfig") @Nullable TimestampConfig timestampConfig,
       @JsonProperty(value = "properties") @Nullable Map<String, String> properties) {
     Preconditions.checkArgument(name != null, "'name' must be configured");
     _name = name;
@@ -75,6 +77,7 @@ public class FieldConfig extends BaseJsonConfig {
     _indexTypes = indexTypes != null ? indexTypes : (
         indexType == null ? Lists.newArrayList() : Lists.newArrayList(indexType));
     _compressionCodec = compressionCodec;
+    _timestampConfig = timestampConfig;
     _properties = properties;
   }
 
@@ -85,7 +88,7 @@ public class FieldConfig extends BaseJsonConfig {
 
   // If null, there won't be any index
   public enum IndexType {
-    INVERTED, SORTED, TEXT, FST, H3, JSON, RANGE
+    INVERTED, SORTED, TEXT, FST, H3, JSON, TIMESTAMP, RANGE
   }
 
   public enum CompressionCodec {
@@ -113,6 +116,11 @@ public class FieldConfig extends BaseJsonConfig {
   @Nullable
   public CompressionCodec getCompressionCodec() {
     return _compressionCodec;
+  }
+
+  @Nullable
+  public TimestampConfig getTimestampConfig() {
+    return _timestampConfig;
   }
 
   @Nullable

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TimestampConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TimestampConfig.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import org.apache.pinot.spi.config.BaseJsonConfig;
+
+
+public class TimestampConfig extends BaseJsonConfig {
+  private final List<TimestampIndexGranularity> _granularities;
+
+  @JsonCreator
+  public TimestampConfig(@JsonProperty(value = "granularities") List<TimestampIndexGranularity> granularities) {
+    _granularities = granularities;
+  }
+
+  public List<TimestampIndexGranularity> getGranularities() {
+    return _granularities;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TimestampIndexGranularity.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TimestampIndexGranularity.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.data.DateTimeFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+
+
+/**
+ * TimestampIndexGranularity is the enum of different time granularities from MILLIS to YEAR.
+ */
+public enum TimestampIndexGranularity {
+  MILLISECOND, SECOND, MINUTE, HOUR, DAY, WEEK, MONTH, QUARTER, YEAR;
+
+  private static final Set<String> VALID_VALUES =
+      Arrays.stream(TimestampIndexGranularity.values()).map(v -> v.toString()).collect(Collectors.toSet());
+
+  public static String getColumnNameWithGranularity(String column, TimestampIndexGranularity granularity) {
+    return "$" + column + "$" + granularity;
+  }
+
+  public static String extractColumnNameFromColumnWithGranularity(String columnWithGranularity) {
+    int index = columnWithGranularity.indexOf('$', 1);
+    return index < 0 ? columnWithGranularity : columnWithGranularity.substring(1, index);
+  }
+
+  public static TimestampIndexGranularity extractGranularityFromColumnWithGranularity(String columnWithGranularity) {
+    return TimestampIndexGranularity.valueOf(
+        columnWithGranularity.substring(columnWithGranularity.indexOf('$', 1) + 1));
+  }
+
+  public static boolean isValidTimeColumnWithGranularityName(String columnName) {
+    if (columnName.charAt(0) != '$') {
+      return false;
+    }
+    int secondDollarPos = columnName.indexOf('$', 1);
+    if (secondDollarPos < 0) {
+      return false;
+    }
+    return VALID_VALUES.contains(columnName.substring(secondDollarPos + 1));
+  }
+
+  public static boolean isValidTimeGranularity(String granularity) {
+    return VALID_VALUES.contains(granularity.toUpperCase());
+  }
+
+  public static Set<String> extractTimestampIndexGranularityColumnNames(TableConfig tableConfig) {
+    // Extract Timestamp granularity columns
+    Set<String> timeColumnWithGranularity = new HashSet<>();
+    if (tableConfig == null || tableConfig.getFieldConfigList() == null) {
+      return timeColumnWithGranularity;
+    }
+    for (FieldConfig fieldConfig : tableConfig.getFieldConfigList()) {
+      TimestampConfig timestampConfig = fieldConfig.getTimestampConfig();
+      if (timestampConfig == null || timestampConfig.getGranularities() == null) {
+        continue;
+      }
+      String timeColumn = fieldConfig.getName();
+      for (TimestampIndexGranularity granularity : timestampConfig.getGranularities()) {
+        timeColumnWithGranularity.add(getColumnNameWithGranularity(timeColumn, granularity));
+      }
+    }
+    return timeColumnWithGranularity;
+  }
+
+  /**
+   * Generate the time column with granularity FieldSpec from existing time column FieldSpec and granularity.
+   * The new FieldSpec keeps same FieldType, only update the field name.
+   *
+   * @param fieldSpec
+   * @param granularity
+   * @return time column with granularity FieldSpec, null if FieldSpec is not Dimension/Metric/DateTime type.
+   */
+  @Nullable
+  public static FieldSpec getFieldSpecForTimestampColumnWithGranularity(FieldSpec fieldSpec,
+      TimestampIndexGranularity granularity) {
+    if (fieldSpec instanceof DateTimeFieldSpec) {
+      DateTimeFieldSpec dateTimeFieldSpec = (DateTimeFieldSpec) fieldSpec;
+      return new DateTimeFieldSpec(
+          TimestampIndexGranularity.getColumnNameWithGranularity(fieldSpec.getName(), granularity),
+          FieldSpec.DataType.TIMESTAMP, dateTimeFieldSpec.getFormat(), dateTimeFieldSpec.getGranularity());
+    }
+    // DIMENSION, METRIC, TIMESTAMP types are not supported
+    return null;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TimestampIndexGranularity.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TimestampIndexGranularity.java
@@ -40,16 +40,6 @@ public enum TimestampIndexGranularity {
     return "$" + column + "$" + granularity;
   }
 
-  public static String extractColumnNameFromColumnWithGranularity(String columnWithGranularity) {
-    int index = columnWithGranularity.indexOf('$', 1);
-    return index < 0 ? columnWithGranularity : columnWithGranularity.substring(1, index);
-  }
-
-  public static TimestampIndexGranularity extractGranularityFromColumnWithGranularity(String columnWithGranularity) {
-    return TimestampIndexGranularity.valueOf(
-        columnWithGranularity.substring(columnWithGranularity.indexOf('$', 1) + 1));
-  }
-
   public static boolean isValidTimeColumnWithGranularityName(String columnName) {
     if (columnName.charAt(0) != '$') {
       return false;
@@ -103,5 +93,17 @@ public enum TimestampIndexGranularity {
     }
     // DIMENSION, METRIC, TIMESTAMP types are not supported
     return null;
+  }
+
+  /**
+   * Generate the dateTrunc expression to convert the base time column to the time column with granularity value
+   * E.g. $ts$DAY -> dateTrunc('DAY', ts)
+   *
+   * @param timeColumn
+   * @param granularity
+   * @return Time conversion expression
+   */
+  public static String getTransformExpression(String timeColumn, TimestampIndexGranularity granularity) {
+    return "dateTrunc(\'" + granularity + "\', " + timeColumn + ")";
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -715,6 +715,15 @@ public final class Schema implements Serializable {
     return result;
   }
 
+  public Schema clone() {
+    Schema cloned = new SchemaBuilder()
+        .setSchemaName(getSchemaName())
+        .setPrimaryKeyColumns(getPrimaryKeyColumns())
+        .build();
+    getAllFieldSpecs().forEach(fieldSpec -> cloned.addField(fieldSpec));
+    return cloned;
+  }
+
   /**
    * Helper method that converts a {@link TimeFieldSpec} to {@link DateTimeFieldSpec}
    * 1) If timeFieldSpec contains only incoming granularity spec, directly convert it to a dateTimeFieldSpec

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/TimestampIndexGranularityTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/TimestampIndexGranularityTest.java
@@ -38,10 +38,6 @@ public class TimestampIndexGranularityTest {
     String timeColumnWithGranularity = "$testTs$DAY";
     Assert.assertEquals(TimestampIndexGranularity.getColumnNameWithGranularity(timeColumn, granularity),
         timeColumnWithGranularity);
-    Assert.assertEquals(
-        TimestampIndexGranularity.extractColumnNameFromColumnWithGranularity(timeColumnWithGranularity), timeColumn);
-    Assert.assertEquals(
-        TimestampIndexGranularity.extractGranularityFromColumnWithGranularity(timeColumnWithGranularity), granularity);
     Assert.assertTrue(TimestampIndexGranularity.isValidTimeColumnWithGranularityName(timeColumnWithGranularity));
     Assert.assertFalse(TimestampIndexGranularity.isValidTimeColumnWithGranularityName(timeColumn));
     Assert.assertFalse(TimestampIndexGranularity.isValidTimeColumnWithGranularityName("$docId"));
@@ -75,5 +71,15 @@ public class TimestampIndexGranularityTest {
     Set<String> timestampIndexGranularityColumnNames =
         TimestampIndexGranularity.extractTimestampIndexGranularityColumnNames(tableConfig);
     Assert.assertEquals(ImmutableSet.of("$f1$DAY", "$f2$WEEK", "$f3$MONTH"), timestampIndexGranularityColumnNames);
+  }
+
+  @Test
+  public void testGetTransformExpression() {
+    Assert.assertEquals(TimestampIndexGranularity.getTransformExpression("ts", TimestampIndexGranularity.DAY),
+        "dateTrunc('DAY', ts)");
+    Assert.assertEquals(TimestampIndexGranularity.getTransformExpression("ts", TimestampIndexGranularity.WEEK),
+        "dateTrunc('WEEK', ts)");
+    Assert.assertEquals(TimestampIndexGranularity.getTransformExpression("ts", TimestampIndexGranularity.MONTH),
+        "dateTrunc('MONTH', ts)");
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/TimestampIndexGranularityTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/TimestampIndexGranularityTest.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import org.apache.pinot.spi.data.DateTimeFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TimestampIndexGranularityTest {
+
+  @Test
+  public void testTimestampIndexGranularity() {
+    String timeColumn = "testTs";
+    TimestampIndexGranularity granularity = TimestampIndexGranularity.DAY;
+    String timeColumnWithGranularity = "$testTs$DAY";
+    Assert.assertEquals(TimestampIndexGranularity.getColumnNameWithGranularity(timeColumn, granularity),
+        timeColumnWithGranularity);
+    Assert.assertEquals(
+        TimestampIndexGranularity.extractColumnNameFromColumnWithGranularity(timeColumnWithGranularity), timeColumn);
+    Assert.assertEquals(
+        TimestampIndexGranularity.extractGranularityFromColumnWithGranularity(timeColumnWithGranularity), granularity);
+    Assert.assertTrue(TimestampIndexGranularity.isValidTimeColumnWithGranularityName(timeColumnWithGranularity));
+    Assert.assertFalse(TimestampIndexGranularity.isValidTimeColumnWithGranularityName(timeColumn));
+    Assert.assertFalse(TimestampIndexGranularity.isValidTimeColumnWithGranularityName("$docId"));
+    Assert.assertFalse(TimestampIndexGranularity.isValidTimeColumnWithGranularityName("$ts$"));
+    Assert.assertTrue(TimestampIndexGranularity.isValidTimeGranularity("day"));
+    Assert.assertTrue(TimestampIndexGranularity.isValidTimeGranularity("DAY"));
+  }
+
+  @Test
+  public void testGetFieldSpecForTimestampColumnWithGranularity() {
+    FieldSpec dateTimeFieldSpec =
+        new DateTimeFieldSpec("t1", FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:SECONDS");
+    FieldSpec dateTimeFieldSpecForTimestampColumnWithGranularity =
+        TimestampIndexGranularity.getFieldSpecForTimestampColumnWithGranularity(dateTimeFieldSpec,
+            TimestampIndexGranularity.DAY);
+    Assert.assertEquals("$t1$DAY", dateTimeFieldSpecForTimestampColumnWithGranularity.getName());
+  }
+
+  @Test
+  public void testExtractTimestampIndexGranularityColumnNames() {
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("t1").setFieldConfigList(
+        ImmutableList.of(new FieldConfig("f1", FieldConfig.EncodingType.DICTIONARY, null,
+                ImmutableList.of(FieldConfig.IndexType.TIMESTAMP), FieldConfig.CompressionCodec.ZSTANDARD,
+                new TimestampConfig(ImmutableList.of(TimestampIndexGranularity.DAY)), ImmutableMap.of()),
+            new FieldConfig("f2", FieldConfig.EncodingType.DICTIONARY, null,
+                ImmutableList.of(FieldConfig.IndexType.TIMESTAMP), FieldConfig.CompressionCodec.LZ4,
+                new TimestampConfig(ImmutableList.of(TimestampIndexGranularity.WEEK)), ImmutableMap.of()),
+            new FieldConfig("f3", FieldConfig.EncodingType.DICTIONARY, null,
+                ImmutableList.of(FieldConfig.IndexType.TIMESTAMP), FieldConfig.CompressionCodec.PASS_THROUGH,
+                new TimestampConfig(ImmutableList.of(TimestampIndexGranularity.MONTH)), ImmutableMap.of()))).build();
+    Set<String> timestampIndexGranularityColumnNames =
+        TimestampIndexGranularity.extractTimestampIndexGranularityColumnNames(tableConfig);
+    Assert.assertEquals(ImmutableSet.of("$f1$DAY", "$f2$WEEK", "$f3$MONTH"), timestampIndexGranularityColumnNames);
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/TimestampIndexQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/TimestampIndexQuickstart.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.tools.Quickstart.Color;
+import org.apache.pinot.tools.admin.PinotAdministrator;
+import org.apache.pinot.tools.admin.command.QuickstartRunner;
+
+import static org.apache.pinot.tools.Quickstart.prettyPrintResponse;
+
+
+public class TimestampIndexQuickstart extends QuickStartBase {
+  @Override
+  public List<String> types() {
+    return Collections.singletonList("TIMESTAMP");
+  }
+
+  private File _schemaFile;
+  private File _ingestionJobSpecFile;
+
+  public static void main(String[] args)
+      throws Exception {
+    List<String> arguments = new ArrayList<>();
+    arguments.addAll(Arrays.asList("QuickStart", "-type", "TIMESTAMP"));
+    arguments.addAll(Arrays.asList(args));
+    PinotAdministrator.main(arguments.toArray(new String[arguments.size()]));
+  }
+
+  private QuickstartTableRequest prepareTableRequest(File baseDir)
+      throws IOException {
+    _schemaFile = new File(baseDir, "airlineStats_schema.json");
+    _ingestionJobSpecFile = new File(baseDir, "ingestionJobSpec.yaml");
+    File tableConfigFile = new File(baseDir, "airlineStats_offline_table_config.json");
+
+    ClassLoader classLoader = Quickstart.class.getClassLoader();
+    URL resource = classLoader.getResource("examples/batch/airlineStats/airlineStats_schema.json");
+    Preconditions.checkNotNull(resource);
+    FileUtils.copyURLToFile(resource, _schemaFile);
+    resource = classLoader.getResource("examples/batch/airlineStats/ingestionJobSpec.yaml");
+    Preconditions.checkNotNull(resource);
+    FileUtils.copyURLToFile(resource, _ingestionJobSpecFile);
+    resource = classLoader.getResource("examples/batch/airlineStats/airlineStats_offline_table_config.json");
+    Preconditions.checkNotNull(resource);
+    FileUtils.copyURLToFile(resource, tableConfigFile);
+    return new QuickstartTableRequest(baseDir.getAbsolutePath());
+  }
+
+  public void execute()
+      throws Exception {
+    File quickstartTmpDir = new File(_dataDir, String.valueOf(System.currentTimeMillis()));
+    File baseDir = new File(quickstartTmpDir, "airlineStats");
+    File dataDir = new File(baseDir, "data");
+    Preconditions.checkState(dataDir.mkdirs());
+    QuickstartTableRequest bootstrapTableRequest = prepareTableRequest(baseDir);
+    final QuickstartRunner runner =
+        new QuickstartRunner(Lists.newArrayList(bootstrapTableRequest), 1, 1, 1, 0, dataDir, getConfigOverrides());
+    printStatus(Color.YELLOW, "***** Starting Zookeeper, 1 servers, 1 brokers and 1 controller *****");
+    runner.startAll();
+    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+      try {
+        printStatus(Color.GREEN, "***** Shutting down timestamp quick start *****");
+        runner.stop();
+        FileUtils.deleteDirectory(quickstartTmpDir);
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }));
+    printStatus(Color.YELLOW, "***** Bootstrap airlineStats offline and realtime table *****");
+    runner.bootstrapTable();
+
+    printStatus(Color.YELLOW, "***** Pinot Timestamp with timestamp table setup is complete *****");
+    printStatus(Color.YELLOW, "***** Sequence of operations *****");
+    printStatus(Color.YELLOW, "*****    1. Started 1 controller instance where tenant creation is enabled *****");
+    printStatus(Color.YELLOW, "*****    2. Started 1 servers and 1 brokers *****");
+    printStatus(Color.YELLOW, "*****    3. Created a server tenant with 1 offline and 1 realtime instance *****");
+    printStatus(Color.YELLOW, "*****    4. Created a broker tenant with 2 instances *****");
+    printStatus(Color.YELLOW, "*****    5. Added a schema *****");
+    printStatus(Color.YELLOW,
+        "*****    6. Created an offline and a realtime table with the tenant names created above *****");
+    printStatus(Color.YELLOW, "*****    7. Built and pushed an offline segment *****");
+    printStatus(Color.YELLOW,
+        "*****    8. Started publishing a Kafka stream for the realtime instance to start consuming *****");
+    printStatus(Color.YELLOW, "*****    9. Sleep 5 Seconds to wait for all components brought up *****");
+    Thread.sleep(5000);
+
+    String q1 = "select ts, $ts$DAY, $ts$WEEK, $ts$MONTH from airlineStats limit 1";
+    printStatus(Color.YELLOW, "Pick one row with timestamp and different granularity using generated column name ");
+    printStatus(Color.CYAN, "Query : " + q1);
+    printStatus(Color.YELLOW, prettyPrintResponse(runner.runQuery(q1)));
+    printStatus(Color.GREEN, "***************************************************");
+
+    String q2 =
+        "select ts, dateTrunc('DAY', ts), dateTrunc('WEEK', ts), dateTrunc('MONTH', ts) from airlineStats limit 1";
+    printStatus(Color.YELLOW, "Pick one row with timestamp and different granularity using dateTrunc function");
+    printStatus(Color.CYAN, "Query : " + q2);
+    printStatus(Color.YELLOW, prettyPrintResponse(runner.runQuery(q2)));
+    printStatus(Color.GREEN, "***************************************************");
+
+    String q3 =
+        "select count(*), toTimestamp(dateTrunc('WEEK', ts)) as tsWeek from airlineStats GROUP BY tsWeek limit 1";
+    printStatus(Color.YELLOW, "Count events in week basis ");
+    printStatus(Color.CYAN, "Query : " + q3);
+    printStatus(Color.YELLOW, prettyPrintResponse(runner.runQuery(q3)));
+    printStatus(Color.GREEN, "***************************************************");
+    printStatus(Color.GREEN, "You can always go to http://localhost:9000 to play around in the query console");
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/TimestampIndexQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/TimestampIndexQuickstart.java
@@ -91,23 +91,10 @@ public class TimestampIndexQuickstart extends QuickStartBase {
         e.printStackTrace();
       }
     }));
-    printStatus(Color.YELLOW, "***** Bootstrap airlineStats offline and realtime table *****");
+    printStatus(Color.YELLOW, "***** Bootstrap airlineStats offline table *****");
     runner.bootstrapTable();
-
     printStatus(Color.YELLOW, "***** Pinot Timestamp with timestamp table setup is complete *****");
-    printStatus(Color.YELLOW, "***** Sequence of operations *****");
-    printStatus(Color.YELLOW, "*****    1. Started 1 controller instance where tenant creation is enabled *****");
-    printStatus(Color.YELLOW, "*****    2. Started 1 servers and 1 brokers *****");
-    printStatus(Color.YELLOW, "*****    3. Created a server tenant with 1 offline and 1 realtime instance *****");
-    printStatus(Color.YELLOW, "*****    4. Created a broker tenant with 2 instances *****");
-    printStatus(Color.YELLOW, "*****    5. Added a schema *****");
-    printStatus(Color.YELLOW,
-        "*****    6. Created an offline and a realtime table with the tenant names created above *****");
-    printStatus(Color.YELLOW, "*****    7. Built and pushed an offline segment *****");
-    printStatus(Color.YELLOW,
-        "*****    8. Started publishing a Kafka stream for the realtime instance to start consuming *****");
-    printStatus(Color.YELLOW, "*****    9. Sleep 5 Seconds to wait for all components brought up *****");
-    Thread.sleep(5000);
+
 
     String q1 = "select ts, $ts$DAY, $ts$WEEK, $ts$MONTH from airlineStats limit 1";
     printStatus(Color.YELLOW, "Pick one row with timestamp and different granularity using generated column name ");

--- a/pinot-tools/src/main/resources/examples/batch/airlineStats/airlineStats_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/airlineStats/airlineStats_offline_table_config.json
@@ -9,10 +9,36 @@
     "replication": "1"
   },
   "tenants": {},
+  "fieldConfigList": [
+    {
+      "name": "ts",
+      "encodingType": "DICTIONARY",
+      "indexTypes": ["TIMESTAMP"],
+      "timestampConfig": {
+        "granularities": [
+          "DAY",
+          "WEEK",
+          "MONTH"
+        ]
+      }
+    }
+  ],
   "tableIndexConfig": {
     "loadMode": "MMAP"
   },
   "metadata": {
     "customConfigs": {}
+  },
+  "ingestionConfig": {
+    "transformConfigs": [
+      {
+        "columnName": "ts",
+        "transformFunction": "fromEpochDays(DaysSinceEpoch)"
+      },
+      {
+        "columnName": "tsRaw",
+        "transformFunction": "fromEpochDays(DaysSinceEpoch)"
+      }
+    ]
   }
 }

--- a/pinot-tools/src/main/resources/examples/batch/airlineStats/airlineStats_schema.json
+++ b/pinot-tools/src/main/resources/examples/batch/airlineStats/airlineStats_schema.json
@@ -330,6 +330,18 @@
       "dataType": "INT",
       "format": "1:DAYS:EPOCH",
       "granularity": "1:DAYS"
+    },
+    {
+      "name": "ts",
+      "dataType": "TIMESTAMP",
+      "format": "1:MILLISECONDS:TIMESTAMP",
+      "granularity": "1:SECONDS"
+    },
+    {
+      "name": "tsRaw",
+      "dataType": "TIMESTAMP",
+      "format": "1:MILLISECONDS:TIMESTAMP",
+      "granularity": "1:SECONDS"
     }
   ],
   "schemaName": "airlineStats"


### PR DESCRIPTION
## Description
Adding Timestamp index for Pinot data type TIMESTAMP.

Timestamp stores value as millisecond epoch long value. Typical workload for timestamp is filtering on a time range and group by with different time granularities(days/month/etc).

The current implementation requires the query executor to extract values, apply the function then do filter/groupBy, no leverage on dictionary or index.

This PR introduces the Timestamp Index. Users can configure the most useful granularities for a Timestamp data type column.

1. Pinot will pre-generate one column per time granularity with forward index and range index. The naming convention is `$${ts_column_name}$${ts_granularity}`, e.g. Timestamp column `ts` with granularities `DAY`, `MONTH` will have two extra columns generated: `$ts$DAY` and `$ts$MONTH`.
2. Query overwrite for predicate and selection/groupby:
2.1 GROUPBY: functions like `dateTrunc('DAY', ts)` will be translated to use the underly column `$ts$DAY` to fetch data.
2.2 PREDICATE: range index is auto-built for all granularity columns.

Example query usage:
```
select count(*), datetrunc('WEEK', ts) as tsWeek from airlineStats WHERE tsWeek > fromDateTime('2014-01-16', 'yyyy-MM-dd') group by tsWeek  limit 10
```

Some preliminary benchmark shows the query perf over 2.7 billion records improved from 45 secs to 4.2 secs
```
select dateTrunc('YEAR', event_time) as y, dateTrunc('MONTH', event_time) as m,  sum(pull_request_commits) from githubEvents group by y, m limit 1000  Option(timeoutMs=3000000)
```

![image](https://user-images.githubusercontent.com/1202120/160910329-0d9ca637-dc95-4137-8c79-2f66cc8fbabf.png)
vs.
![image](https://user-images.githubusercontent.com/1202120/160910364-48424875-1967-42d3-9a76-bdf1ee81a4ca.png)


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
