### PR TITLE
Upgrade Spark Version to 3.2.1

### DIFF
--- a/pinot-distribution/pom.xml
+++ b/pinot-distribution/pom.xml
@@ -34,6 +34,7 @@
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HHmmss'Z'</maven.build.timestamp.format>
+    <shade-prefix>shaded.pinot</shade-prefix>
   </properties>
   <dependencies>
     <dependency>
@@ -173,31 +174,31 @@
               <relocations>
                 <relocation>
                   <pattern>com.google.common</pattern>
-                  <shadedPattern>shaded.com.google.common</shadedPattern>
+                  <shadedPattern>${shade-prefix}.com.google.common</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>com.fasterxml.jackson</pattern>
-                  <shadedPattern>shaded.com.fasterxml.jackson</shadedPattern>
+                  <shadedPattern>${shade-prefix}.com.fasterxml.jackson</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.http</pattern>
-                  <shadedPattern>shaded.org.apache.http</shadedPattern>
+                  <shadedPattern>${shade-prefix}.org.apache.http</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>software.amazon</pattern>
-                  <shadedPattern>shaded.software.amazon</shadedPattern>
+                  <shadedPattern>${shade-prefix}.software.amazon</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.reflections</pattern>
-                  <shadedPattern>shaded.org.reflections</shadedPattern>
+                  <shadedPattern>${shade-prefix}.org.reflections</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>io.netty</pattern>
-                  <shadedPattern>shaded.io.netty</shadedPattern>
+                  <shadedPattern>${shade-prefix}.io.netty</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>org.apache.parquet</pattern>
-                  <shadedPattern>shaded.org.apache.parquet</shadedPattern>
+                  <shadedPattern>${shade-prefix}.org.apache.parquet</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/pom.xml
@@ -36,8 +36,10 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>package</phase.prop>
-    <scala.binary.version>2.11</scala.binary.version>
-    <spark.version>2.4.0</spark.version>
+    <scala.major.version>2.12</scala.major.version>
+    <spark.version>3.2.1</spark.version>
+    <scala.minor.version>2.12.15</scala.minor.version>
+    <kryo.version>4.0.2</kryo.version>
   </properties>
 
   <dependencies>
