### PR TITLE
Add DocIdSetOprator to explain plan

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/DocIdSetOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/DocIdSetOperator.java
@@ -37,7 +37,7 @@ import org.apache.pinot.segment.spi.Constants;
  */
 public class DocIdSetOperator extends BaseOperator<DocIdSetBlock> {
   private static final String OPERATOR_NAME = "DocIdSetOperator";
-  private static final String EXPLAIN_NAME = null;
+  private static final String EXPLAIN_NAME = "DOC_ID_SET";
 
   private static final ThreadLocal<int[]> THREAD_LOCAL_DOC_IDS =
       ThreadLocal.withInitial(() -> new int[DocIdSetPlanNode.MAX_DOC_PER_CALL]);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
@@ -233,7 +233,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result1.add(new Object[]{"PROJECT(sortedIndexCol1, noIndexCol3, rangeIndexCol1, rangeIndexCol2, jsonIndexCol1, "
         + "invertedIndexCol1, noIndexCol2, invertedIndexCol2, noIndexCol1, invertedIndexCol3, rangeIndexCol3, "
         + "textIndexCol1)", 4, 3});
-    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
 
     String query2 = "EXPLAIN PLAN FOR SELECT 'mickey' FROM testTable";
@@ -243,7 +244,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result2.add(new Object[]{"SELECT(selectList:'mickey')", 2, 1});
     result2.add(new Object[]{"TRANSFORM('mickey')", 3, 2});
     result2.add(new Object[]{"PROJECT()", 4, 3});
-    result2.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result2.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
     check(query2, new ResultTable(DATA_SCHEMA, result2));
 
     String query3 = "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1 FROM testTable LIMIT 100";
@@ -253,7 +255,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result3.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1)", 2, 1});
     result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 3, 2});
     result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 4, 3});
-    result3.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 5, 4});
+    result3.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result3.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
     check(query3, new ResultTable(DATA_SCHEMA, result3));
 
     String query4 = "EXPLAIN PLAN FOR SELECT DISTINCT invertedIndexCol1, noIndexCol1 FROM testTable LIMIT 100";
@@ -263,7 +266,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result4.add(new Object[]{"DISTINCT(keyColumns:invertedIndexCol1, noIndexCol1)", 2, 1});
     result4.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 3, 2});
     result4.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 4, 3});
-    result4.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 5, 4});
+    result4.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result4.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
     check(query4, new ResultTable(DATA_SCHEMA, result4));
   }
 
@@ -276,7 +280,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result1.add(new Object[]{"SELECT(selectList:case(less_than(noIndexCol1,'10'),'less','more'))", 2, 1});
     result1.add(new Object[]{"TRANSFORM(case(less_than(noIndexCol1,'10'),'less','more'))", 3, 2});
     result1.add(new Object[]{"PROJECT(noIndexCol1)", 4, 3});
-    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
 
     String query2 = "EXPLAIN PLAN FOR SELECT CONCAT(textIndexCol1, textIndexCol1, ':') FROM testTable";
@@ -286,7 +291,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result2.add(new Object[]{"SELECT(selectList:concat(textIndexCol1,textIndexCol1,':'))", 2, 1});
     result2.add(new Object[]{"TRANSFORM(concat(textIndexCol1,textIndexCol1,':'))", 3, 2});
     result2.add(new Object[]{"PROJECT(textIndexCol1)", 4, 3});
-    result2.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result2.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
     check(query2, new ResultTable(DATA_SCHEMA, result2));
   }
 
@@ -301,7 +307,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result1.add(new Object[]{"SELECT_ORDERBY(selectList:case(less_than(noIndexCol1,'10'),'less','more'))", 2, 1});
     result1.add(new Object[]{"TRANSFORM(case(less_than(noIndexCol1,'10'),'less','more'))", 3, 2});
     result1.add(new Object[]{"PROJECT(noIndexCol1)", 4, 3});
