### PR TITLE
Add support to select timestamp arrays

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -395,6 +395,12 @@ public class DataSchema {
         case TIMESTAMP:
           assert value instanceof Timestamp;
           return value.toString();
+        case BOOLEAN_ARRAY:
+          assert value instanceof Boolean[];
+          return toCsv((Boolean[]) value);
+        case TIMESTAMP_ARRAY:
+          assert value instanceof Timestamp[];
+          return toCsv((Timestamp[]) value);
         case BYTES:
           return BytesUtils.toHexString((byte[]) value);
         default:
@@ -445,6 +451,18 @@ public class DataSchema {
         default:
           throw new IllegalStateException(String.format("Cannot convert and format: '%s' to type: %s", value, this));
       }
+    }
+
+    private Serializable toCsv(Object[] value) {
+      if (value.length <= 0) {
+        return "";
+      }
+      StringBuilder builder = new StringBuilder();
+      for (Object o : value) {
+        builder.append(o).append(",");
+      }
+      builder.deleteCharAt(builder.length() - 1);
+      return builder.toString();
     }
 
     private static double[] toDoubleArray(Object value) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -268,6 +268,7 @@ public class SelectionOperatorUtils {
             dataTableBuilder.setColumn(i, (int[]) columnValue);
             break;
           case LONG_ARRAY:
+          case TIMESTAMP_ARRAY:
             // LONG_ARRAY type covers INT_ARRAY and LONG_ARRAY
             if (columnValue instanceof int[]) {
               int[] ints = (int[]) columnValue;
@@ -365,6 +366,7 @@ public class SelectionOperatorUtils {
           row[i] = dataTable.getIntArray(rowId, i);
           break;
         case LONG_ARRAY:
+        case TIMESTAMP_ARRAY:
           row[i] = dataTable.getLongArray(rowId, i);
           break;
         case FLOAT_ARRAY:

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/selection/SelectionOperatorServiceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/selection/SelectionOperatorServiceTest.java
@@ -49,44 +49,47 @@ import static org.testng.Assert.assertTrue;
 public class SelectionOperatorServiceTest {
   private final String[] _columnNames = {
       "int", "long", "float", "double", "string", "int_array", "long_array", "float_array", "double_array",
-      "string_array", "bytes"
+      "string_array", "bytes", "ts", "ts_array"
   };
   private final DataSchema.ColumnDataType[] _columnDataTypes = {
       DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.FLOAT,
       DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT_ARRAY,
       DataSchema.ColumnDataType.LONG_ARRAY, DataSchema.ColumnDataType.FLOAT_ARRAY,
-      DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.STRING_ARRAY, DataSchema.ColumnDataType.BYTES
+      DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.STRING_ARRAY, DataSchema.ColumnDataType.BYTES,
+      DataSchema.ColumnDataType.TIMESTAMP, DataSchema.ColumnDataType.TIMESTAMP_ARRAY
   };
   private final DataSchema _dataSchema = new DataSchema(_columnNames, _columnDataTypes);
   private final DataSchema.ColumnDataType[] _compatibleColumnDataTypes = {
       DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.FLOAT, DataSchema.ColumnDataType.DOUBLE,
       DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG_ARRAY,
       DataSchema.ColumnDataType.FLOAT_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY,
-      DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.STRING_ARRAY, DataSchema.ColumnDataType.BYTES
+      DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.STRING_ARRAY, DataSchema.ColumnDataType.BYTES,
+      DataSchema.ColumnDataType.TIMESTAMP, DataSchema.ColumnDataType.TIMESTAMP_ARRAY
   };
   private final DataSchema _compatibleDataSchema = new DataSchema(_columnNames, _compatibleColumnDataTypes);
   private final DataSchema.ColumnDataType[] _upgradedColumnDataTypes = new DataSchema.ColumnDataType[]{
       DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
       DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG_ARRAY,
       DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY,
-      DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.STRING_ARRAY, DataSchema.ColumnDataType.BYTES
+      DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.STRING_ARRAY, DataSchema.ColumnDataType.BYTES,
+      DataSchema.ColumnDataType.TIMESTAMP, DataSchema.ColumnDataType.TIMESTAMP_ARRAY
   };
   private final DataSchema _upgradedDataSchema = new DataSchema(_columnNames, _upgradedColumnDataTypes);
   private final Object[] _row1 = {
       0, 1L, 2.0F, 3.0, "4", new int[]{5}, new long[]{6L}, new float[]{7.0F}, new double[]{8.0}, new String[]{"9"},
-      BytesUtils.toByteArray("1020")
+      BytesUtils.toByteArray("1020"), 1651502855000L, new long[]{1651502855000L}
   };
   private final Object[] _row2 = {
       10, 11L, 12.0F, 13.0, "14", new int[]{15}, new long[]{16L}, new float[]{17.0F}, new double[]{18.0},
-      new String[]{"19"}, BytesUtils.toByteArray("3040")
+      new String[]{"19"}, BytesUtils.toByteArray("3040"), 1651506455000L, new long[]{1651506455000L}
   };
   private final Object[] _compatibleRow1 = {
       1L, 2.0F, 3.0, 4, "5", new long[]{6L}, new float[]{7.0F}, new double[]{8.0}, new int[]{9}, new String[]{"10"},
-      BytesUtils.toByteArray("5060")
+      BytesUtils.toByteArray("5060"), 1651510055000L, new long[]{1651510055000L}
   };
   private final Object[] _compatibleRow2 = {
       11L, 12.0F, 13.0, 14, "15", new long[]{16L}, new float[]{17.0F}, new double[]{18.0}, new int[]{19},
-      new String[]{"20"}, BytesUtils.toByteArray("7000")
+      new String[]{"20"}, BytesUtils.toByteArray("7000"), 1651513655000L, new long[]{1651513655000L}
   };
   private QueryContext _queryContext;
 
@@ -213,11 +216,11 @@ public class SelectionOperatorServiceTest {
     DataTable dataTable = SelectionOperatorUtils.getDataTableFromRows(rows, dataSchema);
     Object[] expectedRow1 = {
         0L, 1.0, 2.0, 3.0, "4", new long[]{5L}, new double[]{6.0}, new double[]{7.0}, new double[]{8.0},
-        new String[]{"9"}, BytesUtils.toByteArray("1020")
+        new String[]{"9"}, BytesUtils.toByteArray("1020"), 1651502855000L, new long[]{1651502855000L}
     };
     Object[] expectedCompatibleRow1 = {
         1L, 2.0, 3.0, 4.0, "5", new long[]{6L}, new double[]{7.0}, new double[]{8.0}, new double[]{9.0},
-        new String[]{"10"}, BytesUtils.toByteArray("5060")
+        new String[]{"10"}, BytesUtils.toByteArray("5060"), 1651510055000L, new long[]{1651510055000L}
     };
     assertTrue(Arrays.deepEquals(SelectionOperatorUtils.extractRowFromDataTable(dataTable, 0), expectedRow1));
     assertTrue(Arrays.deepEquals(SelectionOperatorUtils.extractRowFromDataTable(dataTable, 1), expectedCompatibleRow1));


### PR DESCRIPTION
Allow selection and formatting of TIMESTAMP_ARRAY type

This should ideally be patched back to version 0.9 and 0.10