### PR TITLE
Adding missing prometheus metrics to controller.yml

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
@@ -123,3 +123,18 @@ rules:
   labels:
     table: "$1"
     tableType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.tableTotalSizeOnServer.(\\w+)_(\\w+)\"><>(\\w+)"
+  name: "pinot_controller_tableTotalSizeOnServer_$3"
+  labels:
+    table: "$1"
+    tableType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.tableSizePerReplicaOnServer.(\\w+)_(\\w+)\"><>(\\w+)"
+  name: "pinot_controller_tableSizePerReplicaOnServer_$3"
+  labels:
+    table: "$1"
+    tableType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.tableCompressedSize.(\\w+)_(\\w+)\"><>(\\w+)"
+  name: "pinot_controller_tableCompressedSize_$3"
+  labels:
+    table: "$1"
+    tableType: "$2"


### PR DESCRIPTION
Initially added new metrics to the pinot.yml file [PR](https://github.com/apache/pinot/pull/8358) which is now deprecated. PR should be tagged with `observability`.