-    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
 
     String query2 = "EXPLAIN PLAN FOR SELECT CONCAT(textIndexCol1, textIndexCol1, ':') FROM testTable ORDER BY 1 DESC";
@@ -311,7 +318,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result2.add(new Object[]{"SELECT_ORDERBY(selectList:concat(textIndexCol1,textIndexCol1,':'))", 2, 1});
     result2.add(new Object[]{"TRANSFORM(concat(textIndexCol1,textIndexCol1,':'))", 3, 2});
     result2.add(new Object[]{"PROJECT(textIndexCol1)", 4, 3});
-    result2.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result2.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
     check(query2, new ResultTable(DATA_SCHEMA, result2));
   }
 
@@ -327,7 +335,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result1.add(new Object[]{"SELECT(selectList:noIndexCol1, noIndexCol2, sortedIndexCol1)", 2, 1});
     result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, sortedIndexCol1)", 3, 2});
     result1.add(new Object[]{"PROJECT(sortedIndexCol1, noIndexCol2, noIndexCol1)", 4, 3});
-    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
 
     String query2 =
@@ -339,12 +348,13 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result2.add(new Object[]{"SELECT(selectList:noIndexCol1, noIndexCol2)", 2, 1});
     result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2)", 3, 2});
     result2.add(new Object[]{"PROJECT(noIndexCol2, noIndexCol1)", 4, 3});
-    result2.add(new Object[]{"FILTER_AND", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result2.add(new Object[]{"FILTER_AND", 6, 5});
     result2.add(
         new Object[]{"FILTER_EXPRESSION(operator:RANGE,predicate:div(noIndexCol1,noIndexCol2) BETWEEN '10' AND '20')",
-            6, 5});
+            7, 6});
     result2
-        .add(new Object[]{"FILTER_EXPRESSION(operator:RANGE,predicate:times(invertedIndexCol1,'5') < '1000')", 7, 5});
+        .add(new Object[]{"FILTER_EXPRESSION(operator:RANGE,predicate:times(invertedIndexCol1,'5') < '1000')", 8, 6});
     check(query2, new ResultTable(DATA_SCHEMA, result2));
 
     String query3 =
@@ -356,9 +366,10 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result3.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1)", 2, 1});
     result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 3, 2});
     result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 4, 3});
-    result3.add(new Object[]{"FILTER_OR", 5, 4});
-    result3.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol1 > '1')", 6, 5});
-    result3.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol2 BETWEEN '2' AND '101')", 7, 5});
+    result3.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result3.add(new Object[]{"FILTER_OR", 6, 5});
+    result3.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol1 > '1')", 7, 6});
+    result3.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol2 BETWEEN '2' AND '101')", 8, 6});
     check(query3, new ResultTable(DATA_SCHEMA, result3));
   }
 
@@ -373,11 +384,12 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result1.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, sortedIndexCol1)", 2, 1});
     result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1, sortedIndexCol1)", 3, 2});
     result1.add(new Object[]{"PROJECT(sortedIndexCol1, invertedIndexCol1, noIndexCol1)", 4, 3});
-    result1.add(new Object[]{"FILTER_AND", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result1.add(new Object[]{"FILTER_AND", 6, 5});
     result1.add(new Object[]{
-        "FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:sortedIndexCol1 = " + "'100.1')", 6, 5});
+        "FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:sortedIndexCol1 = " + "'100.1')", 7, 6});
     result1.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,"
-        + "predicate:invertedIndexCol1 = '1.1')", 7, 5});
+        + "predicate:invertedIndexCol1 = '1.1')", 8, 6});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
 
     String query2 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, sortedIndexCol1  FROM testTable WHERE "
@@ -389,15 +401,16 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, sortedIndexCol1)", 2, 1});
     result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1, sortedIndexCol1)", 3, 2});
     result2.add(new Object[]{"PROJECT(sortedIndexCol1, invertedIndexCol1, noIndexCol1)", 4, 3});
