### PR TITLE
Add replica group based instance assigment algorithm with FD awareness 

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/FDAwareInstancePartitionSelector.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/FDAwareInstancePartitionSelector.java
@@ -88,7 +88,9 @@ public class FDAwareInstancePartitionSelector extends InstancePartitionSelector 
       int numInstancesToSelect = numInstancesPerReplicaGroup * numReplicaGroups;
 
       Preconditions.checkState(numInstancesToSelect <= numTotalInstances,
-          "Not enough qualified instances (%s in all FDs, asked for %s)", numTotalInstances, numInstancesToSelect);
+          "Not enough qualified instances, ask for: (numInstancesPerReplicaGroup: %d) * "
+              + "(numReplicaGroups: %d) = %d, having only %d",
+          numInstancesPerReplicaGroup, numReplicaGroups, numInstancesToSelect, numTotalInstances);
     } else {
       Preconditions.checkState(numTotalInstances % numReplicaGroups == 0,
           "The total num instances %s cannot be assigned evenly to %s replica groups, please "

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/FDAwareInstancePartitionSelector.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/FDAwareInstancePartitionSelector.java
@@ -88,8 +88,8 @@ public class FDAwareInstancePartitionSelector extends InstancePartitionSelector 
       int numInstancesToSelect = numInstancesPerReplicaGroup * numReplicaGroups;
 
       Preconditions.checkState(numInstancesToSelect <= numTotalInstances,
-          "Not enough qualified instances, ask for: (numInstancesPerReplicaGroup: %d) * "
-              + "(numReplicaGroups: %d) = %d, having only %d",
+          "Not enough qualified instances, ask for: (numInstancesPerReplicaGroup: %s) * "
+              + "(numReplicaGroups: %s) = %s, having only %s",
           numInstancesPerReplicaGroup, numReplicaGroups, numInstancesToSelect, numTotalInstances);
     } else {
       Preconditions.checkState(numTotalInstances % numReplicaGroups == 0,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/FDAwareInstancePartitionSelector.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/FDAwareInstancePartitionSelector.java
@@ -1,0 +1,455 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.assignment.instance;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.common.assignment.InstancePartitions;
+import org.apache.pinot.spi.config.table.assignment.InstanceReplicaGroupPartitionConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * The instance replica-group/partition selector is responsible for selecting the instances for every replica-group/
+ * partition, with each fault-domain mapping 1:1 to a server pool
+ * Algorithm details and proof see
+ * https://docs.google.com/document/d/1KmJ1DsYXVdzrojj_JYBHRJ2gRMQ5y-o63YqPs7ei7nI/edit#heading=h.nrxxvujq7ael
+ */
+public class FDAwareInstancePartitionSelector extends InstancePartitionSelector {
+  private static final Logger LOGGER = LoggerFactory.getLogger(FDAwareInstancePartitionSelector.class);
+
+  public FDAwareInstancePartitionSelector(InstanceReplicaGroupPartitionConfig replicaGroupPartitionConfig,
+      String tableNameWithType, @Nullable InstancePartitions existingInstancePartitions) {
+    super(replicaGroupPartitionConfig, tableNameWithType, existingInstancePartitions);
+  }
+
+  /**
+   * @return pair of (numFaultDomains, numTotalInstances)
+   */
+  private Pair<Integer, Integer> processFaultDomainPreconditions(
+      Map<Integer, List<InstanceConfig>> faultDomainToInstanceConfigsMap) {
+    int numFDs = faultDomainToInstanceConfigsMap.size();
+    Preconditions.checkState(numFDs != 0, "No pool (fault-domain) qualified for selection");
+
+    // Collect the number of instances in each FD into a list and sort
+    List<Integer> numInstancesPerFD =
+        faultDomainToInstanceConfigsMap.values().stream().map(List::size).sorted().collect(Collectors.toList());
+    // Should have non-zero total instances
+    Optional<Integer> totalInstancesOptional = numInstancesPerFD.stream().reduce(Integer::sum);
+    Preconditions.checkState(totalInstancesOptional.orElse(0) > 0, "The number of total instances is zero");
+    int numTotalInstances = totalInstancesOptional.get();
+    // Assume best-effort round-robin assignment of instances to FDs, the assignment should be balanced
+    // i.e., the difference between max num instances and min num instances should be at most 1
+    Preconditions.checkState(numInstancesPerFD.get(numInstancesPerFD.size() - 1) - numInstancesPerFD.get(0) <= 1,
+        "The instances are not balanced for each pool (fault-domain)");
+    return new ImmutablePair<>(numFDs, numTotalInstances);
+  }
+
+  /**
+   * @return (numReplicaGroups, numInstancesPerReplicaGroup)
+   */
+  private Pair<Integer, Integer> processReplicaGroupAssignmentPreconditions(int numFaultDomains, int numTotalInstances,
+      InstanceReplicaGroupPartitionConfig replicaGroupPartitionConfig) {
+    int numReplicaGroups = replicaGroupPartitionConfig.getNumReplicaGroups();
+    Preconditions.checkState(numReplicaGroups > 0, "Number of replica-groups must be positive");
+    int numInstancesPerReplicaGroup = replicaGroupPartitionConfig.getNumInstancesPerReplicaGroup();
+    if (numInstancesPerReplicaGroup > 0) {
+      int numInstancesToSelect = numInstancesPerReplicaGroup * numReplicaGroups;
+
+      Preconditions.checkState(numInstancesToSelect <= numTotalInstances,
+          "Not enough qualified instances (%s in all FDs, asked for %s)", numTotalInstances, numInstancesToSelect);
+    } else {
+      Preconditions.checkState(numTotalInstances % numReplicaGroups == 0,
+          "The total num instances %s cannot be assigned evenly to %s replica groups, please "
+              + "specify a numInstancesPerReplicaGroup in _replicaGroupPartitionConfig", numTotalInstances,
+          numReplicaGroups);
+      numInstancesPerReplicaGroup = numTotalInstances / numReplicaGroups;
+    }
+
+    if (numReplicaGroups > numFaultDomains) {
+      LOGGER.info("Assigning {} replica groups to {} fault domains, "
+              + "will have more than one replica group down if one fault domain is down", numReplicaGroups,
+          numFaultDomains);
+    } else {
+      LOGGER.info("Assigning {} replica groups to {} fault domains", numReplicaGroups, numFaultDomains);
+    }
+    return new ImmutablePair<>(numReplicaGroups, numInstancesPerReplicaGroup);
+  }
+
+  /**
+   * Selects instances based on the replica-group/partition config, and stores the result into the given instance
+   * partitions.
+   */
+  public void selectInstances(Map<Integer, List<InstanceConfig>> faultDomainToInstanceConfigsMap,
+      InstancePartitions instancePartitions) {
+
+    // Check if the instances are evenly assigned to each FD
+    Pair<Integer, Integer> fdRet = processFaultDomainPreconditions(faultDomainToInstanceConfigsMap);
+    int numFaultDomains = fdRet.getLeft();
+    int numTotalInstances = fdRet.getRight();
+
+    if (_replicaGroupPartitionConfig.isReplicaGroupBased()) {
+      // Replica-group based selection
+
+      // Check if the setup specified in _replicaGroupPartitionConfig can be satisfied
+      Pair<Integer, Integer> rgRet =
+          processReplicaGroupAssignmentPreconditions(numFaultDomains, numTotalInstances, _replicaGroupPartitionConfig);
+      int numReplicaGroups = rgRet.getLeft();
+      int numInstancesPerReplicaGroup = rgRet.getRight();
+
+      /*
+       * create an FD_id -> instance_names map and initialize with current instances, we will later exclude instances
+       * in existing assignment, and use the rest instances to do the assigment
+       */
+      Map<Integer, LinkedHashSet<String>> faultDomainToCandidateInstancesMap = new TreeMap<>();
+      faultDomainToInstanceConfigsMap.forEach(
+          (k, v) -> faultDomainToCandidateInstancesMap.put(k, new LinkedHashSet<String>() {{
+            v.forEach(instance -> add(instance.getInstanceName()));
+          }}));
+
+      // create an instance_name -> FD_id map, just for look up
+      Map<String, Integer> aliveInstanceNameToFDMap = new HashMap<>();
+      faultDomainToCandidateInstancesMap.forEach(
+          (faultDomainId, value) -> value.forEach(instance -> aliveInstanceNameToFDMap.put(instance, faultDomainId)));
+
+      // replicaGroupBasedAssignmentState for assignment
+      ReplicaGroupBasedAssignmentState replicaGroupBasedAssignmentState = null;
+
+      /*
+       * initialize the new replicaGroupBasedAssignmentState for assignment,
+       * place existing instances in their corresponding positions
+       */
+      if (_replicaGroupPartitionConfig.isMinimizeDataMovement() && _existingInstancePartitions != null) {
+        int numExistingReplicaGroups = _existingInstancePartitions.getNumReplicaGroups();
+        int numExistingPartitions = _existingInstancePartitions.getNumPartitions();
+        /*
+         * reconstruct a replica group -> instance mapping from _existingInstancePartitions,
+         */
+        LinkedHashSet<String> existingReplicaGroup = new LinkedHashSet<>();
+        for (int i = 0; i < numExistingReplicaGroups; i++, existingReplicaGroup.clear()) {
+          for (int j = 0; j < numExistingPartitions; j++) {
+            existingReplicaGroup.addAll(_existingInstancePartitions.getInstances(j, i));
+          }
+
+          /*
+           * We can only know the numExistingInstancesPerReplicaGroup after we reconstructed the sequence of instances
+           * in the first replica group
+           */
+          if (i == 0) {
+            int numExistingInstancesPerReplicaGroup = existingReplicaGroup.size();
+            replicaGroupBasedAssignmentState =
+                new ReplicaGroupBasedAssignmentState(numReplicaGroups, numInstancesPerReplicaGroup,
+                    numExistingReplicaGroups, numExistingInstancesPerReplicaGroup, numFaultDomains);
+          }
+
+          replicaGroupBasedAssignmentState.reconstructExistingAssignment(existingReplicaGroup, i,
+              aliveInstanceNameToFDMap);
+        }
+      } else {
+        // Fresh new assignment
+        replicaGroupBasedAssignmentState =
+            new ReplicaGroupBasedAssignmentState(numReplicaGroups, numInstancesPerReplicaGroup, numFaultDomains);
+      }
+      /*finish replicaGroupBasedAssignmentState initialization*/
+
+      Preconditions.checkState(replicaGroupBasedAssignmentState != null);
+
+      // preprocess the downsizing and exclude unchanged existing assigment from the candidate list
+      replicaGroupBasedAssignmentState.preprocessing(faultDomainToCandidateInstancesMap);
+
+      // preprocess the problem of numReplicaGroups >= numFaultDomains to a problem
+      replicaGroupBasedAssignmentState.normalize(faultDomainToCandidateInstancesMap);
+
+      // fill the remaining vacant seats
+      replicaGroupBasedAssignmentState.fill(faultDomainToCandidateInstancesMap);
+
+      // adjust the instance assignment to achieve the invariant state
+      replicaGroupBasedAssignmentState.swapToInvariantState();
+
+      // In the following we assign instances to partitions.
+      // TODO: refine this and segment assignment to minimize movement during numInstancesPerReplicaGroup uplift
+      // Assign instances within a replica-group to one partition if not configured
+      int numPartitions = _replicaGroupPartitionConfig.getNumPartitions();
+      if (numPartitions <= 0) {
+        numPartitions = 1;
+      }
+      // Assign all instances within a replica-group to each partition if not configured
+      int numInstancesPerPartition = _replicaGroupPartitionConfig.getNumInstancesPerPartition();
+      if (numInstancesPerPartition > 0) {
+        Preconditions.checkState(numInstancesPerPartition <= numInstancesPerReplicaGroup,
+            "Number of instances per partition: %s must be smaller or equal to number of instances per replica-group:"
+                + " %s", numInstancesPerPartition, numInstancesPerReplicaGroup);
+      } else {
+        numInstancesPerPartition = numInstancesPerReplicaGroup;
+      }
+      LOGGER.info("Selecting {} partitions, {} instances per partition within a replica-group for table: {}",
+          numPartitions, numInstancesPerPartition, _tableNameWithType);
+
+      // Assign consecutive instances within a replica-group to each partition.
+      // E.g. (within a replica-group, 5 instances, 3 partitions, 3 instances per partition)
+      // [i0, i1, i2, i3, i4]
+      //  p0  p0  p0  p1  p1
+      //  p1  p2  p2  p2
+      for (int replicaGroupId = 0; replicaGroupId < numReplicaGroups; replicaGroupId++) {
+        int instanceIdInReplicaGroup = 0;
+        for (int partitionId = 0; partitionId < numPartitions; partitionId++) {
+          List<String> instancesInPartition = new ArrayList<>(numInstancesPerPartition);
+          for (int instanceIdInPartition = 0; instanceIdInPartition < numInstancesPerPartition;
+              instanceIdInPartition++) {
+            instancesInPartition.add(
+                replicaGroupBasedAssignmentState.
+                    _replicaGroupIdToInstancesMap[replicaGroupId][instanceIdInReplicaGroup].getInstanceName());
+            instanceIdInReplicaGroup = (instanceIdInReplicaGroup + 1) % numInstancesPerReplicaGroup;
+          }
+          LOGGER.info("Selecting instances: {} for replica-group: {}, partition: {} for table: {}",
+              instancesInPartition, replicaGroupId, partitionId, _tableNameWithType);
+          instancePartitions.setInstances(partitionId, replicaGroupId, instancesInPartition);
+        }
+      }
+    } else {
+      throw new IllegalStateException("Non-replica-group based selection unfinished");
+      // TODO:Non-replica-group based selection
+    }
+  }
+
+  private static class CandidateQueue {
+    NavigableMap<Integer, Deque<String>> _map;
+    Integer _iter;
+
+    CandidateQueue(Map<Integer, LinkedHashSet<String>> faultDomainToCandidateInstancesMap) {
+      _map = new TreeMap<>();
+      faultDomainToCandidateInstancesMap.entrySet().stream().filter(kv -> !kv.getValue().isEmpty())
+          .forEach(kv -> _map.put(kv.getKey(), new LinkedList<>(kv.getValue())));
+      _iter = _map.firstKey();
+    }
+
+    void seekKey(int startKey) {
+      if (_map.containsKey(startKey)) {
+        _iter = startKey;
+      } else {
+        _iter = _map.ceilingKey(_iter);
+        _iter = (_iter == null && !_map.isEmpty()) ? _map.firstKey() : _iter;
+      }
+    }
+
+    Instance getNextCandidate() {
+      if (_iter == null) {
+        throw new IllegalStateException("Illegal state in fault-domain-aware assignment");
+      }
+
+      Instance ret = new Instance(_map.get(_iter).pollFirst(), _iter, Instance.NEW_INSTANCE);
+
+      if (_map.get(_iter).isEmpty()) {
+        _map.remove(_iter);
+      }
+
+      _iter = _map.higherKey(_iter);
+      _iter = (_iter == null && !_map.isEmpty()) ? _map.firstKey() : _iter;
+      return ret;
+    }
+  }
+
+  private static class ReplicaGroupBasedAssignmentState {
+    private static final int INVALID_FD = -1;
+    Instance[][] _replicaGroupIdToInstancesMap;
+    int _numReplicaGroups;
+    int _numInstancesPerReplicaGroup;
+    int _numExistingReplicaGroups;
+    int _numExistingInstancesPerReplicaGroup;
+    int _numDownInstances = 0;
+    int _mapDimReplicaGroup;
+    int _mapDimInstancePerReplicaGroup;
+    HashMap<String, Integer> _usedInstances = new HashMap<>();
+    int _numFaultDomains;
+    int[][] _fdCounter;
+
+    ReplicaGroupBasedAssignmentState(int numReplicaGroups, int numInstancesPerReplicaGroup,
+        int numExistingReplicaGroups, int numExistingInstancesPerReplicaGroup, int numFaultDomains) {
+
+      _numFaultDomains = numFaultDomains;
+      _numReplicaGroups = numReplicaGroups;
+      _numInstancesPerReplicaGroup = numInstancesPerReplicaGroup;
+      _numExistingReplicaGroups = numExistingReplicaGroups;
+      _numExistingInstancesPerReplicaGroup = numExistingInstancesPerReplicaGroup;
+      _mapDimReplicaGroup = Math.max(numExistingReplicaGroups, numReplicaGroups);
+      _mapDimInstancePerReplicaGroup = Math.max(numExistingInstancesPerReplicaGroup, numInstancesPerReplicaGroup);
+
+      _replicaGroupIdToInstancesMap = new Instance[_mapDimReplicaGroup][_mapDimInstancePerReplicaGroup];
+      _fdCounter = new int[_mapDimInstancePerReplicaGroup][_numFaultDomains];
+    }
+
+    ReplicaGroupBasedAssignmentState(int numReplicaGroups, int numInstancesPerReplicaGroup, int numFaultDomains) {
+      this(numReplicaGroups, numInstancesPerReplicaGroup, 0, numInstancesPerReplicaGroup, numFaultDomains);
+    }
+
+    /**
+     * preprocess the downsizing and exclude unchanged existing assigment from the candidate list
+     */
+    public void preprocessing(Map<Integer, LinkedHashSet<String>> faultDomainToCandidateInstancesMap) {
+      if (_numReplicaGroups < _numExistingReplicaGroups
+          || _numInstancesPerReplicaGroup < _numExistingInstancesPerReplicaGroup) {
+        throw new IllegalStateException("Downsizing unfinished");
+        //TODO: Finish preprocessing for Downsizing using unSetInstance()
+      }
+      // remove unchanged existing assigment from the candidate list
+      for (Map.Entry<String, Integer> instanceFDPair : this.getUsedInstances().entrySet()) {
+        faultDomainToCandidateInstancesMap.get(instanceFDPair.getValue()).remove(instanceFDPair.getKey());
+      }
+    }
+
+    private void setNewInstance(int replicaGroupId, int instanceIndex, Instance instance) {
+      Preconditions.checkState(instance.getExistingReplicaGroupId() == Instance.NEW_INSTANCE);
+      _replicaGroupIdToInstancesMap[replicaGroupId][instanceIndex] = instance;
+      _usedInstances.put(instance.getInstanceName(), instance.getFaultDomainId());
+      _fdCounter[instanceIndex][instance.getFaultDomainId()] += 1;
+    }
+
+    private void setExistingInstance(int replicaGroupId, int instanceIndex, String instance, int fdId) {
+      _replicaGroupIdToInstancesMap[replicaGroupId][instanceIndex] = new Instance(instance, fdId, replicaGroupId);
+      _usedInstances.put(instance, fdId);
+      _fdCounter[instanceIndex][fdId] += 1;
+    }
+
+    private void unSetInstance(int replicaGroupId, int instanceIndex) {
+      int fdId = _replicaGroupIdToInstancesMap[replicaGroupId][instanceIndex].getFaultDomainId();
+      _usedInstances.remove(_replicaGroupIdToInstancesMap[replicaGroupId][instanceIndex].getInstanceName());
+      _replicaGroupIdToInstancesMap[replicaGroupId][instanceIndex] = null;
+      _fdCounter[instanceIndex][fdId] -= 1;
+    }
+
+    /**
+     * From an exising replica group, remove the instances that are gone and set them in _replicaGroupIdToInstancesMap
+     */
+    public void reconstructExistingAssignment(LinkedHashSet<String> existingReplicaGroup, int replicaGroupId,
+        Map<String, Integer> aliveInstanceNameToFDMap) {
+      int instanceIndex = 0;
+      for (String instance : existingReplicaGroup) {
+        int fdId = aliveInstanceNameToFDMap.getOrDefault(instance, INVALID_FD);
+        if (fdId != INVALID_FD) {
+          // Existing assigment still alive should remain unchanged
+          Preconditions.checkState(_replicaGroupIdToInstancesMap != null,
+              "Error state, replicaGroupBasedAssignmentState is not initialized");
+          setExistingInstance(replicaGroupId, instanceIndex, instance, fdId);
+        } else {
+          // Instance not in candidate instances. It is down and removed.
+          _numDownInstances++;
+        }
+        instanceIndex++;
+      }
+    }
+
+    public HashMap<String, Integer> getUsedInstances() {
+      return _usedInstances;
+    }
+
+    /**
+     * this function ensures that: for instances with the same instance id (_replicaGroupIdToInstancesMap[*][id]),
+     * there are at least ceil(numReplicaGroups/numFaultDomain) instances from each fault domain
+     */
+    public void normalize(Map<Integer, LinkedHashSet<String>> faultDomainToCandidateInstancesMap) {
+      LOGGER.info("Warning, normalizing isn't finished yet");
+      //TODO: Finish normalizing for numReplicaGroups>numFaultDomains
+    }
+
+    private boolean isEmpty(int replicaGroupId, int instanceId) {
+      return _replicaGroupIdToInstancesMap[replicaGroupId][instanceId] == null;
+    }
+
+    /**
+     * Fill the vacant instances
+     */
+    public void fill(Map<Integer, LinkedHashSet<String>> faultDomainToCandidateInstancesMap) {
+      // convert set to que and start to assign
+      CandidateQueue candidateQueue = new CandidateQueue(faultDomainToCandidateInstancesMap);
+      if (_numReplicaGroups != 0) { // uplift instance per replica group first if not a fresh new assignment
+        for (int j = _numExistingInstancesPerReplicaGroup; j < _numInstancesPerReplicaGroup; j++) {
+          for (int i = 0; i < _numReplicaGroups; i++) {
+            setNewInstance(i, j, candidateQueue.getNextCandidate());
+          }
+        }
+      }
+
+      candidateQueue.seekKey(_numExistingReplicaGroups * _numExistingInstancesPerReplicaGroup % _numFaultDomains);
+      for (int i = _numExistingReplicaGroups; i < _numReplicaGroups; i++) {
+        for (int j = 0; j < _numExistingInstancesPerReplicaGroup; j++) {
+          int rotatedInstanceIter = j;
+          if (_numExistingInstancesPerReplicaGroup % _numFaultDomains == 0) {
+            /*
+             * if _numExistingInstancesPerReplicaGroup % _numFaultDomains == 0, explicitly rotate j for every replica
+             * group, or we will always have the same FD id in the same position for all replica groups
+             */
+            rotatedInstanceIter = (rotatedInstanceIter + i) % _numExistingInstancesPerReplicaGroup;
+          }
+          setNewInstance(i, rotatedInstanceIter, candidateQueue.getNextCandidate());
+        }
+      }
+
+      for (int i = 0; i < _numExistingReplicaGroups; i++) {
+        for (int j = 0; j < _numExistingInstancesPerReplicaGroup; j++) {
+          if (isEmpty(i, j)) {
+            setNewInstance(i, j, candidateQueue.getNextCandidate());
+          }
+        }
+      }
+    }
+
+    public void swapToInvariantState() {
+    }
+  }
+
+  private static class Instance {
+    static final int NEW_INSTANCE = -1;
+    private final String _instanceName;
+    private final int _faultDomainId;
+    private final int _existingReplicaGroupId;
+
+    public Instance(String instance, int faultDomainId, int existingReplicaGroupId) {
+      _instanceName = instance;
+      _faultDomainId = faultDomainId;
+      _existingReplicaGroupId = existingReplicaGroupId;
+    }
+
+    String getInstanceName() {
+      return _instanceName;
+    }
+
+    int getFaultDomainId() {
+      return _faultDomainId;
+    }
+
+    int getExistingReplicaGroupId() {
+      return _existingReplicaGroupId;
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceAssignmentDriver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceAssignmentDriver.java
@@ -74,12 +74,12 @@ public class InstanceAssignmentDriver {
       poolToInstanceConfigsMap = constraintApplier.applyConstraint(poolToInstanceConfigsMap);
     }
 
-    InstanceReplicaGroupPartitionSelector replicaPartitionSelector =
-        new InstanceReplicaGroupPartitionSelector(assignmentConfig.getReplicaGroupPartitionConfig(), tableNameWithType,
-            existingInstancePartitions);
+    InstancePartitionSelector instancePartitionSelector =
+        InstancePartitionSelectorFactory.getInstance(assignmentConfig.getPartitionSelector(),
+            assignmentConfig.getReplicaGroupPartitionConfig(), tableNameWithType, existingInstancePartitions);
     InstancePartitions instancePartitions = new InstancePartitions(
         instancePartitionsType.getInstancePartitionsName(TableNameBuilder.extractRawTableName(tableNameWithType)));
-    replicaPartitionSelector.selectInstances(poolToInstanceConfigsMap, instancePartitions);
+    instancePartitionSelector.selectInstances(poolToInstanceConfigsMap, instancePartitions);
     return instancePartitions;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/InstancePartitionSelector.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/InstancePartitionSelector.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.assignment.instance;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.common.assignment.InstancePartitions;
+import org.apache.pinot.spi.config.table.assignment.InstanceReplicaGroupPartitionConfig;
+
+
+abstract class InstancePartitionSelector {
+  protected final InstanceReplicaGroupPartitionConfig _replicaGroupPartitionConfig;
+  protected final String _tableNameWithType;
+  protected final InstancePartitions _existingInstancePartitions;
+
+  public InstancePartitionSelector(InstanceReplicaGroupPartitionConfig replicaGroupPartitionConfig,
+      String tableNameWithType, InstancePartitions existingInstancePartitions) {
+    _replicaGroupPartitionConfig = replicaGroupPartitionConfig;
+    _tableNameWithType = tableNameWithType;
+    _existingInstancePartitions = existingInstancePartitions;
+  }
+
+  /**
+   * Selects instances based on the replica-group/partition config, and stores the result into the given instance
+   * partitions.
+   */
+  abstract void selectInstances(Map<Integer, List<InstanceConfig>> poolToInstanceConfigsMap,
+      InstancePartitions instancePartitions);
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/InstancePartitionSelectorFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/InstancePartitionSelectorFactory.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.assignment.instance;
+
+import java.util.Arrays;
+import org.apache.pinot.common.assignment.InstancePartitions;
+import org.apache.pinot.spi.config.table.assignment.InstanceAssignmentConfig;
+import org.apache.pinot.spi.config.table.assignment.InstanceReplicaGroupPartitionConfig;
+
+
+public class InstancePartitionSelectorFactory {
+
+  private InstancePartitionSelectorFactory() {
+  }
+
+  public static InstancePartitionSelector getInstance(InstanceAssignmentConfig.PartitionSelector partitionSelector,
+      InstanceReplicaGroupPartitionConfig instanceReplicaGroupPartitionConfig, String tableNameWithType,
+      InstancePartitions existingInstancePartitions
+  ) {
+    switch (partitionSelector) {
+      case FD_AWARE_INSTANCE_PARTITION_SELECTOR:
+        return new FDAwareInstancePartitionSelector(instanceReplicaGroupPartitionConfig, tableNameWithType,
+            existingInstancePartitions);
+      case INSTANCE_REPLICA_GROUP_PARTITION_SELECTOR:
+        return new InstanceReplicaGroupPartitionSelector(instanceReplicaGroupPartitionConfig, tableNameWithType,
+            existingInstancePartitions);
+      default:
+        throw new IllegalStateException("Unexpected PartitionSelector: " + partitionSelector + ", should be from"
+            + Arrays.toString(InstanceAssignmentConfig.PartitionSelector.values()));
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceReplicaGroupPartitionSelector.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceReplicaGroupPartitionSelector.java
@@ -42,18 +42,12 @@ import org.slf4j.LoggerFactory;
  * The instance replica-group/partition selector is responsible for selecting the instances for each replica-group and
  * partition.
  */
-public class InstanceReplicaGroupPartitionSelector {
+public class InstanceReplicaGroupPartitionSelector extends InstancePartitionSelector {
   private static final Logger LOGGER = LoggerFactory.getLogger(InstanceReplicaGroupPartitionSelector.class);
-
-  private final InstanceReplicaGroupPartitionConfig _replicaGroupPartitionConfig;
-  private final String _tableNameWithType;
-  private final InstancePartitions _existingInstancePartitions;
 
   public InstanceReplicaGroupPartitionSelector(InstanceReplicaGroupPartitionConfig replicaGroupPartitionConfig,
       String tableNameWithType, @Nullable InstancePartitions existingInstancePartitions) {
-    _replicaGroupPartitionConfig = replicaGroupPartitionConfig;
-    _tableNameWithType = tableNameWithType;
-    _existingInstancePartitions = existingInstancePartitions;
+    super(replicaGroupPartitionConfig, tableNameWithType, existingInstancePartitions);
   }
 
   /**

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceAssignmentTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.controller.helix.core.assignment.instance;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.common.assignment.InstanceAssignmentConfigUtils;
@@ -33,6 +34,7 @@ import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.assignment.InstanceAssignmentConfig;
+import org.apache.pinot.spi.config.table.assignment.InstanceConstraintConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.config.table.assignment.InstanceReplicaGroupPartitionConfig;
 import org.apache.pinot.spi.config.table.assignment.InstanceTagPoolConfig;
@@ -50,6 +52,8 @@ public class InstanceAssignmentTest {
   private static final String TENANT_NAME = "tenant";
   private static final String OFFLINE_TAG = TagNameUtils.getOfflineTagForTenant(TENANT_NAME);
   private static final String SERVER_INSTANCE_ID_PREFIX = "Server_localhost_";
+  private static final String SERVER_INSTANCE_POOL_PREFIX = "_pool_";
+  private static final String TABLE_NAME_ZERO_HASH_COMPLEMENT = "12";
 
   @Test
   public void testDefaultOfflineReplicaGroup() {
@@ -909,5 +913,808 @@ public class InstanceAssignmentTest {
         Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 8, SERVER_INSTANCE_ID_PREFIX + 9));
     assertEquals(instancePartitions.getInstances(0, 2),
         Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 1, SERVER_INSTANCE_ID_PREFIX + 4));
+
+    // Illegal partition selector
+    numInstances = 21;
+    int numPools = 5;
+    int numReplicaGroups = 3;
+    int numInstancesPerReplicaGroup = numInstances / numReplicaGroups;
+    instanceConfigs = new ArrayList<>(numInstances);
+    for (int i = 0; i < numInstances; i++) {
+      int pool = i % numPools;
+      InstanceConfig instanceConfig =
+          new InstanceConfig(SERVER_INSTANCE_ID_PREFIX + i + SERVER_INSTANCE_POOL_PREFIX + pool);
+      instanceConfig.addTag(OFFLINE_TAG);
+      instanceConfig.getRecord()
+          .setMapField(InstanceUtils.POOL_KEY, Collections.singletonMap(OFFLINE_TAG, Integer.toString(pool)));
+      instanceConfigs.add(instanceConfig);
+    }
+    tagPoolConfig = new InstanceTagPoolConfig(OFFLINE_TAG, true, numPools, null);
+    InstanceReplicaGroupPartitionConfig replicaPartitionConfig =
+        new InstanceReplicaGroupPartitionConfig(true, 0, numReplicaGroups, numInstancesPerReplicaGroup, 0, 0, false);
+
+    try {
+      tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
+          .setInstanceAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.OFFLINE,
+              new InstanceAssignmentConfig(tagPoolConfig, null, replicaPartitionConfig, "ILLEGAL_SELECTOR"))).build();
+    } catch (IllegalArgumentException e) {
+      assertEquals(e.getMessage(),
+          "No enum constant org.apache.pinot.spi.config.table.assignment.Constants.PartitionSelector.ILLEGAL_SELECTOR");
+    }
+
+    // The total num instances cannot be assigned evenly to replica groups
+    numInstances = 21;
+    numPools = 5;
+    numReplicaGroups = 4;
+    numInstancesPerReplicaGroup = 0;
+    instanceConfigs = new ArrayList<>(numInstances);
+    for (int i = 0; i < numInstances; i++) {
+      int pool = i % numPools;
+      InstanceConfig instanceConfig =
+          new InstanceConfig(SERVER_INSTANCE_ID_PREFIX + i + SERVER_INSTANCE_POOL_PREFIX + pool);
+      instanceConfig.addTag(OFFLINE_TAG);
+      instanceConfig.getRecord()
+          .setMapField(InstanceUtils.POOL_KEY, Collections.singletonMap(OFFLINE_TAG, Integer.toString(pool)));
+      instanceConfigs.add(instanceConfig);
+    }
+    tagPoolConfig = new InstanceTagPoolConfig(OFFLINE_TAG, true, numPools, null);
+    replicaPartitionConfig =
+        new InstanceReplicaGroupPartitionConfig(true, 0, numReplicaGroups, numInstancesPerReplicaGroup, 0, 0, false);
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setInstanceAssignmentConfigMap(
+        Collections.singletonMap(InstancePartitionsType.OFFLINE,
+            new InstanceAssignmentConfig(tagPoolConfig, null, replicaPartitionConfig,
+                InstanceAssignmentConfig.PartitionSelector.FD_AWARE_INSTANCE_PARTITION_SELECTOR.toString()))).build();
+    driver = new InstanceAssignmentDriver(tableConfig);
+    try {
+      instancePartitions = driver.assignInstances(InstancePartitionsType.OFFLINE, instanceConfigs, null);
+      fail();
+    } catch (IllegalStateException e) {
+      assertEquals(e.getMessage(),
+          "The total num instances 21 cannot be assigned evenly to 4 replica groups, please specify a "
+              + "numInstancesPerReplicaGroup in _replicaGroupPartitionConfig");
+    }
+
+    // The total num instances are not enough
+    numInstances = 21;
+    numPools = 5;
+    numReplicaGroups = 4;
+    numInstancesPerReplicaGroup = 6;
+    instanceConfigs = new ArrayList<>(numInstances);
+    for (int i = 0; i < numInstances; i++) {
+      int pool = i % numPools;
+      InstanceConfig instanceConfig =
+          new InstanceConfig(SERVER_INSTANCE_ID_PREFIX + i + SERVER_INSTANCE_POOL_PREFIX + pool);
+      instanceConfig.addTag(OFFLINE_TAG);
+      instanceConfig.getRecord()
+          .setMapField(InstanceUtils.POOL_KEY, Collections.singletonMap(OFFLINE_TAG, Integer.toString(pool)));
+      instanceConfigs.add(instanceConfig);
+    }
+    tagPoolConfig = new InstanceTagPoolConfig(OFFLINE_TAG, true, numPools, null);
+    replicaPartitionConfig =
+        new InstanceReplicaGroupPartitionConfig(true, 0, numReplicaGroups, numInstancesPerReplicaGroup, 0, 0, false);
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setInstanceAssignmentConfigMap(
+        Collections.singletonMap(InstancePartitionsType.OFFLINE,
+            new InstanceAssignmentConfig(tagPoolConfig, null, replicaPartitionConfig,
+                InstanceAssignmentConfig.PartitionSelector.FD_AWARE_INSTANCE_PARTITION_SELECTOR.toString()))).build();
+    driver = new InstanceAssignmentDriver(tableConfig);
+    try {
+      instancePartitions = driver.assignInstances(InstancePartitionsType.OFFLINE, instanceConfigs, null);
+      fail();
+    } catch (IllegalStateException e) {
+      assertEquals(e.getMessage(),
+          "Not enough qualified instances (21 in all FDs, asked for 24)");
+    }
+
+    numInstances = 10;
+    numPools = 5;
+    numReplicaGroups = 5;
+    numInstancesPerReplicaGroup = numInstances / numReplicaGroups;
+    instanceConfigs = new LinkedList<>();
+    for (int i = 0; i < numInstances; i++) {
+      int pool = i % numPools;
+      InstanceConfig instanceConfig =
+          new InstanceConfig(SERVER_INSTANCE_ID_PREFIX + i + SERVER_INSTANCE_POOL_PREFIX + pool);
+      instanceConfig.addTag(OFFLINE_TAG);
+      instanceConfig.getRecord()
+          .setMapField(InstanceUtils.POOL_KEY, Collections.singletonMap(OFFLINE_TAG, Integer.toString(pool)));
+      instanceConfigs.add(instanceConfig);
+    }
+
+    // The instances are not balanced for each pool (fault-domain)
+    instanceConfigs.remove(9);
+    InstanceConfig instanceConfig =
+        new InstanceConfig(SERVER_INSTANCE_ID_PREFIX + 10 + SERVER_INSTANCE_POOL_PREFIX + 0);
+    instanceConfig.addTag(OFFLINE_TAG);
+    instanceConfig.getRecord()
+        .setMapField(InstanceUtils.POOL_KEY, Collections.singletonMap(OFFLINE_TAG, Integer.toString(0)));
+    instanceConfigs.add(instanceConfig);
+
+    tagPoolConfig = new InstanceTagPoolConfig(OFFLINE_TAG, true, numPools, null);
+    replicaPartitionConfig =
+        new InstanceReplicaGroupPartitionConfig(true, 0, numReplicaGroups, numInstancesPerReplicaGroup, 0, 0, false);
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setInstanceAssignmentConfigMap(
+        Collections.singletonMap(InstancePartitionsType.OFFLINE,
+            new InstanceAssignmentConfig(tagPoolConfig, null, replicaPartitionConfig,
+                InstanceAssignmentConfig.PartitionSelector.FD_AWARE_INSTANCE_PARTITION_SELECTOR.toString()))).build();
+    driver = new InstanceAssignmentDriver(tableConfig);
+    try {
+      instancePartitions = driver.assignInstances(InstancePartitionsType.OFFLINE, instanceConfigs, null);
+      fail();
+    } catch (IllegalStateException e) {
+      assertEquals(e.getMessage(), "The instances are not balanced for each pool (fault-domain)");
+    }
+  }
+
+  @Test
+  public void testPoolBasedFDAware() {
+    // 21 instances in 5 pools, with [5,4,4,4,4] instances in each pool
+    int numPartitions = 0;
+    int numInstancesPerPartition = 0;
+    int numInstances = 21;
+    int numPools = 5;
+    int numReplicaGroups = 3;
+    int numInstancesPerReplicaGroup = numInstances / numReplicaGroups;
+    List<InstanceConfig> instanceConfigs = new ArrayList<>(numInstances);
+    for (int i = 0; i < numInstances; i++) {
+      int pool = i % numPools;
+      InstanceConfig instanceConfig =
+          new InstanceConfig(SERVER_INSTANCE_ID_PREFIX + i + SERVER_INSTANCE_POOL_PREFIX + pool);
+      instanceConfig.addTag(OFFLINE_TAG);
+      instanceConfig.getRecord()
+          .setMapField(InstanceUtils.POOL_KEY, Collections.singletonMap(OFFLINE_TAG, Integer.toString(pool)));
+      instanceConfigs.add(instanceConfig);
+    }
+    // Use all pools
+    InstanceTagPoolConfig tagPoolConfig = new InstanceTagPoolConfig(OFFLINE_TAG, true, numPools, null);
+    // Assign to 3 replica-groups so that each replica-group is assigned 7 instances
+    InstanceReplicaGroupPartitionConfig replicaPartitionConfig =
+        new InstanceReplicaGroupPartitionConfig(true, 0, numReplicaGroups, numInstancesPerReplicaGroup, numPartitions,
+            numInstancesPerPartition, false);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
+        .setInstanceAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.OFFLINE,
+            new InstanceAssignmentConfig(tagPoolConfig, null, replicaPartitionConfig,
+                InstanceAssignmentConfig.PartitionSelector.FD_AWARE_INSTANCE_PARTITION_SELECTOR.toString()))).build();
+    InstanceAssignmentDriver driver = new InstanceAssignmentDriver(tableConfig);
+
+    InstancePartitions instancePartitions =
+        driver.assignInstances(InstancePartitionsType.OFFLINE, instanceConfigs, null);
+    assertEquals(instancePartitions.getNumReplicaGroups(), numReplicaGroups);
+    assertEquals(instancePartitions.getNumPartitions(), 1);
+    /*
+     * 21 instances in 5 FDs (pools), with [5,4,4,4,4] instances in each FD
+     * (tableNameHash % poolToInstanceEntriesList.size()) = 3
+     *
+     *         RG1(FD)    RG2(FD)    RG3(FD)
+     *   Host  20 (0)     7  (2)     14 (4)
+     *   Host  1  (1)     8  (3)     10 (0)
+     *   Host  2  (2)     9  (4)     16 (1)
+     *   Host  3  (3)     0  (0)     17 (2)
+     *   Host  4  (4)     11 (1)     18 (3)
+     *   Host  5  (0)     12 (2)     19 (4)
+     *   Host  6  (1)     13 (3)     15 (0)
+     */
+    assertEquals(instancePartitions.getInstances(0, 0),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 20 + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + 1 + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + 2 + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + 3 + SERVER_INSTANCE_POOL_PREFIX + 3,
+            SERVER_INSTANCE_ID_PREFIX + 4 + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + 5 + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + 6 + SERVER_INSTANCE_POOL_PREFIX + 1));
+    assertEquals(instancePartitions.getInstances(0, 1),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 7 + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + 8 + SERVER_INSTANCE_POOL_PREFIX + 3,
+            SERVER_INSTANCE_ID_PREFIX + 9 + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + 0 + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + 11 + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + 12 + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + 13 + SERVER_INSTANCE_POOL_PREFIX + 3));
+    assertEquals(instancePartitions.getInstances(0, 2),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 14 + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + 10 + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + 16 + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + 17 + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + 18 + SERVER_INSTANCE_POOL_PREFIX + 3,
+            SERVER_INSTANCE_ID_PREFIX + 19 + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + 15 + SERVER_INSTANCE_POOL_PREFIX + 0));
+
+    // 28 instances in 5 pools, with [6,6,6,5,5] instances in each pool
+    // minimized movement on top of the above assignment
+    numPartitions = 0;
+    numInstancesPerPartition = 0;
+    numInstances = 28;
+    numPools = 5;
+    numReplicaGroups = 4;
+    numInstancesPerReplicaGroup = numInstances / numReplicaGroups;
+    instanceConfigs = new ArrayList<>(numInstances);
+    for (int i = 0; i < numInstances; i++) {
+      int pool = i % numPools;
+      InstanceConfig instanceConfig =
+          new InstanceConfig(SERVER_INSTANCE_ID_PREFIX + i + SERVER_INSTANCE_POOL_PREFIX + pool);
+      instanceConfig.addTag(OFFLINE_TAG);
+      instanceConfig.getRecord()
+          .setMapField(InstanceUtils.POOL_KEY, Collections.singletonMap(OFFLINE_TAG, Integer.toString(pool)));
+      instanceConfigs.add(instanceConfig);
+    }
+    // Use all pools
+    tagPoolConfig = new InstanceTagPoolConfig(OFFLINE_TAG, true, numPools, null);
+    // Assign to 3 replica-groups so that each replica-group is assigned 7 instances
+    replicaPartitionConfig =
+        new InstanceReplicaGroupPartitionConfig(true, 0, numReplicaGroups, numInstancesPerReplicaGroup, numPartitions,
+            numInstancesPerPartition, true);
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setInstanceAssignmentConfigMap(
+        Collections.singletonMap(InstancePartitionsType.OFFLINE,
+            new InstanceAssignmentConfig(tagPoolConfig, null, replicaPartitionConfig,
+                InstanceAssignmentConfig.PartitionSelector.FD_AWARE_INSTANCE_PARTITION_SELECTOR.toString()))).build();
+    driver = new InstanceAssignmentDriver(tableConfig);
+    // existingInstancePartitions = instancePartitions
+    instancePartitions = driver.assignInstances(InstancePartitionsType.OFFLINE, instanceConfigs, instancePartitions);
+    assertEquals(instancePartitions.getNumReplicaGroups(), numReplicaGroups);
+    assertEquals(instancePartitions.getNumPartitions(), 1);
+    /*
+     * 28 instances in 5 FDs (pools), with [6,6,6,5,5] instances in each FD
+     * incremental assignment based on the previous assignment of 21 instances in 3RGs
+     *
+     *         RG1(FD)    RG2(FD)    RG3(FD)    RG4(FD)
+     *   Host  20 (0)     7  (2)     14 (4)     21 (1)
+     *   Host  1  (1)     8  (3)     10 (0)     22 (2)
+     *   Host  2  (2)     9  (4)     16 (1)     23 (3)
+     *   Host  3  (3)     0  (0)     17 (2)     24 (4)
+     *   Host  4  (4)     11 (1)     18 (3)     25 (0)
+     *   Host  5  (0)     12 (2)     19 (4)     26 (1)
+     *   Host  6  (1)     13 (3)     15 (0)     27 (2)
+     */
+    assertEquals(instancePartitions.getInstances(0, 0),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 20 + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + 1 + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + 2 + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + 3 + SERVER_INSTANCE_POOL_PREFIX + 3,
+            SERVER_INSTANCE_ID_PREFIX + 4 + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + 5 + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + 6 + SERVER_INSTANCE_POOL_PREFIX + 1));
+    assertEquals(instancePartitions.getInstances(0, 1),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 7 + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + 8 + SERVER_INSTANCE_POOL_PREFIX + 3,
+            SERVER_INSTANCE_ID_PREFIX + 9 + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + 0 + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + 11 + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + 12 + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + 13 + SERVER_INSTANCE_POOL_PREFIX + 3));
+    assertEquals(instancePartitions.getInstances(0, 2),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 14 + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + 10 + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + 16 + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + 17 + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + 18 + SERVER_INSTANCE_POOL_PREFIX + 3,
+            SERVER_INSTANCE_ID_PREFIX + 19 + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + 15 + SERVER_INSTANCE_POOL_PREFIX + 0));
+    assertEquals(instancePartitions.getInstances(0, 3),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 21 + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + 22 + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + 23 + SERVER_INSTANCE_POOL_PREFIX + 3,
+            SERVER_INSTANCE_ID_PREFIX + 24 + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + 25 + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + 26 + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + 27 + SERVER_INSTANCE_POOL_PREFIX + 2));
+
+    // 21 instances in 5 pools, with [5,4,4,4,4] instances in each pool
+    // Partitioned at table level (only segments are partitioned, RG not aware of the partitioning)
+    int numPartitionsSegment = 3;
+    numInstances = 21;
+    numPools = 5;
+    numReplicaGroups = 3;
+    numInstancesPerReplicaGroup = numInstances / numReplicaGroups;
+    instanceConfigs = new ArrayList<>(numInstances);
+    for (int i = 0; i < numInstances; i++) {
+      int pool = i % numPools;
+      InstanceConfig instanceConfig =
+          new InstanceConfig(SERVER_INSTANCE_ID_PREFIX + i + SERVER_INSTANCE_POOL_PREFIX + pool);
+      instanceConfig.addTag(OFFLINE_TAG);
+      instanceConfig.getRecord()
+          .setMapField(InstanceUtils.POOL_KEY, Collections.singletonMap(OFFLINE_TAG, Integer.toString(pool)));
+      instanceConfigs.add(instanceConfig);
+    }
+    // Use all pools
+    tagPoolConfig = new InstanceTagPoolConfig(OFFLINE_TAG, true, numPools, null);
+    // Assign to 3 replica-groups so that each replica-group is assigned 7 instances
+    replicaPartitionConfig =
+        new InstanceReplicaGroupPartitionConfig(true, 0, numReplicaGroups, numInstancesPerReplicaGroup, numPartitions,
+            numInstancesPerPartition, false);
+    String partitionColumnName = "partition";
+    SegmentPartitionConfig segmentPartitionConfig = new SegmentPartitionConfig(
+        Collections.singletonMap(partitionColumnName, new ColumnPartitionConfig("Modulo", numPartitionsSegment, null)));
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setInstanceAssignmentConfigMap(
+            Collections.singletonMap(InstancePartitionsType.OFFLINE,
+                new InstanceAssignmentConfig(tagPoolConfig, null, replicaPartitionConfig,
+                    InstanceAssignmentConfig.PartitionSelector.FD_AWARE_INSTANCE_PARTITION_SELECTOR.toString())))
+        .setReplicaGroupStrategyConfig(new ReplicaGroupStrategyConfig(partitionColumnName, numInstancesPerReplicaGroup))
+        .setSegmentPartitionConfig(segmentPartitionConfig).build();
+    driver = new InstanceAssignmentDriver(tableConfig);
+
+    instancePartitions = driver.assignInstances(InstancePartitionsType.OFFLINE, instanceConfigs, null);
+    assertEquals(instancePartitions.getNumReplicaGroups(), numReplicaGroups);
+    assertEquals(instancePartitions.getNumPartitions(), 1);
+    /*
+     * 21 instances in 5 FDs (pools), with [5,4,4,4,4] instances in each FD
+     * (tableNameHash % poolToInstanceEntriesList.size()) = 3
+     *
+     *         RG1(FD)    RG2(FD)    RG3(FD)
+     *   Host  20 (0)     7  (2)     14 (4)
+     *   Host  1  (1)     8  (3)     10 (0)
+     *   Host  2  (2)     9  (4)     16 (1)
+     *   Host  3  (3)     0  (0)     17 (2)
+     *   Host  4  (4)     11 (1)     18 (3)
+     *   Host  5  (0)     12 (2)     19 (4)
+     *   Host  6  (1)     13 (3)     15 (0)
+     */
+    assertEquals(instancePartitions.getInstances(0, 0),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 20 + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + 1 + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + 2 + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + 3 + SERVER_INSTANCE_POOL_PREFIX + 3,
+            SERVER_INSTANCE_ID_PREFIX + 4 + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + 5 + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + 6 + SERVER_INSTANCE_POOL_PREFIX + 1));
+    assertEquals(instancePartitions.getInstances(0, 1),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 7 + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + 8 + SERVER_INSTANCE_POOL_PREFIX + 3,
+            SERVER_INSTANCE_ID_PREFIX + 9 + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + 0 + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + 11 + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + 12 + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + 13 + SERVER_INSTANCE_POOL_PREFIX + 3));
+    assertEquals(instancePartitions.getInstances(0, 2),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 14 + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + 10 + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + 16 + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + 17 + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + 18 + SERVER_INSTANCE_POOL_PREFIX + 3,
+            SERVER_INSTANCE_ID_PREFIX + 19 + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + 15 + SERVER_INSTANCE_POOL_PREFIX + 0));
+
+    // 9 instances in 5 pools, with [2,2,2,2,1] instances in each pool
+    numInstances = 9;
+    numPools = 5;
+    numReplicaGroups = 3;
+    numInstancesPerReplicaGroup = numInstances / numReplicaGroups;
+    instanceConfigs = new ArrayList<>(numInstances);
+    for (int i = 0; i < numInstances; i++) {
+      int pool = i % numPools;
+      InstanceConfig instanceConfig =
+          new InstanceConfig(SERVER_INSTANCE_ID_PREFIX + i + SERVER_INSTANCE_POOL_PREFIX + pool);
+      instanceConfig.addTag(OFFLINE_TAG);
+      instanceConfig.getRecord()
+          .setMapField(InstanceUtils.POOL_KEY, Collections.singletonMap(OFFLINE_TAG, Integer.toString(pool)));
+      instanceConfigs.add(instanceConfig);
+    }
+    // Use all pools
+    tagPoolConfig = new InstanceTagPoolConfig(OFFLINE_TAG, true, numPools, null);
+    // Assign to 3 replica-groups so that each replica-group is assigned 3 instances
+    replicaPartitionConfig =
+        new InstanceReplicaGroupPartitionConfig(true, 0, numReplicaGroups, numInstancesPerReplicaGroup, numPartitions,
+            numInstancesPerPartition, false);
+    // Do not rotate for testing
+    InstanceConstraintConfig instanceConstraintConfig =
+        new InstanceConstraintConfig(Arrays.asList("constraint1", "constraint2"));
+    tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME + TABLE_NAME_ZERO_HASH_COMPLEMENT)
+            .setInstanceAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.OFFLINE,
+                new InstanceAssignmentConfig(tagPoolConfig, instanceConstraintConfig, replicaPartitionConfig,
+                    InstanceAssignmentConfig.PartitionSelector.FD_AWARE_INSTANCE_PARTITION_SELECTOR.toString())))
+            .build();
+    driver = new InstanceAssignmentDriver(tableConfig);
+
+    instancePartitions = driver.assignInstances(InstancePartitionsType.OFFLINE, instanceConfigs, null);
+    assertEquals(instancePartitions.getNumReplicaGroups(), numReplicaGroups);
+    assertEquals(instancePartitions.getNumPartitions(), 1);
+    /*
+     * 15 instances in 5 FDs (pools), with [2,2,2,2,1] instances in each FD
+     *
+     *         RG1(FD)   RG2(FD)   RG3(FD)
+     *   Host  0  (0)    3  (3)    6  (1)
+     *   Host  1  (1)    4  (4)    7  (2)
+     *   Host  2  (2)    5  (0)    8  (3)
+     *
+     */
+    assertEquals(instancePartitions.getInstances(0, 0),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 0 + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + 1 + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + 2 + SERVER_INSTANCE_POOL_PREFIX + 2));
+    assertEquals(instancePartitions.getInstances(0, 1),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 3 + SERVER_INSTANCE_POOL_PREFIX + 3,
+            SERVER_INSTANCE_ID_PREFIX + 4 + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + 5 + SERVER_INSTANCE_POOL_PREFIX + 0));
+    assertEquals(instancePartitions.getInstances(0, 2),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 6 + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + 7 + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + 8 + SERVER_INSTANCE_POOL_PREFIX + 3));
+
+    // 9 instances in 5 pools, with [2,2,2,2,1] instances in each pool
+    numInstances = 16;
+    numPools = 5;
+    numReplicaGroups = 4;
+    numInstancesPerReplicaGroup = numInstances / numReplicaGroups;
+    instanceConfigs = new ArrayList<>(numInstances);
+    for (int i = 0; i < numInstances; i++) {
+      int pool = i % numPools;
+      InstanceConfig instanceConfig =
+          new InstanceConfig(SERVER_INSTANCE_ID_PREFIX + i + SERVER_INSTANCE_POOL_PREFIX + pool);
+      instanceConfig.addTag(OFFLINE_TAG);
+      instanceConfig.getRecord()
+          .setMapField(InstanceUtils.POOL_KEY, Collections.singletonMap(OFFLINE_TAG, Integer.toString(pool)));
+      instanceConfigs.add(instanceConfig);
+    }
+    // Use all pools
+    tagPoolConfig = new InstanceTagPoolConfig(OFFLINE_TAG, true, numPools, null);
+    // Assign to 3 replica-groups so that each replica-group is assigned 3 instances
+    replicaPartitionConfig =
+        new InstanceReplicaGroupPartitionConfig(true, 0, numReplicaGroups, numInstancesPerReplicaGroup, numPartitions,
+            numInstancesPerPartition, true);
+    // Do not rotate for testing
+    instanceConstraintConfig =
+        new InstanceConstraintConfig(Arrays.asList("constraint1", "constraint2"));
+    tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME + TABLE_NAME_ZERO_HASH_COMPLEMENT)
+            .setInstanceAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.OFFLINE,
+                new InstanceAssignmentConfig(tagPoolConfig, instanceConstraintConfig, replicaPartitionConfig,
+                    InstanceAssignmentConfig.PartitionSelector.FD_AWARE_INSTANCE_PARTITION_SELECTOR.toString())))
+            .build();
+    driver = new InstanceAssignmentDriver(tableConfig);
+
+    instancePartitions = driver.assignInstances(InstancePartitionsType.OFFLINE, instanceConfigs, instancePartitions);
+    assertEquals(instancePartitions.getNumReplicaGroups(), numReplicaGroups);
+    assertEquals(instancePartitions.getNumPartitions(), 1);
+    /*
+     * 15 instances in 5 FDs (pools), with [2,2,2,2,1] instances in each FD
+     *
+     *         RG1(FD)   RG2(FD)   RG3(FD)   RG4(FD)
+     *   Host  0  (0)    3  (3)    6  (1)    14 (4)
+     *   Host  1  (1)    4  (4)    7  (2)    15 (0)
+     *   Host  2  (2)    5  (0)    8  (3)    9  (4)
+     *   Host  10 (0)    11 (1)    12 (2)    13 (3)
+     */
+    assertEquals(instancePartitions.getInstances(0, 0),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 0 + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + 1 + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + 2 + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + 10 + SERVER_INSTANCE_POOL_PREFIX + 0));
+    assertEquals(instancePartitions.getInstances(0, 1),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 3 + SERVER_INSTANCE_POOL_PREFIX + 3,
+            SERVER_INSTANCE_ID_PREFIX + 4 + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + 5 + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + 11 + SERVER_INSTANCE_POOL_PREFIX + 1));
+    assertEquals(instancePartitions.getInstances(0, 2),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 6 + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + 7 + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + 8 + SERVER_INSTANCE_POOL_PREFIX + 3,
+            SERVER_INSTANCE_ID_PREFIX + 12 + SERVER_INSTANCE_POOL_PREFIX + 2));
+    assertEquals(instancePartitions.getInstances(0, 3),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 14 + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + 15 + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + 9 + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + 13 + SERVER_INSTANCE_POOL_PREFIX + 3));
+
+    // 15 instances in 5 pools, with [3,3,3,3,3] instances in each pool
+    numPartitions = 0;
+    numInstancesPerPartition = 0;
+    numInstances = 15;
+    numPools = 5;
+    numReplicaGroups = 3;
+    numInstancesPerReplicaGroup = numInstances / numReplicaGroups;
+    instanceConfigs = new ArrayList<>(numInstances);
+    for (int i = 0; i < numInstances; i++) {
+      int pool = i % numPools;
+      InstanceConfig instanceConfig =
+          new InstanceConfig(SERVER_INSTANCE_ID_PREFIX + String.format("%02d", i) + SERVER_INSTANCE_POOL_PREFIX + pool);
+      instanceConfig.addTag(OFFLINE_TAG);
+      instanceConfig.getRecord()
+          .setMapField(InstanceUtils.POOL_KEY, Collections.singletonMap(OFFLINE_TAG, Integer.toString(pool)));
+      instanceConfigs.add(instanceConfig);
+    }
+    // Use all pools
+    tagPoolConfig = new InstanceTagPoolConfig(OFFLINE_TAG, true, numPools, null);
+    // Assign to 3 replica-groups so that each replica-group is assigned 5 instances
+    replicaPartitionConfig =
+        new InstanceReplicaGroupPartitionConfig(true, 0, numReplicaGroups, numInstancesPerReplicaGroup, numPartitions,
+            numInstancesPerPartition, false);
+    // Do not rotate instance sequence in pool (for testing)
+    instanceConstraintConfig = new InstanceConstraintConfig(Arrays.asList("constraint1", "constraint2"));
+    // Do not rotate pool sequence (for testing)
+    tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME + TABLE_NAME_ZERO_HASH_COMPLEMENT)
+            .setInstanceAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.OFFLINE,
+                new InstanceAssignmentConfig(tagPoolConfig, instanceConstraintConfig, replicaPartitionConfig,
+                    InstanceAssignmentConfig.PartitionSelector.FD_AWARE_INSTANCE_PARTITION_SELECTOR.toString())))
+            .build();
+    driver = new InstanceAssignmentDriver(tableConfig);
+
+    instancePartitions = driver.assignInstances(InstancePartitionsType.OFFLINE, instanceConfigs, null);
+    assertEquals(instancePartitions.getNumReplicaGroups(), numReplicaGroups);
+    assertEquals(instancePartitions.getNumPartitions(), 1);
+    /*
+     * 15 instances in 5 FDs (pools), with [3,3,3,3,3] instances in each FD
+     *
+     *         RG1(FD)   RG2(FD)   RG3(FD)
+     *   Host  0  (0)    9  (4)    13  (3)
+     *   Host  1  (1)    5  (0)    14  (4)
+     *   Host  2  (2)    6  (1)    10  (0)
+     *   Host  3  (3)    7  (2)    11  (1)
+     *   Host  4  (4)    8  (3)    12  (2)
+     */
+    assertEquals(instancePartitions.getInstances(0, 0),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + "00" + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + "01" + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + "02" + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + "03" + SERVER_INSTANCE_POOL_PREFIX + 3,
+            SERVER_INSTANCE_ID_PREFIX + "04" + SERVER_INSTANCE_POOL_PREFIX + 4));
+    assertEquals(instancePartitions.getInstances(0, 1),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + "09" + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + "05" + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + "06" + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + "07" + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + "08" + SERVER_INSTANCE_POOL_PREFIX + 3));
+    assertEquals(instancePartitions.getInstances(0, 2),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + "13" + SERVER_INSTANCE_POOL_PREFIX + 3,
+            SERVER_INSTANCE_ID_PREFIX + "14" + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + "10" + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + "11" + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + "12" + SERVER_INSTANCE_POOL_PREFIX + 2));
+
+    // 15 instances in 5 pools, with [3,3,3,3,3] instances in each pool
+    numPartitions = 0;
+    numInstancesPerPartition = 0;
+    numInstances = 20;
+    numPools = 5;
+    numReplicaGroups = 4;
+    numInstancesPerReplicaGroup = numInstances / numReplicaGroups;
+    instanceConfigs = new ArrayList<>(numInstances);
+    for (int i = 0; i < numInstances; i++) {
+      int pool = i % numPools;
+      InstanceConfig instanceConfig =
+          new InstanceConfig(SERVER_INSTANCE_ID_PREFIX + String.format("%02d", i) + SERVER_INSTANCE_POOL_PREFIX + pool);
+      instanceConfig.addTag(OFFLINE_TAG);
+      instanceConfig.getRecord()
+          .setMapField(InstanceUtils.POOL_KEY, Collections.singletonMap(OFFLINE_TAG, Integer.toString(pool)));
+      instanceConfigs.add(instanceConfig);
+    }
+    // Use all pools
+    tagPoolConfig = new InstanceTagPoolConfig(OFFLINE_TAG, true, numPools, null);
+    // Assign to 3 replica-groups so that each replica-group is assigned 5 instances
+    replicaPartitionConfig =
+        new InstanceReplicaGroupPartitionConfig(true, 0, numReplicaGroups, numInstancesPerReplicaGroup, numPartitions,
+            numInstancesPerPartition, true);
+    // Do not rotate instance sequence in pool (for testing)
+    instanceConstraintConfig = new InstanceConstraintConfig(Arrays.asList("constraint1", "constraint2"));
+    // Do not rotate pool sequence (for testing)
+    tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME + TABLE_NAME_ZERO_HASH_COMPLEMENT)
+            .setInstanceAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.OFFLINE,
+                new InstanceAssignmentConfig(tagPoolConfig, instanceConstraintConfig, replicaPartitionConfig,
+                    InstanceAssignmentConfig.PartitionSelector.FD_AWARE_INSTANCE_PARTITION_SELECTOR.toString())))
+            .build();
+    driver = new InstanceAssignmentDriver(tableConfig);
+
+    instancePartitions = driver.assignInstances(InstancePartitionsType.OFFLINE, instanceConfigs, instancePartitions);
+    assertEquals(instancePartitions.getNumReplicaGroups(), numReplicaGroups);
+    assertEquals(instancePartitions.getNumPartitions(), 1);
+    /*
+     * 20 instances in 5 FDs (pools), with [4,4,4,4,4] instances in each FD
+     *
+     *         RG1(FD)   RG2(FD)   RG3(FD)   RG4(FD)
+     *   Host  0  (0)    9  (4)    13  (3)   17  (2)
+     *   Host  1  (1)    5  (0)    14  (4)   18  (3)
+     *   Host  2  (2)    6  (1)    10  (0)   19  (4)
+     *   Host  3  (3)    7  (2)    11  (1)   15  (0)
+     *   Host  4  (4)    8  (3)    12  (2)   16  (1)
+     */
+    assertEquals(instancePartitions.getInstances(0, 0),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + "00" + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + "01" + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + "02" + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + "03" + SERVER_INSTANCE_POOL_PREFIX + 3,
+            SERVER_INSTANCE_ID_PREFIX + "04" + SERVER_INSTANCE_POOL_PREFIX + 4));
+    assertEquals(instancePartitions.getInstances(0, 1),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + "09" + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + "05" + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + "06" + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + "07" + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + "08" + SERVER_INSTANCE_POOL_PREFIX + 3));
+    assertEquals(instancePartitions.getInstances(0, 2),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + "13" + SERVER_INSTANCE_POOL_PREFIX + 3,
+            SERVER_INSTANCE_ID_PREFIX + "14" + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + "10" + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + "11" + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + "12" + SERVER_INSTANCE_POOL_PREFIX + 2));
+    assertEquals(instancePartitions.getInstances(0, 3),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + "17" + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + "18" + SERVER_INSTANCE_POOL_PREFIX + 3,
+            SERVER_INSTANCE_ID_PREFIX + "19" + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + "15" + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + "16" + SERVER_INSTANCE_POOL_PREFIX + 1));
+
+    // 3 instances in 5 pools, with [1,1,1,0,0] instances in each pool
+    numPartitions = 0;
+    numInstancesPerPartition = 0;
+    numInstances = 3;
+    numPools = 3;
+    numReplicaGroups = 3;
+    numInstancesPerReplicaGroup = numInstances / numReplicaGroups;
+    instanceConfigs = new ArrayList<>(numInstances);
+    for (int i = 0; i < numInstances; i++) {
+      int pool = i % numPools;
+      InstanceConfig instanceConfig =
+          new InstanceConfig(SERVER_INSTANCE_ID_PREFIX + i + SERVER_INSTANCE_POOL_PREFIX + pool);
+      instanceConfig.addTag(OFFLINE_TAG);
+      instanceConfig.getRecord()
+          .setMapField(InstanceUtils.POOL_KEY, Collections.singletonMap(OFFLINE_TAG, Integer.toString(pool)));
+      instanceConfigs.add(instanceConfig);
+    }
+    // Use all pools
+    tagPoolConfig = new InstanceTagPoolConfig(OFFLINE_TAG, true, numPools, null);
+    // Assign to 3 replica-groups so that each replica-group is assigned 1 instances
+    replicaPartitionConfig =
+        new InstanceReplicaGroupPartitionConfig(true, 0, numReplicaGroups, numInstancesPerReplicaGroup, numPartitions,
+            numInstancesPerPartition, false);
+    // Do not rotate for testing
+    instanceConstraintConfig = new InstanceConstraintConfig(Arrays.asList("constraint1", "constraint2"));
+    tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME + TABLE_NAME_ZERO_HASH_COMPLEMENT)
+            .setInstanceAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.OFFLINE,
+                new InstanceAssignmentConfig(tagPoolConfig, instanceConstraintConfig, replicaPartitionConfig,
+                    InstanceAssignmentConfig.PartitionSelector.FD_AWARE_INSTANCE_PARTITION_SELECTOR.toString())))
+            .build();
+    driver = new InstanceAssignmentDriver(tableConfig);
+
+    instancePartitions = driver.assignInstances(InstancePartitionsType.OFFLINE, instanceConfigs, null);
+    assertEquals(instancePartitions.getNumReplicaGroups(), numReplicaGroups);
+    assertEquals(instancePartitions.getNumPartitions(), 1);
+    /*
+     * 3 instances in 5 FDs (pools), with [1,1,1,0,0] instances in each FD
+     *
+     *         RG1(FD)   RG2(FD)   RG3(FD)
+     *   Host  0  (0)    1  (1)    2  (2)
+     *
+     */
+    assertEquals(instancePartitions.getInstances(0, 0),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 0 + SERVER_INSTANCE_POOL_PREFIX + 0));
+    assertEquals(instancePartitions.getInstances(0, 1),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 1 + SERVER_INSTANCE_POOL_PREFIX + 1));
+    assertEquals(instancePartitions.getInstances(0, 2),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + 2 + SERVER_INSTANCE_POOL_PREFIX + 2));
+
+    // 12 instances in 5 pools, with [3,3,2,2,2] instances in each pool
+    numPartitions = 0;
+    numInstancesPerPartition = 0;
+    numInstances = 12;
+    numPools = 5;
+    numReplicaGroups = 6;
+    numInstancesPerReplicaGroup = numInstances / numReplicaGroups;
+    instanceConfigs = new ArrayList<>(numInstances);
+    for (int i = 0; i < numInstances; i++) {
+      int pool = i % numPools;
+      InstanceConfig instanceConfig =
+          new InstanceConfig(SERVER_INSTANCE_ID_PREFIX + String.format("%02d", i) + SERVER_INSTANCE_POOL_PREFIX + pool);
+      instanceConfig.addTag(OFFLINE_TAG);
+      instanceConfig.getRecord()
+          .setMapField(InstanceUtils.POOL_KEY, Collections.singletonMap(OFFLINE_TAG, Integer.toString(pool)));
+      instanceConfigs.add(instanceConfig);
+    }
+    // Use all pools
+    tagPoolConfig = new InstanceTagPoolConfig(OFFLINE_TAG, true, numPools, null);
+    // Assign to 6 replica-groups so that each replica-group is assigned 2 instances
+    replicaPartitionConfig =
+        new InstanceReplicaGroupPartitionConfig(true, 0, numReplicaGroups, numInstancesPerReplicaGroup, numPartitions,
+            numInstancesPerPartition, false);
+    // Do not rotate instance sequence in pool (for testing)
+    instanceConstraintConfig = new InstanceConstraintConfig(Arrays.asList("constraint1", "constraint2"));
+    // Do not rotate pool sequence (for testing)
+    tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME + TABLE_NAME_ZERO_HASH_COMPLEMENT)
+            .setInstanceAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.OFFLINE,
+                new InstanceAssignmentConfig(tagPoolConfig, instanceConstraintConfig, replicaPartitionConfig,
+                    InstanceAssignmentConfig.PartitionSelector.FD_AWARE_INSTANCE_PARTITION_SELECTOR.toString())))
+            .build();
+    driver = new InstanceAssignmentDriver(tableConfig);
+
+    instancePartitions = driver.assignInstances(InstancePartitionsType.OFFLINE, instanceConfigs, null);
+    assertEquals(instancePartitions.getNumReplicaGroups(), numReplicaGroups);
+    assertEquals(instancePartitions.getNumPartitions(), 1);
+    /*
+     * 12 instances in 5 FDs (pools), with [3,3,2,2,2] instances in each FD
+     *
+     *         RG0(FD)   RG1(FD)   RG2(FD)   RG3(FD)   RG4(FD)    RG5(FD)
+     *   Host  0  (0)    2 (2)     4  (4)    6  (1)    8  (3)     10  (0)
+     *   Host  1  (1)    3 (3)     5  (0)    7  (2)    9  (4)     11  (1)
+     */
+    assertEquals(instancePartitions.getInstances(0, 0),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + "00" + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + "01" + SERVER_INSTANCE_POOL_PREFIX + 1));
+    assertEquals(instancePartitions.getInstances(0, 1),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + "02" + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + "03" + SERVER_INSTANCE_POOL_PREFIX + 3));
+    assertEquals(instancePartitions.getInstances(0, 2),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + "04" + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + "05" + SERVER_INSTANCE_POOL_PREFIX + 0));
+    assertEquals(instancePartitions.getInstances(0, 3),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + "06" + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + "07" + SERVER_INSTANCE_POOL_PREFIX + 2));
+    assertEquals(instancePartitions.getInstances(0, 4),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + "08" + SERVER_INSTANCE_POOL_PREFIX + 3,
+            SERVER_INSTANCE_ID_PREFIX + "09" + SERVER_INSTANCE_POOL_PREFIX + 4));
+    assertEquals(instancePartitions.getInstances(0, 5),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + "10" + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + "11" + SERVER_INSTANCE_POOL_PREFIX + 1));
+
+    // 18 instances in 5 pools, with [4,4,4,3,3] instances in each pool
+    // increment 1 instance per replica group on top of the above assignment
+    numPartitions = 0;
+    numInstancesPerPartition = 0;
+    numInstances = 18;
+    numPools = 5;
+    numReplicaGroups = 6;
+    numInstancesPerReplicaGroup = numInstances / numReplicaGroups;
+    instanceConfigs = new ArrayList<>(numInstances);
+    for (int i = 0; i < numInstances; i++) {
+      int pool = i % numPools;
+      InstanceConfig instanceConfig =
+          new InstanceConfig(SERVER_INSTANCE_ID_PREFIX + String.format("%02d", i) + SERVER_INSTANCE_POOL_PREFIX + pool);
+      instanceConfig.addTag(OFFLINE_TAG);
+      instanceConfig.getRecord()
+          .setMapField(InstanceUtils.POOL_KEY, Collections.singletonMap(OFFLINE_TAG, Integer.toString(pool)));
+      instanceConfigs.add(instanceConfig);
+    }
+    // Use all pools
+    tagPoolConfig = new InstanceTagPoolConfig(OFFLINE_TAG, true, numPools, null);
+    // Assign to 6 replica-groups so that each replica-group is assigned 2 instances
+    replicaPartitionConfig =
+        new InstanceReplicaGroupPartitionConfig(true, 0, numReplicaGroups, numInstancesPerReplicaGroup, numPartitions,
+            numInstancesPerPartition, true);
+    // Do not rotate instance sequence in pool (for testing)
+    instanceConstraintConfig = new InstanceConstraintConfig(Arrays.asList("constraint1", "constraint2"));
+    // Do not rotate pool sequence (for testing)
+    tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME + TABLE_NAME_ZERO_HASH_COMPLEMENT)
+            .setInstanceAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.OFFLINE,
+                new InstanceAssignmentConfig(tagPoolConfig, instanceConstraintConfig, replicaPartitionConfig,
+                    InstanceAssignmentConfig.PartitionSelector.FD_AWARE_INSTANCE_PARTITION_SELECTOR.toString())))
+            .build();
+    driver = new InstanceAssignmentDriver(tableConfig);
+
+    instancePartitions = driver.assignInstances(InstancePartitionsType.OFFLINE, instanceConfigs, instancePartitions);
+    assertEquals(instancePartitions.getNumReplicaGroups(), numReplicaGroups);
+    assertEquals(instancePartitions.getNumPartitions(), 1);
+    /*
+     * 18 instances in 5 FDs (pools), with [4,4,4,3,3] instances in each FD
+     *
+     *         RG0(FD)   RG1(FD)   RG2(FD)   RG3(FD)   RG4(FD)    RG5(FD)
+     *   Host  0  (0)    2 (2)     4  (4)    6  (1)    8  (3)     10  (0)
+     *   Host  1  (1)    3 (3)     5  (0)    7  (2)    9  (4)     11  (1)
+     *   Host  15 (0)    16(1)     12 (2)    13 (3)    14 (4)     17  (2)
+     *
+     */
+    assertEquals(instancePartitions.getInstances(0, 0),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + "00" + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + "01" + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + "15" + SERVER_INSTANCE_POOL_PREFIX + 0));
+    assertEquals(instancePartitions.getInstances(0, 1),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + "02" + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + "03" + SERVER_INSTANCE_POOL_PREFIX + 3,
+            SERVER_INSTANCE_ID_PREFIX + "16" + SERVER_INSTANCE_POOL_PREFIX + 1));
+    assertEquals(instancePartitions.getInstances(0, 2),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + "04" + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + "05" + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + "12" + SERVER_INSTANCE_POOL_PREFIX + 2));
+    assertEquals(instancePartitions.getInstances(0, 3),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + "06" + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + "07" + SERVER_INSTANCE_POOL_PREFIX + 2,
+            SERVER_INSTANCE_ID_PREFIX + "13" + SERVER_INSTANCE_POOL_PREFIX + 3));
+    assertEquals(instancePartitions.getInstances(0, 4),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + "08" + SERVER_INSTANCE_POOL_PREFIX + 3,
+            SERVER_INSTANCE_ID_PREFIX + "09" + SERVER_INSTANCE_POOL_PREFIX + 4,
+            SERVER_INSTANCE_ID_PREFIX + "14" + SERVER_INSTANCE_POOL_PREFIX + 4));
+    assertEquals(instancePartitions.getInstances(0, 5),
+        Arrays.asList(SERVER_INSTANCE_ID_PREFIX + "10" + SERVER_INSTANCE_POOL_PREFIX + 0,
+            SERVER_INSTANCE_ID_PREFIX + "11" + SERVER_INSTANCE_POOL_PREFIX + 1,
+            SERVER_INSTANCE_ID_PREFIX + "17" + SERVER_INSTANCE_POOL_PREFIX + 2));
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceAssignmentTest.java
@@ -1003,7 +1003,8 @@ public class InstanceAssignmentTest {
       fail();
     } catch (IllegalStateException e) {
       assertEquals(e.getMessage(),
-          "Not enough qualified instances (21 in all FDs, asked for 24)");
+          "Not enough qualified instances, ask for: (numInstancesPerReplicaGroup: 6) * \"\n"
+              + "              + \"(numReplicaGroups: 4) = 24, having only 21");
     }
 
     numInstances = 10;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceAssignmentTest.java
