### PR TITLE
Fix ChildTraceId  in multithreaded environment

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/util/trace/TraceContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/trace/TraceContext.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.utils.JsonUtils;
 
@@ -67,7 +68,7 @@ public final class TraceContext {
 
     final String _traceId;
     final List<LogEntry> _logs = new ArrayList<>();
-    int _numChildren = 0;
+    final AtomicInteger _numChildren = new AtomicInteger(0);
 
     Trace(@Nullable Trace parent) {
       if (parent == null) {
@@ -82,7 +83,7 @@ public final class TraceContext {
     }
 
     String getChildTraceId() {
-      return _traceId + "_" + _numChildren++;
+      return _traceId + "_" + _numChildren.getAndIncrement();
     }
 
     JsonNode toJson() {

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/trace/TraceContextTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/trace/TraceContextTest.java
@@ -32,7 +32,7 @@ import org.testng.annotations.Test;
 
 
 public class TraceContextTest {
-  private static final int NUM_CHILDREN_PER_REQUEST = 10;
+  private static final int NUM_CHILDREN_PER_REQUEST = 5000;
   private static final int NUM_REQUESTS = 10;
   private static final Random RANDOM = new Random();
 
@@ -102,19 +102,21 @@ public class TraceContextTest {
     for (Future future : futures) {
       future.get();
     }
-
+    // to check uniqueness of traceIds
+    Set<String> traceIds = new HashSet<>();
     Queue<TraceContext.Trace> traces = TraceContext.REQUEST_TO_TRACES_MAP.get(requestId);
     Assert.assertNotNull(traces);
     Assert.assertEquals(traces.size(), NUM_CHILDREN_PER_REQUEST + 1);
     for (TraceContext.Trace trace : traces) {
       // Trace Id is not deterministic because it relies on the order of runJob() getting called
       List<TraceContext.Trace.LogEntry> logs = trace._logs;
+      traceIds.add(trace._traceId);
       Assert.assertEquals(logs.size(), requestId + 1);
       for (TraceContext.Trace.LogEntry log : logs) {
         Assert.assertTrue(expectedTraces.contains(log.toJson().toString()));
       }
     }
-
+    Assert.assertEquals(traceIds.size(), NUM_CHILDREN_PER_REQUEST + 1);
     TraceContext.unregister();
   }
 


### PR DESCRIPTION
## Description
The current numChildren used to create a childTraceId is not threadSafe, and can cause different child threads to have same traceID, fix is to make it atomic
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