-    result2.add(new Object[]{"FILTER_OR", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result2.add(new Object[]{"FILTER_OR", 6, 5});
     result2.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,"
-        + "predicate:invertedIndexCol1 = '1.1')", 6, 5});
+        + "predicate:invertedIndexCol1 = '1.1')", 7, 6});
     result2.add(new Object[]{
-        "FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:sortedIndexCol1 = " + "'100.2')", 7, 5});
+        "FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:sortedIndexCol1 = " + "'100.2')", 8, 6});
     result2
-        .add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:invertedIndexCol1 BETWEEN '0.2' AND '5')", 8, 5});
+        .add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:invertedIndexCol1 BETWEEN '0.2' AND '5')", 9, 6});
     result2.add(new Object[]{
-        "FILTER_RANGE_INDEX(indexLookUp:range_index,operator:RANGE,predicate:rangeIndexCol1 > " + "'20')", 9, 5});
+        "FILTER_RANGE_INDEX(indexLookUp:range_index,operator:RANGE,predicate:rangeIndexCol1 > " + "'20')", 10, 6});
     check(query2, new ResultTable(DATA_SCHEMA, result2));
 
     String query3 =
@@ -409,11 +422,12 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result3.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1)", 2, 1});
     result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 3, 2});
     result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 4, 3});
-    result3.add(new Object[]{"FILTER_OR", 5, 4});
+    result3.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result3.add(new Object[]{"FILTER_OR", 6, 5});
     result3.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:IN,"
-        + "predicate:invertedIndexCol2 IN ('1','2','30'))", 6, 5});
+        + "predicate:invertedIndexCol2 IN ('1','2','30'))", 7, 6});
     result3.add(new Object[]{"FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:NOT_IN,"
-        + "predicate:invertedIndexCol3 NOT IN ('foo','mickey'))", 7, 5});
+        + "predicate:invertedIndexCol3 NOT IN ('foo','mickey'))", 8, 6});
     check(query3, new ResultTable(DATA_SCHEMA, result3));
   }
 
@@ -431,14 +445,15 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result1.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1, rangeIndexCol1)", 2, 1});
     result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1, rangeIndexCol1)", 3, 2});
     result1.add(new Object[]{"PROJECT(rangeIndexCol1, invertedIndexCol1, noIndexCol1)", 4, 3});
-    result1.add(new Object[]{"FILTER_OR", 5, 4});
-    result1.add(new Object[]{"FILTER_AND", 6, 5});
+    result1.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result1.add(new Object[]{"FILTER_OR", 6, 5});
+    result1.add(new Object[]{"FILTER_AND", 7, 6});
     result1.add(new Object[]{
-        "FILTER_RANGE_INDEX(indexLookUp:range_index,operator:RANGE,predicate:rangeIndexCol1 > '10" + ".1')", 7, 6});
+        "FILTER_RANGE_INDEX(indexLookUp:range_index,operator:RANGE,predicate:rangeIndexCol1 > '10" + ".1')", 8, 7});
     result1.add(new Object[]{
-        "FILTER_RANGE_INDEX(indexLookUp:range_index,operator:RANGE,predicate:rangeIndexCol2 >= " + "'15')", 8, 6});
+        "FILTER_RANGE_INDEX(indexLookUp:range_index,operator:RANGE,predicate:rangeIndexCol2 >= " + "'15')", 9, 7});
     result1.add(new Object[]{"FILTER_RANGE_INDEX(indexLookUp:range_index,operator:RANGE,predicate:rangeIndexCol3 "
-        + "BETWEEN '21' AND '45')", 9, 5});
+        + "BETWEEN '21' AND '45')", 10, 6});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
   }
 
@@ -455,8 +470,9 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
             + "(noIndexCol3))", 2, 1});
     result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, noIndexCol3)", 3, 2});
     result1.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{"FILTER_TEXT_INDEX(indexLookUp:text_index,operator:TEXT_MATCH,predicate:text_match"
-        + "(textIndexCol1,'foo'))", 5, 4});
+        + "(textIndexCol1,'foo'))", 6, 5});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
 
     String query2 =
