### PR TITLE
Validate schema name before permissions to return proper message

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.controller.api.resources;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.google.common.base.Preconditions;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.controller.api.resources;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.base.Preconditions;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -43,6 +44,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.exception.SchemaAlreadyExistsException;
 import org.apache.pinot.common.exception.SchemaBackwardIncompatibleException;
 import org.apache.pinot.common.exception.SchemaNotFoundException;
@@ -191,6 +193,7 @@ public class PinotSchemaRestletResource {
       @Context Request request) {
     Schema schema = getSchemaFromMultiPart(multiPart);
     String endpointUrl = request.getRequestURL().toString();
+    validateSchemaName(schema);
     _accessControlUtils.validatePermission(schema.getSchemaName(), AccessType.CREATE, httpHeaders, endpointUrl,
         _accessControlFactory.create());
     return addSchema(schema, override);
@@ -212,6 +215,7 @@ public class PinotSchemaRestletResource {
       @QueryParam("override") boolean override, Schema schema, @Context HttpHeaders httpHeaders,
       @Context Request request) {
     String endpointUrl = request.getRequestURL().toString();
+    validateSchemaName(schema);
     _accessControlUtils.validatePermission(schema.getSchemaName(), AccessType.CREATE, httpHeaders, endpointUrl,
         _accessControlFactory.create());
     return addSchema(schema, override);
@@ -229,13 +233,7 @@ public class PinotSchemaRestletResource {
   })
   public String validateSchema(FormDataMultiPart multiPart) {
     Schema schema = getSchemaFromMultiPart(multiPart);
-    try {
-      List<TableConfig> tableConfigs = _pinotHelixResourceManager.getTableConfigsForSchema(schema.getSchemaName());
-      SchemaUtils.validate(schema, tableConfigs);
-    } catch (Exception e) {
-      throw new ControllerApplicationException(LOGGER,
-          "Invalid schema: " + schema.getSchemaName() + ". Reason: " + e.getMessage(), Response.Status.BAD_REQUEST, e);
-    }
+    validateSchemaInternal(schema);
     return schema.toPrettyJsonString();
   }
 
@@ -251,14 +249,27 @@ public class PinotSchemaRestletResource {
       @ApiResponse(code = 500, message = "Internal error")
   })
   public String validateSchema(Schema schema) {
+    validateSchemaInternal(schema);
+    return schema.toPrettyJsonString();
+  }
+
+  private void validateSchemaName(Schema schema) {
+    if (StringUtils.isBlank(schema.getSchemaName())) {
+      throw new ControllerApplicationException(LOGGER,
+          "Invalid schema: " + schema.getSchemaName() + ". Reason: 'schemaName' should not be null",
+          Response.Status.BAD_REQUEST);
+    }
+  }
+
+  private void validateSchemaInternal(Schema schema) {
     try {
+      Preconditions.checkNotNull(schema.getSchemaName(), "'schemaName' should not be null");
       List<TableConfig> tableConfigs = _pinotHelixResourceManager.getTableConfigsForSchema(schema.getSchemaName());
       SchemaUtils.validate(schema, tableConfigs);
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER,
           "Invalid schema: " + schema.getSchemaName() + ". Reason: " + e.getMessage(), Response.Status.BAD_REQUEST, e);
     }
