### PR TITLE
Implement CONTAINS Operator

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
@@ -25,6 +25,7 @@ import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
 import org.apache.pinot.common.request.FilterOperator;
 import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.context.predicate.ContainsPredicate;
 import org.apache.pinot.common.request.context.predicate.EqPredicate;
 import org.apache.pinot.common.request.context.predicate.InPredicate;
 import org.apache.pinot.common.request.context.predicate.IsNotNullPredicate;
@@ -185,7 +186,8 @@ public class RequestContextUtils {
         return new FilterContext(FilterContext.Type.OR, children, null);
       case NOT:
         assert numOperands == 1;
-        return new FilterContext(FilterContext.Type.NOT, new ArrayList<>(Collections.singletonList(getFilter(operands.get(0)))), null);
+        return new FilterContext(FilterContext.Type.NOT,
+            new ArrayList<>(Collections.singletonList(getFilter(operands.get(0)))), null);
       case EQUALS:
         return new FilterContext(FilterContext.Type.PREDICATE, null,
             new EqPredicate(getExpression(operands.get(0)), getStringValue(operands.get(1))));
@@ -239,6 +241,9 @@ public class RequestContextUtils {
       case TEXT_MATCH:
         return new FilterContext(FilterContext.Type.PREDICATE, null,
             new TextMatchPredicate(getExpression(operands.get(0)), getStringValue(operands.get(1))));
+      case CONTAINS:
+        return new FilterContext(FilterContext.Type.PREDICATE, null,
+            new ContainsPredicate(getExpression(operands.get(0)), getStringValue(operands.get(1))));
       case JSON_MATCH:
         return new FilterContext(FilterContext.Type.PREDICATE, null,
             new JsonMatchPredicate(getExpression(operands.get(0)), getStringValue(operands.get(1))));
@@ -286,7 +291,8 @@ public class RequestContextUtils {
         return new FilterContext(FilterContext.Type.OR, children, null);
       case NOT:
         assert numOperands == 1;
-        return new FilterContext(FilterContext.Type.NOT, new ArrayList<>(Collections.singletonList(getFilter(operands.get(0)))), null);
+        return new FilterContext(FilterContext.Type.NOT,
+            new ArrayList<>(Collections.singletonList(getFilter(operands.get(0)))), null);
       case EQUALS:
         return new FilterContext(FilterContext.Type.PREDICATE, null,
             new EqPredicate(operands.get(0), getStringValue(operands.get(1))));
@@ -337,6 +343,9 @@ public class RequestContextUtils {
       case TEXT_MATCH:
         return new FilterContext(FilterContext.Type.PREDICATE, null,
             new TextMatchPredicate(operands.get(0), getStringValue(operands.get(1))));
+      case CONTAINS:
+        return new FilterContext(FilterContext.Type.PREDICATE, null,
+            new ContainsPredicate(operands.get(0), getStringValue(operands.get(1))));
       case JSON_MATCH:
         return new FilterContext(FilterContext.Type.PREDICATE, null,
             new JsonMatchPredicate(operands.get(0), getStringValue(operands.get(1))));

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/ContainsPredicate.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/ContainsPredicate.java
@@ -18,45 +18,49 @@
  */
 package org.apache.pinot.common.request.context.predicate;
 
+import java.util.Objects;
 import org.apache.pinot.common.request.context.ExpressionContext;
 
 
 /**
- * The {@code Predicate} class represents the predicate in the filter.
- * <p>Currently the query engine only accepts string literals as the right-hand side of the predicate, so we store the
- * right-hand side of the predicate as string or list of strings.
+ * Represents a CONTAINS predicate.
  */
-public interface Predicate {
-  enum Type {
-    EQ, NOT_EQ(true), IN, NOT_IN(true), RANGE, REGEXP_LIKE, CONTAINS, TEXT_MATCH, JSON_MATCH, IS_NULL, IS_NOT_NULL(true);
+public class ContainsPredicate extends TextMatchPredicate {
+  private final String _value;
 
-    private final boolean _exclusive;
-
-    Type(boolean exclusive) {
-      _exclusive = exclusive;
-    }
-
-    Type() {
-      this(false);
-    }
-
-    public boolean isExclusive() {
-      return _exclusive;
-    }
+  public ContainsPredicate(ExpressionContext lhs, String value) {
+    super(lhs, value);
+    _value = value;
   }
 
-  /**
-   * Returns the type of the predicate.
-   */
-  Type getType();
+  @Override
+  public Type getType() {
+    return Type.CONTAINS;
+  }
 
-  /**
-   * Returns the left-hand side expression of the predicate.
-   */
-  ExpressionContext getLhs();
+  public String getValue() {
+    return _value;
+  }
 
-  /**
-   * Sets the left-hand side expression of the predicate.
-   */
-  void setLhs(ExpressionContext lhs);
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ContainsPredicate)) {
+      return false;
+    }
+    ContainsPredicate that = (ContainsPredicate) o;
+    return Objects.equals(_lhs, that._lhs) && Objects.equals(_value, that._value);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_lhs, _value);
+  }
+
+  @Override
+  public String toString() {
+    return "contains(" + _lhs + ",'" + _value + "')";
+  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/FilterKind.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/FilterKind.java
@@ -37,7 +37,8 @@ public enum FilterKind {
   IS_NULL,
   IS_NOT_NULL,
   TEXT_MATCH,
-  JSON_MATCH;
+  JSON_MATCH,
+  CONTAINS;
 
   /**
    * Helper method that returns true if the enum maps to a Range.

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -703,6 +703,10 @@ public class CalciteSqlParser {
         negated = ((SqlLikeOperator) functionNode.getOperator()).isNegated();
         canonicalName = SqlKind.LIKE.name();
         break;
+      case CONTAINS:
+        negated = ((SqlLikeOperator) functionNode.getOperator()).isNegated();
+        canonicalName = SqlKind.CONTAINS.name();
+        break;
       case OTHER:
       case OTHER_FUNCTION:
       case DOT:

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -195,6 +195,14 @@ public class FilterPlanNode implements PlanNode {
             return FilterOperatorUtils.getLeafFilterOperator(predicateEvaluator, dataSource, numDocs);
           }
           switch (predicate.getType()) {
+            case CONTAINS:
+              if (dataSource.getTextIndex() != null) {
+                // For now, CONTAINS is executed by the TEXT_MATCH operator. With integration of native text indices
+                // the type of operator used will depend on the type of the underlying text index.
+                return new TextMatchFilterOperator(dataSource.getTextIndex(), (TextMatchPredicate) predicate, numDocs);
+              }
+
+              throw new UnsupportedOperationException("CONTAINS is supported only on text index enabled fields");
             case TEXT_MATCH:
               return new TextMatchFilterOperator(dataSource.getTextIndex(), (TextMatchPredicate) predicate, numDocs);
             case REGEXP_LIKE:


### PR DESCRIPTION
This commit introduces the CONTAINS operator
(https://docs.microsoft.com/en-us/sql/relational-databases/search/query-with-full-text-search?view=sql-server-ver15)

 CONTAINS matches tokens vs LIKE which matches entire documents. CONTAINS operates on the text index and has that as a prerequisite.