@@ -471,8 +487,9 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
             + "(noIndexCol3))", 2, 1});
     result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, invertedIndexCol1)", 3, 2});
     result2.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"DOC_ID_SET", 5, 4});
     result2.add(new Object[]{"FILTER_TEXT_INDEX(indexLookUp:text_index,operator:TEXT_MATCH,predicate:text_match"
-        + "(textIndexCol1,'foo'))", 5, 4});
+        + "(textIndexCol1,'foo'))", 6, 5});
   }
 
   @Test
@@ -487,12 +504,13 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1)", 2, 1});
     result.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 3, 2});
     result.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 4, 3});
-    result.add(new Object[]{"FILTER_AND", 5, 4});
+    result.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result.add(new Object[]{"FILTER_AND", 6, 5});
     result.add(new Object[]{"FILTER_JSON_INDEX(indexLookUp:json_index,operator:JSON_MATCH,predicate:json_match"
-        + "(jsonIndexCol1,'key=1'))", 6, 5});
+        + "(jsonIndexCol1,'key=1'))", 7, 6});
     result.add(new Object[]{"FILTER_TEXT_INDEX(indexLookUp:text_index,operator:TEXT_MATCH,predicate:text_match"
-        + "(textIndexCol1,'foo'))", 7, 5});
-    result.add(new Object[]{"FILTER_FULL_SCAN(operator:NOT_IN,predicate:noIndexCol1 NOT IN ('1','20','30'))", 8, 5});
+        + "(textIndexCol1,'foo'))", 8, 6});
+    result.add(new Object[]{"FILTER_FULL_SCAN(operator:NOT_IN,predicate:noIndexCol1 NOT IN ('1','20','30'))", 9, 6});
     check(query, new ResultTable(DATA_SCHEMA, result));
   }
 
@@ -522,7 +540,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         new Object[]{"AGGREGATE(aggregations:count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol2))", 2, 1});
     result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2)", 3, 2});
     result3.add(new Object[]{"PROJECT(noIndexCol2, noIndexCol1)", 4, 3});
-    result3.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 5, 4});
+    result3.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result3.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
     check(query3, new ResultTable(DATA_SCHEMA, result3));
 
     String query4 = "EXPLAIN PLAN FOR SELECT sum(add(noIndexCol1, noIndexCol2)), MIN(ADD(DIV(noIndexCol1,noIndexCol2),"
@@ -535,7 +554,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result4.add(
         new Object[]{"TRANSFORM(add(div(noIndexCol1,noIndexCol2),noIndexCol3), add(noIndexCol1,noIndexCol2))", 3, 2});
     result4.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
-    result4.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 5, 4});
+    result4.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result4.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
     check(query4, new ResultTable(DATA_SCHEMA, result4));
   }
 
@@ -551,7 +571,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         + "noIndexCol2)), min(noIndexCol3))", 2, 1});
     result1.add(new Object[]{"TRANSFORM(add(noIndexCol1,noIndexCol2), noIndexCol2, noIndexCol3)", 3, 2});
     result1.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
-    result1.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol1 < '3')", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result1.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol1 < '3')", 6, 5});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
   }
 
@@ -573,8 +594,9 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result2.add(new Object[]{"AGGREGATE(aggregations:sum(noIndexCol2))", 2, 1});
     result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol2)", 3, 2});
     result2.add(new Object[]{"PROJECT(noIndexCol2)", 4, 3});
+    result2.add(new Object[]{"DOC_ID_SET", 5, 4});
     result2.add(new Object[]{
-        "FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:invertedIndexCol3 = " + "'mickey')", 5, 4});
+        "FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:invertedIndexCol3 = " + "'mickey')", 6, 5});
     check(query2, new ResultTable(DATA_SCHEMA, result2));
 
     String query3 =
