### PR TITLE
Adding in OBJECT type resolver

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
@@ -51,6 +51,7 @@ public class FunctionUtils {
     put(float[].class, PinotDataType.PRIMITIVE_FLOAT_ARRAY);
     put(double[].class, PinotDataType.PRIMITIVE_DOUBLE_ARRAY);
     put(String[].class, PinotDataType.STRING_ARRAY);
+    put(Object.class, PinotDataType.OBJECT);
   }};
 
   // Types allowed as the function argument (actual value passed into the function) for type conversion
@@ -75,6 +76,7 @@ public class FunctionUtils {
     put(double[].class, PinotDataType.PRIMITIVE_DOUBLE_ARRAY);
     put(Double[].class, PinotDataType.DOUBLE_ARRAY);
     put(String[].class, PinotDataType.STRING_ARRAY);
+    put(Object.class, PinotDataType.OBJECT);
   }};
 
   private static final Map<Class<?>, DataType> DATA_TYPE_MAP = new HashMap<Class<?>, DataType>() {{
@@ -117,6 +119,7 @@ public class FunctionUtils {
     put(float[].class, ColumnDataType.FLOAT_ARRAY);
     put(double[].class, ColumnDataType.DOUBLE_ARRAY);
     put(String[].class, ColumnDataType.STRING_ARRAY);
+    put(Object.class, ColumnDataType.OBJECT);
   }};
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
@@ -682,6 +682,11 @@ public enum PinotDataType {
     public byte[] toBytes(Object value) {
       throw new UnsupportedOperationException("Cannot convert value from OBJECT to BYTES");
     }
+
+    @Override
+    public Object convert(Object value, PinotDataType sourceType) {
+      return value;
+    }
   },
 
   BYTE_ARRAY {

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
@@ -309,7 +309,6 @@ public class PinotDataTypeTest {
       assertInvalidConversion(null, sourceType, BYTE, UnsupportedOperationException.class);
       assertInvalidConversion(null, sourceType, CHARACTER, UnsupportedOperationException.class);
       assertInvalidConversion(null, sourceType, SHORT, UnsupportedOperationException.class);
-      assertInvalidConversion(null, sourceType, OBJECT, UnsupportedOperationException.class);
       assertInvalidConversion(null, sourceType, BYTE_ARRAY, UnsupportedOperationException.class);
       assertInvalidConversion(null, sourceType, CHARACTER_ARRAY, UnsupportedOperationException.class);
       assertInvalidConversion(null, sourceType, SHORT_ARRAY, UnsupportedOperationException.class);

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunctionTest.java
@@ -58,5 +58,10 @@ public class PostAggregationFunctionTest {
     assertEquals(function.invoke(
         new Object[]{GeometrySerializer.serialize(GeometryUtils.GEOMETRY_FACTORY.createPoint(new Coordinate(10, 20)))}),
         "POINT (10 20)");
+
+    // Cast
+    function = new PostAggregationFunction("cast", new ColumnDataType[]{ColumnDataType.INT, ColumnDataType.STRING});
+    assertEquals(function.getResultType(), ColumnDataType.OBJECT);
+    assertEquals(function.invoke(new Object[]{1, "LONG"}), 1L);
   }
 }


### PR DESCRIPTION
This worked to return object type from cast results and eventually return back correct result content via auto-cast. 

This should fix #8424 partially: 
- it can cast correctly but the result is of generic object type to the function caller
- further expression/function processing is not possible

still need to address this systematically, see #8610