### PR TITLE
Adding schema validation for recommendation engine

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/io/InputManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/io/InputManager.java
@@ -55,6 +55,7 @@ import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.BrokerRequestToQueryContextConverter;
 import org.apache.pinot.core.requesthandler.PinotQueryParserFactory;
 import org.apache.pinot.parsers.QueryCompiler;
+import org.apache.pinot.segment.local.utils.SchemaUtils;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -344,6 +345,7 @@ public class InputManager {
       throws IOException {
     ObjectReader reader = new ObjectMapper().readerFor(Schema.class);
     _schema = reader.readValue(jsonNode);
+    SchemaUtils.validate(_schema);
     reader = new ObjectMapper().readerFor(SchemaWithMetaData.class);
     _schemaWithMetaData = reader.readValue(jsonNode);
     _schemaWithMetaData.getDimensionFieldSpecs().forEach(fieldMetadata -> {

--- a/pinot-controller/src/test/resources/recommenderInput/AggregateMetricsRuleInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/AggregateMetricsRuleInput.json
@@ -19,7 +19,7 @@
       },
       {
         "name": "l",
-        "dataType": "STRING",
+        "dataType": "LONG",
         "cardinality":1000,
         "numValuesPerEntry":1,
         "averageLength" : 10

--- a/pinot-controller/src/test/resources/recommenderInput/BloomFilterInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/BloomFilterInput.json
@@ -82,7 +82,7 @@
       },
       {
         "name": "l",
-        "dataType": "STRING",
+        "dataType": "LONG",
         "cardinality":10000,
         "numValuesPerEntry":1,
         "averageLength" : 10

--- a/pinot-controller/src/test/resources/recommenderInput/EmptyQueriesInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/EmptyQueriesInput.json
@@ -46,7 +46,7 @@
       },
       {
         "name": "l",
-        "dataType": "STRING",
+        "dataType": "LONG",
         "cardinality":10000,
         "numValuesPerEntry":1,
         "averageLength" : 10

--- a/pinot-controller/src/test/resources/recommenderInput/FlagQueryInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/FlagQueryInput.json
@@ -83,7 +83,7 @@
       },
       {
         "name": "l",
-        "dataType": "STRING",
+        "dataType": "LONG",
         "cardinality":10000,
         "numValuesPerEntry":1,
         "averageLength" : 10

--- a/pinot-controller/src/test/resources/recommenderInput/InvalidInput1.json
+++ b/pinot-controller/src/test/resources/recommenderInput/InvalidInput1.json
@@ -47,7 +47,7 @@
       },
       {
         "name": "l",
-        "dataType": "STRING",
+        "dataType": "DOUBLE",
         "cardinality":10000,
         "numValuesPerEntry":1,
         "averageLength" : 10

--- a/pinot-controller/src/test/resources/recommenderInput/InvalidInput2.json
+++ b/pinot-controller/src/test/resources/recommenderInput/InvalidInput2.json
@@ -46,7 +46,7 @@
       },
       {
         "name": "l",
-        "dataType": "STRING",
+        "dataType": "DOUBLE",
         "cardinality":10000,
         "numValuesPerEntry":1,
         "averageLength" : 10

--- a/pinot-controller/src/test/resources/recommenderInput/KafkaPartitionRuleInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/KafkaPartitionRuleInput.json
@@ -79,7 +79,7 @@
       },
       {
         "name": "l",
-        "dataType": "STRING",
+        "dataType": "DOUBLE",
         "cardinality":10000,
         "numValuesPerEntry":1,
         "averageLength" : 10

--- a/pinot-controller/src/test/resources/recommenderInput/KafkaPartitionRuleInput2.json
+++ b/pinot-controller/src/test/resources/recommenderInput/KafkaPartitionRuleInput2.json
@@ -82,7 +82,7 @@
       },
       {
         "name": "l",
-        "dataType": "STRING",
+        "dataType": "DOUBLE",
         "cardinality":10000,
         "numValuesPerEntry":1,
         "averageLength" : 10

--- a/pinot-controller/src/test/resources/recommenderInput/NoDictionaryOnHeapDictionaryJointRuleInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/NoDictionaryOnHeapDictionaryJointRuleInput.json
@@ -83,7 +83,7 @@
       },
       {
         "name": "l",
-        "dataType": "STRING",
+        "dataType": "DOUBLE",
         "cardinality":10000,
         "numValuesPerEntry":1,
         "averageLength" : 10

--- a/pinot-controller/src/test/resources/recommenderInput/PinotTablePartitionRuleInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/PinotTablePartitionRuleInput.json
@@ -83,7 +83,7 @@
       },
       {
         "name": "l",
-        "dataType": "STRING",
+        "dataType": "DOUBLE",
         "cardinality":10000,
         "numValuesPerEntry":1,
         "averageLength" : 10

--- a/pinot-controller/src/test/resources/recommenderInput/RangeIndexInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/RangeIndexInput.json
@@ -82,7 +82,7 @@
       },
       {
         "name": "l",
-        "dataType": "STRING",
+        "dataType": "DOUBLE",
         "cardinality":10000,
         "numValuesPerEntry":1,
         "averageLength" : 10

--- a/pinot-controller/src/test/resources/recommenderInput/RealtimeProvisioningInput_dateTimeColumn.json
+++ b/pinot-controller/src/test/resources/recommenderInput/RealtimeProvisioningInput_dateTimeColumn.json
@@ -84,7 +84,7 @@
       },
       {
         "name": "l",
-        "dataType": "STRING",
+        "dataType": "LONG",
         "cardinality":1000,
         "numValuesPerEntry":1,
         "averageLength" : 10

--- a/pinot-controller/src/test/resources/recommenderInput/RealtimeProvisioningInput_timeColumn.json
+++ b/pinot-controller/src/test/resources/recommenderInput/RealtimeProvisioningInput_timeColumn.json
@@ -84,7 +84,7 @@
       },
       {
         "name": "l",
-        "dataType": "STRING",
+        "dataType": "LONG",
         "cardinality":1000,
         "numValuesPerEntry":1,
         "averageLength" : 10

--- a/pinot-controller/src/test/resources/recommenderInput/SegmentSizeRuleInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/SegmentSizeRuleInput.json
@@ -84,7 +84,7 @@
       },
       {
         "name": "l",
-        "dataType": "STRING",
+        "dataType": "LONG",
         "cardinality":1000,
         "numValuesPerEntry":1,
         "averageLength" : 10

--- a/pinot-controller/src/test/resources/recommenderInput/SegmentSizeRuleInput_noNeedToGenerateSegment.json
+++ b/pinot-controller/src/test/resources/recommenderInput/SegmentSizeRuleInput_noNeedToGenerateSegment.json
@@ -84,7 +84,7 @@
       },
       {
         "name": "l",
-        "dataType": "STRING",
+        "dataType": "DOUBLE",
         "cardinality":1000,
         "numValuesPerEntry":1,
         "averageLength" : 10

--- a/pinot-controller/src/test/resources/recommenderInput/SegmentSizeRuleInput_realtimeOnlyTable.json
+++ b/pinot-controller/src/test/resources/recommenderInput/SegmentSizeRuleInput_realtimeOnlyTable.json
@@ -82,7 +82,7 @@
       },
       {
         "name": "l",
-        "dataType": "STRING",
+        "dataType": "DOUBLE",
         "cardinality":1000,
         "numValuesPerEntry":1,
         "averageLength" : 10

--- a/pinot-controller/src/test/resources/recommenderInput/SegmentSizeRuleInput_ruleIsDisableButItNeedsToBeSilentlyRun.json
+++ b/pinot-controller/src/test/resources/recommenderInput/SegmentSizeRuleInput_ruleIsDisableButItNeedsToBeSilentlyRun.json
@@ -82,7 +82,7 @@
       },
       {
         "name": "l",
-        "dataType": "STRING",
+        "dataType": "LONG",
         "cardinality":1000,
         "numValuesPerEntry":1,
         "averageLength" : 10

--- a/pinot-controller/src/test/resources/recommenderInput/SortedInvertedIndexInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/SortedInvertedIndexInput.json
@@ -92,7 +92,7 @@
       },
       {
         "name": "l",
-        "dataType": "STRING",
+        "dataType": "DOUBLE",
         "cardinality":10000,
         "numValuesPerEntry":1,
         "averageLength" : 10

--- a/pinot-controller/src/test/resources/recommenderInput/VariedLengthDictionaryInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/VariedLengthDictionaryInput.json
@@ -44,7 +44,7 @@
       },
       {
         "name": "l",
-        "dataType": "STRING",
+        "dataType": "DOUBLE",
         "cardinality":10000,
         "numValuesPerEntry":1,
         "averageLength" : 10


### PR DESCRIPTION
## Description
Current tests have broken schema which cannot pass schema validation. String type is not allowed in Metrics fields.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
