### PR TITLE
Reduce the size of arrays allocated in DataBlockCache

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataBlockCache.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataBlockCache.java
@@ -64,7 +64,9 @@ public class DataBlockCache {
   public void initNewBlock(int[] docIds, int length) {
     _docIds = docIds;
     if (length > _length) {
+      _dictIdsMap.clear();
       _valuesMap.clear();
+      _numValuesMap.clear();
     }
     _length = length;
     _columnDictIdLoaded.clear();

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataBlockCache.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataBlockCache.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.segment.spi.evaluator.TransformEvaluator;
 import org.apache.pinot.spi.data.FieldSpec;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataBlockCache.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataBlockCache.java
@@ -63,6 +63,9 @@ public class DataBlockCache {
    */
   public void initNewBlock(int[] docIds, int length) {
     _docIds = docIds;
+    if (length > _length) {
+      _valuesMap.clear();
+    }
     _length = length;
     _columnDictIdLoaded.clear();
     for (Set<String> columns : _columnValueLoaded.values()) {
@@ -103,7 +106,7 @@ public class DataBlockCache {
     int[] dictIds = (int[]) _dictIdsMap.get(column);
     if (_columnDictIdLoaded.add(column)) {
       if (dictIds == null) {
-        dictIds = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+        dictIds = new int[_length];
         _dictIdsMap.put(column, dictIds);
       }
       _dataFetcher.fetchDictIds(column, _docIds, _length, dictIds);
@@ -121,7 +124,7 @@ public class DataBlockCache {
     int[] intValues = getValues(FieldSpec.DataType.INT, column);
     if (markLoaded(FieldSpec.DataType.INT, column)) {
       if (intValues == null) {
-        intValues = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+        intValues = new int[_length];
         putValues(FieldSpec.DataType.INT, column, intValues);
       }
       _dataFetcher.fetchIntValues(column, _docIds, _length, intValues);
@@ -150,7 +153,7 @@ public class DataBlockCache {
     long[] longValues = getValues(FieldSpec.DataType.LONG, column);
     if (markLoaded(FieldSpec.DataType.LONG, column)) {
       if (longValues == null) {
-        longValues = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+        longValues = new long[_length];
         putValues(FieldSpec.DataType.LONG, column, longValues);
       }
       _dataFetcher.fetchLongValues(column, _docIds, _length, longValues);
@@ -179,7 +182,7 @@ public class DataBlockCache {
     float[] floatValues = getValues(FieldSpec.DataType.FLOAT, column);
     if (markLoaded(FieldSpec.DataType.FLOAT, column)) {
       if (floatValues == null) {
-        floatValues = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+        floatValues = new float[_length];
         putValues(FieldSpec.DataType.FLOAT, column, floatValues);
       }
       _dataFetcher.fetchFloatValues(column, _docIds, _length, floatValues);
@@ -208,7 +211,7 @@ public class DataBlockCache {
     double[] doubleValues = getValues(FieldSpec.DataType.DOUBLE, column);
     if (markLoaded(FieldSpec.DataType.DOUBLE, column)) {
       if (doubleValues == null) {
-        doubleValues = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+        doubleValues = new double[_length];
         putValues(FieldSpec.DataType.DOUBLE, column, doubleValues);
       }
       _dataFetcher.fetchDoubleValues(column, _docIds, _length, doubleValues);
@@ -237,7 +240,7 @@ public class DataBlockCache {
     String[] stringValues = getValues(FieldSpec.DataType.STRING, column);
     if (markLoaded(FieldSpec.DataType.STRING, column)) {
       if (stringValues == null) {
-        stringValues = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+        stringValues = new String[_length];
         putValues(FieldSpec.DataType.STRING, column, stringValues);
       }
       _dataFetcher.fetchStringValues(column, _docIds, _length, stringValues);
@@ -266,7 +269,7 @@ public class DataBlockCache {
     byte[][] bytesValues = getValues(FieldSpec.DataType.BYTES, column);
     if (markLoaded(FieldSpec.DataType.BYTES, column)) {
       if (bytesValues == null) {
-        bytesValues = new byte[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+        bytesValues = new byte[_length][];
         putValues(FieldSpec.DataType.BYTES, column, bytesValues);
       }
       _dataFetcher.fetchBytesValues(column, _docIds, _length, bytesValues);
@@ -288,7 +291,7 @@ public class DataBlockCache {
     int[][] dictIds = (int[][]) _dictIdsMap.get(column);
     if (_columnDictIdLoaded.add(column)) {
       if (dictIds == null) {
-        dictIds = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+        dictIds = new int[_length][];
         _dictIdsMap.put(column, dictIds);
       }
       _dataFetcher.fetchDictIds(column, _docIds, _length, dictIds);
@@ -306,7 +309,7 @@ public class DataBlockCache {
     int[][] intValues = getValues(FieldSpec.DataType.INT, column);
     if (markLoaded(FieldSpec.DataType.INT, column)) {
       if (intValues == null) {
-        intValues = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+        intValues = new int[_length][];
         putValues(FieldSpec.DataType.INT, column, intValues);
       }
       _dataFetcher.fetchIntValues(column, _docIds, _length, intValues);
@@ -335,7 +338,7 @@ public class DataBlockCache {
     long[][] longValues = getValues(FieldSpec.DataType.LONG, column);
     if (markLoaded(FieldSpec.DataType.LONG, column)) {
       if (longValues == null) {
-        longValues = new long[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+        longValues = new long[_length][];
         putValues(FieldSpec.DataType.LONG, column, longValues);
       }
       _dataFetcher.fetchLongValues(column, _docIds, _length, longValues);
@@ -364,7 +367,7 @@ public class DataBlockCache {
     float[][] floatValues = getValues(FieldSpec.DataType.FLOAT, column);
     if (markLoaded(FieldSpec.DataType.FLOAT, column)) {
       if (floatValues == null) {
-        floatValues = new float[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+        floatValues = new float[_length][];
         putValues(FieldSpec.DataType.FLOAT, column, floatValues);
       }
       _dataFetcher.fetchFloatValues(column, _docIds, _length, floatValues);
@@ -393,7 +396,7 @@ public class DataBlockCache {
     double[][] doubleValues = getValues(FieldSpec.DataType.DOUBLE, column);
     if (markLoaded(FieldSpec.DataType.DOUBLE, column)) {
       if (doubleValues == null) {
-        doubleValues = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+        doubleValues = new double[_length][];
         putValues(FieldSpec.DataType.DOUBLE, column, doubleValues);
       }
       _dataFetcher.fetchDoubleValues(column, _docIds, _length, doubleValues);
@@ -422,7 +425,7 @@ public class DataBlockCache {
     String[][] stringValues = getValues(FieldSpec.DataType.STRING, column);
     if (markLoaded(FieldSpec.DataType.STRING, column)) {
       if (stringValues == null) {
-        stringValues = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
+        stringValues = new String[_length][];
         putValues(FieldSpec.DataType.STRING, column, stringValues);
       }
       _dataFetcher.fetchStringValues(column, _docIds, _length, stringValues);
@@ -451,7 +454,7 @@ public class DataBlockCache {
     int[] numValues = _numValuesMap.get(column);
     if (_columnNumValuesLoaded.add(column)) {
       if (numValues == null) {
-        numValues = new int[DocIdSetPlanNode.MAX_DOC_PER_CALL];
+        numValues = new int[_length];
         _numValuesMap.put(column, numValues);
       }
       _dataFetcher.fetchNumValues(column, _docIds, _length, numValues);


### PR DESCRIPTION
We are seeing ~50% of memory allocated in a given period from these arrays.
Our use case is such that we have heavy filtering from a given segment, producing
fewer than 100 docs in the vast majority of cases.

This patch reduces the size of these arrays to be match the `_length` of each
data block. Given that we already have that length and each iteration over a segment
will likely run many times for up to 10k docs, followed by some remaining smaller
block, this should maintain the same properties of allocating arrays of 10k size,
in the case of full table scans or similar workload where there are many blocks
accessed.

However, it vastly reduces the memory churn on cases that fetch only a few rows.
