### PR TITLE
Use lower level Joda API in DateTimeTransformFunction

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTimeTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTimeTransformFunction.java
@@ -26,8 +26,10 @@ import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.spi.data.FieldSpec;
-import org.joda.time.DateTime;
+import org.joda.time.Chronology;
+import org.joda.time.DateTimeField;
 import org.joda.time.DateTimeZone;
+import org.joda.time.chrono.ISOChronology;
 
 
 public abstract class DateTimeTransformFunction extends BaseTransformFunction {
@@ -36,7 +38,8 @@ public abstract class DateTimeTransformFunction extends BaseTransformFunction {
       new TransformResultMetadata(FieldSpec.DataType.INT, true, false);
   private final String _name;
   private TransformFunction _timestampsFunction;
-  protected DateTimeZone _zoneId;
+  protected static final Chronology UTC = ISOChronology.getInstanceUTC();
+  protected Chronology _chronology;
 
   protected DateTimeTransformFunction(String name) {
     _name = name;
@@ -50,9 +53,10 @@ public abstract class DateTimeTransformFunction extends BaseTransformFunction {
       Preconditions.checkArgument(arguments.get(1) instanceof LiteralTransformFunction,
           "zoneId parameter %s must be a literal",
           _name);
-      _zoneId = DateTimeZone.forID(((LiteralTransformFunction) arguments.get(1)).getLiteral());
+      _chronology =
+          ISOChronology.getInstance(DateTimeZone.forID(((LiteralTransformFunction) arguments.get(1)).getLiteral()));
     } else {
-      _zoneId = DateTimeZone.UTC;
+      _chronology = UTC;
     }
   }
 
@@ -87,8 +91,9 @@ public abstract class DateTimeTransformFunction extends BaseTransformFunction {
 
     @Override
     protected void convert(long[] timestamps, int numDocs, int[] output) {
+      DateTimeField accessor = _chronology.year();
       for (int i = 0; i < numDocs; i++) {
-        output[i] = new DateTime(timestamps[i], _zoneId).getYear();
+        output[i] = accessor.get(timestamps[i]);
       }
     }
   }
@@ -101,8 +106,9 @@ public abstract class DateTimeTransformFunction extends BaseTransformFunction {
 
     @Override
     protected void convert(long[] timestamps, int numDocs, int[] output) {
+      DateTimeField accessor = _chronology.weekyear();
       for (int i = 0; i < numDocs; i++) {
-        output[i] = new DateTime(timestamps[i], _zoneId).getWeekyear();
+        output[i] = accessor.get(timestamps[i]);
       }
     }
   }
@@ -115,8 +121,9 @@ public abstract class DateTimeTransformFunction extends BaseTransformFunction {
 
     @Override
     protected void convert(long[] timestamps, int numDocs, int[] output) {
+      DateTimeField accessor = _chronology.monthOfYear();
       for (int i = 0; i < numDocs; i++) {
-        output[i] = new DateTime(timestamps[i], _zoneId).getMonthOfYear();
+        output[i] = accessor.get(timestamps[i]);
       }
     }
   }
@@ -129,8 +136,9 @@ public abstract class DateTimeTransformFunction extends BaseTransformFunction {
 
     @Override
     protected void convert(long[] timestamps, int numDocs, int[] output) {
+      DateTimeField accessor = _chronology.weekOfWeekyear();
       for (int i = 0; i < numDocs; i++) {
-        output[i] = new DateTime(timestamps[i], _zoneId).getWeekOfWeekyear();
+        output[i] = accessor.get(timestamps[i]);
       }
     }
   }
@@ -143,8 +151,9 @@ public abstract class DateTimeTransformFunction extends BaseTransformFunction {
 
     @Override
     protected void convert(long[] timestamps, int numDocs, int[] output) {
+      DateTimeField accessor = _chronology.dayOfYear();
       for (int i = 0; i < numDocs; i++) {
-        output[i] = new DateTime(timestamps[i], _zoneId).getDayOfYear();
+        output[i] = accessor.get(timestamps[i]);
       }
     }
   }
@@ -157,8 +166,9 @@ public abstract class DateTimeTransformFunction extends BaseTransformFunction {
 
     @Override
     protected void convert(long[] timestamps, int numDocs, int[] output) {
+      DateTimeField accessor = _chronology.dayOfMonth();
       for (int i = 0; i < numDocs; i++) {
-        output[i] = new DateTime(timestamps[i], _zoneId).getDayOfMonth();
+        output[i] = accessor.get(timestamps[i]);
       }
     }
   }
@@ -171,8 +181,9 @@ public abstract class DateTimeTransformFunction extends BaseTransformFunction {
 
     @Override
     protected void convert(long[] timestamps, int numDocs, int[] output) {
+      DateTimeField accessor = _chronology.dayOfWeek();
       for (int i = 0; i < numDocs; i++) {
-        output[i] = new DateTime(timestamps[i], _zoneId).getDayOfWeek();
+        output[i] = accessor.get(timestamps[i]);
       }
     }
   }
@@ -185,8 +196,9 @@ public abstract class DateTimeTransformFunction extends BaseTransformFunction {
 
     @Override
     protected void convert(long[] timestamps, int numDocs, int[] output) {
+      DateTimeField accessor = _chronology.hourOfDay();
       for (int i = 0; i < numDocs; i++) {
-        output[i] = new DateTime(timestamps[i], _zoneId).getHourOfDay();
+        output[i] = accessor.get(timestamps[i]);
       }
     }
   }
@@ -199,8 +211,9 @@ public abstract class DateTimeTransformFunction extends BaseTransformFunction {
 
     @Override
     protected void convert(long[] timestamps, int numDocs, int[] output) {
+      DateTimeField accessor = _chronology.minuteOfHour();
       for (int i = 0; i < numDocs; i++) {
-        output[i] = new DateTime(timestamps[i], _zoneId).getMinuteOfHour();
+        output[i] = accessor.get(timestamps[i]);
       }
     }
   }
@@ -213,8 +226,9 @@ public abstract class DateTimeTransformFunction extends BaseTransformFunction {
 
     @Override
     protected void convert(long[] timestamps, int numDocs, int[] output) {
+      DateTimeField accessor = _chronology.secondOfMinute();
       for (int i = 0; i < numDocs; i++) {
-        output[i] = new DateTime(timestamps[i], _zoneId).getSecondOfMinute();
+        output[i] = accessor.get(timestamps[i]);
       }
     }
   }
@@ -227,8 +241,9 @@ public abstract class DateTimeTransformFunction extends BaseTransformFunction {
 
     @Override
     protected void convert(long[] timestamps, int numDocs, int[] output) {
+      DateTimeField accessor = _chronology.millisOfSecond();
       for (int i = 0; i < numDocs; i++) {
-        output[i] = new DateTime(timestamps[i], _zoneId).getMillisOfSecond();
+        output[i] = accessor.get(timestamps[i]);
       }
     }
   }
@@ -241,8 +256,9 @@ public abstract class DateTimeTransformFunction extends BaseTransformFunction {
 
     @Override
     protected void convert(long[] timestamps, int numDocs, int[] output) {
+      DateTimeField accessor = _chronology.monthOfYear();
       for (int i = 0; i < numDocs; i++) {
-        output[i] = (new DateTime(timestamps[i], _zoneId).getMonthOfYear() - 1) / 3 + 1;
+        output[i] = (accessor.get(timestamps[i]) - 1) / 3 + 1;
       }
     }
   }

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkQueries.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkQueries.java
@@ -126,13 +126,17 @@ public class BenchmarkQueries extends BaseQueriesTest {
       + "FROM MyTable GROUP BY LOW_CARDINALITY_STRING_COL,NO_INDEX_STRING_COL "
       + "ORDER BY LOW_CARDINALITY_STRING_COL, NO_INDEX_STRING_COL ASC";
 
+  public static final String TIME_GROUP_BY = "select count(*), "
+      + "year(INT_COL) as y, month(INT_COL) as m "
+      + "from MyTable group by y, m";
+
   @Param("1500000")
   private int _numRows;
   @Param({"EXP(0.001)", "EXP(0.5)", "EXP(0.999)"})
   String _scenario;
   @Param({
       MULTI_GROUP_BY_WITH_RAW_QUERY, MULTI_GROUP_BY_WITH_RAW_QUERY_2, FILTERED_QUERY, NON_FILTERED_QUERY,
-      SUM_QUERY, NO_INDEX_LIKE_QUERY, MULTI_GROUP_BY_ORDER_BY, MULTI_GROUP_BY_ORDER_BY_LOW_HIGH
+      SUM_QUERY, NO_INDEX_LIKE_QUERY, MULTI_GROUP_BY_ORDER_BY, MULTI_GROUP_BY_ORDER_BY_LOW_HIGH, TIME_GROUP_BY
   })
   String _query;
   private IndexSegment _indexSegment;


### PR DESCRIPTION
#8397 decreased allocation over 1000x and improved query time by ~30% for the query below evaluated over 2.5Bn events.
```sql
select count(*), year(event_time) as y, month(event_time) as m from githubEvents group by y, m
```

The high level API leads to looking up lots of Chronology objects:

<img width="1609" alt="Screenshot 2022-03-25 at 20 53 42" src="https://user-images.githubusercontent.com/16439049/160203730-c3b31e72-3e45-44e7-a1c2-cc1bd0af003c.png">


Joda has a slightly lower level API which allows 10-15% speedup by avoiding this, without taking on too much complexity.
```
Benchmark               (_numRows)                                                                             (_query)  (_scenario)  Mode  Cnt      Score       Error  Units
BenchmarkQueries.query     1500000  select count(*), year(INT_COL) as y, month(INT_COL) as m from MyTable group by y, m   EXP(0.001)  avgt    5  59405.445 ± 2239.678  us/op
BenchmarkQueries.query     1500000  select count(*), year(INT_COL) as y, month(INT_COL) as m from MyTable group by y, m     EXP(0.5)  avgt    5  60158.445 ± 1162.191  us/op
BenchmarkQueries.query     1500000  select count(*), year(INT_COL) as y, month(INT_COL) as m from MyTable group by y, m   EXP(0.999)  avgt    5  59735.354 ± 1363.752  us/op
```

```
Benchmark               (_numRows)                                                                             (_query)  (_scenario)  Mode  Cnt      Score      Error  Units
BenchmarkQueries.query     1500000  select count(*), year(INT_COL) as y, month(INT_COL) as m from MyTable group by y, m   EXP(0.001)  avgt    5  53623.538 ± 1757.387  us/op
BenchmarkQueries.query     1500000  select count(*), year(INT_COL) as y, month(INT_COL) as m from MyTable group by y, m     EXP(0.5)  avgt    5  54116.859 ± 2684.261  us/op
BenchmarkQueries.query     1500000  select count(*), year(INT_COL) as y, month(INT_COL) as m from MyTable group by y, m   EXP(0.999)  avgt    5  54359.302 ± 1790.208  us/op
```