### PR TITLE
Change TableDataManger deletion to message based

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/messages/TableDeletionMessage.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/messages/TableDeletionMessage.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.messages;
+
+import com.google.common.base.Preconditions;
+import java.util.UUID;
+import javax.annotation.Nonnull;
+import org.apache.helix.model.Message;
+
+/**
+ * This Helix message is sent from the controller to the servers to remove TableDataManager when the table is deleted.
+ */
+public class TableDeletionMessage extends Message {
+  public static final String DELETE_TABLE_MSG_SUB_TYPE = "DELETE_TABLE";
+
+  public TableDeletionMessage(@Nonnull String tableNameWithType) {
+    super(MessageType.USER_DEFINE_MSG, UUID.randomUUID().toString());
+    setResourceName(tableNameWithType);
+    setMsgSubType(DELETE_TABLE_MSG_SUB_TYPE);
+    // Give it infinite time to process the message, as long as session is alive
+    setExecutionTimeout(-1);
+  }
+
+  public TableDeletionMessage(Message message) {
+    super(message.getRecord());
+    String msgSubType = message.getMsgSubType();
+    Preconditions.checkArgument(msgSubType.equals(DELETE_TABLE_MSG_SUB_TYPE),
+        "Invalid message sub type: " + msgSubType + " for TableDeletionMessage");
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -33,6 +33,7 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   QUERY_EXECUTION_EXCEPTIONS("exceptions", false),
   HELIX_ZOOKEEPER_RECONNECTS("reconnects", true),
   DELETED_SEGMENT_COUNT("segments", false),
+  DELETE_TABLE_FAILURES("tables", false),
   REALTIME_ROWS_CONSUMED("rows", true),
   INVALID_REALTIME_ROWS_DROPPED("rows", false),
   REALTIME_CONSUMPTION_EXCEPTIONS("exceptions", true),

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
@@ -67,6 +67,12 @@ public interface InstanceDataManager {
   void shutDown();
 
   /**
+   * Delete a table.
+   */
+  void deleteTable(String tableNameWithType)
+      throws Exception;
+
+  /**
    * Adds a segment from local disk into an OFFLINE table.
    */
   void addOfflineSegment(String offlineTableName, String segmentName, File indexDir)

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -245,6 +245,10 @@ public abstract class ClusterTest extends ControllerTest {
     }
   }
 
+  protected List<HelixServerStarter> getServerStarters() {
+    return _serverStarters;
+  }
+
   protected void startServerHttps() {
     FileUtils.deleteQuietly(new File(Server.DEFAULT_INSTANCE_BASE_DIR));
     _serverStarters = new ArrayList<>();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -30,6 +30,7 @@ import org.apache.pinot.client.ResultSetGroup;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.core.query.utils.idset.IdSet;
 import org.apache.pinot.core.query.utils.idset.IdSets;
+import org.apache.pinot.server.starter.helix.HelixServerStarter;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.MetricFieldSpec;
@@ -70,6 +71,27 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
    */
   protected int getNumQueriesToGenerate() {
     return DEFAULT_NUM_QUERIES_TO_GENERATE;
+  }
+
+  /**
+   * Test server table data manager deletion after the table is dropped
+   */
+  protected void cleanupTestTableDataManager(String tableNameWithType)
+      throws Exception {
+    List<HelixServerStarter> serverStarters = getServerStarters();
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        for (HelixServerStarter serverStarter : serverStarters) {
+          if (serverStarter.getServerInstance().getInstanceDataManager().getTableDataManager(tableNameWithType)
+              != null) {
+            return false;
+          }
+        }
+        return true;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, 600_000L, "Failed to delete table data managers");
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeClusterIntegrationTest.java
@@ -25,6 +25,7 @@ import java.util.Random;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -167,6 +168,7 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTestSe
   public void tearDown()
       throws Exception {
     dropRealtimeTable(getTableName());
+    cleanupTestTableDataManager(TableNameBuilder.REALTIME.tableNameWithType(getTableName()));
     stopServer();
     stopBroker();
     stopController();

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.server.starter.helix;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -716,6 +717,11 @@ public abstract class BaseServerStarter implements ServiceStartable {
   @Override
   public PinotConfiguration getConfig() {
     return _serverConf;
+  }
+
+  @VisibleForTesting
+  public ServerInstance getServerInstance() {
+    return _serverInstance;
   }
 
   /**


### PR DESCRIPTION
This pr improves the TableDataManager thread safety issue (#8423) by ~~ ~~update `segmentDataManagerMap` with a place holder (dummy segmentDataManager) before downloading the segment, so `getNumSegment()` can give the correct segment count.~~ ~~
1. Remove the tableDataManager deletion mechanism when the number of segments drops to 0 to avoid race conditions.
2. Add TableDeletionMessage, the tableDataManager can only be removed upon receiving the TableDeletionMessage when the table is dropped.


