### PR TITLE
Make ExpressionContext using ArrayList instead Collection.singletonList

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
@@ -118,7 +118,7 @@ public class RequestContextUtils {
     if (functionName.equalsIgnoreCase(AggregationFunctionType.COUNT.getName())) {
       // NOTE: COUNT always take one single argument "*"
       return new FunctionContext(FunctionContext.Type.AGGREGATION, AggregationFunctionType.COUNT.getName(),
-          Collections.singletonList(ExpressionContext.forIdentifier("*")));
+          new ArrayList<>(Collections.singletonList(ExpressionContext.forIdentifier("*"))));
     }
     FunctionContext.Type functionType =
         AggregationFunctionType.isAggregationFunction(functionName) ? FunctionContext.Type.AGGREGATION
@@ -143,7 +143,7 @@ public class RequestContextUtils {
     if (functionName.equalsIgnoreCase(AggregationFunctionType.COUNT.getName())) {
       // NOTE: COUNT always take one single argument "*"
       return new FunctionContext(FunctionContext.Type.AGGREGATION, AggregationFunctionType.COUNT.getName(),
-          Collections.singletonList(ExpressionContext.forIdentifier("*")));
+          new ArrayList<>(Collections.singletonList(ExpressionContext.forIdentifier("*"))));
     }
     FunctionContext.Type functionType =
         AggregationFunctionType.isAggregationFunction(functionName) ? FunctionContext.Type.AGGREGATION
