### PR TITLE
Simplify the parameters for DistinctCountSmartHLLAggregationFunction

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperator.java
@@ -231,9 +231,9 @@ public class NonScanBasedAggregationOperator extends BaseOperator<IntermediateRe
 
   private static Object getDistinctCountSmartHLLResult(Dictionary dictionary,
       DistinctCountSmartHLLAggregationFunction function) {
-    if (dictionary.length() > function.getHllConversionThreshold()) {
+    if (dictionary.length() > function.getThreshold()) {
       // Store values into a HLL when the dictionary size exceeds the conversion threshold
-      return getDistinctValueHLL(dictionary, function.getHllLog2m());
+      return getDistinctValueHLL(dictionary, function.getLog2m());
     } else {
       return getDistinctValueSet(dictionary);
     }


### PR DESCRIPTION
Currently the parameters for the `DistinctCountSmartHLLAggregationFunction` is too long and can be hard to use. Since they are always under the scope of the function, we may simplify them for usability. The old parameter keys are still supported.

## Release Notes
Change the following parameter keys for `DISTINCT_COUNT_SMART_HLL` aggregation function:
- `hllConversionThreshold` -> `threshold`
- `hllLog2m` ->`log2m`