### PR TITLE
Fixing TIMESTAMP data type usage during segment creation

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/DateTimeTransformerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/transformer/datetime/DateTimeTransformerFactory.java
@@ -35,14 +35,14 @@ public class DateTimeTransformerFactory {
 
     TimeFormat inputTimeFormat = inputFormat.getTimeFormat();
     TimeFormat outputTimeFormat = outputFormat.getTimeFormat();
-    if (inputTimeFormat == TimeFormat.EPOCH) {
-      if (outputTimeFormat == TimeFormat.EPOCH) {
+    if (inputTimeFormat == TimeFormat.EPOCH || inputTimeFormat == TimeFormat.TIMESTAMP) {
+      if (outputTimeFormat == TimeFormat.EPOCH || outputTimeFormat == TimeFormat.TIMESTAMP) {
         return new EpochToEpochTransformer(inputFormat, outputFormat, outputGranularity);
       } else {
         return new EpochToSDFTransformer(inputFormat, outputFormat, outputGranularity);
       }
     } else {
-      if (outputTimeFormat == TimeFormat.EPOCH) {
+      if (outputTimeFormat == TimeFormat.EPOCH || outputTimeFormat == TimeFormat.TIMESTAMP) {
         return new SDFToEpochTransformer(inputFormat, outputFormat, outputGranularity);
       } else {
         return new SDFToSDFTransformer(inputFormat, outputFormat, outputGranularity);

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/mappers/SegmentPreprocessingMapper.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/mappers/SegmentPreprocessingMapper.java
@@ -71,7 +71,8 @@ public class SegmentPreprocessingMapper
       String timeType = _jobConf.get(InternalConfigConstants.SEGMENT_TIME_TYPE);
       String timeFormat = _jobConf.get(InternalConfigConstants.SEGMENT_TIME_FORMAT);
       DateTimeFormatSpec dateTimeFormatSpec;
-      if (timeFormat.equals(DateTimeFieldSpec.TimeFormat.EPOCH.toString())) {
+      if (timeFormat.equals(DateTimeFieldSpec.TimeFormat.EPOCH.toString()) || timeFormat.equals(
+          DateTimeFieldSpec.TimeFormat.TIMESTAMP.toString())) {
         dateTimeFormatSpec = new DateTimeFormatSpec(1, timeType, timeFormat);
       } else {
         dateTimeFormatSpec = new DateTimeFormatSpec(1, timeType, timeFormat,

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGenerator.java
@@ -75,7 +75,7 @@ public class NormalizedDateSegmentNameGenerator implements SegmentNameGenerator 
       // Parse input time format: 'EPOCH' or 'SIMPLE_DATE_FORMAT' using pattern
       Preconditions.checkNotNull(dateTimeFormatSpec);
       TimeFormat timeFormat = dateTimeFormatSpec.getTimeFormat();
-      if (timeFormat == TimeFormat.EPOCH) {
+      if (timeFormat == TimeFormat.EPOCH || timeFormat == TimeFormat.TIMESTAMP) {
         _inputTimeUnit = dateTimeFormatSpec.getColumnUnit();
         _inputSDF = null;
       } else {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGenerator.java
@@ -72,7 +72,7 @@ public class NormalizedDateSegmentNameGenerator implements SegmentNameGenerator 
       }
       _outputSDF.setTimeZone(TimeZone.getTimeZone("UTC"));
 
-      // Parse input time format: 'EPOCH' or 'SIMPLE_DATE_FORMAT' using pattern
+      // Parse input time format: 'EPOCH'/'TIMESTAMP' or 'SIMPLE_DATE_FORMAT' using pattern
       Preconditions.checkNotNull(dateTimeFormatSpec);
       TimeFormat timeFormat = dateTimeFormatSpec.getTimeFormat();
       if (timeFormat == TimeFormat.EPOCH || timeFormat == TimeFormat.TIMESTAMP) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -735,8 +735,7 @@ public final class Schema implements Serializable {
     String outgoingTimeFormat = outgoingGranularitySpec.getTimeFormat();
     String[] split = StringUtils.split(outgoingTimeFormat, DateTimeFormatSpec.COLON_SEPARATOR, 2);
     DateTimeFormatSpec formatSpec;
-    if (split[0].equals(DateTimeFieldSpec.TimeFormat.EPOCH.toString()) || split[0].equals(
-        DateTimeFieldSpec.TimeFormat.TIMESTAMP.toString())) {
+    if (split[0].equals(DateTimeFieldSpec.TimeFormat.EPOCH.toString())) {
       formatSpec = new DateTimeFormatSpec(outgoingTimeSize, outgoingTimeUnit.toString(), split[0]);
     } else {
       formatSpec = new DateTimeFormatSpec(outgoingTimeSize, outgoingTimeUnit.toString(), split[0], split[1]);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -735,7 +735,8 @@ public final class Schema implements Serializable {
     String outgoingTimeFormat = outgoingGranularitySpec.getTimeFormat();
     String[] split = StringUtils.split(outgoingTimeFormat, DateTimeFormatSpec.COLON_SEPARATOR, 2);
     DateTimeFormatSpec formatSpec;
-    if (split[0].equals(DateTimeFieldSpec.TimeFormat.EPOCH.toString())) {
+    if (split[0].equals(DateTimeFieldSpec.TimeFormat.EPOCH.toString()) || split[0].equals(
+        DateTimeFieldSpec.TimeFormat.TIMESTAMP.toString())) {
       formatSpec = new DateTimeFormatSpec(outgoingTimeSize, outgoingTimeUnit.toString(), split[0]);
     } else {
       formatSpec = new DateTimeFormatSpec(outgoingTimeSize, outgoingTimeUnit.toString(), split[0], split[1]);
@@ -752,8 +753,8 @@ public final class Schema implements Serializable {
       TimeUnit incomingTimeUnit = incomingGranularitySpec.getTimeType();
       String incomingTimeFormat = incomingGranularitySpec.getTimeFormat();
       Preconditions.checkState(
-          incomingTimeFormat.equals(DateTimeFieldSpec.TimeFormat.EPOCH.toString()) && outgoingTimeFormat
-              .equals(DateTimeFieldSpec.TimeFormat.EPOCH.toString()),
+          (incomingTimeFormat.equals(DateTimeFieldSpec.TimeFormat.EPOCH.toString()) || incomingTimeFormat.equals(
+              DateTimeFieldSpec.TimeFormat.TIMESTAMP.toString())) && outgoingTimeFormat.equals(incomingTimeFormat),
           "Conversion from incoming to outgoing is not supported for SIMPLE_DATE_FORMAT");
       String transformFunction =
           constructTransformFunctionString(incomingName, incomingTimeSize, incomingTimeUnit, outgoingTimeSize,


### PR DESCRIPTION
## Description
Missed a few places during segment creation/segment name generation for TimeFormat.TIMESTAMP usage.

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
