### PR TITLE
Error message if the dimension table in memory hasn't been populated

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTable.java
@@ -51,6 +51,10 @@ class DimensionTable {
     return _lookupTable.get(pk);
   }
 
+  boolean isEmpty() {
+    return _lookupTable.isEmpty();
+  }
+
   FieldSpec getFieldSpecFor(String columnName) {
     return _tableSchema.getFieldSpecFor(columnName);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
@@ -154,6 +154,10 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
     }
   }
 
+  public boolean isPopulated() {
+    return !_dimensionTable.isEmpty();
+  }
+
   public GenericRow lookupRowByPrimaryKey(PrimaryKey pk) {
     return _dimensionTable.get(pk);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunction.java
@@ -130,6 +130,8 @@ public class LookupTransformFunction extends BaseTransformFunction {
     _dataManager = DimensionTableDataManager.getInstanceByTableName(dimTableName);
     Preconditions.checkArgument(_dataManager != null, "Dimension table does not exist: %s", dimTableName);
 
+    Preconditions.checkArgument(_dataManager.isPopulated(), "Dimension table is not populated: %s", dimTableName);
+
     _lookupColumnFieldSpec = _dataManager.getColumnFieldSpec(_dimColumnName);
     Preconditions
         .checkArgument(_lookupColumnFieldSpec != null, "Column does not exist in dimension table: %s:%s", dimTableName,

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunctionTest.java
@@ -37,7 +37,6 @@ import org.testng.annotations.Test;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.fail;
 
 
@@ -190,7 +189,8 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
 
     try {
       ExpressionContext expression = RequestContextUtils
-          .getExpressionFromSQL(String.format("lookup('baseballLeagues','leagueName','leagueID',%s)", STRING_SV_COLUMN));
+          .getExpressionFromSQL(String.format("lookup('baseballLeagues','leagueName','leagueID',%s)",
+              STRING_SV_COLUMN));
       TransformFunctionFactory.get(expression, _dataSourceMap);
       fail("Should have thrown BadQueryRequestException");
     } catch (Exception ex) {
@@ -211,7 +211,8 @@ public class LookupTransformFunctionTest extends BaseTransformFunctionTest {
     DimensionTableDataManager.registerDimensionTable("baseballPlayers_OFFLINE", tableManager);
 
       ExpressionContext expression = RequestContextUtils
-          .getExpressionFromSQL(String.format("lookup('baseballPlayers','playerName','playerID',%s)", STRING_SV_COLUMN));
+          .getExpressionFromSQL(String.format("lookup('baseballPlayers','playerName','playerID',%s)",
+              STRING_SV_COLUMN));
       TransformFunctionFactory.get(expression, _dataSourceMap);
   }
 


### PR DESCRIPTION
There's a scenario where the Pinot Server previously downloaded the segment for a dimension table and is then restarted, which means the `addSegment` flow doesn't get called. 

This means that the in-memory `DimensionTable` is empty and the `lookupJoin` function always returns null values. I'm not sure what the proper solution for solving that problem is - I guess the user could delete the segment and re-download it?

But this PR doesn't address that - instead, it throws an exception if you try to do a lookup join when the in-memory dimensions table is empty.
