### PR TITLE
Add retainInstancesSequence feature to table rebalance to minimize data movement between instances

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -569,9 +569,12 @@ public class PinotTableRestletResource {
           boolean downtime, @ApiParam(
       value = "For no-downtime rebalance, minimum number of replicas to keep alive during rebalance, or maximum "
           + "number of replicas allowed to be unavailable if value is negative") @DefaultValue("1")
-  @QueryParam("minAvailableReplicas") int minAvailableReplicas, @ApiParam(
-      value = "Whether to use best-efforts to rebalance (not fail the rebalance when the no-downtime contract cannot "
-          + "be achieved)") @DefaultValue("false") @QueryParam("bestEfforts") boolean bestEfforts) {
+  @QueryParam("minAvailableReplicas") int minAvailableReplicas,
+      @ApiParam(value = "Whether to use best-efforts to rebalance (not fail the rebalance"
+          + " when the no-downtime contract cannot be achieved)") @DefaultValue("false")
+      @QueryParam("bestEfforts") boolean bestEfforts,
+      @ApiParam(value = "Whether to retain instance sequence during rebalancing in order to minimize data movement")
+      @DefaultValue("false") @QueryParam("retainInstancesSequence") boolean retainInstancesSequence) {
 
     String tableNameWithType = constructTableNameWithType(tableName, tableTypeStr);
 
@@ -583,6 +586,7 @@ public class PinotTableRestletResource {
     rebalanceConfig.addProperty(RebalanceConfigConstants.DOWNTIME, downtime);
     rebalanceConfig.addProperty(RebalanceConfigConstants.MIN_REPLICAS_TO_KEEP_UP_FOR_NO_DOWNTIME, minAvailableReplicas);
     rebalanceConfig.addProperty(RebalanceConfigConstants.BEST_EFFORTS, bestEfforts);
+    rebalanceConfig.addProperty(RebalanceConfigConstants.RETAIN_INSTANCE_SEQUENCE, retainInstancesSequence);
 
     try {
       if (dryRun || downtime) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1649,7 +1649,7 @@ public class PinotHelixResourceManager {
       List<InstanceConfig> instanceConfigs = getAllHelixInstanceConfigs();
       for (InstancePartitionsType instancePartitionsType : instancePartitionsTypesToAssign) {
         InstancePartitions instancePartitions =
-            instanceAssignmentDriver.assignInstances(instancePartitionsType, instanceConfigs);
+            instanceAssignmentDriver.assignInstances(instancePartitionsType, instanceConfigs, null);
         LOGGER.info("Persisting instance partitions: {}", instancePartitions);
         InstancePartitionsUtils.persistInstancePartitions(_propertyStore, instancePartitions);
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceAssignmentDriver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceAssignmentDriver.java
@@ -21,12 +21,13 @@ package org.apache.pinot.controller.helix.core.assignment.instance;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
+import javax.annotation.Nullable;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.common.assignment.InstanceAssignmentConfigUtils;
 import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.assignment.InstanceAssignmentConfig;
-import org.apache.pinot.spi.config.table.assignment.InstanceConstraintConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
@@ -51,33 +52,73 @@ public class InstanceAssignmentDriver {
     _tableConfig = tableConfig;
   }
 
+  /**
+   * Assign instances to InstancePartitions object.
+   * @param instancePartitionsType type of instance partitions
+   * @param instanceConfigs list of instance configs
+   * @param existingPoolToInstancesMap a map of existing pools and the instances with sequence that should be respected.
+   *                                   If it's null, there is no requirement to respect the existing sequence and thus
+   *                                   the instance will be sorted.
+   *                                   If it's not null but an empty list, there is no preceding sequence to respect,
+   *                                   and the instances will also be sorted.
+   */
   public InstancePartitions assignInstances(InstancePartitionsType instancePartitionsType,
-      List<InstanceConfig> instanceConfigs) {
+      List<InstanceConfig> instanceConfigs, @Nullable Map<Integer, List<String>> existingPoolToInstancesMap) {
+    boolean shouldRetainInstanceSequence = (existingPoolToInstancesMap != null);
     String tableNameWithType = _tableConfig.getTableName();
-    LOGGER.info("Starting {} instance assignment for table: {}", instancePartitionsType, tableNameWithType);
+    LOGGER.info("Starting {} instance assignment for table: {}. Should retain instance sequence: {}",
+        instancePartitionsType, tableNameWithType, shouldRetainInstanceSequence);
 
+    // Step 0: initialize an instance assignment config.
     InstanceAssignmentConfig assignmentConfig =
         InstanceAssignmentConfigUtils.getInstanceAssignmentConfig(_tableConfig, instancePartitionsType);
-    InstanceTagPoolSelector tagPoolSelector =
-        new InstanceTagPoolSelector(assignmentConfig.getTagPoolConfig(), tableNameWithType);
+
+    // Step 1: select pools and lists of instance configs given the latest instance configs from the ZK.
+    InstanceTagPoolSelector tagPoolSelector = TagPoolSelectorFactory
+        .getInstanceTagPoolSelector(tableNameWithType, assignmentConfig.getTagPoolConfig(), existingPoolToInstancesMap);
     Map<Integer, List<InstanceConfig>> poolToInstanceConfigsMap = tagPoolSelector.selectInstances(instanceConfigs);
 
-    InstanceConstraintConfig constraintConfig = assignmentConfig.getConstraintConfig();
-    List<InstanceConstraintApplier> constraintAppliers = new ArrayList<>();
-    if (constraintConfig == null) {
-      LOGGER.info("No instance constraint is configured, using default hash-based-rotate instance constraint");
-      constraintAppliers.add(new HashBasedRotateInstanceConstraintApplier(tableNameWithType));
-    }
-    // TODO: support more constraints
+    // Step 2: apply instance constraints to the poolToInstanceConfigsMap.
+    List<InstanceConstraintApplier> constraintAppliers = InstanceConstraintAppliersFactory
+        .constructConstraintAppliers(tableNameWithType, assignmentConfig.getConstraintConfig(),
+            existingPoolToInstancesMap);
     for (InstanceConstraintApplier constraintApplier : constraintAppliers) {
       poolToInstanceConfigsMap = constraintApplier.applyConstraint(poolToInstanceConfigsMap);
     }
 
+    // Step 3: select instances based on the replica group partition strategy.
     InstanceReplicaGroupPartitionSelector replicaPartitionSelector =
         new InstanceReplicaGroupPartitionSelector(assignmentConfig.getReplicaGroupPartitionConfig(), tableNameWithType);
     InstancePartitions instancePartitions = new InstancePartitions(
         instancePartitionsType.getInstancePartitionsName(TableNameBuilder.extractRawTableName(tableNameWithType)));
     replicaPartitionSelector.selectInstances(poolToInstanceConfigsMap, instancePartitions);
+
+    // Step 4: persist instance sequence if necessary.
+    if (shouldRetainInstanceSequence) {
+      // Keep the pool to instances map if instance sequence should be retained.
+      // This map will be persisted into ZNode if dryRun is false.
+      instancePartitions
+          .setPoolToInstancesMap(generatePoolToInstanceNamesMapFromPoolToInstanceConfigsMap(poolToInstanceConfigsMap));
+    }
     return instancePartitions;
+  }
+
+  private Map<Integer, List<String>> generatePoolToInstanceNamesMapFromPoolToInstanceConfigsMap(
+      Map<Integer, List<InstanceConfig>> poolToInstanceConfigsMap) {
+    Map<Integer, List<String>> partitionToInstancesMap = new TreeMap<>();
+    for (Map.Entry<Integer, List<InstanceConfig>> entry : poolToInstanceConfigsMap.entrySet()) {
+      Integer pool = entry.getKey();
+      List<InstanceConfig> instanceConfigs = entry.getValue();
+      partitionToInstancesMap.put(pool, extractInstanceNamesFromInstanceConfigs(instanceConfigs));
+    }
+    return partitionToInstancesMap;
+  }
+
+  private List<String> extractInstanceNamesFromInstanceConfigs(List<InstanceConfig> instanceConfigs) {
+    List<String> instanceNames = new ArrayList<>(instanceConfigs.size());
+    for (InstanceConfig instanceConfig : instanceConfigs) {
+      instanceNames.add(instanceConfig.getInstanceName());
+    }
+    return instanceNames;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceConstraintAppliersFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceConstraintAppliersFactory.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.assignment.instance;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.collections.MapUtils;
+import org.apache.pinot.spi.config.table.assignment.InstanceConstraintConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A factory class to construct instance constraint appliers given the table name with type,
+ * instance constraint configs, and the existing poolToInstancesMap.
+ */
+public class InstanceConstraintAppliersFactory {
+  private static final Logger LOGGER = LoggerFactory.getLogger(InstanceConstraintAppliersFactory.class);
+
+  private InstanceConstraintAppliersFactory() {
+  }
+
+  public static List<InstanceConstraintApplier> constructConstraintAppliers(String tableNameWithType,
+      InstanceConstraintConfig constraintConfig, Map<Integer, List<String>> existingPoolToInstancesMap) {
+    List<InstanceConstraintApplier> constraintAppliers = new ArrayList<>();
+    // If there is some k-v pair in the existingPoolToInstancesMap, retain the instance sequence for existing pools.
+    // For new pools, rotation will be applied just as the default constraint applier.
+    if (MapUtils.isNotEmpty(existingPoolToInstancesMap)) {
+      constraintAppliers
+          .add(new RetainedSequenceInstanceConstraintApplier(tableNameWithType, existingPoolToInstancesMap));
+    }
+    if (constraintConfig == null && constraintAppliers.isEmpty()) {
+      LOGGER.info("No instance constraint is configured, using default hash-based-rotate instance constraint");
+      constraintAppliers.add(new HashBasedRotateInstanceConstraintApplier(tableNameWithType));
+    }
+    // TODO: support more constraints
+    return constraintAppliers;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceTagPoolSelector.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceTagPoolSelector.java
@@ -38,8 +38,8 @@ import org.slf4j.LoggerFactory;
 public class InstanceTagPoolSelector {
   private static final Logger LOGGER = LoggerFactory.getLogger(InstanceTagPoolSelector.class);
 
-  private final InstanceTagPoolConfig _tagPoolConfig;
-  private final String _tableNameWithType;
+  protected final InstanceTagPoolConfig _tagPoolConfig;
+  protected final String _tableNameWithType;
 
   public InstanceTagPoolSelector(InstanceTagPoolConfig tagPoolConfig, String tableNameWithType) {
     _tagPoolConfig = tagPoolConfig;
@@ -48,6 +48,7 @@ public class InstanceTagPoolSelector {
 
   /**
    * Returns a map from pool to instance configs based on the tag and pool config for the given instance configs.
+   * @param instanceConfigs list of latest instance configs from ZK.
    */
   public Map<Integer, List<InstanceConfig>> selectInstances(List<InstanceConfig> instanceConfigs) {
     int tableNameHash = Math.abs(_tableNameWithType.hashCode());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/RetainedSequenceBasedInstanceTagPoolSelector.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/RetainedSequenceBasedInstanceTagPoolSelector.java
@@ -1,0 +1,233 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.assignment.instance;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.common.utils.config.InstanceUtils;
+import org.apache.pinot.spi.config.table.assignment.InstanceTagPoolConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * An extended version of {@link InstanceTagPoolSelector} that retains existing instance sequence
+ * from the last instance assignment given the existing pool to instances map. If the map is null or empty,
+ * there is no instance sequence to respect, and the instance configs will be sorted based on the instance ids.
+ */
+public class RetainedSequenceBasedInstanceTagPoolSelector extends InstanceTagPoolSelector {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RetainedSequenceBasedInstanceTagPoolSelector.class);
+
+  private final Map<Integer, List<String>> _existingPoolToInstancesMap;
+
+  public RetainedSequenceBasedInstanceTagPoolSelector(InstanceTagPoolConfig tagPoolConfig, String tableNameWithType,
+      Map<Integer, List<String>> existingPoolToInstancesMap) {
+    super(tagPoolConfig, tableNameWithType);
+    // The existing poolToInstancesMap must not be null.
+    _existingPoolToInstancesMap = existingPoolToInstancesMap;
+  }
+
+  @Override
+  public Map<Integer, List<InstanceConfig>> selectInstances(List<InstanceConfig> instanceConfigs) {
+    int tableNameHash = Math.abs(_tableNameWithType.hashCode());
+    LOGGER.info("Starting instance tag/pool selection for table: {} with hash: {}", _tableNameWithType, tableNameHash);
+
+    // Filter out the instances with the correct tag.
+    // Use LinkedHashMap here to retain the sorted list of instance names.
+    String tag = _tagPoolConfig.getTag();
+    Map<String, InstanceConfig> candidateInstanceConfigsMap = new LinkedHashMap<>();
+    for (InstanceConfig instanceConfig : instanceConfigs) {
+      if (instanceConfig.getTags().contains(tag)) {
+        candidateInstanceConfigsMap.put(instanceConfig.getInstanceName(), instanceConfig);
+      }
+    }
+
+    // Find out newly added instances from the latest copies of instance configs.
+    // A deque is used here in order to retain the sequence,
+    // given the fact that the list of instance configs is always sorted.
+    Deque<String> newlyAddedInstances = new LinkedList<>(candidateInstanceConfigsMap.keySet());
+    for (List<String> existingInstancesWithSequence : _existingPoolToInstancesMap.values()) {
+      newlyAddedInstances.removeAll(existingInstancesWithSequence);
+    }
+
+    int numCandidateInstances = candidateInstanceConfigsMap.size();
+    Preconditions.checkState(numCandidateInstances > 0, "No enabled instance has the tag: %s", tag);
+    LOGGER.info("{} enabled instances have the tag: {} for table: {}", numCandidateInstances, tag, _tableNameWithType);
+
+    Map<Integer, List<InstanceConfig>> poolToLatestInstanceConfigsMap = new TreeMap<>();
+    if (_tagPoolConfig.isPoolBased()) {
+      // Pool based selection. All the instances should be associated with a specific pool number.
+      // Instance selection should be done within the same pool.
+      // E.g.: Pool0 -> [ I1, I2, I3 ]
+      //       Pool1 -> [ I4, I5, I6 ]
+
+      // Each pool number associates with a map that key is the instance name and value is the instance config.
+      Map<Integer, Map<String, InstanceConfig>> poolToInstanceConfigsMap = new HashMap<>();
+      // Each pool number associates with a list of newly added instance configs,
+      // so that new instances can be fetched from this list.
+      Map<Integer, Deque<InstanceConfig>> poolToNewInstanceConfigsMap = new HashMap<>();
+
+      // Extract the pool information from the instance configs.
+      for (Map.Entry<String, InstanceConfig> entry : candidateInstanceConfigsMap.entrySet()) {
+        String instanceName = entry.getKey();
+        InstanceConfig instanceConfig = entry.getValue();
+        Map<String, String> poolMap = instanceConfig.getRecord().getMapField(InstanceUtils.POOL_KEY);
+        if (poolMap != null && poolMap.containsKey(tag)) {
+          int pool = Integer.parseInt(poolMap.get(tag));
+          poolToInstanceConfigsMap.computeIfAbsent(pool, k -> new TreeMap<>()).put(instanceName, instanceConfig);
+          if (newlyAddedInstances.contains(instanceName)) {
+            poolToNewInstanceConfigsMap.computeIfAbsent(pool, k -> new LinkedList<>()).add(instanceConfig);
+          }
+        }
+      }
+
+      for (Map.Entry<Integer, List<String>> entry : _existingPoolToInstancesMap.entrySet()) {
+        Integer pool = entry.getKey();
+        List<String> existingInstanceAssignmentInPool = entry.getValue();
+        List<InstanceConfig> candidateInstanceConfigsWithSequence = new ArrayList<>();
+        for (String existingInstance : existingInstanceAssignmentInPool) {
+          InstanceConfig instanceConfig = poolToInstanceConfigsMap.get(pool).get(existingInstance);
+          // Add instances to the candidate list and respect the sequence of the existing instances from the ZK.
+          // The missing/removed instances will be replaced by the newly instances.
+          // If the instance still exists from ZK, then add it to the candidate list.
+          // E.g. if the old instances are: [I1, I2, I3, I4] and the new instance are: [I1, I3, I4, I5, I6],
+          // the removed instance is I2 and the newly added instances are I5 and I6.
+          // The position of I2 would be replaced by I5, the new remaining I6 would be appended to the tail.
+          // Thus, the new order would be [I1, I5, I3, I4, I6].
+          if (instanceConfig != null) {
+            candidateInstanceConfigsWithSequence.add(instanceConfig);
+          } else {
+            // The current chosen instance no longer lives in the cluster any more, thus pick a new instance.
+            InstanceConfig newInstanceConfig = poolToNewInstanceConfigsMap.get(pool).pollFirst();
+            // If there is no new instance from the same pool, then don't add it.
+            if (newInstanceConfig != null) {
+              candidateInstanceConfigsWithSequence.add(newInstanceConfig);
+            }
+          }
+        }
+        if (!candidateInstanceConfigsMap.isEmpty()) {
+          poolToLatestInstanceConfigsMap.put(pool, candidateInstanceConfigsWithSequence);
+        }
+      }
+
+      // The preceding list of instances has been traversed. Add the remaining new instances.
+      for (Map.Entry<Integer, Deque<InstanceConfig>> entry : poolToNewInstanceConfigsMap.entrySet()) {
+        Integer pool = entry.getKey();
+        Deque<InstanceConfig> remainingNewInstanceConfigs = entry.getValue();
+        poolToLatestInstanceConfigsMap.computeIfAbsent(pool, k -> new ArrayList<>())
+            .addAll(remainingNewInstanceConfigs);
+      }
+
+      Preconditions.checkState(!poolToInstanceConfigsMap.isEmpty(),
+          "No enabled instance has the pool configured for the tag: %s", tag);
+      Map<Integer, Integer> poolToNumInstancesMap = new TreeMap<>();
+      for (Map.Entry<Integer, List<InstanceConfig>> entry : poolToLatestInstanceConfigsMap.entrySet()) {
+        poolToNumInstancesMap.put(entry.getKey(), entry.getValue().size());
+      }
+      LOGGER.info("Number instances for each pool: {} for table: {}", poolToNumInstancesMap, _tableNameWithType);
+
+      // Calculate the pools to select based on the selection config.
+      // Note: the pools here refers to the key set of poolToLatestInstanceConfigsMap,
+      //       so that removing the pool from the set means removing the key-value pair from the map.
+      Set<Integer> pools = poolToLatestInstanceConfigsMap.keySet();
+      List<Integer> poolsToSelect = _tagPoolConfig.getPools();
+      if (poolsToSelect != null && !poolsToSelect.isEmpty()) {
+        Preconditions.checkState(pools.containsAll(poolsToSelect), "Cannot find all instance pools configured: %s",
+            poolsToSelect);
+      } else {
+        int numPools = poolToLatestInstanceConfigsMap.size();
+        int numPoolsToSelect = _tagPoolConfig.getNumPools();
+        if (numPoolsToSelect > 0) {
+          Preconditions
+              .checkState(numPoolsToSelect <= numPools, "Not enough instance pools (%s in the cluster, asked for %s)",
+                  numPools, numPoolsToSelect);
+        } else {
+          numPoolsToSelect = numPools;
+        }
+
+        // Directly return the map if all the pools are selected
+        if (numPools == numPoolsToSelect) {
+          LOGGER.info("Selecting all {} pools: {} for table: {}", numPools, pools, _tableNameWithType);
+          return poolToLatestInstanceConfigsMap;
+        }
+
+        // Select pools based on the table name hash to evenly distribute the tables
+        poolsToSelect = new ArrayList<>(numPoolsToSelect);
+        List<Integer> poolsInCluster = new ArrayList<>(pools);
+        for (int i = 0; i < numPoolsToSelect; i++) {
+          poolsToSelect.add(poolsInCluster.get((tableNameHash + i) % numPools));
+        }
+      }
+
+      // Keep the pools selected
+      LOGGER.info("Selecting pools: {} for table: {}", poolsToSelect, _tableNameWithType);
+      pools.retainAll(poolsToSelect);
+    } else {
+      // Non-pool based selection. All the instances should be associated with a single pool, which is always 0.
+      // E.g.: Pool0 -> [ I1, I2, I3, I4, I5, I6 ]
+
+      LOGGER.info("Selecting {} instances for table: {}", candidateInstanceConfigsMap.size(), _tableNameWithType);
+      // Put all instance configs as pool 0
+
+      for (Map.Entry<Integer, List<String>> entry : _existingPoolToInstancesMap.entrySet()) {
+        Integer pool = entry.getKey();
+        List<String> existingInstanceAssignmentInPool = entry.getValue();
+        List<InstanceConfig> candidateInstanceConfigsWithSequence = new ArrayList<>();
+        for (String existingInstance : existingInstanceAssignmentInPool) {
+          InstanceConfig instanceConfig = candidateInstanceConfigsMap.get(existingInstance);
+          // Add instances to the candidate list and respect the sequence of the existing instances from the ZK.
+          // The missing/removed instances will be replaced by the newly instances.
+          // If the instance still exists from ZK, then add it to the candidate list.
+          // E.g. if the old instances are: [I1, I2, I3, I4] and the new instance are: [I1, I3, I4, I5, I6],
+          // the removed instance is I2 and the newly added instances are I5 and I6.
+          // The position of I2 would be replaced by I5, the new remaining I6 would be appended to the tail.
+          // Thus, the new order would be [I1, I5, I3, I4, I6].
+          if (instanceConfig != null) {
+            candidateInstanceConfigsWithSequence.add(instanceConfig);
+          } else {
+            // The current chosen instance no longer lives in the cluster any more, thus pick a new instance.
+            String newInstance = newlyAddedInstances.pollFirst();
+            // If there is no new instance from the same pool, then don't add it.
+            if (newInstance != null) {
+              candidateInstanceConfigsWithSequence.add(candidateInstanceConfigsMap.get(newInstance));
+            }
+          }
+        }
+        if (!candidateInstanceConfigsWithSequence.isEmpty()) {
+          poolToLatestInstanceConfigsMap.put(pool, candidateInstanceConfigsWithSequence);
+        }
+      }
+      // The preceding list of instances has been traversed. Add the remaining new instances.
+      for (String remainingNewInstance : newlyAddedInstances) {
+        poolToLatestInstanceConfigsMap.computeIfAbsent(0, k -> new ArrayList<>())
+            .add(candidateInstanceConfigsMap.get(remainingNewInstance));
+      }
+    }
+    return poolToLatestInstanceConfigsMap;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/TagPoolSelectorFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/instance/TagPoolSelectorFactory.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.assignment.instance;
+
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.commons.collections.MapUtils;
+import org.apache.pinot.spi.config.table.assignment.InstanceTagPoolConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A factory class to generate the instance tag pool selector based on the table name with type,
+ * instance tag pool config, and the existing poolToInstancesMap.
+ */
+public class TagPoolSelectorFactory {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TagPoolSelectorFactory.class);
+
+  private TagPoolSelectorFactory() {
+  }
+
+  public static InstanceTagPoolSelector getInstanceTagPoolSelector(String tableNameWithType,
+      InstanceTagPoolConfig tagPoolConfig, @Nullable Map<Integer, List<String>> existingPoolToInstancesMap) {
+    if (MapUtils.isEmpty(existingPoolToInstancesMap)) {
+      LOGGER.info("Constructing {} for table: {}", InstanceTagPoolSelector.class.getName(), tableNameWithType);
+      return new InstanceTagPoolSelector(tagPoolConfig, tableNameWithType);
+    } else {
+      LOGGER.info("Constructing {} for table: {}", RetainedSequenceBasedInstanceTagPoolSelector.class.getName(),
+          tableNameWithType);
+      return new RetainedSequenceBasedInstanceTagPoolSelector(tagPoolConfig, tableNameWithType,
+          existingPoolToInstancesMap);
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfigConstants.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfigConstants.java
@@ -33,6 +33,10 @@ public class RebalanceConfigConstants {
   public static final String REASSIGN_INSTANCES = "reassignInstances";
   public static final boolean DEFAULT_REASSIGN_INSTANCES = false;
 
+  // Whether to retain the sequence for the existing instances
+  public static final String RETAIN_INSTANCE_SEQUENCE = "retainInstancesSequence";
+  public static final boolean DEFAULT_RETAIN_INSTANCE_SEQUENCE = false;
+
   // Whether to reassign CONSUMING segments
   public static final String INCLUDE_CONSUMING = "includeConsuming";
   public static final boolean DEFAULT_INCLUDE_CONSUMING = false;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -185,8 +185,8 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     // Result should be the same as the result in dry-run mode
     instanceAssignment = rebalanceResult.getInstanceAssignment();
     assertEquals(instanceAssignment.size(), 1);
-    assertEquals(instanceAssignment.get(InstancePartitionsType.OFFLINE).getPartitionToInstancesMap(),
-        instancePartitions.getPartitionToInstancesMap());
+    assertEquals(instanceAssignment.get(InstancePartitionsType.OFFLINE).getPoolToInstancesMap(),
+        instancePartitions.getPoolToInstancesMap());
     assertEquals(rebalanceResult.getSegmentAssignment(), newSegmentAssignment);
 
     // ExternalView should match the new segment assignment

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotTableRebalancer.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotTableRebalancer.java
@@ -36,7 +36,7 @@ public class PinotTableRebalancer extends PinotZKChanger {
 
   public PinotTableRebalancer(String zkAddress, String clusterName, boolean dryRun, boolean reassignInstances,
       boolean includeConsuming, boolean bootstrap, boolean downtime, int minReplicasToKeepUpForNoDowntime,
-      boolean bestEffort) {
+      boolean bestEffort, boolean retainInstancesSequence) {
     super(zkAddress, clusterName);
     _rebalanceConfig.addProperty(RebalanceConfigConstants.DRY_RUN, dryRun);
     _rebalanceConfig.addProperty(RebalanceConfigConstants.REASSIGN_INSTANCES, reassignInstances);
@@ -46,6 +46,7 @@ public class PinotTableRebalancer extends PinotZKChanger {
     _rebalanceConfig.addProperty(RebalanceConfigConstants.MIN_REPLICAS_TO_KEEP_UP_FOR_NO_DOWNTIME,
         minReplicasToKeepUpForNoDowntime);
     _rebalanceConfig.addProperty(RebalanceConfigConstants.BEST_EFFORTS, bestEffort);
+    _rebalanceConfig.addProperty(RebalanceConfigConstants.RETAIN_INSTANCE_SEQUENCE, retainInstancesSequence);
   }
 
   public RebalanceResult rebalance(String tableNameWithType) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RebalanceTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RebalanceTableCommand.java
@@ -77,6 +77,10 @@ public class RebalanceTableCommand extends AbstractBaseAdminCommand implements C
           + " cannot be achieved, false by default)")
   private boolean _bestEfforts = false;
 
+  @CommandLine.Option(names = {"-retainInstancesSequence"},
+      description = "Whether to retain instance sequence during rebalancing in order to minimize data movement")
+  private boolean _retainInstancesSequence = false;
+
   @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, help = true, description = "Print this message")
   private boolean _help = false;
 
@@ -94,7 +98,7 @@ public class RebalanceTableCommand extends AbstractBaseAdminCommand implements C
       throws Exception {
     PinotTableRebalancer tableRebalancer =
         new PinotTableRebalancer(_zkAddress, _clusterName, _dryRun, _reassignInstances, _includeConsuming, _bootstrap,
-            _downtime, _minAvailableReplicas, _bestEfforts);
+            _downtime, _minAvailableReplicas, _bestEfforts, _retainInstancesSequence);
     RebalanceResult rebalanceResult = tableRebalancer.rebalance(_tableNameWithType);
     LOGGER
         .info("Got rebalance result: {} for table: {}", JsonUtils.objectToString(rebalanceResult), _tableNameWithType);


### PR DESCRIPTION
## Description
This PR adds `retainInstancesSequence` feature to table rebalance to minimize data movement between instances within the pool.

Related issue: https://github.com/apache/pinot/issues/8371

E.g. if the old instances are: [I1, I2, I3, I4] and the new instances become: [I1, I3, I4, I5, I6], the removed instance is I2 and the newly added instances are I5 and I6.
The position of I2 would be replaced by I5, the new remaining I6 would be appended to the tail.
Thus, the new order would be [I1, I5, I3, I4, I6].
The copy of poolToInstances information would be kept in the ZNRecord if this feature is enabled, so that this copy can be reused for the next calculation.

E.g. here is the sample znode of instance partition:
```
{
  "id" : "mytable2_OFFLINE",
  "simpleFields" : { },
  "mapFields" : {
    "pools" : {
      "0" : "Server_localhost_8098/Server_localhost_8099/Server_localhost_8100",
      "1" : "Server_localhost_8101/Server_localhost_8102/Server_localhost_8103"
    }
  },
  "listFields" : {
    "0_0" : [ "Server_localhost_8098" ],
    "0_1" : [ "Server_localhost_8101" ],
    "0_2" : [ "Server_localhost_8099" ]
  }
}
```
The existing instancePartitions in `listFields` cannot be reused as there's no way to know about which pool the gone instance belongs to.

Take the above sample as an example. Both two pools are used for instance assignment for the current instancePartitions (`Server_localhost_8098` and `Server_localhost_8099` are from Pool0. `Server_localhost_8101` is from Pool1). If `Server_localhost_8101` is down and needs to be swapped out, its instance config will no longer exist in the ZK. Without the poolToInstances mapping, there is no way to know from which pool the new instance needs to be picked up.

On the other hand, this feature can be enabled only for the tables with very large table size, so the extra overhead of ZNode is controllable. 

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
