### PR TITLE
Use MultiThreadedHttpConnectionManager in SegmentStatusChecker

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/http/MultiGetRequest.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/http/MultiGetRequest.java
@@ -38,9 +38,9 @@ import org.slf4j.LoggerFactory;
  *
  * The execute method is re-usable but there is no real benefit to it. All
  * the connection management is handled by the input HttpConnectionManager.
- * For access through multiple-threads, use MultiThreadedHttpConnectionManager
- * as shown in the example below.
- *
+ * Note that we cannot use SimpleHttpConnectionManager as it is not thread
+ * safe. Use MultiThreadedHttpConnectionManager as shown in the example
+ * below
  * Usage:
  * <pre>
  * {@code
@@ -74,6 +74,8 @@ public class MultiGetRequest {
   private static final Logger LOGGER = LoggerFactory.getLogger(MultiGetRequest.class);
 
   private final Executor _executor;
+  // TODO: Verify that _connectionManager is an instaceOf MultithreadedHttpConnectionManager.
+  //       SimpleHttpConnectionManager is not thread-safe.
   private final HttpConnectionManager _connectionManager;
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.httpclient.SimpleHttpConnectionManager;
+import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
@@ -82,8 +82,9 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
         controllerMetrics);
 
     _waitForPushTimeSeconds = config.getStatusCheckerWaitForPushTimeInSeconds();
-    _tableSizeReader = new TableSizeReader(executorService, new SimpleHttpConnectionManager(true), _controllerMetrics,
-        _pinotHelixResourceManager);
+    _tableSizeReader =
+        new TableSizeReader(executorService, new MultiThreadedHttpConnectionManager(), _controllerMetrics,
+            _pinotHelixResourceManager);
   }
 
   @Override


### PR DESCRIPTION
Currently, SegmentStatusChecker initializes an object of type
SimpleHttpConnectionManager. Further down the stack, we use this object to
issue parallel HTTP GET requests to multiple servers containing segments for
the table (in MultiGetRequest). However, SimpleHttpConnectionManager is not
thread safe. So we should be using an instance of MultithreadedHttpConnectionManager.

Added a TODO to improve MultiGetRequest.java to only work on HttpConnectionManager
object that is an instanceOf MultithreadedHttpConnectionManager.
