### PR TITLE
Handle BYTES and BIG_DECIMAL Multi-value columns in indices

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentDictionaryCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentDictionaryCreator.java
@@ -345,6 +345,16 @@ public class SegmentDictionaryCreator implements Closeable {
           indexes[i] = _stringValueToIndexMap.getInt(multiValues[i]);
         }
         break;
+      case BIG_DECIMAL:
+        for (int i = 0; i < multiValues.length; i++) {
+          indexes[i] = _bigDecimalValueToIndexMap.getInt((BigDecimal) multiValues[i]);
+        }
+        break;
+      case BYTES:
+        for (int i = 0; i < multiValues.length; i++) {
+          indexes[i] = _bytesValueToIndexMap.get(new ByteArray((byte[]) multiValues[i]));
+        }
+        break;
       default:
         throw new UnsupportedOperationException("Unsupported data type : " + _storedType);
     }


### PR DESCRIPTION
Related to #8635 

Currently, BYTES and BIG_DECIMAL data types in are handled only for single-value columns in `SegmentDictionaryCreator`. The PR fixes this issue.