### PR TITLE
Avoid creationg of max length result arrays

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunction.java
@@ -68,7 +68,7 @@ public class AdditionTransformFunction extends BaseTransformFunction {
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
 
-    if (_sums == null) {
+    if (_sums == null || _sums.length < length) {
       _sums = new double[length];
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunction.java
@@ -66,11 +66,12 @@ public class AdditionTransformFunction extends BaseTransformFunction {
 
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+
     if (_sums == null) {
-      _sums = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      _sums = new double[length];
     }
 
-    int length = projectionBlock.getNumDocs();
     Arrays.fill(_sums, 0, length, _literalSum);
     for (TransformFunction transformFunction : _transformFunctions) {
       double[] values = transformFunction.transformToDoubleValuesSV(projectionBlock);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayAverageTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayAverageTransformFunction.java
@@ -71,11 +71,12 @@ public class ArrayAverageTransformFunction extends BaseTransformFunction {
 
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
+    int numDocs = projectionBlock.getNumDocs();
+
     if (_results == null) {
-      _results = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      _results = new double[numDocs];
     }
 
-    int numDocs = projectionBlock.getNumDocs();
     switch (_argument.getResultMetadata().getDataType().getStoredType()) {
       case INT:
         int[][] intValuesMV = _argument.transformToIntValuesMV(projectionBlock);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayAverageTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayAverageTransformFunction.java
@@ -73,7 +73,7 @@ public class ArrayAverageTransformFunction extends BaseTransformFunction {
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
 
-    if (_results == null) {
+    if (_results == null || _results.length < numDocs) {
       _results = new double[numDocs];
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayLengthTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayLengthTransformFunction.java
@@ -68,11 +68,12 @@ public class ArrayLengthTransformFunction extends BaseTransformFunction {
 
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    int numDocs = projectionBlock.getNumDocs();
+
     if (_results == null) {
-      _results = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      _results = new int[numDocs];
     }
 
-    int numDocs = projectionBlock.getNumDocs();
     switch (_argument.getResultMetadata().getDataType().getStoredType()) {
       case INT:
         int[][] intValuesMV = _argument.transformToIntValuesMV(projectionBlock);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayLengthTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayLengthTransformFunction.java
@@ -70,7 +70,7 @@ public class ArrayLengthTransformFunction extends BaseTransformFunction {
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
 
-    if (_results == null) {
+    if (_results == null || _results.length < numDocs) {
       _results = new int[numDocs];
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayMaxTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayMaxTransformFunction.java
@@ -79,10 +79,12 @@ public class ArrayMaxTransformFunction extends BaseTransformFunction {
     if (_argument.getResultMetadata().getDataType().getStoredType() != DataType.INT) {
       return super.transformToIntValuesSV(projectionBlock);
     }
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-    }
+
     int length = projectionBlock.getNumDocs();
+
+    if (_intValuesSV == null) {
+      _intValuesSV = new int[length];
+    }
     int[][] intValuesMV = _argument.transformToIntValuesMV(projectionBlock);
     for (int i = 0; i < length; i++) {
       int maxRes = Integer.MIN_VALUE;
@@ -99,10 +101,12 @@ public class ArrayMaxTransformFunction extends BaseTransformFunction {
     if (_argument.getResultMetadata().getDataType().getStoredType() != DataType.LONG) {
       return super.transformToLongValuesSV(projectionBlock);
     }
-    if (_longValuesSV == null) {
-      _longValuesSV = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-    }
+
     int length = projectionBlock.getNumDocs();
+
+    if (_longValuesSV == null) {
+      _longValuesSV = new long[length];
+    }
     long[][] longValuesMV = _argument.transformToLongValuesMV(projectionBlock);
     for (int i = 0; i < length; i++) {
       long maxRes = Long.MIN_VALUE;
@@ -119,10 +123,12 @@ public class ArrayMaxTransformFunction extends BaseTransformFunction {
     if (_argument.getResultMetadata().getDataType().getStoredType() != DataType.FLOAT) {
       return super.transformToFloatValuesSV(projectionBlock);
     }
-    if (_floatValuesSV == null) {
-      _floatValuesSV = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-    }
+
     int length = projectionBlock.getNumDocs();
+
+    if (_floatValuesSV == null) {
+      _floatValuesSV = new float[length];
+    }
     float[][] floatValuesMV = _argument.transformToFloatValuesMV(projectionBlock);
     for (int i = 0; i < length; i++) {
       float maxRes = Float.NEGATIVE_INFINITY;
@@ -139,10 +145,12 @@ public class ArrayMaxTransformFunction extends BaseTransformFunction {
     if (_argument.getResultMetadata().getDataType().getStoredType() != DataType.DOUBLE) {
       return super.transformToDoubleValuesSV(projectionBlock);
     }
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-    }
+
     int length = projectionBlock.getNumDocs();
+
+    if (_doubleValuesSV == null) {
+      _doubleValuesSV = new double[length];
+    }
     double[][] doubleValuesMV = _argument.transformToDoubleValuesMV(projectionBlock);
     for (int i = 0; i < length; i++) {
       double maxRes = Double.NEGATIVE_INFINITY;
@@ -159,10 +167,12 @@ public class ArrayMaxTransformFunction extends BaseTransformFunction {
     if (_argument.getResultMetadata().getDataType().getStoredType() != DataType.STRING) {
       return super.transformToStringValuesSV(projectionBlock);
     }
-    if (_stringValuesSV == null) {
-      _stringValuesSV = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-    }
+
     int length = projectionBlock.getNumDocs();
+
+    if (_stringValuesSV == null) {
+      _stringValuesSV = new String[length];
+    }
     String[][] stringValuesMV = _argument.transformToStringValuesMV(projectionBlock);
     for (int i = 0; i < length; i++) {
       String maxRes = null;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayMaxTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayMaxTransformFunction.java
@@ -82,7 +82,7 @@ public class ArrayMaxTransformFunction extends BaseTransformFunction {
 
     int length = projectionBlock.getNumDocs();
 
-    if (_intValuesSV == null) {
+    if (_intValuesSV == null || _intValuesSV.length < length) {
       _intValuesSV = new int[length];
     }
     int[][] intValuesMV = _argument.transformToIntValuesMV(projectionBlock);
@@ -104,7 +104,7 @@ public class ArrayMaxTransformFunction extends BaseTransformFunction {
 
     int length = projectionBlock.getNumDocs();
 
-    if (_longValuesSV == null) {
+    if (_longValuesSV == null || _longValuesSV.length < length) {
       _longValuesSV = new long[length];
     }
     long[][] longValuesMV = _argument.transformToLongValuesMV(projectionBlock);
@@ -126,7 +126,7 @@ public class ArrayMaxTransformFunction extends BaseTransformFunction {
 
     int length = projectionBlock.getNumDocs();
 
-    if (_floatValuesSV == null) {
+    if (_floatValuesSV == null || _floatValuesSV.length < length) {
       _floatValuesSV = new float[length];
     }
     float[][] floatValuesMV = _argument.transformToFloatValuesMV(projectionBlock);
@@ -148,7 +148,7 @@ public class ArrayMaxTransformFunction extends BaseTransformFunction {
 
     int length = projectionBlock.getNumDocs();
 
-    if (_doubleValuesSV == null) {
+    if (_doubleValuesSV == null || _doubleValuesSV.length < length) {
       _doubleValuesSV = new double[length];
     }
     double[][] doubleValuesMV = _argument.transformToDoubleValuesMV(projectionBlock);
@@ -170,7 +170,7 @@ public class ArrayMaxTransformFunction extends BaseTransformFunction {
 
     int length = projectionBlock.getNumDocs();
 
-    if (_stringValuesSV == null) {
+    if (_stringValuesSV == null || _stringValuesSV.length < length) {
       _stringValuesSV = new String[length];
     }
     String[][] stringValuesMV = _argument.transformToStringValuesMV(projectionBlock);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayMinTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayMinTransformFunction.java
@@ -82,7 +82,7 @@ public class ArrayMinTransformFunction extends BaseTransformFunction {
 
     int length = projectionBlock.getNumDocs();
 
-    if (_intValuesSV == null) {
+    if (_intValuesSV == null || _intValuesSV.length < length) {
       _intValuesSV = new int[length];
     }
     int[][] intValuesMV = _argument.transformToIntValuesMV(projectionBlock);
@@ -104,7 +104,7 @@ public class ArrayMinTransformFunction extends BaseTransformFunction {
 
     int length = projectionBlock.getNumDocs();
 
-    if (_longValuesSV == null) {
+    if (_longValuesSV == null || _longValuesSV.length < length) {
       _longValuesSV = new long[length];
     }
 
@@ -127,7 +127,7 @@ public class ArrayMinTransformFunction extends BaseTransformFunction {
 
     int length = projectionBlock.getNumDocs();
 
-    if (_floatValuesSV == null) {
+    if (_floatValuesSV == null || _floatValuesSV.length < length) {
       _floatValuesSV = new float[length];
     }
 
@@ -150,7 +150,7 @@ public class ArrayMinTransformFunction extends BaseTransformFunction {
 
     int length = projectionBlock.getNumDocs();
 
-    if (_doubleValuesSV == null) {
+    if (_doubleValuesSV == null || _doubleValuesSV.length < length) {
       _doubleValuesSV = new double[length];
     }
 
@@ -173,7 +173,7 @@ public class ArrayMinTransformFunction extends BaseTransformFunction {
 
     int length = projectionBlock.getNumDocs();
 
-    if (_stringValuesSV == null) {
+    if (_stringValuesSV == null || _stringValuesSV.length < length) {
       _stringValuesSV = new String[length];
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayMinTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayMinTransformFunction.java
@@ -79,10 +79,12 @@ public class ArrayMinTransformFunction extends BaseTransformFunction {
     if (_argument.getResultMetadata().getDataType().getStoredType() != DataType.INT) {
       return super.transformToIntValuesSV(projectionBlock);
     }
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-    }
+
     int length = projectionBlock.getNumDocs();
+
+    if (_intValuesSV == null) {
+      _intValuesSV = new int[length];
+    }
     int[][] intValuesMV = _argument.transformToIntValuesMV(projectionBlock);
     for (int i = 0; i < length; i++) {
       int minRes = Integer.MAX_VALUE;
@@ -99,10 +101,13 @@ public class ArrayMinTransformFunction extends BaseTransformFunction {
     if (_argument.getResultMetadata().getDataType().getStoredType() != DataType.LONG) {
       return super.transformToLongValuesSV(projectionBlock);
     }
-    if (_longValuesSV == null) {
-      _longValuesSV = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-    }
+
     int length = projectionBlock.getNumDocs();
+
+    if (_longValuesSV == null) {
+      _longValuesSV = new long[length];
+    }
+
     long[][] longValuesMV = _argument.transformToLongValuesMV(projectionBlock);
     for (int i = 0; i < length; i++) {
       long minRes = Long.MAX_VALUE;
@@ -119,10 +124,13 @@ public class ArrayMinTransformFunction extends BaseTransformFunction {
     if (_argument.getResultMetadata().getDataType().getStoredType() != DataType.FLOAT) {
       return super.transformToFloatValuesSV(projectionBlock);
     }
-    if (_floatValuesSV == null) {
-      _floatValuesSV = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-    }
+
     int length = projectionBlock.getNumDocs();
+
+    if (_floatValuesSV == null) {
+      _floatValuesSV = new float[length];
+    }
+
     float[][] floatValuesMV = _argument.transformToFloatValuesMV(projectionBlock);
     for (int i = 0; i < length; i++) {
       float minRes = Float.POSITIVE_INFINITY;
@@ -139,10 +147,13 @@ public class ArrayMinTransformFunction extends BaseTransformFunction {
     if (_argument.getResultMetadata().getDataType().getStoredType() != DataType.DOUBLE) {
       return super.transformToDoubleValuesSV(projectionBlock);
     }
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-    }
+
     int length = projectionBlock.getNumDocs();
+
+    if (_doubleValuesSV == null) {
+      _doubleValuesSV = new double[length];
+    }
+
     double[][] doubleValuesMV = _argument.transformToDoubleValuesMV(projectionBlock);
     for (int i = 0; i < length; i++) {
       double minRes = Double.POSITIVE_INFINITY;
@@ -159,10 +170,13 @@ public class ArrayMinTransformFunction extends BaseTransformFunction {
     if (_argument.getResultMetadata().getDataType().getStoredType() != DataType.STRING) {
       return super.transformToStringValuesSV(projectionBlock);
     }
-    if (_stringValuesSV == null) {
-      _stringValuesSV = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-    }
+
     int length = projectionBlock.getNumDocs();
+
+    if (_stringValuesSV == null) {
+      _stringValuesSV = new String[length];
+    }
+
     String[][] stringValuesMV = _argument.transformToStringValuesMV(projectionBlock);
     for (int i = 0; i < length; i++) {
       String minRes = null;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArraySumTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArraySumTransformFunction.java
@@ -71,10 +71,12 @@ public class ArraySumTransformFunction extends BaseTransformFunction {
 
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
-    if (_results == null) {
-      _results = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-    }
     int length = projectionBlock.getNumDocs();
+
+    if (_results == null) {
+      _results = new double[length];
+    }
+
     double[][] doubleValuesMV = _argument.transformToDoubleValuesMV(projectionBlock);
     for (int i = 0; i < length; i++) {
       double sumRes = 0;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArraySumTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArraySumTransformFunction.java
@@ -73,7 +73,7 @@ public class ArraySumTransformFunction extends BaseTransformFunction {
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
 
-    if (_results == null) {
+    if (_results == null || _results.length < length) {
       _results = new double[length];
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
@@ -81,11 +81,12 @@ public abstract class BaseTransformFunction implements TransformFunction {
 
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+
     if (_intValuesSV == null) {
-      _intValuesSV = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      _intValuesSV = new int[length];
     }
 
-    int length = projectionBlock.getNumDocs();
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[] dictIds = transformToDictIdsSV(projectionBlock);
@@ -117,11 +118,12 @@ public abstract class BaseTransformFunction implements TransformFunction {
 
   @Override
   public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+
     if (_longValuesSV == null) {
-      _longValuesSV = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      _longValuesSV = new long[length];
     }
 
-    int length = projectionBlock.getNumDocs();
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[] dictIds = transformToDictIdsSV(projectionBlock);
@@ -153,11 +155,12 @@ public abstract class BaseTransformFunction implements TransformFunction {
 
   @Override
   public float[] transformToFloatValuesSV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+
     if (_floatValuesSV == null) {
-      _floatValuesSV = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      _floatValuesSV = new float[length];
     }
 
-    int length = projectionBlock.getNumDocs();
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[] dictIds = transformToDictIdsSV(projectionBlock);
@@ -189,11 +192,12 @@ public abstract class BaseTransformFunction implements TransformFunction {
 
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+
     if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      _doubleValuesSV = new double[length];
     }
 
-    int length = projectionBlock.getNumDocs();
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[] dictIds = transformToDictIdsSV(projectionBlock);
@@ -225,11 +229,12 @@ public abstract class BaseTransformFunction implements TransformFunction {
 
   @Override
   public String[] transformToStringValuesSV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+
     if (_stringValuesSV == null) {
-      _stringValuesSV = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      _stringValuesSV = new String[length];
     }
 
-    int length = projectionBlock.getNumDocs();
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[] dictIds = transformToDictIdsSV(projectionBlock);
@@ -265,11 +270,12 @@ public abstract class BaseTransformFunction implements TransformFunction {
 
   @Override
   public byte[][] transformToBytesValuesSV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+
     if (_byteValuesSV == null) {
-      _byteValuesSV = new byte[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+      _byteValuesSV = new byte[length][];
     }
 
-    int length = projectionBlock.getNumDocs();
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[] dictIds = transformToDictIdsSV(projectionBlock);
@@ -284,11 +290,12 @@ public abstract class BaseTransformFunction implements TransformFunction {
 
   @Override
   public int[][] transformToIntValuesMV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+
     if (_intValuesMV == null) {
-      _intValuesMV = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+      _intValuesMV = new int[length][];
     }
 
-    int length = projectionBlock.getNumDocs();
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[][] dictIdsMV = transformToDictIdsMV(projectionBlock);
@@ -350,11 +357,12 @@ public abstract class BaseTransformFunction implements TransformFunction {
 
   @Override
   public long[][] transformToLongValuesMV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+
     if (_longValuesMV == null) {
-      _longValuesMV = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+      _longValuesMV = new long[length][];
     }
 
-    int length = projectionBlock.getNumDocs();
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[][] dictIdsMV = transformToDictIdsMV(projectionBlock);
@@ -416,11 +424,12 @@ public abstract class BaseTransformFunction implements TransformFunction {
 
   @Override
   public float[][] transformToFloatValuesMV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+
     if (_floatValuesMV == null) {
-      _floatValuesMV = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+      _floatValuesMV = new float[length][];
     }
 
-    int length = projectionBlock.getNumDocs();
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[][] dictIdsMV = transformToDictIdsMV(projectionBlock);
@@ -482,11 +491,12 @@ public abstract class BaseTransformFunction implements TransformFunction {
 
   @Override
   public double[][] transformToDoubleValuesMV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+
     if (_doubleValuesMV == null) {
-      _doubleValuesMV = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+      _doubleValuesMV = new double[length][];
     }
 
-    int length = projectionBlock.getNumDocs();
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[][] dictIdsMV = transformToDictIdsMV(projectionBlock);
@@ -548,11 +558,12 @@ public abstract class BaseTransformFunction implements TransformFunction {
 
   @Override
   public String[][] transformToStringValuesMV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+
     if (_stringValuesMV == null) {
-      _stringValuesMV = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+      _stringValuesMV = new String[length][];
     }
 
-    int length = projectionBlock.getNumDocs();
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[][] dictIdsMV = transformToDictIdsMV(projectionBlock);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
@@ -99,10 +99,11 @@ public class CastTransformFunction extends BaseTransformFunction {
     if (resultStoredType == DataType.INT) {
       return _transformFunction.transformToIntValuesSV(projectionBlock);
     } else {
-      if (_intValuesSV == null) {
-        _intValuesSV = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-      }
       int numDocs = projectionBlock.getNumDocs();
+      
+      if (_intValuesSV == null) {
+        _intValuesSV = new int[numDocs];
+      }
       switch (resultStoredType) {
         case LONG:
           long[] longValues = _transformFunction.transformToLongValuesSV(projectionBlock);
@@ -134,10 +135,11 @@ public class CastTransformFunction extends BaseTransformFunction {
     if (resultStoredType == DataType.LONG) {
       return _transformFunction.transformToLongValuesSV(projectionBlock);
     } else {
-      if (_longValuesSV == null) {
-        _longValuesSV = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-      }
       int numDocs = projectionBlock.getNumDocs();
+
+      if (_longValuesSV == null) {
+        _longValuesSV = new long[numDocs];
+      }
       switch (resultStoredType) {
         case INT:
           int[] intValues = _transformFunction.transformToIntValuesSV(projectionBlock);
@@ -169,10 +171,11 @@ public class CastTransformFunction extends BaseTransformFunction {
     if (resultStoredType == DataType.FLOAT) {
       return _transformFunction.transformToFloatValuesSV(projectionBlock);
     } else {
-      if (_floatValuesSV == null) {
-        _floatValuesSV = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-      }
       int numDocs = projectionBlock.getNumDocs();
+
+      if (_floatValuesSV == null) {
+        _floatValuesSV = new float[numDocs];
+      }
       switch (resultStoredType) {
         case INT:
           int[] intValues = _transformFunction.transformToIntValuesSV(projectionBlock);
@@ -204,10 +207,11 @@ public class CastTransformFunction extends BaseTransformFunction {
     if (resultStoredType == DataType.DOUBLE) {
       return _transformFunction.transformToDoubleValuesSV(projectionBlock);
     } else {
-      if (_doubleValuesSV == null) {
-        _doubleValuesSV = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-      }
       int numDocs = projectionBlock.getNumDocs();
+
+      if (_doubleValuesSV == null) {
+        _doubleValuesSV = new double[numDocs];
+      }
       switch (resultStoredType) {
         case INT:
           int[] intValues = _transformFunction.transformToIntValuesSV(projectionBlock);
@@ -243,7 +247,7 @@ public class CastTransformFunction extends BaseTransformFunction {
       DataType inputDataType = _transformFunction.getResultMetadata().getDataType();
       if (inputDataType.getStoredType() != inputDataType) {
         if (_stringValuesSV == null) {
-          _stringValuesSV = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+          _stringValuesSV = new String[numDocs];
         }
         if (inputDataType == DataType.BOOLEAN) {
           int[] intValues = _transformFunction.transformToIntValuesSV(projectionBlock);
@@ -263,7 +267,7 @@ public class CastTransformFunction extends BaseTransformFunction {
       }
     } else {
       if (_stringValuesSV == null) {
-        _stringValuesSV = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+        _stringValuesSV = new String[numDocs];
       }
       switch (resultDataType) {
         case INT:

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
@@ -101,7 +101,7 @@ public class CastTransformFunction extends BaseTransformFunction {
     } else {
       int numDocs = projectionBlock.getNumDocs();
       
-      if (_intValuesSV == null) {
+      if (_intValuesSV == null || _intValuesSV.length < numDocs) {
         _intValuesSV = new int[numDocs];
       }
       switch (resultStoredType) {
@@ -137,7 +137,7 @@ public class CastTransformFunction extends BaseTransformFunction {
     } else {
       int numDocs = projectionBlock.getNumDocs();
 
-      if (_longValuesSV == null) {
+      if (_longValuesSV == null || _longValuesSV.length < numDocs) {
         _longValuesSV = new long[numDocs];
       }
       switch (resultStoredType) {
@@ -173,7 +173,7 @@ public class CastTransformFunction extends BaseTransformFunction {
     } else {
       int numDocs = projectionBlock.getNumDocs();
 
-      if (_floatValuesSV == null) {
+      if (_floatValuesSV == null || _floatValuesSV.length < numDocs) {
         _floatValuesSV = new float[numDocs];
       }
       switch (resultStoredType) {
@@ -209,7 +209,7 @@ public class CastTransformFunction extends BaseTransformFunction {
     } else {
       int numDocs = projectionBlock.getNumDocs();
 
-      if (_doubleValuesSV == null) {
+      if (_doubleValuesSV == null || _doubleValuesSV.length < numDocs) {
         _doubleValuesSV = new double[numDocs];
       }
       switch (resultStoredType) {
@@ -246,7 +246,7 @@ public class CastTransformFunction extends BaseTransformFunction {
       // Specialize BOOlEAN and TIMESTAMP when casting to STRING
       DataType inputDataType = _transformFunction.getResultMetadata().getDataType();
       if (inputDataType.getStoredType() != inputDataType) {
-        if (_stringValuesSV == null) {
+        if (_stringValuesSV == null || _stringValuesSV.length < numDocs) {
           _stringValuesSV = new String[numDocs];
         }
         if (inputDataType == DataType.BOOLEAN) {
@@ -266,7 +266,7 @@ public class CastTransformFunction extends BaseTransformFunction {
         return _transformFunction.transformToStringValuesSV(projectionBlock);
       }
     } else {
-      if (_stringValuesSV == null) {
+      if (_stringValuesSV == null || _stringValuesSV.length < numDocs) {
         _stringValuesSV = new String[numDocs];
       }
       switch (resultDataType) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunction.java
@@ -129,7 +129,7 @@ public class DateTimeConversionTransformFunction extends BaseTransformFunction {
     if (_resultMetadata == LONG_SV_NO_DICTIONARY_METADATA) {
       int length = projectionBlock.getNumDocs();
 
-      if (_longOutputTimes == null) {
+      if (_longOutputTimes == null || _longOutputTimes.length < length) {
         _longOutputTimes = new long[length];
       }
 
@@ -153,7 +153,7 @@ public class DateTimeConversionTransformFunction extends BaseTransformFunction {
     if (_resultMetadata == STRING_SV_NO_DICTIONARY_METADATA) {
       int length = projectionBlock.getNumDocs();
 
-      if (_stringOutputTimes == null) {
+      if (_stringOutputTimes == null || _stringOutputTimes.length < length) {
         _stringOutputTimes = new String[length];
       }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunction.java
@@ -127,11 +127,12 @@ public class DateTimeConversionTransformFunction extends BaseTransformFunction {
   @Override
   public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
     if (_resultMetadata == LONG_SV_NO_DICTIONARY_METADATA) {
+      int length = projectionBlock.getNumDocs();
+
       if (_longOutputTimes == null) {
-        _longOutputTimes = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+        _longOutputTimes = new long[length];
       }
 
-      int length = projectionBlock.getNumDocs();
       if (_dateTimeTransformer instanceof EpochToEpochTransformer) {
         EpochToEpochTransformer dateTimeTransformer = (EpochToEpochTransformer) _dateTimeTransformer;
         dateTimeTransformer
@@ -150,11 +151,12 @@ public class DateTimeConversionTransformFunction extends BaseTransformFunction {
   @Override
   public String[] transformToStringValuesSV(ProjectionBlock projectionBlock) {
     if (_resultMetadata == STRING_SV_NO_DICTIONARY_METADATA) {
+      int length = projectionBlock.getNumDocs();
+
       if (_stringOutputTimes == null) {
-        _stringOutputTimes = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+        _stringOutputTimes = new String[length];
       }
 
-      int length = projectionBlock.getNumDocs();
       if (_dateTimeTransformer instanceof EpochToSDFTransformer) {
         EpochToSDFTransformer dateTimeTransformer = (EpochToSDFTransformer) _dateTimeTransformer;
         dateTimeTransformer

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTruncTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTruncTransformFunction.java
@@ -130,11 +130,12 @@ public class DateTruncTransformFunction extends BaseTransformFunction {
 
   @Override
   public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+
     if (_longOutputTimes == null) {
-      _longOutputTimes = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      _longOutputTimes = new long[length];
     }
 
-    int length = projectionBlock.getNumDocs();
     long[] input = _mainTransformFunction.transformToLongValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
       _longOutputTimes[i] = _outputTimeUnit

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunction.java
@@ -77,11 +77,11 @@ public class DivisionTransformFunction extends BaseTransformFunction {
   @SuppressWarnings("Duplicates")
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
-    if (_quotients == null) {
-      _quotients = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-    }
-
     int length = projectionBlock.getNumDocs();
+
+    if (_quotients == null) {
+      _quotients = new double[length];
+    }
 
     if (_firstTransformFunction == null) {
       Arrays.fill(_quotients, 0, length, _firstLiteral);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunction.java
@@ -79,7 +79,7 @@ public class DivisionTransformFunction extends BaseTransformFunction {
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
 
-    if (_quotients == null) {
+    if (_quotients == null || _quotients.length < length) {
       _quotients = new double[length];
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/InIdSetTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/InIdSetTransformFunction.java
@@ -77,7 +77,7 @@ public class InIdSetTransformFunction extends BaseTransformFunction {
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
 
-    if (_results == null) {
+    if (_results == null || _results.length < length) {
       _results = new int[length];
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/InIdSetTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/InIdSetTransformFunction.java
@@ -75,11 +75,12 @@ public class InIdSetTransformFunction extends BaseTransformFunction {
 
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+
     if (_results == null) {
-      _results = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      _results = new int[length];
     }
 
-    int length = projectionBlock.getNumDocs();
     DataType storedType = _transformFunction.getResultMetadata().getDataType().getStoredType();
     switch (storedType) {
       case INT:

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/InTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/InTransformFunction.java
@@ -139,13 +139,14 @@ public class InTransformFunction extends BaseTransformFunction {
 
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+
     if (_intValuesSV == null) {
-      _intValuesSV = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      _intValuesSV = new int[length];
     } else {
       Arrays.fill(_intValuesSV, 0);
     }
 
-    int length = projectionBlock.getNumDocs();
     TransformResultMetadata mainFunctionMetadata = _mainFunction.getResultMetadata();
     DataType storedType = mainFunctionMetadata.getDataType().getStoredType();
     if (_valueSet != null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractKeyTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractKeyTransformFunction.java
@@ -86,12 +86,13 @@ public class JsonExtractKeyTransformFunction extends BaseTransformFunction {
 
   @Override
   public String[][] transformToStringValuesMV(ProjectionBlock projectionBlock) {
+    int numDocs = projectionBlock.getNumDocs();
+
     if (_stringValuesMV == null) {
-      _stringValuesMV = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+      _stringValuesMV = new String[numDocs][];
     }
 
     String[] jsonStrings = _jsonFieldTransformFunction.transformToStringValuesSV(projectionBlock);
-    int numDocs = projectionBlock.getNumDocs();
     for (int i = 0; i < numDocs; i++) {
       List<String> values = JSON_PARSER_CONTEXT.parse(jsonStrings[i]).read(_jsonPath);
       _stringValuesMV[i] = values.toArray(new String[0]);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractKeyTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractKeyTransformFunction.java
@@ -88,7 +88,7 @@ public class JsonExtractKeyTransformFunction extends BaseTransformFunction {
   public String[][] transformToStringValuesMV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
 
-    if (_stringValuesMV == null) {
+    if (_stringValuesMV == null || _stringValuesSV.length < numDocs) {
       _stringValuesMV = new String[numDocs][];
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LogicalOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LogicalOperatorTransformFunction.java
@@ -62,7 +62,7 @@ public abstract class LogicalOperatorTransformFunction extends BaseTransformFunc
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
 
-    if (_results == null) {
+    if (_results == null || _results.length < numDocs) {
       _results = new int[numDocs];
     }
     ArrayCopyUtils.copy(_arguments.get(0).transformToIntValuesSV(projectionBlock), _results, numDocs);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LogicalOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LogicalOperatorTransformFunction.java
@@ -60,10 +60,11 @@ public abstract class LogicalOperatorTransformFunction extends BaseTransformFunc
 
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
-    if (_results == null) {
-      _results = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-    }
     int numDocs = projectionBlock.getNumDocs();
+
+    if (_results == null) {
+      _results = new int[numDocs];
+    }
     ArrayCopyUtils.copy(_arguments.get(0).transformToIntValuesSV(projectionBlock), _results, numDocs);
     int numArguments = _arguments.size();
     for (int i = 1; i < numArguments; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MapValueTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MapValueTransformFunction.java
@@ -97,13 +97,14 @@ public class MapValueTransformFunction extends BaseTransformFunction {
 
   @Override
   public int[] transformToDictIdsSV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+
     if (_dictIds == null) {
-      _dictIds = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      _dictIds = new int[length];
     }
 
     int[][] keyDictIdsMV = _keyColumnFunction.transformToDictIdsMV(projectionBlock);
     int[][] valueDictIdsMV = _valueColumnFunction.transformToDictIdsMV(projectionBlock);
-    int length = projectionBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
       int[] keyDictIds = keyDictIdsMV[i];
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MapValueTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MapValueTransformFunction.java
@@ -99,7 +99,7 @@ public class MapValueTransformFunction extends BaseTransformFunction {
   public int[] transformToDictIdsSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
 
-    if (_dictIds == null) {
+    if (_dictIds == null || _dictIds.length < length) {
       _dictIds = new int[length];
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ModuloTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ModuloTransformFunction.java
@@ -77,11 +77,11 @@ public class ModuloTransformFunction extends BaseTransformFunction {
   @SuppressWarnings("Duplicates")
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
-    if (_modulos == null) {
-      _modulos = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-    }
-
     int length = projectionBlock.getNumDocs();
+
+    if (_modulos == null) {
+      _modulos = new double[length];
+    }
 
     if (_firstTransformFunction == null) {
       Arrays.fill(_modulos, 0, length, _firstLiteral);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ModuloTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ModuloTransformFunction.java
@@ -79,7 +79,7 @@ public class ModuloTransformFunction extends BaseTransformFunction {
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
 
-    if (_modulos == null) {
+    if (_modulos == null || _modulos.length < length) {
       _modulos = new double[length];
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunction.java
@@ -68,7 +68,7 @@ public class MultiplicationTransformFunction extends BaseTransformFunction {
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
 
-    if (_products == null) {
+    if (_products == null || _products.length < length) {
       _products = new double[length];
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunction.java
@@ -66,11 +66,12 @@ public class MultiplicationTransformFunction extends BaseTransformFunction {
 
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+
     if (_products == null) {
-      _products = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      _products = new double[length];
     }
 
-    int length = projectionBlock.getNumDocs();
     Arrays.fill(_products, 0, length, _literalProduct);
     for (TransformFunction transformFunction : _transformFunctions) {
       double[] values = transformFunction.transformToDoubleValuesSV(projectionBlock);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapper.java
@@ -125,11 +125,12 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     if (_resultMetadata.getDataType().getStoredType() != DataType.INT) {
       return super.transformToIntValuesSV(projectionBlock);
     }
+    int length = projectionBlock.getNumDocs();
+
     if (_intResults == null) {
-      _intResults = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      _intResults = new int[length];
     }
     getNonLiteralValues(projectionBlock);
-    int length = projectionBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
         _arguments[_nonLiteralIndices[j]] = _nonLiteralValues[j][i];
@@ -144,11 +145,12 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     if (_resultMetadata.getDataType().getStoredType() != DataType.LONG) {
       return super.transformToLongValuesSV(projectionBlock);
     }
+    int length = projectionBlock.getNumDocs();
+
     if (_longResults == null) {
-      _longResults = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      _longResults = new long[length];
     }
     getNonLiteralValues(projectionBlock);
-    int length = projectionBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
         _arguments[_nonLiteralIndices[j]] = _nonLiteralValues[j][i];
@@ -163,11 +165,12 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     if (_resultMetadata.getDataType().getStoredType() != DataType.FLOAT) {
       return super.transformToFloatValuesSV(projectionBlock);
     }
+    int length = projectionBlock.getNumDocs();
+
     if (_floatResults == null) {
-      _floatResults = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      _floatResults = new float[length];
     }
     getNonLiteralValues(projectionBlock);
-    int length = projectionBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
         _arguments[_nonLiteralIndices[j]] = _nonLiteralValues[j][i];
@@ -182,11 +185,12 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     if (_resultMetadata.getDataType().getStoredType() != DataType.DOUBLE) {
       return super.transformToDoubleValuesSV(projectionBlock);
     }
+    int length = projectionBlock.getNumDocs();
+
     if (_doubleResults == null) {
-      _doubleResults = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      _doubleResults = new double[length];
     }
     getNonLiteralValues(projectionBlock);
-    int length = projectionBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
         _arguments[_nonLiteralIndices[j]] = _nonLiteralValues[j][i];
@@ -201,11 +205,12 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     if (_resultMetadata.getDataType().getStoredType() != DataType.STRING) {
       return super.transformToStringValuesSV(projectionBlock);
     }
+    int length = projectionBlock.getNumDocs();
+
     if (_stringResults == null) {
-      _stringResults = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      _stringResults = new String[length];
     }
     getNonLiteralValues(projectionBlock);
-    int length = projectionBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
         _arguments[_nonLiteralIndices[j]] = _nonLiteralValues[j][i];
@@ -222,11 +227,12 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     if (_resultMetadata.getDataType().getStoredType() != DataType.BYTES) {
       return super.transformToBytesValuesSV(projectionBlock);
     }
+    int length = projectionBlock.getNumDocs();
+
     if (_bytesResults == null) {
-      _bytesResults = new byte[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+      _bytesResults = new byte[length][];
     }
     getNonLiteralValues(projectionBlock);
-    int length = projectionBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
         _arguments[_nonLiteralIndices[j]] = _nonLiteralValues[j][i];
@@ -241,11 +247,12 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     if (_resultMetadata.getDataType().getStoredType() != DataType.INT) {
       return super.transformToIntValuesMV(projectionBlock);
     }
+    int length = projectionBlock.getNumDocs();
+
     if (_intMVResults == null) {
-      _intMVResults = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+      _intMVResults = new int[length][];
     }
     getNonLiteralValues(projectionBlock);
-    int length = projectionBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
         _arguments[_nonLiteralIndices[j]] = _nonLiteralValues[j][i];
@@ -260,11 +267,12 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     if (_resultMetadata.getDataType().getStoredType() != DataType.LONG) {
       return super.transformToLongValuesMV(projectionBlock);
     }
+    int length = projectionBlock.getNumDocs();
+
     if (_longMVResults == null) {
-      _longMVResults = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+      _longMVResults = new long[length][];
     }
     getNonLiteralValues(projectionBlock);
-    int length = projectionBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
         _arguments[_nonLiteralIndices[j]] = _nonLiteralValues[j][i];
@@ -279,11 +287,12 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     if (_resultMetadata.getDataType().getStoredType() != DataType.FLOAT) {
       return super.transformToFloatValuesMV(projectionBlock);
     }
+    int length = projectionBlock.getNumDocs();
+
     if (_floatMVResults == null) {
-      _floatMVResults = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+      _floatMVResults = new float[length][];
     }
     getNonLiteralValues(projectionBlock);
-    int length = projectionBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
         _arguments[_nonLiteralIndices[j]] = _nonLiteralValues[j][i];
@@ -298,11 +307,12 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     if (_resultMetadata.getDataType().getStoredType() != DataType.DOUBLE) {
       return super.transformToDoubleValuesMV(projectionBlock);
     }
+    int length = projectionBlock.getNumDocs();
+
     if (_doubleMVResults == null) {
-      _doubleMVResults = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+      _doubleMVResults = new double[length][];
     }
     getNonLiteralValues(projectionBlock);
-    int length = projectionBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
         _arguments[_nonLiteralIndices[j]] = _nonLiteralValues[j][i];
@@ -317,11 +327,12 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     if (_resultMetadata.getDataType().getStoredType() != DataType.STRING) {
       return super.transformToStringValuesMV(projectionBlock);
     }
+    int length = projectionBlock.getNumDocs();
+
     if (_stringMVResults == null) {
-      _stringMVResults = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+      _stringMVResults = new String[length][];
     }
     getNonLiteralValues(projectionBlock);
-    int length = projectionBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
         _arguments[_nonLiteralIndices[j]] = _nonLiteralValues[j][i];

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapper.java
@@ -127,7 +127,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     }
     int length = projectionBlock.getNumDocs();
 
-    if (_intResults == null) {
+    if (_intResults == null || _intResults.length < length) {
       _intResults = new int[length];
     }
     getNonLiteralValues(projectionBlock);
@@ -147,7 +147,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     }
     int length = projectionBlock.getNumDocs();
 
-    if (_longResults == null) {
+    if (_longResults == null || _longResults.length < length) {
       _longResults = new long[length];
     }
     getNonLiteralValues(projectionBlock);
@@ -167,7 +167,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     }
     int length = projectionBlock.getNumDocs();
 
-    if (_floatResults == null) {
+    if (_floatResults == null || _floatResults.length < length) {
       _floatResults = new float[length];
     }
     getNonLiteralValues(projectionBlock);
@@ -187,7 +187,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     }
     int length = projectionBlock.getNumDocs();
 
-    if (_doubleResults == null) {
+    if (_doubleResults == null || _doubleResults.length < length) {
       _doubleResults = new double[length];
     }
     getNonLiteralValues(projectionBlock);
@@ -207,7 +207,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     }
     int length = projectionBlock.getNumDocs();
 
-    if (_stringResults == null) {
+    if (_stringResults == null || _stringResults.length < length) {
       _stringResults = new String[length];
     }
     getNonLiteralValues(projectionBlock);
@@ -229,7 +229,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     }
     int length = projectionBlock.getNumDocs();
 
-    if (_bytesResults == null) {
+    if (_bytesResults == null || _bytesResults.length < length) {
       _bytesResults = new byte[length][];
     }
     getNonLiteralValues(projectionBlock);
@@ -269,7 +269,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     }
     int length = projectionBlock.getNumDocs();
 
-    if (_longMVResults == null) {
+    if (_longMVResults == null || _longMVResults.length < length) {
       _longMVResults = new long[length][];
     }
     getNonLiteralValues(projectionBlock);
@@ -289,7 +289,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     }
     int length = projectionBlock.getNumDocs();
 
-    if (_floatMVResults == null) {
+    if (_floatMVResults == null || _floatMVResults.length < length) {
       _floatMVResults = new float[length][];
     }
     getNonLiteralValues(projectionBlock);
@@ -309,7 +309,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     }
     int length = projectionBlock.getNumDocs();
 
-    if (_doubleMVResults == null) {
+    if (_doubleMVResults == null || _doubleMVResults.length < length) {
       _doubleMVResults = new double[length][];
     }
     getNonLiteralValues(projectionBlock);
@@ -329,7 +329,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
     }
     int length = projectionBlock.getNumDocs();
 
-    if (_stringMVResults == null) {
+    if (_stringMVResults == null || _stringMVResults.length < length) {
       _stringMVResults = new String[length][];
     }
     getNonLiteralValues(projectionBlock);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
@@ -33,7 +33,6 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
  */
 public abstract class SingleParamMathTransformFunction extends BaseTransformFunction {
   private TransformFunction _transformFunction;
-  protected double[] _results;
 
   @Override
   public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
@@ -55,13 +54,15 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
 
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
-    if (_results == null) {
-      _results = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+    int length = projectionBlock.getNumDocs();
+
+    if (_doubleValuesSV == null) {
+      _doubleValuesSV = new double[length];
     }
 
     double[] values = _transformFunction.transformToDoubleValuesSV(projectionBlock);
     applyMathOperator(values, projectionBlock.getNumDocs());
-    return _results;
+    return _doubleValuesSV;
   }
 
   abstract protected void applyMathOperator(double[] values, int length);
@@ -77,7 +78,7 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
     @Override
     protected void applyMathOperator(double[] values, int length) {
       for (int i = 0; i < length; i++) {
-        _results[i] = Math.abs(values[i]);
+        _doubleValuesSV[i] = Math.abs(values[i]);
       }
     }
   }
@@ -93,7 +94,7 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
     @Override
     protected void applyMathOperator(double[] values, int length) {
       for (int i = 0; i < length; i++) {
-        _results[i] = Math.ceil(values[i]);
+        _doubleValuesSV[i] = Math.ceil(values[i]);
       }
     }
   }
@@ -109,7 +110,7 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
     @Override
     protected void applyMathOperator(double[] values, int length) {
       for (int i = 0; i < length; i++) {
-        _results[i] = Math.exp(values[i]);
+        _doubleValuesSV[i] = Math.exp(values[i]);
       }
     }
   }
@@ -125,7 +126,7 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
     @Override
     protected void applyMathOperator(double[] values, int length) {
       for (int i = 0; i < length; i++) {
-        _results[i] = Math.floor(values[i]);
+        _doubleValuesSV[i] = Math.floor(values[i]);
       }
     }
   }
@@ -141,7 +142,7 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
     @Override
     protected void applyMathOperator(double[] values, int length) {
       for (int i = 0; i < length; i++) {
-        _results[i] = Math.log(values[i]);
+        _doubleValuesSV[i] = Math.log(values[i]);
       }
     }
   }
@@ -157,7 +158,7 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
     @Override
     protected void applyMathOperator(double[] values, int length) {
       for (int i = 0; i < length; i++) {
-        _results[i] = Math.sqrt(values[i]);
+        _doubleValuesSV[i] = Math.sqrt(values[i]);
       }
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
@@ -56,7 +56,7 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
 
-    if (_doubleValuesSV == null) {
+    if (_doubleValuesSV == null || _doubleValuesMV.length < length) {
       _doubleValuesSV = new double[length];
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunction.java
@@ -79,7 +79,7 @@ public class SubtractionTransformFunction extends BaseTransformFunction {
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
 
-    if (_differences == null) {
+    if (_differences == null || _differences.length < length) {
       _differences = new double[length];
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunction.java
@@ -77,11 +77,11 @@ public class SubtractionTransformFunction extends BaseTransformFunction {
   @SuppressWarnings("Duplicates")
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
-    if (_differences == null) {
-      _differences = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-    }
-
     int length = projectionBlock.getNumDocs();
+
+    if (_differences == null) {
+      _differences = new double[length];
+    }
 
     if (_firstTransformFunction == null) {
       Arrays.fill(_differences, 0, length, _firstLiteral);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TimeConversionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TimeConversionTransformFunction.java
@@ -68,12 +68,14 @@ public class TimeConversionTransformFunction extends BaseTransformFunction {
 
   @Override
   public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+
     if (_outputTimes == null) {
-      _outputTimes = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+      _outputTimes = new long[length];
     }
 
     _timeUnitTransformer.transform(_mainTransformFunction.transformToLongValuesSV(projectionBlock), _outputTimes,
-        projectionBlock.getNumDocs());
+        length);
     return _outputTimes;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TimeConversionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TimeConversionTransformFunction.java
@@ -70,7 +70,7 @@ public class TimeConversionTransformFunction extends BaseTransformFunction {
   public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
 
-    if (_outputTimes == null) {
+    if (_outputTimes == null || _outputTimes.length < length) {
       _outputTimes = new long[length];
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ValueInTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ValueInTransformFunction.java
@@ -109,6 +109,8 @@ public class ValueInTransformFunction extends BaseTransformFunction {
 
   @Override
   public int[][] transformToDictIdsMV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+
     if (_dictIdSet == null) {
       _dictIdSet = new IntOpenHashSet();
       assert _dictionary != null;
@@ -118,10 +120,9 @@ public class ValueInTransformFunction extends BaseTransformFunction {
           _dictIdSet.add(dictId);
         }
       }
-      _dictIds = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+      _dictIds = new int[length][];
     }
     int[][] unFilteredDictIds = _mainTransformFunction.transformToDictIdsMV(projectionBlock);
-    int length = projectionBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
       _dictIds[i] = filterInts(_dictIdSet, unFilteredDictIds[i]);
     }
@@ -134,15 +135,15 @@ public class ValueInTransformFunction extends BaseTransformFunction {
       return super.transformToIntValuesMV(projectionBlock);
     }
 
+    int length = projectionBlock.getNumDocs();
     if (_intValueSet == null) {
       _intValueSet = new IntOpenHashSet();
       for (String inValue : _stringValueSet) {
         _intValueSet.add(Integer.parseInt(inValue));
       }
-      _intValues = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+      _intValues = new int[length][];
     }
     int[][] unFilteredIntValues = _mainTransformFunction.transformToIntValuesMV(projectionBlock);
-    int length = projectionBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
       _intValues[i] = filterInts(_intValueSet, unFilteredIntValues[i]);
     }
@@ -155,15 +156,15 @@ public class ValueInTransformFunction extends BaseTransformFunction {
       return super.transformToLongValuesMV(projectionBlock);
     }
 
+    int length = projectionBlock.getNumDocs();
     if (_longValueSet == null) {
       _longValueSet = new LongOpenHashSet();
       for (String inValue : _stringValueSet) {
         _longValueSet.add(Long.parseLong(inValue));
       }
-      _longValues = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+      _longValues = new long[length][];
     }
     long[][] unFilteredLongValues = _mainTransformFunction.transformToLongValuesMV(projectionBlock);
-    int length = projectionBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
       _longValues[i] = filterLongs(_longValueSet, unFilteredLongValues[i]);
     }
@@ -176,15 +177,15 @@ public class ValueInTransformFunction extends BaseTransformFunction {
       return super.transformToFloatValuesMV(projectionBlock);
     }
 
+    int length = projectionBlock.getNumDocs();
     if (_floatValueSet == null) {
       _floatValueSet = new FloatOpenHashSet();
       for (String inValue : _stringValueSet) {
         _floatValueSet.add(Float.parseFloat(inValue));
       }
-      _floatValues = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+      _floatValues = new float[length][];
     }
     float[][] unFilteredFloatValues = _mainTransformFunction.transformToFloatValuesMV(projectionBlock);
-    int length = projectionBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
       _floatValues[i] = filterFloats(_floatValueSet, unFilteredFloatValues[i]);
     }
@@ -197,15 +198,15 @@ public class ValueInTransformFunction extends BaseTransformFunction {
       return super.transformToDoubleValuesMV(projectionBlock);
     }
 
+    int length = projectionBlock.getNumDocs();
     if (_doubleValueSet == null) {
       _doubleValueSet = new DoubleOpenHashSet();
       for (String inValue : _stringValueSet) {
         _doubleValueSet.add(Double.parseDouble(inValue));
       }
-      _doubleValues = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+      _doubleValues = new double[length][];
     }
     double[][] unFilteredDoubleValues = _mainTransformFunction.transformToDoubleValuesMV(projectionBlock);
-    int length = projectionBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
       _doubleValues[i] = filterDoubles(_doubleValueSet, unFilteredDoubleValues[i]);
     }
@@ -218,11 +219,11 @@ public class ValueInTransformFunction extends BaseTransformFunction {
       return super.transformToStringValuesMV(projectionBlock);
     }
 
+    int length = projectionBlock.getNumDocs();
     if (_stringValues == null) {
-      _stringValues = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+      _stringValues = new String[length][];
     }
     String[][] unFilteredStringValues = _mainTransformFunction.transformToStringValuesMV(projectionBlock);
-    int length = projectionBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
       _stringValues[i] = filterStrings(_stringValueSet, unFilteredStringValues[i]);
     }


### PR DESCRIPTION
This PR consists of two changes for existing transform function - 

- Only create results array for length of input and not for `DocIdSetPlanNode.MAX_DOC_PER_CALL`
- Reuse result arrays if input length is less than existing array length

