### PR TITLE
Improve StarTree traversal performance

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/operator/StarTreeFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/operator/StarTreeFilterOperator.java
@@ -21,13 +21,13 @@ package org.apache.pinot.core.startree.operator;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -235,7 +235,7 @@ public class StarTreeFilterOperator extends BaseFilterOperator {
     StarTreeNode starTreeRootNode = starTree.getRoot();
 
     // Use BFS to traverse the star tree
-    Queue<SearchEntry> queue = new LinkedList<>();
+    Queue<SearchEntry> queue = new ArrayDeque<>();
     queue.add(new SearchEntry(starTreeRootNode, _predicateEvaluatorsMap.keySet(), _groupByColumns));
     SearchEntry searchEntry;
     while ((searchEntry = queue.poll()) != null) {

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkQueries.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkQueries.java
@@ -38,10 +38,13 @@ import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoa
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair;
 import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -150,6 +153,9 @@ public class BenchmarkQueries extends BaseQueriesTest {
       + "MIN(RAW_INT_COL), MAX(RAW_INT_COL), COUNT(*) "
       + "FROM MyTable";
 
+  public static final String STARTREE_SUM_QUERY = "SELECT INT_COL, SORTED_COL, SUM(RAW_INT_COL) from MyTable "
+      + "GROUP BY INT_COL, SORTED_COL ORDER BY SORTED_COL, INT_COL ASC";
+
   @Param("1500000")
   private int _numRows;
   @Param({"EXP(0.001)", "EXP(0.5)", "EXP(0.999)"})
@@ -158,7 +164,7 @@ public class BenchmarkQueries extends BaseQueriesTest {
       MULTI_GROUP_BY_WITH_RAW_QUERY, MULTI_GROUP_BY_WITH_RAW_QUERY_2, FILTERED_QUERY, NON_FILTERED_QUERY,
       SUM_QUERY, NO_INDEX_LIKE_QUERY, MULTI_GROUP_BY_ORDER_BY, MULTI_GROUP_BY_ORDER_BY_LOW_HIGH, TIME_GROUP_BY,
       RAW_COLUMN_SUMMARY_STATS, COUNT_OVER_BITMAP_INDEX_IN, COUNT_OVER_BITMAP_INDEXES,
-      COUNT_OVER_BITMAP_AND_SORTED_INDEXES, COUNT_OVER_BITMAP_INDEX_EQUALS
+      COUNT_OVER_BITMAP_AND_SORTED_INDEXES, COUNT_OVER_BITMAP_INDEX_EQUALS, STARTREE_SUM_QUERY
   })
   String _query;
   private IndexSegment _indexSegment;
@@ -230,6 +236,10 @@ public class BenchmarkQueries extends BaseQueriesTest {
         .setFieldConfigList(fieldConfigs)
         .setNoDictionaryColumns(Arrays.asList(RAW_INT_COL_NAME, RAW_STRING_COL_NAME))
         .setSortedColumn(SORTED_COL_NAME)
+        .setStarTreeIndexConfigs(Collections.singletonList(new StarTreeIndexConfig(
+            Arrays.asList(SORTED_COL_NAME, INT_COL_NAME), null, Collections.singletonList(
+                new AggregationFunctionColumnPair(AggregationFunctionType.SUM, RAW_INT_COL_NAME).toColumnName()),
+            Integer.MAX_VALUE)))
         .build();
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
         .addSingleValueDimension(SORTED_COL_NAME, FieldSpec.DataType.INT)


### PR DESCRIPTION
1. Replace `LinkedList` with `ArrayDeque` for storing search entries in the bread-first traversal.
2. Delay deserialization of most of the `OffHeapStarTreeNode` fields until the fields are used, because most are never used during a traversal.

Change 1 this is motivated by a profile of a StarTree over a high cardinality dimension where the `LinkedList` is of a size large enough to cause problems, resulting in a large number of (doubly-linked) `LinkedList$Node` objects allocated. `ArrayDeque` just stores the values in an array which it maintains as a circular buffer
<img width="1027" alt="Screenshot 2022-04-20 at 13 31 00" src="https://user-images.githubusercontent.com/16439049/164230787-6c304c49-2601-4209-b98e-6d11242e3532.png">

Change 2 is motivated by a observing a lot of samples being taken within `OffHeapStarTreeNode$1.next` 
<img width="847" alt="Screenshot 2022-04-20 at 13 35 01" src="https://user-images.githubusercontent.com/16439049/164231624-fbdeb8e7-b05f-43a6-8472-1c9e8d7fc885.png">

There is also a high allocation rate of `OffHeapStarTreeNode` objects:
<img width="1266" alt="Screenshot 2022-04-20 at 13 36 48" src="https://user-images.githubusercontent.com/16439049/164231771-1f9eed17-8860-48aa-9233-5b8fe18818de.png">

Reducing the number of fields reduces the size of instances when compressed references are enabled by half: 

before:
```
org.apache.pinot.segment.local.startree.OffHeapStarTreeNode object internals:
OFF  SZ                                                  TYPE DESCRIPTION                            VALUE
  0   8                                                       (object header: mark)                  N/A
  8   4                                                       (object header: class)                 N/A
 12   4                                                   int OffHeapStarTreeNode._dimensionId       N/A
 16   4                                                   int OffHeapStarTreeNode._dimensionValue    N/A
 20   4                                                   int OffHeapStarTreeNode._startDocId        N/A
 24   4                                                   int OffHeapStarTreeNode._endDocId          N/A
 28   4                                                   int OffHeapStarTreeNode._aggregatedDocId   N/A
 32   4                                                   int OffHeapStarTreeNode._firstChildId      N/A
 36   4                                                   int OffHeapStarTreeNode._lastChildId       N/A
 40   4   org.apache.pinot.segment.spi.memory.PinotDataBuffer OffHeapStarTreeNode._dataBuffer        N/A
 44   4                                                       (object alignment gap)                 
Instance size: 48 bytes
Space losses: 0 bytes internal + 4 bytes external = 4 bytes total
```

after:
```
org.apache.pinot.segment.local.startree.OffHeapStarTreeNode object internals:
OFF  SZ                                                  TYPE DESCRIPTION                         VALUE
  0   8                                                       (object header: mark)               N/A
  8   4                                                       (object header: class)              N/A
 12   4                                                   int OffHeapStarTreeNode._nodeId         N/A
 16   4                                                   int OffHeapStarTreeNode._firstChildId   N/A
 20   4   org.apache.pinot.segment.spi.memory.PinotDataBuffer OffHeapStarTreeNode._dataBuffer     N/A
Instance size: 24 bytes
Space losses: 0 bytes internal + 0 bytes external = 0 bytes total
```