### PR TITLE
Add TLS configuration to JDBC driver

### DIFF
--- a/pinot-clients/pinot-jdbc-client/pom.xml
+++ b/pinot-clients/pinot-jdbc-client/pom.xml
@@ -66,6 +66,10 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <scope>test</scope>

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/PinotControllerTransportFactory.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/PinotControllerTransportFactory.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.client.controller;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.net.ssl.SSLContext;
+import org.apache.pinot.spi.utils.CommonConstants;
+
+
+public class PinotControllerTransportFactory {
+  private Map<String, String> _headers = new HashMap<>();
+  private String _scheme = CommonConstants.HTTP_PROTOCOL;
+  private SSLContext _sslContext = null;
+
+  public PinotControllerTransport buildTransport() {
+    return new PinotControllerTransport(_headers, _scheme, _sslContext);
+  }
+
+  public Map<String, String> getHeaders() {
+    return _headers;
+  }
+
+  public void setHeaders(Map<String, String> headers) {
+    _headers = headers;
+  }
+
+  public String getScheme() {
+    return _scheme;
+  }
+
+  public void setScheme(String scheme) {
+    _scheme = scheme;
+  }
+
+  public SSLContext getSslContext() {
+    return _sslContext;
+  }
+
+  public void setSslContext(SSLContext sslContext) {
+    _sslContext = sslContext;
+  }
+}

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
@@ -27,7 +27,10 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.net.ssl.SSLContext;
+import org.apache.commons.configuration.MapConfiguration;
+import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.utils.TlsUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,33 +39,18 @@ public class DriverUtils {
   public static final String SCHEME = "jdbc";
   public static final String DRIVER = "pinot";
   public static final Logger LOG = LoggerFactory.getLogger(DriverUtils.class);
-  public static final String QUERY_SEPERATOR = "&";
-  public static final String PARAM_SEPERATOR = "=";
-  public static final String CONTROLLER = "controller";
   private static final String LIMIT_STATEMENT_REGEX = "\\s(limit)\\s";
 
   // SSL Properties
-  public static final String KEYSTORE_TYPE = "keystore.type";
-  public static final String KEYSTORE_PATH = "keystore.path";
-  public static final String KEYSTORE_PASSWORD = "keystore.password";
-  public static final String TRUSTSTORE_TYPE = "truststore.type";
-  public static final String TRUSTSTORE_PATH = "truststore.path";
-  public static final String TRUSTSTORE_PASSWORD = "truststore.password";
+  public static final String PINOT_JDBC_TLS_PREFIX = "pinot.jdbc.tls";
 
   private DriverUtils() {
   }
 
   public static SSLContext getSSLContextFromJDBCProps(Properties properties) {
-    String keyStorePath = properties.getProperty(KEYSTORE_PATH);
-    String keyStoreType = properties.getProperty(KEYSTORE_TYPE);
-    String keyStorePass = properties.getProperty(KEYSTORE_PASSWORD);
-
-    String trustStorePath = properties.getProperty(TRUSTSTORE_PATH);
-    String trustStoreType = properties.getProperty(TRUSTSTORE_TYPE);
-    String trustStorePass = properties.getProperty(TRUSTSTORE_PASSWORD);
-
-    TlsUtils.installDefaultSSLSocketFactory(keyStoreType, keyStorePath, keyStorePass,
-        trustStoreType, trustStorePath, trustStorePass);
+    TlsConfig tlsConfig = TlsUtils.extractTlsConfig(
+        new PinotConfiguration(new MapConfiguration(properties)), PINOT_JDBC_TLS_PREFIX);
+    TlsUtils.installDefaultSSLSocketFactory(tlsConfig);
     return TlsUtils.getSslContext();
   }
 

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
@@ -23,8 +23,11 @@ import java.sql.Timestamp;
 import java.sql.Types;
 import java.util.Collections;
 import java.util.List;
+import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.net.ssl.SSLContext;
+import org.apache.pinot.common.utils.TlsUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +41,29 @@ public class DriverUtils {
   public static final String CONTROLLER = "controller";
   private static final String LIMIT_STATEMENT_REGEX = "\\s(limit)\\s";
 
+  // SSL Properties
+  public static final String KEYSTORE_TYPE = "keystore.type";
+  public static final String KEYSTORE_PATH = "keystore.path";
+  public static final String KEYSTORE_PASSWORD = "keystore.password";
+  public static final String TRUSTSTORE_TYPE = "truststore.type";
+  public static final String TRUSTSTORE_PATH = "truststore.path";
+  public static final String TRUSTSTORE_PASSWORD = "truststore.password";
+
   private DriverUtils() {
+  }
+
+  public static SSLContext getSSLContextFromJDBCProps(Properties properties) {
+    String keyStorePath = properties.getProperty(KEYSTORE_PATH);
+    String keyStoreType = properties.getProperty(KEYSTORE_TYPE);
+    String keyStorePass = properties.getProperty(KEYSTORE_PASSWORD);
+
+    String trustStorePath = properties.getProperty(TRUSTSTORE_PATH);
+    String trustStoreType = properties.getProperty(TRUSTSTORE_TYPE);
+    String trustStorePass = properties.getProperty(TRUSTSTORE_PASSWORD);
+
+    TlsUtils.installDefaultSSLSocketFactory(keyStoreType, keyStorePath, keyStorePass,
+        trustStoreType, trustStorePath, trustStorePass);
+    return TlsUtils.getSslContext();
   }
 
   public static List<String> getBrokersFromURL(String url) {

--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -195,6 +195,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-jdbc-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-server</artifactId>
     </dependency>
     <dependency>

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
@@ -24,10 +24,13 @@ import java.io.File;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.sql.ResultSet;
+import java.sql.Statement;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.stream.Collectors;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.io.FileUtils;
@@ -44,6 +47,7 @@ import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.pinot.client.Connection;
 import org.apache.pinot.client.ConnectionFactory;
 import org.apache.pinot.client.JsonAsyncHttpPinotClientTransportFactory;
+import org.apache.pinot.client.PinotDriver;
 import org.apache.pinot.client.ResultSetGroup;
 import org.apache.pinot.common.helix.ExtraInstanceConfig;
 import org.apache.pinot.common.utils.SimpleHttpResponse;
@@ -496,6 +500,53 @@ public class TlsIntegrationTest extends BaseClusterIntegrationTest {
           sendGetRequest(_controllerSegmentUrlBuilder.forSegmentDownload(getTableName(), segment), AUTH_HEADER).length()
               > 200000); // download segment
     }
+  }
+
+  @Test
+  public void testJDBCClient()
+      throws Exception {
+    String query = "SELECT count(*) FROM " + getTableName();
+    java.sql.Connection connection = getValidJDBCConnection(DEFAULT_CONTROLLER_PORT);
+    Statement statement = connection.createStatement();
+    ResultSet resultSet = statement.executeQuery(query);
+    resultSet.first();
+    Assert.assertTrue(resultSet.getLong(1) > 0);
+
+    try {
+      java.sql.Connection invalidConnection = getInValidJDBCConnection(DEFAULT_CONTROLLER_PORT);
+      statement = invalidConnection.createStatement();
+      resultSet = statement.executeQuery(query);
+      Assert.fail("Should not allow queries with invalid TLS configuration");
+    } catch (Exception e) {
+      // this should fail
+    }
+  }
+
+  private java.sql.Connection getValidJDBCConnection(int controllerPort) throws Exception {
+    SSLContextBuilder sslContextBuilder = SSLContextBuilder.create();
+    sslContextBuilder.setKeyStoreType(PKCS_12);
+    sslContextBuilder.loadKeyMaterial(_tlsStorePKCS12, PASSWORD_CHAR, PASSWORD_CHAR);
+    sslContextBuilder.loadTrustMaterial(_tlsStorePKCS12, PASSWORD_CHAR);
+
+    PinotDriver pinotDriver = new PinotDriver(sslContextBuilder.build());
+    Properties jdbcProps = new Properties();
+    jdbcProps.setProperty(PinotDriver.INFO_SCHEME, CommonConstants.HTTPS_PROTOCOL);
+    jdbcProps.setProperty(PinotDriver.INFO_HEADERS + "." + CLIENT_HEADER.getName(), CLIENT_HEADER.getValue());
+    return pinotDriver.connect("jdbc:pinot://localhost:" + controllerPort, jdbcProps);
+  }
+
+  private java.sql.Connection getInValidJDBCConnection(int controllerPort) throws Exception {
+    SSLContextBuilder sslContextBuilder = SSLContextBuilder.create();
+    sslContextBuilder.setKeyStoreType(PKCS_12);
+    sslContextBuilder.loadKeyMaterial(_tlsStoreEmptyPKCS12, PASSWORD_CHAR, PASSWORD_CHAR);
+    sslContextBuilder.loadTrustMaterial(_tlsStorePKCS12, PASSWORD_CHAR);
+
+    PinotDriver pinotDriver = new PinotDriver(sslContextBuilder.build());
+    Properties jdbcProps = new Properties();
+
+    jdbcProps.setProperty(PinotDriver.INFO_SCHEME, CommonConstants.HTTPS_PROTOCOL);
+    jdbcProps.setProperty(PinotDriver.INFO_HEADERS + "." + CLIENT_HEADER.getName(), CLIENT_HEADER.getValue());
+    return pinotDriver.connect("jdbc:pinot://localhost:" + controllerPort, jdbcProps);
   }
 
   private static CloseableHttpClient makeClient(String keyStoreType, URL keyStoreUrl, URL trustStoreUrl) {

--- a/pom.xml
+++ b/pom.xml
@@ -348,6 +348,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.pinot</groupId>
+        <artifactId>pinot-jdbc-client</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.pinot</groupId>
         <artifactId>pinot-core</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
Adresses issue #8577 

Add supports to specifiy the following configs as part of JDBC connection properties 

```properties
    pinot.jdbc.tls.keystore.path
    pinot.jdbc.tls.keystore.password
    pinot.jdbc.tls.keystore.type
    pinot.jdbc.tls.truststore.path
    pinot.jdbc.tls.truststore.password
    pinot.jdbc.tls.truststore.type
```

To use HTTPS, users can set `scheme=https` in properties and add rest of the SSL configs.