@@ -939,7 +939,8 @@ public class InstanceAssignmentTest {
               new InstanceAssignmentConfig(tagPoolConfig, null, replicaPartitionConfig, "ILLEGAL_SELECTOR"))).build();
     } catch (IllegalArgumentException e) {
       assertEquals(e.getMessage(),
-          "No enum constant org.apache.pinot.spi.config.table.assignment.Constants.PartitionSelector.ILLEGAL_SELECTOR");
+          "No enum constant org.apache.pinot.spi.config.table.assignment.InstanceAssignmentConfig.PartitionSelector"
+              + ".ILLEGAL_SELECTOR");
     }
 
     // The total num instances cannot be assigned evenly to replica groups

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceAssignmentTest.java
@@ -1003,8 +1003,8 @@ public class InstanceAssignmentTest {
       fail();
     } catch (IllegalStateException e) {
       assertEquals(e.getMessage(),
-          "Not enough qualified instances, ask for: (numInstancesPerReplicaGroup: 6) * \"\n"
-              + "              + \"(numReplicaGroups: 4) = 24, having only 21");
+          "Not enough qualified instances, ask for: (numInstancesPerReplicaGroup: 6) * "
+              + "(numReplicaGroups: 4) = 24, having only 21");
     }
 
     numInstances = 10;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/assignment/InstanceAssignmentConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/assignment/InstanceAssignmentConfig.java
