### PR TITLE
Support filtering on bool/scalar fields without evaluator

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/FilterKind.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/FilterKind.java
@@ -48,4 +48,13 @@ public enum FilterKind {
     return this == GREATER_THAN || this == GREATER_THAN_OR_EQUAL || this == LESS_THAN || this == LESS_THAN_OR_EQUAL
         || this == BETWEEN || this == RANGE;
   }
+
+  /**
+   * Returns true if the filter is a predicate. Returns false otherwise. This logic should mimic FilterContext.Type.
+   *
+   * @return where the filter is a predicate.
+   */
+  public boolean isPredicate() {
+    return this != AND && this != OR && this != NOT;
+  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/FilterKind.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/FilterKind.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.pql.parsers.pql2.ast;
 
+import java.util.EnumSet;
+
 public enum FilterKind {
   AND,
   OR,
@@ -39,14 +41,18 @@ public enum FilterKind {
   TEXT_MATCH,
   JSON_MATCH;
 
+  private static final EnumSet<FilterKind> RANGE_FILTERS = EnumSet.of(GREATER_THAN, GREATER_THAN_OR_EQUAL, LESS_THAN,
+      LESS_THAN_OR_EQUAL, BETWEEN, RANGE);
+  private static final EnumSet<FilterKind> PREDICATE_FILTERS = EnumSet.of(EQUALS, NOT_EQUALS, GREATER_THAN,
+      GREATER_THAN_OR_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL, LIKE, BETWEEN, RANGE, IN, NOT_IN, REGEXP_LIKE, IS_NULL,
+      IS_NOT_NULL, TEXT_MATCH, JSON_MATCH);
   /**
    * Helper method that returns true if the enum maps to a Range.
    *
    * @return True if the enum is of Range type, false otherwise.
    */
   public boolean isRange() {
-    return this == GREATER_THAN || this == GREATER_THAN_OR_EQUAL || this == LESS_THAN || this == LESS_THAN_OR_EQUAL
-        || this == BETWEEN || this == RANGE;
+    return RANGE_FILTERS.contains(this);
   }
 
   /**
@@ -55,6 +61,6 @@ public enum FilterKind {
    * @return where the filter is a predicate.
    */
   public boolean isPredicate() {
-    return this != AND && this != OR && this != NOT;
+    return PREDICATE_FILTERS.contains(this);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/FilterKind.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/FilterKind.java
@@ -19,41 +19,33 @@
 package org.apache.pinot.pql.parsers.pql2.ast;
 
 public enum FilterKind {
-  AND(false, false),
-  OR(false, false),
-  NOT(false, false),
-  EQUALS(true, false),
-  NOT_EQUALS(true, false),
-  GREATER_THAN(true, true),
-  GREATER_THAN_OR_EQUAL(true, true),
-  LESS_THAN(true, true),
-  LESS_THAN_OR_EQUAL(true, true),
-  LIKE(true, false),
-  BETWEEN(true, true),
-  RANGE(true, true),
-  IN(true, false),
-  NOT_IN(true, false),
-  REGEXP_LIKE(true, false),
-  IS_NULL(true, false),
-  IS_NOT_NULL(true, false),
-  TEXT_MATCH(true, false),
-  JSON_MATCH(true, false);
+  AND,
+  OR,
+  NOT,
+  EQUALS,
+  NOT_EQUALS,
+  GREATER_THAN,
+  GREATER_THAN_OR_EQUAL,
+  LESS_THAN,
+  LESS_THAN_OR_EQUAL,
+  LIKE,
+  BETWEEN,
+  RANGE,
+  IN,
+  NOT_IN,
+  REGEXP_LIKE,
+  IS_NULL,
+  IS_NOT_NULL,
+  TEXT_MATCH,
+  JSON_MATCH;
 
-  private final boolean _isPredicate;
-  private final boolean _isRange;
-
-  FilterKind(boolean isPredicate, boolean isRange) {
-    _isPredicate = isPredicate;
-    _isRange = isRange;
-  }
-
-  /** @return true if the enum is of Range type, false otherwise. */
+  /**
+   * Helper method that returns true if the enum maps to a Range.
+   *
+   * @return True if the enum is of Range type, false otherwise.
+   */
   public boolean isRange() {
-    return _isRange;
-  }
-
-  /** @return true if the filter is a predicate. This logic should mimic FilterContext.Type. */
-  public boolean isPredicate() {
-    return _isPredicate;
+    return this == GREATER_THAN || this == GREATER_THAN_OR_EQUAL || this == LESS_THAN || this == LESS_THAN_OR_EQUAL
+        || this == BETWEEN || this == RANGE;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/FilterKind.java
+++ b/pinot-common/src/main/java/org/apache/pinot/pql/parsers/pql2/ast/FilterKind.java
@@ -18,49 +18,42 @@
  */
 package org.apache.pinot.pql.parsers.pql2.ast;
 
-import java.util.EnumSet;
-
 public enum FilterKind {
-  AND,
-  OR,
-  NOT,
-  EQUALS,
-  NOT_EQUALS,
-  GREATER_THAN,
-  GREATER_THAN_OR_EQUAL,
-  LESS_THAN,
-  LESS_THAN_OR_EQUAL,
-  LIKE,
-  BETWEEN,
-  RANGE,
-  IN,
-  NOT_IN,
-  REGEXP_LIKE,
-  IS_NULL,
-  IS_NOT_NULL,
-  TEXT_MATCH,
-  JSON_MATCH;
+  AND(false, false),
+  OR(false, false),
+  NOT(false, false),
+  EQUALS(true, false),
+  NOT_EQUALS(true, false),
+  GREATER_THAN(true, true),
+  GREATER_THAN_OR_EQUAL(true, true),
+  LESS_THAN(true, true),
+  LESS_THAN_OR_EQUAL(true, true),
+  LIKE(true, false),
+  BETWEEN(true, true),
+  RANGE(true, true),
+  IN(true, false),
+  NOT_IN(true, false),
+  REGEXP_LIKE(true, false),
+  IS_NULL(true, false),
+  IS_NOT_NULL(true, false),
+  TEXT_MATCH(true, false),
+  JSON_MATCH(true, false);
 
-  private static final EnumSet<FilterKind> RANGE_FILTERS = EnumSet.of(GREATER_THAN, GREATER_THAN_OR_EQUAL, LESS_THAN,
-      LESS_THAN_OR_EQUAL, BETWEEN, RANGE);
-  private static final EnumSet<FilterKind> PREDICATE_FILTERS = EnumSet.of(EQUALS, NOT_EQUALS, GREATER_THAN,
-      GREATER_THAN_OR_EQUAL, LESS_THAN, LESS_THAN_OR_EQUAL, LIKE, BETWEEN, RANGE, IN, NOT_IN, REGEXP_LIKE, IS_NULL,
-      IS_NOT_NULL, TEXT_MATCH, JSON_MATCH);
-  /**
-   * Helper method that returns true if the enum maps to a Range.
-   *
-   * @return True if the enum is of Range type, false otherwise.
-   */
-  public boolean isRange() {
-    return RANGE_FILTERS.contains(this);
+  private final boolean _isPredicate;
+  private final boolean _isRange;
+
+  FilterKind(boolean isPredicate, boolean isRange) {
+    _isPredicate = isPredicate;
+    _isRange = isRange;
   }
 
-  /**
-   * Returns true if the filter is a predicate. Returns false otherwise. This logic should mimic FilterContext.Type.
-   *
-   * @return where the filter is a predicate.
-   */
+  /** @return true if the enum is of Range type, false otherwise. */
+  public boolean isRange() {
+    return _isRange;
+  }
+
+  /** @return true if the filter is a predicate. This logic should mimic FilterContext.Type. */
   public boolean isPredicate() {
-    return PREDICATE_FILTERS.contains(this);
+    return _isPredicate;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriter.java
@@ -30,52 +30,109 @@ import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.pql.parsers.pql2.ast.FilterKind;
 import org.apache.pinot.sql.parsers.SqlCompilationException;
 
+
 public class PredicateComparisonRewriter implements QueryRewriter {
   @Override
   public PinotQuery rewrite(PinotQuery pinotQuery) {
     Expression filterExpression = pinotQuery.getFilterExpression();
     if (filterExpression != null) {
-      filterExpression = updateBooleanPredicates(filterExpression, null);
-      pinotQuery.setFilterExpression(filterExpression);
-
-      filterExpression = updateComparisonPredicate(filterExpression);
-      pinotQuery.setFilterExpression(updateComparisonPredicate(filterExpression));
+      pinotQuery.setFilterExpression(updatePredicate(filterExpression, null));
     }
     Expression havingExpression = pinotQuery.getHavingExpression();
     if (havingExpression != null) {
-      pinotQuery.setHavingExpression(updateComparisonPredicate(havingExpression));
+      pinotQuery.setHavingExpression(updatePredicate(havingExpression, null));
     }
     return pinotQuery;
   }
 
   /**
-   * Updates boolean predicates (literals and scalar functions) that are missing an EQUALS filter.
-   * E.g. 1:  'WHERE a' will be updated to 'WHERE a = true'
-   * E.g. 2: "WHERE startsWith(col, 'str')" will be updated to "WHERE startsWith(col, 'str') = true"
+   This method converts a predicate expression to the what Pinot could evaluate.
+   1. For comparison expression, left operand could be any expression, but right operand only
+   supports literal. E.g. 'WHERE a > b' will be converted to 'WHERE a - b > 0'
+   2. Updates boolean predicates (literals and scalar functions) that are missing an EQUALS filter.
+   *
    *
    * @param expression current expression in the expression tree
    * @param parentFunction parent expression
    * @return re-written expression.
    */
-  private static Expression updateBooleanPredicates(Expression expression, Function parentFunction) {
+
+  /**
+   * This method converts a predicate expression to the what Pinot could evaluate.
+   * 1. For comparison expression, left operand could be any expression, but right operand only
+   *    supports literal. E.g. 'WHERE a > b' will be converted to 'WHERE a - b > 0'
+   * 2. Updates boolean predicates (literals and scalar functions) that are missing an EQUALS filter.
+   *    E.g. 1:  'WHERE a' will be updated to 'WHERE a = true'
+   *    E.g. 2: "WHERE startsWith(col, 'str')" will be updated to "WHERE startsWith(col, 'str') = true"
+   *
+   * @param expression current expression in the expression tree
+   * @param parentFunction parentFunction parent expression
+   * @return re-written expression.
+   */
+  private static Expression updatePredicate(Expression expression, Function parentFunction) {
     ExpressionType type = expression.getType();
     if (type == ExpressionType.FUNCTION) {
       Function function = expression.getFunctionCall();
       String functionOperator = function.getOperator();
 
-      // If the function is not of FilterKind, we might have to rewrite the function if parentFunction is not a
-      // predicate.
-      // Example: A query like "select col1 from table where startsWith(col1, 'myStr') AND col2 > 10;" should be
-      //          rewritten to "select col1 from table where startsWith(col1, 'myStr') = true AND col2 > 10;".
       if (!EnumUtils.isValidEnum(FilterKind.class, functionOperator)) {
+        // If the function is not of FilterKind, we might have to rewrite the function if parentFunction is not a
+        // predicate.
+        // Example: A query like "select col1 from table where startsWith(col1, 'myStr') AND col2 > 10;" should be
+        //          rewritten to "select col1 from table where startsWith(col1, 'myStr') = true AND col2 > 10;".
         expression = convertPredicateToBooleanExpression(expression, parentFunction);
         return expression;
-      }
+      } else {
+        FilterKind filterKind = FilterKind.valueOf(function.getOperator());
+        List<Expression> operands = function.getOperands();
+        switch (filterKind) {
+          case AND:
+          case OR:
+          case NOT:
+            for (int i = 0; i < operands.size(); i++) {
+              Expression operand = operands.get(i);
+              operands.set(i, updatePredicate(operand, function));
+            }
+            break;
+          case EQUALS:
+          case NOT_EQUALS:
+          case GREATER_THAN:
+          case GREATER_THAN_OR_EQUAL:
+          case LESS_THAN:
+          case LESS_THAN_OR_EQUAL:
+            Expression firstOperand = operands.get(0);
+            Expression secondOperand = operands.get(1);
 
-      List<Expression> operands = function.getOperands();
-      for (int i = 0; i < operands.size(); i++) {
-        Expression operand = function.getOperands().get(i);
-        operands.set(i, updateBooleanPredicates(operand, function));
+            // Handle predicate like '10 = a' -> 'a = 10'
+            if (firstOperand.isSetLiteral()) {
+              if (!secondOperand.isSetLiteral()) {
+                function.setOperator(getOppositeOperator(filterKind).name());
+                operands.set(0, secondOperand);
+                operands.set(1, firstOperand);
+              }
+              break;
+            }
+
+            // Handle predicate like 'a > b' -> 'a - b > 0'
+            if (!secondOperand.isSetLiteral()) {
+              Expression minusExpression = RequestUtils.getFunctionExpression("minus");
+              minusExpression.getFunctionCall().setOperands(Arrays.asList(firstOperand, secondOperand));
+              operands.set(0, minusExpression);
+              operands.set(1, RequestUtils.getLiteralExpression(0));
+              break;
+            }
+            break;
+          default:
+            int numOperands = operands.size();
+            for (int i = 1; i < numOperands; i++) {
+              if (!operands.get(i).isSetLiteral()) {
+                throw new SqlCompilationException(String
+                    .format("For %s predicate, the operands except for the first one must be literal, got: %s",
+                        filterKind, expression));
+              }
+            }
+            break;
+        }
       }
     } else if (type == ExpressionType.IDENTIFIER) {
       expression = convertPredicateToBooleanExpression(expression, parentFunction);
@@ -99,8 +156,8 @@ public class PredicateComparisonRewriter implements QueryRewriter {
    * @return Rewritten expression
    */
   private static Expression convertPredicateToBooleanExpression(Expression expression, Function parentFunction) {
-    if (parentFunction == null || (EnumUtils.isValidEnum(FilterKind.class, parentFunction.getOperator())
-        && !FilterKind.valueOf(parentFunction.getOperator()).isPredicate())) {
+    if (parentFunction == null || (EnumUtils.isValidEnum(FilterKind.class, parentFunction.getOperator()) && !FilterKind
+        .valueOf(parentFunction.getOperator()).isPredicate())) {
       Expression newExpression;
       newExpression = RequestUtils.getFunctionExpression(FilterKind.EQUALS.name());
       List<Expression> operands = new ArrayList<>();
@@ -111,69 +168,6 @@ public class PredicateComparisonRewriter implements QueryRewriter {
       return newExpression;
     }
 
-    return expression;
-  }
-
-  // This method converts a predicate expression to the what Pinot could evaluate.
-  // For comparison expression, left operand could be any expression, but right operand only
-  // supports literal.
-  // E.g. 'WHERE a > b' will be updated to 'WHERE a - b > 0'
-  private static Expression updateComparisonPredicate(Expression expression) {
-    Function function = expression.getFunctionCall();
-    if (function != null) {
-      FilterKind filterKind;
-      try {
-        filterKind = FilterKind.valueOf(function.getOperator());
-      } catch (Exception e) {
-        throw new SqlCompilationException("Unsupported filter kind: " + function.getOperator());
-      }
-      List<Expression> operands = function.getOperands();
-      switch (filterKind) {
-        case AND:
-        case OR:
-        case NOT:
-          operands.replaceAll(PredicateComparisonRewriter::updateComparisonPredicate);
-          break;
-        case EQUALS:
-        case NOT_EQUALS:
-        case GREATER_THAN:
-        case GREATER_THAN_OR_EQUAL:
-        case LESS_THAN:
-        case LESS_THAN_OR_EQUAL:
-          Expression firstOperand = operands.get(0);
-          Expression secondOperand = operands.get(1);
-
-          // Handle predicate like '10 = a' -> 'a = 10'
-          if (firstOperand.isSetLiteral()) {
-            if (!secondOperand.isSetLiteral()) {
-              function.setOperator(getOppositeOperator(filterKind).name());
-              operands.set(0, secondOperand);
-              operands.set(1, firstOperand);
-            }
-            break;
-          }
-
-          // Handle predicate like 'a > b' -> 'a - b > 0'
-          if (!secondOperand.isSetLiteral()) {
-            Expression minusExpression = RequestUtils.getFunctionExpression("minus");
-            minusExpression.getFunctionCall().setOperands(Arrays.asList(firstOperand, secondOperand));
-            operands.set(0, minusExpression);
-            operands.set(1, RequestUtils.getLiteralExpression(0));
-            break;
-          }
-          break;
-        default:
-          int numOperands = operands.size();
-          for (int i = 1; i < numOperands; i++) {
-            if (!operands.get(i).isSetLiteral()) {
-              throw new SqlCompilationException(
-                  String.format("For %s predicate, the operands except for the first one must be literal, got: %s",
-                      filterKind, expression));
-            }
-          }
-          break;
-      }
-    }
     return expression;
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriter.java
@@ -46,18 +46,6 @@ public class PredicateComparisonRewriter implements QueryRewriter {
   }
 
   /**
-   This method converts a predicate expression to the what Pinot could evaluate.
-   1. For comparison expression, left operand could be any expression, but right operand only
-   supports literal. E.g. 'WHERE a > b' will be converted to 'WHERE a - b > 0'
-   2. Updates boolean predicates (literals and scalar functions) that are missing an EQUALS filter.
-   *
-   *
-   * @param expression current expression in the expression tree
-   * @param parentFunction parent expression
-   * @return re-written expression.
-   */
-
-  /**
    * This method converts a predicate expression to the what Pinot could evaluate.
    * 1. For comparison expression, left operand could be any expression, but right operand only
    *    supports literal. E.g. 'WHERE a > b' will be converted to 'WHERE a - b > 0'

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -2206,6 +2206,19 @@ public class CalciteSqlCompilerTest {
     }
 
     {
+      String query = "SELECT * FROM foo WHERE col1 > 0 AND (col2 AND col3 > 0) AND startsWith(col4, 'myStr')";
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      Function functionCall = pinotQuery.getFilterExpression().getFunctionCall();
+      Assert.assertEquals(functionCall.getOperator(), FilterKind.AND.name());
+      List<Expression> operands = functionCall.getOperands();
+      Assert.assertEquals(operands.size(), 4);
+      Assert.assertEquals(operands.get(0).getFunctionCall().getOperator(), FilterKind.GREATER_THAN.name());
+      Assert.assertEquals(operands.get(1).getFunctionCall().getOperator(), FilterKind.EQUALS.name());
+      Assert.assertEquals(operands.get(2).getFunctionCall().getOperator(), FilterKind.GREATER_THAN.name());
+      Assert.assertEquals(operands.get(3).getFunctionCall().getOperator(), FilterKind.EQUALS.name());
+    }
+
+    {
       String query = "SELECT * FROM foo WHERE col1 > 0 AND (col2 AND col3 > 0) AND col4";
       PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
       Function functionCall = pinotQuery.getFilterExpression().getFunctionCall();
@@ -2213,9 +2226,9 @@ public class CalciteSqlCompilerTest {
       List<Expression> operands = functionCall.getOperands();
       Assert.assertEquals(operands.size(), 4);
       Assert.assertEquals(operands.get(0).getFunctionCall().getOperator(), FilterKind.GREATER_THAN.name());
-      Assert.assertEquals(operands.get(1).getIdentifier().getName(), "col2");
+      Assert.assertEquals(operands.get(1).getFunctionCall().getOperator(), FilterKind.EQUALS.name());
       Assert.assertEquals(operands.get(2).getFunctionCall().getOperator(), FilterKind.GREATER_THAN.name());
-      Assert.assertEquals(operands.get(3).getIdentifier().getName(), "col4");
+      Assert.assertEquals(operands.get(3).getFunctionCall().getOperator(), FilterKind.EQUALS.name());
 
       // NOTE: PQL does not support logical identifier
     }
@@ -2249,9 +2262,9 @@ public class CalciteSqlCompilerTest {
       List<Expression> operands = functionCall.getOperands();
       Assert.assertEquals(operands.size(), 4);
       Assert.assertEquals(operands.get(0).getFunctionCall().getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
-      Assert.assertEquals(operands.get(1).getIdentifier().getName(), "col2");
+      Assert.assertEquals(operands.get(1).getFunctionCall().getOperator(), FilterKind.EQUALS.name());
       Assert.assertEquals(operands.get(2).getFunctionCall().getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
-      Assert.assertEquals(operands.get(3).getIdentifier().getName(), "col4");
+      Assert.assertEquals(operands.get(3).getFunctionCall().getOperator(), FilterKind.EQUALS.name());
 
       // NOTE: PQL does not support logical identifier
     }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -82,9 +82,13 @@ public class CalciteSqlCompilerTest {
   public void testCaseWhenStatements() {
     //@formatter:off
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
-        "SELECT OrderID, Quantity,\n" + "CASE\n" + "    WHEN Quantity > 30 THEN 'The quantity is greater than 30'\n"
-            + "    WHEN Quantity = 30 THEN 'The quantity is 30'\n" + "    ELSE 'The quantity is under 30'\n"
-            + "END AS QuantityText\n" + "FROM OrderDetails");
+        "SELECT OrderID, Quantity,\n"
+            + "CASE\n"
+            + "    WHEN Quantity > 30 THEN 'The quantity is greater than 30'\n"
+            + "    WHEN Quantity = 30 THEN 'The quantity is 30'\n"
+            + "    ELSE 'The quantity is under 30'\n"
+            + "END AS QuantityText\n"
+            + "FROM OrderDetails");
     //@formatter:on
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getIdentifier().getName(), "OrderID");
     Assert.assertEquals(pinotQuery.getSelectList().get(1).getIdentifier().getName(), "Quantity");
@@ -107,8 +111,13 @@ public class CalciteSqlCompilerTest {
 
     //@formatter:off
     pinotQuery = CalciteSqlParser.compileToPinotQuery(
-        "SELECT Quantity,\n" + "SUM(CASE\n" + "    WHEN Quantity > 30 THEN 3\n" + "    WHEN Quantity > 20 THEN 2\n"
-            + "    WHEN Quantity > 10 THEN 1\n" + "    ELSE 0\n" + "END) AS new_sum_quant\n"
+        "SELECT Quantity,\n"
+            + "SUM(CASE\n"
+            + "    WHEN Quantity > 30 THEN 3\n"
+            + "    WHEN Quantity > 20 THEN 2\n"
+            + "    WHEN Quantity > 10 THEN 1\n"
+            + "    ELSE 0\n"
+            + "END) AS new_sum_quant\n"
             + "FROM OrderDetails GROUP BY Quantity");
     //@formatter:on
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getIdentifier().getName(), "Quantity");
@@ -142,10 +151,14 @@ public class CalciteSqlCompilerTest {
     // Not support Aggregation functions in case statements.
     try {
       //@formatter:off
-      CalciteSqlParser.compileToPinotQuery("SELECT OrderID, Quantity,\n" + "CASE\n"
-          + "    WHEN sum(Quantity) > 30 THEN 'The quantity is greater than 30'\n"
-          + "    WHEN sum(Quantity) = 30 THEN 'The quantity is 30'\n" + "    ELSE 'The quantity is under 30'\n"
-          + "END AS QuantityText\n" + "FROM OrderDetails");
+      CalciteSqlParser.compileToPinotQuery(
+          "SELECT OrderID, Quantity,\n"
+              + "CASE\n"
+              + "    WHEN sum(Quantity) > 30 THEN 'The quantity is greater than 30'\n"
+              + "    WHEN sum(Quantity) = 30 THEN 'The quantity is 30'\n"
+              + "    ELSE 'The quantity is under 30'\n"
+              + "END AS QuantityText\n"
+              + "FROM OrderDetails");
       //@formatter:on
     } catch (SqlCompilationException e) {
       Assert.assertEquals(e.getMessage(),

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -82,13 +82,9 @@ public class CalciteSqlCompilerTest {
   public void testCaseWhenStatements() {
     //@formatter:off
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
-        "SELECT OrderID, Quantity,\n"
-            + "CASE\n"
-            + "    WHEN Quantity > 30 THEN 'The quantity is greater than 30'\n"
-            + "    WHEN Quantity = 30 THEN 'The quantity is 30'\n"
-            + "    ELSE 'The quantity is under 30'\n"
-            + "END AS QuantityText\n"
-            + "FROM OrderDetails");
+        "SELECT OrderID, Quantity,\n" + "CASE\n" + "    WHEN Quantity > 30 THEN 'The quantity is greater than 30'\n"
+            + "    WHEN Quantity = 30 THEN 'The quantity is 30'\n" + "    ELSE 'The quantity is under 30'\n"
+            + "END AS QuantityText\n" + "FROM OrderDetails");
     //@formatter:on
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getIdentifier().getName(), "OrderID");
     Assert.assertEquals(pinotQuery.getSelectList().get(1).getIdentifier().getName(), "Quantity");
@@ -111,13 +107,8 @@ public class CalciteSqlCompilerTest {
 
     //@formatter:off
     pinotQuery = CalciteSqlParser.compileToPinotQuery(
-        "SELECT Quantity,\n"
-            + "SUM(CASE\n"
-            + "    WHEN Quantity > 30 THEN 3\n"
-            + "    WHEN Quantity > 20 THEN 2\n"
-            + "    WHEN Quantity > 10 THEN 1\n"
-            + "    ELSE 0\n"
-            + "END) AS new_sum_quant\n"
+        "SELECT Quantity,\n" + "SUM(CASE\n" + "    WHEN Quantity > 30 THEN 3\n" + "    WHEN Quantity > 20 THEN 2\n"
+            + "    WHEN Quantity > 10 THEN 1\n" + "    ELSE 0\n" + "END) AS new_sum_quant\n"
             + "FROM OrderDetails GROUP BY Quantity");
     //@formatter:on
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getIdentifier().getName(), "Quantity");
@@ -151,14 +142,10 @@ public class CalciteSqlCompilerTest {
     // Not support Aggregation functions in case statements.
     try {
       //@formatter:off
-      CalciteSqlParser.compileToPinotQuery(
-          "SELECT OrderID, Quantity,\n"
-              + "CASE\n"
-              + "    WHEN sum(Quantity) > 30 THEN 'The quantity is greater than 30'\n"
-              + "    WHEN sum(Quantity) = 30 THEN 'The quantity is 30'\n"
-              + "    ELSE 'The quantity is under 30'\n"
-              + "END AS QuantityText\n"
-              + "FROM OrderDetails");
+      CalciteSqlParser.compileToPinotQuery("SELECT OrderID, Quantity,\n" + "CASE\n"
+          + "    WHEN sum(Quantity) > 30 THEN 'The quantity is greater than 30'\n"
+          + "    WHEN sum(Quantity) = 30 THEN 'The quantity is 30'\n" + "    ELSE 'The quantity is under 30'\n"
+          + "END AS QuantityText\n" + "FROM OrderDetails");
       //@formatter:on
     } catch (SqlCompilationException e) {
       Assert.assertEquals(e.getMessage(),
@@ -194,45 +181,148 @@ public class CalciteSqlCompilerTest {
 
   @Test
   public void testFilterClauses() {
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where a > 1.5");
-    Function func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN.name());
-    Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "a");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getDoubleValue(), 1.5);
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where b < 100");
-    func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN.name());
-    Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "b");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 100L);
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where c >= 10");
-    func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN_OR_EQUAL.name());
-    Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "c");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 10L);
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where d <= 50");
-    func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
-    Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "d");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 50L);
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where e BETWEEN 70 AND 80");
-    func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), FilterKind.BETWEEN.name());
-    Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "e");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 70L);
-    Assert.assertEquals(func.getOperands().get(2).getLiteral().getLongValue(), 80L);
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where regexp_like(E, '^U.*')");
-    func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), "REGEXP_LIKE");
-    Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "E");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getStringValue(), "^U.*");
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where g IN (12, 13, 15.2, 17)");
-    func = pinotQuery.getFilterExpression().getFunctionCall();
-    Assert.assertEquals(func.getOperator(), FilterKind.IN.name());
-    Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "g");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 12L);
-    Assert.assertEquals(func.getOperands().get(2).getLiteral().getLongValue(), 13L);
-    Assert.assertEquals(func.getOperands().get(3).getLiteral().getDoubleValue(), 15.2);
-    Assert.assertEquals(func.getOperands().get(4).getLiteral().getLongValue(), 17L);
+    {
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where a > 1.5");
+      Function func = pinotQuery.getFilterExpression().getFunctionCall();
+      Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN.name());
+      Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "a");
+      Assert.assertEquals(func.getOperands().get(1).getLiteral().getDoubleValue(), 1.5);
+    }
+
+    {
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where b < 100");
+      Function func = pinotQuery.getFilterExpression().getFunctionCall();
+      Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN.name());
+      Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "b");
+      Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 100L);
+    }
+
+    {
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where c >= 10");
+      Function func = pinotQuery.getFilterExpression().getFunctionCall();
+      Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN_OR_EQUAL.name());
+      Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "c");
+      Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 10L);
+    }
+
+    {
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where d <= 50");
+      Function func = pinotQuery.getFilterExpression().getFunctionCall();
+      Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
+      Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "d");
+      Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 50L);
+    }
+
+    {
+      PinotQuery pinotQuery =
+          CalciteSqlParser.compileToPinotQuery("select * from vegetables where e BETWEEN 70 AND 80");
+      Function func = pinotQuery.getFilterExpression().getFunctionCall();
+      Assert.assertEquals(func.getOperator(), FilterKind.BETWEEN.name());
+      Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "e");
+      Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 70L);
+      Assert.assertEquals(func.getOperands().get(2).getLiteral().getLongValue(), 80L);
+    }
+
+    {
+      PinotQuery pinotQuery =
+          CalciteSqlParser.compileToPinotQuery("select * from vegetables where regexp_like(E, '^U.*')");
+      Function func = pinotQuery.getFilterExpression().getFunctionCall();
+      Assert.assertEquals(func.getOperator(), "REGEXP_LIKE");
+      Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "E");
+      Assert.assertEquals(func.getOperands().get(1).getLiteral().getStringValue(), "^U.*");
+    }
+
+    {
+      PinotQuery pinotQuery =
+          CalciteSqlParser.compileToPinotQuery("select * from vegetables where g IN (12, 13, 15.2, 17)");
+      Function func = pinotQuery.getFilterExpression().getFunctionCall();
+      Assert.assertEquals(func.getOperator(), FilterKind.IN.name());
+      Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "g");
+      Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 12L);
+      Assert.assertEquals(func.getOperands().get(2).getLiteral().getLongValue(), 13L);
+      Assert.assertEquals(func.getOperands().get(3).getLiteral().getDoubleValue(), 15.2);
+      Assert.assertEquals(func.getOperands().get(4).getLiteral().getLongValue(), 17L);
+    }
+
+    {
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetable where g");
+      Function func = pinotQuery.getFilterExpression().getFunctionCall();
+      Assert.assertEquals(func.getOperator(), FilterKind.EQUALS.name());
+      Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "g");
+      Assert.assertEquals(func.getOperands().get(1).getLiteral(), Literal.boolValue(true));
+    }
+
+    {
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetable where g or f = true");
+      Function func = pinotQuery.getFilterExpression().getFunctionCall();
+      Assert.assertEquals(func.getOperator(), FilterKind.OR.name());
+      List<Expression> operands = func.getOperands();
+      Assert.assertEquals(operands.size(), 2);
+      Assert.assertEquals(operands.get(0).getFunctionCall().getOperator(), FilterKind.EQUALS.name());
+      List<Expression> eqOperands = operands.get(0).getFunctionCall().getOperands();
+      Assert.assertEquals(eqOperands.get(0).getIdentifier().getName(), "g");
+      Assert.assertEquals(eqOperands.get(1).getLiteral(), Literal.boolValue(true));
+      eqOperands = operands.get(1).getFunctionCall().getOperands();
+      Assert.assertEquals(eqOperands.get(0).getIdentifier().getName(), "f");
+      Assert.assertEquals(eqOperands.get(1).getLiteral(), Literal.stringValue("true"));
+    }
+
+    {
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetable where startsWith(g, "
+          + "'str')");
+      Function func = pinotQuery.getFilterExpression().getFunctionCall();
+      Assert.assertEquals(func.getOperator(), FilterKind.EQUALS.name());
+      Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "startswith");
+      Assert.assertEquals(func.getOperands().get(1).getLiteral(), Literal.boolValue(true));
+    }
+
+    {
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetable where startsWith(g, "
+          + "'str')=true and startsWith(f, 'str')");
+      Function func = pinotQuery.getFilterExpression().getFunctionCall();
+      Assert.assertEquals(func.getOperator(), FilterKind.AND.name());
+      List<Expression> operands = func.getOperands();
+      Assert.assertEquals(operands.size(), 2);
+
+      Assert.assertEquals(operands.get(0).getFunctionCall().getOperator(), FilterKind.EQUALS.name());
+      List<Expression> eqOperands = operands.get(0).getFunctionCall().getOperands();
+      Assert.assertEquals(eqOperands.get(0).getFunctionCall().getOperator(), "startswith");
+      Assert.assertEquals(eqOperands.get(1).getLiteral(), Literal.stringValue("true"));
+
+      Assert.assertEquals(operands.get(1).getFunctionCall().getOperator(), FilterKind.EQUALS.name());
+      eqOperands = operands.get(1).getFunctionCall().getOperands();
+      Assert.assertEquals(eqOperands.get(0).getFunctionCall().getOperator(), "startswith");
+      Assert.assertEquals(eqOperands.get(1).getLiteral(), Literal.boolValue(true));
+    }
+
+    {
+      PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetable where (startsWith(g, "
+          + "'str')=true and startsWith(f, 'str')) AND (e and d=true)");
+      Function func = pinotQuery.getFilterExpression().getFunctionCall();
+      Assert.assertEquals(func.getOperator(), FilterKind.AND.name());
+      List<Expression> operands = func.getOperands();
+      Assert.assertEquals(operands.size(), 4);
+
+      Assert.assertEquals(operands.get(0).getFunctionCall().getOperator(), FilterKind.EQUALS.name());
+      List<Expression> eqOperands = operands.get(0).getFunctionCall().getOperands();
+      Assert.assertEquals(eqOperands.get(0).getFunctionCall().getOperator(), "startswith");
+      Assert.assertEquals(eqOperands.get(1).getLiteral(), Literal.stringValue("true"));
+
+      Assert.assertEquals(operands.get(1).getFunctionCall().getOperator(), FilterKind.EQUALS.name());
+      eqOperands = operands.get(1).getFunctionCall().getOperands();
+      Assert.assertEquals(eqOperands.get(0).getFunctionCall().getOperator(), "startswith");
+      Assert.assertEquals(eqOperands.get(1).getLiteral(), Literal.boolValue(true));
+
+      Assert.assertEquals(operands.get(2).getFunctionCall().getOperator(), FilterKind.EQUALS.name());
+      eqOperands = operands.get(2).getFunctionCall().getOperands();
+      Assert.assertEquals(eqOperands.get(0).getIdentifier().getName(), "e");
+      Assert.assertEquals(eqOperands.get(1).getLiteral(), Literal.boolValue(true));
+
+      Assert.assertEquals(operands.get(3).getFunctionCall().getOperator(), FilterKind.EQUALS.name());
+      eqOperands = operands.get(3).getFunctionCall().getOperands();
+      Assert.assertEquals(eqOperands.get(0).getIdentifier().getName(), "d");
+      Assert.assertEquals(eqOperands.get(1).getLiteral(), Literal.stringValue("true"));
+    }
   }
 
   @Test
@@ -241,29 +331,30 @@ public class CalciteSqlCompilerTest {
     Function func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN.name());
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "minus");
-    Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
-        "a");
-    Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(),
-        "b");
+    Assert
+        .assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "a");
+    Assert
+        .assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "b");
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where 0 < a-b");
     func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN.name());
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "minus");
-    Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
-        "a");
-    Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(),
-        "b");
+    Assert
+        .assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "a");
+    Assert
+        .assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "b");
     Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
 
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where b < 100 + c");
     func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN.name());
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "minus");
-    Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
-        "b");
-    Assert.assertEquals(
-        func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "plus");
+    Assert
+        .assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "b");
+    Assert
+        .assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(),
+            "plus");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
             .getLiteral().getLongValue(), 100L);
@@ -275,10 +366,11 @@ public class CalciteSqlCompilerTest {
     func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN.name());
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "minus");
-    Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
-        "b");
-    Assert.assertEquals(
-        func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "plus");
+    Assert
+        .assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "b");
+    Assert
+        .assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(),
+            "plus");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
             .getLiteral().getLongValue(), 100L);
@@ -292,10 +384,12 @@ public class CalciteSqlCompilerTest {
     func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "minus");
-    Assert.assertEquals(
-        func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "foo1");
-    Assert.assertEquals(
-        func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "foo2");
+    Assert
+        .assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+            "foo1");
+    Assert
+        .assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(),
+            "foo2");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getFunctionCall().getOperator(), "bar1");
@@ -330,10 +424,12 @@ public class CalciteSqlCompilerTest {
     func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperator(), "minus");
-    Assert.assertEquals(
-        func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "foo1");
-    Assert.assertEquals(
-        func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "foo2");
+    Assert
+        .assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+            "foo1");
+    Assert
+        .assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(),
+            "foo2");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getFunctionCall().getOperator(), "bar1");
@@ -676,8 +772,8 @@ public class CalciteSqlCompilerTest {
     } catch (SqlCompilationException e) {
       // Expected
       Assert.assertTrue(e.getCause().getMessage().contains("at line 1, column 31."),
-          "Compilation exception should contain line and character for error message. Error message is "
-              + e.getMessage());
+          "Compilation exception should contain line and character for error message. Error message is " + e
+              .getMessage());
       return;
     }
 
@@ -701,8 +797,8 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 0);
     Assert.assertNull(pinotQuery.getQueryOptions());
 
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(
-        "select * from vegetables where name <> 'Brussels sprouts' OPTION (delicious=yes)");
+    pinotQuery = CalciteSqlParser
+        .compileToPinotQuery("select * from vegetables where name <> 'Brussels sprouts' OPTION (delicious=yes)");
     Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1);
     Assert.assertTrue(pinotQuery.getQueryOptions().containsKey("delicious"));
     Assert.assertEquals(pinotQuery.getQueryOptions().get("delicious"), "yes");
@@ -777,8 +873,8 @@ public class CalciteSqlCompilerTest {
 
   @Test
   public void testIdentifierQuoteCharacter() {
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
-        "select avg(attributes.age) as avg_age from person group by attributes.address_city");
+    PinotQuery pinotQuery = CalciteSqlParser
+        .compileToPinotQuery("select avg(attributes.age) as avg_age from person group by attributes.address_city");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "attributes.age");
@@ -805,14 +901,15 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(groupbyList.get(1).getIdentifier().getName(), "bar");
 
     // For UDF, string literal won't be treated as column but as LITERAL
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(
-        "SELECT SUM(ADD(foo, 'bar')) FROM myTable GROUP BY sub(foo, bar), SUB(BAR, FOO)");
+    pinotQuery = CalciteSqlParser
+        .compileToPinotQuery("SELECT SUM(ADD(foo, 'bar')) FROM myTable GROUP BY sub(foo, bar), SUB(BAR, FOO)");
     selectFunctionList = pinotQuery.getSelectList();
     Assert.assertEquals(selectFunctionList.size(), 1);
     Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperator(), "sum");
     Assert.assertEquals(selectFunctionList.get(0).getFunctionCall().getOperands().size(), 1);
-    Assert.assertEquals(
-        selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "add");
+    Assert
+        .assertEquals(selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+            "add");
     Assert.assertEquals(
         selectFunctionList.get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().size(), 2);
     Assert.assertEquals(
@@ -878,8 +975,8 @@ public class CalciteSqlCompilerTest {
 
   @Test
   public void testSelectionTransformFunction() {
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
-        "  select mapKey(mapField,k1) from baseballStats where mapKey(mapField,k1) = 'v1'");
+    PinotQuery pinotQuery = CalciteSqlParser
+        .compileToPinotQuery("  select mapKey(mapField,k1) from baseballStats where mapKey(mapField,k1) = 'v1'");
     Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "mapkey");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "mapField");
@@ -1525,8 +1622,9 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(
         pinotQuery.getSelectList().get(4).getFunctionCall().getOperands().get(1).getIdentifier().getName(), "avg");
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), FilterKind.EQUALS.name());
-    Assert.assertEquals(
-        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(), "groups");
+    Assert
+        .assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+            "groups");
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getStringValue(), "foo");
 
@@ -1946,8 +2044,8 @@ public class CalciteSqlCompilerTest {
     expression = pinotQuery.getFilterExpression();
     Assert.assertNotNull(expression.getFunctionCall());
     Assert.assertEquals(expression.getFunctionCall().getOperator(), "todatetime");
-    Assert.assertEquals(expression.getFunctionCall().getOperands().get(0).getIdentifier().getName(),
-        "millisSinceEpoch");
+    Assert
+        .assertEquals(expression.getFunctionCall().getOperands().get(0).getIdentifier().getName(), "millisSinceEpoch");
 
     expression = CalciteSqlParser.compileToExpression("encodeUrl('key1=value 1&key2=value@!$2&key3=value%3')");
     Assert.assertNotNull(expression.getFunctionCall());
@@ -2047,8 +2145,9 @@ public class CalciteSqlCompilerTest {
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     brokerRequest = converter.convert(pinotQuery);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "IS_NOT_NULL");
-    Assert.assertEquals(
-        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col");
+    Assert
+        .assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+            "col");
     Assert.assertEquals(brokerRequest.getFilterQuery().getOperator(), FilterOperator.IS_NOT_NULL);
     Assert.assertEquals(brokerRequest.getFilterQuery().getColumn(), "col");
 
@@ -2056,8 +2155,9 @@ public class CalciteSqlCompilerTest {
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     brokerRequest = converter.convert(pinotQuery);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "IS_NOT_NULL");
-    Assert.assertEquals(
-        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col");
+    Assert
+        .assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+            "col");
     Assert.assertEquals(brokerRequest.getFilterQuery().getOperator(), FilterOperator.IS_NOT_NULL);
     Assert.assertEquals(brokerRequest.getFilterQuery().getColumn(), "col");
 
@@ -2065,8 +2165,9 @@ public class CalciteSqlCompilerTest {
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     brokerRequest = converter.convert(pinotQuery);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "IS_NULL");
-    Assert.assertEquals(
-        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col");
+    Assert
+        .assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+            "col");
     Assert.assertEquals(brokerRequest.getFilterQuery().getOperator(), FilterOperator.IS_NULL);
     Assert.assertEquals(brokerRequest.getFilterQuery().getColumn(), "col");
 
@@ -2074,8 +2175,9 @@ public class CalciteSqlCompilerTest {
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     brokerRequest = converter.convert(pinotQuery);
     Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperator(), "IS_NULL");
-    Assert.assertEquals(
-        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col");
+    Assert
+        .assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+            "col");
     Assert.assertEquals(brokerRequest.getFilterQuery().getOperator(), FilterOperator.IS_NULL);
     Assert.assertEquals(brokerRequest.getFilterQuery().getColumn(), "col");
   }
@@ -2214,12 +2316,18 @@ public class CalciteSqlCompilerTest {
       Assert.assertEquals(operands.size(), 4);
       Assert.assertEquals(operands.get(0).getFunctionCall().getOperator(), FilterKind.GREATER_THAN.name());
       Assert.assertEquals(operands.get(1).getFunctionCall().getOperator(), FilterKind.EQUALS.name());
+      List<Expression> eqOperands = operands.get(1).getFunctionCall().getOperands();
+      Assert.assertEquals(eqOperands.get(0).getIdentifier(), new Identifier("col2"));
+      Assert.assertEquals(eqOperands.get(1).getLiteral(), Literal.boolValue(true));
       Assert.assertEquals(operands.get(2).getFunctionCall().getOperator(), FilterKind.GREATER_THAN.name());
       Assert.assertEquals(operands.get(3).getFunctionCall().getOperator(), FilterKind.EQUALS.name());
+      eqOperands = operands.get(3).getFunctionCall().getOperands();
+      Assert.assertEquals(eqOperands.get(0).getFunctionCall().getOperator(), "startswith");
+      Assert.assertEquals(eqOperands.get(1).getLiteral(), Literal.boolValue(true));
     }
 
     {
-      String query = "SELECT * FROM foo WHERE col1 > 0 AND (col2 AND col3 > 0) AND col4";
+      String query = "SELECT * FROM foo WHERE col1 > 0 AND (col2 AND col3 > 0) AND col4 = true";
       PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
       Function functionCall = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(functionCall.getOperator(), FilterKind.AND.name());
@@ -2227,9 +2335,14 @@ public class CalciteSqlCompilerTest {
       Assert.assertEquals(operands.size(), 4);
       Assert.assertEquals(operands.get(0).getFunctionCall().getOperator(), FilterKind.GREATER_THAN.name());
       Assert.assertEquals(operands.get(1).getFunctionCall().getOperator(), FilterKind.EQUALS.name());
+      List<Expression> eqOperands = operands.get(1).getFunctionCall().getOperands();
+      Assert.assertEquals(eqOperands.get(0).getIdentifier(), new Identifier("col2"));
+      Assert.assertEquals(eqOperands.get(1).getLiteral(), Literal.boolValue(true));
       Assert.assertEquals(operands.get(2).getFunctionCall().getOperator(), FilterKind.GREATER_THAN.name());
       Assert.assertEquals(operands.get(3).getFunctionCall().getOperator(), FilterKind.EQUALS.name());
-
+      eqOperands = operands.get(3).getFunctionCall().getOperands();
+      Assert.assertEquals(eqOperands.get(0).getIdentifier(), new Identifier("col4"));
+      Assert.assertEquals(eqOperands.get(1).getLiteral(), Literal.stringValue("true"));
       // NOTE: PQL does not support logical identifier
     }
 
@@ -2265,6 +2378,9 @@ public class CalciteSqlCompilerTest {
       Assert.assertEquals(operands.get(1).getFunctionCall().getOperator(), FilterKind.EQUALS.name());
       Assert.assertEquals(operands.get(2).getFunctionCall().getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
       Assert.assertEquals(operands.get(3).getFunctionCall().getOperator(), FilterKind.EQUALS.name());
+      List<Expression> eqOperands = operands.get(3).getFunctionCall().getOperands();
+      Assert.assertEquals(eqOperands.get(0).getIdentifier(), new Identifier("col4"));
+      Assert.assertEquals(eqOperands.get(1).getLiteral(), Literal.boolValue(true));
 
       // NOTE: PQL does not support logical identifier
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -582,9 +582,6 @@ public class QueryContext {
           Preconditions.checkState(aggregation != null && aggregation.getType() == FunctionContext.Type.AGGREGATION,
               "First argument of FILTER must be an aggregation function");
           ExpressionContext filterExpression = arguments.get(1);
-          Preconditions.checkState(filterExpression.getFunction() != null
-                  && filterExpression.getFunction().getType() == FunctionContext.Type.TRANSFORM,
-              "Second argument of FILTER must be a filter expression");
           FilterContext filter = RequestContextUtils.getFilter(filterExpression);
           filteredAggregations.add(Pair.of(aggregation, filter));
         } else {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BooleanQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BooleanQueriesTest.java
@@ -164,7 +164,7 @@ public class BooleanQueriesTest extends BaseQueriesTest {
     }
     {
       String query = "SELECT booleanColumn FROM testTable WHERE booleanColumn";
-      BrokerResponseNative brokerResponse = getBrokerResponseForSqlQuery(query);
+      BrokerResponseNative brokerResponse = getBrokerResponse(query);
       ResultTable resultTable = brokerResponse.getResultTable();
       DataSchema dataSchema = resultTable.getDataSchema();
       assertEquals(dataSchema,

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BooleanQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BooleanQueriesTest.java
@@ -163,6 +163,21 @@ public class BooleanQueriesTest extends BaseQueriesTest {
       }
     }
     {
+      String query = "SELECT booleanColumn FROM testTable WHERE booleanColumn";
+      BrokerResponseNative brokerResponse = getBrokerResponseForSqlQuery(query);
+      ResultTable resultTable = brokerResponse.getResultTable();
+      DataSchema dataSchema = resultTable.getDataSchema();
+      assertEquals(dataSchema,
+          new DataSchema(new String[]{"booleanColumn"}, new ColumnDataType[]{ColumnDataType.BOOLEAN}));
+      List<Object[]> rows = resultTable.getRows();
+      assertEquals(rows.size(), 10);
+      for (int i = 0; i < 10; i++) {
+        Object[] row = rows.get(i);
+        assertEquals(row.length, 1);
+        assertEquals(row[0], true);
+      }
+    }
+    {
       String query = "SELECT * FROM testTable ORDER BY booleanColumn DESC LIMIT 20";
       BrokerResponseNative brokerResponse = getBrokerResponse(query);
       ResultTable resultTable = brokerResponse.getResultTable();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
@@ -55,6 +55,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
   private final static String COL1_NO_INDEX = "noIndexCol1";
   private final static String COL2_NO_INDEX = "noIndexCol2";
   private final static String COL3_NO_INDEX = "noIndexCol3";
+  private final static String COL4_NO_INDEX = "noIndexCol4";
   private final static String COL1_INVERTED_INDEX = "invertedIndexCol1";
   private final static String COL2_INVERTED_INDEX = "invertedIndexCol2";
   private final static String COL3_INVERTED_INDEX = "invertedIndexCol3";
@@ -69,6 +70,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
       .addSingleValueDimension(COL1_NO_INDEX, FieldSpec.DataType.INT)
       .addSingleValueDimension(COL2_NO_INDEX, FieldSpec.DataType.INT)
       .addSingleValueDimension(COL3_NO_INDEX, FieldSpec.DataType.INT)
+      .addSingleValueDimension(COL4_NO_INDEX, FieldSpec.DataType.BOOLEAN)
       .addSingleValueDimension(COL1_INVERTED_INDEX, FieldSpec.DataType.DOUBLE)
       .addSingleValueDimension(COL2_INVERTED_INDEX, FieldSpec.DataType.INT)
       .addSingleValueDimension(COL3_INVERTED_INDEX, FieldSpec.DataType.STRING)
@@ -104,14 +106,16 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     return _indexSegments;
   }
 
-  GenericRow createMockRecord(int noIndexCol1, int noIndexCol2, int noIndexCol3, double invertedIndexCol1,
-      int invertedIndexCol2, String intervedIndexCol3, double rangeIndexCol1, int rangeIndexCol2, int rangeIndexCol3,
-      double sortedIndexCol1, String jsonIndexCol1, String textIndexCol1) {
+  GenericRow createMockRecord(int noIndexCol1, int noIndexCol2, int noIndexCol3,
+      boolean noIndexCol4, double invertedIndexCol1, int invertedIndexCol2, String intervedIndexCol3,
+      double rangeIndexCol1, int rangeIndexCol2, int rangeIndexCol3, double sortedIndexCol1, String jsonIndexCol1,
+      String textIndexCol1) {
 
     GenericRow record = new GenericRow();
     record.putValue(COL1_NO_INDEX, noIndexCol1);
     record.putValue(COL2_NO_INDEX, noIndexCol2);
     record.putValue(COL3_NO_INDEX, noIndexCol3);
+    record.putValue(COL4_NO_INDEX, noIndexCol4);
 
     record.putValue(COL1_INVERTED_INDEX, invertedIndexCol1);
     record.putValue(COL2_INVERTED_INDEX, invertedIndexCol2);
@@ -135,11 +139,11 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     FileUtils.deleteDirectory(INDEX_DIR);
 
     List<GenericRow> records = new ArrayList<>(NUM_RECORDS);
-    records.add(createMockRecord(1, 2, 3, 1.1, 2, "daffy", 10.1, 20, 30, 100.1,
+    records.add(createMockRecord(1, 2, 3, true, 1.1, 2, "daffy", 10.1, 20, 30, 100.1,
         "{\"first\": \"daffy\", \"last\": " + "\"duck\"}", "daffy"));
-    records.add(createMockRecord(0, 1, 2, 0.1, 1, "mickey", 0.1, 10, 20, 100.2,
+    records.add(createMockRecord(0, 1, 2, false, 0.1, 1, "mickey", 0.1, 10, 20, 100.2,
         "{\"first\": \"mickey\", \"last\": " + "\"mouse\"}", "mickey"));
-    records.add(createMockRecord(3, 4, 5, 2.1, 3, "mickey", 20.1, 30, 40, 100.3,
+    records.add(createMockRecord(3, 4, 5, true, 2.1, 3, "mickey", 20.1, 30, 40, 100.3,
         "{\"first\": \"mickey\", \"last\": " + "\"mouse\"}", "mickey"));
 
     IndexingConfig indexingConfig = TABLE_CONFIG.getIndexingConfig();
@@ -191,14 +195,14 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result1.add(new Object[]{"COMBINE_SELECT", 1, 0});
     result1.add(new Object[]{
         "SELECT(selectList:invertedIndexCol1, invertedIndexCol2, invertedIndexCol3, jsonIndexCol1, "
-            + "noIndexCol1, noIndexCol2, noIndexCol3, rangeIndexCol1, rangeIndexCol2, rangeIndexCol3, "
+            + "noIndexCol1, noIndexCol2, noIndexCol3, noIndexCol4, rangeIndexCol1, rangeIndexCol2, rangeIndexCol3, "
             + "sortedIndexCol1, textIndexCol1)", 2, 1});
     result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, invertedIndexCol2, invertedIndexCol3, "
-        + "jsonIndexCol1, noIndexCol1, noIndexCol2, noIndexCol3, rangeIndexCol1, rangeIndexCol2, rangeIndexCol3, "
-        + "sortedIndexCol1, textIndexCol1)", 3, 2});
-    result1.add(new Object[]{"PROJECT(sortedIndexCol1, noIndexCol3, rangeIndexCol1, rangeIndexCol2, jsonIndexCol1, "
-        + "invertedIndexCol1, noIndexCol2, invertedIndexCol2, noIndexCol1, invertedIndexCol3, rangeIndexCol3, "
-        + "textIndexCol1)", 4, 3});
+        + "jsonIndexCol1, noIndexCol1, noIndexCol2, noIndexCol3, noIndexCol4, rangeIndexCol1, rangeIndexCol2, "
+        + "rangeIndexCol3, sortedIndexCol1, textIndexCol1)", 3, 2});
+    result1.add(new Object[]{"PROJECT(noIndexCol4, sortedIndexCol1, noIndexCol3, rangeIndexCol1, rangeIndexCol2, "
+        + "invertedIndexCol1, noIndexCol2, invertedIndexCol2, noIndexCol1, rangeIndexCol3, textIndexCol1, "
+        + "jsonIndexCol1, invertedIndexCol3)", 4, 3});
     result1.add(new Object[]{"DOC_ID_SET", 5, 4});
     result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
@@ -337,6 +341,47 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result3.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol1 > '1')", 7, 6});
     result3.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol2 BETWEEN '2' AND '101')", 8, 6});
     check(query3, new ResultTable(DATA_SCHEMA, result3));
+
+    String query4 = "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1 FROM testTable WHERE noIndexCol1 > 1 OR "
+        + "contains(textIndexCol1, 'daff') OR noIndexCol2 BETWEEN 2 AND 101 LIMIT 100";
+    List<Object[]> result4 = new ArrayList<>();
+    result4.add(new Object[]{"BROKER_REDUCE(limit:100)", 0, -1});
+    result4.add(new Object[]{"COMBINE_SELECT", 1, 0});
+    result4.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1)", 2, 1});
+    result4.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 3, 2});
+    result4.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result4.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result4.add(new Object[]{"FILTER_OR", 6, 5});
+    result4.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol1 > '1')", 7, 6});
+    result4.add(new Object[]{"FILTER_EXPRESSION(operator:EQ,predicate:contains(textIndexCol1,'daff') = 'true')", 8, 6});
+    result4.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol2 BETWEEN '2' AND '101')", 9, 6});
+    check(query4, new ResultTable(DATA_SCHEMA, result4));
+
+    String query5 = "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1 FROM testTable WHERE noIndexCol4 LIMIT 100";
+    List<Object[]> result5 = new ArrayList<>();
+    result5.add(new Object[]{"BROKER_REDUCE(limit:100)", 0, -1});
+    result5.add(new Object[]{"COMBINE_SELECT", 1, 0});
+    result5.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1)", 2, 1});
+    result5.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 3, 2});
+    result5.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result5.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result5.add(new Object[]{"FILTER_FULL_SCAN(operator:EQ,predicate:noIndexCol4 = 'true')", 6, 5});
+    check(query5, new ResultTable(DATA_SCHEMA, result5));
+
+    String query6 = "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1 FROM testTable WHERE startsWith "
+        + "(textIndexCol1, 'daff') AND noIndexCol4";
+    List<Object[]> result6 = new ArrayList<>();
+    result6.add(new Object[]{"BROKER_REDUCE(limit:10)", 0, -1});
+    result6.add(new Object[]{"COMBINE_SELECT", 1, 0});
+    result6.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1)", 2, 1});
+    result6.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 3, 2});
+    result6.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result6.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result6.add(new Object[]{"FILTER_AND", 6, 5});
+    result6.add(new Object[]{"FILTER_FULL_SCAN(operator:EQ,predicate:noIndexCol4 = 'true')", 7, 6});
+    result6.add(new Object[]{"FILTER_EXPRESSION(operator:EQ,predicate:startswith(textIndexCol1,'daff') = 'true')", 8,
+        6});
+    check(query6, new ResultTable(DATA_SCHEMA, result6));
   }
 
   /** Test case for SQL statements with filter that involves inverted or sorted index access. */

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FilteredAggregationsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FilteredAggregationsTest.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang.math.RandomUtils;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
@@ -59,6 +60,7 @@ public class FilteredAggregationsTest extends BaseQueriesTest {
   private static final String NO_INDEX_INT_COL_NAME = "NO_INDEX_COL";
   private static final String STATIC_INT_COL_NAME = "STATIC_INT_COL";
   private static final String BOOLEAN_COL_NAME = "BOOLEAN_COL";
+  private static final String STRING_COL_NAME = "STRING_COL";
   private static final Integer NUM_ROWS = 30000;
 
   private IndexSegment _indexSegment;
@@ -114,6 +116,7 @@ public class FilteredAggregationsTest extends BaseQueriesTest {
       row.putValue(NO_INDEX_INT_COL_NAME, i);
       row.putValue(STATIC_INT_COL_NAME, 10);
       row.putValue(BOOLEAN_COL_NAME, RandomUtils.nextBoolean());
+      row.putValue(STRING_COL_NAME, RandomStringUtils.randomAlphabetic(4));
       rows.add(row);
     }
     return rows;
@@ -130,6 +133,7 @@ public class FilteredAggregationsTest extends BaseQueriesTest {
         .addSingleValueDimension(NO_INDEX_INT_COL_NAME, FieldSpec.DataType.INT)
         .addSingleValueDimension(STATIC_INT_COL_NAME, FieldSpec.DataType.INT)
         .addSingleValueDimension(BOOLEAN_COL_NAME, FieldSpec.DataType.BOOLEAN)
+        .addSingleValueDimension(STRING_COL_NAME, FieldSpec.DataType.STRING)
         .addMetric(INT_COL_NAME, FieldSpec.DataType.INT).build();
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
     config.setOutDir(INDEX_DIR.getPath());
@@ -157,8 +161,8 @@ public class FilteredAggregationsTest extends BaseQueriesTest {
 
   @Test
   public void testSimpleQueries() {
-    String filterQuery = "SELECT SUM(INT_COL) FILTER(WHERE BOOLEAN_COL) FROM MyTable";
-    String nonFilterQuery = "SELECT SUM(INT_COL) FROM MyTable WHERE BOOLEAN_COL";
+    String filterQuery = "SELECT SUM(INT_COL) FILTER(WHERE INT_COL > 9999) FROM MyTable WHERE INT_COL < 1000000";
+    String nonFilterQuery = "SELECT SUM(INT_COL) FROM MyTable WHERE INT_COL > 9999 AND INT_COL < 1000000";
     testQuery(filterQuery, nonFilterQuery);
 
     filterQuery = "SELECT SUM(INT_COL) FILTER(WHERE INT_COL < 3) FROM MyTable WHERE INT_COL > 1";
@@ -188,6 +192,20 @@ public class FilteredAggregationsTest extends BaseQueriesTest {
     filterQuery = "SELECT MIN(INT_COL) FILTER(WHERE NO_INDEX_COL > 29990), MAX(INT_COL) FILTER(WHERE INT_COL > 29990) "
         + "FROM MyTable";
     nonFilterQuery = "SELECT MIN(INT_COL), MAX(INT_COL) FROM MyTable WHERE INT_COL > 29990";
+    testQuery(filterQuery, nonFilterQuery);
+
+    filterQuery = "SELECT SUM(INT_COL) FILTER(WHERE BOOLEAN_COL) FROM MyTable";
+    nonFilterQuery = "SELECT SUM(INT_COL) FROM MyTable WHERE BOOLEAN_COL=true";
+    testQuery(filterQuery, nonFilterQuery);
+
+    filterQuery = "SELECT SUM(INT_COL) FILTER(WHERE BOOLEAN_COL AND STARTSWITH(STRING_COL, 'abc')) FROM MyTable";
+    nonFilterQuery = "SELECT SUM(INT_COL) FROM MyTable WHERE BOOLEAN_COL=true AND STARTSWITH(STRING_COL, 'abc')";
+    testQuery(filterQuery, nonFilterQuery);
+
+    filterQuery = "SELECT SUM(INT_COL) FILTER(WHERE BOOLEAN_COL AND STARTSWITH(REVERSE(STRING_COL), 'abc')) FROM "
+        + "MyTable";
+    nonFilterQuery = "SELECT SUM(INT_COL) FROM MyTable WHERE BOOLEAN_COL=true AND STARTSWITH(REVERSE(STRING_COL), "
+        + "'abc')";
     testQuery(filterQuery, nonFilterQuery);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FilteredAggregationsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FilteredAggregationsTest.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.math.RandomUtils;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
@@ -57,6 +58,7 @@ public class FilteredAggregationsTest extends BaseQueriesTest {
   private static final String INT_COL_NAME = "INT_COL";
   private static final String NO_INDEX_INT_COL_NAME = "NO_INDEX_COL";
   private static final String STATIC_INT_COL_NAME = "STATIC_INT_COL";
+  private static final String BOOLEAN_COL_NAME = "BOOLEAN_COL";
   private static final Integer NUM_ROWS = 30000;
 
   private IndexSegment _indexSegment;
@@ -111,6 +113,7 @@ public class FilteredAggregationsTest extends BaseQueriesTest {
       row.putValue(INT_COL_NAME, i);
       row.putValue(NO_INDEX_INT_COL_NAME, i);
       row.putValue(STATIC_INT_COL_NAME, 10);
+      row.putValue(BOOLEAN_COL_NAME, RandomUtils.nextBoolean());
       rows.add(row);
     }
     return rows;
@@ -126,6 +129,7 @@ public class FilteredAggregationsTest extends BaseQueriesTest {
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
         .addSingleValueDimension(NO_INDEX_INT_COL_NAME, FieldSpec.DataType.INT)
         .addSingleValueDimension(STATIC_INT_COL_NAME, FieldSpec.DataType.INT)
+        .addSingleValueDimension(BOOLEAN_COL_NAME, FieldSpec.DataType.BOOLEAN)
         .addMetric(INT_COL_NAME, FieldSpec.DataType.INT).build();
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
     config.setOutDir(INDEX_DIR.getPath());
@@ -153,8 +157,8 @@ public class FilteredAggregationsTest extends BaseQueriesTest {
 
   @Test
   public void testSimpleQueries() {
-    String filterQuery = "SELECT SUM(INT_COL) FILTER(WHERE INT_COL > 9999) FROM MyTable WHERE INT_COL < 1000000";
-    String nonFilterQuery = "SELECT SUM(INT_COL) FROM MyTable WHERE INT_COL > 9999 AND INT_COL < 1000000";
+    String filterQuery = "SELECT SUM(INT_COL) FILTER(WHERE BOOLEAN_COL) FROM MyTable";
+    String nonFilterQuery = "SELECT SUM(INT_COL) FROM MyTable WHERE BOOLEAN_COL";
     testQuery(filterQuery, nonFilterQuery);
 
     filterQuery = "SELECT SUM(INT_COL) FILTER(WHERE INT_COL < 3) FROM MyTable WHERE INT_COL > 1";


### PR DESCRIPTION
Fixes the bugs in #8444 and #8487.
Added unit tests.
