### PR TITLE
Fix ingestion transform config bugs.

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
@@ -83,8 +83,8 @@ public class ExpressionTransformer implements RecordTransformer {
   private void topologicalSort(String column, Map<String, FunctionEvaluator> expressionEvaluators,
       Set<String> discoveredNames) {
     if (discoveredNames.contains(column)) {
-      throw new IllegalStateException("Expression cycle found for column '" + column + "' in Ingestion Transform Function"
-          + " definitions.");
+      throw new IllegalStateException("Expression cycle found for column '" + column + "' in Ingestion Transform "
+          + "Function definitions.");
     }
 
     FunctionEvaluator functionEvaluator = expressionEvaluators.get(column);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformerTest.java
@@ -261,8 +261,8 @@ public class ExpressionTransformerTest {
   }
 
   /** Check if there is more than one transform function definition for the same column. */
-  @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Cannot set more than one "
-      + "ingestion transform function on a column \\(column name: 'a'\\).")
+  @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "Cannot set more than one"
+      + " ingestion transform function on column: a.")
   public void testMultipleTransformFunctionSortOrder() {
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("a", FieldSpec.DataType.INT)
         .addSingleValueDimension("b", FieldSpec.DataType.INT).addSingleValueDimension("c", FieldSpec.DataType.INT)
@@ -310,7 +310,7 @@ public class ExpressionTransformerTest {
   }
 
   /* Check if we throw exception when Ingestion Transform Functions have a cycle. */
-  @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Expression "
+  @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "Expression "
       + "cycle found for column 'a' in Ingestion Transform Function definitions.")
   public void testCyclicTransformFunctionSortOrder() {
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("a", FieldSpec.DataType.INT)

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformerTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.segment.local.recordtransformer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -257,5 +258,75 @@ public class ExpressionTransformerTest {
     Assert.assertEquals(transform.getValue("d"), 110.0);
     Assert.assertEquals(transform.getValue("e"), 200);
     Assert.assertEquals(transform.getValue("f"), 210.0);
+  }
+
+  /** Check if there is more than one transform function definition for the same column. */
+  @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Cannot set more than one "
+      + "ingestion transform function on a column \\(column name: 'a'\\).")
+  public void testMultipleTransformFunctionSortOrder() {
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("a", FieldSpec.DataType.INT)
+        .addSingleValueDimension("b", FieldSpec.DataType.INT).addSingleValueDimension("c", FieldSpec.DataType.INT)
+        .build();
+
+    List<TransformConfig> transformConfigs = new ArrayList<>();
+    transformConfigs.add(new TransformConfig("a", "plus(b,10)"));
+    transformConfigs.add(new TransformConfig("a", "plus(c,10)"));
+
+    IngestionConfig ingestionConfig = new IngestionConfig(null, null, null, transformConfigs, null);
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName("testMultipleTransformFunctionSortOrder")
+            .setIngestionConfig(ingestionConfig).build();
+
+    // should throw runtime exception indicating that there are multiple transform config on column a
+    ExpressionTransformer expressionTransformer = new ExpressionTransformer(tableConfig, schema);
+  }
+
+  /* Check if Ingestion Transform Functions are parsed successfully when there is no cycle. */
+  @Test
+  public void testNonCyclicTransformFunctionSortOrder() {
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("a", FieldSpec.DataType.INT)
+        .addSingleValueDimension("b", FieldSpec.DataType.INT).addSingleValueDimension("c", FieldSpec.DataType.INT)
+        .build();
+
+    // Define transform function dependencies: a -> (b,c), b -> d, d -> e, c -> (d,e)
+    List<TransformConfig> transformConfigs = new ArrayList<>();
+    transformConfigs.add(new TransformConfig("a", "plus(b,c)"));
+    transformConfigs.add(new TransformConfig("b", "plus(d,10)"));
+    transformConfigs.add(new TransformConfig("d", "plus(e,10)"));
+    transformConfigs.add(new TransformConfig("c", "plus(d,e)"));
+
+    IngestionConfig ingestionConfig = new IngestionConfig(null, null, null, transformConfigs, null);
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName("testNonCyclicTransformFunctionSortOrder")
+            .setIngestionConfig(ingestionConfig).build();
+    ExpressionTransformer expressionTransformer = new ExpressionTransformer(tableConfig, schema);
+
+    // Check topological sort order
+    Iterator<String> sortedColumns = expressionTransformer._expressionEvaluators.keySet().iterator();
+    Assert.assertEquals(sortedColumns.next(), "d");
+    Assert.assertEquals(sortedColumns.next(), "b");
+    Assert.assertEquals(sortedColumns.next(), "c");
+    Assert.assertEquals(sortedColumns.next(), "a");
+  }
+
+  /* Check if we throw exception when Ingestion Transform Functions have a cycle. */
+  @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = "Expression "
+      + "cycle found for column 'a' in Ingestion Transform Function definitions.")
+  public void testCyclicTransformFunctionSortOrder() {
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("a", FieldSpec.DataType.INT)
+        .addSingleValueDimension("b", FieldSpec.DataType.INT).addSingleValueDimension("c", FieldSpec.DataType.INT)
+        .build();
+
+    // Define transform function dependencies: a -> b, b -> c, c -> a
+    List<TransformConfig> transformConfigs = new ArrayList<>();
+    transformConfigs.add(new TransformConfig("a", "plus(b,10)"));
+    transformConfigs.add(new TransformConfig("b", "plus(c,10)"));
+    transformConfigs.add(new TransformConfig("c", "plus(a,10)"));
+
+    IngestionConfig ingestionConfig = new IngestionConfig(null, null, null, transformConfigs, null);
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName("testRecrusiveTransformFunctionSortOrder")
+            .setIngestionConfig(ingestionConfig).build();
+    ExpressionTransformer expressionTransformer = new ExpressionTransformer(tableConfig, schema);
   }
 }


### PR DESCRIPTION
Fix ingestion transform config bugs.

## Description
This PR fixes two bugs in Ingestion Transform Function: 1) if a column is being set by multiple ingestion transform functions, then it is not clear which ingestion transform function will actually be used (depends upon which one is discovered first through DFS traversal) and 2) if ingestion transform function dependency chain contains a cycle, then the `ExpressionTransformer.topologicalSort()` function will get into an infinite loop causing a `StackOverflowError`.

For Issue #1, see `testMultipleTransformFunctionSortOrder()` test case.
For Issue #2, see `testCyclicTransformFunctionSortOrder()` test case.
 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