@@ -28,6 +28,8 @@ import org.apache.pinot.spi.config.BaseJsonConfig;
 
 public class InstanceAssignmentConfig extends BaseJsonConfig {
 
+  @JsonPropertyDescription("Configuration for the strategy to assign instances to partitions")
+  public final PartitionSelector _partitionSelector;
   @JsonPropertyDescription("Configuration for the instance tag and pool of the instance assignment (mandatory)")
   private final InstanceTagPoolConfig _tagPoolConfig;
 
@@ -44,13 +46,26 @@ public class InstanceAssignmentConfig extends BaseJsonConfig {
       @JsonProperty(value = "tagPoolConfig", required = true) InstanceTagPoolConfig tagPoolConfig,
       @JsonProperty("constraintConfig") @Nullable InstanceConstraintConfig constraintConfig,
       @JsonProperty(value = "replicaGroupPartitionConfig", required = true)
-          InstanceReplicaGroupPartitionConfig replicaGroupPartitionConfig) {
+          InstanceReplicaGroupPartitionConfig replicaGroupPartitionConfig,
+      @JsonProperty("partitionSelector") @Nullable String partitionSelector) {
     Preconditions.checkArgument(tagPoolConfig != null, "'tagPoolConfig' must be configured");
     Preconditions
         .checkArgument(replicaGroupPartitionConfig != null, "'replicaGroupPartitionConfig' must be configured");
     _tagPoolConfig = tagPoolConfig;
     _constraintConfig = constraintConfig;
     _replicaGroupPartitionConfig = replicaGroupPartitionConfig;
+    _partitionSelector =
+        partitionSelector == null ? PartitionSelector.INSTANCE_REPLICA_GROUP_PARTITION_SELECTOR
+            : PartitionSelector.valueOf(partitionSelector);
+  }
+
+  public InstanceAssignmentConfig(InstanceTagPoolConfig tagPoolConfig, InstanceConstraintConfig constraintConfig,
+      InstanceReplicaGroupPartitionConfig replicaGroupPartitionConfig) {
+    this(tagPoolConfig, constraintConfig, replicaGroupPartitionConfig, null);
+  }
+
+  public PartitionSelector getPartitionSelector() {
+    return _partitionSelector;
   }
 
   public InstanceTagPoolConfig getTagPoolConfig() {
@@ -64,5 +79,9 @@ public class InstanceAssignmentConfig extends BaseJsonConfig {
 
   public InstanceReplicaGroupPartitionConfig getReplicaGroupPartitionConfig() {
     return _replicaGroupPartitionConfig;
+  }
+
+  public enum PartitionSelector {
+    FD_AWARE_INSTANCE_PARTITION_SELECTOR, INSTANCE_REPLICA_GROUP_PARTITION_SELECTOR
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/assignment/InstanceAssignmentConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/assignment/InstanceAssignmentConfig.java
@@ -29,7 +29,7 @@ import org.apache.pinot.spi.config.BaseJsonConfig;
 public class InstanceAssignmentConfig extends BaseJsonConfig {
 
   @JsonPropertyDescription("Configuration for the strategy to assign instances to partitions")
-  public final PartitionSelector _partitionSelector;
+  private final PartitionSelector _partitionSelector;
   @JsonPropertyDescription("Configuration for the instance tag and pool of the instance assignment (mandatory)")
   private final InstanceTagPoolConfig _tagPoolConfig;
 


### PR DESCRIPTION
## Description

This PR address the FD-diverse instance assignment problem. For more details please refer to https://docs.google.com/document/d/1KmJ1DsYXVdzrojj_JYBHRJ2gRMQ5y-o63YqPs7ei7nI/edit#heading=h.nrxxvujq7ael

<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [x] No (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [x] No (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Signature changes to public methods/interfaces
* [x] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes

## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
