### PR TITLE
Allow updating start/end offset for pushed segments

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
@@ -227,7 +227,7 @@ public class HelixBrokerStarterTest extends ControllerTest {
         _helixResourceManager.getSegmentZKMetadata(OFFLINE_TABLE_NAME, segmentToRefresh);
     _helixResourceManager.refreshSegment(OFFLINE_TABLE_NAME,
         SegmentMetadataMockUtils.mockSegmentMetadataWithEndTimeInfo(RAW_TABLE_NAME, segmentToRefresh, newEndTime),
-        segmentZKMetadata, EXPECTED_VERSION, "downloadUrl", null, -1);
+        segmentZKMetadata, EXPECTED_VERSION, "downloadUrl");
 
     TestUtils.waitForCondition(aVoid -> routingManager.getTimeBoundaryInfo(OFFLINE_TABLE_NAME).getTimeValue()
         .equals(Integer.toString(newEndTime - 1)), 30_000L, "Failed to update the time boundary for refreshed segment");

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadata.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.metadata.segment;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.TimeUnit;
+import org.apache.commons.collections.MapUtils;
 import org.apache.helix.ZNRecord;
 import org.apache.pinot.common.metadata.ZKMetadata;
 import org.apache.pinot.spi.utils.CommonConstants.Segment;
