### PR TITLE
adding jacoco inclusive rule

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1612,6 +1612,11 @@
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <includes>
+            <include>org/apache/pinot/**/*</include>
+          </includes>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
no need to put instrumentation on non-pinot code. 
this should also result in build time speed up (and potentially test reporting speed up)