### PR TITLE
Add Pulsar plugin back to distribution

### DIFF
--- a/pinot-distribution/pinot-assembly.xml
+++ b/pinot-distribution/pinot-assembly.xml
@@ -69,12 +69,10 @@
       <destName>plugins/pinot-stream-ingestion/pinot-kinesis/pinot-kinesis-${project.version}-shaded.jar</destName>
     </file>
 
-    <!-- TODO: fix the runtime issue for Apache Pulsar plug-in and add this back. (https://github.com/apache/pinot/issues/7270)
     <file>
       <source>${pinot.root}/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/target/pinot-pulsar-${project.version}-shaded.jar</source>
       <destName>plugins/pinot-stream-ingestion/pinot-pulsar/pinot-pulsar-${project.version}-shaded.jar</destName>
     </file>
-    -->
 
     <!-- End Include Pinot Stream Ingestion Plugins-->
     <!-- Start Include Pinot Batch Ingestion Plugins-->

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -136,7 +136,8 @@ public class ComplexTypeTransformer implements RecordTransformer {
    */
   @Nullable
   public static ComplexTypeTransformer getComplexTypeTransformer(TableConfig tableConfig) {
-    if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getComplexTypeConfig() != null) {
+    if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getComplexTypeConfig() != null
+    && tableConfig.getIngestionConfig().getComplexTypeConfig().getFieldsToUnnest() != null) {
       return new ComplexTypeTransformer(tableConfig);
     }
     return null;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -136,8 +136,7 @@ public class ComplexTypeTransformer implements RecordTransformer {
    */
   @Nullable
   public static ComplexTypeTransformer getComplexTypeTransformer(TableConfig tableConfig) {
-    if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getComplexTypeConfig() != null
-    && tableConfig.getIngestionConfig().getComplexTypeConfig().getFieldsToUnnest() != null) {
+    if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getComplexTypeConfig() != null) {
       return new ComplexTypeTransformer(tableConfig);
     }
     return null;


### PR DESCRIPTION
Pulsar plugin was removed from the distribution due to issue #7270 

The issue has been fixed for a while now and so this plugin can be added back to the binary dist.