### PR TITLE
Make endReplaceSegments() idempotent.

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -3175,8 +3175,12 @@ public class PinotHelixResourceManager {
             .format("Invalid segment lineage entry id (tableName='%s', segmentLineageEntryId='%s')", tableNameWithType,
                 segmentLineageEntryId));
 
-        // NO-OPS if the entry is already 'COMPLETED' or 'REVERTED'
-        if (lineageEntry.getState() != LineageEntryState.IN_PROGRESS) {
+        // NO-OPS if the entry is already 'COMPLETED', reject if the entry is 'REVERTED'
+        if (lineageEntry.getState() == LineageEntryState.COMPLETED) {
+          LOGGER.info("Found lineage entry is already in COMPLETED status. (tableNameWithType = {}, "
+              + "segmentLineageEntryId = {})", tableNameWithType, segmentLineageEntryId);
+          return true;
+        } else if (lineageEntry.getState() == LineageEntryState.REVERTED) {
           String errorMsg = String.format(
               "The target lineage entry state is not 'IN_PROGRESS'. Cannot update to 'COMPLETED' state. "
                   + "(tableNameWithType=%s, segmentLineageEntryId=%s, state=%s)", tableNameWithType,

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerTest.java
@@ -762,6 +762,11 @@ public class PinotHelixResourceManagerTest {
     Assert.assertEquals(segmentLineage.getLineageEntry(lineageEntryId8).getSegmentsFrom(), Arrays.asList("s0", "s9"));
     Assert.assertEquals(segmentLineage.getLineageEntry(lineageEntryId8).getSegmentsTo(), Arrays.asList("s13", "s14"));
     Assert.assertEquals(segmentLineage.getLineageEntry(lineageEntryId8).getState(), LineageEntryState.COMPLETED);
+
+    // Check endReplaceSegments is idempotent
+    ControllerTestUtils.getHelixResourceManager()
+        .endReplaceSegments(OFFLINE_SEGMENTS_REPLACE_TEST_TABLE_NAME, lineageEntryId8);
+    Assert.assertEquals(segmentLineage.getLineageEntry(lineageEntryId8).getState(), LineageEntryState.COMPLETED);
   }
 
   private void testSegmentReplacementForRefresh()


### PR DESCRIPTION
This pr makes `endReplaceSegments()` idempotent so that no exception is thrown even if lineage entry is already in `COMPLETED` state.