### PR TITLE
Fix table creation bug for invalid realtime consumer props

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1384,7 +1384,7 @@ public class PinotHelixResourceManager {
   public void addTable(TableConfig tableConfig)
       throws IOException {
     String tableNameWithType = tableConfig.getTableName();
-    if (getTableConfig(tableNameWithType) != null) {
+    if (hasTable(tableNameWithType)) {
       throw new TableAlreadyExistsException("Table " + tableNameWithType + " already exists");
     }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotResourceManagerTest.java
@@ -73,6 +73,30 @@ public class PinotResourceManagerTest {
   }
 
   @Test
+  public void testTableCleanupAfterRealtimeClusterException()
+      throws Exception {
+    String invalidRealtimeTable = "invalidTable_REALTIME";
+    Schema dummySchema = ControllerTestUtils.createDummySchema(invalidRealtimeTable);
+    ControllerTestUtils.addSchema(dummySchema);
+
+    Map<String, String> streamConfigs = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap();
+    // Missing replicasPerPartition
+    TableConfig invalidRealtimeTableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setStreamConfigs(streamConfigs).setTableName(invalidRealtimeTable)
+            .setSchemaName(dummySchema.getSchemaName()).build();
+    try {
+      ControllerTestUtils.getHelixResourceManager().addTable(invalidRealtimeTableConfig);
+      Assert.fail(
+          "Table creation should have thrown exception due to missing replicasPerPartition in validation config");
+    } catch (Exception e) {
+      // expected
+    }
+
+    // Verify invalid table config is cleaned up
+    Assert.assertNull(ControllerTestUtils.getHelixResourceManager().getTableConfig(invalidRealtimeTable));
+  }
+
+  @Test
   public void testUpdateSegmentZKMetadata() {
     SegmentZKMetadata segmentZKMetadata = new SegmentZKMetadata("testSegment");
 


### PR DESCRIPTION
Fix for issue: https://github.com/apache/pinot/issues/8500. Should be tagged with: `bugfix`

**Context**
When a realtime table is being created, the table config is first uploaded to the ZK property store. After that, we try to create the realtime consumer. But as reported, if there is an invalid config for the consumer, an exception is thrown. The next time you try to create the table (with correct configs), it checks the ZK property store for the existence of the table config and throws an exception saying that the table already exists (although the table creation process did not finish).

**Proposed solution**
1. Add clearer exception message if a table config is already found for the table being created
2. Cleanup table + associated metadata if the realtime setup fails
