### PR TITLE
builtin datetime functions to avoid throwing NullPointerException when input value is null

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.function.scalar;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
 import org.apache.pinot.common.function.DateTimePatternHandler;
 import org.apache.pinot.common.function.DateTimeUtils;
 import org.apache.pinot.common.function.TimeZoneKey;
@@ -248,7 +249,7 @@ public class DateTimeFunctions {
    * Converts Timestamp to epoch millis
    */
   @ScalarFunction
-  public static long fromTimestamp(Timestamp timestamp) {
+  public static long fromTimestamp(@Nonnull Timestamp timestamp) {
     return timestamp.getTime();
   }
 
@@ -272,7 +273,7 @@ public class DateTimeFunctions {
    * Converts DateTime string represented by pattern to epoch millis
    */
   @ScalarFunction
-  public static long fromDateTime(String dateTimeString, String pattern) {
+  public static long fromDateTime(@Nonnull String dateTimeString, String pattern) {
     return DateTimePatternHandler.parseDateTimeStringToEpochMillis(dateTimeString, pattern);
   }
 
@@ -307,7 +308,7 @@ public class DateTimeFunctions {
    *           "-P-6H+3M"  -- parses as "+6 hours and -3 minutes"
    */
   @ScalarFunction
-  public static long ago(String periodString) {
+  public static long ago(@Nonnull String periodString) {
     Duration period = Duration.parse(periodString);
     return System.currentTimeMillis() - period.toMillis();
   }
@@ -321,7 +322,7 @@ public class DateTimeFunctions {
    * Returns the hour of the time zone offset.
    */
   @ScalarFunction
-  public static int timezoneHour(String timezoneId) {
+  public static int timezoneHour(@Nonnull String timezoneId) {
     return new DateTime(DateTimeZone.forID(timezoneId).getOffset(null), DateTimeZone.UTC).getHourOfDay();
   }
 
@@ -329,7 +330,7 @@ public class DateTimeFunctions {
    * Returns the minute of the time zone offset.
    */
   @ScalarFunction
-  public static int timezoneMinute(String timezoneId) {
+  public static int timezoneMinute(@Nonnull String timezoneId) {
     return new DateTime(DateTimeZone.forID(timezoneId).getOffset(null), DateTimeZone.UTC).getMinuteOfHour();
   }
 
@@ -678,7 +679,7 @@ public class DateTimeFunctions {
    * date format.
    */
   @ScalarFunction
-  public static String dateTimeConvert(String timeValueStr, String inputFormatStr, String outputFormatStr,
+  public static String dateTimeConvert(@Nonnull String timeValueStr, String inputFormatStr, String outputFormatStr,
       String outputGranularityStr) {
     long timeValueMs = new DateTimeFormatSpec(inputFormatStr).fromFormatToMillis(timeValueStr);
     DateTimeFormatSpec outputFormat = new DateTimeFormatSpec(outputFormatStr);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
@@ -251,6 +251,13 @@ public class DateTimeFunctionsTest {
         "fromDateTime(dateTime, 'EEE MMM dd HH:mm:ss ZZZ yyyy')", Lists.newArrayList("dateTime"), row112, 1251142606000L
     });
 
+    // fromDateTime with null
+    GenericRow row113 = new GenericRow();
+    row113.putValue("dateTime", null);
+    inputs.add(new Object[]{
+        "fromDateTime(dateTime, 'yyyy-MM-dd''T''HH:mm:ss.SSS''Z''')", Lists.newArrayList("dateTime"), row113, null
+    });
+
     // timezone_hour and timezone_minute
     List<String> expectedArguments = Collections.singletonList("tz");
     GenericRow row120 = new GenericRow();
@@ -325,6 +332,16 @@ public class DateTimeFunctionsTest {
     inputs.add(new Object[]{"minute(millis, tz)", expectedArguments, row131, 23});
     inputs.add(new Object[]{"second(millis, tz)", expectedArguments, row131, 13});
     inputs.add(new Object[]{"millisecond(millis, tz)", expectedArguments, row131, 123});
+
+
+    GenericRow row140 = new GenericRow();
+    row140.putValue("duration", null);
+    inputs.add(new Object[]{"ago(duration)", Lists.newArrayList("duration"), row140, null});
+
+    GenericRow row141 = new GenericRow();
+    row141.putValue("timezoneId", null);
+    inputs.add(new Object[]{"timezoneHour(timezoneId)", Lists.newArrayList("timezoneId"), row141, null});
+
 
     return inputs.toArray(new Object[0][]);
   }
@@ -426,6 +443,8 @@ public class DateTimeFunctionsTest {
     testDateTimeConvert(5019675L/* 20170920T03:15:00 */, "5:MINUTES:EPOCH", "1:MILLISECONDS:EPOCH", "1:HOURS",
         1505901600000L/* 20170920T03:00:00 */);
 
+    testDateTimeConvert(null, "5:MINUTES:EPOCH", "1:MILLISECONDS:EPOCH", "1:HOURS", null);
+
     // EPOCH to SDF
     // Test conversion from millis since epoch to simple date format (UTC)
     testDateTimeConvert(1505985360000L/* 20170921T02:16:00 */, "1:MILLISECONDS:EPOCH",
@@ -524,6 +543,6 @@ public class DateTimeFunctionsTest {
     row.putValue("timeCol", timeValue);
     List<String> arguments = Collections.singletonList("timeCol");
     testFunction(String.format("dateTimeConvert(timeCol, '%s', '%s', '%s')", inputFormatStr, outputFormatStr,
-        outputGranularityStr), arguments, row, expectedResult.toString());
+        outputGranularityStr), arguments, row, expectedResult == null ? null : expectedResult.toString());
   }
 }


### PR DESCRIPTION
## Description
PR to fix github issue: https://github.com/apache/pinot/issues/8374

Add an annotation for DateTime functions that cannot take null, and just return null when the function is annotated and the input value is null.

**<code>release-notes</code>**
## Release Notes
Prevent datetime functions that cannot work w/ null from throwing NullPointerException. Preserve null input values so they can be marked as such in null index.
