### PR TITLE
Support st_contains using H3 index

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
@@ -84,6 +84,8 @@ public class H3InclusionIndexFilterOperator extends BaseFilterOperator {
     for (long h3IndexId : _h3Ids) {
       partialMatchDocIds[i++] = _h3IndexReader.getDocIds(h3IndexId);
     }
+    // TODO: this can be further optimized to skip the H3 cells fully contained in the polygon
+    // https://github.com/apache/pinot/issues/8547
     MutableRoaringBitmap mutableRoaringBitmap = BufferFastAggregation.or(partialMatchDocIds);
     if (mutableRoaringBitmap.isEmpty()) {
       // No doc is covered by the geometry.
@@ -96,8 +98,6 @@ public class H3InclusionIndexFilterOperator extends BaseFilterOperator {
    * Returns the filter block based on the given the partial match doc ids.
    */
   private FilterBlock getFilterBlock(MutableRoaringBitmap partialMatchDocIds) {
-    // TODO: this can be further optimized to skip the H3 cells fully contained in the polygon
-    // https://github.com/apache/pinot/issues/8547
     ExpressionFilterOperator expressionFilterOperator = new ExpressionFilterOperator(_segment, _predicate, _numDocs);
     ScanBasedDocIdIterator docIdIterator =
         (ScanBasedDocIdIterator) expressionFilterOperator.getNextBlock().getBlockDocIdSet().iterator();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.filter;
 
+import it.unimi.dsi.fastutil.longs.LongIterator;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import java.util.Collections;
 import java.util.List;
@@ -78,36 +79,42 @@ public class H3InclusionIndexFilterOperator extends BaseFilterOperator {
   @Override
   protected FilterBlock getNextBlock() {
     // get the set of H3 cells at the specified resolution which completely cover the input shape and potential cover.
-    final Pair<LongSet, LongSet> fullCoverAndPotentialCoverCells =
+    Pair<LongSet, LongSet> fullCoverAndPotentialCoverCells =
         H3Utils.coverGeometryInH3(_geometry, _h3IndexReader.getH3IndexResolution().getLowestResolution());
-    final LongSet fullyCoverH3Cells = fullCoverAndPotentialCoverCells.getLeft();
-    final LongSet potentialCoverH3Cells = fullCoverAndPotentialCoverCells.getRight();
+    LongSet fullyCoverH3Cells = fullCoverAndPotentialCoverCells.getLeft();
+    LongSet potentialCoverH3Cells = fullCoverAndPotentialCoverCells.getRight();
 
     // have list of h3 cell ids for polygon provided
     // return filtered num_docs
     ImmutableRoaringBitmap[] potentialMatchDocIds = new ImmutableRoaringBitmap[potentialCoverH3Cells.size()];
     int i = 0;
-    for (long h3IndexId : potentialCoverH3Cells) {
-      potentialMatchDocIds[i++] = _h3IndexReader.getDocIds(h3IndexId);
+    LongIterator potentialCoverH3CellsIterator = potentialCoverH3Cells.iterator();
+    while (potentialCoverH3CellsIterator.hasNext()) {
+      potentialMatchDocIds[i++] = _h3IndexReader.getDocIds(potentialCoverH3CellsIterator.nextLong());
     }
     MutableRoaringBitmap potentialMatchMutableRoaringBitmap = BufferFastAggregation.or(potentialMatchDocIds);
     if (_isPositiveCheck) {
       ImmutableRoaringBitmap[] fullMatchDocIds = new ImmutableRoaringBitmap[fullyCoverH3Cells.size()];
       i = 0;
-      for (long h3IndexId : fullyCoverH3Cells) {
-        fullMatchDocIds[i++] = _h3IndexReader.getDocIds(h3IndexId);
+      LongIterator fullyCoverH3CellsIterator = fullyCoverH3Cells.iterator();
+      while (fullyCoverH3CellsIterator.hasNext()) {
+        fullMatchDocIds[i++] = _h3IndexReader.getDocIds(fullyCoverH3CellsIterator.nextLong());
       }
       MutableRoaringBitmap fullMatchMutableRoaringBitmap = BufferFastAggregation.or(fullMatchDocIds);
       return getFilterBlock(fullMatchMutableRoaringBitmap, potentialMatchMutableRoaringBitmap);
     } else {
       i = 0;
+      // remove full match from potential match to get potential not match cells.
       potentialCoverH3Cells.removeAll(fullyCoverH3Cells);
       ImmutableRoaringBitmap[] potentialNotMatchMutableRoaringBitmap =
           new ImmutableRoaringBitmap[potentialCoverH3Cells.size()];
-      for (long h3IndexId : potentialCoverH3Cells) {
-        potentialNotMatchMutableRoaringBitmap[i++] = _h3IndexReader.getDocIds(h3IndexId);
+      LongIterator potentialNotMatchH3CellsIterator = potentialCoverH3Cells.iterator();
+      while (potentialNotMatchH3CellsIterator.hasNext()) {
+        potentialNotMatchMutableRoaringBitmap[i++] =
+            _h3IndexReader.getDocIds(potentialNotMatchH3CellsIterator.nextLong());
       }
       MutableRoaringBitmap potentialNotMatch = BufferFastAggregation.or(potentialNotMatchMutableRoaringBitmap);
+      // flip potential match bit map to get exactly not match bitmap.
       potentialMatchMutableRoaringBitmap.flip(0L, _numDocs);
       return getFilterBlock(potentialMatchMutableRoaringBitmap, potentialNotMatch);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
@@ -85,7 +85,7 @@ public class H3InclusionIndexFilterOperator extends BaseFilterOperator {
       partialMatchDocIds[i++] = _h3IndexReader.getDocIds(h3IndexId);
     }
     MutableRoaringBitmap mutableRoaringBitmap = BufferFastAggregation.or(partialMatchDocIds);
-    if (mutableRoaringBitmap.getCardinality() == 0) {
+    if (mutableRoaringBitmap.isEmpty()) {
       // No doc is coverd by the geometry.
       mutableRoaringBitmap.flip(0L, _numDocs);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
@@ -96,6 +96,8 @@ public class H3InclusionIndexFilterOperator extends BaseFilterOperator {
    * Returns the filter block based on the given the partial match doc ids.
    */
   private FilterBlock getFilterBlock(MutableRoaringBitmap partialMatchDocIds) {
+    // TODO: this can be further optimized to skip the H3 cells fully contained in the polygon
+    // https://github.com/apache/pinot/issues/8547
     ExpressionFilterOperator expressionFilterOperator = new ExpressionFilterOperator(_segment, _predicate, _numDocs);
     ScanBasedDocIdIterator docIdIterator =
         (ScanBasedDocIdIterator) expressionFilterOperator.getNextBlock().getBlockDocIdSet().iterator();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
@@ -72,7 +72,7 @@ public class H3InclusionIndexFilterOperator extends BaseFilterOperator {
       _geometry = GeometrySerializer.deserialize(BytesUtils.toBytes(arguments.get(0).getLiteral()));
     }
     // must be some h3 index
-    assert _h3IndexReader != null;
+    assert _h3IndexReader != null : "the column must have H3 index setup.";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
@@ -146,11 +146,6 @@ public class H3InclusionIndexFilterOperator extends BaseFilterOperator {
   }
 
   @Override
-  public String getOperatorName() {
-    return OPERATOR_NAME;
-  }
-
-  @Override
   public List<Operator> getChildOperators() {
     return Collections.emptyList();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.filter;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.ExpressionContext.Type;
+import org.apache.pinot.common.request.context.predicate.Predicate;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.operator.blocks.FilterBlock;
+import org.apache.pinot.core.operator.dociditerators.ScanBasedDocIdIterator;
+import org.apache.pinot.core.operator.docidsets.BitmapDocIdSet;
+import org.apache.pinot.segment.local.utils.GeometrySerializer;
+import org.apache.pinot.segment.local.utils.H3Utils;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.index.reader.H3IndexReader;
+import org.apache.pinot.spi.utils.BytesUtils;
+import org.locationtech.jts.geom.Geometry;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
+
+/**
+ * A filter operator that uses H3 index for geospatial data inclusion
+ */
+public class H3InclusionIndexFilterOperator extends BaseFilterOperator {
+
+  private static final String EXPLAIN_NAME = "INCLUSION_FILTER_H3_INDEX";
+
+  private static final String OPERATOR_NAME = "H3InclusionIndexFilterOperator";
+
+  private final IndexSegment _segment;
+  private final Predicate _predicate;
+  private final int _numDocs;
+  private final H3IndexReader _h3IndexReader;
+  private final Collection<Long> _h3Ids;
+
+  public H3InclusionIndexFilterOperator(IndexSegment segment, Predicate predicate, int numDocs) {
+    _segment = segment;
+    _predicate = predicate;
+    _numDocs = numDocs;
+
+    List<ExpressionContext> arguments = predicate.getLhs().getFunction().getArguments();
+    Geometry geometry;
+    // Assume first argument is Literal, and second argument is IDENTIFIER for St_Contains.
+    assert arguments.get(1).getType() == Type.IDENTIFIER;
+    assert arguments.get(0).getType() == Type.LITERAL;
+    // look up arg1's h3 indices
+    _h3IndexReader = segment.getDataSource(arguments.get(1).getIdentifier()).getH3Index();
+    // arg0 is the literal
+    geometry = GeometrySerializer.deserialize(BytesUtils.toBytes(arguments.get(0).getLiteral()));
+    // must be some h3 index
+    assert _h3IndexReader != null;
+
+    // get the set of H3 cells at the specified resolution which completely cover the input shape.
+    _h3Ids = H3Utils.coverGeometryInH3(geometry, _h3IndexReader.getH3IndexResolution().getLowestResolution());
+  }
+
+  @Override
+  protected FilterBlock getNextBlock() {
+    // have list of h3 cell ids for polygon provided
+    // return filtered num_docs
+    MutableRoaringBitmap partialMatchDocIds = new MutableRoaringBitmap();
+    for (long h3IndexId : _h3Ids) {
+      partialMatchDocIds.or(_h3IndexReader.getDocIds(h3IndexId));
+    }
+    partialMatchDocIds.flip(0L, _numDocs);
+    return getFilterBlock(partialMatchDocIds);
+  }
+
+  /**
+   * Returns the filter block based on the given the partial match doc ids.
+   */
+  private FilterBlock getFilterBlock(MutableRoaringBitmap partialMatchDocIds) {
+    ExpressionFilterOperator expressionFilterOperator = new ExpressionFilterOperator(_segment, _predicate, _numDocs);
+    ScanBasedDocIdIterator docIdIterator =
+        (ScanBasedDocIdIterator) expressionFilterOperator.getNextBlock().getBlockDocIdSet().iterator();
+    MutableRoaringBitmap result = docIdIterator.applyAnd(partialMatchDocIds);
+    return new FilterBlock(new BitmapDocIdSet(result, _numDocs) {
+      @Override
+      public long getNumEntriesScannedInFilter() {
+        return docIdIterator.getNumEntriesScanned();
+      }
+    });
+  }
+
+  @Override
+  public String getOperatorName() {
+    return OPERATOR_NAME;
+  }
+
+  @Override
+  public List<Operator> getChildOperators() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public String toExplainString() {
+    StringBuilder stringBuilder = new StringBuilder(EXPLAIN_NAME).append("(inclusionIndex:h3_index");
+    stringBuilder.append(",operator:").append(_predicate.getType());
+    stringBuilder.append(",predicate:").append(_predicate.toString());
+    return stringBuilder.append(')').toString();
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
@@ -86,7 +86,7 @@ public class H3InclusionIndexFilterOperator extends BaseFilterOperator {
     }
     MutableRoaringBitmap mutableRoaringBitmap = BufferFastAggregation.or(partialMatchDocIds);
     if (mutableRoaringBitmap.isEmpty()) {
-      // No doc is coverd by the geometry.
+      // No doc is covered by the geometry.
       mutableRoaringBitmap.flip(0L, _numDocs);
     }
     return getFilterBlock(mutableRoaringBitmap);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/H3IndexQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/H3IndexQueriesTest.java
@@ -227,13 +227,23 @@ public class H3IndexQueriesTest extends BaseQueriesTest {
       Assert.assertEquals((long) aggregationResult.get(0), NUM_RECORDS);
     }
 
-    // Test st contains in polygon
-    testQueryStContain("SELECT COUNT(*) FROM testTable WHERE ST_Contains(ST_GeomFromText('POLYGON ((\n"
-        + "             -122.0008564 37.5004316, \n"
-        + "             -121.9991291 37.5005168, \n"
-        + "             -121.9990325 37.4995294, \n"
-        + "             -122.0001268 37.4993506,  \n"
-        + "             -122.0008564 37.5004316))'), %s) = 1");
+    {
+      // Test st contains in polygon
+      testQueryStContain("SELECT COUNT(*) FROM testTable WHERE ST_Contains(ST_GeomFromText('POLYGON ((\n"
+          + "             -122.0008564 37.5004316, \n"
+          + "             -121.9991291 37.5005168, \n"
+          + "             -121.9990325 37.4995294, \n"
+          + "             -122.0001268 37.4993506,  \n"
+          + "             -122.0008564 37.5004316))'), %s) = 1");
+
+      // negative test
+      testQueryStContain("SELECT COUNT(*) FROM testTable WHERE ST_Contains(ST_GeomFromText('POLYGON ((\n"
+          + "             -122.0008564 37.5004316, \n"
+          + "             -121.9991291 37.5005168, \n"
+          + "             -121.9990325 37.4995294, \n"
+          + "             -122.0001268 37.4993506,  \n"
+          + "             -122.0008564 37.5004316))'), %s) = 0");
+    }
     {
       // Test st contains in polygon, doesn't have
       String query = "SELECT COUNT(*) FROM testTable WHERE ST_Contains(ST_GeomFromText('POLYGON ((\n"
@@ -246,7 +256,7 @@ public class H3IndexQueriesTest extends BaseQueriesTest {
       IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();
       // Expect 0 entries scanned in filter
       QueriesTestUtils
-          .testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 0, NUM_RECORDS, 0,
+          .testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 0, 0, 0,
               NUM_RECORDS);
       List<Object> aggregationResult = resultsBlock.getAggregationResult();
       Assert.assertNotNull(aggregationResult);
@@ -260,7 +270,7 @@ public class H3IndexQueriesTest extends BaseQueriesTest {
     List<GenericRow> records = new ArrayList<>(1);
     addRecord(records, -122.0008081, 37.5004231);
     setUp(records);
-    // Test point is vertex of a polygon.
+    // Test point is closed to border of a polygon but inside.
     String query = "SELECT COUNT(*) FROM testTable WHERE ST_Contains(ST_GeomFromText('POLYGON ((\n"
         + "             -122.0008564 37.5004316, \n"
         + "             -121.9991291 37.5005168, \n"
@@ -281,7 +291,7 @@ public class H3IndexQueriesTest extends BaseQueriesTest {
     List<GenericRow> records = new ArrayList<>(1);
     addRecord(records, -122.0007277, 37.5005785);
     setUp(records);
-    // Test point is vertex of a polygon.
+    // Test point is closed to border of a polygon but outside.
     String query = "SELECT COUNT(*) FROM testTable WHERE ST_Contains(ST_GeomFromText('POLYGON ((\n"
         + "             -122.0008564 37.5004316, \n"
         + "             -121.9991291 37.5005168, \n"

--- a/pinot-core/src/test/java/org/apache/pinot/queries/H3IndexQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/H3IndexQueriesTest.java
@@ -288,7 +288,7 @@ public class H3IndexQueriesTest extends BaseQueriesTest {
           + "             121.9990325 -37.4995294, \n"
           + "             122.0001268 -37.4993506,  \n"
           + "             122.0008564 -37.5004316))')) = 1";
-      AggregationOperator aggregationOperator = getOperatorForSqlQuery(query);
+      AggregationOperator aggregationOperator = getOperator(query);
       IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();
       // Expect 0 entries scanned in filter
       QueriesTestUtils
@@ -313,7 +313,7 @@ public class H3IndexQueriesTest extends BaseQueriesTest {
         + "             -121.9990325 37.4995294, \n"
         + "             -122.0001268 37.4993506,  \n"
         + "             -122.0008564 37.5004316))'), h3Column_geometry) = 1";
-    AggregationOperator aggregationOperator = getOperatorForSqlQuery(query);
+    AggregationOperator aggregationOperator = getOperator(query);
     IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 1, 1, 0, 1);
     List<Object> aggregationResult = resultsBlock.getAggregationResult();
@@ -334,7 +334,7 @@ public class H3IndexQueriesTest extends BaseQueriesTest {
         + "             -121.9990325 37.4995294, \n"
         + "             -122.0001268 37.4993506,  \n"
         + "             -122.0008564 37.5004316))')) = 1";
-    AggregationOperator aggregationOperator = getOperatorForSqlQuery(query);
+    AggregationOperator aggregationOperator = getOperator(query);
     IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 1, 1, 0, 1);
     List<Object> aggregationResult = resultsBlock.getAggregationResult();
@@ -355,7 +355,7 @@ public class H3IndexQueriesTest extends BaseQueriesTest {
         + "             -121.9990325 37.4995294, \n"
         + "             -122.0001268 37.4993506,  \n"
         + "             -122.0008564 37.5004316))'), h3Column_geometry) = 1";
-    AggregationOperator aggregationOperator = getOperatorForSqlQuery(query);
+    AggregationOperator aggregationOperator = getOperator(query);
     IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 0, 1, 0, 1);
     List<Object> aggregationResult = resultsBlock.getAggregationResult();
@@ -376,7 +376,7 @@ public class H3IndexQueriesTest extends BaseQueriesTest {
         + "             -121.9990325 37.4995294, \n"
         + "             -122.0001268 37.4993506,  \n"
         + "             -122.0008564 37.5004316))')) = 1";
-    AggregationOperator aggregationOperator = getOperatorForSqlQuery(query);
+    AggregationOperator aggregationOperator = getOperator(query);
     IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 0, 1, 0, 1);
     List<Object> aggregationResult = resultsBlock.getAggregationResult();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/H3Utils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/H3Utils.java
@@ -18,11 +18,27 @@
  */
 package org.apache.pinot.segment.local.utils;
 
+import com.google.common.collect.ImmutableList;
 import com.uber.h3core.H3Core;
+import com.uber.h3core.exceptions.LineUndefinedException;
+import com.uber.h3core.util.GeoCoord;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryCollection;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.Polygon;
 
 
 public class H3Utils {
+
   private H3Utils() {
   }
 
@@ -34,5 +50,51 @@ public class H3Utils {
     } catch (IOException e) {
       throw new RuntimeException("Failed to instantiate H3 instance", e);
     }
+  }
+
+  private static Set<Long> coverLineInH3(LineString lineString, int resolution) {
+    Set<Long> coveringH3Cells = new HashSet<>();
+    List<Long> endpointH3Cells = new ArrayList<>();
+    for (Coordinate endpoint : lineString.getCoordinates()) {
+      endpointH3Cells.add(H3_CORE.geoToH3(endpoint.y, endpoint.x, resolution));
+    }
+    for (int i = 0; i < endpointH3Cells.size() - 1; i++) {
+      try {
+        coveringH3Cells.addAll(H3_CORE.h3Line(endpointH3Cells.get(i), endpointH3Cells.get(i + 1)));
+      } catch (LineUndefinedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    return coveringH3Cells;
+  }
+
+  private static Set<Long> coverPolygonInH3(Polygon polygon, int resolution) {
+    Set<Long> coveringH3Cells = new HashSet<>(coverLineInH3(polygon.getExteriorRing(), resolution));
+
+    coveringH3Cells.addAll(H3_CORE.polyfill(Arrays.asList(polygon.getCoordinates()).stream()
+        .map(coordinate -> new GeoCoord(coordinate.y, coordinate.x)).collect(
+            Collectors.toList()), ImmutableList.of(), resolution));
+    return coveringH3Cells;
+  }
+
+  // Return the set of H3 cells at the specified resolution which completely cover the input shape.
+  // inspired by https://github.com/uber/h3/issues/275
+  public static Set<Long> coverGeometryInH3(Geometry geometry, int resolution) {
+    Set<Long> coveringH3Cells = new HashSet<>();
+    if (geometry instanceof Point) {
+      coveringH3Cells
+          .add(H3_CORE.geoToH3(geometry.getCoordinate().y, geometry.getCoordinate().x, resolution));
+    } else if (geometry instanceof LineString) {
+      coveringH3Cells.addAll(coverLineInH3(((LineString) geometry), resolution));
+    } else if (geometry instanceof Polygon) {
+      coveringH3Cells.addAll(coverPolygonInH3(((Polygon) geometry), resolution));
+    } else if (geometry instanceof GeometryCollection) {
+      for (int i = 0; i < geometry.getNumGeometries(); i++) {
+        coveringH3Cells.addAll(coverGeometryInH3(geometry.getGeometryN(i), resolution));
+      }
+    } else {
+      throw new UnsupportedOperationException("Unexpected type: " + geometry.getGeometryType());
+    }
+    return coveringH3Cells;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/H3Utils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/H3Utils.java
@@ -109,7 +109,6 @@ public class H3Utils {
         fullCover.addAll(coverGeometryInH3(geometry.getGeometryN(i), resolution).getLeft());
         potentialCover.addAll(coverGeometryInH3(geometry.getGeometryN(i), resolution).getRight());
       }
-      potentialCover.removeAll(fullCover);
       return Pair.of(fullCover, potentialCover);
     } else {
       throw new UnsupportedOperationException("Unexpected type: " + geometry.getGeometryType());

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/H3Utils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/H3Utils.java
@@ -22,12 +22,12 @@ import com.google.common.collect.ImmutableList;
 import com.uber.h3core.H3Core;
 import com.uber.h3core.exceptions.LineUndefinedException;
 import com.uber.h3core.util.GeoCoord;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongList;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
+import it.unimi.dsi.fastutil.longs.LongSet;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
@@ -52,9 +52,9 @@ public class H3Utils {
     }
   }
 
-  private static Set<Long> coverLineInH3(LineString lineString, int resolution) {
-    Set<Long> coveringH3Cells = new HashSet<>();
-    List<Long> endpointH3Cells = new ArrayList<>();
+  private static LongSet coverLineInH3(LineString lineString, int resolution) {
+    LongSet coveringH3Cells = new LongOpenHashSet();
+    LongList endpointH3Cells = new LongArrayList();
     for (Coordinate endpoint : lineString.getCoordinates()) {
       endpointH3Cells.add(H3_CORE.geoToH3(endpoint.y, endpoint.x, resolution));
     }
@@ -68,22 +68,21 @@ public class H3Utils {
     return coveringH3Cells;
   }
 
-  private static Set<Long> coverPolygonInH3(Polygon polygon, int resolution) {
-    Set<Long> coveringH3Cells = new HashSet<>(coverLineInH3(polygon.getExteriorRing(), resolution));
+  private static LongSet coverPolygonInH3(Polygon polygon, int resolution) {
+    LongSet coveringH3Cells = new LongOpenHashSet(coverLineInH3(polygon.getExteriorRing(), resolution));
 
-    coveringH3Cells.addAll(H3_CORE.polyfill(Arrays.asList(polygon.getCoordinates()).stream()
-        .map(coordinate -> new GeoCoord(coordinate.y, coordinate.x)).collect(
-            Collectors.toList()), ImmutableList.of(), resolution));
+    coveringH3Cells.addAll(H3_CORE.polyfill(
+        Arrays.asList(polygon.getCoordinates()).stream().map(coordinate -> new GeoCoord(coordinate.y, coordinate.x))
+            .collect(Collectors.toList()), ImmutableList.of(), resolution));
     return coveringH3Cells;
   }
 
   // Return the set of H3 cells at the specified resolution which completely cover the input shape.
   // inspired by https://github.com/uber/h3/issues/275
-  public static Set<Long> coverGeometryInH3(Geometry geometry, int resolution) {
-    Set<Long> coveringH3Cells = new HashSet<>();
+  public static LongSet coverGeometryInH3(Geometry geometry, int resolution) {
+    LongSet coveringH3Cells = new LongOpenHashSet();
     if (geometry instanceof Point) {
-      coveringH3Cells
-          .add(H3_CORE.geoToH3(geometry.getCoordinate().y, geometry.getCoordinate().x, resolution));
+      coveringH3Cells.add(H3_CORE.geoToH3(geometry.getCoordinate().y, geometry.getCoordinate().x, resolution));
     } else if (geometry instanceof LineString) {
       coveringH3Cells.addAll(coverLineInH3(((LineString) geometry), resolution));
     } else if (geometry instanceof Polygon) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/H3Utils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/H3Utils.java
@@ -60,7 +60,7 @@ public class H3Utils {
     }
     for (int i = 0; i < endpointH3Cells.size() - 1; i++) {
       try {
-        coveringH3Cells.addAll(H3_CORE.h3Line(endpointH3Cells.get(i), endpointH3Cells.get(i + 1)));
+        coveringH3Cells.addAll(H3_CORE.h3Line(endpointH3Cells.getLong(i), endpointH3Cells.getLong(i + 1)));
       } catch (LineUndefinedException e) {
         throw new RuntimeException(e);
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/H3Utils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/H3Utils.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.segment.local.utils;
 
-import com.google.common.collect.ImmutableList;
 import com.uber.h3core.H3Core;
 import com.uber.h3core.exceptions.LineUndefinedException;
 import com.uber.h3core.util.GeoCoord;
@@ -28,6 +27,7 @@ import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongSet;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.locationtech.jts.geom.Coordinate;
@@ -77,7 +77,7 @@ public class H3Utils {
     LongSet polyfilledSet = new LongOpenHashSet(H3_CORE.polyfill(
         Arrays.stream(polygon.getExteriorRing().getCoordinates())
             .map(coordinate -> new GeoCoord(coordinate.y, coordinate.x))
-            .collect(Collectors.toList()), ImmutableList.of(), resolution));
+            .collect(Collectors.toList()), Collections.emptyList(), resolution));
 
     potentialH3Cells.addAll(polyfilledSet.stream()
         .flatMap(cell -> H3_CORE.kRing(cell, 1).stream()).collect(Collectors.toSet()));
@@ -91,6 +91,7 @@ public class H3Utils {
   }
 
   // Return a pair of cell ids: The first fully contain, the second is potential contain.
+  // potential contains contain the fully contain.
   public static Pair<LongSet, LongSet> coverGeometryInH3(Geometry geometry, int resolution) {
     if (geometry instanceof Point) {
       LongSet potentialCover = new LongOpenHashSet();

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <netty.version>4.1.74.Final</netty.version>
     <reactivestreams.version>1.0.3</reactivestreams.version>
     <jts.version>1.16.1</jts.version>
-    <h3.version>3.0.3</h3.version>
+    <h3.version>3.7.0</h3.version>
     <jmh.version>1.26</jmh.version>
     <audienceannotations.version>0.13.0</audienceannotations.version>
 


### PR DESCRIPTION
This is a follow up PR for : https://github.com/apache/pinot/pull/7252 since that one seems doesn't get update for long time. 

The idea is to convert input geometry into a list of h3 cells by using polyfill. But h3 [polyfill](https://h3geo.org/docs/api/regions/) only fills with the hexagons whose centers are contained by the geometry. 
so creating a method `coverGeometryInH3` to return the set of H3 cells at the specified resolution which completely cover the input shape.
Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`


(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
