### PR TITLE
Add tracing for operator planning

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/BaseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/BaseOperator.java
@@ -35,7 +35,7 @@ public abstract class BaseOperator<T extends Block> implements Operator<T> {
     if (Thread.interrupted()) {
       throw new EarlyTerminationException();
     }
-    try (InvocationScope execution = Tracing.getTracer().createScope(getClass())) {
+    try (InvocationScope ignored = Tracing.getTracer().createScope(getClass())) {
       return getNextBlock();
     }
   }


### PR DESCRIPTION
Adds the tracing for the `CombinePlanNode`. We don't add tracing for individual plan node because planning is in general very cheap, but during cold start we can still observe time spent in planning the operators.