### PR TITLE
Cleanup and simplify the integration test instance start

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -148,6 +148,10 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
         _brokerConf.getProperty(Helix.CONFIG_OF_BROKER_FLAPPING_TIME_WINDOW_MS, Helix.DEFAULT_FLAPPING_TIME_WINDOW_MS));
   }
 
+  public int getPort() {
+    return _port;
+  }
+
   /**
    * Adds an ideal state change handler to handle Helix ideal state change callbacks.
    * <p>NOTE: all change handlers will be run in a single thread, so any slow change handler can block other change
@@ -261,6 +265,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
                 queryQuotaManager, tableCache, _brokerMetrics, nettyDefaults, null);
       }
     }
+    _brokerRequestHandler.start();
 
     LOGGER.info("Starting broker admin application on: {}", ListenerConfigUtil.toString(_listenerConfigs));
     _brokerAdminApplication =

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/AdminConsoleIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/AdminConsoleIntegrationTest.java
@@ -24,8 +24,6 @@ import org.apache.pinot.broker.broker.BrokerAdminApiApplication;
 import org.apache.pinot.controller.api.ControllerAdminApiApplication;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.util.TestUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -36,7 +34,6 @@ import org.testng.annotations.Test;
  * Tests that the controller, broker and server admin consoles return the expected pages.
  */
 public class AdminConsoleIntegrationTest extends BaseClusterIntegrationTest {
-  private static final Logger LOGGER = LoggerFactory.getLogger(AdminConsoleIntegrationTest.class);
 
   @BeforeClass
   public void setUp()

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
@@ -23,10 +23,8 @@ import java.util.Map;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.broker.broker.helix.HelixBrokerStarter;
-import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.BrokerResourceStateModel;
-import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.Test;
 
@@ -53,26 +51,18 @@ public class MultiNodesOfflineClusterIntegrationTest extends OfflineClusterInteg
   }
 
   @Override
-  protected void startServers() {
-    startServers(NUM_SERVERS);
+  protected int getNumReplicas() {
+    return NUM_SERVERS;
   }
 
   @Test
   public void testUpdateBrokerResource()
       throws Exception {
     // Add a new broker to the cluster
-    Map<String, Object> properties = getDefaultBrokerConfiguration().toMap();
-    String clusterName = getHelixClusterName();
-    properties.put(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, clusterName);
-    properties.put(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER, getZkUrl());
-    int port = NetUtils.findOpenPort(DEFAULT_BROKER_PORT);
-    properties.put(CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT, port);
-    properties.put(CommonConstants.Broker.CONFIG_OF_DELAY_SHUTDOWN_TIME_MS, 0);
-    HelixBrokerStarter brokerStarter = new HelixBrokerStarter();
-    brokerStarter.init(new PinotConfiguration(properties));
-    brokerStarter.start();
+    HelixBrokerStarter brokerStarter = startOneBroker(NUM_BROKERS);
 
     // Check if broker is added to all the tables in broker resource
+    String clusterName = getHelixClusterName();
     String brokerId = brokerStarter.getInstanceId();
     IdealState brokerResourceIdealState =
         _helixAdmin.getResourceIdealState(clusterName, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE);
@@ -126,6 +116,41 @@ public class MultiNodesOfflineClusterIntegrationTest extends OfflineClusterInteg
 
     // Check if broker is dropped from the cluster
     assertFalse(_helixAdmin.getInstancesInCluster(clusterName).contains(brokerId));
+  }
+
+  // Disabled because with multiple replicas, there is no guarantee that all replicas are reloaded
+  @Test(enabled = false)
+  @Override
+  public void testStarTreeTriggering() {
+    // Ignored
+  }
+
+  // Disabled because with multiple replicas, there is no guarantee that all replicas are reloaded
+  @Test(enabled = false)
+  @Override
+  public void testDefaultColumns() {
+    // Ignored
+  }
+
+  // Disabled because with multiple replicas, there is no guarantee that all replicas are reloaded
+  @Test(enabled = false)
+  @Override
+  public void testBloomFilterTriggering() {
+    // Ignored
+  }
+
+  // Disabled because with multiple replicas, there is no guarantee that all replicas are reloaded
+  @Test(enabled = false)
+  @Override
+  public void testRangeIndexTriggering() {
+    // Ignored
+  }
+
+  // Disabled because with multiple replicas, there is no guarantee that all replicas are reloaded
+  @Test(enabled = false)
+  @Override
+  public void testInvertedIndexTriggering() {
+    // Ignored
   }
 
   @Test(enabled = false)

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -60,7 +60,6 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.NetUtils;
@@ -166,7 +165,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     // Start the Pinot cluster
     startZk();
     startController();
-    startBrokers(getNumBrokers());
+    startBrokers();
     startServers();
 
     // Create and upload the schema and table config
@@ -217,10 +216,14 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     waitForAllDocsLoaded(600_000L);
   }
 
