### PR TITLE
Enable minion liveness probe

### DIFF
--- a/kubernetes/helm/pinot/values.yaml
+++ b/kubernetes/helm/pinot/values.yaml
@@ -341,8 +341,8 @@ minion:
 
   probes:
     endpoint: "/health"
-    livenessEnabled: false
-    readinessEnabled: false
+    livenessEnabled: true
+    readinessEnabled: true
 
   dataDir: /var/pinot/minion/data
   jvmOpts: "-Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-minion.log"


### PR DESCRIPTION
/health endpoint was added to minion with https://github.com/apache/pinot/pull/8574/files. This change enables k8s liveness and readiness probes for minion.