### PR TITLE
Add big decimal conversion functions with fixed scale and precision

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DataTypeConversionFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DataTypeConversionFunctions.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.common.function.scalar;
 
 import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
 import java.util.Base64;
 import org.apache.pinot.spi.annotations.ScalarFunction;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
@@ -42,6 +44,34 @@ public class DataTypeConversionFunctions {
   @ScalarFunction
   public static byte[] bigDecimalToBytes(String number) {
     return BigDecimalUtils.serialize(new BigDecimal(number));
+  }
+
+  /**
+   * Converts big decimal string representation to bytes.
+   * Only scale of upto 2 bytes is supported by the function
+   * @param number big decimal number in plain string. e.g. '1234.12121'
+   * @param precision apply a specific precision to BigDecimal
+   * @return The result byte array contains the bytes of the unscaled value appended to bytes of the scale in BIG
+   * ENDIAN order.
+   */
+  @ScalarFunction
+  public static byte[] bigDecimalToBytes(String number, int precision) {
+    return BigDecimalUtils.serialize(new BigDecimal(number, new MathContext(precision, RoundingMode.HALF_EVEN)));
+  }
+
+  /**
+   * Converts big decimal string representation to bytes.
+   * Only scale of upto 2 bytes is supported by the function
+   * @param number big decimal number in plain string. e.g. '1234.12121'
+   * @param precision apply a specific precision to BigDecimal
+   * @param scale specify the number of digits after decimal
+   * @return The result byte array contains the bytes of the unscaled value appended to bytes of the scale in BIG
+   * ENDIAN order.
+   */
+  @ScalarFunction
+  public static byte[] bigDecimalToBytes(String number, int precision, int scale) {
+    return BigDecimalUtils.serialize(new BigDecimal(number, new MathContext(precision, RoundingMode.HALF_EVEN))
+        .setScale(scale, RoundingMode.HALF_EVEN));
   }
 
   /**


### PR DESCRIPTION
There are requirements sometimes when we need to limit the number of decimal places in the stored values. These transform functions can serve as a way to do that for `BigDecimal` data types. 

Not sure if this is required though. Just thought of putting it out there in case a usecase comes such as handling currency data.

The ideal solution should be the one suggested in issue #8418 which is WIP.


Pending - 
* Unit tests