-    return schema.toPrettyJsonString();
   }
 
   /**
@@ -268,13 +279,7 @@ public class PinotSchemaRestletResource {
    */
   private SuccessResponse addSchema(Schema schema, boolean override) {
     String schemaName = schema.getSchemaName();
-    try {
-      List<TableConfig> tableConfigs = _pinotHelixResourceManager.getTableConfigsForSchema(schemaName);
-      SchemaUtils.validate(schema, tableConfigs);
-    } catch (Exception e) {
-      throw new ControllerApplicationException(LOGGER,
-          "Cannot add invalid schema: " + schemaName + ". Reason: " + e.getMessage(), Response.Status.BAD_REQUEST, e);
-    }
+    validateSchemaInternal(schema);
 
     try {
       _pinotHelixResourceManager.addSchema(schema, override);
@@ -304,14 +309,7 @@ public class PinotSchemaRestletResource {
    * @return
    */
   private SuccessResponse updateSchema(String schemaName, Schema schema, boolean reload) {
-    try {
-      List<TableConfig> tableConfigs = _pinotHelixResourceManager.getTableConfigsForSchema(schemaName);
-      SchemaUtils.validate(schema, tableConfigs);
-    } catch (Exception e) {
-      throw new ControllerApplicationException(LOGGER,
-          String.format("Cannot add invalid schema: %s. Reason: %s", schemaName, e.getMessage()),
-          Response.Status.BAD_REQUEST, e);
-    }
+    validateSchemaInternal(schema);
 
     if (schemaName != null && !schema.getSchemaName().equals(schemaName)) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_SCHEMA_UPLOAD_ERROR, 1L);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
@@ -193,7 +193,7 @@ public class PinotSchemaRestletResource {
       @Context Request request) {
     Schema schema = getSchemaFromMultiPart(multiPart);
     String endpointUrl = request.getRequestURL().toString();
-    validateSchemaName(schema);
+    validateSchemaName(schema.getSchemaName());
     _accessControlUtils.validatePermission(schema.getSchemaName(), AccessType.CREATE, httpHeaders, endpointUrl,
         _accessControlFactory.create());
     return addSchema(schema, override);
@@ -215,7 +215,7 @@ public class PinotSchemaRestletResource {
       @QueryParam("override") boolean override, Schema schema, @Context HttpHeaders httpHeaders,
       @Context Request request) {
     String endpointUrl = request.getRequestURL().toString();
-    validateSchemaName(schema);
+    validateSchemaName(schema.getSchemaName());
     _accessControlUtils.validatePermission(schema.getSchemaName(), AccessType.CREATE, httpHeaders, endpointUrl,
         _accessControlFactory.create());
     return addSchema(schema, override);
@@ -253,17 +253,16 @@ public class PinotSchemaRestletResource {
     return schema.toPrettyJsonString();
   }
 
-  private void validateSchemaName(Schema schema) {
-    if (StringUtils.isBlank(schema.getSchemaName())) {
-      throw new ControllerApplicationException(LOGGER,
-          "Invalid schema: " + schema.getSchemaName() + ". Reason: 'schemaName' should not be null",
+  private void validateSchemaName(String schemaName) {
+    if (StringUtils.isBlank(schemaName)) {
+      throw new ControllerApplicationException(LOGGER, "Invalid schema. Reason: 'schemaName' should not be null",
           Response.Status.BAD_REQUEST);
     }
   }
 
   private void validateSchemaInternal(Schema schema) {
+    validateSchemaName(schema.getSchemaName());
     try {
-      Preconditions.checkNotNull(schema.getSchemaName(), "'schemaName' should not be null");
       List<TableConfig> tableConfigs = _pinotHelixResourceManager.getTableConfigsForSchema(schema.getSchemaName());
       SchemaUtils.validate(schema, tableConfigs);
     } catch (Exception e) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSchemaRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSchemaRestletResourceTest.java
@@ -182,6 +182,11 @@ public class PinotSchemaRestletResourceTest {
     putMethod = ControllerTestUtils.sendMultipartPutRequest(updateSchemaUrl, invalidSchemaString);
     Assert.assertEquals(putMethod.getStatusCode(), 400);
 
+    // Update schema with null schema name
+    schema.setSchemaName(null);
+    putMethod = ControllerTestUtils.sendMultipartPutRequest(updateSchemaUrl, schema.toSingleLineJsonString());
+    Assert.assertEquals(putMethod.getStatusCode(), 400);
+
     // Update schema with non-matching schema name
     String newSchemaName = "newSchemaName";
     schema.setSchemaName(newSchemaName);


### PR DESCRIPTION
Without this fix, a user who has an invalida name in schema, hits the exception from validatiePermissions, and gets very confused.
```
ERROR [WebApplicationExceptionMapper] [grizzly-http-server-4] Server error: 
java.lang.NullPointerException: null
	at java.util.Objects.requireNonNull(Objects.java:221) ~[?:?]
	at java.util.Optional.<init>(Optional.java:107) ~[?:?]
	at java.util.Optional.of(Optional.java:120) ~[?:?]
	at org.apache.pinot.controller.api.access.AccessControlUtils.validatePermission(AccessControlUtils.java:48) ~[pinot-all-0.10.0-SNAPSHOT-jar-with-dependencies.jar:0.10.0-SNAPSHOT-b7c181a77289fccb10cea139a097efb5d82f634a]
	at org.apache.pinot.controller.api.resources.PinotSchemaRestletResource.addSchema(PinotSchemaRestletResource.java:194) ~[pinot-all-0.10.0-SNAPSHOT-jar-with-dependencies.jar:0.10.0-SNAPSHOT-b7c181a77289fccb10cea139a097efb5d82f634a]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52) ~[pinot-all-0.10.0-SNAPSHOT-jar-with-dependencies.jar:0.10.0-SNAPSHOT-b7c181a77289fccb10cea139a097efb5d82f634a]
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:124) ~[pinot-all-0.10.0-SNAPSHOT-jar-with-dependencies.jar:0.10.0-SNAPSHOT-b7c181a77289fccb10cea139a097efb5d82f634a]
	at 
```