### PR TITLE
Use netty-bom to keep the netty-related libraries sync

### DIFF
--- a/pinot-connectors/prestodb-pinot-dependencies/pinot-core-jdk8/pom.xml
+++ b/pinot-connectors/prestodb-pinot-dependencies/pinot-core-jdk8/pom.xml
@@ -112,8 +112,10 @@
     </dependency>-->
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>${netty-tcnative.version}</version>
+      <artifactId>netty-bom</artifactId>
+      <version>${netty.version}</version>
+      <type>pom</type>
+      <scope>import</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -124,8 +124,10 @@
     </dependency>-->
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>${netty-tcnative.version}</version>
+      <artifactId>netty-bom</artifactId>
+      <version>${netty.version}</version>
+      <type>pom</type>
+      <scope>import</scope>
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
@@ -134,18 +136,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-all</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-epoll</artifactId>
-      <version>${netty.version}</version>
-      <classifier>linux-x86_64</classifier>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-kqueue</artifactId>
-      <version>${netty.version}</version>
-      <classifier>osx-x86_64</classifier>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/pom.xml
@@ -304,8 +304,10 @@
     </dependency>
     <dependency>
       <groupId>io.netty</groupId>
-      <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>${netty-tcnative.version}</version>
+      <artifactId>netty-bom</artifactId>
+      <version>${netty.version}</version>
+      <type>pom</type>
+      <scope>import</scope>
     </dependency>
     <dependency>
       <groupId>commons-codec</groupId>
@@ -380,11 +382,6 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-codec-socks</artifactId>
-      <version>${netty.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>io.netty</groupId>
-      <artifactId>netty-transport-native-unix-common</artifactId>
       <version>${netty.version}</version>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,6 @@
     <lz4-java.version>1.7.1</lz4-java.version>
     <log4j.version>2.17.1</log4j.version>
     <netty.version>4.1.74.Final</netty.version>
-    <netty-tcnative.version>2.0.36.Final</netty-tcnative.version>
     <reactivestreams.version>1.0.3</reactivestreams.version>
     <jts.version>1.16.1</jts.version>
     <h3.version>3.0.3</h3.version>


### PR DESCRIPTION
Netty related libraries  (`netty-tcnative-boringssl-static`, `netty-transport-native-unix-common`, `netty-transport-native-epoll`, `netty-transport-native-kqueue`, etc.) needs be in sync with `netty.version` version to avoid incompatibility . The netty-bom(https://github.com/netty/netty/blob/4.1/bom/pom.xml) can help to get correct lib versions every time we bump up `netty.version`.

Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] No (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)