@@ -185,7 +185,7 @@ public class RequestContextUtils {
         return new FilterContext(FilterContext.Type.OR, children, null);
       case NOT:
         assert numOperands == 1;
-        return new FilterContext(FilterContext.Type.NOT, Collections.singletonList(getFilter(operands.get(0))), null);
+        return new FilterContext(FilterContext.Type.NOT, new ArrayList<>(Collections.singletonList(getFilter(operands.get(0)))), null);
       case EQUALS:
         return new FilterContext(FilterContext.Type.PREDICATE, null,
             new EqPredicate(getExpression(operands.get(0)), getStringValue(operands.get(1))));
@@ -286,7 +286,7 @@ public class RequestContextUtils {
         return new FilterContext(FilterContext.Type.OR, children, null);
       case NOT:
         assert numOperands == 1;
-        return new FilterContext(FilterContext.Type.NOT, Collections.singletonList(getFilter(operands.get(0))), null);
+        return new FilterContext(FilterContext.Type.NOT, new ArrayList<>(Collections.singletonList(getFilter(operands.get(0)))), null);
       case EQUALS:
         return new FilterContext(FilterContext.Type.PREDICATE, null,
             new EqPredicate(operands.get(0), getStringValue(operands.get(1))));

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/PinotQuery2BrokerRequestConverter.java
@@ -199,7 +199,7 @@ public class PinotQuery2BrokerRequestConverter {
     String functionName = function.getOperator();
 
     if (functionName.equalsIgnoreCase(AggregationFunctionType.COUNT.getName())) {
-      args = Collections.singletonList("*");
+      args = new ArrayList<>(Collections.singletonList("*"));
     } else {
       // Need to de-dup columns for distinct.
       if (functionName.equalsIgnoreCase(AggregationFunctionType.DISTINCT.getName())) {

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -292,7 +292,8 @@ public class CalciteSqlParser {
       Function function = expression.getFunctionCall();
       if (function != null) {
         if (excludeAs && function.getOperator().equals("as")) {
-          identifiers.addAll(extractIdentifiers(Collections.singletonList(function.getOperands().get(0)), true));
+          identifiers.addAll(
+              extractIdentifiers(new ArrayList<>(Collections.singletonList(function.getOperands().get(0))), true));
         } else {
           identifiers.addAll(extractIdentifiers(function.getOperands(), excludeAs));
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -152,7 +152,7 @@ public class SelectionOperatorUtils {
       // NOTE: The data schema might be generated from DataTableBuilder.buildEmptyDataTable(), where for 'SELECT *' it
       //       contains a single column "*". In such case, return as is to build the empty selection result.
       if (numColumns == 1 && columnNames[0].equals("*")) {
-        return Collections.singletonList("*");
+        return new ArrayList<>(Collections.singletonList("*"));
       }
 
       // Directly return all columns for selection-only queries

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/QueryOverrideWithHintsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/QueryOverrideWithHintsTest.java
@@ -199,7 +199,9 @@ public class QueryOverrideWithHintsTest {
 
   @Test
   public void testRewriteExpressionsWithHints() {
-    BrokerRequest brokerRequest = _sqlCompiler.compileToBrokerRequest("SELECT datetrunc('MONTH', ts) from myTable");
+    BrokerRequest brokerRequest =
+        _sqlCompiler.compileToBrokerRequest(
+            "SELECT datetrunc('MONTH', ts), count(*), sum(abc) from myTable group by datetrunc('MONTH', ts) ");
     Expression dateTruncFunctionExpr = RequestUtils.getFunctionExpression("datetrunc");
     dateTruncFunctionExpr.getFunctionCall().setOperands(new ArrayList<>(
         ImmutableList.of(RequestUtils.getLiteralExpression("MONTH"), RequestUtils.getIdentifierExpression("ts"))));
@@ -209,11 +211,14 @@ public class QueryOverrideWithHintsTest {
     QueryContext queryContext = BrokerRequestToQueryContextConverter.convert(brokerRequest);
     InstancePlanMakerImplV2.rewriteQueryContextWithHints(queryContext, _indexSegment);
     assertEquals(queryContext.getSelectExpressions().get(0).getIdentifier(), "$ts$MONTH");
+    assertEquals(queryContext.getGroupByExpressions().get(0).getIdentifier(), "$ts$MONTH");
   }
 
   @Test
   public void testNotRewriteExpressionsWithHints() {
-    BrokerRequest brokerRequest = _sqlCompiler.compileToBrokerRequest("SELECT datetrunc('DAY', ts) from myTable");
+    BrokerRequest brokerRequest =
+        _sqlCompiler.compileToBrokerRequest(
+            "SELECT datetrunc('DAY', ts), count(*), sum(abc) from myTable group by datetrunc('DAY', ts)");
     Expression dateTruncFunctionExpr = RequestUtils.getFunctionExpression("datetrunc");
     dateTruncFunctionExpr.getFunctionCall().setOperands(new ArrayList<>(
         ImmutableList.of(RequestUtils.getLiteralExpression("DAY"), RequestUtils.getIdentifierExpression("ts"))));

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/scheduler/TestHelper.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/scheduler/TestHelper.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.scheduler;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import org.apache.pinot.common.metrics.ServerMetrics;
@@ -44,7 +45,7 @@ public class TestHelper {
     qs.setTableName(table);
     br.setQuerySource(qs);
     Selection selection = new Selection();
-    selection.setSelectionColumns(Collections.singletonList("*"));
+    selection.setSelectionColumns(new ArrayList<>(Collections.singletonList("*")));
     br.setSelections(selection);
     request.setQuery(br);
     return new ServerQueryRequest(request, metrics, queryArrivalTimeMs);

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/selection/SelectionOperatorServiceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/selection/SelectionOperatorServiceTest.java
@@ -165,7 +165,7 @@ public class SelectionOperatorServiceTest {
     when(dataSchema.getColumnNames()).thenReturn(new String[]{"*"});
     selectionColumns = SelectionOperatorUtils
         .getSelectionColumns(QueryContextConverterUtils.getQueryContextFromSQL("SELECT * FROM testTable"), dataSchema);
-    assertEquals(selectionColumns, Collections.singletonList("*"));
+    assertEquals(selectionColumns, new ArrayList<>(Collections.singletonList("*")));
   }
 
   @Test


### PR DESCRIPTION
## Description
Override hints don't work on `Collection.singletonList` when replace the override expression.
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
