### PR TITLE
add metric for largest segment size

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
@@ -106,6 +106,11 @@ rules:
   cache: true
   labels:
     table: "$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.largestSegmentSizeOnServer.(\\w+)\"><>(\\w+)"
+  name: "pinot_controller_largestSegmentSizeOnServer_$2"
+  cache: true
+  labels:
+    table: "$1"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.tableTotalSizeOnServer.(\\w+)_(\\w+)\"><>(\\w+)"
   name: "pinot_controller_tableTotalSizeOnServer_$3"
   labels:

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -70,7 +70,7 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   @Deprecated // Instead use TABLE_TOTAL_SIZE_ON_SERVER
   OFFLINE_TABLE_ESTIMATED_SIZE("OfflineTableEstimatedSize", false),
 
-  LARGEST_SEGMENT_SIZE_ON_DISK("LargestSegmentSizeOnDisk", false),
+  LARGEST_SEGMENT_SIZE_ON_SERVER("LargestSegmentSizeOnServer", false),
 
   // Total size of table across replicas on servers
   TABLE_TOTAL_SIZE_ON_SERVER("TableTotalSizeOnServer", false),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -70,6 +70,8 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   @Deprecated // Instead use TABLE_TOTAL_SIZE_ON_SERVER
   OFFLINE_TABLE_ESTIMATED_SIZE("OfflineTableEstimatedSize", false),
 
+  LARGEST_SEGMENT_SIZE_ON_DISK("LargestSegmentSizeOnDisk", false),
+
   // Total size of table across replicas on servers
   TABLE_TOTAL_SIZE_ON_SERVER("TableTotalSizeOnServer", false),
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableSizeReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableSizeReader.java
@@ -101,7 +101,7 @@ public class TableSizeReader {
           tableSizeDetails._realtimeSegments._estimatedSizeInBytes / _helixResourceManager.getNumReplicas(
               realtimeTableConfig));
 
