### PR TITLE
Add endpoints for some finer control on minion tasks

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.ws.rs.DELETE;
 import javax.ws.rs.DefaultValue;
@@ -37,6 +38,8 @@ import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
 import javax.ws.rs.QueryParam;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.helix.task.TaskPartitionState;
 import org.apache.helix.task.TaskState;
 import org.apache.pinot.controller.api.access.AccessType;
 import org.apache.pinot.controller.api.access.Authenticate;
@@ -196,6 +199,14 @@ public class PinotTaskRestletResource {
     return _pinotHelixTaskResourceManager.getTaskState(taskName);
   }
 
+  @GET
+  @Path("/tasks/subtask/{taskName}/state")
+  @ApiOperation("Get the task state for the given task")
+  public Map<String, TaskPartitionState> getSubTaskStates(
+      @ApiParam(value = "Task name", required = true) @PathParam("taskName") String taskName) {
+    return _pinotHelixTaskResourceManager.getSubTaskStates(taskName);
+  }
+
   @Deprecated
   @GET
   @Path("/tasks/taskstate/{taskName}")
@@ -211,6 +222,16 @@ public class PinotTaskRestletResource {
   public List<PinotTaskConfig> getTaskConfigs(
       @ApiParam(value = "Task name", required = true) @PathParam("taskName") String taskName) {
     return _pinotHelixTaskResourceManager.getTaskConfigs(taskName);
+  }
+
+  @GET
+  @Path("/tasks/subtask/{taskName}/config")
+  @ApiOperation("Get the task state for the given task")
+  public Map<String, PinotTaskConfig> getSubTaskConfigs(
+      @ApiParam(value = "Task name", required = true) @PathParam("taskName") String taskName,
+      @ApiParam(value = "Sub task names separated by comma") @QueryParam("subTaskNames") @Nullable
+          String subTaskNames) {
+    return _pinotHelixTaskResourceManager.getSubTaskConfigs(taskName, subTaskNames);
   }
 
   @Deprecated
@@ -419,12 +440,17 @@ public class PinotTaskRestletResource {
   @DELETE
   @Path("/tasks/{taskType}")
   @Authenticate(AccessType.DELETE)
-  @ApiOperation("Delete all tasks (as well as the task queue) for the given task type")
+  @ApiOperation("Delete specified tasks or all the tasks (as well as the task queue) for the given task type")
   public SuccessResponse deleteTasks(
       @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType,
       @ApiParam(value = "Whether to force deleting the tasks (expert only option, enable with cautious")
-      @DefaultValue("false") @QueryParam("forceDelete") boolean forceDelete) {
-    _pinotHelixTaskResourceManager.deleteTaskQueue(taskType, forceDelete);
+      @DefaultValue("false") @QueryParam("forceDelete") boolean forceDelete,
+      @ApiParam(value = "Task names separated by comma") @QueryParam("taskNames") @Nullable String taskNames) {
+    if (StringUtils.isEmpty(taskNames)) {
+      _pinotHelixTaskResourceManager.deleteTaskQueue(taskType, forceDelete);
+    } else {
+      _pinotHelixTaskResourceManager.deleteTasks(taskType, taskNames, forceDelete);
+    }
     return new SuccessResponse("Successfully deleted tasks for task type: " + taskType);
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
@@ -200,7 +200,7 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     // Task deletion requires the task queue to be stopped,
     // so deleting task1 here before resuming the task queue.
     assertTrue(_helixTaskResourceManager.getTaskStates(TASK_TYPE).containsKey(task1));
-    _helixTaskResourceManager.deleteTasks(TASK_TYPE, task1, false);
+    _helixTaskResourceManager.deleteTask(task1, false);
     // Resume the task queue, and let the task complete
     _helixTaskResourceManager.resumeTaskQueue(TASK_TYPE);
     HOLD.set(false);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
@@ -79,8 +79,8 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     // Set task timeout in cluster config
     PinotHelixResourceManager helixResourceManager = _controllerStarter.getHelixResourceManager();
     helixResourceManager.getHelixAdmin().setConfig(
-        new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(
-            helixResourceManager.getHelixClusterName()).build(),
+        new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER)
+            .forCluster(helixResourceManager.getHelixClusterName()).build(),
         Collections.singletonMap(TASK_TYPE + MinionConstants.TIMEOUT_MS_KEY_SUFFIX, Long.toString(600_000L)));
 
     // Add 3 offline tables, where 2 of them have TestTask enabled
@@ -106,9 +106,7 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     // Wait for at most 10 seconds for Helix to generate the tasks
     TestUtils.waitForCondition((aVoid) -> {
       PinotHelixTaskResourceManager.TaskCount taskCount = _helixTaskResourceManager.getTaskCount(task);
-      return taskCount.getError() == errors
-          && taskCount.getWaiting() == waiting
-          && taskCount.getRunning() == running
+      return taskCount.getError() == errors && taskCount.getWaiting() == waiting && taskCount.getRunning() == running
           && taskCount.getTotal() == total;
     }, 10_000L, "Failed to reach expected task count");
   }
@@ -199,6 +197,10 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
             && controllerMetrics.getValueOfTableGauge(completedGauge, ControllerGauge.TASK_STATUS) == 0,
         ZK_CALLBACK_TIMEOUT_MS, "Failed to update the controller gauges");
 
