### PR TITLE
identify running tasks based on task final states

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/generator/TaskGeneratorUtilsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/generator/TaskGeneratorUtilsTest.java
@@ -1,0 +1,83 @@
+package org.apache.pinot.controller.helix.core.minion.generator;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.task.TaskState;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.minion.ClusterInfoAccessor;
+import org.apache.pinot.core.common.MinionConstants;
+import org.apache.pinot.core.minion.PinotTaskConfig;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.fail;
+
+
+public class TaskGeneratorUtilsTest {
+  @Test
+  public void testForRunningTasks() {
+    String tableName = "mytable_OFFLINE";
+    String taskType = "myTaskType";
+    ClusterInfoAccessor mockClusterInfoAccessor = createMockClusterInfoAccessor();
+
+    Map<String, TaskState> taskStatesMap = new HashMap<>();
+    String taskID = System.currentTimeMillis() + "_0";
+    when(mockClusterInfoAccessor.getTaskStates(taskType)).thenReturn(taskStatesMap);
+    when(mockClusterInfoAccessor.getTaskConfigs(taskID))
+        .thenReturn(Collections.singletonList(createTaskConfig(taskType, tableName, taskID)));
+
+    int[] count = new int[1];
+    TaskState[] nonFinalTaskStates = new TaskState[]{
+        TaskState.NOT_STARTED, TaskState.IN_PROGRESS, TaskState.FAILING, TaskState.STOPPING, TaskState.STOPPED,
+        TaskState.TIMING_OUT
+    };
+    for (TaskState taskState : nonFinalTaskStates) {
+      taskStatesMap.put(taskID, taskState);
+      TaskGeneratorUtils.forRunningTasks(tableName, taskType, mockClusterInfoAccessor, taskConfig -> {
+        assertEquals(taskConfig.get(MinionConstants.TABLE_NAME_KEY), tableName);
+        assertEquals(taskConfig.get("taskID"), taskID);
+        count[0]++;
+      });
+    }
+    assertEquals(count[0], nonFinalTaskStates.length);
+    for (TaskState taskState : new TaskState[]{
+        TaskState.COMPLETED, TaskState.FAILED, TaskState.ABORTED, TaskState.TIMED_OUT
+    }) {
+      taskStatesMap.put(taskID, taskState);
+      TaskGeneratorUtils.forRunningTasks(tableName, taskType, mockClusterInfoAccessor, taskConfig -> {
+        fail("Task should be in final state");
+      });
+    }
+    TaskGeneratorUtils.forRunningTasks("fooTable", taskType, mockClusterInfoAccessor, taskConfig -> {
+      fail("Different table name");
+    });
+    TaskGeneratorUtils.forRunningTasks(tableName, "fooTask", mockClusterInfoAccessor, taskConfig -> {
+      fail("Different task type");
+    });
+  }
+
+  private static PinotTaskConfig createTaskConfig(String taskType, String tableNameWithType, String taskID) {
+    Map<String, String> taskConfigs = new HashMap<>();
+    taskConfigs.put(MinionConstants.TABLE_NAME_KEY, tableNameWithType);
+    taskConfigs.put("taskID", taskID);
+    return new PinotTaskConfig(taskType, taskConfigs);
+  }
+
+  private static ClusterInfoAccessor createMockClusterInfoAccessor() {
+    ZkHelixPropertyStore<ZNRecord> mockPropertyStore = mock(ZkHelixPropertyStore.class);
+    when(mockPropertyStore.set(Mockito.anyString(), Mockito.any(), Mockito.anyInt(), Mockito.anyInt()))
+        .thenReturn(true);
+    PinotHelixResourceManager mockHelixResourceManager = mock(PinotHelixResourceManager.class);
+    when(mockHelixResourceManager.getPropertyStore()).thenReturn(mockPropertyStore);
+    ClusterInfoAccessor mockClusterInfoAcessor = mock(ClusterInfoAccessor.class);
+    when(mockClusterInfoAcessor.getVipUrl()).thenReturn("http://localhost:9000");
+    when(mockClusterInfoAcessor.getPinotHelixResourceManager()).thenReturn(mockHelixResourceManager);
+    return mockClusterInfoAcessor;
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/generator/TaskGeneratorUtilsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/generator/TaskGeneratorUtilsTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.controller.helix.core.minion.generator;
 
 import java.util.Collections;


### PR DESCRIPTION
## Description
This PR adds a util method to get running helix tasks based on task state. A running task is one not in final state yet. Once task reaches final state, it won't run again. Note that  "STOPPED" is not a final state for helix task, as it can be resumed and start from beginning. 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
