### PR TITLE
range index shouldn’t be loaded when the column is sorted

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
@@ -123,7 +123,7 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
       _bloomFilter = null;
     }
 
-    if (loadRangeIndex) {
+    if (loadRangeIndex && !metadata.isSorted()) {
       PinotDataBuffer buffer = segmentReader.getIndexFor(columnName, ColumnIndexType.RANGE_INDEX);
       _rangeIndex = indexReaderProvider.newRangeIndexReader(buffer, metadata);
     } else {


### PR DESCRIPTION
This PR fixes a bug where an attempt is made to load a range index for sorted columns.