@@ -587,9 +609,10 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         new Object[]{"AGGREGATE(aggregations:count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol3))", 2, 1});
     result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, noIndexCol3)", 3, 2});
     result3.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
+    result3.add(new Object[]{"DOC_ID_SET", 5, 4});
     result3.add(new Object[]{
         "FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol1 = '1"
-            + ".1')", 5, 4});
+            + ".1')", 6, 5});
     check(query3, new ResultTable(DATA_SCHEMA, result3));
 
     // Use a Transform function in filter on an indexed column.
@@ -601,11 +624,12 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result4.add(new Object[]{"SELECT(selectList:invertedIndexCol3)", 2, 1});
     result4.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol3)", 3, 2});
     result4.add(new Object[]{"PROJECT(invertedIndexCol3)", 4, 3});
-    result4.add(new Object[]{"FILTER_OR", 5, 4});
+    result4.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result4.add(new Object[]{"FILTER_OR", 6, 5});
     result4.add(new Object[]{
-        "FILTER_EXPRESSION(operator:EQ,predicate:concat(invertedIndexCol3,'test','-') = " + "'mickey-test')", 6, 5});
+        "FILTER_EXPRESSION(operator:EQ,predicate:concat(invertedIndexCol3,'test','-') = " + "'mickey-test')", 7, 6});
     result4.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,"
-        + "predicate:invertedIndexCol1 = '1.1')", 7, 5});
+        + "predicate:invertedIndexCol1 = '1.1')", 8, 6});
     check(query4, new ResultTable(DATA_SCHEMA, result4));
   }
 
@@ -621,9 +645,10 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
             + ")", 2, 1});
     result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, noIndexCol3)", 3, 2});
     result1.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(
         new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol2 = '1')",
-            5, 4});
+            6, 5});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
   }
 
@@ -642,9 +667,10 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         + "aggregations:count(*))", 2, 1});
     result1.add(new Object[]{"TRANSFORM(concat(invertedIndexCol3,'test','-'), noIndexCol1)", 3, 2});
     result1.add(new Object[]{"PROJECT(invertedIndexCol3, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{
         "FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:NOT_EQ,predicate:invertedIndexCol2 !="
-            + " '1')", 5, 4});
+            + " '1')", 6, 5});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
   }
 
@@ -662,9 +688,10 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
             + ")", 2, 1});
     result.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, noIndexCol3)", 3, 2});
     result.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
+    result.add(new Object[]{"DOC_ID_SET", 5, 4});
     result.add(
         new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol2 = '1')",
-            5, 4});
+            6, 5});
     check(query, new ResultTable(DATA_SCHEMA, result));
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -1999,7 +1999,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         + "\"columnDataTypes\":[\"STRING\",\"INT\",\"INT\"]},\"rows\":[[\"BROKER_REDUCE(sort:[count(*) ASC],limit:10)"
         + "\",0,-1],[\"COMBINE_GROUPBY_ORDERBY\",1,0],[\"AGGREGATE_GROUPBY_ORDERBY(groupKeys:Carrier, "
         + "aggregations:count(*))\",2,1],[\"TRANSFORM_PASSTHROUGH(Carrier)\",3,2],[\"PROJECT(Carrier)\",4,3],"
-        + "[\"FILTER_MATCH_ENTIRE_SEGMENT(docs:*)\",5,4]]}");
+        + "[\"DOC_ID_SET\",5,4],[\"FILTER_MATCH_ENTIRE_SEGMENT(docs:*)\",6,5]]}");
 
     // In the query below, FlightNum column has an inverted index and there is no data satisfying the predicate
     // "FlightNum < 0". Hence, all segments are pruned out before query execution on the server side.


### PR DESCRIPTION
## Description
The current implementation of explain plan skips creating an
entry for DocIdSetOperator. This PR adds it.

Testing:
* Modified ExplainPlanQueriesTest to reflect the changes.