@@ -231,7 +232,7 @@ public class SegmentZKMetadata implements ZKMetadata {
 
   public void setCustomMap(Map<String, String> customMap) {
     Map<String, Map<String, String>> mapFields = _znRecord.getMapFields();
-    if (customMap != null) {
+    if (MapUtils.isNotEmpty(customMap)) {
       mapFields.put(Segment.CUSTOM_MAP, customMap);
     } else {
       mapFields.remove(Segment.CUSTOM_MAP);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/ZKMetadataUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/util/ZKMetadataUtils.java
@@ -20,58 +20,106 @@ package org.apache.pinot.controller.helix.core.util;
 
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
-import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
 import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.SegmentMetadata;
-import org.apache.pinot.segment.spi.creator.SegmentVersion;
-import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.segment.spi.partition.metadata.ColumnPartitionMetadata;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 
 public class ZKMetadataUtils {
   private ZKMetadataUtils() {
   }
 
-  public static void updateSegmentMetadata(SegmentZKMetadata segmentZKMetadata, SegmentMetadata segmentMetadata) {
-    SegmentVersion segmentVersion = segmentMetadata.getVersion();
-    if (segmentVersion != null) {
-      segmentZKMetadata.setIndexVersion(segmentVersion.name());
-    }
+  /**
+   * Creates the segment ZK metadata for a new segment.
+   */
+  public static SegmentZKMetadata createSegmentZKMetadata(String tableNameWithType, SegmentMetadata segmentMetadata,
+      String downloadUrl, @Nullable String crypter, long segmentSizeInBytes) {
+    SegmentZKMetadata segmentZKMetadata = new SegmentZKMetadata(segmentMetadata.getName());
+    updateSegmentZKMetadata(tableNameWithType, segmentZKMetadata, segmentMetadata, downloadUrl, crypter,
+        segmentSizeInBytes);
+    segmentZKMetadata.setPushTime(System.currentTimeMillis());
+    return segmentZKMetadata;
+  }
+
+  /**
+   * Refreshes the segment ZK metadata for a segment being replaced.
+   */
+  public static void refreshSegmentZKMetadata(String tableNameWithType, SegmentZKMetadata segmentZKMetadata,
+      SegmentMetadata segmentMetadata, String downloadUrl, @Nullable String crypter, long segmentSizeInBytes) {
+    updateSegmentZKMetadata(tableNameWithType, segmentZKMetadata, segmentMetadata, downloadUrl, crypter,
+        segmentSizeInBytes);
+    segmentZKMetadata.setRefreshTime(System.currentTimeMillis());
+  }
+
+  private static void updateSegmentZKMetadata(String tableNameWithType, SegmentZKMetadata segmentZKMetadata,
+      SegmentMetadata segmentMetadata, String downloadUrl, @Nullable String crypter, long segmentSizeInBytes) {
     if (segmentMetadata.getTimeInterval() != null) {
       segmentZKMetadata.setStartTime(segmentMetadata.getStartTime());
       segmentZKMetadata.setEndTime(segmentMetadata.getEndTime());
       segmentZKMetadata.setTimeUnit(segmentMetadata.getTimeUnit());
+    } else {
+      segmentZKMetadata.setStartTime(-1);
+      segmentZKMetadata.setEndTime(-1);
+      segmentZKMetadata.setTimeUnit(null);
+    }
+    if (segmentMetadata.getVersion() != null) {
+      segmentZKMetadata.setIndexVersion(segmentMetadata.getVersion().name());
+    } else {
+      segmentZKMetadata.setIndexVersion(null);
     }
     segmentZKMetadata.setTotalDocs(segmentMetadata.getTotalDocs());
-    segmentZKMetadata.setCreationTime(segmentMetadata.getIndexCreationTime());
+    segmentZKMetadata.setSizeInBytes(segmentSizeInBytes);
     segmentZKMetadata.setCrc(Long.parseLong(segmentMetadata.getCrc()));
-    SegmentZKMetadataCustomMapModifier segmentZKMetadataCustomMapModifier =
-        new SegmentZKMetadataCustomMapModifier(SegmentZKMetadataCustomMapModifier.ModifyMode.UPDATE,
-            segmentZKMetadata.getCustomMap());
-    segmentZKMetadata.setCustomMap(segmentZKMetadataCustomMapModifier.modifyMap(segmentMetadata.getCustomMap()));
+    segmentZKMetadata.setCreationTime(segmentMetadata.getIndexCreationTime());
+    segmentZKMetadata.setDownloadUrl(downloadUrl);
+    segmentZKMetadata.setCrypterName(crypter);
 
-    // Extract column partition metadata (if any), and set it into segment ZK metadata.
+    // Set partition metadata
     Map<String, ColumnPartitionMetadata> columnPartitionMap = new HashMap<>();
-    if (segmentMetadata instanceof SegmentMetadataImpl) {
-      for (Map.Entry<String, ColumnMetadata> entry : segmentMetadata.getColumnMetadataMap().entrySet()) {
-        String column = entry.getKey();
-        ColumnMetadata columnMetadata = entry.getValue();
-        PartitionFunction partitionFunction = columnMetadata.getPartitionFunction();
-
-        if (partitionFunction != null) {
-          ColumnPartitionMetadata columnPartitionMetadata =
-              new ColumnPartitionMetadata(partitionFunction.getName(), partitionFunction.getNumPartitions(),
-                  columnMetadata.getPartitions(), partitionFunction.getFunctionConfig());
-          columnPartitionMap.put(column, columnPartitionMetadata);
-        }
+    for (Map.Entry<String, ColumnMetadata> entry : segmentMetadata.getColumnMetadataMap().entrySet()) {
+      String column = entry.getKey();
+      ColumnMetadata columnMetadata = entry.getValue();
+      PartitionFunction partitionFunction = columnMetadata.getPartitionFunction();
+      if (partitionFunction != null) {
+        ColumnPartitionMetadata columnPartitionMetadata =
+            new ColumnPartitionMetadata(partitionFunction.getName(), partitionFunction.getNumPartitions(),
+                columnMetadata.getPartitions(), partitionFunction.getFunctionConfig());
+        columnPartitionMap.put(column, columnPartitionMetadata);
       }
     }
-
     if (!columnPartitionMap.isEmpty()) {
       segmentZKMetadata.setPartitionMetadata(new SegmentPartitionMetadata(columnPartitionMap));
+    } else {
+      segmentZKMetadata.setPartitionMetadata(null);
+    }
+
+    // Update custom metadata
+    // NOTE: Do not remove existing keys because they can be set by the HTTP header from the segment upload request
+    Map<String, String> customMap = segmentZKMetadata.getCustomMap();
+    if (customMap == null) {
+      customMap = segmentMetadata.getCustomMap();
+    } else {
+      customMap.putAll(segmentMetadata.getCustomMap());
+    }
+    segmentZKMetadata.setCustomMap(customMap);
+
+    // Set fields specific to realtime table
+    if (TableNameBuilder.isRealtimeTableResource(tableNameWithType)) {
+      segmentZKMetadata.setStatus(CommonConstants.Segment.Realtime.Status.UPLOADED);
+
+      // NOTE: Keep offset as is if it is not explicitly set in the segment metadata
+      if (segmentMetadata.getStartOffset() != null) {
+        segmentZKMetadata.setStartOffset(segmentMetadata.getStartOffset());
+      }
+      if (segmentMetadata.getEndOffset() != null) {
+        segmentZKMetadata.setEndOffset(segmentMetadata.getEndOffset());
+      }
     }
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -23,7 +23,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.helix.HelixAdmin;
+import org.apache.helix.ZNRecord;
 import org.apache.helix.model.IdealState;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.metrics.PinotMetricUtils;
@@ -33,16 +35,12 @@ import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.PinotTableIdealStateBuilder;
 import org.apache.pinot.controller.helix.core.SegmentDeletionManager;
-import org.apache.pinot.controller.helix.core.util.ZKMetadataUtils;
-import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
-import org.joda.time.Duration;
-import org.joda.time.Interval;
 import org.mockito.ArgumentMatchers;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -66,18 +64,14 @@ public class RetentionManagerTest {
     final int numOlderSegments = 10;
     List<String> removedSegments = new ArrayList<>();
     for (int i = 0; i < numOlderSegments; i++) {
-      SegmentMetadata segmentMetadata = mockSegmentMetadata(pastTimeStamp, pastTimeStamp, timeUnit);
-      SegmentZKMetadata segmentZKMetadata = new SegmentZKMetadata(segmentMetadata.getName());
-      ZKMetadataUtils.updateSegmentMetadata(segmentZKMetadata, segmentMetadata);
+      SegmentZKMetadata segmentZKMetadata = mockSegmentZKMetadata(pastTimeStamp, pastTimeStamp, timeUnit);
       segmentsZKMetadata.add(segmentZKMetadata);
       removedSegments.add(segmentZKMetadata.getSegmentName());
     }
     // Create metadata for 5 segments that will not be removed.
     for (int i = 0; i < 5; i++) {
-      SegmentMetadata segmentMetadata =
-          mockSegmentMetadata(dayAfterTomorrowTimeStamp, dayAfterTomorrowTimeStamp, timeUnit);
-      SegmentZKMetadata segmentZKMetadata = new SegmentZKMetadata(segmentMetadata.getName());
-      ZKMetadataUtils.updateSegmentMetadata(segmentZKMetadata, segmentMetadata);
+      SegmentZKMetadata segmentZKMetadata =
+          mockSegmentZKMetadata(dayAfterTomorrowTimeStamp, dayAfterTomorrowTimeStamp, timeUnit);
       segmentsZKMetadata.add(segmentZKMetadata);
     }
     final TableConfig tableConfig = createOfflineTableConfig();
@@ -166,6 +160,9 @@ public class RetentionManagerTest {
       PinotHelixResourceManager resourceManager) {
     final String tableNameWithType = tableConfig.getTableName();
     when(resourceManager.getAllTables()).thenReturn(Collections.singletonList(tableNameWithType));
+
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(resourceManager.getPropertyStore()).thenReturn(propertyStore);
 
     SegmentDeletionManager deletionManager = mock(SegmentDeletionManager.class);
     // Ignore the call to SegmentDeletionManager.removeAgedDeletedSegments. we only test that the call is made once per
@@ -308,18 +305,13 @@ public class RetentionManagerTest {
     return segmentMetadata;
   }
 
-  private SegmentMetadata mockSegmentMetadata(long startTime, long endTime, TimeUnit timeUnit) {
+  private SegmentZKMetadata mockSegmentZKMetadata(long startTime, long endTime, TimeUnit timeUnit) {
     long creationTime = System.currentTimeMillis();
-    SegmentMetadata segmentMetadata = mock(SegmentMetadata.class);
-    when(segmentMetadata.getName()).thenReturn(TEST_TABLE_NAME + creationTime);
-    when(segmentMetadata.getIndexCreationTime()).thenReturn(creationTime);
-    when(segmentMetadata.getCrc()).thenReturn(Long.toString(creationTime));
-    when(segmentMetadata.getStartTime()).thenReturn(startTime);
-    when(segmentMetadata.getEndTime()).thenReturn(endTime);
-    when(segmentMetadata.getTimeUnit()).thenReturn(timeUnit);
-    when(segmentMetadata.getTimeInterval())
-        .thenReturn(new Interval(timeUnit.toMillis(startTime), timeUnit.toMillis(endTime)));
-    when(segmentMetadata.getTimeGranularity()).thenReturn(new Duration(timeUnit.toMillis(1)));
-    return segmentMetadata;
+    SegmentZKMetadata segmentZKMetadata = mock(SegmentZKMetadata.class);
+    when(segmentZKMetadata.getSegmentName()).thenReturn(TEST_TABLE_NAME + creationTime);
+    when(segmentZKMetadata.getCreationTime()).thenReturn(creationTime);
+    when(segmentZKMetadata.getStartTimeMs()).thenReturn(timeUnit.toMillis(startTime));
+    when(segmentZKMetadata.getEndTimeMs()).thenReturn(timeUnit.toMillis(endTime));
+    return segmentZKMetadata;
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/validation/ValidationManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/validation/ValidationManagerTest.java
@@ -89,8 +89,7 @@ public class ValidationManagerTest {
     }, 30_000L, "Failed to find the segment in the ExternalView");
     Mockito.when(segmentMetadata.getCrc()).thenReturn(Long.toString(System.nanoTime()));
     ControllerTestUtils.getHelixResourceManager()
-        .refreshSegment(offlineTableName, segmentMetadata, segmentZKMetadata, EXPECTED_VERSION, "downloadUrl", null,
-            -1);
+        .refreshSegment(offlineTableName, segmentMetadata, segmentZKMetadata, EXPECTED_VERSION, "downloadUrl");
 
     segmentZKMetadata =
         ControllerTestUtils.getHelixResourceManager().getSegmentZKMetadata(OFFLINE_TEST_TABLE_NAME, TEST_SEGMENT_NAME);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -64,7 +64,6 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Interval;
@@ -285,8 +284,8 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
     // Do not create dictionary if index size with dictionary is going to be larger than index size without dictionary
     // This is done to reduce the cost of dictionary for high cardinality columns
     // Off by default and needs optimizeDictionaryEnabled to be set to true
-    if (config.isOptimizeDictionaryForMetrics() && spec.getFieldType() == FieldType.METRIC
-        && spec.isSingleValueField() && spec.getDataType().isFixedWidth()) {
+    if (config.isOptimizeDictionaryForMetrics() && spec.getFieldType() == FieldType.METRIC && spec.isSingleValueField()
+        && spec.getDataType().isFixedWidth()) {
       long dictionarySize = info.getDistinctValueCount() * spec.getDataType().size();
       long forwardIndexSize =
           ((long) info.getTotalNumberOfEntries() * PinotDataBitSet.getNumBitsPerValue(info.getDistinctValueCount() - 1)
@@ -663,8 +662,8 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
 
     SegmentZKPropsConfig segmentZKPropsConfig = _config.getSegmentZKPropsConfig();
     if (segmentZKPropsConfig != null) {
-      properties.setProperty(CommonConstants.Segment.Realtime.START_OFFSET, segmentZKPropsConfig.getStartOffset());
-      properties.setProperty(CommonConstants.Segment.Realtime.END_OFFSET, segmentZKPropsConfig.getEndOffset());
+      properties.setProperty(Realtime.START_OFFSET, segmentZKPropsConfig.getStartOffset());
+      properties.setProperty(Realtime.END_OFFSET, segmentZKPropsConfig.getEndOffset());
     }
 
     properties.save();

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentMetadata.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentMetadata.java
@@ -94,6 +94,10 @@ public interface SegmentMetadata {
 
   Map<String, String> getCustomMap();
 
+  String getStartOffset();
+
+  String getEndOffset();
+
   default Set<String> getAllColumns() {
     return getSchema().getColumnNames();
   }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
@@ -77,6 +77,11 @@ public class V1Constants {
       public static final String SEGMENT_PADDING_CHARACTER = "segment.padding.character";
 
       public static final String CUSTOM_SUBSET = "custom";
+
+      public static class Realtime {
+        public static final String START_OFFSET = "segment.realtime.startOffset";
+        public static final String END_OFFSET = "segment.realtime.endOffset";
+      }
     }
 
     public static class Column {


### PR DESCRIPTION
Subtask of #8283 

- Support updating start/end offset in the segment ZK metadata for pushed segments if provided in the segment metadata
- Refactor the updating segment ZK metadata logic to have consistent behavior for adding new segment and refreshing existing segment