### PR TITLE
Make spark-core dependency provided

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark/pom.xml
@@ -50,6 +50,7 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
       <version>${spark.version}</version>
+      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>org.scala-lang</groupId>


### PR DESCRIPTION
Spark-core classes in Pinot currently creates a lot of conflicts with spark runtime classes present in user environment.  These dependencies should not be part of the jar in the first place. 

[Spark docs](https://spark.apache.org/docs/latest/cluster-overview.html) recommend the same - 

```
Application jar | A jar containing the user's Spark application. In some cases users will want to create an "uber jar" containing their application along with its dependencies. The user's jar should never include Hadoop or Spark libraries, however, these will be added at runtime.
```

