### PR TITLE
Upgrade helix to 0.9.10

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HelixZNodeSizeLimitTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HelixZNodeSizeLimitTest.java
@@ -39,7 +39,8 @@ public class HelixZNodeSizeLimitTest extends BaseClusterIntegrationTest {
       throws Exception {
     // This line of code has to be executed before the org.apache.helix.manager.zk.zookeeper.ZkClient.WRITE_SIZE_LIMIT
     // is initialized. The code is in
-    // https://github.com/apache/helix/blob/helix-0.9.9/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java#L89
+    // https://github.com/apache/helix/blob/helix-0.9.9/helix-core/src/main/java/org/
+    // apache/helix/manager/zk/zookeeper/ZkClient.java#L89
     // Not sure how this works but this below line executes before ZkClient.WRITE_SIZE_LIMIT is created
     System.setProperty(SystemPropertyKeys.JUTE_MAXBUFFER, "4000000");
     TestUtils.ensureDirectoriesExistAndEmpty(_tempDir);
@@ -65,10 +66,13 @@ public class HelixZNodeSizeLimitTest extends BaseClusterIntegrationTest {
   @Test
   public void testUpdateIdealState() {
     // In Helix 0.9.8, we get error logs like below:
-    // 13:03:51.576 ERROR [ZkBaseDataAccessor] [main] Exception while setting path: /HelixZNodeSizeLimitTest/IDEALSTATES/mytable_OFFLINE
+    // 13:03:51.576 ERROR [ZkBaseDataAccessor] [main] Exception while setting path:
+    // /HelixZNodeSizeLimitTest/IDEALSTATES/mytable_OFFLINE
     //  org.apache.helix.HelixException: Data size larger than 1M
-    //	at org.apache.helix.manager.zk.zookeeper.ZkClient.checkDataSizeLimit(ZkClient.java:1513) ~[helix-core-0.9.8.jar:0.9.8]
-    //	at org.apache.helix.manager.zk.zookeeper.ZkClient.writeDataReturnStat(ZkClient.java:1406) ~[helix-core-0.9.8.jar:0.9.8]
+    //	at org.apache.helix.manager.zk.zookeeper.ZkClient.checkDataSizeLimit(ZkClient.java:1513) ~[helix-core-0.9.8
+    //	.jar:0.9.8]
+    //	at org.apache.helix.manager.zk.zookeeper.ZkClient.writeDataReturnStat(ZkClient.java:1406) ~[helix-core-0.9.8
+    //	.jar:0.9.8]
     String tableNameWithType = getTableName() + "_OFFLINE";
     System.setProperty(SystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES, "4000000");
     // The updated IdealState after compression is roughly 2MB

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HelixZNodeSizeLimitTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HelixZNodeSizeLimitTest.java
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.apache.pinot.integration.tests;
 
 import java.util.Map;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HelixZNodeSizeLimitTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HelixZNodeSizeLimitTest.java
@@ -69,9 +69,9 @@ public class HelixZNodeSizeLimitTest extends BaseClusterIntegrationTest {
     // 13:03:51.576 ERROR [ZkBaseDataAccessor] [main] Exception while setting path:
     // /HelixZNodeSizeLimitTest/IDEALSTATES/mytable_OFFLINE
     //  org.apache.helix.HelixException: Data size larger than 1M
-    //	at org.apache.helix.manager.zk.zookeeper.ZkClient.checkDataSizeLimit(ZkClient.java:1513) ~[helix-core-0.9.8
+    //  at org.apache.helix.manager.zk.zookeeper.ZkClient.checkDataSizeLimit(ZkClient.java:1513) ~[helix-core-0.9.8
     //	.jar:0.9.8]
-    //	at org.apache.helix.manager.zk.zookeeper.ZkClient.writeDataReturnStat(ZkClient.java:1406) ~[helix-core-0.9.8
+    //  at org.apache.helix.manager.zk.zookeeper.ZkClient.writeDataReturnStat(ZkClient.java:1406) ~[helix-core-0.9.8
     //	.jar:0.9.8]
     String tableNameWithType = getTableName() + "_OFFLINE";
     System.setProperty(SystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES, "4000000");

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HelixZNodeSizeLimitTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HelixZNodeSizeLimitTest.java
@@ -33,7 +33,7 @@ import org.testng.annotations.Test;
  * compression, it cannot be updated anymore. Somehow this test can also make sure in future we will support
  * large IdealStates
  */
-public class HelixZNodeSizeLimitTest extends BaseClusterIntegrationTest{
+public class HelixZNodeSizeLimitTest extends BaseClusterIntegrationTest {
   @BeforeClass
   public void setUp()
       throws Exception {
@@ -51,7 +51,6 @@ public class HelixZNodeSizeLimitTest extends BaseClusterIntegrationTest{
     startServer();
     addSchema(createSchema());
     addTableConfig(createOfflineTableConfig());
-
   }
 
   @AfterClass(alwaysRun = true)

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HelixZNodeSizeLimitTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HelixZNodeSizeLimitTest.java
@@ -80,8 +80,10 @@ public class HelixZNodeSizeLimitTest extends BaseClusterIntegrationTest {
     HelixHelper.updateIdealState(_helixManager, tableNameWithType, idealState -> {
       Map<String, Map<String, String>> currentAssignment = idealState.getRecord().getMapFields();
       for (int i = 0; i < 500_000; i++) {
-        currentAssignment.put("segment_" + i, ImmutableMap.of("Server_with_some_reasonable_long_prefix_" + (i % 10), "ONLINE"));
-        currentAssignment.put("segment_" + i, ImmutableMap.of("Server_with_some_reasonable_long_prefix_" + (i % 9), "ONLINE"));
+        currentAssignment.put("segment_" + i,
+            ImmutableMap.of("Server_with_some_reasonable_long_prefix_" + (i % 10), "ONLINE"));
+        currentAssignment.put("segment_" + i,
+            ImmutableMap.of("Server_with_some_reasonable_long_prefix_" + (i % 9), "ONLINE"));
       }
       return idealState;
     });

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HelixZNodeSizeLimitTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HelixZNodeSizeLimitTest.java
@@ -70,9 +70,9 @@ public class HelixZNodeSizeLimitTest extends BaseClusterIntegrationTest {
     // /HelixZNodeSizeLimitTest/IDEALSTATES/mytable_OFFLINE
     //  org.apache.helix.HelixException: Data size larger than 1M
     //  at org.apache.helix.manager.zk.zookeeper.ZkClient.checkDataSizeLimit(ZkClient.java:1513) ~[helix-core-0.9.8
-    //	.jar:0.9.8]
+    //  .jar:0.9.8]
     //  at org.apache.helix.manager.zk.zookeeper.ZkClient.writeDataReturnStat(ZkClient.java:1406) ~[helix-core-0.9.8
-    //	.jar:0.9.8]
+    //  .jar:0.9.8]
     String tableNameWithType = getTableName() + "_OFFLINE";
     System.setProperty(SystemPropertyKeys.ZK_SERIALIZER_ZNRECORD_WRITE_SIZE_LIMIT_BYTES, "4000000");
     // The updated IdealState after compression is roughly 2MB

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HelixZNodeSizeLimitTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HelixZNodeSizeLimitTest.java
@@ -19,6 +19,7 @@
 
 package org.apache.pinot.integration.tests;
 
+import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.apache.helix.SystemPropertyKeys;
 import org.apache.pinot.common.utils.helix.HelixHelper;
@@ -79,8 +80,8 @@ public class HelixZNodeSizeLimitTest extends BaseClusterIntegrationTest {
     HelixHelper.updateIdealState(_helixManager, tableNameWithType, idealState -> {
       Map<String, Map<String, String>> currentAssignment = idealState.getRecord().getMapFields();
       for (int i = 0; i < 500_000; i++) {
-        currentAssignment.put("segment_" + i, Map.of("Server_with_some_reasonable_long_prefix_" + (i % 10), "ONLINE"));
-        currentAssignment.put("segment_" + i, Map.of("Server_with_some_reasonable_long_prefix_" + (i % 9), "ONLINE"));
+        currentAssignment.put("segment_" + i, ImmutableMap.of("Server_with_some_reasonable_long_prefix_" + (i % 10), "ONLINE"));
+        currentAssignment.put("segment_" + i, ImmutableMap.of("Server_with_some_reasonable_long_prefix_" + (i % 9), "ONLINE"));
       }
       return idealState;
     });

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
     <!-- Configuration for unit/integration tests section 1 of 3 (properties) ENDS HERE.-->
     <avro.version>1.9.2</avro.version>
     <parquet.version>1.11.1</parquet.version>
-    <helix.version>0.9.8</helix.version>
+    <helix.version>0.9.10</helix.version>
     <zkclient.version>0.7</zkclient.version>
     <jackson.version>2.10.0</jackson.version>
     <zookeeper.version>3.5.8</zookeeper.version>


### PR DESCRIPTION
## Description
Upgrade helix dependency to `0.9.10` for fixing the issues related to ZNode size limit.
1. Stripe has tested out helix `0.9.10` on private build and surpassed the ZNode limit. (David Yang at Stripe is the POC)
2. The fix in Helix 0.9.10 unblocks the case when the ZNode is larger than 1MB even after compression.

The [code change in 0.9.9 is here](https://github.com/apache/helix/blame/5acf3e14c96281e3d83323f2b630efa4f474458a/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java#L89)  while the limit is applied when we [update Zookeeper nodes from the same ZkClient](https://github.com/apache/helix/blob/helix-0.9.9/helix-core/src/main/java/org/apache/helix/manager/zk/zookeeper/ZkClient.java#L1416). It happens when the Pinot table has lots of segments with long hostnames, for IdealStates node.

### Extra Note

The Helix binary release `0.9.9` in Maven open repo is not in sync with the source code tags. The `0.9.10` is actually the one that we should use.

## Release Notes
Upgraded helix dependency to `0.9.10` for fixing the issues caused by ZNode size limit.