### PR TITLE
Upgrade snappy version to 1.1.8.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
     <commons-net.version>3.1</commons-net.version>
     <!-- helix-core, spark-core use libraries from io.dropwizard.metrics -->
     <dropwizard-metrics.version>4.2.2</dropwizard-metrics.version>
-    <snappy-java.version>1.1.1.7</snappy-java.version>
+    <snappy-java.version>1.1.8.2</snappy-java.version>
     <zstd-jni.version>1.4.9-5</zstd-jni.version>
     <lz4-java.version>1.7.1</lz4-java.version>
     <log4j.version>2.17.1</log4j.version>


### PR DESCRIPTION
Current snappy version doesn't work for M1 Mac devices. It throws `[FAILED_TO_LOAD_NATIVE_LIBRARY] no native library is found for os.name=Mac and os.arch=aarch64`.  This generally happens when ingesting files encoded with Snappy compression and is not triggered in regular flows.

The solution is to upgrade to 1.1.8.2 since that has M1 binaries.

