### PR TITLE
Fix setting of metrics compression type in RealtimeSegmentConverter

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
@@ -30,13 +30,11 @@ import org.apache.pinot.segment.local.realtime.converter.stats.RealtimeSegmentSe
 import org.apache.pinot.segment.local.recordtransformer.CompositeTransformer;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
-import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 
 
@@ -89,17 +87,6 @@ public class RealtimeSegmentConverter {
     if (_invertedIndexColumns != null && !_invertedIndexColumns.isEmpty()) {
       for (String column : _invertedIndexColumns) {
         genConfig.createInvertedIndexForColumn(column);
-      }
-    }
-    if (_noDictionaryColumns != null) {
-      genConfig.setRawIndexCreationColumns(_noDictionaryColumns);
-      for (String column : _noDictionaryColumns) {
-        FieldSpec fieldSpec = _dataSchema.getFieldSpecFor(column);
-        // Compression type is already configured in the constructor of genConfig.
-        // Only update metrics compression type.
-        if (fieldSpec.getFieldType().equals(FieldSpec.FieldType.METRIC)) {
-          genConfig.setRawIndexCompressionType(column, ChunkCompressionType.PASS_THROUGH);
-        }
       }
     }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
@@ -20,7 +20,6 @@ package org.apache.pinot.segment.local.realtime.converter;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -94,14 +93,14 @@ public class RealtimeSegmentConverter {
     }
     if (_noDictionaryColumns != null) {
       genConfig.setRawIndexCreationColumns(_noDictionaryColumns);
-      Map<String, ChunkCompressionType> columnToCompressionType = new HashMap<>();
       for (String column : _noDictionaryColumns) {
         FieldSpec fieldSpec = _dataSchema.getFieldSpecFor(column);
+        // Compression type is already configured in the constructor of genConfig.
+        // Only update metrics compression type.
         if (fieldSpec.getFieldType().equals(FieldSpec.FieldType.METRIC)) {
-          columnToCompressionType.put(column, ChunkCompressionType.PASS_THROUGH);
+          genConfig.setRawIndexCompressionType(column, ChunkCompressionType.PASS_THROUGH);
         }
       }
-      genConfig.setRawIndexCompressionType(columnToCompressionType);
     }
 
     if (_varLengthDictionaryColumns != null) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -656,10 +656,6 @@ public class SegmentGeneratorConfig implements Serializable {
     _rawIndexCompressionType.putAll(rawIndexCompressionType);
   }
 
-  public void setRawIndexCompressionType(String column, ChunkCompressionType compressionType) {
-    _rawIndexCompressionType.put(column, compressionType);
-  }
-
   public List<String> getMetrics() {
     return getQualifyingFields(FieldType.METRIC, true);
   }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -656,6 +656,10 @@ public class SegmentGeneratorConfig implements Serializable {
     _rawIndexCompressionType.putAll(rawIndexCompressionType);
   }
 
+  public void setRawIndexCompressionType(String column, ChunkCompressionType compressionType) {
+    _rawIndexCompressionType.put(column, compressionType);
+  }
+
   public List<String> getMetrics() {
     return getQualifyingFields(FieldType.METRIC, true);
   }


### PR DESCRIPTION
## Description
Introduce a method in SegmentGeneratorConfig that allows
setting a specific column's compression type.
Use this method instead when setting metric compression type.
Otherwise, no dictionary config compression type for other columns
are getting reset to default.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