-  protected void startServers() {
-    // Enable gRPC server
-    PinotConfiguration serverConfig = getDefaultServerConfiguration();
-    startServer(serverConfig);
+  protected void startBrokers()
+      throws Exception {
+    startBrokers(getNumBrokers());
+  }
+
+  protected void startServers()
+      throws Exception {
+    startServers(getNumServers());
   }
 
   private void registerCallbackHandlers() {
@@ -428,8 +431,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       }
       Thread.sleep(EXTERNAL_VIEW_CHECK_INTERVAL_MS);
     } while (System.currentTimeMillis() < endTimeMs);
-    throw new TimeoutException(String
-        .format("Time out while waiting segments become ONLINE. (tableNameWithType = %s)", tableNameWithType));
+    throw new TimeoutException(
+        String.format("Time out while waiting segments become ONLINE. (tableNameWithType = %s)", tableNameWithType));
   }
 
   @Test(dependsOnMethods = "testRangeIndexTriggering")

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineSecureGRPCServerIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineSecureGRPCServerIntegrationTest.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.pinot.common.utils.grpc.GrpcQueryClient;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Server;
 
 
 public class OfflineSecureGRPCServerIntegrationTest extends OfflineGRPCServerIntegrationTest {
@@ -33,16 +33,17 @@ public class OfflineSecureGRPCServerIntegrationTest extends OfflineGRPCServerInt
   private final URL _tlsStoreJKS = OfflineSecureGRPCServerIntegrationTest.class.getResource("/tlstest.jks");
 
   @Override
-  protected void setExtraServerConfigs(PinotConfiguration serverConfig) {
-    serverConfig.setProperty(CommonConstants.Server.CONFIG_OF_GRPCTLS_SERVER_ENABLED, true);
-    serverConfig.setProperty("pinot.server.grpctls.client.auth.enabled", true);
-    serverConfig.setProperty("pinot.server.grpctls.keystore.type", JKS);
-    serverConfig.setProperty("pinot.server.grpctls.keystore.path", _tlsStoreJKS);
-    serverConfig.setProperty("pinot.server.grpctls.keystore.password", PASSWORD);
-    serverConfig.setProperty("pinot.server.grpctls.truststore.type", JKS);
-    serverConfig.setProperty("pinot.server.grpctls.truststore.path", _tlsStoreJKS);
-    serverConfig.setProperty("pinot.server.grpctls.truststore.password", PASSWORD);
-    serverConfig.setProperty("pinot.server.grpctls.ssl.provider", JDK);
+  protected void overrideServerConf(PinotConfiguration serverConf) {
+    serverConf.setProperty(Server.CONFIG_OF_ENABLE_GRPC_SERVER, true);
+    serverConf.setProperty(Server.CONFIG_OF_GRPCTLS_SERVER_ENABLED, true);
+    serverConf.setProperty("pinot.server.grpctls.client.auth.enabled", true);
+    serverConf.setProperty("pinot.server.grpctls.keystore.type", JKS);
+    serverConf.setProperty("pinot.server.grpctls.keystore.path", _tlsStoreJKS);
+    serverConf.setProperty("pinot.server.grpctls.keystore.password", PASSWORD);
+    serverConf.setProperty("pinot.server.grpctls.truststore.type", JKS);
+    serverConf.setProperty("pinot.server.grpctls.truststore.path", _tlsStoreJKS);
+    serverConf.setProperty("pinot.server.grpctls.truststore.password", PASSWORD);
+    serverConf.setProperty("pinot.server.grpctls.ssl.provider", JDK);
   }
 
   @Override
@@ -57,6 +58,6 @@ public class OfflineSecureGRPCServerIntegrationTest extends OfflineGRPCServerInt
     configMap.put("tls.truststore.type", JKS);
     configMap.put("tls.ssl.provider", JDK);
     GrpcQueryClient.Config config = new GrpcQueryClient.Config(configMap);
-    return new GrpcQueryClient("localhost", CommonConstants.Server.DEFAULT_GRPC_PORT, config);
+    return new GrpcQueryClient("localhost", Server.DEFAULT_GRPC_PORT, config);
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PeerDownloadLLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PeerDownloadLLCRealtimeClusterIntegrationTest.java
@@ -114,7 +114,8 @@ public class PeerDownloadLLCRealtimeClusterIntegrationTest extends RealtimeClust
   }
 
   @Override
-  public void startServer() {
+  public void startServer()
+      throws Exception {
     startServers(NUM_SERVERS);
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentUploadIntegrationTest.java
@@ -173,7 +173,7 @@ public class UpsertTableSegmentUploadIntegrationTest extends BaseClusterIntegrat
     verifyTableIdealStates(idealState);
 
     // Restart the servers and check every segment is not in ERROR state.
-    restartServers(NUM_SERVERS);
+    restartServers();
     verifyTableIdealStates(idealState);
     ExternalView ev =
         HelixHelper.getExternalViewForResource(_helixAdmin, this.getHelixClusterName(), TABLE_NAME_WITH_TYPE);


### PR DESCRIPTION
NOTE: Some methods within the integration tests are changed/removed/simplified. Custom tests that extends the integration test might need to revised.