### PR TITLE
add shouldNotMerge field in segment metadata to indicate if it is safe to merge

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -101,6 +101,11 @@ public class MinionConstants {
     public static final String SEGMENT_NAME_PREFIX_KEY = "segmentNamePrefix";
     public static final String SEGMENT_NAME_POSTFIX_KEY = "segmentNamePostfix";
     public static final String FIXED_SEGMENT_NAME_KEY = "fixedSegmentName";
+
+    // This field is set in segment metadata custom map to indicate if the segment is safe to be merged.
+    // Tasks can take use of this field to coordinate with the merge task. By default, segment is safe
+    // to merge, so existing segments w/o this field can be merged just as before.
+    public static final String SEGMENT_ZK_METADATA_SHOULD_NOT_MERGE = "shouldNotMerge";
   }
 
   public static class MergeRollupTask extends MergeTask {

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -105,7 +105,7 @@ public class MinionConstants {
     // This field is set in segment metadata custom map to indicate if the segment is safe to be merged.
     // Tasks can take use of this field to coordinate with the merge task. By default, segment is safe
     // to merge, so existing segments w/o this field can be merged just as before.
-    public static final String SEGMENT_ZK_METADATA_SHOULD_NOT_MERGE = "shouldNotMerge";
+    public static final String SEGMENT_ZK_METADATA_SHOULD_NOT_MERGE_KEY = "shouldNotMerge";
   }
 
   public static class MergeRollupTask extends MergeTask {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtils.java
@@ -24,6 +24,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.commons.collections.MapUtils;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.core.common.MinionConstants.MergeTask;
 import org.apache.pinot.core.segment.processing.framework.MergeType;
 import org.apache.pinot.core.segment.processing.framework.SegmentConfig;
@@ -145,5 +147,15 @@ public class MergeTaskUtils {
     segmentConfigBuilder.setSegmentNamePostfix(taskConfig.get(MergeTask.SEGMENT_NAME_POSTFIX_KEY));
     segmentConfigBuilder.setFixedSegmentName(taskConfig.get(MergeTask.FIXED_SEGMENT_NAME_KEY));
     return segmentConfigBuilder.build();
+  }
+
+  /**
+   * Check if the segment can be merged. Only skip merging the segment if 'shouldNotMerge'
+   * field exists and is set to true in its segment metadata custom map.
+   */
+  public static boolean allowMerge(SegmentZKMetadata segmentZKMetadata) {
+    Map<String, String> customMap = segmentZKMetadata.getCustomMap();
+    return MapUtils.isEmpty(customMap) || !Boolean
+        .parseBoolean(customMap.get(MergeTask.SEGMENT_ZK_METADATA_SHOULD_NOT_MERGE));
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtils.java
@@ -156,6 +156,6 @@ public class MergeTaskUtils {
   public static boolean allowMerge(SegmentZKMetadata segmentZKMetadata) {
     Map<String, String> customMap = segmentZKMetadata.getCustomMap();
     return MapUtils.isEmpty(customMap) || !Boolean
-        .parseBoolean(customMap.get(MergeTask.SEGMENT_ZK_METADATA_SHOULD_NOT_MERGE));
+        .parseBoolean(customMap.get(MergeTask.SEGMENT_ZK_METADATA_SHOULD_NOT_MERGE_KEY));
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
@@ -46,6 +46,7 @@ import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.common.MinionConstants.MergeRollupTask;
 import org.apache.pinot.core.common.MinionConstants.MergeTask;
 import org.apache.pinot.core.minion.PinotTaskConfig;
+import org.apache.pinot.plugin.minion.tasks.MergeTaskUtils;
 import org.apache.pinot.spi.annotations.minion.TaskGenerator;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
@@ -146,7 +147,8 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
 
       List<SegmentZKMetadata> preSelectedSegments = new ArrayList<>();
       for (SegmentZKMetadata segment : allSegments) {
-        if (preSelectedSegmentsBasedOnLineage.contains(segment.getSegmentName()) && segment.getTotalDocs() > 0) {
+        if (preSelectedSegmentsBasedOnLineage.contains(segment.getSegmentName()) && segment.getTotalDocs() > 0
+            && MergeTaskUtils.allowMerge(segment)) {
           preSelectedSegments.add(segment);
         }
       }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtilsTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtilsTest.java
@@ -187,13 +187,15 @@ public class MergeTaskUtilsTest {
     assertNull(segmentZKMetadata.getCustomMap());
     assertTrue(MergeTaskUtils.allowMerge(segmentZKMetadata));
 
-    segmentZKMetadata.setCustomMap(Map.of());
+    segmentZKMetadata.setCustomMap(Collections.emptyMap());
     assertTrue(MergeTaskUtils.allowMerge(segmentZKMetadata));
 
-    segmentZKMetadata.setCustomMap(Map.of(MergeTask.SEGMENT_ZK_METADATA_SHOULD_NOT_MERGE_KEY, "false"));
+    segmentZKMetadata
+        .setCustomMap(Collections.singletonMap(MergeTask.SEGMENT_ZK_METADATA_SHOULD_NOT_MERGE_KEY, "false"));
     assertTrue(MergeTaskUtils.allowMerge(segmentZKMetadata));
 
-    segmentZKMetadata.setCustomMap(Map.of(MergeTask.SEGMENT_ZK_METADATA_SHOULD_NOT_MERGE_KEY, "true"));
+    segmentZKMetadata
+        .setCustomMap(Collections.singletonMap(MergeTask.SEGMENT_ZK_METADATA_SHOULD_NOT_MERGE_KEY, "true"));
     assertFalse(MergeTaskUtils.allowMerge(segmentZKMetadata));
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtilsTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtilsTest.java
@@ -190,10 +190,10 @@ public class MergeTaskUtilsTest {
     segmentZKMetadata.setCustomMap(Map.of());
     assertTrue(MergeTaskUtils.allowMerge(segmentZKMetadata));
 
-    segmentZKMetadata.setCustomMap(Map.of(MergeTask.SEGMENT_ZK_METADATA_SHOULD_NOT_MERGE, "false"));
+    segmentZKMetadata.setCustomMap(Map.of(MergeTask.SEGMENT_ZK_METADATA_SHOULD_NOT_MERGE_KEY, "false"));
     assertTrue(MergeTaskUtils.allowMerge(segmentZKMetadata));
 
-    segmentZKMetadata.setCustomMap(Map.of(MergeTask.SEGMENT_ZK_METADATA_SHOULD_NOT_MERGE, "true"));
+    segmentZKMetadata.setCustomMap(Map.of(MergeTask.SEGMENT_ZK_METADATA_SHOULD_NOT_MERGE_KEY, "true"));
     assertFalse(MergeTaskUtils.allowMerge(segmentZKMetadata));
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtilsTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtilsTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.core.common.MinionConstants.MergeTask;
 import org.apache.pinot.core.segment.processing.framework.MergeType;
 import org.apache.pinot.core.segment.processing.framework.SegmentConfig;
@@ -178,5 +179,21 @@ public class MergeTaskUtilsTest {
     assertNull(segmentConfig.getSegmentNamePrefix());
     assertNull(segmentConfig.getSegmentNamePostfix());
     assertNull(segmentConfig.getFixedSegmentName());
+  }
+
+  @Test
+  public void testAllowMerge() {
+    SegmentZKMetadata segmentZKMetadata = new SegmentZKMetadata("seg01");
+    assertNull(segmentZKMetadata.getCustomMap());
+    assertTrue(MergeTaskUtils.allowMerge(segmentZKMetadata));
+
+    segmentZKMetadata.setCustomMap(Map.of());
+    assertTrue(MergeTaskUtils.allowMerge(segmentZKMetadata));
+
+    segmentZKMetadata.setCustomMap(Map.of(MergeTask.SEGMENT_ZK_METADATA_SHOULD_NOT_MERGE, "false"));
+    assertTrue(MergeTaskUtils.allowMerge(segmentZKMetadata));
+
+    segmentZKMetadata.setCustomMap(Map.of(MergeTask.SEGMENT_ZK_METADATA_SHOULD_NOT_MERGE, "true"));
+    assertFalse(MergeTaskUtils.allowMerge(segmentZKMetadata));
   }
 }


### PR DESCRIPTION
Add shouldNotMerge field in SegmentZKMetadata customMap to indicate if segment can be merged. Tasks can take use of this field to coordinate with the merge task. By default, segment is safe to merge, so existing segments w/o this field can be merged just as before.
