### PR TITLE
Only discover public methods annotated with @ScalarFunction

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionInfo.java
@@ -27,7 +27,6 @@ public class FunctionInfo {
   private final boolean _nullableParameters;
 
   public FunctionInfo(Method method, Class<?> clazz, boolean nullableParameters) {
-    method.setAccessible(true);
     _method = method;
     _clazz = clazz;
     _nullableParameters = nullableParameters;

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionInvoker.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionInvoker.java
@@ -53,7 +53,6 @@ public class FunctionInvoker {
       Class<?> clazz = functionInfo.getClazz();
       try {
         Constructor<?> constructor = functionInfo.getClazz().getDeclaredConstructor();
-        constructor.setAccessible(true);
         _instance = constructor.newInstance();
       } catch (Exception e) {
         throw new IllegalStateException("Caught exception while constructing class: " + clazz, e);

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
@@ -20,6 +20,7 @@ package org.apache.pinot.common.function;
 
 import com.google.common.base.Preconditions;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -59,6 +60,9 @@ public class FunctionRegistry {
             .setScanners(new MethodAnnotationsScanner()));
     Set<Method> methodSet = reflections.getMethodsAnnotatedWith(ScalarFunction.class);
     for (Method method : methodSet) {
+      if (!Modifier.isPublic(method.getModifiers())) {
+        continue;
+      }
       ScalarFunction scalarFunction = method.getAnnotation(ScalarFunction.class);
       if (scalarFunction.enabled()) {
         // Annotated function names

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluatorTest.java
@@ -140,10 +140,10 @@ public class InbuiltFunctionEvaluatorTest {
     }
   }
 
-  private static class MyFunc {
+  public static class MyFunc {
     String _baseString = "";
 
-    String appendToStringAndReturn(String addedString) {
+    public String appendToStringAndReturn(String addedString) {
       _baseString += addedString;
       return _baseString;
     }


### PR DESCRIPTION
Stop discovering private scalar functions to avoid unpredictable illegal reflective access.

This is a breaking change; if a user has a non-public method annotated with `@ScalarFunction` then it will no longer be evaluated. The migration path is for the user to make the appropriate methods public, since they own the code.