### PR TITLE
docker: Remove cron for github action to build and push docker images

### DIFF
--- a/.github/workflows/build-pinot-docker-image.yml
+++ b/.github/workflows/build-pinot-docker-image.yml
@@ -19,9 +19,6 @@
 name: Pinot Docker Image Build and Publish
 
 on:
-  schedule:
-  - cron: '0 1 * * *' # run at 1 AM UTC
-
   workflow_dispatch:
     inputs:
       gitUrl:
@@ -31,6 +28,10 @@ on:
       commit:
         description: "The branch/commit to check out to build Pinot image."
         default: "master"
+        required: true
+      platform:
+        description: "The platform of the image to build, e.g. linux/amd64,linux/arm64"
+        default: "linux/amd64"
         required: true
       dockerImageName:
         description: "The docker image name, default to 'apachepinot/pinot'."
@@ -44,9 +45,6 @@ jobs:
   build-pinot-docker-image:
     name: Build Pinot Docker Image
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        platform: [ "linux/amd64", "linux/arm64" ]
     steps:
     - name: Login to DockerHub
       uses: docker/login-action@v1
@@ -62,7 +60,7 @@ jobs:
       env:
         DOCKER_FILE_BASE_DIR: "docker/images/pinot"
         DOCKER_IMAGE_NAME: ${{ github.event.inputs.dockerImageName }}
-        BUILD_PLATFORM: ${{ matrix.platform }}
+        BUILD_PLATFORM: ${{ github.event.inputs.platform }}
         PINOT_GIT_URL: ${{ github.event.inputs.gitUrl }}
         PINOT_BRANCH: ${{ github.event.inputs.commit }}
         TAGS: ${{ github.event.inputs.tags }}

--- a/.github/workflows/build-presto-docker-image.yml
+++ b/.github/workflows/build-presto-docker-image.yml
@@ -19,9 +19,6 @@
 name: Presto Pinot Docker Image Build and Publish
 
 on:
-  schedule:
-  - cron: '0 0 * * *' # run at 0 AM UTC
-
   workflow_dispatch:
     inputs:
       gitUrl:

--- a/.github/workflows/build-superset-docker-image.yml
+++ b/.github/workflows/build-superset-docker-image.yml
@@ -19,9 +19,6 @@
 name: Superset Pinot Docker Image Build and Publish
 
 on:
-  schedule:
-  - cron: '0 0 * * *' # run at 0 AM UTC
-
   workflow_dispatch:
     inputs:
       supersetImageTag:


### PR DESCRIPTION
Remove cron for github action to build and push docker images. 