### PR TITLE
collapse redundant function types and add missing aliases

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -30,29 +30,23 @@ import org.apache.commons.lang.StringUtils;
 
 public enum TransformFunctionType {
   // Aggregation functions for single-valued columns
-  ADD("add"),
-  SUB("sub"),
-  MULT("mult"),
-  DIV("div"),
+  ADD("add", "plus"),
+  SUB("sub", "minus"),
+  MULT("mult", "times"),
+  DIV("div", "divide"),
   MOD("mod"),
 
-  PLUS("plus"),
-  MINUS("minus"),
-  TIMES("times"),
-  DIVIDE("divide"),
-
   ABS("abs"),
-  CEIL("ceil"),
+  CEIL("ceil", "ceiling"),
   EXP("exp"),
   FLOOR("floor"),
-  LN("ln"),
-  LOG("log"),
+  LOG("log", "ln"),
   LOG2("log2"),
   LOG10("log10"),
   SIGN("sign"),
   ROUND_DECIMAL("roundDecimal"),
   TRUNCATE("truncate"),
-  POWER("power"),
+  POWER("power", "pow"),
   SQRT("sqrt"),
 
   LEAST("least"),

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -90,16 +90,10 @@ public class TransformFunctionFactory {
     typeToImplementation.put(TransformFunctionType.DIV, DivisionTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.MOD, ModuloTransformFunction.class);
 
-    typeToImplementation.put(TransformFunctionType.PLUS, AdditionTransformFunction.class);
-    typeToImplementation.put(TransformFunctionType.MINUS, SubtractionTransformFunction.class);
-    typeToImplementation.put(TransformFunctionType.TIMES, MultiplicationTransformFunction.class);
-    typeToImplementation.put(TransformFunctionType.DIVIDE, DivisionTransformFunction.class);
-
     typeToImplementation.put(TransformFunctionType.ABS, AbsTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.CEIL, CeilTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.EXP, ExpTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.FLOOR, FloorTransformFunction.class);
-    typeToImplementation.put(TransformFunctionType.LN, LnTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.LOG, LnTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.LOG2, Log2TransformFunction.class);
     typeToImplementation.put(TransformFunctionType.LOG10, Log10TransformFunction.class);


### PR DESCRIPTION
Adds missing aliases so transform functions can be used (instead of falling back to scalar functions) and collapses redundant function types.