### PR TITLE
Fix the flakiness of MultiNodesOfflineClusterIntegrationTest

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
@@ -20,13 +20,14 @@ package org.apache.pinot.integration.tests;
 
 import java.util.Collections;
 import java.util.Map;
+import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.broker.broker.helix.HelixBrokerStarter;
-import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.BrokerResourceStateModel;
 import org.apache.pinot.spi.utils.NetUtils;
+import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -61,42 +62,70 @@ public class MultiNodesOfflineClusterIntegrationTest extends OfflineClusterInteg
       throws Exception {
     // Add a new broker to the cluster
     Map<String, Object> properties = getDefaultBrokerConfiguration().toMap();
-    properties.put(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, getHelixClusterName());
+    String clusterName = getHelixClusterName();
+    properties.put(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, clusterName);
     properties.put(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER, getZkUrl());
     int port = NetUtils.findOpenPort(DEFAULT_BROKER_PORT);
     properties.put(CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT, port);
     properties.put(CommonConstants.Broker.CONFIG_OF_DELAY_SHUTDOWN_TIME_MS, 0);
-
     HelixBrokerStarter brokerStarter = new HelixBrokerStarter();
     brokerStarter.init(new PinotConfiguration(properties));
     brokerStarter.start();
 
     // Check if broker is added to all the tables in broker resource
     String brokerId = brokerStarter.getInstanceId();
-    IdealState brokerResource = HelixHelper.getBrokerIdealStates(_helixAdmin, getHelixClusterName());
-    for (Map<String, String> brokerAssignment : brokerResource.getRecord().getMapFields().values()) {
+    IdealState brokerResourceIdealState =
+        _helixAdmin.getResourceIdealState(clusterName, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);
+    for (Map<String, String> brokerAssignment : brokerResourceIdealState.getRecord().getMapFields().values()) {
       assertEquals(brokerAssignment.get(brokerId), BrokerResourceStateModel.ONLINE);
     }
+    TestUtils.waitForCondition(aVoid -> {
+      ExternalView brokerResourceExternalView =
+          _helixAdmin.getResourceExternalView(clusterName, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);
+      for (Map<String, String> brokerAssignment : brokerResourceExternalView.getRecord().getMapFields().values()) {
+        if (!brokerAssignment.containsKey(brokerId)) {
+          return false;
+        }
+      }
+      return true;
+    }, 60_000L, "Failed to find broker in broker resource ExternalView");
 
-    // Stop and drop the broker
+    // Stop the broker
     brokerStarter.stop();
+
+    // Dropping the broker should fail because it is still in the broker resource
     try {
       sendDeleteRequest(_controllerRequestURLBuilder.forInstance(brokerId));
       fail("Dropping instance should fail because it is still in the broker resource");
     } catch (Exception e) {
       // Expected
     }
+
     // Untag the broker and update the broker resource so that it is removed from the broker resource
     sendPutRequest(_controllerRequestURLBuilder.forInstanceUpdateTags(brokerId, Collections.emptyList(), true));
+
     // Check if broker is removed from all the tables in broker resource
-    brokerResource = HelixHelper.getBrokerIdealStates(_helixAdmin, getHelixClusterName());
-    for (Map<String, String> brokerAssignment : brokerResource.getRecord().getMapFields().values()) {
+    brokerResourceIdealState =
+        _helixAdmin.getResourceIdealState(clusterName, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);
+    for (Map<String, String> brokerAssignment : brokerResourceIdealState.getRecord().getMapFields().values()) {
       assertFalse(brokerAssignment.containsKey(brokerId));
     }
-    // Dropping instance should success
+    TestUtils.waitForCondition(aVoid -> {
+      ExternalView brokerResourceExternalView =
+          _helixAdmin.getResourceExternalView(clusterName, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);
+      for (Map<String, String> brokerAssignment : brokerResourceExternalView.getRecord().getMapFields().values()) {
+        if (brokerAssignment.containsKey(brokerId)) {
+          return false;
+        }
+      }
+      return true;
+    }, 60_000L, "Failed to remove broker from broker resource ExternalView");
+
+    // Dropping the broker should success now
     sendDeleteRequest(_controllerRequestURLBuilder.forInstance(brokerId));
+
     // Check if broker is dropped from the cluster
-    assertFalse(_helixAdmin.getInstancesInCluster(getHelixClusterName()).contains(brokerId));
+    assertFalse(_helixAdmin.getInstancesInCluster(clusterName).contains(brokerId));
   }
 
   @Test(enabled = false)


### PR DESCRIPTION
Fix #8324 

The flakiness is caused by the following race condition:
- The broker is removed from the IdealState
- The broker is dropped from the cluster
- The state transition message is created which recreates the ZK nodes for the dropped broker
- The broker shows up again when querying the instances from the cluster

The fix is to wait until ExternalView to converge before dropping the broker.
The race condition itself is hard to fix as it is caused by Helix behavior (filed a [Helix issue](https://github.com/apache/helix/issues/1990)). This PR enhances the drop instance rest API to still try to remove all instance ZK nodes even if instance config is already deleted so that there is a way to recover when the race condition happens.