### PR TITLE
Add unrecognizedProperties to schema and tableConfigs APIs

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pinot.controller.api.resources;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -44,6 +46,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.exception.SchemaAlreadyExistsException;
 import org.apache.pinot.common.exception.SchemaBackwardIncompatibleException;
 import org.apache.pinot.common.exception.SchemaNotFoundException;
@@ -145,16 +148,19 @@ public class PinotSchemaRestletResource {
   @Authenticate(AccessType.UPDATE)
   @ApiOperation(value = "Update a schema", notes = "Updates a schema")
   @ApiResponses(value = {
-      @ApiResponse(code = 200, message = "Successfully updated schema"),
-      @ApiResponse(code = 404, message = "Schema not found"),
-      @ApiResponse(code = 400, message = "Missing or invalid request body"),
-      @ApiResponse(code = 500, message = "Internal error")
+      @ApiResponse(code = 200, message = "Successfully updated schema"), @ApiResponse(code = 404, message = "Schema "
+      + "not found"), @ApiResponse(code = 400, message = "Missing or invalid request body"), @ApiResponse(code = 500,
+      message = "Internal error")
   })
-  public SuccessResponse updateSchema(
+  public ConfigSuccessResponse updateSchema(
       @ApiParam(value = "Name of the schema", required = true) @PathParam("schemaName") String schemaName,
       @ApiParam(value = "Whether to reload the table if the new schema is backward compatible") @DefaultValue("false")
       @QueryParam("reload") boolean reload, FormDataMultiPart multiPart) {
-    return updateSchema(schemaName, getSchemaFromMultiPart(multiPart), reload);
+    Pair<Schema, Map<String, Object>> schemaAndUnrecognizedProps =
+        getSchemaAndUnrecognizedPropertiesFromMultiPart(multiPart);
+    Schema schema = schemaAndUnrecognizedProps.getLeft();
+    SuccessResponse successResponse = updateSchema(schemaName, schema, reload);
+    return new ConfigSuccessResponse(successResponse.getStatus(), schemaAndUnrecognizedProps.getRight());
   }
 
   @PUT
@@ -164,16 +170,24 @@ public class PinotSchemaRestletResource {
   @Authenticate(AccessType.UPDATE)
   @ApiOperation(value = "Update a schema", notes = "Updates a schema")
   @ApiResponses(value = {
-      @ApiResponse(code = 200, message = "Successfully updated schema"),
-      @ApiResponse(code = 404, message = "Schema not found"),
-      @ApiResponse(code = 400, message = "Missing or invalid request body"),
-      @ApiResponse(code = 500, message = "Internal error")
+      @ApiResponse(code = 200, message = "Successfully updated schema"), @ApiResponse(code = 404, message = "Schema "
+      + "not found"), @ApiResponse(code = 400, message = "Missing or invalid request body"), @ApiResponse(code = 500,
+      message = "Internal error")
   })
-  public SuccessResponse updateSchema(
+  public ConfigSuccessResponse updateSchema(
       @ApiParam(value = "Name of the schema", required = true) @PathParam("schemaName") String schemaName,
       @ApiParam(value = "Whether to reload the table if the new schema is backward compatible") @DefaultValue("false")
-      @QueryParam("reload") boolean reload, Schema schema) {
-    return updateSchema(schemaName, schema, reload);
+      @QueryParam("reload") boolean reload, String schemaJsonString) {
+    Pair<Schema, Map<String, Object>> schemaAndUnrecognizedProps = null;
+    try {
+      schemaAndUnrecognizedProps = JsonUtils.stringToObjectAndUnrecognizedProperties(schemaJsonString, Schema.class);
+    } catch (Exception e) {
+      String msg = String.format("Invalid schema config json string: %s", schemaJsonString);
+      throw new ControllerApplicationException(LOGGER, msg, Response.Status.BAD_REQUEST, e);
+    }
+    Schema schema = schemaAndUnrecognizedProps.getLeft();
+    SuccessResponse successResponse = updateSchema(schemaName, schema, reload);
+    return new ConfigSuccessResponse(successResponse.getStatus(), schemaAndUnrecognizedProps.getRight());
   }
 
   @POST
@@ -181,21 +195,23 @@ public class PinotSchemaRestletResource {
   @Path("/schemas")
   @ApiOperation(value = "Add a new schema", notes = "Adds a new schema")
   @ApiResponses(value = {
-      @ApiResponse(code = 200, message = "Successfully created schema"),
-      @ApiResponse(code = 409, message = "Schema already exists"),
-      @ApiResponse(code = 400, message = "Missing or invalid request body"),
-      @ApiResponse(code = 500, message = "Internal error")
+      @ApiResponse(code = 200, message = "Successfully created schema"), @ApiResponse(code = 409, message = "Schema "
+      + "already exists"), @ApiResponse(code = 400, message = "Missing or invalid request body"), @ApiResponse(code =
+      500, message = "Internal error")
   })
-  public SuccessResponse addSchema(
+  public ConfigSuccessResponse addSchema(
       @ApiParam(value = "Whether to override the schema if the schema exists") @DefaultValue("true")
       @QueryParam("override") boolean override, FormDataMultiPart multiPart, @Context HttpHeaders httpHeaders,
       @Context Request request) {
-    Schema schema = getSchemaFromMultiPart(multiPart);
+    Pair<Schema, Map<String, Object>> schemaAndUnrecognizedProps =
+        getSchemaAndUnrecognizedPropertiesFromMultiPart(multiPart);
+    Schema schema = schemaAndUnrecognizedProps.getLeft();
     String endpointUrl = request.getRequestURL().toString();
     validateSchemaName(schema.getSchemaName());
     _accessControlUtils.validatePermission(schema.getSchemaName(), AccessType.CREATE, httpHeaders, endpointUrl,
         _accessControlFactory.create());
-    return addSchema(schema, override);
+    SuccessResponse successResponse = addSchema(schema, override);
+    return new ConfigSuccessResponse(successResponse.getStatus(), schemaAndUnrecognizedProps.getRight());
   }
 
   @POST
@@ -204,20 +220,29 @@ public class PinotSchemaRestletResource {
   @Path("/schemas")
   @ApiOperation(value = "Add a new schema", notes = "Adds a new schema")
   @ApiResponses(value = {
-      @ApiResponse(code = 200, message = "Successfully created schema"),
-      @ApiResponse(code = 409, message = "Schema already exists"),
-      @ApiResponse(code = 400, message = "Missing or invalid request body"),
-      @ApiResponse(code = 500, message = "Internal error")
+      @ApiResponse(code = 200, message = "Successfully created schema"), @ApiResponse(code = 409, message = "Schema "
+      + "already exists"), @ApiResponse(code = 400, message = "Missing or invalid request body"), @ApiResponse(code =
+      500, message = "Internal error")
   })
-  public SuccessResponse addSchema(
+  public ConfigSuccessResponse addSchema(
       @ApiParam(value = "Whether to override the schema if the schema exists") @DefaultValue("true")
-      @QueryParam("override") boolean override, Schema schema, @Context HttpHeaders httpHeaders,
+      @QueryParam("override") boolean override, String schemaJsonString, @Context HttpHeaders httpHeaders,
       @Context Request request) {
+    Pair<Schema, Map<String, Object>> schemaAndUnrecognizedProperties = null;
+    try {
+      schemaAndUnrecognizedProperties =
+          JsonUtils.stringToObjectAndUnrecognizedProperties(schemaJsonString, Schema.class);
+    } catch (Exception e) {
+      String msg = String.format("Invalid schema config json string: %s", schemaJsonString);
+      throw new ControllerApplicationException(LOGGER, msg, Response.Status.BAD_REQUEST, e);
+    }
+    Schema schema = schemaAndUnrecognizedProperties.getLeft();
     String endpointUrl = request.getRequestURL().toString();
     validateSchemaName(schema.getSchemaName());
     _accessControlUtils.validatePermission(schema.getSchemaName(), AccessType.CREATE, httpHeaders, endpointUrl,
         _accessControlFactory.create());
-    return addSchema(schema, override);
+    SuccessResponse successResponse = addSchema(schema, override);
+    return new ConfigSuccessResponse(successResponse.getStatus(), schemaAndUnrecognizedProperties.getRight());
   }
 
   @POST
@@ -231,9 +256,17 @@ public class PinotSchemaRestletResource {
       @ApiResponse(code = 500, message = "Internal error")
   })
   public String validateSchema(FormDataMultiPart multiPart) {
-    Schema schema = getSchemaFromMultiPart(multiPart);
+    Pair<Schema, Map<String, Object>> schemaAndUnrecognizedProps =
+        getSchemaAndUnrecognizedPropertiesFromMultiPart(multiPart);
+    Schema schema = schemaAndUnrecognizedProps.getLeft();
     validateSchemaInternal(schema);
-    return schema.toPrettyJsonString();
+    ObjectNode response = schema.toJsonObject();
+    response.set("unrecognizedProperties", JsonUtils.objectToJsonNode(schemaAndUnrecognizedProps.getRight()));
+    try {
+      return JsonUtils.objectToPrettyString(response);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @POST
@@ -243,13 +276,26 @@ public class PinotSchemaRestletResource {
   @ApiOperation(value = "Validate schema", notes = "This API returns the schema that matches the one you get "
       + "from 'GET /schema/{schemaName}'. This allows us to validate schema before apply.")
   @ApiResponses(value = {
-      @ApiResponse(code = 200, message = "Successfully validated schema"),
-      @ApiResponse(code = 400, message = "Missing or invalid request body"),
-      @ApiResponse(code = 500, message = "Internal error")
+      @ApiResponse(code = 200, message = "Successfully validated schema"), @ApiResponse(code = 400, message =
+      "Missing or invalid request body"), @ApiResponse(code = 500, message = "Internal error")
   })
-  public String validateSchema(Schema schema) {
+  public String validateSchema(String schemaJsonString) {
+    Pair<Schema, Map<String, Object>> schemaAndUnrecognizedProps = null;
+    try {
+      schemaAndUnrecognizedProps = JsonUtils.stringToObjectAndUnrecognizedProperties(schemaJsonString, Schema.class);
+    } catch (Exception e) {
+      String msg = String.format("Invalid schema config json string: %s", schemaJsonString);
+      throw new ControllerApplicationException(LOGGER, msg, Response.Status.BAD_REQUEST, e);
+    }
+    Schema schema = schemaAndUnrecognizedProps.getLeft();
     validateSchemaInternal(schema);
-    return schema.toPrettyJsonString();
+    ObjectNode response = schema.toJsonObject();
+    response.set("unrecognizedProperties", JsonUtils.objectToJsonNode(schemaAndUnrecognizedProps.getRight()));
+    try {
+      return JsonUtils.objectToPrettyString(response);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   private void validateSchemaName(String schemaName) {
@@ -342,7 +388,8 @@ public class PinotSchemaRestletResource {
     }
   }
 
-  private Schema getSchemaFromMultiPart(FormDataMultiPart multiPart) {
+  private Pair<Schema, Map<String, Object>> getSchemaAndUnrecognizedPropertiesFromMultiPart(
+      FormDataMultiPart multiPart) {
     try {
       Map<String, List<FormDataBodyPart>> map = multiPart.getFields();
       if (!PinotSegmentUploadDownloadRestletResource.validateMultiPart(map, null)) {
@@ -351,7 +398,7 @@ public class PinotSchemaRestletResource {
       }
       FormDataBodyPart bodyPart = map.values().iterator().next().get(0);
       try (InputStream inputStream = bodyPart.getValueAs(InputStream.class)) {
-        return Schema.fromInputSteam(inputStream);
+        return Schema.parseSchemaAndUnrecognizedPropsfromInputStream(inputStream);
       } catch (IOException e) {
         throw new ControllerApplicationException(LOGGER,
             "Caught exception while de-serializing the schema from request body: " + e.getMessage(),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
@@ -148,9 +148,10 @@ public class PinotSchemaRestletResource {
   @Authenticate(AccessType.UPDATE)
   @ApiOperation(value = "Update a schema", notes = "Updates a schema")
   @ApiResponses(value = {
-      @ApiResponse(code = 200, message = "Successfully updated schema"), @ApiResponse(code = 404, message = "Schema "
-      + "not found"), @ApiResponse(code = 400, message = "Missing or invalid request body"), @ApiResponse(code = 500,
-      message = "Internal error")
+      @ApiResponse(code = 200, message = "Successfully updated schema"),
+      @ApiResponse(code = 404, message = "Schema not found"),
+      @ApiResponse(code = 400, message = "Missing or invalid request body"),
+      @ApiResponse(code = 500, message = "Internal error")
   })
   public ConfigSuccessResponse updateSchema(
       @ApiParam(value = "Name of the schema", required = true) @PathParam("schemaName") String schemaName,
@@ -170,9 +171,10 @@ public class PinotSchemaRestletResource {
   @Authenticate(AccessType.UPDATE)
   @ApiOperation(value = "Update a schema", notes = "Updates a schema")
   @ApiResponses(value = {
-      @ApiResponse(code = 200, message = "Successfully updated schema"), @ApiResponse(code = 404, message = "Schema "
-      + "not found"), @ApiResponse(code = 400, message = "Missing or invalid request body"), @ApiResponse(code = 500,
-      message = "Internal error")
+      @ApiResponse(code = 200, message = "Successfully updated schema"),
+      @ApiResponse(code = 404, message = "Schema not found"),
+      @ApiResponse(code = 400, message = "Missing or invalid request body"),
+      @ApiResponse(code = 500, message = "Internal error")
   })
   public ConfigSuccessResponse updateSchema(
       @ApiParam(value = "Name of the schema", required = true) @PathParam("schemaName") String schemaName,
@@ -195,9 +197,10 @@ public class PinotSchemaRestletResource {
   @Path("/schemas")
   @ApiOperation(value = "Add a new schema", notes = "Adds a new schema")
   @ApiResponses(value = {
-      @ApiResponse(code = 200, message = "Successfully created schema"), @ApiResponse(code = 409, message = "Schema "
-      + "already exists"), @ApiResponse(code = 400, message = "Missing or invalid request body"), @ApiResponse(code =
-      500, message = "Internal error")
+      @ApiResponse(code = 200, message = "Successfully created schema"),
+      @ApiResponse(code = 409, message = "Schema already exists"),
+      @ApiResponse(code = 400, message = "Missing or invalid request body"),
+      @ApiResponse(code = 500, message = "Internal error")
   })
   public ConfigSuccessResponse addSchema(
       @ApiParam(value = "Whether to override the schema if the schema exists") @DefaultValue("true")
@@ -220,9 +223,10 @@ public class PinotSchemaRestletResource {
   @Path("/schemas")
   @ApiOperation(value = "Add a new schema", notes = "Adds a new schema")
   @ApiResponses(value = {
-      @ApiResponse(code = 200, message = "Successfully created schema"), @ApiResponse(code = 409, message = "Schema "
-      + "already exists"), @ApiResponse(code = 400, message = "Missing or invalid request body"), @ApiResponse(code =
-      500, message = "Internal error")
+      @ApiResponse(code = 200, message = "Successfully created schema"),
+      @ApiResponse(code = 409, message = "Schema already exists"),
+      @ApiResponse(code = 400, message = "Missing or invalid request body"),
+      @ApiResponse(code = 500, message = "Internal error")
   })
   public ConfigSuccessResponse addSchema(
       @ApiParam(value = "Whether to override the schema if the schema exists") @DefaultValue("true")
@@ -276,8 +280,9 @@ public class PinotSchemaRestletResource {
   @ApiOperation(value = "Validate schema", notes = "This API returns the schema that matches the one you get "
       + "from 'GET /schema/{schemaName}'. This allows us to validate schema before apply.")
   @ApiResponses(value = {
-      @ApiResponse(code = 200, message = "Successfully validated schema"), @ApiResponse(code = 400, message =
-      "Missing or invalid request body"), @ApiResponse(code = 500, message = "Internal error")
+      @ApiResponse(code = 200, message = "Successfully validated schema"),
+      @ApiResponse(code = 400, message = "Missing or invalid request body"),
+      @ApiResponse(code = 500, message = "Internal error")
   })
   public String validateSchema(String schemaJsonString) {
     Pair<Schema, Map<String, Object>> schemaAndUnrecognizedProps = null;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.controller.api.resources;
 
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -26,6 +27,7 @@ import io.swagger.annotations.ApiParam;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.ws.rs.DELETE;
@@ -41,6 +43,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.controller.ControllerConf;
@@ -147,16 +150,18 @@ public class TableConfigsRestletResource {
   @POST
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/tableConfigs")
-  @ApiOperation(value = "Add the TableConfigs using the tableConfigsStr json",
-      notes = "Add the TableConfigs using the tableConfigsStr json")
-  public SuccessResponse addConfig(
-      String tableConfigsStr,
+  @ApiOperation(value = "Add the TableConfigs using the tableConfigsStr json", notes = "Add the TableConfigs using "
+      + "the tableConfigsStr json")
+  public ConfigSuccessResponse addConfig(String tableConfigsStr,
       @ApiParam(value = "comma separated list of validation type(s) to skip. supported types: (ALL|TASK|UPSERT)")
       @QueryParam("validationTypesToSkip") @Nullable String typesToSkip, @Context HttpHeaders httpHeaders,
       @Context Request request) {
+    Pair<TableConfigs, Map<String, Object>> tableConfigsAndUnrecognizedProps;
     TableConfigs tableConfigs;
     try {
-      tableConfigs = JsonUtils.stringToObject(tableConfigsStr, TableConfigs.class);
+      tableConfigsAndUnrecognizedProps =
+          JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigsStr, TableConfigs.class);
+      tableConfigs = tableConfigsAndUnrecognizedProps.getLeft();
       validateConfig(tableConfigs, typesToSkip);
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER, String.format("Invalid TableConfigs. %s", e.getMessage()),
@@ -214,7 +219,8 @@ public class TableConfigsRestletResource {
         throw e;
       }
 
-      return new SuccessResponse("TableConfigs " + tableConfigs.getTableName() + " successfully added");
+      return new ConfigSuccessResponse("TableConfigs " + tableConfigs.getTableName() + " successfully added",
+          tableConfigsAndUnrecognizedProps.getRight());
     } catch (Exception e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_ADD_ERROR, 1L);
       if (e instanceof InvalidTableConfigException) {
@@ -278,9 +284,9 @@ public class TableConfigsRestletResource {
   @Path("/tableConfigs/{tableName}")
   @Authenticate(AccessType.UPDATE)
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation(value = "Update the TableConfigs provided by the tableConfigsStr json",
-      notes = "Update the TableConfigs provided by the tableConfigsStr json")
-  public SuccessResponse updateConfig(
+  @ApiOperation(value = "Update the TableConfigs provided by the tableConfigsStr json", notes = "Update the "
+      + "TableConfigs provided by the tableConfigsStr json")
+  public ConfigSuccessResponse updateConfig(
       @ApiParam(value = "TableConfigs name i.e. raw table name", required = true) @PathParam("tableName")
           String tableName,
       @ApiParam(value = "comma separated list of validation type(s) to skip. supported types: (ALL|TASK|UPSERT)")
@@ -288,9 +294,12 @@ public class TableConfigsRestletResource {
       @ApiParam(value = "Reload the table if the new schema is backward compatible") @DefaultValue("false")
       @QueryParam("reload") boolean reload, String tableConfigsStr)
       throws Exception {
+    Pair<TableConfigs, Map<String, Object>> tableConfigsAndUnrecognizedProps;
     TableConfigs tableConfigs;
     try {
-      tableConfigs = JsonUtils.stringToObject(tableConfigsStr, TableConfigs.class);
+      tableConfigsAndUnrecognizedProps =
+          JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigsStr, TableConfigs.class);
+      tableConfigs = tableConfigsAndUnrecognizedProps.getLeft();
       Preconditions.checkState(tableConfigs.getTableName().equals(tableName),
           "'tableName' in TableConfigs: %s must match provided tableName: %s", tableConfigs.getTableName(), tableName);
 
@@ -346,7 +355,8 @@ public class TableConfigsRestletResource {
           Response.Status.INTERNAL_SERVER_ERROR, e);
     }
 
-    return new SuccessResponse("TableConfigs updated for " + tableName);
+    return new ConfigSuccessResponse("TableConfigs updated for " + tableName,
+        tableConfigsAndUnrecognizedProps.getRight());
   }
 
   /**
@@ -360,14 +370,20 @@ public class TableConfigsRestletResource {
   public String validateConfig(String tableConfigsStr,
       @ApiParam(value = "comma separated list of validation type(s) to skip. supported types: (ALL|TASK|UPSERT)")
       @QueryParam("validationTypesToSkip") @Nullable String typesToSkip) {
+    Pair<TableConfigs, Map<String, Object>> tableConfigsAndUnrecognizedProps;
     TableConfigs tableConfigs;
     try {
-      tableConfigs = JsonUtils.stringToObject(tableConfigsStr, TableConfigs.class);
+      tableConfigsAndUnrecognizedProps =
+          JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigsStr, TableConfigs.class);
+      tableConfigs = tableConfigsAndUnrecognizedProps.getLeft();
     } catch (IOException e) {
       throw new ControllerApplicationException(LOGGER,
           String.format("Invalid TableConfigs json string: %s", tableConfigsStr), Response.Status.BAD_REQUEST, e);
     }
-    return validateConfig(tableConfigs, typesToSkip);
+    TableConfigs validatedTableConfigs = validateConfig(tableConfigs, typesToSkip);
+    ObjectNode response = JsonUtils.objectToJsonNode(validatedTableConfigs).deepCopy();
+    response.set("unrecognizedProperties", JsonUtils.objectToJsonNode(tableConfigsAndUnrecognizedProps.getRight()));
+    return response.toString();
   }
 
   private void tuneConfig(TableConfig tableConfig, Schema schema) {
@@ -376,7 +392,7 @@ public class TableConfigsRestletResource {
     TableConfigUtils.ensureStorageQuotaConstraints(tableConfig, _controllerConf.getDimTableMaxSize());
   }
 
-  private String validateConfig(TableConfigs tableConfigs, @Nullable String typesToSkip) {
+  private TableConfigs validateConfig(TableConfigs tableConfigs, @Nullable String typesToSkip) {
     String rawTableName = tableConfigs.getTableName();
     TableConfig offlineTableConfig = tableConfigs.getOffline();
     TableConfig realtimeTableConfig = tableConfigs.getRealtime();
@@ -410,7 +426,7 @@ public class TableConfigsRestletResource {
         TableConfigUtils.verifyHybridTableConfigs(rawTableName, offlineTableConfig, realtimeTableConfig);
       }
 
-      return tableConfigs.toJsonString();
+      return tableConfigs;
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER,
           String.format("Invalid TableConfigs: %s. %s", rawTableName, e.getMessage()), Response.Status.BAD_REQUEST, e);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -150,9 +150,10 @@ public class TableConfigsRestletResource {
   @POST
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/tableConfigs")
-  @ApiOperation(value = "Add the TableConfigs using the tableConfigsStr json", notes = "Add the TableConfigs using "
-      + "the tableConfigsStr json")
-  public ConfigSuccessResponse addConfig(String tableConfigsStr,
+  @ApiOperation(value = "Add the TableConfigs using the tableConfigsStr json",
+      notes = "Add the TableConfigs using the tableConfigsStr json")
+  public ConfigSuccessResponse addConfig(
+      String tableConfigsStr,
       @ApiParam(value = "comma separated list of validation type(s) to skip. supported types: (ALL|TASK|UPSERT)")
       @QueryParam("validationTypesToSkip") @Nullable String typesToSkip, @Context HttpHeaders httpHeaders,
       @Context Request request) {
@@ -284,8 +285,8 @@ public class TableConfigsRestletResource {
   @Path("/tableConfigs/{tableName}")
   @Authenticate(AccessType.UPDATE)
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation(value = "Update the TableConfigs provided by the tableConfigsStr json", notes = "Update the "
-      + "TableConfigs provided by the tableConfigsStr json")
+  @ApiOperation(value = "Update the TableConfigs provided by the tableConfigsStr json",
+      notes = "Update the TableConfigs provided by the tableConfigsStr json")
   public ConfigSuccessResponse updateConfig(
       @ApiParam(value = "TableConfigs name i.e. raw table name", required = true) @PathParam("tableName")
           String tableName,

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.controller.api;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.util.List;
@@ -554,13 +556,45 @@ public class TableConfigsRestletResourceTest {
     Assert.assertEquals(tableConfigsResponse.getTableName(), tableName);
 
     // delete & check
-    ControllerTestUtils
-        .sendDeleteRequest(ControllerTestUtils.getControllerRequestURLBuilder().forTableConfigsDelete(tableName));
+    ControllerTestUtils.sendDeleteRequest(
+        ControllerTestUtils.getControllerRequestURLBuilder().forTableConfigsDelete(tableName));
     getResponse =
         ControllerTestUtils.sendGetRequest(ControllerTestUtils.getControllerRequestURLBuilder().forTableConfigsList());
     configs = JsonUtils.stringToObject(getResponse, new TypeReference<List<String>>() {
     });
     Assert.assertEquals(configs.size(), 0);
+  }
+
+  @Test
+  public void testUnrecognizedProperties()
+      throws IOException {
+    String tableName = "testDelete1";
+    TableConfig offlineTableConfig = getOfflineTableConfig(tableName);
+    Schema schema = getSchema(tableName);
+    TableConfigs tableConfigs = new TableConfigs(tableName, schema, offlineTableConfig, null);
+    ObjectNode tableConfigsJson = JsonUtils.objectToJsonNode(tableConfigs).deepCopy();
+    tableConfigsJson.put("illegalKey1", 1);
+
+    // Validate
+    ControllerTestUtils.getControllerRequestURLBuilder().forTableConfigsValidate();
+    String response = ControllerTestUtils.sendPostRequest(
+        ControllerTestUtils.getControllerRequestURLBuilder().forTableConfigsValidate(),
+        tableConfigsJson.toPrettyString());
+    JsonNode responseJson = JsonUtils.stringToJsonNode(response);
+    Assert.assertTrue(responseJson.has("unrecognizedProperties"));
+    Assert.assertTrue(responseJson.get("unrecognizedProperties").has("/illegalKey1"));
+
+    // Create
+    response = ControllerTestUtils.sendPostRequest(_createTableConfigsUrl, tableConfigsJson.toPrettyString());
+    Assert.assertEquals(response, "{\"unrecognizedProperties\":{\"/illegalKey1\":1},\"status\":\"TableConfigs "
+        + "testDelete1 successfully added\"}");
+
+    // Update
+    response = ControllerTestUtils.sendPutRequest(
+        ControllerTestUtils.getControllerRequestURLBuilder().forTableConfigsUpdate("testDelete1"),
+        tableConfigsJson.toPrettyString());
+    Assert.assertEquals(response,
+        "{\"unrecognizedProperties\":{\"/illegalKey1\":1},\"status\":\"TableConfigs updated for testDelete1\"}");
   }
 
   @AfterClass

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
@@ -568,7 +568,7 @@ public class TableConfigsRestletResourceTest {
   @Test
   public void testUnrecognizedProperties()
       throws IOException {
-    String tableName = "testDelete1";
+    String tableName = "testUnrecognized1";
     TableConfig offlineTableConfig = getOfflineTableConfig(tableName);
     Schema schema = getSchema(tableName);
     TableConfigs tableConfigs = new TableConfigs(tableName, schema, offlineTableConfig, null);
@@ -587,14 +587,17 @@ public class TableConfigsRestletResourceTest {
     // Create
     response = ControllerTestUtils.sendPostRequest(_createTableConfigsUrl, tableConfigsJson.toPrettyString());
     Assert.assertEquals(response, "{\"unrecognizedProperties\":{\"/illegalKey1\":1},\"status\":\"TableConfigs "
-        + "testDelete1 successfully added\"}");
+        + "testUnrecognized1 successfully added\"}");
 
     // Update
     response = ControllerTestUtils.sendPutRequest(
-        ControllerTestUtils.getControllerRequestURLBuilder().forTableConfigsUpdate("testDelete1"),
+        ControllerTestUtils.getControllerRequestURLBuilder().forTableConfigsUpdate(tableName),
         tableConfigsJson.toPrettyString());
     Assert.assertEquals(response,
-        "{\"unrecognizedProperties\":{\"/illegalKey1\":1},\"status\":\"TableConfigs updated for testDelete1\"}");
+        "{\"unrecognizedProperties\":{\"/illegalKey1\":1},\"status\":\"TableConfigs updated for testUnrecognized1\"}");
+    // Delete
+    ControllerTestUtils.sendDeleteRequest(
+        ControllerTestUtils.getControllerRequestURLBuilder().forTableConfigsDelete(tableName));
   }
 
   @AfterClass

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -278,7 +278,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
     InputStream inputStream =
         BaseClusterIntegrationTest.class.getClassLoader().getResourceAsStream(getSchemaFileName());
     Assert.assertNotNull(inputStream);
-    return Schema.fromInputSteam(inputStream);
+    return Schema.fromInputStream(inputStream);
   }
 
   /**

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/HadoopSegmentPreprocessingJob.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/HadoopSegmentPreprocessingJob.java
@@ -262,7 +262,7 @@ public class HadoopSegmentPreprocessingJob extends SegmentPreprocessingJob {
         return controllerRestApi.getSchema();
       } else {
         try (InputStream inputStream = FileSystem.get(_schemaFile.toUri(), getConf()).open(_schemaFile)) {
-          return org.apache.pinot.spi.data.Schema.fromInputSteam(inputStream);
+          return org.apache.pinot.spi.data.Schema.fromInputStream(inputStream);
         }
       }
     }

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-ingestion-common/src/main/java/org/apache/pinot/ingestion/jobs/SegmentCreationJob.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-ingestion-common/src/main/java/org/apache/pinot/ingestion/jobs/SegmentCreationJob.java
@@ -135,7 +135,7 @@ public abstract class SegmentCreationJob extends BaseSegmentJob {
         // Schema file could be stored local or remotely.
         try (InputStream inputStream = FileSystem.get(new Path(_schemaFile).toUri(), getConf())
             .open(new Path(_schemaFile))) {
-          return Schema.fromInputSteam(inputStream);
+          return Schema.fromInputStream(inputStream);
         }
       }
     }

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-ingestion-common/src/main/java/org/apache/pinot/ingestion/jobs/SegmentPreprocessingJob.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-ingestion-common/src/main/java/org/apache/pinot/ingestion/jobs/SegmentPreprocessingJob.java
@@ -80,7 +80,7 @@ public abstract class SegmentPreprocessingJob extends BaseSegmentJob {
         return controllerRestApi.getSchema();
       } else {
         try (InputStream inputStream = FileSystem.get(_schemaFile.toUri(), getConf()).open(_schemaFile)) {
-          return org.apache.pinot.spi.data.Schema.fromInputSteam(inputStream);
+          return org.apache.pinot.spi.data.Schema.fromInputStream(inputStream);
         }
       }
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.utils.EqualityUtils;
@@ -91,7 +92,13 @@ public final class Schema implements Serializable {
     return JsonUtils.stringToObject(schemaString, Schema.class);
   }
 
-  public static Schema fromInputSteam(InputStream schemaInputStream)
+  public static Pair<Schema, Map<String, Object>> parseSchemaAndUnrecognizedPropsfromInputStream(
+      InputStream schemaInputStream)
+      throws IOException {
+    return JsonUtils.inputStreamToObjectAndUnrecognizedProperties(schemaInputStream, Schema.class);
+  }
+
+  public static Schema fromInputStream(InputStream schemaInputStream)
       throws IOException {
     return JsonUtils.inputStreamToObject(schemaInputStream, Schema.class);
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
@@ -91,9 +91,8 @@ public class JsonUtils {
   public static <T> Pair<T, Map<String, Object>> inputStreamToObjectAndUnrecognizedProperties(
       InputStream jsonInputStream, Class<T> valueType)
       throws IOException {
-    T instance = DEFAULT_READER.forType(valueType).readValue(jsonInputStream);
-    Map<String, Object> inputJsonMap = flatten(DEFAULT_MAPPER.readValue(jsonInputStream, GENERIC_JSON_TYPE));
-    return compareObjectAndJson(inputJsonMap, instance);
+    String jsonString = StringUtil.inputStreamToString(jsonInputStream);
+    return stringToObjectAndUnrecognizedProperties(jsonString, valueType);
   }
 
   public static <T> Pair<T, Map<String, Object>> stringToObjectAndUnrecognizedProperties(String jsonString,
@@ -101,11 +100,7 @@ public class JsonUtils {
       throws IOException {
     T instance = DEFAULT_READER.forType(valueType).readValue(jsonString);
     Map<String, Object> inputJsonMap = flatten(DEFAULT_MAPPER.readValue(jsonString, GENERIC_JSON_TYPE));
-    return compareObjectAndJson(inputJsonMap, instance);
-  }
 
-  private static <T> Pair<T, Map<String, Object>> compareObjectAndJson(Map<String, Object> inputJsonMap, T instance)
-      throws JsonProcessingException {
     String instanceJson = DEFAULT_MAPPER.writeValueAsString(instance);
     Map<String, Object> instanceJsonMap = flatten(DEFAULT_MAPPER.readValue(instanceJson, GENERIC_JSON_TYPE));
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
@@ -37,6 +37,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -50,6 +51,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
@@ -91,7 +93,7 @@ public class JsonUtils {
   public static <T> Pair<T, Map<String, Object>> inputStreamToObjectAndUnrecognizedProperties(
       InputStream jsonInputStream, Class<T> valueType)
       throws IOException {
-    String jsonString = StringUtil.inputStreamToString(jsonInputStream);
+    String jsonString = IOUtils.toString(jsonInputStream, StandardCharsets.UTF_8);
     return stringToObjectAndUnrecognizedProperties(jsonString, valueType);
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/StringUtil.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/StringUtil.java
@@ -73,6 +73,6 @@ public class StringUtil {
       buffer.write(data, 0, nRead);
     }
     buffer.flush();
-    return buffer.toString(StandardCharsets.UTF_8);
+    return buffer.toString(StandardCharsets.UTF_8.toString());
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/StringUtil.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/StringUtil.java
@@ -18,6 +18,10 @@
  */
 package org.apache.pinot.spi.utils;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import org.apache.commons.lang.StringUtils;
 
 
@@ -52,5 +56,23 @@ public class StringUtil {
       return value.length() <= maxLength ? value : value.substring(0, maxLength);
     }
     return value.substring(0, Math.min(index, maxLength));
+  }
+
+  /**
+   * InputStream object to String
+   * @param inputStream InputStream to be converted
+   * @return String holding the contents of the inputStream
+   * @throws IOException
+   */
+  public static String inputStreamToString(InputStream inputStream)
+      throws IOException {
+    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+    int nRead;
+    byte[] data = new byte[1024];
+    while ((nRead = inputStream.read(data, 0, data.length)) != -1) {
+      buffer.write(data, 0, nRead);
+    }
+    buffer.flush();
+    return buffer.toString(StandardCharsets.UTF_8);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/StringUtil.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/StringUtil.java
@@ -18,10 +18,6 @@
  */
 package org.apache.pinot.spi.utils;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import org.apache.commons.lang.StringUtils;
 
 
@@ -56,23 +52,5 @@ public class StringUtil {
       return value.length() <= maxLength ? value : value.substring(0, maxLength);
     }
     return value.substring(0, Math.min(index, maxLength));
-  }
-
-  /**
-   * InputStream object to String
-   * @param inputStream InputStream to be converted
-   * @return String holding the contents of the inputStream
-   * @throws IOException
-   */
-  public static String inputStreamToString(InputStream inputStream)
-      throws IOException {
-    ByteArrayOutputStream buffer = new ByteArrayOutputStream();
-    int nRead;
-    byte[] data = new byte[1024];
-    while ((nRead = inputStream.read(data, 0, data.length)) != -1) {
-      buffer.write(data, 0, nRead);
-    }
-    buffer.flush();
-    return buffer.toString(StandardCharsets.UTF_8.toString());
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
@@ -238,6 +238,10 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", _baseUrl, "tables", tableName, "externalview");
   }
 
+  public String forSchemaValidate() {
+    return StringUtil.join("/", _baseUrl, "schemas", "validate");
+  }
+
   public String forSchemaCreate() {
     return StringUtil.join("/", _baseUrl, "schemas");
   }


### PR DESCRIPTION
This PR is a follow up of https://github.com/apache/pinot/pull/8514. It adds the "unrecognizedProperties" fields to /schemas and /tableConfigs APIs
GH issue: https://github.com/apache/pinot/issues/8318