### PR TITLE
Change controller metrics to exclude the replaced segments

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -39,6 +39,11 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   PERCENT_SEGMENTS_AVAILABLE("segments", false),
 
   SEGMENT_COUNT("SegmentCount", false),
+
+  // Number of segments including the replaced segments which are specified in the segment lineage entries and cannot
+  // be queried from the table.
+  SEGMENT_COUNT_INCLUDING_REPLACED("SegmentCount", false),
+
   IDEALSTATE_ZNODE_SIZE("idealstate", false),
   IDEALSTATE_ZNODE_BYTE_SIZE("idealstate", false),
   REALTIME_TABLE_COUNT("TableCount", true),


### PR DESCRIPTION

~~Add following controller metrics for the segments excluding replaced segments which are specified in the segment lineage entries and cannot be queried from the table.~~
~~NUMBER_OF_REPLICAS_EXCLUDE_REPLACED~~
~~PERCENT_OF_REPLICAS_EXCLUDE_REPLACED~~
~~SEGMENTS_IN_ERROR_STATE_EXCLUDE_REPLACED~~
~~PERCENT_SEGMENTS_AVAILABLE_EXCLUDE_REPLACED~~
~~SEGMENT_COUNT_EXCLUDE_REPLACED~~

Change following controller metrics to exclude the replaced segments which are specified in the segment lineage entries and cannot be queried from the table:
```
NUMBER_OF_REPLICAS
PERCENT_OF_REPLICAS
SEGMENTS_IN_ERROR_STATE
PERCENT_SEGMENTS_AVAILABLE
SEGMENT_COUNT
```
Add `SEGMENT_COUNT_INCLUDING_REPLACED` for debugging purposes.