### PR TITLE
Add query option to use more replica groups

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -363,13 +363,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
     // Validate the request
     try {
-      int numReplicas = 1;
-      if (offlineTableConfig != null) {
-        numReplicas = offlineTableConfig.getValidationConfig().getReplicationNumber();
-      } else if (realtimeTableConfig != null) {
-        numReplicas = realtimeTableConfig.getValidationConfig().getReplicationNumber();
-      }
-      validateRequest(pinotQuery, _queryResponseLimit, numReplicas);
+      validateRequest(pinotQuery, _queryResponseLimit);
     } catch (Exception e) {
       LOGGER.info("Caught exception while validating request {}: {}, {}", requestId, query, e.getMessage());
       requestStatistics.setErrorCode(QueryException.QUERY_VALIDATION_ERROR_CODE);
@@ -2139,11 +2133,11 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
    * <ul>
    *   <li>Value for 'LIMIT' <= configured value</li>
    *   <li>Query options must be set to SQL mode</li>
-   *   <li>Check if numReplicaGroups option provided is valid</li>
+   *   <li>Check if numReplicaGroupsToQuery option provided is valid</li>
    * </ul>
    */
   @VisibleForTesting
-  static void validateRequest(PinotQuery pinotQuery, int queryResponseLimit, int numReplicas) {
+  static void validateRequest(PinotQuery pinotQuery, int queryResponseLimit) {
     // Verify LIMIT
     int limit = pinotQuery.getLimit();
     if (limit > queryResponseLimit) {
@@ -2158,17 +2152,21 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         || !QueryOptionsUtils.isResponseFormatSQL(queryOptions)) {
       throw new IllegalStateException("SQL query should always have response format and group-by mode set to SQL");
     }
-
-    // throw errors if options is less than 1, rectify if larger that current replicas
-    if (queryOptions.get(Broker.Request.QueryOptionKey.NUM_REPLICA_GROUPS) != null) {
-      Integer numReplicaGroups = QueryOptionsUtils.getNumReplicaGroups(queryOptions);
-      if (numReplicaGroups > numReplicas) {
-        queryOptions.put(Broker.Request.QueryOptionKey.NUM_REPLICA_GROUPS, String.valueOf(numReplicas));
+    try {
+    // throw errors if options is less than 1 or invalid
+      Integer numReplicaGroupsToQuery = QueryOptionsUtils.getNumReplicaGroupsToQuery(queryOptions);
+      if (numReplicaGroupsToQuery != null) {
+        Preconditions.checkState(numReplicaGroupsToQuery > 0, "numReplicaGroups must be "
+            + "positive number, got: %d", numReplicaGroupsToQuery);
       }
+    } catch (NumberFormatException ex) {
+      String numReplicaGroupsToQuery = queryOptions.get(Broker.Request.QueryOptionKey.NUM_REPLICA_GROUPS_TO_QUERY);
+      throw new IllegalStateException(String.format("numReplicaGroups must be a positive number, got: %s",
+          numReplicaGroupsToQuery));
     }
 
     if (pinotQuery.getDataSource().getSubquery() != null) {
-      validateRequest(pinotQuery.getDataSource().getSubquery(), queryResponseLimit, numReplicas);
+      validateRequest(pinotQuery.getDataSource().getSubquery(), queryResponseLimit);
     }
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BalancedInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BalancedInstanceSelector.java
@@ -39,7 +39,7 @@ public class BalancedInstanceSelector extends BaseInstanceSelector {
 
   @Override
   Map<String, String> select(List<String> segments, int requestId,
-      Map<String, List<String>> segmentToEnabledInstancesMap) {
+      Map<String, List<String>> segmentToEnabledInstancesMap, Map<String, String> queryOptions) {
     Map<String, String> segmentToSelectedInstanceMap = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
     for (String segment : segments) {
       List<String> enabledInstances = segmentToEnabledInstancesMap.get(segment);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
@@ -265,7 +265,11 @@ abstract class BaseInstanceSelector implements InstanceSelector {
   @Override
   public SelectionResult select(BrokerRequest brokerRequest, List<String> segments) {
     int requestId = (int) (_requestId.getAndIncrement() % MAX_REQUEST_ID);
-    Map<String, String> segmentToInstanceMap = select(segments, requestId, _segmentToEnabledInstancesMap);
+    Map<String, String> queryOptions = brokerRequest.getPinotQuery().getQueryOptions();
+    if (queryOptions == null) {
+      queryOptions = new HashMap<>();
+    }
+    Map<String, String> segmentToInstanceMap = select(segments, requestId, _segmentToEnabledInstancesMap, queryOptions);
     Set<String> unavailableSegments = _unavailableSegments;
     if (unavailableSegments.isEmpty()) {
       return new SelectionResult(segmentToInstanceMap, Collections.emptyList());
@@ -287,5 +291,5 @@ abstract class BaseInstanceSelector implements InstanceSelector {
    * ONLINE/CONSUMING instances). If enabled instances are not {@code null}, they are sorted in alphabetical order.
    */
   abstract Map<String, String> select(List<String> segments, int requestId,
-      Map<String, List<String>> segmentToEnabledInstancesMap);
+      Map<String, List<String>> segmentToEnabledInstancesMap, Map<String, String> queryOptions);
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
@@ -265,10 +265,10 @@ abstract class BaseInstanceSelector implements InstanceSelector {
   @Override
   public SelectionResult select(BrokerRequest brokerRequest, List<String> segments) {
     int requestId = (int) (_requestId.getAndIncrement() % MAX_REQUEST_ID);
-    Map<String, String> queryOptions = brokerRequest.getPinotQuery().getQueryOptions();
-    if (queryOptions == null) {
-      queryOptions = new HashMap<>();
-    }
+    Map<String, String> queryOptions = (brokerRequest.getPinotQuery() != null
+        && brokerRequest.getPinotQuery().getQueryOptions() != null)
+        ? brokerRequest.getPinotQuery().getQueryOptions()
+        : Collections.emptyMap();
     Map<String, String> segmentToInstanceMap = select(segments, requestId, _segmentToEnabledInstancesMap, queryOptions);
     Set<String> unavailableSegments = _unavailableSegments;
     if (unavailableSegments.isEmpty()) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
@@ -23,7 +23,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.utils.HashUtil;
-import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.core.util.QueryOptionsUtils;
 
 
 /**
@@ -41,6 +41,12 @@ import org.apache.pinot.spi.utils.CommonConstants;
  * request (there is no guarantee on choosing servers from the same replica-group though). In transitioning/error
  * scenario (external view does not match ideal state), there is no guarantee on picking the least server instances, but
  * the traffic is guaranteed to be evenly distributed to all available instances to avoid overwhelming hotspot servers.
+ *<p> If the query option NUM_REPLICA_GROUPS_TO_QUERY is provided, the servers to be picked will be from different
+ * replica groups such that segments are evenly distributed amongst the provided value of NUM_REPLICA_GROUPS_TO_QUERY.
+ * Thus in case of [S1, S2, S3] if NUM_REPLICA_GROUPS_TO_QUERY = 2, the ReplicaGroup S1 and ReplicaGroup S2 will be
+ * selected such that half the segments will come from S1 and other half from S2. If NUM_REPLICA_GROUPS_TO_QUERY value
+ * is much greater than available servers, then ReplicaGroupInstanceSelector will behave similar to
+ * BalancedInstanceSelector.
  */
 public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
 
@@ -52,24 +58,21 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
   Map<String, String> select(List<String> segments, int requestId,
       Map<String, List<String>> segmentToEnabledInstancesMap, Map<String, String> queryOptions) {
     Map<String, String> segmentToSelectedInstanceMap = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
-    // validate queryOptions to get query
-    String replicaGroup = queryOptions.get(CommonConstants.Broker.Request.QueryOptionKey.NUM_REPLICA_GROUPS);
-    int replicaGroupNum = 1;
-    int currentRequest = 0;
-    if (replicaGroup != null) {
-      replicaGroupNum = Integer.parseInt(replicaGroup);
-    }
+    int replicaOffset = 0;
+    Integer replicaGroup = QueryOptionsUtils.getNumReplicaGroupsToQuery(queryOptions);
+    int numReplicaGroupsToQuery = replicaGroup == null ? 1 : replicaGroup;
     for (String segment : segments) {
       List<String> enabledInstances = segmentToEnabledInstancesMap.get(segment);
       // NOTE: enabledInstances can be null when there is no enabled instances for the segment, or the instance selector
       // has not been updated (we update all components for routing in sequence)
       if (enabledInstances != null) {
         int numEnabledInstances = enabledInstances.size();
-        int instanceToSelect = (requestId + currentRequest++) % numEnabledInstances;
+        int instanceToSelect = (requestId + replicaOffset) % numEnabledInstances;
         segmentToSelectedInstanceMap.put(segment, enabledInstances.get(instanceToSelect));
-        if (currentRequest % replicaGroupNum == 0) {
-          currentRequest = 0;
+        if (numReplicaGroupsToQuery > numEnabledInstances) {
+          numReplicaGroupsToQuery = numEnabledInstances;
         }
+        replicaOffset = (replicaOffset + 1) % numReplicaGroupsToQuery;
       }
     }
     return segmentToSelectedInstanceMap;

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
@@ -202,6 +202,13 @@ public class QueryValidationTest {
     testRejectGroovyQuery("SELECT foo FROM bar", false);
   }
 
+  @Test
+  public void testReplicaGroupToQueryInvalidQuery() {
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT COUNT(*) FROM MY_TABLE "
+        + "OPTION(numReplicaGroupsToQuery=illegal)");
+    Assert.assertThrows(IllegalStateException.class, () -> BaseBrokerRequestHandler.validateRequest(pinotQuery, 10));
+  }
+
   private void testRejectGroovyQuery(String query, boolean queryContainsGroovy) {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
 
@@ -228,7 +235,7 @@ public class QueryValidationTest {
   private void testUnsupportedSQLQuery(String query, String errorMessage) {
     try {
       PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-      BaseBrokerRequestHandler.validateRequest(pinotQuery, 1000, 1);
+      BaseBrokerRequestHandler.validateRequest(pinotQuery, 1000);
       Assert.fail("Query should have failed");
     } catch (Exception e) {
       Assert.assertEquals(e.getMessage(), errorMessage);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
@@ -228,7 +228,7 @@ public class QueryValidationTest {
   private void testUnsupportedSQLQuery(String query, String errorMessage) {
     try {
       PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-      BaseBrokerRequestHandler.validateRequest(pinotQuery, 1000);
+      BaseBrokerRequestHandler.validateRequest(pinotQuery, 1000, 1);
       Assert.fail("Query should have failed");
     } catch (Exception e) {
       Assert.assertEquals(e.getMessage(), errorMessage);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -30,6 +30,7 @@ import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.spi.config.table.RoutingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -174,6 +175,9 @@ public class InstanceSelectorTest {
     //     segment2 -> instance1
     //     segment3 -> instance1
     BrokerRequest brokerRequest = mock(BrokerRequest.class);
+    PinotQuery pinotQuery = mock(PinotQuery.class);
+    when(brokerRequest.getPinotQuery()).thenReturn(pinotQuery);
+    when(pinotQuery.getQueryOptions()).thenReturn(null);
     Map<String, String> expectedBalancedInstanceSelectorResult = new HashMap<>();
     expectedBalancedInstanceSelectorResult.put(segment0, instance0);
     expectedBalancedInstanceSelectorResult.put(segment1, instance2);
@@ -582,6 +586,132 @@ public class InstanceSelectorTest {
   }
 
   @Test
+  public void testReplicaGroupInstanceSelectorNumReplicaGroups() {
+    String offlineTableName = "testTable_OFFLINE";
+    BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
+    BrokerRequest brokerRequest = mock(BrokerRequest.class);
+    PinotQuery pinotQuery = mock(PinotQuery.class);
+    Map<String, String> queryOptions = new HashMap<>();
+    queryOptions.put("numReplicaGroups", "2");
+    when(brokerRequest.getPinotQuery()).thenReturn(pinotQuery);
+    when(pinotQuery.getQueryOptions()).thenReturn(queryOptions);
+
+    ReplicaGroupInstanceSelector replicaGroupInstanceSelector =
+        new ReplicaGroupInstanceSelector(offlineTableName, brokerMetrics);
+
+    Set<String> enabledInstances = new HashSet<>();
+    IdealState idealState = new IdealState(offlineTableName);
+    Map<String, Map<String, String>> idealStateSegmentAssignment = idealState.getRecord().getMapFields();
+    ExternalView externalView = new ExternalView(offlineTableName);
+    Map<String, Map<String, String>> externalViewSegmentAssignment = externalView.getRecord().getMapFields();
+    Set<String> onlineSegments = new HashSet<>();
+
+    // 12 online segments with each segment having all 3 instances as online
+    // replicas are 3
+    String instance0 = "instance0";
+    String instance1 = "instance1";
+    String instance2 = "instance2";
+    enabledInstances.add(instance0);
+    enabledInstances.add(instance1);
+    enabledInstances.add(instance2);
+
+    String segment0 = "segment0";
+    String segment1 = "segment1";
+    String segment2 = "segment2";
+    String segment3 = "segment3";
+    String segment4 = "segment4";
+    String segment5 = "segment5";
+    String segment6 = "segment6";
+    String segment7 = "segment7";
+    String segment8 = "segment8";
+    String segment9 = "segment9";
+    String segment10 = "segment10";
+    String segment11 = "segment11";
+
+    Map<String, String> idealStateInstanceStateMap0 = new TreeMap<>();
+    idealStateInstanceStateMap0.put(instance0, ONLINE);
+    idealStateInstanceStateMap0.put(instance1, ONLINE);
+    idealStateInstanceStateMap0.put(instance2, ONLINE);
+    idealStateSegmentAssignment.put(segment0, idealStateInstanceStateMap0);
+    idealStateSegmentAssignment.put(segment1, idealStateInstanceStateMap0);
+    idealStateSegmentAssignment.put(segment2, idealStateInstanceStateMap0);
+    idealStateSegmentAssignment.put(segment3, idealStateInstanceStateMap0);
+    idealStateSegmentAssignment.put(segment4, idealStateInstanceStateMap0);
+    idealStateSegmentAssignment.put(segment5, idealStateInstanceStateMap0);
+    idealStateSegmentAssignment.put(segment6, idealStateInstanceStateMap0);
+    idealStateSegmentAssignment.put(segment7, idealStateInstanceStateMap0);
+    idealStateSegmentAssignment.put(segment8, idealStateInstanceStateMap0);
+    idealStateSegmentAssignment.put(segment9, idealStateInstanceStateMap0);
+    idealStateSegmentAssignment.put(segment10, idealStateInstanceStateMap0);
+    idealStateSegmentAssignment.put(segment11, idealStateInstanceStateMap0);
+
+    Map<String, String> externalViewInstanceStateMap0 = new TreeMap<>();
+    externalViewInstanceStateMap0.put(instance0, ONLINE);
+    externalViewInstanceStateMap0.put(instance1, ONLINE);
+    externalViewInstanceStateMap0.put(instance2, ONLINE);
+    externalViewSegmentAssignment.put(segment0, externalViewInstanceStateMap0);
+    externalViewSegmentAssignment.put(segment1, externalViewInstanceStateMap0);
+    externalViewSegmentAssignment.put(segment2, externalViewInstanceStateMap0);
+    externalViewSegmentAssignment.put(segment3, externalViewInstanceStateMap0);
+    externalViewSegmentAssignment.put(segment4, externalViewInstanceStateMap0);
+    externalViewSegmentAssignment.put(segment5, externalViewInstanceStateMap0);
+    externalViewSegmentAssignment.put(segment6, externalViewInstanceStateMap0);
+    externalViewSegmentAssignment.put(segment7, externalViewInstanceStateMap0);
+    externalViewSegmentAssignment.put(segment8, externalViewInstanceStateMap0);
+    externalViewSegmentAssignment.put(segment9, externalViewInstanceStateMap0);
+    externalViewSegmentAssignment.put(segment10, externalViewInstanceStateMap0);
+    externalViewSegmentAssignment.put(segment11, externalViewInstanceStateMap0);
+
+
+    onlineSegments.add(segment0);
+    onlineSegments.add(segment1);
+    onlineSegments.add(segment2);
+    onlineSegments.add(segment3);
+    onlineSegments.add(segment4);
+    onlineSegments.add(segment5);
+    onlineSegments.add(segment6);
+    onlineSegments.add(segment7);
+    onlineSegments.add(segment8);
+    onlineSegments.add(segment9);
+    onlineSegments.add(segment10);
+    onlineSegments.add(segment11);
+
+    List<String> segments = Arrays.asList(segment0, segment1, segment2, segment3, segment4, segment5, segment6,
+        segment7, segment8, segment9, segment10, segment11);
+    replicaGroupInstanceSelector.init(enabledInstances, idealState, externalView, onlineSegments);
+    //   ReplicaGroupInstanceSelector
+    //     segment0 -> instance0
+    //     segment2 -> instance0
+    //     segment4 -> instance0
+    //     segment6 -> instance0
+    //     segment8 -> instance0
+    //     segment10 -> instance0
+    //     segment1 -> instance1
+    //     segment3 -> instance1
+    //     segment5 -> instance1
+    //     segment7 -> instance1
+    //     segment9 -> instance1
+    //     segment11 -> instance1
+
+    Map<String, String> expectedReplicaGroupInstanceSelectorResult = new HashMap<>();
+    expectedReplicaGroupInstanceSelectorResult.put(segment0, instance0);
+    expectedReplicaGroupInstanceSelectorResult.put(segment1, instance1);
+    expectedReplicaGroupInstanceSelectorResult.put(segment2, instance0);
+    expectedReplicaGroupInstanceSelectorResult.put(segment3, instance1);
+    expectedReplicaGroupInstanceSelectorResult.put(segment4, instance0);
+    expectedReplicaGroupInstanceSelectorResult.put(segment5, instance1);
+    expectedReplicaGroupInstanceSelectorResult.put(segment6, instance0);
+    expectedReplicaGroupInstanceSelectorResult.put(segment7, instance1);
+    expectedReplicaGroupInstanceSelectorResult.put(segment8, instance0);
+    expectedReplicaGroupInstanceSelectorResult.put(segment9, instance1);
+    expectedReplicaGroupInstanceSelectorResult.put(segment10, instance0);
+    expectedReplicaGroupInstanceSelectorResult.put(segment11, instance1);
+    InstanceSelector.SelectionResult selectionResult = replicaGroupInstanceSelector.select(brokerRequest, segments);
+    assertEquals(selectionResult.getSegmentToInstanceMap(), expectedReplicaGroupInstanceSelectorResult);
+    assertTrue(selectionResult.getUnavailableSegments().isEmpty());
+  }
+
+  @Test
   public void testUnavailableSegments() {
     String offlineTableName = "testTable_OFFLINE";
     BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
@@ -632,6 +762,9 @@ public class InstanceSelectorTest {
     balancedInstanceSelector.init(enabledInstances, idealState, externalView, onlineSegments);
     strictReplicaGroupInstanceSelector.init(enabledInstances, idealState, externalView, onlineSegments);
     BrokerRequest brokerRequest = mock(BrokerRequest.class);
+    PinotQuery pinotQuery = mock(PinotQuery.class);
+    when(brokerRequest.getPinotQuery()).thenReturn(pinotQuery);
+    when(pinotQuery.getQueryOptions()).thenReturn(null);
     InstanceSelector.SelectionResult selectionResult = balancedInstanceSelector.select(brokerRequest, segments);
     assertTrue(selectionResult.getSegmentToInstanceMap().isEmpty());
     assertEquals(selectionResult.getUnavailableSegments(), Arrays.asList(segment0, segment1));

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
@@ -59,15 +59,9 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.SKIP_UPSERT));
   }
 
-  public static Integer getNumReplicaGroups(Map<String, String> queryOptions) {
-    String numReplicaGroups = queryOptions.get(Request.QueryOptionKey.NUM_REPLICA_GROUPS);
-    if (numReplicaGroups != null) {
-      int replicaGroups = Integer.parseInt(numReplicaGroups);
-      Preconditions.checkState(replicaGroups > 0, "numReplicaGroups must be positive, got: %s", numReplicaGroups);
-      return replicaGroups;
-    } else {
-      return null;
-    }
+  public static Integer getNumReplicaGroupsToQuery(Map<String, String> queryOptions) {
+    String numReplicaGroupsToQuery = queryOptions.get(Request.QueryOptionKey.NUM_REPLICA_GROUPS_TO_QUERY);
+    return numReplicaGroupsToQuery != null ? Integer.parseInt(numReplicaGroupsToQuery) : null;
   }
 
   @Nullable

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
@@ -59,6 +59,17 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.SKIP_UPSERT));
   }
 
+  public static Integer getNumReplicaGroups(Map<String, String> queryOptions) {
+    String numReplicaGroups = queryOptions.get(Request.QueryOptionKey.NUM_REPLICA_GROUPS);
+    if (numReplicaGroups != null) {
+      int replicaGroups = Integer.parseInt(numReplicaGroups);
+      Preconditions.checkState(replicaGroups > 0, "numReplicaGroups must be positive, got: %s", numReplicaGroups);
+      return replicaGroups;
+    } else {
+      return null;
+    }
+  }
+
   @Nullable
   public static Integer getMaxExecutionThreads(Map<String, String> queryOptions) {
     String maxExecutionThreadsString = queryOptions.get(Request.QueryOptionKey.MAX_EXECUTION_THREADS);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -247,7 +247,7 @@ public class CommonConstants {
         public static final String MAX_EXECUTION_THREADS = "maxExecutionThreads";
         public static final String MIN_SEGMENT_GROUP_TRIM_SIZE = "minSegmentGroupTrimSize";
         public static final String MIN_SERVER_GROUP_TRIM_SIZE = "minServerGroupTrimSize";
-        public static final String NUM_REPLICA_GROUPS = "numReplicaGroups";
+        public static final String NUM_REPLICA_GROUPS_TO_QUERY = "numReplicaGroupsToQuery";
       }
     }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -247,6 +247,7 @@ public class CommonConstants {
         public static final String MAX_EXECUTION_THREADS = "maxExecutionThreads";
         public static final String MIN_SEGMENT_GROUP_TRIM_SIZE = "minSegmentGroupTrimSize";
         public static final String MIN_SERVER_GROUP_TRIM_SIZE = "minServerGroupTrimSize";
+        public static final String NUM_REPLICA_GROUPS = "numReplicaGroups";
       }
     }
 


### PR DESCRIPTION
In case when the routingConfig is replicaGroup, user can provide an option to
fan out a query to x replicaGroups where 1 <= x <= replicaGroups so that more
resources could be used for an expensive query
Fixes  #8217

`Release Notes`

When the instance selection criteria for segments is based on replica groups `REPLICA_GROUP_INSTANCE_SELECTOR_TYPE`, the query goes to just one of the many replica groups, this helps in limiting the number of servers used to serve this query. This may sometimes have a negative effect on time consuming queries, which would get served slower. If we can somehow give an option to the user to fan their query to more replica groups, the query can be served faster. 
This PR will add an option to the Sql query `numReplicaGroupsToQuery` which will take a positive integer, specifying the number of replica groups the query should be fanned out to.

Eg: When the replica group is set to 3, and with 3 servers `S1, S2, S3.` All the segments will be available on all the servers and we would choose any of `S1 | S2 | S3` to serve the segments, with numReplicaGroupsToQuery set to 2 option passed with the query, we will chose two servers to serve the query with the number of segments coming equally from both the servers. 
An example query should look like : 
```
SELECT COUNT(*) FROM T GROUP BY A OPTION(numReplicaGroupsToQuery=2)
```

