### PR TITLE
DataTable deserialization improvements

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -22,9 +22,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
@@ -177,38 +175,9 @@ public class DataSchema {
     return byteArrayOutputStream.toByteArray();
   }
 
-  public static DataSchema fromBytes(byte[] buffer)
-      throws IOException {
-    ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(buffer);
-    DataInputStream dataInputStream = new DataInputStream(byteArrayInputStream);
-
-    // Read the number of columns.
-    int numColumns = dataInputStream.readInt();
-    String[] columnNames = new String[numColumns];
-    ColumnDataType[] columnDataTypes = new ColumnDataType[numColumns];
-
-    // Read the column names.
-    int readLength;
-    for (int i = 0; i < numColumns; i++) {
-      int length = dataInputStream.readInt();
-      byte[] bytes = new byte[length];
-      readLength = dataInputStream.read(bytes);
-      assert readLength == length;
-      columnNames[i] = new String(bytes, UTF_8);
-    }
-
-    // Read the column types.
-    for (int i = 0; i < numColumns; i++) {
-      int length = dataInputStream.readInt();
-      byte[] bytes = new byte[length];
-      readLength = dataInputStream.read(bytes);
-      assert readLength == length;
-      columnDataTypes[i] = ColumnDataType.valueOf(new String(bytes, UTF_8));
-    }
-
-    return new DataSchema(columnNames, columnDataTypes);
-  }
-
+  /**
+   * This method use relative operations on the ByteBuffer and expects the buffer's position to be set correctly.
+   */
   public static DataSchema fromBytes(ByteBuffer buffer)
       throws IOException {
     // Read the number of columns.

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -28,6 +28,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.Serializable;
+import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.EnumSet;
@@ -205,6 +206,29 @@ public class DataSchema {
       columnDataTypes[i] = ColumnDataType.valueOf(new String(bytes, UTF_8));
     }
 
+    return new DataSchema(columnNames, columnDataTypes);
+  }
+
+  public static DataSchema fromBytes(ByteBuffer buffer)
+      throws IOException {
+    // Read the number of columns.
+    int numColumns = buffer.getInt();
+    String[] columnNames = new String[numColumns];
+    ColumnDataType[] columnDataTypes = new ColumnDataType[numColumns];
+    // Read the column names.
+    for (int i = 0; i < numColumns; i++) {
+      int length = buffer.getInt();
+      byte[] bytes = new byte[length];
+      buffer.get(bytes);
+      columnNames[i] = new String(bytes, UTF_8);
+    }
+    // Read the column types.
+    for (int i = 0; i < numColumns; i++) {
+      int length = buffer.getInt();
+      byte[] bytes = new byte[length];
+      buffer.get(bytes);
+      columnDataTypes[i] = ColumnDataType.valueOf(new String(bytes, UTF_8));
+    }
     return new DataSchema(columnNames, columnDataTypes);
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataTable.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.common.utils;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -109,6 +110,7 @@ public interface DataTable {
     SYSTEM_ACTIVITIES_CPU_TIME_NS("systemActivitiesCpuTimeNs", MetadataValueType.LONG),
     RESPONSE_SER_CPU_TIME_NS("responseSerializationCpuTimeNs", MetadataValueType.LONG);
 
+    private static final MetadataKey[] VALUES;
     private static final Map<String, MetadataKey> NAME_TO_ENUM_KEY_MAP = new HashMap<>();
     private final String _name;
     private final MetadataValueType _valueType;
@@ -121,10 +123,7 @@ public interface DataTable {
     // getByOrdinal returns an enum key for a given ordinal or null if the key does not exist.
     @Nullable
     public static MetadataKey getByOrdinal(int ordinal) {
-      if (ordinal >= MetadataKey.values().length) {
-        return null;
-      }
-      return MetadataKey.values()[ordinal];
+      return VALUES[Math.min(ordinal, VALUES.length - 1)];
     }
 
     // getByName returns an enum key for a given name or null if the key does not exist.
@@ -143,11 +142,13 @@ public interface DataTable {
     }
 
     static {
-      for (MetadataKey key : MetadataKey.values()) {
+      MetadataKey[] values = values();
+      for (MetadataKey key : values) {
         if (NAME_TO_ENUM_KEY_MAP.put(key.getName(), key) != null) {
           throw new IllegalArgumentException("Duplicate name defined in the MetadataKey definition: " + key.getName());
         }
       }
+      VALUES = Arrays.copyOf(values, values.length + 1);
     }
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/DataSchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/DataSchemaTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.utils;
 
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.testng.Assert;
@@ -65,7 +66,7 @@ public class DataSchemaTest {
   public void testSerDe()
       throws Exception {
     DataSchema dataSchema = new DataSchema(COLUMN_NAMES, COLUMN_DATA_TYPES);
-    DataSchema dataSchemaAfterSerDe = DataSchema.fromBytes(dataSchema.toBytes());
+    DataSchema dataSchemaAfterSerDe = DataSchema.fromBytes(ByteBuffer.wrap(dataSchema.toBytes()));
     Assert.assertEquals(dataSchema, dataSchemaAfterSerDe);
     Assert.assertEquals(dataSchema.hashCode(), dataSchemaAfterSerDe.hashCode());
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/BaseDataTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/BaseDataTable.java
@@ -18,9 +18,7 @@
  */
 package org.apache.pinot.core.common.datatable;
 
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -115,27 +113,24 @@ public abstract class BaseDataTable implements DataTable {
   /**
    * Helper method to deserialize dictionary map.
    */
-  protected Map<String, Map<Integer, String>> deserializeDictionaryMap(byte[] bytes)
+  protected Map<String, Map<Integer, String>> deserializeDictionaryMap(ByteBuffer buffer)
       throws IOException {
-    try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
-        DataInputStream dataInputStream = new DataInputStream(byteArrayInputStream)) {
-      int numDictionaries = dataInputStream.readInt();
+      int numDictionaries = buffer.getInt();
       Map<String, Map<Integer, String>> dictionaryMap = new HashMap<>(numDictionaries);
 
       for (int i = 0; i < numDictionaries; i++) {
-        String column = DataTableUtils.decodeString(dataInputStream);
-        int dictionarySize = dataInputStream.readInt();
+        String column = DataTableUtils.decodeString(buffer);
+        int dictionarySize = buffer.getInt();
         Map<Integer, String> dictionary = new HashMap<>(dictionarySize);
         for (int j = 0; j < dictionarySize; j++) {
-          int key = dataInputStream.readInt();
-          String value = DataTableUtils.decodeString(dataInputStream);
+          int key = buffer.getInt();
+          String value = DataTableUtils.decodeString(buffer);
           dictionary.put(key, value);
         }
         dictionaryMap.put(column, dictionary);
       }
 
       return dictionaryMap;
-    }
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableImplV3.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableImplV3.java
@@ -21,9 +21,7 @@ package org.apache.pinot.core.common.datatable;
 
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -111,30 +109,24 @@ public class DataTableImplV3 extends BaseDataTable {
 
     // Read exceptions.
     if (exceptionsLength != 0) {
-      byte[] exceptionsBytes = new byte[exceptionsLength];
       byteBuffer.position(exceptionsStart);
-      byteBuffer.get(exceptionsBytes);
-      _errCodeToExceptionMap = deserializeExceptions(exceptionsBytes);
+      _errCodeToExceptionMap = deserializeExceptions(byteBuffer);
     } else {
       _errCodeToExceptionMap = new HashMap<>();
     }
 
     // Read dictionary.
     if (dictionaryMapLength != 0) {
-      byte[] dictionaryMapBytes = new byte[dictionaryMapLength];
       byteBuffer.position(dictionaryMapStart);
-      byteBuffer.get(dictionaryMapBytes);
-      _dictionaryMap = deserializeDictionaryMap(dictionaryMapBytes);
+      _dictionaryMap = deserializeDictionaryMap(byteBuffer);
     } else {
       _dictionaryMap = null;
     }
 
     // Read data schema.
     if (dataSchemaLength != 0) {
-      byte[] schemaBytes = new byte[dataSchemaLength];
       byteBuffer.position(dataSchemaStart);
-      byteBuffer.get(schemaBytes);
-      _dataSchema = DataSchema.fromBytes(schemaBytes);
+      _dataSchema = DataSchema.fromBytes(byteBuffer);
       _columnOffsets = new int[_dataSchema.size()];
       _rowSizeInBytes = DataTableUtils.computeColumnOffsets(_dataSchema, _columnOffsets);
     } else {
@@ -168,9 +160,7 @@ public class DataTableImplV3 extends BaseDataTable {
     // Read metadata.
     int metadataLength = byteBuffer.getInt();
     if (metadataLength != 0) {
-      byte[] metadataBytes = new byte[metadataLength];
-      byteBuffer.get(metadataBytes);
-      _metadata = deserializeMetadata(metadataBytes);
+      _metadata = deserializeMetadata(byteBuffer);
     }
   }
 
@@ -350,32 +340,29 @@ public class DataTableImplV3 extends BaseDataTable {
    * This is to make V3 implementation keep the consumers of Map<String, String> getMetadata() API in the code happy
    * by internally converting it.
    */
-  private Map<String, String> deserializeMetadata(byte[] bytes)
+  private Map<String, String> deserializeMetadata(ByteBuffer buffer)
       throws IOException {
-    try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
-        DataInputStream dataInputStream = new DataInputStream(byteArrayInputStream)) {
-      int numEntries = dataInputStream.readInt();
-      Map<String, String> metadata = new HashMap<>();
-      for (int i = 0; i < numEntries; i++) {
-        int keyId = dataInputStream.readInt();
-        MetadataKey key = MetadataKey.getByOrdinal(keyId);
-        // Ignore unknown keys.
-        if (key == null) {
-          continue;
-        }
-        if (key.getValueType() == MetadataValueType.INT) {
-          String value = String.valueOf(DataTableUtils.decodeInt(dataInputStream));
-          metadata.put(key.getName(), value);
-        } else if (key.getValueType() == MetadataValueType.LONG) {
-          String value = String.valueOf(DataTableUtils.decodeLong(dataInputStream));
-          metadata.put(key.getName(), value);
-        } else {
-          String value = String.valueOf(DataTableUtils.decodeString(dataInputStream));
-          metadata.put(key.getName(), value);
-        }
+    int numEntries = buffer.getInt();
+    Map<String, String> metadata = new HashMap<>();
+    for (int i = 0; i < numEntries; i++) {
+      int keyId = buffer.getInt();
+      MetadataKey key = MetadataKey.getByOrdinal(keyId);
+      // Ignore unknown keys.
+      if (key == null) {
+        continue;
       }
-      return metadata;
+      if (key.getValueType() == MetadataValueType.INT) {
+        String value = "" + buffer.getInt();
+        metadata.put(key.getName(), value);
+      } else if (key.getValueType() == MetadataValueType.LONG) {
+        String value = "" + buffer.getLong();
+        metadata.put(key.getName(), value);
+      } else {
+        String value = DataTableUtils.decodeString(buffer);
+        metadata.put(key.getName(), value);
+      }
     }
+    return metadata;
   }
 
   private byte[] serializeExceptions()
@@ -397,18 +384,15 @@ public class DataTableImplV3 extends BaseDataTable {
     return byteArrayOutputStream.toByteArray();
   }
 
-  private Map<Integer, String> deserializeExceptions(byte[] bytes)
+  private Map<Integer, String> deserializeExceptions(ByteBuffer buffer)
       throws IOException {
-    try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(bytes);
-        DataInputStream dataInputStream = new DataInputStream(byteArrayInputStream)) {
-      int numExceptions = dataInputStream.readInt();
-      Map<Integer, String> exceptions = new HashMap<>(numExceptions);
-      for (int i = 0; i < numExceptions; i++) {
-        int errCode = dataInputStream.readInt();
-        String errMessage = DataTableUtils.decodeString(dataInputStream);
-        exceptions.put(errCode, errMessage);
-      }
-      return exceptions;
+    int numExceptions = buffer.getInt();
+    Map<Integer, String> exceptions = new HashMap<>(numExceptions);
+    for (int i = 0; i < numExceptions; i++) {
+      int errCode = buffer.getInt();
+      String errMessage = DataTableUtils.decodeString(buffer);
+      exceptions.put(errCode, errMessage);
     }
+    return exceptions;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableImplV3.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableImplV3.java
@@ -339,6 +339,8 @@ public class DataTableImplV3 extends BaseDataTable {
    * DataTable from each server and aggregates the values).
    * This is to make V3 implementation keep the consumers of Map<String, String> getMetadata() API in the code happy
    * by internally converting it.
+   *
+   * This method use relative operations on the ByteBuffer and expects the buffer's position to be set correctly.
    */
   private Map<String, String> deserializeMetadata(ByteBuffer buffer)
       throws IOException {

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableUtils.java
@@ -22,6 +22,7 @@ import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
 import java.io.DataInputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -254,6 +255,21 @@ public class DataTableUtils {
       int numBytesRead = dataInputStream.read(buffer);
       assert numBytesRead == length;
       return new String(buffer, UTF_8);
+    }
+  }
+
+  /**
+   * Helper method to decode string.
+   */
+  public static String decodeString(ByteBuffer buffer)
+      throws IOException {
+    int length = buffer.getInt();
+    if (length == 0) {
+      return "";
+    } else {
+      byte[] bytes = new byte[length];
+      buffer.get(bytes);
+      return new String(bytes, UTF_8);
     }
   }
 


### PR DESCRIPTION
Calling `Enum.values()` allocates an array every time it is called, and this method gets called a lot during `DataTable` deserialization, which shows up in allocation profiles.

Also deserializes table directly from `ByteBuffer` to avoid allocating lots of `byte[]` during deserialization. This isn't done when the `DataTable` retains a copy of the `ByteBuffer` because of ambiguity of ownership, though it looks like it could be done safely.