+    // Task deletion requires the task queue to be stopped,
+    // so deleting task1 here before resuming the task queue.
+    assertTrue(_helixTaskResourceManager.getTaskStates(TASK_TYPE).containsKey(task1));
+    _helixTaskResourceManager.deleteTasks(TASK_TYPE, task1, false);
     // Resume the task queue, and let the task complete
     _helixTaskResourceManager.resumeTaskQueue(TASK_TYPE);
     HOLD.set(false);
@@ -206,12 +208,14 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     // Wait at most 60 seconds for all tasks COMPLETED
     TestUtils.waitForCondition(input -> {
       Collection<TaskState> taskStates = _helixTaskResourceManager.getTaskStates(TASK_TYPE).values();
-      assertEquals(taskStates.size(), NUM_TASKS);
       for (TaskState taskState : taskStates) {
         if (taskState != TaskState.COMPLETED) {
           return false;
         }
       }
+      // Task deletion happens eventually along with other state transitions.
+      assertFalse(_helixTaskResourceManager.getTaskStates(TASK_TYPE).containsKey(task1));
+      assertEquals(taskStates.size(), (NUM_TASKS - 1));
       assertTrue(TASK_START_NOTIFIED.get());
       assertTrue(TASK_SUCCESS_NOTIFIED.get());
       assertTrue(TASK_CANCELLED_NOTIFIED.get());
@@ -223,7 +227,7 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     TestUtils.waitForCondition(
         input -> controllerMetrics.getValueOfTableGauge(inProgressGauge, ControllerGauge.TASK_STATUS) == 0
             && controllerMetrics.getValueOfTableGauge(stoppedGauge, ControllerGauge.TASK_STATUS) == 0
-            && controllerMetrics.getValueOfTableGauge(completedGauge, ControllerGauge.TASK_STATUS) == NUM_TASKS,
+            && controllerMetrics.getValueOfTableGauge(completedGauge, ControllerGauge.TASK_STATUS) == (NUM_TASKS - 1),
         ZK_CALLBACK_TIMEOUT_MS, "Failed to update the controller gauges");
 
     // Delete the task queue


### PR DESCRIPTION
add endpoints for some finer control on minion tasks:
- inspect the states or configs of the subtasks of a task
- allow to delete individual tasks w/o deleting the task queue

## Description
<!-- Add a description of your PR here.
A good description should include pointers to an issue or design document, etc.
-->
## Upgrade Notes
Does this PR prevent a zero down-time upgrade? (Assume upgrade order: Controller, Broker, Server, Minion)
* [ ] Yes (Please label as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR fix a zero-downtime upgrade introduced earlier?
* [ ] Yes (Please label this as **<code>backward-incompat</code>**, and complete the section below on Release Notes)

Does this PR otherwise need attention when creating release notes? Things to consider:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
* [ ] Yes (Please label this PR as **<code>release-notes</code>** and complete the section on Release Notes)
## Release Notes
<!-- If you have tagged this as either backward-incompat or release-notes,
you MUST add text here that you would like to see appear in release notes of the
next release. -->

<!-- If you have a series of commits adding or enabling a feature, then
add this section only in final commit that marks the feature completed.
Refer to earlier release notes to see examples of text.
-->
## Documentation
<!-- If you have introduced a new feature or configuration, please add it to the documentation as well.
See https://docs.pinot.apache.org/developers/developers-and-contributors/update-document
-->
