### PR TITLE
Adjust comparison of numDocsScanned

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/SqlResultComparator.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/SqlResultComparator.java
@@ -148,8 +148,11 @@ public class SqlResultComparator {
      * queries are selection queries during Calcite parsing (DISTINCT queries are selection queries with
      * selectNode.getModifierNode(SqlSelectKeyword.DISTINCT) != null).
      */
-    if (areResultsEqual && !isSelectionQuery(query) && !isNumDocsScannedBetter(actual, expected)) {
-      return false;
+    if (areResultsEqual) {
+      // Results are good, check for any metadata differences here.
+      if (!isSelectionQuery(query) && !isNumDocsScannedBetter(actual, expected)) {
+        return false;
+      }
     }
     return areResultsEqual;
   }
@@ -377,7 +380,7 @@ public class SqlResultComparator {
     long expectedNumEntriesScannedInFilter = expected.get(FIELD_NUM_ENTRIES_SCANNED_IN_FILTER).asLong();
     if (actualNumEntriesScannedInFilter > expectedNumEntriesScannedInFilter) {
       LOGGER
-          .error("The numEntriesScannedInFilter don't match! Actual: {}, Expected: {}", actualNumEntriesScannedInFilter,
+          .error("The numEntriesScannedInFilter is worse. Actual: {}, Expected: {}", actualNumEntriesScannedInFilter,
               expectedNumEntriesScannedInFilter);
       return false;
     }
@@ -388,7 +391,7 @@ public class SqlResultComparator {
     long actualNumEntriesScannedPostFilter = actual.get(FIELD_NUM_ENTRIES_SCANNED_POST_FILTER).asLong();
     long expectedNumEntriesScannedPostFilter = expected.get(FIELD_NUM_ENTRIES_SCANNED_POST_FILTER).asLong();
     if (actualNumEntriesScannedPostFilter > expectedNumEntriesScannedPostFilter) {
-      LOGGER.error("The numEntriesScannedPostFilter don't match! Actual: {}, Expected: {}",
+      LOGGER.error("The numEntriesScannedPostFilter is worse. Actual: {}, Expected: {}",
           actualNumEntriesScannedPostFilter, expectedNumEntriesScannedPostFilter);
       return false;
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/SqlResultComparator.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/SqlResultComparator.java
@@ -130,7 +130,7 @@ public class SqlResultComparator {
     if (!areLengthsEqual(actual, expected)) {
       return false;
     }
-    boolean areResultsEqual =  isOrderByQuery(query) ? areOrderByQueryElementsEqual(actualRows, expectedRows,
+    boolean areResultsEqual = isOrderByQuery(query) ? areOrderByQueryElementsEqual(actualRows, expectedRows,
         actualElementsSerialized, expectedElementsSerialized, query)
         : areNonOrderByQueryElementsEqual(actualElementsSerialized, expectedElementsSerialized);
     /*
@@ -278,7 +278,7 @@ public class SqlResultComparator {
     return true;
   }
 
-  public static boolean hasExceptions(JsonNode actual) {
+  private static boolean hasExceptions(JsonNode actual) {
     if (!actual.get(FIELD_EXCEPTIONS).isEmpty()) {
       LOGGER.error("Got exception: {} when querying!", actual.get(FIELD_EXCEPTIONS));
       return true;
@@ -372,10 +372,10 @@ public class SqlResultComparator {
     return true;
   }
 
-  private static boolean areNumEntriesScannedInFilterEqual(JsonNode actual, JsonNode expected) {
+  private static boolean isNumEntriesScannedInFilterBetter(JsonNode actual, JsonNode expected) {
     long actualNumEntriesScannedInFilter = actual.get(FIELD_NUM_ENTRIES_SCANNED_IN_FILTER).asLong();
     long expectedNumEntriesScannedInFilter = expected.get(FIELD_NUM_ENTRIES_SCANNED_IN_FILTER).asLong();
-    if (actualNumEntriesScannedInFilter != expectedNumEntriesScannedInFilter) {
+    if (actualNumEntriesScannedInFilter > expectedNumEntriesScannedInFilter) {
       LOGGER
           .error("The numEntriesScannedInFilter don't match! Actual: {}, Expected: {}", actualNumEntriesScannedInFilter,
               expectedNumEntriesScannedInFilter);
@@ -384,10 +384,10 @@ public class SqlResultComparator {
     return true;
   }
 
-  private static boolean areNumEntriesScannedPostFilterEqual(JsonNode actual, JsonNode expected) {
+  private static boolean isNumEntriesScannedPostFilterBetter(JsonNode actual, JsonNode expected) {
     long actualNumEntriesScannedPostFilter = actual.get(FIELD_NUM_ENTRIES_SCANNED_POST_FILTER).asLong();
     long expectedNumEntriesScannedPostFilter = expected.get(FIELD_NUM_ENTRIES_SCANNED_POST_FILTER).asLong();
-    if (actualNumEntriesScannedPostFilter != expectedNumEntriesScannedPostFilter) {
+    if (actualNumEntriesScannedPostFilter > expectedNumEntriesScannedPostFilter) {
       LOGGER.error("The numEntriesScannedPostFilter don't match! Actual: {}, Expected: {}",
           actualNumEntriesScannedPostFilter, expectedNumEntriesScannedPostFilter);
       return false;


### PR DESCRIPTION
Number of documents scanned can be lower than expected when comparing
results of compatibility tests. We don't like it to be higher since that
may indicate a performance regression.

Changed the code to not expect numDocsScanned to be equal all the time

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
