### PR TITLE
Add connection based FailureDetector

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/broker.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/broker.yml
@@ -83,6 +83,9 @@ rules:
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.nettyConnection(\\w+)\"><>(\\w+)"
   name: "pinot_broker_nettyConnection_$1_$2"
   cache: true
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.unhealthyServers\"><>(\\w+)"
+  name: "pinot_broker_unhealthyServers_$1"
+  cache: true
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.clusterChangeCheck\"\"><>(\\w+)"
   name: "pinot_broker_clusterChangeCheck_$1"
   cache: true

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
@@ -230,6 +230,9 @@ rules:
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.nettyConnection(\\w+)\"><>(\\w+)"
   name: "pinot_broker_nettyConnection_$1_$2"
   cache: true
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.unhealthyServers\"><>(\\w+)"
+  name: "pinot_broker_unhealthyServers_$1"
+  cache: true
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.clusterChangeCheck\"\"><>(\\w+)"
   name: "pinot_broker_clusterChangeCheck_$1"
   cache: true

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/failuredetector/BaseExponentialBackoffRetryFailureDetector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/failuredetector/BaseExponentialBackoffRetryFailureDetector.java
@@ -1,0 +1,174 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.failuredetector;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.concurrent.ThreadSafe;
+import org.apache.pinot.common.metrics.BrokerGauge;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants.Broker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * The {@code BaseExponentialBackoffRetryFailureDetector} is a base failure detector implementation that retries the
+ * unhealthy servers with exponential increasing delays.
+ */
+@ThreadSafe
+public abstract class BaseExponentialBackoffRetryFailureDetector implements FailureDetector {
+  protected final Logger _logger = LoggerFactory.getLogger(getClass());
+  protected final String _name = getClass().getSimpleName();
+  protected final List<Listener> _listeners = new ArrayList<>();
+  protected final ConcurrentHashMap<String, RetryInfo> _unhealthyServerRetryInfoMap = new ConcurrentHashMap<>();
+
+  protected BrokerMetrics _brokerMetrics;
+  protected long _retryInitialDelayNs;
+  protected double _retryDelayFactor;
+  protected int _maxRetries;
+  protected Thread _retryThread;
+
+  protected volatile boolean _running;
+
+  @Override
+  public void init(PinotConfiguration config, BrokerMetrics brokerMetrics) {
+    _brokerMetrics = brokerMetrics;
+    long retryInitialDelayMs = config.getProperty(Broker.FailureDetector.CONFIG_OF_RETRY_INITIAL_DELAY_MS,
+        Broker.FailureDetector.DEFAULT_RETRY_INITIAL_DELAY_MS);
+    _retryInitialDelayNs = TimeUnit.MILLISECONDS.toNanos(retryInitialDelayMs);
+    _retryDelayFactor = config.getProperty(Broker.FailureDetector.CONFIG_OF_RETRY_DELAY_FACTOR,
+        Broker.FailureDetector.DEFAULT_RETRY_DELAY_FACTOR);
+    _maxRetries =
+        config.getProperty(Broker.FailureDetector.CONFIG_OF_MAX_RETRIES, Broker.FailureDetector.DEFAULT_MAX_RETIRES);
+    _logger.info("Initialized {} with retry initial delay: {}ms, exponential backoff factor: {}, max " + "retries: {}",
+        _name, retryInitialDelayMs, _retryDelayFactor, _maxRetries);
+  }
+
+  @Override
+  public void register(Listener listener) {
+    _listeners.add(listener);
+  }
+
+  @Override
+  public void start() {
+    _logger.info("Starting {}", _name);
+    _running = true;
+
+    _retryThread = new Thread(() -> {
+      while (_running) {
+        try {
+          long earliestRetryTimeNs = System.nanoTime() + _retryInitialDelayNs;
+          for (Map.Entry<String, RetryInfo> entry : _unhealthyServerRetryInfoMap.entrySet()) {
+            RetryInfo retryInfo = entry.getValue();
+            if (System.nanoTime() > retryInfo._retryTimeNs) {
+              String instanceId = entry.getKey();
+              if (retryInfo._numRetires == _maxRetries) {
+                _logger.warn(
+                    "Unhealthy server: {} already reaches the max retries: {}, do not retry again and treat it as "
+                        + "healthy so that the listeners do not lose track of the server", instanceId, _maxRetries);
+                markServerHealthy(instanceId);
+                continue;
+              }
+              _logger.info("Retry unhealthy server: {}", instanceId);
+              for (Listener listener : _listeners) {
+                listener.retryUnhealthyServer(instanceId, this);
+              }
+              // Update the retry info
+              retryInfo._retryDelayNs = (long) (retryInfo._retryDelayNs * _retryDelayFactor);
+              retryInfo._retryTimeNs = System.nanoTime() + retryInfo._retryDelayNs;
+              retryInfo._numRetires++;
+            } else {
+              earliestRetryTimeNs = Math.min(earliestRetryTimeNs, retryInfo._retryTimeNs);
+            }
+          }
+          //noinspection BusyWait
+          Thread.sleep(TimeUnit.NANOSECONDS.toMillis(earliestRetryTimeNs - System.nanoTime()));
+        } catch (Exception e) {
+          if (_running) {
+            _logger.error("Caught exception in the retry thread, continuing with errors", e);
+          }
+        }
+      }
+    });
+    _retryThread.setName("failure-detector-retry");
+    _retryThread.setDaemon(true);
+    _retryThread.start();
+  }
+
+  @Override
+  public void markServerHealthy(String instanceId) {
+    if (_unhealthyServerRetryInfoMap.remove(instanceId) != null) {
+      _logger.info("Mark server: {} as healthy", instanceId);
+      _brokerMetrics.setValueOfGlobalGauge(BrokerGauge.UNHEALTHY_SERVERS, _unhealthyServerRetryInfoMap.size());
+      for (Listener listener : _listeners) {
+        listener.notifyHealthyServer(instanceId, this);
+      }
+    }
+  }
+
+  @Override
+  public void markServerUnhealthy(String instanceId) {
+    if (_unhealthyServerRetryInfoMap.putIfAbsent(instanceId, new RetryInfo()) == null) {
+      _logger.warn("Mark server: {} as unhealthy", instanceId);
+      _brokerMetrics.setValueOfGlobalGauge(BrokerGauge.UNHEALTHY_SERVERS, _unhealthyServerRetryInfoMap.size());
+      for (Listener listener : _listeners) {
+        listener.notifyUnhealthyServer(instanceId, this);
+      }
+    }
+  }
+
+  @Override
+  public Set<String> getUnhealthyServers() {
+    return _unhealthyServerRetryInfoMap.keySet();
+  }
+
+  @Override
+  public void stop() {
+    _logger.info("Stopping {}", _name);
+    _running = false;
+
+    try {
+      _retryThread.interrupt();
+      _retryThread.join();
+    } catch (InterruptedException e) {
+      throw new RuntimeException("Interrupted while waiting for retry thread to finish", e);
+    }
+  }
+
+  /**
+   * Encapsulates the retry related information.
+   */
+  protected class RetryInfo {
+    long _retryTimeNs;
+    long _retryDelayNs;
+    int _numRetires;
+
+    RetryInfo() {
+      _retryTimeNs = System.nanoTime() + _retryInitialDelayNs;
+      _retryDelayNs = _retryInitialDelayNs;
+      _numRetires = 0;
+    }
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/failuredetector/BaseExponentialBackoffRetryFailureDetector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/failuredetector/BaseExponentialBackoffRetryFailureDetector.java
@@ -178,13 +178,13 @@ public abstract class BaseExponentialBackoffRetryFailureDetector implements Fail
 
     @Override
     public long getDelay(TimeUnit unit) {
-      return unit.convert(System.nanoTime() - _retryTimeNs, TimeUnit.NANOSECONDS);
+      return unit.convert(_retryTimeNs - System.nanoTime(), TimeUnit.NANOSECONDS);
     }
 
     @Override
     public int compareTo(Delayed o) {
       RetryInfo that = (RetryInfo) o;
-      return Long.compare(that._retryTimeNs, _retryTimeNs);
+      return Long.compare(_retryTimeNs, that._retryTimeNs);
     }
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/failuredetector/ConnectionFailureDetector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/failuredetector/ConnectionFailureDetector.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.failuredetector;
+
+import javax.annotation.concurrent.ThreadSafe;
+import org.apache.pinot.core.transport.QueryResponse;
+import org.apache.pinot.core.transport.ServerRoutingInstance;
+
+
+/**
+ * The {@code ConnectionFailureDetector} marks failed server (connection failure) from query response as unhealthy, and
+ * retries the unhealthy servers with exponential increasing delays.
+ */
+@ThreadSafe
+public class ConnectionFailureDetector extends BaseExponentialBackoffRetryFailureDetector {
+
+  @Override
+  public void notifyQuerySubmitted(QueryResponse queryResponse) {
+  }
+
+  @Override
+  public void notifyQueryFinished(QueryResponse queryResponse) {
+    ServerRoutingInstance failedServer = queryResponse.getFailedServer();
+    if (failedServer != null) {
+      markServerUnhealthy(failedServer.getInstanceId());
+    }
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/failuredetector/FailureDetector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/failuredetector/FailureDetector.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.failuredetector;
+
+import java.util.Set;
+import javax.annotation.concurrent.ThreadSafe;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.core.transport.QueryResponse;
+import org.apache.pinot.spi.annotations.InterfaceAudience;
+import org.apache.pinot.spi.annotations.InterfaceStability;
+import org.apache.pinot.spi.env.PinotConfiguration;
+
+
+/**
+ * The {@code FailureDetector} detects unhealthy servers based on the query responses. When it detects an unhealthy
+ * server, it will notify the listener via a callback, and schedule a delay to retry the unhealthy server later via
+ * another callback.
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Evolving
+@ThreadSafe
+public interface FailureDetector {
+
+  /**
+   * Listener for the failure detector.
+   */
+  interface Listener {
+
+    /**
+     * Notifies the listener of an unhealthy server.
+     */
+    void notifyUnhealthyServer(String instanceId, FailureDetector failureDetector);
+
+    /**
+     * Notifies the listener to retry a previous unhealthy server.
+     */
+    void retryUnhealthyServer(String instanceId, FailureDetector failureDetector);
+
+    /**
+     * Notifies the listener of a previous unhealthy server turning healthy.
+     */
+    void notifyHealthyServer(String instanceId, FailureDetector failureDetector);
+  }
+
+  /**
+   * Initializes the failure detector.
+   */
+  void init(PinotConfiguration config, BrokerMetrics brokerMetrics);
+
+  /**
+   * Registers a listener to the failure detector.
+   */
+  void register(Listener listener);
+
+  /**
+   * Starts the failure detector. Listeners should be registered before starting the failure detector.
+   */
+  void start();
+
+  /**
+   * Notifies the failure detector that a query is submitted.
+   */
+  void notifyQuerySubmitted(QueryResponse queryResponse);
+
+  /**
+   * Notifies the failure detector that a query is finished (COMPLETED, FAILED or TIMED_OUT).
+   */
+  void notifyQueryFinished(QueryResponse queryResponse);
+
+  /**
+   * Marks a server as healthy.
+   */
+  void markServerHealthy(String instanceId);
+
+  /**
+   * Marks a server as unhealthy.
+   */
+  void markServerUnhealthy(String instanceId);
+
+  /**
+   * Returns all the unhealthy servers.
+   */
+  Set<String> getUnhealthyServers();
+
+  /**
+   * Stops the failure detector.
+   */
+  void stop();
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/failuredetector/FailureDetectorFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/failuredetector/FailureDetectorFactory.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.failuredetector;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants.Broker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class FailureDetectorFactory {
+  private FailureDetectorFactory() {
+  }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(FailureDetectorFactory.class);
+
+  public static FailureDetector getFailureDetector(PinotConfiguration config, BrokerMetrics brokerMetrics) {
+    String className = config.getProperty(Broker.FailureDetector.CONFIG_OF_CLASS_NAME);
+    if (StringUtils.isEmpty(className)) {
+      LOGGER.info("Class name is not configured, falling back to NoOpFailureDetector");
+      return new NoOpFailureDetector();
+    } else {
+      LOGGER.info("Initializing failure detector with class: {}", className);
+      try {
+        FailureDetector failureDetector =
+            (FailureDetector) Class.forName(className).getDeclaredConstructor().newInstance();
+        failureDetector.init(config, brokerMetrics);
+        LOGGER.info("Initialized failure detector with class: {}", className);
+        return failureDetector;
+      } catch (Exception e) {
+        LOGGER.error(
+            "Caught exception while initializing failure detector with class: {}, falling back to NoOpFailureDetector",
+            className);
+        return new NoOpFailureDetector();
+      }
+    }
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/failuredetector/FailureDetectorFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/failuredetector/FailureDetectorFactory.java
@@ -21,6 +21,7 @@ package org.apache.pinot.broker.failuredetector;
 import org.apache.commons.lang.StringUtils;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.utils.CommonConstants.Broker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,8 +41,7 @@ public class FailureDetectorFactory {
     } else {
       LOGGER.info("Initializing failure detector with class: {}", className);
       try {
-        FailureDetector failureDetector =
-            (FailureDetector) Class.forName(className).getDeclaredConstructor().newInstance();
+        FailureDetector failureDetector = PluginManager.get().createInstance(className);
         failureDetector.init(config, brokerMetrics);
         LOGGER.info("Initialized failure detector with class: {}", className);
         return failureDetector;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/failuredetector/NoOpFailureDetector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/failuredetector/NoOpFailureDetector.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.failuredetector;
+
+import java.util.Collections;
+import java.util.Set;
+import javax.annotation.concurrent.ThreadSafe;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.core.transport.QueryResponse;
+import org.apache.pinot.spi.env.PinotConfiguration;
+
+
+@ThreadSafe
+public class NoOpFailureDetector implements FailureDetector {
+
+  @Override
+  public void init(PinotConfiguration config, BrokerMetrics brokerMetrics) {
+  }
+
+  @Override
+  public void register(Listener listener) {
+  }
+
+  @Override
+  public void start() {
+  }
+
+  @Override
+  public void notifyQuerySubmitted(QueryResponse queryResponse) {
+  }
+
+  @Override
+  public void notifyQueryFinished(QueryResponse queryResponse) {
+  }
+
+  @Override
+  public void markServerHealthy(String instanceId) {
+  }
+
+  @Override
+  public void markServerUnhealthy(String instanceId) {
+  }
+
+  @Override
+  public Set<String> getUnhealthyServers() {
+    return Collections.emptySet();
+  }
+
+  @Override
+  public void stop() {
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/GrpcBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/GrpcBrokerRequestHandler.java
@@ -83,6 +83,7 @@ public class GrpcBrokerRequestHandler extends BaseBrokerRequestHandler {
       List<String>> offlineRoutingTable, @Nullable BrokerRequest realtimeBrokerRequest, @Nullable Map<ServerInstance,
       List<String>> realtimeRoutingTable, long timeoutMs, ServerStats serverStats, RequestStatistics requestStatistics)
       throws Exception {
+    // TODO: Support failure detection
     assert offlineBrokerRequest != null || realtimeBrokerRequest != null;
     Map<ServerRoutingInstance, Iterator<Server.ServerResponse>> responseMap = new HashMap<>();
     if (offlineBrokerRequest != null) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
@@ -27,6 +27,8 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.broker.api.RequestStatistics;
 import org.apache.pinot.broker.broker.AccessControlFactory;
+import org.apache.pinot.broker.failuredetector.FailureDetector;
+import org.apache.pinot.broker.failuredetector.FailureDetectorFactory;
 import org.apache.pinot.broker.queryquota.QueryQuotaManager;
 import org.apache.pinot.broker.routing.BrokerRoutingManager;
 import org.apache.pinot.common.config.NettyConfig;
@@ -49,6 +51,8 @@ import org.apache.pinot.core.transport.ServerResponse;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -56,9 +60,12 @@ import org.apache.pinot.spi.utils.builder.TableNameBuilder;
  * connection per server to route the queries.
  */
 @ThreadSafe
-public class SingleConnectionBrokerRequestHandler extends BaseBrokerRequestHandler {
+public class SingleConnectionBrokerRequestHandler extends BaseBrokerRequestHandler implements FailureDetector.Listener {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SingleConnectionBrokerRequestHandler.class);
+
   private final BrokerReduceService _brokerReduceService;
   private final QueryRouter _queryRouter;
+  private final FailureDetector _failureDetector;
 
   public SingleConnectionBrokerRequestHandler(PinotConfiguration config, BrokerRoutingManager routingManager,
       AccessControlFactory accessControlFactory, QueryQuotaManager queryQuotaManager, TableCache tableCache,
@@ -67,42 +74,49 @@ public class SingleConnectionBrokerRequestHandler extends BaseBrokerRequestHandl
 
     _brokerReduceService = new BrokerReduceService(_config);
     _queryRouter = new QueryRouter(_brokerId, brokerMetrics, nettyConfig, tlsConfig);
+    _failureDetector = FailureDetectorFactory.getFailureDetector(config, brokerMetrics);
   }
 
   @Override
   public void start() {
+    _failureDetector.register(this);
+    _failureDetector.start();
   }
 
   @Override
   public synchronized void shutDown() {
+    _failureDetector.stop();
     _queryRouter.shutDown();
     _brokerReduceService.shutDown();
   }
 
   @Override
   protected BrokerResponseNative processBrokerRequest(long requestId, BrokerRequest originalBrokerRequest,
-      BrokerRequest serverBrokerRequest, @Nullable BrokerRequest offlineBrokerRequest, @Nullable Map<ServerInstance,
-      List<String>> offlineRoutingTable, @Nullable BrokerRequest realtimeBrokerRequest, @Nullable Map<ServerInstance,
-      List<String>> realtimeRoutingTable, long timeoutMs, ServerStats serverStats, RequestStatistics requestStatistics)
+      BrokerRequest serverBrokerRequest, @Nullable BrokerRequest offlineBrokerRequest,
+      @Nullable Map<ServerInstance, List<String>> offlineRoutingTable, @Nullable BrokerRequest realtimeBrokerRequest,
+      @Nullable Map<ServerInstance, List<String>> realtimeRoutingTable, long timeoutMs, ServerStats serverStats,
+      RequestStatistics requestStatistics)
       throws Exception {
     assert offlineBrokerRequest != null || realtimeBrokerRequest != null;
 
     String rawTableName = TableNameBuilder.extractRawTableName(originalBrokerRequest.getQuerySource().getTableName());
     long scatterGatherStartTimeNs = System.nanoTime();
-    AsyncQueryResponse asyncQueryResponse = _queryRouter
-        .submitQuery(requestId, rawTableName, offlineBrokerRequest, offlineRoutingTable, realtimeBrokerRequest,
-            realtimeRoutingTable, timeoutMs);
-    Map<ServerRoutingInstance, ServerResponse> response = asyncQueryResponse.getResponse();
-    _brokerMetrics
-        .addPhaseTiming(rawTableName, BrokerQueryPhase.SCATTER_GATHER, System.nanoTime() - scatterGatherStartTimeNs);
+    AsyncQueryResponse asyncQueryResponse =
+        _queryRouter.submitQuery(requestId, rawTableName, offlineBrokerRequest, offlineRoutingTable,
+            realtimeBrokerRequest, realtimeRoutingTable, timeoutMs);
+    _failureDetector.notifyQuerySubmitted(asyncQueryResponse);
+    Map<ServerRoutingInstance, ServerResponse> finalResponses = asyncQueryResponse.getFinalResponses();
+    _failureDetector.notifyQueryFinished(asyncQueryResponse);
+    _brokerMetrics.addPhaseTiming(rawTableName, BrokerQueryPhase.SCATTER_GATHER,
+        System.nanoTime() - scatterGatherStartTimeNs);
     // TODO Use scatterGatherStats as serverStats
-    serverStats.setServerStats(asyncQueryResponse.getStats());
+    serverStats.setServerStats(asyncQueryResponse.getServerStats());
 
-    int numServersQueried = response.size();
+    int numServersQueried = finalResponses.size();
     long totalResponseSize = 0;
     Map<ServerRoutingInstance, DataTable> dataTableMap = new HashMap<>(HashUtil.getHashMapCapacity(numServersQueried));
     List<ServerRoutingInstance> serversNotResponded = new ArrayList<>();
-    for (Map.Entry<ServerRoutingInstance, ServerResponse> entry : response.entrySet()) {
+    for (Map.Entry<ServerRoutingInstance, ServerResponse> entry : finalResponses.entrySet()) {
       ServerResponse serverResponse = entry.getValue();
       DataTable dataTable = serverResponse.getDataTable();
       if (dataTable != null) {
@@ -116,8 +130,9 @@ public class SingleConnectionBrokerRequestHandler extends BaseBrokerRequestHandl
 
     long reduceStartTimeNs = System.nanoTime();
     long reduceTimeOutMs = timeoutMs - TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - scatterGatherStartTimeNs);
-    BrokerResponseNative brokerResponse = _brokerReduceService.reduceOnDataTable(
-        originalBrokerRequest, serverBrokerRequest, dataTableMap, reduceTimeOutMs, _brokerMetrics);
+    BrokerResponseNative brokerResponse =
+        _brokerReduceService.reduceOnDataTable(originalBrokerRequest, serverBrokerRequest, dataTableMap,
+            reduceTimeOutMs, _brokerMetrics);
     final long reduceTimeNanos = System.nanoTime() - reduceStartTimeNs;
     requestStatistics.setReduceTimeNanos(reduceTimeNanos);
     _brokerMetrics.addPhaseTiming(rawTableName, BrokerQueryPhase.REDUCE, reduceTimeNanos);
@@ -125,11 +140,11 @@ public class SingleConnectionBrokerRequestHandler extends BaseBrokerRequestHandl
     brokerResponse.setNumServersQueried(numServersQueried);
     brokerResponse.setNumServersResponded(numServersResponded);
 
-    Exception brokerRequestSendException = asyncQueryResponse.getBrokerRequestSendException();
+    Exception brokerRequestSendException = asyncQueryResponse.getException();
     if (brokerRequestSendException != null) {
       String errorMsg = QueryException.getTruncatedStackTrace(brokerRequestSendException);
-      brokerResponse
-          .addToExceptions(new QueryProcessingException(QueryException.BROKER_REQUEST_SEND_ERROR_CODE, errorMsg));
+      brokerResponse.addToExceptions(
+          new QueryProcessingException(QueryException.BROKER_REQUEST_SEND_ERROR_CODE, errorMsg));
     }
     int numServersNotResponded = serversNotResponded.size();
     if (numServersNotResponded != 0) {
@@ -143,5 +158,31 @@ public class SingleConnectionBrokerRequestHandler extends BaseBrokerRequestHandl
     _brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.TOTAL_SERVER_RESPONSE_SIZE, totalResponseSize);
 
     return brokerResponse;
+  }
+
+  @Override
+  public void notifyUnhealthyServer(String instanceId, FailureDetector failureDetector) {
+    _routingManager.excludeServerFromRouting(instanceId);
+  }
+
+  @Override
+  public void retryUnhealthyServer(String instanceId, FailureDetector failureDetector) {
+    LOGGER.info("Retrying unhealthy server: {}", instanceId);
+    ServerInstance serverInstance = _routingManager.getEnabledServerInstanceMap().get(instanceId);
+    if (serverInstance == null) {
+      LOGGER.info("Failed to find enabled server: {} in routing manager, skipping the retry", instanceId);
+      return;
+    }
+    if (_queryRouter.connect(serverInstance)) {
+      LOGGER.info("Successfully connect to server: {}, marking it healthy", instanceId);
+      failureDetector.markServerHealthy(instanceId);
+    } else {
+      LOGGER.warn("Still cannot connect to server: {}, retry later", instanceId);
+    }
+  }
+
+  @Override
+  public void notifyHealthyServer(String instanceId, FailureDetector failureDetector) {
+    _routingManager.includeServerToRouting(instanceId);
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
@@ -318,11 +318,11 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
         instanceConfigZNRecord.getSimpleField(InstanceConfig.InstanceConfigProperty.HELIX_ENABLED.name()))) {
       return false;
     }
-    if ("true".equalsIgnoreCase(instanceConfigZNRecord.getSimpleField(Helix.IS_SHUTDOWN_IN_PROGRESS))) {
+    if (Boolean.parseBoolean(instanceConfigZNRecord.getSimpleField(Helix.IS_SHUTDOWN_IN_PROGRESS))) {
       return false;
     }
     //noinspection RedundantIfStatement
-    if ("true".equalsIgnoreCase(instanceConfigZNRecord.getSimpleField(Helix.QUERIES_DISABLED))) {
+    if (Boolean.parseBoolean(instanceConfigZNRecord.getSimpleField(Helix.QUERIES_DISABLED))) {
       return false;
     }
     return true;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
@@ -59,7 +59,7 @@ import org.apache.pinot.core.routing.RoutingTable;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.spi.config.table.QueryConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Helix;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.zookeeper.data.Stat;
@@ -90,12 +90,16 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
   private final BrokerMetrics _brokerMetrics;
   private final Map<String, RoutingEntry> _routingEntryMap = new ConcurrentHashMap<>();
   private final Map<String, ServerInstance> _enabledServerInstanceMap = new ConcurrentHashMap<>();
+  // NOTE: _excludedServers doesn't need to be concurrent because it is only accessed within the synchronized block
+  private final Set<String> _excludedServers = new HashSet<>();
 
   private BaseDataAccessor<ZNRecord> _zkDataAccessor;
   private String _externalViewPathPrefix;
   private String _idealStatePathPrefix;
   private String _instanceConfigsPath;
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;
+
+  private Set<String> _routableServers;
 
   public BrokerRoutingManager(BrokerMetrics brokerMetrics) {
     _brokerMetrics = brokerMetrics;
@@ -118,6 +122,7 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
     } else if (changeType == ChangeType.INSTANCE_CONFIG) {
       processInstanceConfigChange();
     } else {
+      // NOTE: We don't track live instances change because that will be reflected through the external view change
       throw new IllegalArgumentException("Illegal change type: " + changeType);
     }
   }
@@ -214,50 +219,70 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
     long startTimeMs = System.currentTimeMillis();
 
     List<ZNRecord> instanceConfigZNRecords =
-        _zkDataAccessor.getChildren(_instanceConfigsPath, null, AccessOption.PERSISTENT,
-            CommonConstants.Helix.ZkClient.RETRY_COUNT, CommonConstants.Helix.ZkClient.RETRY_INTERVAL_MS);
+        _zkDataAccessor.getChildren(_instanceConfigsPath, null, AccessOption.PERSISTENT, Helix.ZkClient.RETRY_COUNT,
+            Helix.ZkClient.RETRY_INTERVAL_MS);
     long fetchInstanceConfigsEndTimeMs = System.currentTimeMillis();
 
-    // Calculate new enabled and disabled instances
-    Set<String> enabledInstances = new HashSet<>();
-    List<String> newEnabledInstances = new ArrayList<>();
+    // Calculate new enabled and disabled servers
+    Set<String> enabledServers = new HashSet<>();
+    List<String> newEnabledServers = new ArrayList<>();
     for (ZNRecord instanceConfigZNRecord : instanceConfigZNRecords) {
-      String instance = instanceConfigZNRecord.getId();
-      if (isInstanceEnabled(instanceConfigZNRecord)) {
-        enabledInstances.add(instance);
+      String instanceId = instanceConfigZNRecord.getId();
+      if (isEnabledServer(instanceConfigZNRecord)) {
+        enabledServers.add(instanceId);
 
         // Always refresh the server instance with the latest instance config in case it changes
         ServerInstance serverInstance = new ServerInstance(new InstanceConfig(instanceConfigZNRecord));
-        if (_enabledServerInstanceMap.put(instance, serverInstance) == null) {
-          newEnabledInstances.add(instance);
+        if (_enabledServerInstanceMap.put(instanceId, serverInstance) == null) {
+          newEnabledServers.add(instanceId);
+
+          // NOTE: Remove new enabled server from excluded servers because the server is likely being restarted
+          if (_excludedServers.remove(instanceId)) {
+            LOGGER.info("Got excluded server: {} re-enabled, including it into the routing", instanceId);
+          }
         }
       }
     }
-    List<String> newDisabledInstances = new ArrayList<>();
+    List<String> newDisabledServers = new ArrayList<>();
     for (String instance : _enabledServerInstanceMap.keySet()) {
-      if (!enabledInstances.contains(instance)) {
-        newDisabledInstances.add(instance);
+      if (!enabledServers.contains(instance)) {
+        newDisabledServers.add(instance);
       }
     }
-    List<String> changedInstances = new ArrayList<>(newEnabledInstances.size() + newDisabledInstances.size());
-    changedInstances.addAll(newEnabledInstances);
-    changedInstances.addAll(newDisabledInstances);
-    long calculateChangedInstancesEndTimeMs = System.currentTimeMillis();
 
-    // Early terminate if there is no instance changed
-    if (changedInstances.isEmpty()) {
-      LOGGER.info(
-          "Processed instance config change in {}ms (fetch {} instance configs: {}ms, calculate changed instances: "
-              + "{}ms) without instance change", calculateChangedInstancesEndTimeMs - startTimeMs,
-          instanceConfigZNRecords.size(), fetchInstanceConfigsEndTimeMs - startTimeMs,
-          calculateChangedInstancesEndTimeMs - fetchInstanceConfigsEndTimeMs);
+    // Calculate the routable servers and the changed routable servers
+    List<String> changedServers = new ArrayList<>(newEnabledServers.size() + newDisabledServers.size());
+    if (_excludedServers.isEmpty()) {
+      _routableServers = enabledServers;
+      changedServers.addAll(newEnabledServers);
+      changedServers.addAll(newDisabledServers);
+    } else {
+      enabledServers.removeAll(_excludedServers);
+      _routableServers = enabledServers;
+      // NOTE: All new enabled servers are routable
+      changedServers.addAll(newEnabledServers);
+      for (String newDisabledServer : newDisabledServers) {
+        if (_excludedServers.contains(newDisabledServer)) {
+          changedServers.add(newDisabledServer);
+        }
+      }
+    }
+    long calculateChangedServersEndTimeMs = System.currentTimeMillis();
+
+    // Early terminate if there is no changed servers
+    if (changedServers.isEmpty()) {
+      LOGGER.info("Processed instance config change in {}ms "
+              + "(fetch {} instance configs: {}ms, calculate changed servers: {}ms) without instance change",
+          calculateChangedServersEndTimeMs - startTimeMs, instanceConfigZNRecords.size(),
+          fetchInstanceConfigsEndTimeMs - startTimeMs,
+          calculateChangedServersEndTimeMs - fetchInstanceConfigsEndTimeMs);
       return;
     }
 
     // Update routing entry for all tables
     for (RoutingEntry routingEntry : _routingEntryMap.values()) {
       try {
-        routingEntry.onInstancesChange(enabledInstances, changedInstances);
+        routingEntry.onInstancesChange(_routableServers, changedServers);
       } catch (Exception e) {
         LOGGER.error("Caught unexpected exception while updating routing entry on instances change for table: {}",
             routingEntry.getTableNameWithType(), e);
@@ -265,34 +290,105 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
     }
     long updateRoutingEntriesEndTimeMs = System.currentTimeMillis();
 
-    // Remove new disabled instances from _enabledServerInstanceMap after updating all routing entries to ensure it
-    // always contains the selected instances
-    for (String newDisabledInstance : newDisabledInstances) {
+    // Remove new disabled servers from _enabledServerInstanceMap after updating all routing entries to ensure it
+    // always contains the selected servers
+    for (String newDisabledInstance : newDisabledServers) {
       _enabledServerInstanceMap.remove(newDisabledInstance);
     }
 
-    LOGGER.info(
-        "Processed instance config change in {}ms (fetch {} instance configs: {}ms, calculate changed instances: "
-            + "{}ms, update {} routing entries: {}ms), new enabled instances: {}, new disabled instances: {}",
+    LOGGER.info("Processed instance config change in {}ms "
+            + "(fetch {} instance configs: {}ms, calculate changed servers: {}ms, update {} routing entries: {}ms), "
+            + "new enabled servers: {}, new disabled servers: {}, excluded servers: {}",
         updateRoutingEntriesEndTimeMs - startTimeMs, instanceConfigZNRecords.size(),
-        fetchInstanceConfigsEndTimeMs - startTimeMs, calculateChangedInstancesEndTimeMs - fetchInstanceConfigsEndTimeMs,
-        _routingEntryMap.size(), updateRoutingEntriesEndTimeMs - calculateChangedInstancesEndTimeMs,
-        newEnabledInstances, newDisabledInstances);
+        fetchInstanceConfigsEndTimeMs - startTimeMs, calculateChangedServersEndTimeMs - fetchInstanceConfigsEndTimeMs,
+        _routingEntryMap.size(), updateRoutingEntriesEndTimeMs - calculateChangedServersEndTimeMs, newEnabledServers,
+        newDisabledServers, _excludedServers);
   }
 
-  private static boolean isInstanceEnabled(ZNRecord instanceConfigZNRecord) {
+  private static boolean isEnabledServer(ZNRecord instanceConfigZNRecord) {
+    String instanceId = instanceConfigZNRecord.getId();
+    if (!instanceId.startsWith(Helix.PREFIX_OF_SERVER_INSTANCE)) {
+      // NOTE: Some legacy configs might not contain the instance type prefix
+      if (instanceId.startsWith(Helix.PREFIX_OF_CONTROLLER_INSTANCE) || instanceId.startsWith(
+          Helix.PREFIX_OF_BROKER_INSTANCE) || instanceId.startsWith(Helix.PREFIX_OF_MINION_INSTANCE)) {
+        return false;
+      }
+    }
     if ("false".equalsIgnoreCase(
         instanceConfigZNRecord.getSimpleField(InstanceConfig.InstanceConfigProperty.HELIX_ENABLED.name()))) {
       return false;
     }
-    if ("true".equalsIgnoreCase(instanceConfigZNRecord.getSimpleField(CommonConstants.Helix.IS_SHUTDOWN_IN_PROGRESS))) {
+    if ("true".equalsIgnoreCase(instanceConfigZNRecord.getSimpleField(Helix.IS_SHUTDOWN_IN_PROGRESS))) {
       return false;
     }
     //noinspection RedundantIfStatement
-    if ("true".equalsIgnoreCase(instanceConfigZNRecord.getSimpleField(CommonConstants.Helix.QUERIES_DISABLED))) {
+    if ("true".equalsIgnoreCase(instanceConfigZNRecord.getSimpleField(Helix.QUERIES_DISABLED))) {
       return false;
     }
     return true;
+  }
+
+  /**
+   * Excludes a server from the routing.
+   */
+  public synchronized void excludeServerFromRouting(String instanceId) {
+    LOGGER.warn("Excluding server: {} from routing", instanceId);
+    if (!_excludedServers.add(instanceId)) {
+      LOGGER.info("Server: {} is already excluded from routing, skipping updating the routing", instanceId);
+      return;
+    }
+    if (!_routableServers.contains(instanceId)) {
+      LOGGER.info("Server: {} is not enabled, skipping updating the routing", instanceId);
+      return;
+    }
+
+    // Update routing entry for all tables
+    long startTimeMs = System.currentTimeMillis();
+    Set<String> routableServers = new HashSet<>(_routableServers);
+    routableServers.remove(instanceId);
+    _routableServers = routableServers;
+    List<String> changedServers = Collections.singletonList(instanceId);
+    for (RoutingEntry routingEntry : _routingEntryMap.values()) {
+      try {
+        routingEntry.onInstancesChange(_routableServers, changedServers);
+      } catch (Exception e) {
+        LOGGER.error("Caught unexpected exception while updating routing entry when excluding server: {} for table: {}",
+            instanceId, routingEntry.getTableNameWithType(), e);
+      }
+    }
+    LOGGER.info("Excluded server: {} from routing in {}ms (updated {} routing entries)", instanceId,
+        System.currentTimeMillis() - startTimeMs, _routingEntryMap.size());
+  }
+
+  /**
+   * Includes a previous excluded server to the routing.
+   */
+  public synchronized void includeServerToRouting(String instanceId) {
+    LOGGER.info("Including server: {} to routing", instanceId);
+    if (!_excludedServers.remove(instanceId)) {
+      LOGGER.info("Server: {} is not previously excluded, skipping updating the routing", instanceId);
+    }
+    if (!_enabledServerInstanceMap.containsKey(instanceId)) {
+      LOGGER.info("Server: {} is not enabled, skipping updating the routing", instanceId);
+      return;
+    }
+
+    // Update routing entry for all tables
+    long startTimeMs = System.currentTimeMillis();
+    Set<String> routableServers = new HashSet<>(_routableServers);
+    routableServers.add(instanceId);
+    _routableServers = routableServers;
+    List<String> changedServers = Collections.singletonList(instanceId);
+    for (RoutingEntry routingEntry : _routingEntryMap.values()) {
+      try {
+        routingEntry.onInstancesChange(_routableServers, changedServers);
+      } catch (Exception e) {
+        LOGGER.error("Caught unexpected exception while updating routing entry when including server: {} for table: {}",
+            instanceId, routingEntry.getTableNameWithType(), e);
+      }
+    }
+    LOGGER.info("Included server: {} to routing in {}ms (updated {} routing entries)", instanceId,
+        System.currentTimeMillis() - startTimeMs, _routingEntryMap.size());
   }
 
   /**
@@ -333,7 +429,7 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
       segmentPruner.init(idealState, externalView, preSelectedOnlineSegments);
     }
     InstanceSelector instanceSelector = InstanceSelectorFactory.getInstanceSelector(tableConfig, _brokerMetrics);
-    instanceSelector.init(_enabledServerInstanceMap.keySet(), idealState, externalView, preSelectedOnlineSegments);
+    instanceSelector.init(_routableServers, idealState, externalView, preSelectedOnlineSegments);
 
     // Add time boundary manager if both offline and real-time part exist for a hybrid table
     TimeBoundaryManager timeBoundaryManager = null;
@@ -540,8 +636,7 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
     RoutingEntry(String tableNameWithType, String idealStatePath, String externalViewPath,
         SegmentPreSelector segmentPreSelector, SegmentSelector segmentSelector, List<SegmentPruner> segmentPruners,
         InstanceSelector instanceSelector, int lastUpdateIdealStateVersion, int lastUpdateExternalViewVersion,
-        @Nullable TimeBoundaryManager timeBoundaryManager,
-        @Nullable Long queryTimeoutMs) {
+        @Nullable TimeBoundaryManager timeBoundaryManager, @Nullable Long queryTimeoutMs) {
       _tableNameWithType = tableNameWithType;
       _idealStatePath = idealStatePath;
       _externalViewPath = externalViewPath;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
@@ -33,7 +33,7 @@ import org.apache.pinot.common.request.BrokerRequest;
 public interface InstanceSelector {
 
   /**
-   * Initializes the instance selector with the enabled instances, ideal stateexternal view,  and online segments
+   * Initializes the instance selector with the enabled instances, ideal state, external view and online segments
    * (segments with ONLINE/CONSUMING instances in the ideal state and pre-selected by the {@link SegmentPreSelector}).
    * Should be called only once before calling other methods.
    */

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/failuredetector/ConnectionFailureDetectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/failuredetector/ConnectionFailureDetectorTest.java
@@ -1,0 +1,160 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.failuredetector;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.pinot.common.metrics.BrokerGauge;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.metrics.PinotMetricUtils;
+import org.apache.pinot.core.transport.QueryResponse;
+import org.apache.pinot.core.transport.ServerRoutingInstance;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants.Broker;
+import org.apache.pinot.util.TestUtils;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class ConnectionFailureDetectorTest {
+  private static final String INSTANCE_ID = "Server_localhost_1234";
+
+  private BrokerMetrics _brokerMetrics;
+  private FailureDetector _failureDetector;
+  private Listener _listener;
+
+  @BeforeClass
+  public void setUp() {
+    PinotConfiguration config = new PinotConfiguration();
+    config.setProperty(Broker.FailureDetector.CONFIG_OF_CLASS_NAME, ConnectionFailureDetector.class.getName());
+    config.setProperty(Broker.FailureDetector.CONFIG_OF_RETRY_INITIAL_DELAY_MS, 100);
+    config.setProperty(Broker.FailureDetector.CONFIG_OF_RETRY_DELAY_FACTOR, 1);
+    _brokerMetrics = new BrokerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+    _failureDetector = FailureDetectorFactory.getFailureDetector(config, _brokerMetrics);
+    assertTrue(_failureDetector instanceof ConnectionFailureDetector);
+    _listener = new Listener();
+    _failureDetector.register(_listener);
+    _failureDetector.start();
+  }
+
+  @Test
+  public void testConnectionFailure() {
+    QueryResponse queryResponse = mock(QueryResponse.class);
+    when(queryResponse.getFailedServer()).thenReturn(new ServerRoutingInstance("localhost", 1234, TableType.OFFLINE));
+
+    // No failure detection when submitting the query
+    _failureDetector.notifyQuerySubmitted(queryResponse);
+    assertTrue(_failureDetector.getUnhealthyServers().isEmpty());
+    assertEquals(_brokerMetrics.getValueOfGlobalGauge(BrokerGauge.UNHEALTHY_SERVERS), 0);
+    assertEquals(_listener._notifyUnhealthyServerCalled.get(), 0);
+    assertEquals(_listener._notifyHealthyServerCalled.get(), 0);
+
+    // When query finishes, the failed server should be count as unhealthy and trigger a callback
+    _failureDetector.notifyQueryFinished(queryResponse);
+    assertEquals(_failureDetector.getUnhealthyServers(), Collections.singleton(INSTANCE_ID));
+    assertEquals(_brokerMetrics.getValueOfGlobalGauge(BrokerGauge.UNHEALTHY_SERVERS), 1);
+    assertEquals(_listener._notifyUnhealthyServerCalled.get(), 1);
+    assertEquals(_listener._notifyHealthyServerCalled.get(), 0);
+
+    // Mark server unhealthy again should have no effect
+    _failureDetector.markServerUnhealthy(INSTANCE_ID);
+    assertEquals(_failureDetector.getUnhealthyServers(), Collections.singleton(INSTANCE_ID));
+    assertEquals(_brokerMetrics.getValueOfGlobalGauge(BrokerGauge.UNHEALTHY_SERVERS), 1);
+    assertEquals(_listener._notifyUnhealthyServerCalled.get(), 1);
+    assertEquals(_listener._notifyHealthyServerCalled.get(), 0);
+
+    // Mark server healthy should remove it from the unhealthy servers and trigger a callback
+    _failureDetector.markServerHealthy(INSTANCE_ID);
+    assertTrue(_failureDetector.getUnhealthyServers().isEmpty());
+    assertEquals(_brokerMetrics.getValueOfGlobalGauge(BrokerGauge.UNHEALTHY_SERVERS), 0);
+    assertEquals(_listener._notifyUnhealthyServerCalled.get(), 1);
+    assertEquals(_listener._notifyHealthyServerCalled.get(), 1);
+
+    _listener.reset();
+  }
+
+  @Test
+  public void testRetry() {
+    _failureDetector.markServerUnhealthy(INSTANCE_ID);
+    assertEquals(_failureDetector.getUnhealthyServers(), Collections.singleton(INSTANCE_ID));
+    assertEquals(_brokerMetrics.getValueOfGlobalGauge(BrokerGauge.UNHEALTHY_SERVERS), 1);
+    assertEquals(_listener._notifyUnhealthyServerCalled.get(), 1);
+    assertEquals(_listener._notifyHealthyServerCalled.get(), 0);
+    // Should get 10 retries in 1s, then remove the failed server from the unhealthy servers.
+    // Wait for up to 5s to avoid flakiness
+    TestUtils.waitForCondition(aVoid -> {
+      int numRetries = _listener._retryUnhealthyServerCalled.get();
+      if (numRetries < Broker.FailureDetector.DEFAULT_MAX_RETIRES) {
+        assertEquals(_failureDetector.getUnhealthyServers(), Collections.singleton(INSTANCE_ID));
+        assertEquals(_brokerMetrics.getValueOfGlobalGauge(BrokerGauge.UNHEALTHY_SERVERS), 1);
+        return false;
+      }
+      assertEquals(numRetries, Broker.FailureDetector.DEFAULT_MAX_RETIRES);
+      // There might be a small delay between the last retry and removing failed server from the unhealthy servers.
+      // Perform a check instead of an assertion.
+      return _failureDetector.getUnhealthyServers().isEmpty()
+          && _brokerMetrics.getValueOfGlobalGauge(BrokerGauge.UNHEALTHY_SERVERS) == 0
+          && _listener._notifyUnhealthyServerCalled.get() == 1 && _listener._notifyHealthyServerCalled.get() == 1;
+    }, 5_000L, "Failed to get 10 retires");
+
+    _listener.reset();
+  }
+
+  @AfterClass
+  public void tearDown() {
+    _failureDetector.stop();
+  }
+
+  private static class Listener implements FailureDetector.Listener {
+    final AtomicInteger _notifyUnhealthyServerCalled = new AtomicInteger();
+    final AtomicInteger _retryUnhealthyServerCalled = new AtomicInteger();
+    final AtomicInteger _notifyHealthyServerCalled = new AtomicInteger();
+
+    @Override
+    public void notifyUnhealthyServer(String instanceId, FailureDetector failureDetector) {
+      assertEquals(instanceId, INSTANCE_ID);
+      _notifyUnhealthyServerCalled.getAndIncrement();
+    }
+
+    @Override
+    public void retryUnhealthyServer(String instanceId, FailureDetector failureDetector) {
+      assertEquals(instanceId, INSTANCE_ID);
+      _retryUnhealthyServerCalled.getAndIncrement();
+    }
+
+    @Override
+    public void notifyHealthyServer(String instanceId, FailureDetector failureDetector) {
+      assertEquals(instanceId, INSTANCE_ID);
+      _notifyHealthyServerCalled.getAndIncrement();
+    }
+
+    void reset() {
+      _notifyUnhealthyServerCalled.set(0);
+      _retryUnhealthyServerCalled.set(0);
+      _notifyHealthyServerCalled.set(0);
+    }
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/failuredetector/ConnectionFailureDetectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/failuredetector/ConnectionFailureDetectorTest.java
@@ -50,7 +50,7 @@ public class ConnectionFailureDetectorTest {
   @BeforeClass
   public void setUp() {
     PinotConfiguration config = new PinotConfiguration();
-    config.setProperty(Broker.FailureDetector.CONFIG_OF_CLASS_NAME, ConnectionFailureDetector.class.getName());
+    config.setProperty(Broker.FailureDetector.CONFIG_OF_TYPE, Broker.FailureDetector.Type.CONNECTION.name());
     config.setProperty(Broker.FailureDetector.CONFIG_OF_RETRY_INITIAL_DELAY_MS, 100);
     config.setProperty(Broker.FailureDetector.CONFIG_OF_RETRY_DELAY_FACTOR, 1);
     _brokerMetrics = new BrokerMetrics(PinotMetricUtils.getPinotMetricsRegistry());

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
@@ -31,7 +31,8 @@ public enum BrokerGauge implements AbstractMetrics.Gauge {
   QUERY_RATE_LIMIT_DISABLED("queryQuota", true),
   NETTY_CONNECTION_CONNECT_TIME_MS("nettyConnection", true),
   REQUEST_SIZE("requestSize", false),
-  RESIZE_TIME_MS("milliseconds", false);
+  RESIZE_TIME_MS("milliseconds", false),
+  UNHEALTHY_SERVERS("servers", true);
 
   private final String _brokerGaugeName;
   private final String _unit;

--- a/pinot-connectors/pinot-spark-connector/src/main/scala/org/apache/pinot/connector/spark/connector/PinotServerDataFetcher.scala
+++ b/pinot-connectors/pinot-spark-connector/src/main/scala/org/apache/pinot/connector/spark/connector/PinotServerDataFetcher.scala
@@ -64,7 +64,7 @@ private[pinot] class PinotServerDataFetcher(
         submitRequestToPinotServer(offlineBrokerRequest, routingTableForRequest, null, null)
     }
 
-    val pinotServerResponse = pinotServerAsyncQueryResponse.getResponse.values().asScala.toList
+    val pinotServerResponse = pinotServerAsyncQueryResponse.getFinalResponses.values().asScala.toList
     logInfo(s"Pinot server total response time in millis: ${System.nanoTime() - requestStartTime}")
 
     closePinotServerConnection()

--- a/pinot-connectors/prestodb-pinot-dependencies/presto-pinot-driver/src/main/java/org/apache/pinot/connector/presto/PinotScatterGatherQueryClient.java
+++ b/pinot-connectors/prestodb-pinot-dependencies/presto-pinot-driver/src/main/java/org/apache/pinot/connector/presto/PinotScatterGatherQueryClient.java
@@ -312,7 +312,7 @@ public class PinotScatterGatherQueryClient {
       Map<org.apache.pinot.core.transport.ServerInstance, List<String>> routingTable,
       AsyncQueryResponse asyncQueryResponse, String tableNameWithType) {
     try {
-      Map<ServerRoutingInstance, ServerResponse> queryResponses = asyncQueryResponse.getResponse();
+      Map<ServerRoutingInstance, ServerResponse> queryResponses = asyncQueryResponse.getFinalResponses();
       if (!ignoreEmptyResponses) {
         if (queryResponses.size() != routingTable.size()) {
           Map<String, String> routingTableForLogging = new HashMap<>();
@@ -323,7 +323,8 @@ public class PinotScatterGatherQueryClient {
           });
           throw new PinotException(ErrorCode.PINOT_INSUFFICIENT_SERVER_RESPONSE,
               String.format("%d of %d servers responded with routing table servers: %s, query stats: %s",
-                  queryResponses.size(), routingTable.size(), routingTableForLogging, asyncQueryResponse.getStats()));
+                  queryResponses.size(), routingTable.size(), routingTableForLogging,
+                  asyncQueryResponse.getServerStats()));
         }
       }
       Map<ServerInstance, DataTable> serverResponseMap = new HashMap<>();

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/DataTableHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/DataTableHandler.java
@@ -55,7 +55,8 @@ public class DataTableHandler extends SimpleChannelInboundHandler<ByteBuf> {
   @Override
   public void channelInactive(ChannelHandlerContext ctx) {
     LOGGER.error("Channel for server: {} is now inactive, marking server down", _serverRoutingInstance);
-    _queryRouter.markServerDown(_serverRoutingInstance);
+    _queryRouter.markServerDown(_serverRoutingInstance,
+        new RuntimeException(String.format("Channel for server: %s is inactive", _serverRoutingInstance)));
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryResponse.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryResponse.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.transport;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+import org.apache.pinot.spi.annotations.InterfaceAudience;
+import org.apache.pinot.spi.annotations.InterfaceStability;
+
+
+/**
+ * The {@code QueryResponse} interface represents the server responses for a query.
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Evolving
+@ThreadSafe
+public interface QueryResponse {
+  enum Status {
+    IN_PROGRESS, COMPLETED, FAILED, TIMED_OUT
+  }
+
+  /**
+   * Returns the current {@link Status} of the query.
+   */
+  Status getStatus();
+
+  /**
+   * Returns the number of servers responded.
+   */
+  int getNumServersResponded();
+
+  /**
+   * Returns the current server responses without blocking.
+   */
+  Map<ServerRoutingInstance, ServerResponse> getCurrentResponses();
+
+  /**
+   * Waits until the query is done (COMPLETED, FAILED or TIMED_OUT) and returns the final server responses.
+   */
+  Map<ServerRoutingInstance, ServerResponse> getFinalResponses()
+      throws InterruptedException;
+
+  /**
+   * Returns the server stats for the query. Should be called after query is done (COMPLETED, FAILED or TIMED_OUT).
+   */
+  String getServerStats();
+
+  /**
+   * Returns the failed server if the query fails.
+   */
+  @Nullable
+  ServerRoutingInstance getFailedServer();
+
+  /**
+   * Returns the exception if the query fails.
+   */
+  @Nullable
+  Exception getException();
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
@@ -142,8 +142,18 @@ public class QueryRouter {
       AsyncQueryResponse asyncQueryResponse, Exception e) {
     LOGGER.error("Caught exception while sending request {} to server: {}, marking query failed", requestId,
         serverRoutingInstance, e);
-    asyncQueryResponse.setBrokerRequestSendException(e);
-    asyncQueryResponse.markQueryFailed();
+    asyncQueryResponse.markQueryFailed(serverRoutingInstance, e);
+  }
+
+  /**
+   * Connects to the given server, returns {@code true} if the server is successfully connected.
+   */
+  public boolean connect(ServerInstance serverInstance) {
+    if (_serverChannelsTls != null) {
+      return _serverChannelsTls.connect(serverInstance.toServerRoutingInstance(TableType.OFFLINE, true));
+    } else {
+      return _serverChannels.connect(serverInstance.toServerRoutingInstance(TableType.OFFLINE, false));
+    }
   }
 
   public void shutDown() {
@@ -161,9 +171,9 @@ public class QueryRouter {
     }
   }
 
-  void markServerDown(ServerRoutingInstance serverRoutingInstance) {
+  void markServerDown(ServerRoutingInstance serverRoutingInstance, Exception exception) {
     for (AsyncQueryResponse asyncQueryResponse : _asyncQueryResponseMap.values()) {
-      asyncQueryResponse.markServerDown(serverRoutingInstance);
+      asyncQueryResponse.markServerDown(serverRoutingInstance, exception);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
@@ -149,10 +149,16 @@ public class QueryRouter {
    * Connects to the given server, returns {@code true} if the server is successfully connected.
    */
   public boolean connect(ServerInstance serverInstance) {
-    if (_serverChannelsTls != null) {
-      return _serverChannelsTls.connect(serverInstance.toServerRoutingInstance(TableType.OFFLINE, true));
-    } else {
-      return _serverChannels.connect(serverInstance.toServerRoutingInstance(TableType.OFFLINE, false));
+    try {
+      if (_serverChannelsTls != null) {
+        _serverChannelsTls.connect(serverInstance.toServerRoutingInstance(TableType.OFFLINE, true));
+      } else {
+        _serverChannels.connect(serverInstance.toServerRoutingInstance(TableType.OFFLINE, false));
+      }
+      return true;
+    } catch (Exception e) {
+      LOGGER.debug("Failed to connect to server: {}", serverInstance, e);
+      return false;
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerInstance.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerInstance.java
@@ -143,9 +143,6 @@ public class ServerInstance {
     return _instanceId.hashCode();
   }
 
-  /**
-   * Use default format {@code Server_<hostname>_<port>} for backward-compatibility.
-   */
   @Override
   public String toString() {
     return _instanceId;

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerInstance.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerInstance.java
@@ -34,6 +34,7 @@ public class ServerInstance {
   private static final char HOSTNAME_PORT_DELIMITER = '_';
   private static final int INVALID_PORT = -1;
 
+  private final String _instanceId;
   private final String _hostname;
   private final int _port;
   private final int _grpcPort;
@@ -44,6 +45,7 @@ public class ServerInstance {
    * {@code Server_localhost_12345}, hostname is of format: {@code Server_<hostname>}, e.g. {@code Server_localhost}.
    */
   public ServerInstance(InstanceConfig instanceConfig) {
+    _instanceId = instanceConfig.getInstanceName();
     String hostname = instanceConfig.getHostName();
     if (hostname != null) {
       if (hostname.startsWith(Helix.PREFIX_OF_SERVER_INSTANCE)) {
@@ -69,10 +71,15 @@ public class ServerInstance {
 
   @VisibleForTesting
   ServerInstance(String hostname, int port) {
+    _instanceId = Helix.PREFIX_OF_SERVER_INSTANCE + hostname + "_" + port;
     _hostname = hostname;
     _port = port;
     _grpcPort = INVALID_PORT;
     _nettyTlsPort = INVALID_PORT;
+  }
+
+  public String getInstanceId() {
+    return _instanceId;
   }
 
   public String getHostname() {
@@ -95,43 +102,45 @@ public class ServerInstance {
   @Deprecated
   public ServerRoutingInstance toServerRoutingInstance(TableType tableType, boolean preferNettyTls) {
     if (preferNettyTls && _nettyTlsPort > 0) {
-      return new ServerRoutingInstance(_hostname, _nettyTlsPort, tableType, true);
+      return new ServerRoutingInstance(_instanceId, _hostname, _nettyTlsPort, tableType, true);
     } else {
-      return new ServerRoutingInstance(_hostname, _port, tableType);
+      return new ServerRoutingInstance(_instanceId, _hostname, _port, tableType);
     }
   }
 
   public ServerRoutingInstance toServerRoutingInstance(TableType tableType, RoutingType routingType) {
     switch (routingType) {
       case NETTY:
-        Preconditions.checkState(_port > 0, "Netty port is not configured on host: %s", _hostname);
-        return new ServerRoutingInstance(_hostname, _port, tableType);
+        Preconditions.checkState(_port > 0, "Netty port is not configured for server: %s", _instanceId);
+        return new ServerRoutingInstance(_instanceId, _hostname, _port, tableType);
       case GRPC:
-        Preconditions.checkState(_grpcPort > 0, "GRPC port is not configured on host: %s", _hostname);
-        return new ServerRoutingInstance(_hostname, _grpcPort, tableType);
+        Preconditions.checkState(_grpcPort > 0, "GRPC port is not configured for server: %s", _instanceId);
+        return new ServerRoutingInstance(_instanceId, _hostname, _grpcPort, tableType);
       case NETTY_TLS:
-        Preconditions.checkState(_nettyTlsPort > 0, "Netty TLS port is not configured on host: %s", _hostname);
-        return new ServerRoutingInstance(_hostname, _nettyTlsPort, tableType, true);
+        Preconditions.checkState(_nettyTlsPort > 0, "Netty TLS port is not configured for server: %s", _instanceId);
+        return new ServerRoutingInstance(_instanceId, _hostname, _nettyTlsPort, tableType, true);
       default:
         throw new IllegalStateException("Unsupported routing type: " + routingType);
     }
   }
 
   @Override
-  public int hashCode() {
-    return 31 * _hostname.hashCode() + _port;
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof ServerInstance)) {
+      return false;
+    }
+    ServerInstance that = (ServerInstance) o;
+    // Only check instanceId because it can identify an instance within the same query
+    return _instanceId.equals(that._instanceId);
   }
 
   @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj instanceof ServerInstance) {
-      ServerInstance that = (ServerInstance) obj;
-      return _hostname.equals(that._hostname) && _port == that._port;
-    }
-    return false;
+  public int hashCode() {
+    // Only hash instanceId because it can identify an instance within the same query
+    return _instanceId.hashCode();
   }
 
   /**
@@ -139,6 +148,6 @@ public class ServerInstance {
    */
   @Override
   public String toString() {
-    return Helix.PREFIX_OF_SERVER_INSTANCE + _hostname + HOSTNAME_PORT_DELIMITER + _port;
+    return _instanceId;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerResponse.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerResponse.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.transport;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.common.utils.DataTable;
 
@@ -39,6 +40,7 @@ public class ServerResponse {
     _startTimeMs = startTimeMs;
   }
 
+  @Nullable
   public DataTable getDataTable() {
     return _dataTable;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerRoutingInstance.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerRoutingInstance.java
@@ -18,12 +18,14 @@
  */
 package org.apache.pinot.core.transport;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.net.InternetDomainName;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.CommonConstants.Helix;
 
 
 /**
@@ -38,20 +40,31 @@ public class ServerRoutingInstance {
   private static final String SHORT_REALTIME_SUFFIX = "_R";
   private static final Map<String, String> SHORT_HOSTNAME_MAP = new ConcurrentHashMap<>();
 
-  private final boolean _tlsEnabled;
+  private final String _instanceId;
   private final String _hostname;
   private final int _port;
   private final TableType _tableType;
+  private final boolean _tlsEnabled;
 
-  public ServerRoutingInstance(String hostname, int port, TableType tableType) {
-    this(hostname, port, tableType, false);
-  }
-
-  public ServerRoutingInstance(String hostname, int port, TableType tableType, boolean tlsEnabled) {
+  public ServerRoutingInstance(String instanceId, String hostname, int port, TableType tableType, boolean tlsEnabled) {
+    _instanceId = instanceId;
     _hostname = hostname;
     _port = port;
     _tableType = tableType;
     _tlsEnabled = tlsEnabled;
+  }
+
+  public ServerRoutingInstance(String instanceId, String hostname, int port, TableType tableType) {
+    this(instanceId, hostname, port, tableType, false);
+  }
+
+  @VisibleForTesting
+  public ServerRoutingInstance(String hostname, int port, TableType tableType) {
+    this(Helix.PREFIX_OF_SERVER_INSTANCE + hostname + "_" + port, hostname, port, tableType);
+  }
+
+  public String getInstanceId() {
+    return _instanceId;
   }
 
   public String getHostname() {
@@ -87,17 +100,20 @@ public class ServerRoutingInstance {
     if (this == o) {
       return true;
     }
-    if (o == null || getClass() != o.getClass()) {
+    if (!(o instanceof ServerRoutingInstance)) {
       return false;
     }
     ServerRoutingInstance that = (ServerRoutingInstance) o;
-    return _tlsEnabled == that._tlsEnabled && _port == that._port && _hostname.equals(that._hostname)
-        && _tableType == that._tableType;
+    // NOTE: Only check hostname, port and tableType for performance concern because they can identify a routing
+    //       instance within the same query
+    return _hostname.equals(that._hostname) && _port == that._port && _tableType == that._tableType;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_tlsEnabled, _hostname, _port, _tableType);
+    // NOTE: Only check hostname, port and tableType for performance concern because they can identify a routing
+    //       instance within the same query
+    return Objects.hash(_hostname, _port, _tableType);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerRoutingInstance.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerRoutingInstance.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.transport;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.net.InternetDomainName;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.spi.config.table.TableType;
@@ -113,7 +112,7 @@ public class ServerRoutingInstance {
   public int hashCode() {
     // NOTE: Only check hostname, port and tableType for performance concern because they can identify a routing
     //       instance within the same query
-    return Objects.hash(_hostname, _port, _tableType);
+    return 31 * 31 * _hostname.hashCode() + 31 * Integer.hashCode(_port) + _tableType.hashCode();
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/reduce/StreamingReduceServiceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/reduce/StreamingReduceServiceTest.java
@@ -52,11 +52,14 @@ public class StreamingReduceServiceTest {
     // supposedly we can use TestNG's annotation like @Test(expectedExceptions = { IOException.class }) to verify
     // here we hope to verify deeper to make sure the thrown exception is nested inside the exception
     assertTrue(verifyException(() -> {
-      StreamingReduceService.processIterativeServerResponse(mock(StreamingReducer.class), threadPoolService,
-          ImmutableMap.of(routingInstance, mockedResponse), 1000,
-          mock(BaseReduceService.ExecutionStatsAggregator.class));
-      return null;
-    }, cause -> cause.getMessage().contains(exceptionMessage)));
+          StreamingReduceService.processIterativeServerResponse(mock(StreamingReducer.class),
+              threadPoolService,
+              ImmutableMap.of(routingInstance, mockedResponse),
+              1000,
+              mock(BaseReduceService.ExecutionStatsAggregator.class));
+          return null;
+        }, cause -> cause.getMessage().contains(exceptionMessage))
+    );
   }
 
   @Test
@@ -75,13 +78,17 @@ public class StreamingReduceServiceTest {
     });
     final ExecutorService threadPoolService = Executors.newFixedThreadPool(1);
     final ServerRoutingInstance routingInstance = new ServerRoutingInstance("localhost", 9527, TableType.OFFLINE);
-    // We cannot use TestNG's annotation like @Test(expectedExceptions = { IOException.class }) to verify
+    //We cannot use TestNG's annotation like @Test(expectedExceptions = { IOException.class }) to verify
     // because the Exception we hope to verify is nested inside the final exception.
     assertTrue(verifyException(() -> {
-      StreamingReduceService.processIterativeServerResponse(mock(StreamingReducer.class), threadPoolService,
-          ImmutableMap.of(routingInstance, mockedResponse), 10, mock(BaseReduceService.ExecutionStatsAggregator.class));
-      return null;
-    }, (cause) -> cause instanceof TimeoutException));
+          StreamingReduceService.processIterativeServerResponse(mock(StreamingReducer.class),
+              threadPoolService,
+              ImmutableMap.of(routingInstance, mockedResponse),
+              10,
+              mock(BaseReduceService.ExecutionStatsAggregator.class));
+          return null;
+        },
+        (cause) -> cause instanceof TimeoutException));
   }
 
   private static boolean verifyException(Callable<Void> verifyTarget, Predicate<Throwable> verifyCause) {
@@ -92,7 +99,8 @@ public class StreamingReduceServiceTest {
     try {
       verifyTarget.call();
     } catch (Exception ex) {
-      for (Throwable child = ex; child != null && child.getCause() != child && !exceptionVerified;
+      for (Throwable child = ex;
+          child != null && child.getCause() != child && !exceptionVerified;
           child = child.getCause()) {
         exceptionVerified = verifyCause.test(child);
       }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/reduce/StreamingReduceServiceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/reduce/StreamingReduceServiceTest.java
@@ -48,19 +48,15 @@ public class StreamingReduceServiceTest {
     RuntimeException innerException = new RuntimeException(exceptionMessage);
     when(mockedResponse.next()).thenThrow(innerException);
     ExecutorService threadPoolService = Executors.newFixedThreadPool(1);
-    ServerRoutingInstance routingInstance =
-        new ServerRoutingInstance("localhost", 9527, TableType.OFFLINE, false);
+    ServerRoutingInstance routingInstance = new ServerRoutingInstance("localhost", 9527, TableType.OFFLINE);
     // supposedly we can use TestNG's annotation like @Test(expectedExceptions = { IOException.class }) to verify
     // here we hope to verify deeper to make sure the thrown exception is nested inside the exception
     assertTrue(verifyException(() -> {
-          StreamingReduceService.processIterativeServerResponse(mock(StreamingReducer.class),
-              threadPoolService,
-              ImmutableMap.of(routingInstance, mockedResponse),
-              1000,
-              mock(BaseReduceService.ExecutionStatsAggregator.class));
-          return null;
-        }, cause -> cause.getMessage().contains(exceptionMessage))
-    );
+      StreamingReduceService.processIterativeServerResponse(mock(StreamingReducer.class), threadPoolService,
+          ImmutableMap.of(routingInstance, mockedResponse), 1000,
+          mock(BaseReduceService.ExecutionStatsAggregator.class));
+      return null;
+    }, cause -> cause.getMessage().contains(exceptionMessage)));
   }
 
   @Test
@@ -78,19 +74,14 @@ public class StreamingReduceServiceTest {
       }
     });
     final ExecutorService threadPoolService = Executors.newFixedThreadPool(1);
-    final ServerRoutingInstance routingInstance =
-        new ServerRoutingInstance("localhost", 9527, TableType.OFFLINE, false);
-    //We cannot use TestNG's annotation like @Test(expectedExceptions = { IOException.class }) to verify
+    final ServerRoutingInstance routingInstance = new ServerRoutingInstance("localhost", 9527, TableType.OFFLINE);
+    // We cannot use TestNG's annotation like @Test(expectedExceptions = { IOException.class }) to verify
     // because the Exception we hope to verify is nested inside the final exception.
     assertTrue(verifyException(() -> {
-          StreamingReduceService.processIterativeServerResponse(mock(StreamingReducer.class),
-              threadPoolService,
-              ImmutableMap.of(routingInstance, mockedResponse),
-              10,
-              mock(BaseReduceService.ExecutionStatsAggregator.class));
-          return null;
-        },
-        (cause) -> cause instanceof TimeoutException));
+      StreamingReduceService.processIterativeServerResponse(mock(StreamingReducer.class), threadPoolService,
+          ImmutableMap.of(routingInstance, mockedResponse), 10, mock(BaseReduceService.ExecutionStatsAggregator.class));
+      return null;
+    }, (cause) -> cause instanceof TimeoutException));
   }
 
   private static boolean verifyException(Callable<Void> verifyTarget, Predicate<Throwable> verifyCause) {
@@ -101,8 +92,7 @@ public class StreamingReduceServiceTest {
     try {
       verifyTarget.call();
     } catch (Exception ex) {
-      for (Throwable child = ex;
-          child != null && child.getCause() != child && !exceptionVerified;
+      for (Throwable child = ex; child != null && child.getCause() != child && !exceptionVerified;
           child = child.getCause()) {
         exceptionVerified = verifyCause.test(child);
       }

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
@@ -92,7 +92,7 @@ public class QueryRoutingTest {
     // OFFLINE only
     AsyncQueryResponse asyncQueryResponse =
         _queryRouter.submitQuery(requestId, "testTable", BROKER_REQUEST, ROUTING_TABLE, null, null, 1_000L);
-    Map<ServerRoutingInstance, ServerResponse> response = asyncQueryResponse.getResponse();
+    Map<ServerRoutingInstance, ServerResponse> response = asyncQueryResponse.getFinalResponses();
     assertEquals(response.size(), 1);
     assertTrue(response.containsKey(OFFLINE_SERVER_ROUTING_INSTANCE));
     ServerResponse serverResponse = response.get(OFFLINE_SERVER_ROUTING_INSTANCE);
@@ -102,7 +102,7 @@ public class QueryRoutingTest {
     // REALTIME only
     asyncQueryResponse =
         _queryRouter.submitQuery(requestId, "testTable", null, null, BROKER_REQUEST, ROUTING_TABLE, 1_000L);
-    response = asyncQueryResponse.getResponse();
+    response = asyncQueryResponse.getFinalResponses();
     assertEquals(response.size(), 1);
     assertTrue(response.containsKey(REALTIME_SERVER_ROUTING_INSTANCE));
     serverResponse = response.get(REALTIME_SERVER_ROUTING_INSTANCE);
@@ -113,7 +113,7 @@ public class QueryRoutingTest {
     asyncQueryResponse =
         _queryRouter.submitQuery(requestId, "testTable", BROKER_REQUEST, ROUTING_TABLE, BROKER_REQUEST, ROUTING_TABLE,
             1_000L);
-    response = asyncQueryResponse.getResponse();
+    response = asyncQueryResponse.getFinalResponses();
     assertEquals(response.size(), 2);
     assertTrue(response.containsKey(OFFLINE_SERVER_ROUTING_INSTANCE));
     serverResponse = response.get(OFFLINE_SERVER_ROUTING_INSTANCE);
@@ -140,7 +140,7 @@ public class QueryRoutingTest {
     long startTimeMs = System.currentTimeMillis();
     AsyncQueryResponse asyncQueryResponse =
         _queryRouter.submitQuery(requestId, "testTable", BROKER_REQUEST, ROUTING_TABLE, null, null, 1_000L);
-    Map<ServerRoutingInstance, ServerResponse> response = asyncQueryResponse.getResponse();
+    Map<ServerRoutingInstance, ServerResponse> response = asyncQueryResponse.getFinalResponses();
     assertEquals(response.size(), 1);
     assertTrue(response.containsKey(OFFLINE_SERVER_ROUTING_INSTANCE));
     ServerResponse serverResponse = response.get(OFFLINE_SERVER_ROUTING_INSTANCE);
@@ -170,7 +170,7 @@ public class QueryRoutingTest {
     long startTimeMs = System.currentTimeMillis();
     AsyncQueryResponse asyncQueryResponse =
         _queryRouter.submitQuery(requestId + 1, "testTable", BROKER_REQUEST, ROUTING_TABLE, null, null, 1_000L);
-    Map<ServerRoutingInstance, ServerResponse> response = asyncQueryResponse.getResponse();
+    Map<ServerRoutingInstance, ServerResponse> response = asyncQueryResponse.getFinalResponses();
     assertEquals(response.size(), 1);
     assertTrue(response.containsKey(OFFLINE_SERVER_ROUTING_INSTANCE));
     ServerResponse serverResponse = response.get(OFFLINE_SERVER_ROUTING_INSTANCE);
@@ -207,7 +207,7 @@ public class QueryRoutingTest {
     // Shut down the server before getting the response
     queryServer.shutDown();
 
-    Map<ServerRoutingInstance, ServerResponse> response = asyncQueryResponse.getResponse();
+    Map<ServerRoutingInstance, ServerResponse> response = asyncQueryResponse.getFinalResponses();
     assertEquals(response.size(), 1);
     assertTrue(response.containsKey(OFFLINE_SERVER_ROUTING_INSTANCE));
     ServerResponse serverResponse = response.get(OFFLINE_SERVER_ROUTING_INSTANCE);
@@ -222,7 +222,7 @@ public class QueryRoutingTest {
     startTimeMs = System.currentTimeMillis();
     asyncQueryResponse =
         _queryRouter.submitQuery(requestId + 1, "testTable", BROKER_REQUEST, ROUTING_TABLE, null, null, timeoutMs);
-    response = asyncQueryResponse.getResponse();
+    response = asyncQueryResponse.getFinalResponses();
     assertEquals(response.size(), 1);
     assertTrue(response.containsKey(OFFLINE_SERVER_ROUTING_INSTANCE));
     serverResponse = response.get(OFFLINE_SERVER_ROUTING_INSTANCE);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
@@ -18,18 +18,25 @@
  */
 package org.apache.pinot.integration.tests;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.broker.broker.helix.BaseBrokerStarter;
+import org.apache.pinot.broker.failuredetector.ConnectionFailureDetector;
+import org.apache.pinot.common.exception.QueryException;
+import org.apache.pinot.server.starter.helix.BaseServerStarter;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Broker.FailureDetector;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.BrokerResourceStateModel;
 import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
 
@@ -53,6 +60,11 @@ public class MultiNodesOfflineClusterIntegrationTest extends OfflineClusterInteg
   @Override
   protected int getNumReplicas() {
     return NUM_SERVERS;
+  }
+
+  @Override
+  protected void overrideBrokerConf(PinotConfiguration brokerConf) {
+    brokerConf.setProperty(FailureDetector.CONFIG_OF_CLASS_NAME, ConnectionFailureDetector.class.getName());
   }
 
   @Test
@@ -116,6 +128,58 @@ public class MultiNodesOfflineClusterIntegrationTest extends OfflineClusterInteg
 
     // Check if broker is dropped from the cluster
     assertFalse(_helixAdmin.getInstancesInCluster(clusterName).contains(brokerId));
+  }
+
+  @Test
+  public void testServerHardFailure()
+      throws Exception {
+    long expectedCountStarResult = getCountStarResult();
+    testCountStarQuery(3, false);
+    assertEquals(getCurrentCountStarResult(), expectedCountStarResult);
+
+    // Take a server and shut down its query server to mimic a hard failure
+    BaseServerStarter serverStarter = _serverStarters.get(NUM_SERVERS - 1);
+    serverStarter.getServerInstance().shutDown();
+
+    // First query should hit all servers and get connection refused exception
+    testCountStarQuery(NUM_SERVERS, true);
+
+    // Second query should not hit the failed server, and should return the correct result
+    testCountStarQuery(NUM_SERVERS - 1, false);
+
+    // Restart the failed server, and it should be included in the routing again
+    serverStarter.stop();
+    serverStarter = startOneServer(NUM_SERVERS - 1);
+    _serverStarters.set(NUM_SERVERS - 1, serverStarter);
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        JsonNode queryResult = postQuery("SELECT COUNT(*) FROM mytable");
+        // Result should always be correct
+        assertEquals(queryResult.get("resultTable").get("rows").get(0).get(0).longValue(), getCountStarResult());
+        return queryResult.get("numServersQueried").intValue() == NUM_SERVERS;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, 10_000L, "Failed to include the restarted server into the routing");
+  }
+
+  private void testCountStarQuery(int expectedNumServersQueried, boolean exceptionExpected)
+      throws Exception {
+    JsonNode queryResult = postQuery("SELECT COUNT(*) FROM mytable");
+    assertEquals(queryResult.get("numServersQueried").intValue(), expectedNumServersQueried);
+    if (exceptionExpected) {
+      // 2 exceptions expected: 1. connection refused from the failed server; 2. servers not responded
+      JsonNode exceptions = queryResult.get("exceptions");
+      assertEquals(exceptions.size(), 2);
+      JsonNode firstException = exceptions.get(0);
+      assertEquals(firstException.get("errorCode").intValue(), QueryException.BROKER_REQUEST_SEND_ERROR_CODE);
+      assertTrue(firstException.get("message").textValue().contains("Connection refused"));
+      JsonNode secondException = exceptions.get(1);
+      assertEquals(secondException.get("errorCode").intValue(), QueryException.SERVER_NOT_RESPONDING_ERROR_CODE);
+    } else {
+      assertEquals(queryResult.get("resultTable").get("rows").get(0).get(0).longValue(), getCountStarResult());
+      assertTrue(queryResult.get("exceptions").isEmpty());
+    }
   }
 
   // Disabled because with multiple replicas, there is no guarantee that all replicas are reloaded

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.broker.broker.helix.BaseBrokerStarter;
-import org.apache.pinot.broker.failuredetector.ConnectionFailureDetector;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.server.starter.helix.BaseServerStarter;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -64,7 +63,7 @@ public class MultiNodesOfflineClusterIntegrationTest extends OfflineClusterInteg
 
   @Override
   protected void overrideBrokerConf(PinotConfiguration brokerConf) {
-    brokerConf.setProperty(FailureDetector.CONFIG_OF_CLASS_NAME, ConnectionFailureDetector.class.getName());
+    brokerConf.setProperty(FailureDetector.CONFIG_OF_TYPE, FailureDetector.Type.CONNECTION.name());
   }
 
   @Test

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.server.starter;
 
-import com.google.common.base.Preconditions;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.LongAccumulator;
@@ -97,8 +96,8 @@ public class ServerInstance {
 
     TlsConfig tlsConfig =
         TlsUtils.extractTlsConfig(serverConf.getPinotConfig(), CommonConstants.Server.SERVER_TLS_PREFIX);
-    NettyConfig nettyConfig = NettyConfig
-        .extractNettyConfig(serverConf.getPinotConfig(), CommonConstants.Server.SERVER_NETTY_PREFIX);
+    NettyConfig nettyConfig =
+        NettyConfig.extractNettyConfig(serverConf.getPinotConfig(), CommonConstants.Server.SERVER_NETTY_PREFIX);
     accessControlFactory.init(
         serverConf.getPinotConfig().subset(CommonConstants.Server.PREFIX_OF_CONFIG_OF_ACCESS_CONTROL));
     _accessControl = accessControlFactory.create();
@@ -178,7 +177,11 @@ public class ServerInstance {
   }
 
   public synchronized void shutDown() {
-    Preconditions.checkState(_started, "Server instance is not running");
+    if (!_started) {
+      LOGGER.warn("Server instance is not running, skipping the shut down");
+      return;
+    }
+
     LOGGER.info("Shutting down server instance");
 
     if (_nettyTlsQueryServer != null) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -251,6 +251,19 @@ public class CommonConstants {
     }
 
     public static class FailureDetector {
+      public enum Type {
+        // Do not detect any failure
+        NO_OP,
+
+        // Detect connection failures
+        CONNECTION,
+
+        // Use the custom failure detector of the configured class name
+        CUSTOM
+      }
+
+      public static final String CONFIG_OF_TYPE = "pinot.broker.failure.detector.type";
+      public static final String DEFAULT_TYPE = Type.NO_OP.name();
       public static final String CONFIG_OF_CLASS_NAME = "pinot.broker.failure.detector.class";
 
       // Exponential backoff delay of retrying an unhealthy server when a failure is detected
@@ -510,11 +523,9 @@ public class CommonConstants {
     public static class Realtime {
       public enum Status {
         // Means the segment is in CONSUMING state.
-        IN_PROGRESS,
-        // Means the segment is in ONLINE state (segment completed consuming and has been saved in
+        IN_PROGRESS, // Means the segment is in ONLINE state (segment completed consuming and has been saved in
         // segment store).
-        DONE,
-        // Means the segment is uploaded to a Pinot controller by an external party.
+        DONE, // Means the segment is uploaded to a Pinot controller by an external party.
         UPLOADED
       }
 
@@ -525,8 +536,7 @@ public class CommonConstants {
       public enum CompletionMode {
         // default behavior - if the in memory segment in the non-winner server is equivalent to the committed
         // segment, then build and replace, else download
-        DEFAULT,
-        // non-winner servers always download the segment, never build it
+        DEFAULT, // non-winner servers always download the segment, never build it
         DOWNLOAD
       }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -249,6 +249,19 @@ public class CommonConstants {
         public static final String MIN_SERVER_GROUP_TRIM_SIZE = "minServerGroupTrimSize";
       }
     }
+
+    public static class FailureDetector {
+      public static final String CONFIG_OF_CLASS_NAME = "pinot.broker.failure.detector.class";
+
+      // Exponential backoff delay of retrying an unhealthy server when a failure is detected
+      public static final String CONFIG_OF_RETRY_INITIAL_DELAY_MS =
+          "pinot.broker.failure.detector.retry.initial.delay.ms";
+      public static final long DEFAULT_RETRY_INITIAL_DELAY_MS = 5_000L;
+      public static final String CONFIG_OF_RETRY_DELAY_FACTOR = "pinot.broker.failure.detector.retry.delay.factor";
+      public static final double DEFAULT_RETRY_DELAY_FACTOR = 2.0;
+      public static final String CONFIG_OF_MAX_RETRIES = "pinot.broker.failure.detector.max.retries";
+      public static final int DEFAULT_MAX_RETIRES = 10;
+    }
   }
 
   public static class Server {


### PR DESCRIPTION
For issue #8490 

## Description
- Add FailureDetector module to the broker
- Add QueryResponse interface
- Add ConnectionFailureDetector to detect server connection failures

## Release Notes
Added the following failure detector related configs to the broker config:
- `pinot.broker.failure.detector.type`: can be `NO_OP` (default), `CONNECTION`, `CUSTOM`
- `pinot.broker.failure.detector.class`: for `CUSTOM` type
- `pinot.broker.failure.detector.retry.initial.delay.ms`: 5000 by default
- `pinot.broker.failure.detector.retry.delay.factor`: 2 by default
- `pinot.broker.failure.detector.max.retries`: 10 by default