### PR TITLE
Fix BigDecimal ser/de on negative scale

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/BigDecimalUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/BigDecimalUtils.java
@@ -42,7 +42,7 @@ public class BigDecimalUtils {
     BigInteger unscaledValue = value.unscaledValue();
     byte[] unscaledValueBytes = unscaledValue.toByteArray();
     byte[] valueBytes = new byte[unscaledValueBytes.length + 2];
-    valueBytes[0] = (byte) (scale >>> 8);
+    valueBytes[0] = (byte) (scale >> 8);
     valueBytes[1] = (byte) scale;
     System.arraycopy(unscaledValueBytes, 0, valueBytes, 2, unscaledValueBytes.length);
     return valueBytes;
@@ -52,7 +52,7 @@ public class BigDecimalUtils {
    * Deserializes a big decimal from a byte array.
    */
   public static BigDecimal deserialize(byte[] bytes) {
-    int scale = ((bytes[0] & 0xFF) << 8) | (bytes[1] & 0xFF);
+    int scale = (short) ((bytes[0] & 0xFF) << 8) | (bytes[1] & 0xFF);
     byte[] unscaledValueBytes = new byte[bytes.length - 2];
     System.arraycopy(bytes, 2, unscaledValueBytes, 0, unscaledValueBytes.length);
     BigInteger unscaledValue = new BigInteger(unscaledValueBytes);

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/BigDecimalUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/BigDecimalUtilsTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.spi.utils;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -34,8 +35,15 @@ public class BigDecimalUtilsTest {
     BigDecimal deserializedValue = BigDecimalUtils.deserialize(serializedValue);
     assertEquals(deserializedValue, value);
 
+    // Set the scale to a negative value
+    value = value.setScale(-1, RoundingMode.HALF_UP);
+    serializedValue = BigDecimalUtils.serialize(value);
+    assertEquals(BigDecimalUtils.byteSize(value), serializedValue.length);
+    deserializedValue = BigDecimalUtils.deserialize(serializedValue);
+    assertEquals(deserializedValue, value);
+
     // Set the scale to a negative value in byte
-    value = value.setScale(128, BigDecimal.ROUND_UNNECESSARY);
+    value = value.setScale(128, RoundingMode.HALF_UP);
     serializedValue = BigDecimalUtils.serialize(value);
     assertEquals(BigDecimalUtils.byteSize(value), serializedValue.length);
     deserializedValue = BigDecimalUtils.deserialize(serializedValue);


### PR DESCRIPTION
Fix the bug in BigDecimal deserialization where negative scale will be read as positive