### PR TITLE
Revert "Enable minion liveness probe"

### DIFF
--- a/kubernetes/helm/pinot/values.yaml
+++ b/kubernetes/helm/pinot/values.yaml
@@ -341,8 +341,8 @@ minion:
 
   probes:
     endpoint: "/health"
-    livenessEnabled: true
-    readinessEnabled: true
+    livenessEnabled: false
+    readinessEnabled: false
 
   dataDir: /var/pinot/minion/data
   jvmOpts: "-Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-minion.log"


### PR DESCRIPTION
Reverts apache/pinot#8593

Minion /health port is 6500, and not 9514