### PR TITLE
Remove secrets from job spec

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncher.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncher.java
@@ -94,7 +94,7 @@ public class IngestionJobLauncher {
   }
 
   public static void runIngestionJob(SegmentGenerationJobSpec spec) {
-    LOGGER.info("SegmentGenerationJobSpec: \n{}", spec.asJSONString(true));
+    LOGGER.info("SegmentGenerationJobSpec: \n{}", spec.toJSONString(true));
     ExecutionFrameworkSpec executionFramework = spec.getExecutionFrameworkSpec();
     PinotIngestionJobType jobType = PinotIngestionJobType.fromString(spec.getJobType());
     switch (jobType) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncher.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/IngestionJobLauncher.java
@@ -23,7 +23,6 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
-import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -95,9 +94,7 @@ public class IngestionJobLauncher {
   }
 
   public static void runIngestionJob(SegmentGenerationJobSpec spec) {
-    StringWriter sw = new StringWriter();
-    new Yaml().dump(spec, sw);
-    LOGGER.info("SegmentGenerationJobSpec: \n{}", sw.toString());
+    LOGGER.info("SegmentGenerationJobSpec: \n{}", spec.asJSONString(true));
     ExecutionFrameworkSpec executionFramework = spec.getExecutionFrameworkSpec();
     PinotIngestionJobType jobType = PinotIngestionJobType.fromString(spec.getJobType());
     switch (jobType) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
@@ -18,8 +18,10 @@
  */
 package org.apache.pinot.spi.ingestion.batch.spec;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.Serializable;
 import java.util.List;
+import org.apache.pinot.spi.utils.JsonUtils;
 
 
 /**
@@ -287,5 +289,13 @@ public class SegmentGenerationJobSpec implements Serializable {
 
   public void setAuthToken(String authToken) {
     _authToken = authToken;
+  }
+
+  public String asJSONString(boolean removeSensitiveKeys) {
+    ObjectNode jsonNode = (ObjectNode) JsonUtils.objectToJsonNode(this);
+    if (removeSensitiveKeys) {
+      jsonNode.remove("authToken"); //Removing auth token as it is a sensitive key
+    }
+    return jsonNode.toPrettyString();
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
@@ -291,7 +291,7 @@ public class SegmentGenerationJobSpec implements Serializable {
     _authToken = authToken;
   }
 
-  public String asJSONString(boolean removeSensitiveKeys) {
+  public String toJSONString(boolean removeSensitiveKeys) {
     ObjectNode jsonNode = (ObjectNode) JsonUtils.objectToJsonNode(this);
     if (removeSensitiveKeys) {
       jsonNode.remove("authToken"); //Removing auth token as it is a sensitive key


### PR DESCRIPTION
This PR addresses the issue https://github.com/apache/pinot/issues/8363
We may need to make changes at other places as well where auth token is going into logs.
I have also switched the output format to JSON instead of YAML as we already support JSON in ingestion spec and all the other configs are dumped as JSON as well.