-      Long largestSegmentSizeOnServer = DEFAULT_SIZE_WHEN_MISSING_OR_ERROR;
+      long largestSegmentSizeOnServer = DEFAULT_SIZE_WHEN_MISSING_OR_ERROR;
       for (SegmentSizeDetails segmentSizeDetail : tableSizeDetails._realtimeSegments._segments.values()) {
         for (SegmentSizeInfo segmentSizeInfo : segmentSizeDetail._serverInfo.values()) {
           largestSegmentSizeOnServer = Math.max(largestSegmentSizeOnServer, segmentSizeInfo.getDiskSizeInBytes());
@@ -125,7 +125,7 @@ public class TableSizeReader {
           tableSizeDetails._offlineSegments._estimatedSizeInBytes / _helixResourceManager.getNumReplicas(
               offlineTableConfig));
 
-      Long largestSegmentSizeOnServer = DEFAULT_SIZE_WHEN_MISSING_OR_ERROR;
+      long largestSegmentSizeOnServer = DEFAULT_SIZE_WHEN_MISSING_OR_ERROR;
       for (SegmentSizeDetails segmentSizeDetail : tableSizeDetails._offlineSegments._segments.values()) {
         for (SegmentSizeInfo segmentSizeInfo : segmentSizeDetail._serverInfo.values()) {
           largestSegmentSizeOnServer = Math.max(largestSegmentSizeOnServer, segmentSizeInfo.getDiskSizeInBytes());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableSizeReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableSizeReader.java
@@ -99,6 +99,13 @@ public class TableSizeReader {
       _controllerMetrics.setValueOfTableGauge(realtimeTableName, ControllerGauge.TABLE_SIZE_PER_REPLICA_ON_SERVER,
           tableSizeDetails._realtimeSegments._estimatedSizeInBytes / _helixResourceManager.getNumReplicas(
               realtimeTableConfig));
+
+      tableSizeDetails._realtimeSegments._segments.values().stream()
+          .flatMap(segmentSizeDetails -> segmentSizeDetails._serverInfo.values().stream())
+          .map(segmentSizeInfo -> segmentSizeInfo.getDiskSizeInBytes()).max(Long::compare).ifPresent(
+              maxSize -> _controllerMetrics.setValueOfTableGauge(realtimeTableName,
+                  ControllerGauge.LARGEST_SEGMENT_SIZE_ON_DISK,
+                  maxSize));
     }
     if (offlineTableConfig != null) {
       String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
@@ -111,6 +118,13 @@ public class TableSizeReader {
       _controllerMetrics.setValueOfTableGauge(offlineTableName, ControllerGauge.TABLE_SIZE_PER_REPLICA_ON_SERVER,
           tableSizeDetails._offlineSegments._estimatedSizeInBytes / _helixResourceManager.getNumReplicas(
               offlineTableConfig));
+
+      tableSizeDetails._offlineSegments._segments.values().stream()
+          .flatMap(segmentSizeDetails -> segmentSizeDetails._serverInfo.values().stream())
+          .map(segmentSizeInfo -> segmentSizeInfo.getDiskSizeInBytes()).max(Long::compare).ifPresent(
+              maxSize -> _controllerMetrics.setValueOfTableGauge(offlineTableName,
+                  ControllerGauge.LARGEST_SEGMENT_SIZE_ON_DISK,
+                  maxSize));
     }
 
     return tableSizeDetails;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableSizeReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableSizeReader.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TableSizeReader {
   private static final Logger LOGGER = LoggerFactory.getLogger(TableSizeReader.class);
+  public static long DEFAULT_SIZE_WHEN_MISSING_OR_ERROR = -1L;
 
   private final Executor _executor;
   private final HttpConnectionManager _connectionManager;
@@ -100,12 +101,17 @@ public class TableSizeReader {
           tableSizeDetails._realtimeSegments._estimatedSizeInBytes / _helixResourceManager.getNumReplicas(
               realtimeTableConfig));
 
-      tableSizeDetails._realtimeSegments._segments.values().stream()
-          .flatMap(segmentSizeDetails -> segmentSizeDetails._serverInfo.values().stream())
-          .map(segmentSizeInfo -> segmentSizeInfo.getDiskSizeInBytes()).max(Long::compare).ifPresent(
-              maxSize -> _controllerMetrics.setValueOfTableGauge(realtimeTableName,
-                  ControllerGauge.LARGEST_SEGMENT_SIZE_ON_DISK,
-                  maxSize));
+      Long largestSegmentSizeOnServer = DEFAULT_SIZE_WHEN_MISSING_OR_ERROR;
+      for (SegmentSizeDetails segmentSizeDetail : tableSizeDetails._realtimeSegments._segments.values()) {
+        for (SegmentSizeInfo segmentSizeInfo : segmentSizeDetail._serverInfo.values()) {
+          largestSegmentSizeOnServer = Math.max(largestSegmentSizeOnServer, segmentSizeInfo.getDiskSizeInBytes());
+        }
+      }
+      if (largestSegmentSizeOnServer != DEFAULT_SIZE_WHEN_MISSING_OR_ERROR) {
+        _controllerMetrics.setValueOfTableGauge(realtimeTableName,
+            ControllerGauge.LARGEST_SEGMENT_SIZE_ON_SERVER,
+            largestSegmentSizeOnServer);
+      }
     }
     if (offlineTableConfig != null) {
       String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
@@ -119,12 +125,17 @@ public class TableSizeReader {
           tableSizeDetails._offlineSegments._estimatedSizeInBytes / _helixResourceManager.getNumReplicas(
               offlineTableConfig));
 
-      tableSizeDetails._offlineSegments._segments.values().stream()
-          .flatMap(segmentSizeDetails -> segmentSizeDetails._serverInfo.values().stream())
-          .map(segmentSizeInfo -> segmentSizeInfo.getDiskSizeInBytes()).max(Long::compare).ifPresent(
-              maxSize -> _controllerMetrics.setValueOfTableGauge(offlineTableName,
-                  ControllerGauge.LARGEST_SEGMENT_SIZE_ON_DISK,
-                  maxSize));
+      Long largestSegmentSizeOnServer = DEFAULT_SIZE_WHEN_MISSING_OR_ERROR;
+      for (SegmentSizeDetails segmentSizeDetail : tableSizeDetails._offlineSegments._segments.values()) {
+        for (SegmentSizeInfo segmentSizeInfo : segmentSizeDetail._serverInfo.values()) {
+          largestSegmentSizeOnServer = Math.max(largestSegmentSizeOnServer, segmentSizeInfo.getDiskSizeInBytes());
+        }
+      }
+      if (largestSegmentSizeOnServer != DEFAULT_SIZE_WHEN_MISSING_OR_ERROR) {
+        _controllerMetrics.setValueOfTableGauge(offlineTableName,
+            ControllerGauge.LARGEST_SEGMENT_SIZE_ON_SERVER,
+            largestSegmentSizeOnServer);
+      }
     }
 
     return tableSizeDetails;
@@ -219,7 +230,7 @@ public class TableSizeReader {
         for (String segment : segments) {
           SegmentSizeDetails segmentSizeDetails =
               segmentToSizeDetailsMap.computeIfAbsent(segment, k -> new SegmentSizeDetails());
-          segmentSizeDetails._serverInfo.put(server, new SegmentSizeInfo(segment, -1L));
+          segmentSizeDetails._serverInfo.put(server, new SegmentSizeInfo(segment, DEFAULT_SIZE_WHEN_MISSING_OR_ERROR));
         }
       }
     }
@@ -240,7 +251,7 @@ public class TableSizeReader {
       long segmentLevelMax = -1L;
       int errors = 0;
       for (SegmentSizeInfo sizeInfo : sizeDetails._serverInfo.values()) {
-        if (sizeInfo.getDiskSizeInBytes() != -1) {
+        if (sizeInfo.getDiskSizeInBytes() != DEFAULT_SIZE_WHEN_MISSING_OR_ERROR) {
           sizeDetails._reportedSizeInBytes += sizeInfo.getDiskSizeInBytes();
           segmentLevelMax = Math.max(segmentLevelMax, sizeInfo.getDiskSizeInBytes());
         } else {
@@ -256,8 +267,8 @@ public class TableSizeReader {
       } else {
         // Segment is missing from all servers
         missingSegments.add(segment);
-        sizeDetails._reportedSizeInBytes = -1L;
-        sizeDetails._estimatedSizeInBytes = -1L;
+        sizeDetails._reportedSizeInBytes = DEFAULT_SIZE_WHEN_MISSING_OR_ERROR;
+        sizeDetails._estimatedSizeInBytes = DEFAULT_SIZE_WHEN_MISSING_OR_ERROR;
         subTypeSizeDetails._missingSegments++;
       }
     }
@@ -271,8 +282,8 @@ public class TableSizeReader {
               missingPercent);
       if (subTypeSizeDetails._missingSegments == numSegments) {
         LOGGER.warn("Failed to get size report for all {} segments of table: {}", numSegments, tableNameWithType);
-        subTypeSizeDetails._reportedSizeInBytes = -1;
-        subTypeSizeDetails._estimatedSizeInBytes = -1;
+        subTypeSizeDetails._reportedSizeInBytes = DEFAULT_SIZE_WHEN_MISSING_OR_ERROR;
+        subTypeSizeDetails._estimatedSizeInBytes = DEFAULT_SIZE_WHEN_MISSING_OR_ERROR;
       } else {
         LOGGER.warn("Missing size report for {} out of {} segments for table {}", subTypeSizeDetails._missingSegments,
             numSegments, tableNameWithType);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableSizeReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableSizeReader.java
@@ -49,7 +49,7 @@ import org.slf4j.LoggerFactory;
  */
 public class TableSizeReader {
   private static final Logger LOGGER = LoggerFactory.getLogger(TableSizeReader.class);
-  public static long DEFAULT_SIZE_WHEN_MISSING_OR_ERROR = -1L;
+  public static final long DEFAULT_SIZE_WHEN_MISSING_OR_ERROR = -1L;
 
   private final Executor _executor;
   private final HttpConnectionManager _connectionManager;


### PR DESCRIPTION
## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
This adds a metric for the largest segment size on disk by table
- it only publishes the metric if there is at least 1 segment
- the gauge is not reset if all segments are deleted for example. this should be very rare
- this includes the entire segment directory including indices, not just the `columns.psf` file

I tested by running the batch quickstart with a breakpoint and asserting the value at debug time equalled what I saw on disk

## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->
This adds a metric for the largest segment size on disk in a server. You can use this to track the growth of you largest segments.

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
