### PR TITLE
accelerate counts over filters

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BaseFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BaseFilterOperator.java
@@ -40,4 +40,32 @@ public abstract class BaseFilterOperator extends BaseOperator<FilterBlock> {
   public boolean isResultMatchingAll() {
     return false;
   }
+
+  /**
+   * Returns {@code true} if the filter has an optimized count implementation.
+   */
+  public boolean canOptimizeCount() {
+    return false;
+  }
+
+  /**
+   * @return the number of matching docs, or throws if it cannot produce this count.
+   */
+  public int getNumMatchingDocs() {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * @return true if the filter operator can produce a bitmap of docIds
+   */
+  public boolean canProduceBitmaps() {
+    return false;
+  }
+
+  /**
+   * @return bitmaps of matching docIds
+   */
+  public BitmapCollection getBitmaps() {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BitmapCollection.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BitmapCollection.java
@@ -1,0 +1,129 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.filter;
+
+import org.roaringbitmap.buffer.BufferFastAggregation;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
+
+/**
+ * Encapsulates a collection of bitmaps, and allows inversion without modifying the bitmaps.
+ * Provides simplified access to efficient cardinality calculation which work regardless of
+ * inversion status without computing the complement of the union of the bitmaps.
+ */
+public class BitmapCollection {
+  private final int _numDocs;
+  private boolean _inverted;
+  private final ImmutableRoaringBitmap[] _bitmaps;
+
+  public BitmapCollection(int numDocs, boolean inverted, ImmutableRoaringBitmap... bitmaps) {
+    _numDocs = numDocs;
+    _inverted = inverted;
+    _bitmaps = bitmaps;
+  }
+
+  /**
+   * Inverts the bitmaps in constant time and space.
+   * @return this bitmap collection inverted.
+   */
+  public BitmapCollection invert() {
+    _inverted = !_inverted;
+    return this;
+  }
+
+  /**
+   * Computes the size of the intersection of the bitmaps efficiently regardless of negation, without
+   * needing to invert inputs or materialize an intermediate bitmap.
+   *
+   * @param bitmaps to intersect with
+   * @return the size of the intersection of the bitmaps in this collection and in the other collection
+   */
+  public int andCardinality(BitmapCollection bitmaps) {
+    ImmutableRoaringBitmap left = reduceInternal();
+    ImmutableRoaringBitmap right = bitmaps.reduceInternal();
+    if (!_inverted) {
+      if (!bitmaps._inverted) {
+        return ImmutableRoaringBitmap.andCardinality(left, right);
+      }
+      return ImmutableRoaringBitmap.andNotCardinality(left, right);
+    } else {
+      if (!bitmaps._inverted) {
+        return ImmutableRoaringBitmap.andNotCardinality(right, left);
+      }
+      return _numDocs - ImmutableRoaringBitmap.orCardinality(left, right);
+    }
+  }
+
+  /**
+   * Computes the size of the union of the bitmaps efficiently regardless of negation, without
+   * needing to invert inputs or materialize an intermediate bitmap. If either this collection
+   * or the other collection has more than one bitmap, the union will be materialized.
+   *
+   * @param bitmaps to intersect with
+   * @return the size of the union of the bitmaps in this collection and in the other collection
+   */
+  public int orCardinality(BitmapCollection bitmaps) {
+    ImmutableRoaringBitmap left = reduceInternal();
+    ImmutableRoaringBitmap right = bitmaps.reduceInternal();
+    if (!_inverted) {
+      if (!bitmaps._inverted) {
+        return ImmutableRoaringBitmap.orCardinality(left, right);
+      }
+      return _numDocs - right.getCardinality() - ImmutableRoaringBitmap.andCardinality(left, right);
+    } else {
+      if (!bitmaps._inverted) {
+        return _numDocs - left.getCardinality()
+            + ImmutableRoaringBitmap.andCardinality(right, left);
+      }
+      return _numDocs - ImmutableRoaringBitmap.andCardinality(left, right);
+    }
+  }
+
+  private ImmutableRoaringBitmap reduceInternal() {
+    if (_bitmaps.length == 1) {
+      return _bitmaps[0];
+    }
+    return BufferFastAggregation.or(_bitmaps);
+  }
+
+  /**
+   * Reduces the bitmaps to a single bitmap. In common cases, when the collection
+   * is not inverted and only has one bitmap, this operation is cheap. However,
+   * this may be a costly operation: a new bitmap may be allocated, one or many
+   * bitmaps may need to be inverted. Prefer {@see andCardinality} or {@see orCardinality}
+   * when appropriate.
+   * @return a bitmap
+   */
+  public ImmutableRoaringBitmap reduce() {
+    if (!_inverted) {
+      return reduceInternal();
+    }
+    return invertedOr();
+  }
+
+  private MutableRoaringBitmap invertedOr() {
+    MutableRoaringBitmap complement = new MutableRoaringBitmap();
+    complement.add(0L, _numDocs);
+    for (ImmutableRoaringBitmap bitmap : _bitmaps) {
+      complement.andNot(bitmap);
+    }
+    return complement;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/EmptyFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/EmptyFilterOperator.java
@@ -47,6 +47,16 @@ public final class EmptyFilterOperator extends BaseFilterOperator {
   }
 
   @Override
+  public boolean canOptimizeCount() {
+    return true;
+  }
+
+  @Override
+  public int getNumMatchingDocs() {
+    return 0;
+  }
+
+  @Override
   protected FilterBlock getNextBlock() {
     return EmptyFilterBlock.getInstance();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/JsonMatchFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/JsonMatchFilterOperator.java
@@ -51,6 +51,26 @@ public class JsonMatchFilterOperator extends BaseFilterOperator {
   }
 
   @Override
+  public boolean canOptimizeCount() {
+    return true;
+  }
+
+  @Override
+  public int getNumMatchingDocs() {
+    return _jsonIndex.getMatchingDocIds(_predicate.getValue()).getCardinality();
+  }
+
+  @Override
+  public boolean canProduceBitmaps() {
+    return true;
+  }
+
+  @Override
+  public BitmapCollection getBitmaps() {
+    return new BitmapCollection(_numDocs, false, _jsonIndex.getMatchingDocIds(_predicate.getValue()));
+  }
+
+  @Override
   public String getOperatorName() {
     return OPERATOR_NAME;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MatchAllFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MatchAllFilterOperator.java
@@ -55,6 +55,16 @@ public class MatchAllFilterOperator extends BaseFilterOperator {
   }
 
   @Override
+  public boolean canOptimizeCount() {
+    return true;
+  }
+
+  @Override
+  public int getNumMatchingDocs() {
+    return _numDocs;
+  }
+
+  @Override
   public String toExplainString() {
     return new StringBuilder(EXPLAIN_NAME).append("(docs:").append(_numDocs).append(')').toString();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/NotFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/NotFilterOperator.java
@@ -58,6 +58,26 @@ public class NotFilterOperator extends BaseFilterOperator {
     return new FilterBlock(new NotDocIdSet(_filterOperator.nextBlock().getBlockDocIdSet(), _numDocs));
   }
 
+  @Override
+  public boolean canOptimizeCount() {
+    return _filterOperator.canOptimizeCount();
+  }
+
+  @Override
+  public int getNumMatchingDocs() {
+    return _numDocs - _filterOperator.getNumMatchingDocs();
+  }
+
+  @Override
+  public boolean canProduceBitmaps() {
+    return _filterOperator.canProduceBitmaps();
+  }
+
+  @Override
+  public BitmapCollection getBitmaps() {
+    return _filterOperator.getBitmaps().invert();
+  }
+
   public BaseFilterOperator getChildFilterOperator() {
     return _filterOperator;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/TextMatchFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/TextMatchFilterOperator.java
@@ -51,6 +51,26 @@ public class TextMatchFilterOperator extends BaseFilterOperator {
   }
 
   @Override
+  public boolean canOptimizeCount() {
+    return true;
+  }
+
+  @Override
+  public int getNumMatchingDocs() {
+    return _textIndexReader.getDocIds(_predicate.getValue()).getCardinality();
+  }
+
+  @Override
+  public boolean canProduceBitmaps() {
+    return true;
+  }
+
+  @Override
+  public BitmapCollection getBitmaps() {
+    return new BitmapCollection(_numDocs, false, _textIndexReader.getDocIds(_predicate.getValue()));
+  }
+
+  @Override
   public String getOperatorName() {
     return OPERATOR_NAME;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FastFilteredCountOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FastFilteredCountOperator.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.query;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.operator.BaseOperator;
+import org.apache.pinot.core.operator.ExecutionStatistics;
+import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
+import org.apache.pinot.core.operator.filter.BaseFilterOperator;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.segment.spi.SegmentMetadata;
+
+
+@SuppressWarnings("rawtypes")
+public class FastFilteredCountOperator extends BaseOperator<IntermediateResultsBlock> {
+
+  private static final String EXPLAIN_NAME = "FAST_FILTERED_COUNT";
+
+  private final BaseFilterOperator _filterOperator;
+  private final AggregationFunction[] _aggregationFunctions;
+  private final SegmentMetadata _segmentMetadata;
+
+  private long _docsCounted;
+
+  public FastFilteredCountOperator(AggregationFunction[] aggregationFunctions, BaseFilterOperator filterOperator,
+      SegmentMetadata segmentMetadata) {
+    _filterOperator = filterOperator;
+    _segmentMetadata = segmentMetadata;
+    _aggregationFunctions = aggregationFunctions;
+  }
+
+  @Override
+  public String getOperatorName() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
+  public String toExplainString() {
+    return EXPLAIN_NAME;
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Override
+  public List<Operator> getChildOperators() {
+    return Collections.singletonList(_filterOperator);
+  }
+
+  @Override
+  protected IntermediateResultsBlock getNextBlock() {
+    long count = _filterOperator.getNumMatchingDocs();
+    List<Object> aggregates = new ArrayList<>(1);
+    aggregates.add(count);
+    _docsCounted += count;
+    return new IntermediateResultsBlock(_aggregationFunctions, aggregates, false);
+  }
+
+  @Override
+  public ExecutionStatistics getExecutionStatistics() {
+    // fabricate the number of docs scanned to keep compatibility tests happy for now, but this should be set to zero
+    return new ExecutionStatistics(_docsCounted, 0, 0,
+        _segmentMetadata.getTotalDocs());
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/BitmapCollectionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/BitmapCollectionTest.java
@@ -1,0 +1,237 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.filter;
+
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class BitmapCollectionTest {
+
+  @DataProvider
+  public static Object[][] andCardinalityTestCases() {
+    return new Object[][]{
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), false,
+            ImmutableRoaringBitmap.bitmapOf(0, 4), false, 1
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), false,
+            ImmutableRoaringBitmap.bitmapOf(1, 4), false, 0
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), false,
+            ImmutableRoaringBitmap.bitmapOf(), false, 0
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(), false,
+            ImmutableRoaringBitmap.bitmapOf(0, 5), false, 0
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(), false,
+            ImmutableRoaringBitmap.bitmapOf(), false, 0
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), true,
+            ImmutableRoaringBitmap.bitmapOf(0, 4), false, 1
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), true,
+            ImmutableRoaringBitmap.bitmapOf(1, 4), false, 2
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), true,
+            ImmutableRoaringBitmap.bitmapOf(), false, 0
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(), true,
+            ImmutableRoaringBitmap.bitmapOf(0, 5), false, 2
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(), true,
+            ImmutableRoaringBitmap.bitmapOf(), false, 0
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), false,
+            ImmutableRoaringBitmap.bitmapOf(0, 4), true, 1
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), false,
+            ImmutableRoaringBitmap.bitmapOf(1, 4), true, 2
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), false,
+            ImmutableRoaringBitmap.bitmapOf(), true, 2
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(), false,
+            ImmutableRoaringBitmap.bitmapOf(), true, 0
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(), false,
+            ImmutableRoaringBitmap.bitmapOf(0, 5), true, 0
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), true,
+            ImmutableRoaringBitmap.bitmapOf(0, 4), true, 7
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), true,
+            ImmutableRoaringBitmap.bitmapOf(1, 4), true, 6
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), true,
+            ImmutableRoaringBitmap.bitmapOf(), true, 8
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(), true,
+            ImmutableRoaringBitmap.bitmapOf(0, 5), true, 8
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(), true,
+            ImmutableRoaringBitmap.bitmapOf(), true, 10
+        },
+    };
+  }
+
+  @Test(dataProvider = "andCardinalityTestCases")
+  public void testAndCardinality(int numDocs, ImmutableRoaringBitmap left, boolean leftInverted,
+      ImmutableRoaringBitmap right, boolean rightInverted, int expected) {
+    assertEquals(new BitmapCollection(numDocs, leftInverted, left).andCardinality(
+        new BitmapCollection(numDocs, rightInverted, right)), expected);
+    assertEquals(new BitmapCollection(numDocs, leftInverted, split(left)).andCardinality(
+        new BitmapCollection(numDocs, rightInverted, right)), expected);
+    assertEquals(new BitmapCollection(numDocs, leftInverted, left).andCardinality(
+        new BitmapCollection(numDocs, rightInverted, split(right))), expected);
+    assertEquals(new BitmapCollection(numDocs, leftInverted, split(left)).andCardinality(
+        new BitmapCollection(numDocs, rightInverted, split(right))), expected);
+  }
+
+  @DataProvider
+  public static Object[][] orCardinalityTestCases() {
+    return new Object[][]{
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), false,
+            ImmutableRoaringBitmap.bitmapOf(0, 4), false, 3
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), false,
+            ImmutableRoaringBitmap.bitmapOf(1, 4), false, 4
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), false,
+            ImmutableRoaringBitmap.bitmapOf(), false, 2
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(), false,
+            ImmutableRoaringBitmap.bitmapOf(0, 5), false, 2
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(), false,
+            ImmutableRoaringBitmap.bitmapOf(), false, 0
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), true,
+            ImmutableRoaringBitmap.bitmapOf(0, 4), false, 9
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), true,
+            ImmutableRoaringBitmap.bitmapOf(1, 4), false, 8
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), true,
+            ImmutableRoaringBitmap.bitmapOf(), false, 8
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(), true,
+            ImmutableRoaringBitmap.bitmapOf(0, 5), false, 10
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(), true,
+            ImmutableRoaringBitmap.bitmapOf(), false, 10
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), false,
+            ImmutableRoaringBitmap.bitmapOf(0, 4), true, 7
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), false,
+            ImmutableRoaringBitmap.bitmapOf(1, 4), true, 8
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), false,
+            ImmutableRoaringBitmap.bitmapOf(), true, 10
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(), false,
+            ImmutableRoaringBitmap.bitmapOf(0, 5), true, 8
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(), false,
+            ImmutableRoaringBitmap.bitmapOf(), true, 10
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), true,
+            ImmutableRoaringBitmap.bitmapOf(0, 4), true, 9
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), true,
+            ImmutableRoaringBitmap.bitmapOf(1, 4), true, 10
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(0, 5), true,
+            ImmutableRoaringBitmap.bitmapOf(), true, 10
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(), true,
+            ImmutableRoaringBitmap.bitmapOf(0, 5), true, 10
+        },
+        {
+            10, ImmutableRoaringBitmap.bitmapOf(), true,
+            ImmutableRoaringBitmap.bitmapOf(), true, 10
+        },
+    };
+  }
+
+  @Test(dataProvider = "orCardinalityTestCases")
+  public void testOrCardinality(int numDocs, ImmutableRoaringBitmap left, boolean leftInverted,
+      ImmutableRoaringBitmap right, boolean rightInverted, int expected) {
+    assertEquals(new BitmapCollection(numDocs, leftInverted, left).orCardinality(
+        new BitmapCollection(numDocs, rightInverted, right)), expected);
+    assertEquals(new BitmapCollection(numDocs, leftInverted, split(left)).orCardinality(
+        new BitmapCollection(numDocs, rightInverted, right)), expected);
+    assertEquals(new BitmapCollection(numDocs, leftInverted, left).orCardinality(
+        new BitmapCollection(numDocs, rightInverted, split(right))), expected);
+    assertEquals(new BitmapCollection(numDocs, leftInverted, split(left)).orCardinality(
+        new BitmapCollection(numDocs, rightInverted, split(right))), expected);
+  }
+
+  private ImmutableRoaringBitmap[] split(ImmutableRoaringBitmap bitmap) {
+    if (bitmap.isEmpty()) {
+      return new ImmutableRoaringBitmap[]{bitmap};
+    }
+    ImmutableRoaringBitmap[] split = new ImmutableRoaringBitmap[2];
+    split[0] = bitmap;
+    split[1] = ImmutableRoaringBitmap.bitmapOf(bitmap.last());
+    return split;
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -29,6 +29,7 @@ import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.query.AggregationGroupByOperator;
 import org.apache.pinot.core.operator.query.AggregationOperator;
+import org.apache.pinot.core.operator.query.FastFilteredCountOperator;
 import org.apache.pinot.core.operator.query.NonScanBasedAggregationOperator;
 import org.apache.pinot.core.operator.query.SelectionOnlyOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
@@ -162,14 +163,15 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     entries.add(new Object[]{
         "select * from testTable where daysSinceEpoch > 100", SelectionOnlyOperator.class, SelectionOnlyOperator.class
     });
-    // COUNT from metadata
+    // COUNT from metadata (via fast filtered count which knows the number of docs in the segment)
     entries.add(new Object[]{
-        "select count(*) from testTable", NonScanBasedAggregationOperator.class, AggregationOperator.class
+        "select count(*) from testTable", FastFilteredCountOperator.class,
+        FastFilteredCountOperator.class
     });
     // COUNT from metadata with match all filter
     entries.add(new Object[]{
-        "select count(*) from testTable where column1 > 10", NonScanBasedAggregationOperator.class,
-        AggregationOperator.class
+        "select count(*) from testTable where column1 > 10", FastFilteredCountOperator.class,
+        FastFilteredCountOperator.class
     });
     // MIN/MAX from dictionary
     entries.add(new Object[]{

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FastFilteredCountTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FastFilteredCountTest.java
@@ -1,0 +1,300 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.IntStream;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.operator.query.FastFilteredCountOperator;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class FastFilteredCountTest extends BaseQueriesTest {
+
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "FastFilteredCountTest");
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String SEGMENT_NAME = "testSegment";
+
+  private static final int NUM_RECORDS = 1000;
+  private static final int BUCKET_SIZE = 8;
+  private static final String SORTED_COLUMN = "sorted";
+  private static final String CLASSIFICATION_COLUMN = "class";
+  private static final String TEXT_COLUMN = "textCol";
+  private static final String JSON_COLUMN = "jsonCol";
+
+  private static final Schema SCHEMA = new Schema.SchemaBuilder()
+      .addSingleValueDimension(SORTED_COLUMN, FieldSpec.DataType.INT)
+      .addSingleValueDimension(CLASSIFICATION_COLUMN, FieldSpec.DataType.INT)
+      .addSingleValueDimension(TEXT_COLUMN, FieldSpec.DataType.STRING)
+      .addSingleValueDimension(JSON_COLUMN, FieldSpec.DataType.JSON)
+      .build();
+
+  private static final TableConfig TABLE_CONFIG =
+      new TableConfigBuilder(TableType.OFFLINE)
+          .setTableName(RAW_TABLE_NAME)
+          .setSortedColumn(SORTED_COLUMN)
+          .build();
+
+  private IndexSegment _indexSegment;
+  private List<IndexSegment> _indexSegments;
+
+  @Override
+  protected String getFilter() {
+    return "";
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteQuietly(INDEX_DIR);
+
+    List<GenericRow> records = new ArrayList<>(NUM_RECORDS);
+    for (int i = 0; i < NUM_RECORDS; i++) {
+      GenericRow record = new GenericRow();
+      record.putValue(CLASSIFICATION_COLUMN, i % BUCKET_SIZE);
+      record.putValue(SORTED_COLUMN, i);
+      record.putValue(TEXT_COLUMN, "text" + (i % BUCKET_SIZE));
+      record.putValue(JSON_COLUMN, "{\"field\":" + (i % BUCKET_SIZE) + "}");
+      records.add(record);
+    }
+
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE_CONFIG, SCHEMA);
+    segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
+    segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
+    segmentGeneratorConfig.setOutDir(INDEX_DIR.getPath());
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records));
+    driver.build();
+
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
+    indexLoadingConfig.setInvertedIndexColumns(new HashSet<>(Arrays.asList(CLASSIFICATION_COLUMN, SORTED_COLUMN)));
+    indexLoadingConfig.setTextIndexColumns(Collections.singleton(TEXT_COLUMN));
+    indexLoadingConfig.setJsonIndexColumns(Collections.singleton(JSON_COLUMN));
+
+    ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME),
+        indexLoadingConfig);
+    _indexSegment = immutableSegment;
+    _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    FileUtils.deleteDirectory(INDEX_DIR);
+  }
+
+  @DataProvider
+  public Object[][] testCases() {
+    int bucketCount = NUM_RECORDS / BUCKET_SIZE;
+    int bucketCountComplement = NUM_RECORDS - NUM_RECORDS / BUCKET_SIZE;
+    int min = 20;
+    int max = NUM_RECORDS - 20;
+    String allBuckets = Arrays.toString(IntStream.range(0, BUCKET_SIZE).toArray())
+        .replace('[', '(').replace(']', ')');
+    String twoBuckets = Arrays.toString(new int[] {0, 7})
+        .replace('[', '(').replace(']', ')');
+    return new Object[][] {
+        {"select count(*) from " + RAW_TABLE_NAME, NUM_RECORDS},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + CLASSIFICATION_COLUMN + " = 1", bucketCount},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where JSON_MATCH(" + JSON_COLUMN + ", '\"$.field\"=1')", bucketCount},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where NOT JSON_MATCH(" + JSON_COLUMN + ", '\"$.field\"=1')", bucketCountComplement},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where TEXT_MATCH(" + TEXT_COLUMN + ", 'text1')", bucketCount},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where NOT TEXT_MATCH(" + TEXT_COLUMN + ", 'text1')", bucketCountComplement},
+        {"select count(*) from " + RAW_TABLE_NAME + " where " + SORTED_COLUMN + " = 1", 1},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + SORTED_COLUMN + " between " + min + " and " + max, max - min + 1},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + SORTED_COLUMN + " not between " + min + " and " + max, NUM_RECORDS - (max - min + 1)},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + SORTED_COLUMN + " in " + allBuckets, BUCKET_SIZE},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + SORTED_COLUMN + " in " + allBuckets
+            + " and " + CLASSIFICATION_COLUMN + " in " + allBuckets, BUCKET_SIZE},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + CLASSIFICATION_COLUMN + " <> 1", bucketCountComplement},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + CLASSIFICATION_COLUMN + " in " + twoBuckets, 2 * bucketCount},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + CLASSIFICATION_COLUMN + " not in " + twoBuckets, NUM_RECORDS - 2 * bucketCount},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + CLASSIFICATION_COLUMN + " in " + twoBuckets
+            + " and " + SORTED_COLUMN + " < " + (NUM_RECORDS / 2), bucketCount},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + SORTED_COLUMN + " = 1"
+            + " and " + CLASSIFICATION_COLUMN + " = 1", 1},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + SORTED_COLUMN + " = 1"
+            + " and " + CLASSIFICATION_COLUMN + " <> 1", 0},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + SORTED_COLUMN + " = 1"
+            + " and " + CLASSIFICATION_COLUMN + " <> 0", 1},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where TEXT_MATCH(" + TEXT_COLUMN + ", 'text0')"
+            + " and " + CLASSIFICATION_COLUMN + " <> 1", bucketCount},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where TEXT_MATCH(" + TEXT_COLUMN + ", 'text0')"
+            + " or " + CLASSIFICATION_COLUMN + " <> 1", bucketCountComplement},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where TEXT_MATCH(" + TEXT_COLUMN + ", 'text0')"
+            + " or " + CLASSIFICATION_COLUMN + " = 1", 2 * bucketCount},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where not TEXT_MATCH(" + TEXT_COLUMN + ", 'text0')"
+            + " or " + CLASSIFICATION_COLUMN + " = 1", bucketCountComplement},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where TEXT_MATCH(" + TEXT_COLUMN + ", 'text0')"
+            + " or JSON_MATCH(" + JSON_COLUMN + ", '\"$.field\"=1')"
+            + " or " + CLASSIFICATION_COLUMN + " = 2", 3 * bucketCount},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where not TEXT_MATCH(" + TEXT_COLUMN + ", 'text0')"
+            + " or not JSON_MATCH(" + JSON_COLUMN + ", '\"$.field\"=0')"
+            + " or " + CLASSIFICATION_COLUMN + " <> 0", bucketCountComplement},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where TEXT_MATCH(" + TEXT_COLUMN + ", 'text0')"
+            + " or JSON_MATCH(" + JSON_COLUMN + ", '\"$.field\"=1')"
+            + " or " + CLASSIFICATION_COLUMN + " <> 2", bucketCountComplement},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where not TEXT_MATCH(" + TEXT_COLUMN + ", 'text0')"
+            + " or not JSON_MATCH(" + JSON_COLUMN + ", '\"$.field\"=1')"
+            + " or " + CLASSIFICATION_COLUMN + " <> 2", NUM_RECORDS},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where not TEXT_MATCH(" + TEXT_COLUMN + ", 'text0')"
+            + " or JSON_MATCH(" + JSON_COLUMN + ", '\"$.field\"=1')"
+            + " or " + CLASSIFICATION_COLUMN + " <> 2", NUM_RECORDS},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where not TEXT_MATCH(" + TEXT_COLUMN + ", 'text0')"
+            + " or JSON_MATCH(" + JSON_COLUMN + ", '\"$.field\"=1')"
+            + " or " + CLASSIFICATION_COLUMN + " = 0", NUM_RECORDS},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + SORTED_COLUMN + " <> 1"
+            + " and " + CLASSIFICATION_COLUMN + " = 1", bucketCount - 1},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + SORTED_COLUMN + " >= 0"
+            + " and " + CLASSIFICATION_COLUMN + " = 1", bucketCount},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + SORTED_COLUMN + " > 1"
+            + " and " + CLASSIFICATION_COLUMN + " = 1", bucketCount - 1},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + SORTED_COLUMN + " >= 0"
+            + " and " + CLASSIFICATION_COLUMN + " <> 1", bucketCountComplement},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where not TEXT_MATCH(" + TEXT_COLUMN + ", 'text0')"
+            + " and " + CLASSIFICATION_COLUMN + " <> 1", NUM_RECORDS - 2 * bucketCount},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where not TEXT_MATCH(" + TEXT_COLUMN + ", 'text0')"
+            + " or " + CLASSIFICATION_COLUMN + " <> 1", NUM_RECORDS},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where not TEXT_MATCH(" + TEXT_COLUMN + ", 'text0')"
+            + " or " + CLASSIFICATION_COLUMN + " <> 0", bucketCountComplement},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + SORTED_COLUMN + " >= 0"
+            + " or " + CLASSIFICATION_COLUMN + " <> 0", NUM_RECORDS},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where TEXT_MATCH(" + TEXT_COLUMN + ",  'text0')"
+            + " and " + SORTED_COLUMN + " <> 1", bucketCount},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where TEXT_MATCH(" + TEXT_COLUMN + ",  'text1')"
+            + " and " + SORTED_COLUMN + " <> 1", bucketCount - 1},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where TEXT_MATCH(" + TEXT_COLUMN + ",  'text0')"
+            + " and " + CLASSIFICATION_COLUMN + " <> 1", bucketCount},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + SORTED_COLUMN + " >= 500"
+            + " and " + CLASSIFICATION_COLUMN + " <> 0"
+            + " and not TEXT_MATCH(" + TEXT_COLUMN + ", 'text0')", bucketCountComplement / 2 + 1},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + SORTED_COLUMN + " >= 500"
+            + " and " + CLASSIFICATION_COLUMN + " <> 0"
+            + " and TEXT_MATCH(" + TEXT_COLUMN + ", 'text0')", 0},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + SORTED_COLUMN + " < " + bucketCount
+            + " and " + CLASSIFICATION_COLUMN + " <> 0", bucketCount - bucketCount / BUCKET_SIZE - 1},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + SORTED_COLUMN + " >= " + bucketCount
+            + " and " + CLASSIFICATION_COLUMN + " <> 0", bucketCountComplement - bucketCountComplement / BUCKET_SIZE},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + SORTED_COLUMN + " < " + (BUCKET_SIZE - 1)
+            + " and " + CLASSIFICATION_COLUMN + " = " + (BUCKET_SIZE - 1), 0},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + SORTED_COLUMN + " >= " + (BUCKET_SIZE - 2)
+            + " and " + CLASSIFICATION_COLUMN + " = " + (BUCKET_SIZE - 2), bucketCount},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + SORTED_COLUMN + " >= " + min
+            + " and " + SORTED_COLUMN + " < " + max
+            + " and " + CLASSIFICATION_COLUMN + " = 0", bucketCount - (min + NUM_RECORDS - max) / BUCKET_SIZE},
+        {"select count(*) from " + RAW_TABLE_NAME
+            + " where " + SORTED_COLUMN + " >= 500"
+            + " and " + CLASSIFICATION_COLUMN + " <> 0"
+            + " and not JSON_MATCH(" + JSON_COLUMN + ", '\"$.field\"=0')"
+            + " and not TEXT_MATCH(" + TEXT_COLUMN + ", 'text0')", bucketCountComplement / 2 + 1}
+    };
+  }
+
+  @Test(dataProvider = "testCases")
+  public void test(String query, int expectedCount) {
+    Operator<?> operator = getOperatorForSqlQuery(query);
+    assertTrue(operator instanceof FastFilteredCountOperator);
+    List<Object> aggregationResult = ((FastFilteredCountOperator) operator).nextBlock().getAggregationResult();
+    assertNotNull(aggregationResult);
+    assertEquals(aggregationResult.size(), 1);
+    assertEquals(((Number) aggregationResult.get(0)).intValue(), expectedCount, query);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/NotOperatorQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/NotOperatorQueriesTest.java
@@ -25,7 +25,8 @@ import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
-import org.apache.pinot.core.operator.query.AggregationOperator;
+import org.apache.pinot.core.operator.BaseOperator;
+import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
@@ -136,7 +137,7 @@ public class NotOperatorQueriesTest extends BaseQueriesTest {
 
   private void testNotOperator(String filter, long expectedSegmentResult) {
     String query = "SELECT COUNT(*) FROM testTable WHERE " + filter;
-    AggregationOperator aggregationOperator = getOperatorForSqlQuery(query);
+    BaseOperator<IntermediateResultsBlock> aggregationOperator = getOperatorForSqlQuery(query);
     List<Object> segmentResults = aggregationOperator.nextBlock().getAggregationResult();
     assertNotNull(segmentResults);
     assertEquals((long) segmentResults.get(0), expectedSegmentResult);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
@@ -56,8 +56,8 @@ import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.response.broker.SelectionResults;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
-import org.apache.pinot.core.operator.query.AggregationOperator;
 import org.apache.pinot.core.operator.query.SelectionOnlyOperator;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.realtime.impl.invertedindex.RealtimeLuceneTextIndex;
@@ -1693,7 +1693,7 @@ public class TextSearchQueriesTest extends BaseQueriesTest {
   }
 
   private void testTextSearchAggregationQueryHelper(String query, int expectedCount) {
-    AggregationOperator operator = getOperatorForPqlQuery(query);
+    BaseOperator<IntermediateResultsBlock> operator = getOperatorForPqlQuery(query);
     IntermediateResultsBlock operatorResult = operator.nextBlock();
     long count = (Long) operatorResult.getAggregationResult().get(0);
     Assert.assertEquals(expectedCount, count);


### PR DESCRIPTION
Implements the one dimensional case of #8410 

Before:
```
Benchmark               (_numRows)                                                                    (_query)  (_scenario)  Mode  Cnt     Score      Error  Units
BenchmarkQueries.query     1500000  SELECT COUNT(*) FROM MyTable WHERE INT_COL IN (0, 1, 2, 3, 4, 5, 7, 9, 10)   EXP(0.001)  avgt    5   575.001 ±  170.398  us/op
BenchmarkQueries.query     1500000  SELECT COUNT(*) FROM MyTable WHERE INT_COL IN (0, 1, 2, 3, 4, 5, 7, 9, 10)     EXP(0.5)  avgt    5  6863.184 ±  887.486  us/op
BenchmarkQueries.query     1500000  SELECT COUNT(*) FROM MyTable WHERE INT_COL IN (0, 1, 2, 3, 4, 5, 7, 9, 10)   EXP(0.999)  avgt    5  7414.995 ± 1247.503  us/op
```
After:

```
Benchmark               (_numRows)                                                                    (_query)  (_scenario)  Mode  Cnt    Score     Error  Units
BenchmarkQueries.query     1500000  SELECT COUNT(*) FROM MyTable WHERE INT_COL IN (0, 1, 2, 3, 4, 5, 7, 9, 10)   EXP(0.001)  avgt    5  713.136 ±  41.245  us/op
BenchmarkQueries.query     1500000  SELECT COUNT(*) FROM MyTable WHERE INT_COL IN (0, 1, 2, 3, 4, 5, 7, 9, 10)     EXP(0.5)  avgt    5  816.003 ± 103.969  us/op
BenchmarkQueries.query     1500000  SELECT COUNT(*) FROM MyTable WHERE INT_COL IN (0, 1, 2, 3, 4, 5, 7, 9, 10)   EXP(0.999)  avgt    5  546.664 ± 181.613  us/op
```
