### PR TITLE
add segment size metric on segment push

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -69,8 +69,8 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   // Estimated size of offline table
   OFFLINE_TABLE_ESTIMATED_SIZE("OfflineTableEstimatedSize", false),
 
-  // Size of an uploaded offline segment
-  OFFLINE_SEGMENT_SIZE("OfflineSegmentSize", false),
+  // Size of the last uploaded offline segment
+  LAST_PUSHED_SEGMENT_SIZE("LastPushedSegmentSize", false),
 
 
   // Table quota based on setting in table config

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -69,6 +69,10 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   // Estimated size of offline table
   OFFLINE_TABLE_ESTIMATED_SIZE("OfflineTableEstimatedSize", false),
 
+  // Size of an uploaded offline segment
+  OFFLINE_SEGMENT_SIZE("OfflineSegmentSize", false),
+
+
   // Table quota based on setting in table config
   TABLE_QUOTA("TableQuotaBasedOnTableConfig", false),
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -306,7 +306,7 @@ public class PinotSegmentUploadDownloadRestletResource {
           segmentName, zkDownloadUri, moveSegmentToFinalLocation, crypterClassName, allowRefresh);
 
       // We only set this gauge after the segment is successfully pushed.
-      _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.OFFLINE_SEGMENT_SIZE,
+      _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.LAST_PUSHED_SEGMENT_SIZE,
           FileUtils.sizeOfDirectory(tempSegmentDir));
 
       return new SuccessResponse("Successfully uploaded segment: " + segmentName + " of table: " + tableNameWithType);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -61,6 +61,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.restlet.resources.StartReplaceSegmentsRequest;
@@ -303,6 +304,10 @@ public class PinotSegmentUploadDownloadRestletResource {
       // Zk operations
       completeZkOperations(enableParallelPushProtection, headers, finalSegmentFile, tableNameWithType, segmentMetadata,
           segmentName, zkDownloadUri, moveSegmentToFinalLocation, crypterClassName, allowRefresh);
+
+      // We only set this gauge after the segment is successfully pushed.
+      _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.OFFLINE_SEGMENT_SIZE,
+          FileUtils.sizeOfDirectory(tempSegmentDir));
 
       return new SuccessResponse("Successfully uploaded segment: " + segmentName + " of table: " + tableNameWithType);
     } catch (WebApplicationException e) {


### PR DESCRIPTION
## Description
Adds an offline segment size metric only when a new segment is pushed. this is stored as a gauge and based on table name. This is useful to build detectors in case:
- someone tries to push a segment that is too large
- your segments are organically growing in size and you want to know once you've hit a threshold

I tested this by deploying this change to one of our clusters, manually uploading a CSV file, and observing the metric in our metrics platform.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->

This adds a metric for the last pushed segment size in bytes after the segment is successfully pushed.

## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
