### PR TITLE
Change default memory allocation for consuming segments from on-heap to off-heap

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -184,7 +184,7 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
 
   @Override
   public boolean isRealtimeOffHeapAllocation() {
-    return _instanceDataManagerConfiguration.getProperty(REALTIME_OFFHEAP_ALLOCATION, false);
+    return _instanceDataManagerConfiguration.getProperty(REALTIME_OFFHEAP_ALLOCATION, true);
   }
 
   @Override


### PR DESCRIPTION
## Description

It has been observed as well as established across several production deployments
that allocating consuming segments off-heap is better than allocating on-heap.

- Modifying the default value of `pinot.server.instance.realtime.alloc.offheap` to true.
- Note, that the default off-heap setting implies MMAP, and we still require setting
  `pinot.server.instance.realtime.alloc.offheap.direct` to true if using DirectMemory
  is preferred over MMAP.


## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
The default behavior of `pinot.server.instance.realtime.alloc.offheap` has been changed to true.
This implies that memory for consuming segments will be allocated off-heap. Off-heap here defaults
to MMAP, and can be changed to DirectMemory by setting the confing
`pinot.server.instance.realtime.alloc.offheap.direct` to true.

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
