### PR TITLE
bump roaringbitmap 0.9.26

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -419,8 +419,8 @@ org.json4s:json4s-jackson_2.11:3.5.3
 org.json4s:json4s-scalap_2.11:3.5.3
 org.lz4:lz4-java:1.7.1
 org.quartz-scheduler:quartz:2.3.2
-org.roaringbitmap:RoaringBitmap:0.9.25
-org.roaringbitmap:shims:0.9.25
+org.roaringbitmap:RoaringBitmap:0.9.26
+org.roaringbitmap:shims:0.9.26
 org.scala-lang.modules:scala-collection-compat_2.12:2.3.0
 org.scala-lang.modules:scala-java8-compat_2.12:0.9.1
 org.scala-lang.modules:scala-xml_2.12:1.3.0

--- a/pom.xml
+++ b/pom.xml
@@ -435,7 +435,7 @@
       <dependency>
         <groupId>org.roaringbitmap</groupId>
         <artifactId>RoaringBitmap</artifactId>
-        <version>0.9.25</version>
+        <version>0.9.26</version>
       </dependency>
       <dependency>
         <groupId>com.101tec</groupId>


### PR DESCRIPTION
Upgrade RoaringBitmap to pick up a bug fix which affects range indexes in very rare edge cases: https://github.com/RoaringBitmap/RoaringBitmap/pull/557

This release also makes it possible to count rows in a range without materialising a bitmap: https://github.com/RoaringBitmap/RoaringBitmap/pull/555
