### PR TITLE
endpoints to get and delete minion task metadata

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -393,7 +393,8 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     _helixResourceManager.start(_helixParticipantManager);
 
     LOGGER.info("Starting task resource manager");
-    _helixTaskResourceManager = new PinotHelixTaskResourceManager(new TaskDriver(_helixParticipantManager));
+    _helixTaskResourceManager =
+        new PinotHelixTaskResourceManager(_helixResourceManager, new TaskDriver(_helixParticipantManager));
 
     // Helix resource manager must be started in order to create PinotLLCRealtimeSegmentManager
     LOGGER.info("Starting realtime segment manager");

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/exception/NoTaskMetadataException.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/exception/NoTaskMetadataException.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.exception;
+
+public class NoTaskMetadataException extends RuntimeException {
+  public NoTaskMetadataException(String message) {
+    super(message);
+  }
+
+  public NoTaskMetadataException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -150,6 +150,28 @@ public class PinotTaskRestletResource {
   }
 
   @GET
+  @Path("/tasks/{taskType}/{tableNameWithType}/metadata")
+  @ApiOperation("Get task metadata for the given task type and table")
+  public String getTaskMetadataByTable(
+      @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType,
+      @ApiParam(value = "Table name with type", required = true) @PathParam("tableNameWithType")
+          String tableNameWithType) {
+    return _pinotHelixTaskResourceManager.getTaskMetadataByTable(taskType, tableNameWithType);
+  }
+
+  @DELETE
+  @Path("/tasks/{taskType}/{tableNameWithType}/metadata")
+  @ApiOperation("Delete task metadata for the given task type and table")
+  public SuccessResponse deleteTaskMetadataByTable(
+      @ApiParam(value = "Task type", required = true) @PathParam("taskType") String taskType,
+      @ApiParam(value = "Table name with type", required = true) @PathParam("tableNameWithType")
+          String tableNameWithType) {
+    _pinotHelixTaskResourceManager.deleteTaskMetadataByTable(taskType, tableNameWithType);
+    return new SuccessResponse(
+        String.format("Successfully deleted metadata for task type: %s from table: %s", taskType, tableNameWithType));
+  }
+
+  @GET
   @Path("/tasks/{taskType}/taskcounts")
   @ApiOperation("Fetch count of sub-tasks for each of the tasks for the given task type")
   public Map<String, PinotHelixTaskResourceManager.TaskCount> getTaskCounts(

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
@@ -20,6 +20,7 @@ package org.apache.pinot.controller.helix.core.minion;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.Uninterruptibles;
 import java.util.ArrayList;
@@ -35,6 +36,8 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.commons.lang.StringUtils;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.task.JobConfig;
 import org.apache.helix.task.JobContext;
 import org.apache.helix.task.JobQueue;
@@ -44,10 +47,13 @@ import org.apache.helix.task.TaskPartitionState;
 import org.apache.helix.task.TaskState;
 import org.apache.helix.task.WorkflowConfig;
 import org.apache.helix.task.WorkflowContext;
+import org.apache.pinot.common.minion.MinionTaskMetadataUtils;
 import org.apache.pinot.common.utils.DateTimeUtils;
 import org.apache.pinot.controller.api.exception.UnknownTaskTypeException;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.spi.utils.CommonConstants.Helix;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,8 +74,10 @@ public class PinotHelixTaskResourceManager {
   private static final String TASK_PREFIX = "Task" + TASK_NAME_SEPARATOR;
 
   private final TaskDriver _taskDriver;
+  private final PinotHelixResourceManager _helixResourceManager;
 
-  public PinotHelixTaskResourceManager(TaskDriver taskDriver) {
+  public PinotHelixTaskResourceManager(PinotHelixResourceManager helixResourceManager, TaskDriver taskDriver) {
+    _helixResourceManager = helixResourceManager;
     _taskDriver = taskDriver;
   }
 
@@ -234,8 +242,7 @@ public class PinotHelixTaskResourceManager {
     Preconditions.checkState(numConcurrentTasksPerInstance > 0);
 
     String taskType = pinotTaskConfigs.get(0).getTaskType();
-    String parentTaskName =
-        getParentTaskName(taskType, UUID.randomUUID() + "_" + System.currentTimeMillis());
+    String parentTaskName = getParentTaskName(taskType, UUID.randomUUID() + "_" + System.currentTimeMillis());
     return submitTask(parentTaskName, pinotTaskConfigs, minionInstanceTag, taskTimeoutMs,
         numConcurrentTasksPerInstance);
   }
@@ -641,6 +648,23 @@ public class PinotHelixTaskResourceManager {
 
   public String getParentTaskName(String taskType, String taskName) {
     return TASK_PREFIX + taskType + TASK_NAME_SEPARATOR + taskName;
+  }
+
+  public String getTaskMetadataByTable(String taskType, String tableNameWithType) {
+    ZkHelixPropertyStore<ZNRecord> propertyStore = _helixResourceManager.getPropertyStore();
+    ZNRecord raw = MinionTaskMetadataUtils.fetchTaskMetadata(propertyStore, taskType, tableNameWithType);
+    Preconditions
+        .checkState(raw != null, "Found task metadata for task type: %s for table: %s", taskType, tableNameWithType);
+    try {
+      return JsonUtils.objectToString(raw);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to convert task metadata to Json format", e);
+    }
+  }
+
+  public void deleteTaskMetadataByTable(String taskType, String tableNameWithType) {
+    ZkHelixPropertyStore<ZNRecord> propertyStore = _helixResourceManager.getPropertyStore();
+    MinionTaskMetadataUtils.deleteTaskMetadata(propertyStore, taskType, tableNameWithType);
   }
 
   @JsonPropertyOrder({"taskState", "subtaskCount", "startTime", "executionStartTime", "subtaskInfos"})


### PR DESCRIPTION
add two minion tasks related endpoints to allow GET and DELETE /tasks/{taskType}/{tableNameWithType}/metadata 