@@ -48,47 +50,14 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <artifactId>spark-core_${scala.major.version}</artifactId>
       <version>${spark.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.scala-lang</groupId>
-          <artifactId>scala-library</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.twitter</groupId>
-          <artifactId>chill_2.11</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.twitter</groupId>
-          <artifactId>chill-java</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.curator</groupId>
-          <artifactId>curator-recipes</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.protobuf</groupId>
-          <artifactId>protobuf-java</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.zaxxer</groupId>
-          <artifactId>HikariCP-java7</artifactId>
-        </exclusion>
-      </exclusions>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>2.11.11</version>
+      <version>${scala.minor.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
@@ -114,5 +83,19 @@
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
     </dependency>
+    <!-- For testing import of csv files -->
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-csv</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.esotericsoftware</groupId>
+      <artifactId>kryo-shaded</artifactId>
+      <version>${kryo.version}</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/pom.xml
@@ -53,6 +53,40 @@
       <artifactId>spark-core_${scala.major.version}</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.scala-lang</groupId>
+          <artifactId>scala-library</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.curator</groupId>
+          <artifactId>curator-recipes</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.zaxxer</groupId>
+          <artifactId>HikariCP-java7</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.hk2.external</groupId>
+          <artifactId>jakarta.inject</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>jakarta.ws.rs</groupId>
+          <artifactId>jakarta.ws.rs-api</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.scala-lang</groupId>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/test/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunnerTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/test/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunnerTest.java
@@ -19,6 +19,10 @@
 package org.apache.pinot.plugin.ingestion.batch.spark;
 
 import com.google.common.collect.Lists;
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.plugin.inputformat.csv.CSVRecordReader;
 import org.apache.pinot.plugin.inputformat.csv.CSVRecordReaderConfig;
@@ -27,23 +31,23 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
-import org.apache.pinot.spi.ingestion.batch.spec.*;
+import org.apache.pinot.spi.ingestion.batch.spec.ExecutionFrameworkSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.RecordReaderSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.TableSpec;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.io.File;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.util.Collections;
-
 public class SparkSegmentGenerationJobRunnerTest {
 
     @BeforeClass
-    public void setup(){
-        JavaSparkContext javaSparkContext = new JavaSparkContext("local", SparkSegmentGenerationJobRunnerTest.class.getName());
+    public void setup() {
+        JavaSparkContext javaSparkContext = new JavaSparkContext("local",
+                SparkSegmentGenerationJobRunnerTest.class.getName());
     }
 
     @Test

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/test/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunnerTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/test/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunnerTest.java
@@ -1,0 +1,202 @@
+package org.apache.pinot.plugin.ingestion.batch.spark;
+
+import com.google.common.collect.Lists;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.plugin.inputformat.csv.CSVRecordReader;
+import org.apache.pinot.plugin.inputformat.csv.CSVRecordReaderConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.filesystem.LocalPinotFS;
+import org.apache.pinot.spi.ingestion.batch.spec.*;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Collections;
+
+public class SparkSegmentGenerationJobRunnerTest {
+    @Test
+    public void testSegmentGeneration() throws Exception {
+        // TODO use common resource definitions & code shared with Hadoop unit test.
+        // So probably need a pinot-batch-ingestion-common tests jar that we depend on.
+
+        File testDir = Files.createTempDirectory("testSegmentGeneration-").toFile();
+        testDir.delete();
+        testDir.mkdirs();
+
+        File inputDir = new File(testDir, "input");
+        inputDir.mkdirs();
+        File inputFile = new File(inputDir, "input.csv");
+        FileUtils.writeLines(inputFile, Lists.newArrayList("col1,col2", "value1,1", "value2,2"));
+
+        // Create an output directory, with two empty files in it. One we'll overwrite,
+        // and one we'll leave alone.
+        final String outputFilename = "myTable_OFFLINE_0.tar.gz";
+        final String existingFilename = "myTable_OFFLINE_100.tar.gz";
+        File outputDir = new File(testDir, "output");
+        FileUtils.touch(new File(outputDir, outputFilename));
+        FileUtils.touch(new File(outputDir, existingFilename));
+
+        // Set up schema file.
+        final String schemaName = "mySchema";
+        File schemaFile = new File(testDir, "schema");
+        Schema schema = new Schema.SchemaBuilder()
+                .setSchemaName(schemaName)
+                .addSingleValueDimension("col1", FieldSpec.DataType.STRING)
+                .addMetric("col2", FieldSpec.DataType.INT)
+                .build();
+        FileUtils.write(schemaFile, schema.toPrettyJsonString(), StandardCharsets.UTF_8);
+
+        // Set up table config file.
+        File tableConfigFile = new File(testDir, "tableConfig");
+        TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+                .setTableName("myTable")
+                .setSchemaName(schemaName)
+                .setNumReplicas(1)
+                .build();
+        FileUtils.write(tableConfigFile, tableConfig.toJsonString(), StandardCharsets.UTF_8);
+
+        SegmentGenerationJobSpec jobSpec = new SegmentGenerationJobSpec();
+        jobSpec.setJobType("SegmentCreation");
+        jobSpec.setInputDirURI(inputDir.toURI().toString());
+        jobSpec.setOutputDirURI(outputDir.toURI().toString());
+        jobSpec.setOverwriteOutput(false);
+
+        RecordReaderSpec recordReaderSpec = new RecordReaderSpec();
+        recordReaderSpec.setDataFormat("csv");
+        recordReaderSpec.setClassName(CSVRecordReader.class.getName());
+        recordReaderSpec.setConfigClassName(CSVRecordReaderConfig.class.getName());
+        jobSpec.setRecordReaderSpec(recordReaderSpec);
+
+        TableSpec tableSpec = new TableSpec();
+        tableSpec.setTableName("myTable");
+        tableSpec.setSchemaURI(schemaFile.toURI().toString());
+        tableSpec.setTableConfigURI(tableConfigFile.toURI().toString());
+        jobSpec.setTableSpec(tableSpec);
+
+        ExecutionFrameworkSpec efSpec = new ExecutionFrameworkSpec();
+        efSpec.setName("spark");
+        efSpec.setSegmentGenerationJobRunnerClassName(SparkSegmentGenerationJobRunner.class.getName());
+        jobSpec.setExecutionFrameworkSpec(efSpec);
+
+        PinotFSSpec pfsSpec = new PinotFSSpec();
+        pfsSpec.setScheme("file");
+        pfsSpec.setClassName(LocalPinotFS.class.getName());
+        jobSpec.setPinotFSSpecs(Collections.singletonList(pfsSpec));
+
+        SparkSegmentGenerationJobRunner jobRunner = new SparkSegmentGenerationJobRunner(jobSpec);
+        jobRunner.run();
+        // The output directory should still have the original file in it.
+        File oldSegmentFile = new File(outputDir, existingFilename);
+        Assert.assertTrue(oldSegmentFile.exists());
+
+        // The output directory should have the original file in it (since we aren't overwriting)
+        File newSegmentFile = new File(outputDir, outputFilename);
+        Assert.assertTrue(newSegmentFile.exists());
+        Assert.assertTrue(newSegmentFile.isFile());
+        Assert.assertTrue(newSegmentFile.length() == 0);
+
+        // Now run again, but this time with overwriting of output files, and confirm we got a valid segment file.
+        jobSpec.setOverwriteOutput(true);
+        jobRunner = new SparkSegmentGenerationJobRunner(jobSpec);
+        jobRunner.run();
+
+        // The original file should still be there.
+        Assert.assertTrue(oldSegmentFile.exists());
+
+        Assert.assertTrue(newSegmentFile.exists());
+        Assert.assertTrue(newSegmentFile.isFile());
+        Assert.assertTrue(newSegmentFile.length() > 0);
+
+        // FUTURE - validate contents of file?
+    }
+
+    @Test
+    public void testInputFilesWithSameNameInDifferentDirectories()
+            throws Exception {
+        File testDir = Files.createTempDirectory("testSegmentGeneration-").toFile();
+        testDir.delete();
+        testDir.mkdirs();
+
+        File inputDir = new File(testDir, "input");
+        File inputSubDir1 = new File(inputDir, "2009");
+        File inputSubDir2 = new File(inputDir, "2010");
+        inputSubDir1.mkdirs();
+        inputSubDir2.mkdirs();
+
+        File inputFile1 = new File(inputSubDir1, "input.csv");
+        FileUtils.writeLines(inputFile1, Lists.newArrayList("col1,col2", "value1,1", "value2,2"));
+
+        File inputFile2 = new File(inputSubDir2, "input.csv");
+        FileUtils.writeLines(inputFile2, Lists.newArrayList("col1,col2", "value3,3", "value4,4"));
+
+        File outputDir = new File(testDir, "output");
+
+        // Set up schema file.
+        final String schemaName = "mySchema";
+        File schemaFile = new File(testDir, "schema");
+        Schema schema = new Schema.SchemaBuilder()
+                .setSchemaName(schemaName)
+                .addSingleValueDimension("col1", FieldSpec.DataType.STRING)
+                .addMetric("col2", FieldSpec.DataType.INT)
+                .build();
+        FileUtils.write(schemaFile, schema.toPrettyJsonString(), StandardCharsets.UTF_8);
+
+        // Set up table config file.
+        File tableConfigFile = new File(testDir, "tableConfig");
+        TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+                .setTableName("myTable")
+                .setSchemaName(schemaName)
+                .setNumReplicas(1)
+                .build();
+        FileUtils.write(tableConfigFile, tableConfig.toJsonString(), StandardCharsets.UTF_8);
+
+        SegmentGenerationJobSpec jobSpec = new SegmentGenerationJobSpec();
+        jobSpec.setJobType("SegmentCreation");
+        jobSpec.setInputDirURI(inputDir.toURI().toString());
+        jobSpec.setOutputDirURI(outputDir.toURI().toString());
+        jobSpec.setOverwriteOutput(true);
+
+        RecordReaderSpec recordReaderSpec = new RecordReaderSpec();
+        recordReaderSpec.setDataFormat("csv");
+        recordReaderSpec.setClassName(CSVRecordReader.class.getName());
+        recordReaderSpec.setConfigClassName(CSVRecordReaderConfig.class.getName());
+        jobSpec.setRecordReaderSpec(recordReaderSpec);
+
+        TableSpec tableSpec = new TableSpec();
+        tableSpec.setTableName("myTable");
+        tableSpec.setSchemaURI(schemaFile.toURI().toString());
+        tableSpec.setTableConfigURI(tableConfigFile.toURI().toString());
+        jobSpec.setTableSpec(tableSpec);
+
+        ExecutionFrameworkSpec efSpec = new ExecutionFrameworkSpec();
+        efSpec.setName("spark");
+        efSpec.setSegmentGenerationJobRunnerClassName(SparkSegmentGenerationJobRunner.class.getName());
+        jobSpec.setExecutionFrameworkSpec(efSpec);
+
+        PinotFSSpec pfsSpec = new PinotFSSpec();
+        pfsSpec.setScheme("file");
+        pfsSpec.setClassName(LocalPinotFS.class.getName());
+        jobSpec.setPinotFSSpecs(Collections.singletonList(pfsSpec));
+
+        SparkSegmentGenerationJobRunner jobRunner = new SparkSegmentGenerationJobRunner(jobSpec);
+        jobRunner.run();
+
+        // Check that both segment files are created
+
+        File newSegmentFile2009 = new File(outputDir, "2009/myTable_OFFLINE_0.tar.gz");
+        Assert.assertTrue(newSegmentFile2009.exists());
+        Assert.assertTrue(newSegmentFile2009.isFile());
+        Assert.assertTrue(newSegmentFile2009.length() > 0);
+
+        File newSegmentFile2010 = new File(outputDir, "2010/myTable_OFFLINE_0.tar.gz");
+        Assert.assertTrue(newSegmentFile2010.exists());
+        Assert.assertTrue(newSegmentFile2010.isFile());
+        Assert.assertTrue(newSegmentFile2010.length() > 0);
+    }
+}

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/test/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunnerTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/test/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunnerTest.java
@@ -20,7 +20,7 @@ import java.nio.file.Files;
 import java.util.Collections;
 
 public class SparkSegmentGenerationJobRunnerTest {
-    @Test
+    @Test(enabled = false)
     public void testSegmentGeneration() throws Exception {
         // TODO use common resource definitions & code shared with Hadoop unit test.
         // So probably need a pinot-batch-ingestion-common tests jar that we depend on.
@@ -116,7 +116,7 @@ public class SparkSegmentGenerationJobRunnerTest {
         // FUTURE - validate contents of file?
     }
 
-    @Test
+    @Test(enabled = false)
     public void testInputFilesWithSameNameInDifferentDirectories()
             throws Exception {
         File testDir = Files.createTempDirectory("testSegmentGeneration-").toFile();

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/test/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunnerTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/src/test/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunnerTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.plugin.ingestion.batch.spark;
 
 import com.google.common.collect.Lists;
@@ -11,7 +29,9 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
 import org.apache.pinot.spi.ingestion.batch.spec.*;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.spark.api.java.JavaSparkContext;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -20,7 +40,13 @@ import java.nio.file.Files;
 import java.util.Collections;
 
 public class SparkSegmentGenerationJobRunnerTest {
-    @Test(enabled = false)
+
+    @BeforeClass
+    public void setup(){
+        JavaSparkContext javaSparkContext = new JavaSparkContext("local", SparkSegmentGenerationJobRunnerTest.class.getName());
+    }
+
+    @Test
     public void testSegmentGeneration() throws Exception {
         // TODO use common resource definitions & code shared with Hadoop unit test.
         // So probably need a pinot-batch-ingestion-common tests jar that we depend on.
@@ -116,7 +142,7 @@ public class SparkSegmentGenerationJobRunnerTest {
         // FUTURE - validate contents of file?
     }
 
-    @Test(enabled = false)
+    @Test
     public void testInputFilesWithSameNameInDifferentDirectories()
             throws Exception {
         File testDir = Files.createTempDirectory("testSegmentGeneration-").toFile();

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
     <parquet.version>1.11.1</parquet.version>
     <helix.version>0.9.8</helix.version>
     <zkclient.version>0.7</zkclient.version>
-    <jackson.version>2.10.0</jackson.version>
+    <jackson.version>2.12.6</jackson.version>
     <zookeeper.version>3.5.8</zookeeper.version>
     <async-http-client.version>2.12.3</async-http-client.version>
     <jersey.version>2.28</jersey.version>
@@ -465,7 +465,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.5</version>
+        <version>3.11</version>
       </dependency>
       <dependency>
         <groupId>commons-collections</groupId>


### PR DESCRIPTION
- Upgrading Spark Version to 3.2.1 from 2.4.0. Also scope is set to `provided`
- Requires upgrade of Scala to 2.12
- Also, requires upgrade of Jackson libraries otherwise it throws 
     `Scala module 2.12.3 requires Jackson Databind version >= 2.12.0 and < 2.13.0`


Minor changes - 

* Changed shading prefix from `shaded` to `shaded.pinot`. The former is quite common and thus can still cause dependency conflicts when used with other modules.

Pending - 

* E2E verification