### PR TITLE
Make the PR template simpler

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,14 +1,26 @@
 Instructions:
-1. The PR has to be tagged with at least one of the following labels:
+1. The PR has to be tagged with at least one of the following labels (*):
    1. `feature`
    2. `bugfix`
    3. `performance`
    4. `ui`
    5. `backward-incompat`
-   6. `release-notes` (*)
+   6. `release-notes` (**)
 2. Remove these instructions before publishing the PR.
  
-(*) Use `release-notes` label for scenarios like:
+(*) Other labels to consider:
+- `testing`
+- `dependencies`
+- `docker`
+- `kubernetes`
+- `observability`
+- `security`
+- `code-style`
+- `extension-point`
+- `refactor`
+- `cleanup`
+
+(**) Use `release-notes` label for scenarios like:
 - New configuration options
 - Deprecation of configurations
 - Signature changes to public methods/interfaces

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,30 +1,15 @@
-## Description
-<!-- Add a description of your PR here.
-A good description should include pointers to an issue or design document, etc.
--->
-## Upgrade Notes
-Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
-* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)
-
-Does this PR fix a zero-downtime upgrade introduced earlier?
-* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)
-
-Does this PR otherwise need attention when creating release notes? Things to consider:
+Instructions:
+1. The PR has to be tagged with at least one of the following labels:
+   1. `feature`
+   2. `bugfix`
+   3. `performance`
+   4. `ui`
+   5. `backward-incompat`
+   6. `release-notes` (*)
+2. Remove these instructions before publishing the PR.
+ 
+(*) Use `release-notes` label for scenarios like:
 - New configuration options
 - Deprecation of configurations
 - Signature changes to public methods/interfaces
 - New plugins added or old plugins removed
-* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
-## Release Notes
-<!-- If you have tagged this as either backward-incompat or release-notes,
-you MUST add text here that you would like to see appear in release notes of the
-next release. -->
-
-<!-- If you have a series of commits adding or enabling a feature, then
-add this section only in final commit that marks the feature completed.
-Refer to earlier release notes to see examples of text.
--->
-## Documentation
-<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
-See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
--->


### PR DESCRIPTION
Nowadays people usually don't follow the current PR template. They either delete the whole thing and add the description text, or they add the description on top of the prefilled template.

This PR makes the template simpler and the only ask from author is to add proper labels. This will be super helpful during the release phase. I had to go over 300 commits one by one and let's say the experience wasn't pleasant ;) 
I added all PMC members as reviewers for this PR to get a consensus on it and afterwards committers as well as reviewers should follow the new simple process.