### PR TITLE
allow to take data outside the time window by negating the window filter

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -87,6 +87,7 @@ public class MinionConstants {
     // Time handling config
     public static final String WINDOW_START_MS_KEY = "windowStartMs";
     public static final String WINDOW_END_MS_KEY = "windowEndMs";
+    public static final String NEGATE_WINDOW_FILTER = "negateWindowFilter";
     public static final String ROUND_BUCKET_TIME_PERIOD_KEY = "roundBucketTimePeriod";
     public static final String PARTITION_BUCKET_TIME_PERIOD_KEY = "partitionBucketTimePeriod";
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/timehandler/EpochTimeHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/timehandler/EpochTimeHandler.java
@@ -34,16 +34,19 @@ public class EpochTimeHandler implements TimeHandler {
   private final DateTimeFormatSpec _formatSpec;
   private final long _startTimeMs;
   private final long _endTimeMs;
+  private final boolean _negateWindowFilter;
+
   private final long _roundBucketMs;
   private final long _partitionBucketMs;
 
-  public EpochTimeHandler(DateTimeFieldSpec fieldSpec, long startTimeMs, long endTimeMs, long roundBucketMs,
-      long partitionBucketMs) {
+  public EpochTimeHandler(DateTimeFieldSpec fieldSpec, long startTimeMs, long endTimeMs, boolean negateWindowFilter,
+      long roundBucketMs, long partitionBucketMs) {
     _timeColumn = fieldSpec.getName();
     _dataType = fieldSpec.getDataType();
     _formatSpec = new DateTimeFormatSpec(fieldSpec.getFormat());
     _startTimeMs = startTimeMs;
     _endTimeMs = endTimeMs;
+    _negateWindowFilter = negateWindowFilter;
     _roundBucketMs = roundBucketMs;
     _partitionBucketMs = partitionBucketMs;
   }
@@ -52,7 +55,8 @@ public class EpochTimeHandler implements TimeHandler {
   public String handleTime(GenericRow row) {
     long timeMs = _formatSpec.fromFormatToMillis(row.getValue(_timeColumn).toString());
     if (_startTimeMs > 0) {
-      if (timeMs < _startTimeMs || timeMs >= _endTimeMs) {
+      boolean outsideTimeWindow = (timeMs < _startTimeMs || timeMs >= _endTimeMs);
+      if (outsideTimeWindow != _negateWindowFilter) {
         return null;
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/timehandler/TimeHandlerConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/timehandler/TimeHandlerConfig.java
@@ -24,7 +24,8 @@ package org.apache.pinot.core.segment.processing.timehandler;
 public class TimeHandlerConfig {
   private final TimeHandler.Type _type;
 
-  // Time values not within the time range [_startTimeMs, _endTimeMs) are filtered out
+  // By default negateWindowFilter is false, and the time values not within the time range [_startTimeMs, _endTimeMs)
+  // are filtered out. Otherwise, those inside the time range are filtered out instead.
   private final long _startTimeMs;
   private final long _endTimeMs;
   private final boolean _negateWindowFilter;
@@ -59,7 +60,7 @@ public class TimeHandlerConfig {
     return _endTimeMs;
   }
 
-  public boolean getNegateWindowFilter() {
+  public boolean isNegateWindowFilter() {
     return _negateWindowFilter;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/timehandler/TimeHandlerConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/timehandler/TimeHandlerConfig.java
@@ -27,6 +27,7 @@ public class TimeHandlerConfig {
   // Time values not within the time range [_startTimeMs, _endTimeMs) are filtered out
   private final long _startTimeMs;
   private final long _endTimeMs;
+  private final boolean _negateWindowFilter;
 
   // Time values are rounded (floored) to the nearest time bucket
   // newTimeValue = (originalTimeValue / _roundBucketMs) * _roundBucketMs
@@ -36,11 +37,12 @@ public class TimeHandlerConfig {
   // partition = Long.toString(timeMs / _partitionBucketMs)
   private final long _partitionBucketMs;
 
-  private TimeHandlerConfig(TimeHandler.Type type, long startTimeMs, long endTimeMs, long roundBucketMs,
-      long partitionBucketMs) {
+  private TimeHandlerConfig(TimeHandler.Type type, long startTimeMs, long endTimeMs, boolean negateWindowFilter,
+      long roundBucketMs, long partitionBucketMs) {
     _type = type;
     _startTimeMs = startTimeMs;
     _endTimeMs = endTimeMs;
+    _negateWindowFilter = negateWindowFilter;
     _roundBucketMs = roundBucketMs;
     _partitionBucketMs = partitionBucketMs;
   }
@@ -57,6 +59,10 @@ public class TimeHandlerConfig {
     return _endTimeMs;
   }
 
+  public boolean getNegateWindowFilter() {
+    return _negateWindowFilter;
+  }
+
   public long getRoundBucketMs() {
     return _roundBucketMs;
   }
@@ -68,7 +74,8 @@ public class TimeHandlerConfig {
   @Override
   public String toString() {
     return "TimeHandlerConfig{" + "_type=" + _type + ", _startTimeMs=" + _startTimeMs + ", _endTimeMs=" + _endTimeMs
-        + ", _roundBucketMs=" + _roundBucketMs + ", _partitionBucketMs=" + _partitionBucketMs + '}';
+        + ", _negateWindowFilter=" + _negateWindowFilter + ", _roundBucketMs=" + _roundBucketMs
+        + ", _partitionBucketMs=" + _partitionBucketMs + '}';
   }
 
   public static class Builder {
@@ -76,6 +83,7 @@ public class TimeHandlerConfig {
 
     private long _startTimeMs = -1;
     private long _endTimeMs = -1;
+    private boolean _negateWindowFilter = false;
     private long _roundBucketMs = -1;
     private long _partitionBucketMs = -1;
 
@@ -86,6 +94,11 @@ public class TimeHandlerConfig {
     public Builder setTimeRange(long startTimeMs, long endTimeMs) {
       _startTimeMs = startTimeMs;
       _endTimeMs = endTimeMs;
+      return this;
+    }
+
+    public Builder setNegateWindowFilter(boolean negateWindowFilter) {
+      _negateWindowFilter = negateWindowFilter;
       return this;
     }
 
@@ -100,7 +113,8 @@ public class TimeHandlerConfig {
     }
 
     public TimeHandlerConfig build() {
-      return new TimeHandlerConfig(_type, _startTimeMs, _endTimeMs, _roundBucketMs, _partitionBucketMs);
+      return new TimeHandlerConfig(_type, _startTimeMs, _endTimeMs, _negateWindowFilter, _roundBucketMs,
+          _partitionBucketMs);
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/timehandler/TimeHandlerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/timehandler/TimeHandlerFactory.java
@@ -48,7 +48,7 @@ public class TimeHandlerFactory {
         Preconditions.checkState(dateTimeFieldSpec != null,
             "Time column: %s is not configured as DateTimeField within the schema", timeColumn);
         return new EpochTimeHandler(dateTimeFieldSpec, timeHandlerConfig.getStartTimeMs(),
-            timeHandlerConfig.getEndTimeMs(), timeHandlerConfig.getNegateWindowFilter(),
+            timeHandlerConfig.getEndTimeMs(), timeHandlerConfig.isNegateWindowFilter(),
             timeHandlerConfig.getRoundBucketMs(), timeHandlerConfig.getPartitionBucketMs());
       default:
         throw new IllegalStateException("Unsupported time handler type: " + type);

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/timehandler/TimeHandlerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/timehandler/TimeHandlerFactory.java
@@ -48,8 +48,8 @@ public class TimeHandlerFactory {
         Preconditions.checkState(dateTimeFieldSpec != null,
             "Time column: %s is not configured as DateTimeField within the schema", timeColumn);
         return new EpochTimeHandler(dateTimeFieldSpec, timeHandlerConfig.getStartTimeMs(),
-            timeHandlerConfig.getEndTimeMs(), timeHandlerConfig.getRoundBucketMs(),
-            timeHandlerConfig.getPartitionBucketMs());
+            timeHandlerConfig.getEndTimeMs(), timeHandlerConfig.getNegateWindowFilter(),
+            timeHandlerConfig.getRoundBucketMs(), timeHandlerConfig.getPartitionBucketMs());
       default:
         throw new IllegalStateException("Unsupported time handler type: " + type);
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFrameworkTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFrameworkTest.java
@@ -281,6 +281,23 @@ public class SegmentProcessorFrameworkTest {
     FileUtils.cleanDirectory(workingDir);
     rewindRecordReaders(_singleSegment);
 
+    // Negate time filter
+    config = new SegmentProcessorConfig.Builder().setTableConfig(_tableConfig).setSchema(_schema).setTimeHandlerConfig(
+        new TimeHandlerConfig.Builder(TimeHandler.Type.EPOCH).setTimeRange(1597795200000L, 1597881600000L)
+            .setNegateWindowFilter(true).build()).build();
+    framework = new SegmentProcessorFramework(_singleSegment, config, workingDir);
+    outputSegments = framework.process();
+    assertEquals(outputSegments.size(), 1);
+    segmentMetadata = new SegmentMetadataImpl(outputSegments.get(0));
+    assertEquals(segmentMetadata.getTotalDocs(), 5);
+    timeMetadata = segmentMetadata.getColumnMetadataFor("time");
+    assertEquals(timeMetadata.getCardinality(), 5);
+    assertEquals(timeMetadata.getMinValue(), 1597719600000L);
+    assertEquals(timeMetadata.getMaxValue(), 1597892400000L);
+    assertEquals(segmentMetadata.getName(), "myTable_1597719600000_1597892400000_0");
+    FileUtils.cleanDirectory(workingDir);
+    rewindRecordReaders(_singleSegment);
+
     // Time filter - filtered everything
     config = new SegmentProcessorConfig.Builder().setTableConfig(_tableConfig).setSchema(_schema).setTimeHandlerConfig(
         new TimeHandlerConfig.Builder(TimeHandler.Type.EPOCH).setTimeRange(1597968000000L, 1598054400000L).build())

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtils.java
@@ -64,8 +64,9 @@ public class MergeTaskUtils {
       return null;
     }
     DateTimeFieldSpec fieldSpec = schema.getSpecForTimeColumn(timeColumn);
-    Preconditions.checkState(fieldSpec != null, "No valid spec found for time column: %s in schema for table: %s", timeColumn,
-        tableConfig.getTableName());
+    Preconditions
+        .checkState(fieldSpec != null, "No valid spec found for time column: %s in schema for table: %s", timeColumn,
+            tableConfig.getTableName());
 
     TimeHandlerConfig.Builder timeHandlerConfigBuilder = new TimeHandlerConfig.Builder(TimeHandler.Type.EPOCH);
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MergeTaskUtils.java
@@ -64,15 +64,16 @@ public class MergeTaskUtils {
       return null;
     }
     DateTimeFieldSpec fieldSpec = schema.getSpecForTimeColumn(timeColumn);
-    Preconditions.checkState(fieldSpec != null, "No valid spec found for time column: %s in schema for table: %s",
-        timeColumn, tableConfig.getTableName());
+    Preconditions.checkState(fieldSpec != null, "No valid spec found for time column: %s in schema for table: %s", timeColumn,
+        tableConfig.getTableName());
 
     TimeHandlerConfig.Builder timeHandlerConfigBuilder = new TimeHandlerConfig.Builder(TimeHandler.Type.EPOCH);
 
     String windowStartMs = taskConfig.get(MergeTask.WINDOW_START_MS_KEY);
     String windowEndMs = taskConfig.get(MergeTask.WINDOW_END_MS_KEY);
     if (windowStartMs != null && windowEndMs != null) {
-      timeHandlerConfigBuilder.setTimeRange(Long.parseLong(windowStartMs), Long.parseLong(windowEndMs));
+      timeHandlerConfigBuilder.setTimeRange(Long.parseLong(windowStartMs), Long.parseLong(windowEndMs))
+          .setNegateWindowFilter(Boolean.parseBoolean(taskConfig.get(MergeTask.NEGATE_WINDOW_FILTER)));
     }
 
     String roundBucketTimePeriod = taskConfig.get(MergeTask.ROUND_BUCKET_TIME_PERIOD_KEY);


### PR DESCRIPTION
add config `negateWindowFilter` to let SegmentProcessorFramework take data outside the time window when generating segments

## Release Note
new config `negateWindowFilter` for SegmentProcessorFramework. It's false by default to be backward compatible. 