### PR TITLE
Update default helm image to latest

### DIFF
--- a/kubernetes/helm/pinot/values.yaml
+++ b/kubernetes/helm/pinot/values.yaml
@@ -21,8 +21,8 @@
 
 image:
   repository: apachepinot/pinot
-  tag: latest # release-0.7.1
-  pullPolicy: Always
+  tag: latest # release-0.10.0
+  pullPolicy: Always # Use IfNotPresent when you pinged a version of image tag
 
 cluster:
   name: pinot-quickstart

--- a/kubernetes/helm/pinot/values.yaml
+++ b/kubernetes/helm/pinot/values.yaml
@@ -21,8 +21,8 @@
 
 image:
   repository: apachepinot/pinot
-  tag: latest-jdk11 # release-0.7.1
-  pullPolicy: IfNotPresent
+  tag: latest # release-0.7.1
+  pullPolicy: Always
 
 cluster:
   name: pinot-quickstart


### PR DESCRIPTION
Update default helm docker image to `latest` since the `latest-jdk11` is not published anymore.