### PR TITLE
Adding pinot file system command

### DIFF
--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -468,6 +468,16 @@
                 </extraArguments>
               </jvmSettings>
             </program>
+            <program>
+              <mainClass>org.apache.pinot.tools.admin.command.FileSystemCommand</mainClass>
+              <name>pinot-fs-util</name>
+              <jvmSettings>
+                <initialMemorySize>4G</initialMemorySize>
+                <extraArguments>
+                  <extraArgument>-Dlog4j2.configurationFile=conf/pinot-tools-log4j2.xml</extraArgument>
+                </extraArguments>
+              </jvmSettings>
+            </program>
           </programs>
           <binFileExtensions>
             <unix>.sh</unix>

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
@@ -33,6 +33,7 @@ import org.apache.pinot.tools.admin.command.ChangeNumReplicasCommand;
 import org.apache.pinot.tools.admin.command.ChangeTableState;
 import org.apache.pinot.tools.admin.command.CreateSegmentCommand;
 import org.apache.pinot.tools.admin.command.DeleteClusterCommand;
+import org.apache.pinot.tools.admin.command.FileSystemCommand;
 import org.apache.pinot.tools.admin.command.GenerateDataCommand;
 import org.apache.pinot.tools.admin.command.GitHubEventsQuickStartCommand;
 import org.apache.pinot.tools.admin.command.ImportDataCommand;
@@ -128,6 +129,7 @@ public class PinotAdministrator {
     SUBCOMMAND_MAP.put("StreamGitHubEvents", new StreamGitHubEventsCommand());
     SUBCOMMAND_MAP.put("BootstrapTable", new BootstrapTableCommand());
     SUBCOMMAND_MAP.put("SegmentProcessorFramework", new SegmentProcessorFrameworkCommand());
+    SUBCOMMAND_MAP.put("FileSystem", new FileSystemCommand());
   }
 
   @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false,

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/FileSystemCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/FileSystemCommand.java
@@ -18,65 +18,40 @@
  */
 package org.apache.pinot.tools.admin.command;
 
-import com.google.common.collect.ImmutableMap;
-import java.io.File;
-import java.io.PrintStream;
-import java.net.URI;
 import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.filesystem.PinotFS;
-import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.plugin.PluginManager;
-import org.apache.pinot.spi.utils.StringUtil;
 import org.apache.pinot.tools.Command;
-import org.apache.pinot.tools.utils.PinotConfigUtils;
+import org.apache.pinot.tools.admin.command.filesystem.CopyFiles;
+import org.apache.pinot.tools.admin.command.filesystem.DeleteFiles;
+import org.apache.pinot.tools.admin.command.filesystem.ListFiles;
+import org.apache.pinot.tools.admin.command.filesystem.MoveFiles;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
 
 
-@CommandLine.Command(name = "FileSystem")
+@CommandLine.Command(name = "FileSystem", subcommands = {
+    ListFiles.class,
+    CopyFiles.class,
+    MoveFiles.class,
+    DeleteFiles.class
+})
 public class FileSystemCommand extends AbstractBaseAdminCommand implements Command {
   private static final Logger LOGGER = LoggerFactory.getLogger(FileSystemCommand.class.getName());
 
-  private static final String[] SUPPORTED_FS_COMMANDS = new String[]{
-      "EXISTS", "IS_DIR", "LAST_MODIFIED", "LENGTH",
-      "LIST_FILE", "LIST_FILE_RECURSIVE",
-      "CP", "COPY_DIR",
-      "COPY_FROM_LOCAL_FILE", "COPY_FROM_LOCAL_DIR", "COPY_TO_LOCAL_FILE",
-      "MV", "DELETE"
-  };
-
-  @CommandLine.Option(names = {"-scheme"}, required = true, description = "PinotFS scheme name, e.g. "
-      + "file/s3/adls/gcs/hdfs.")
-  private String _scheme;
-
-  @CommandLine.Option(names = {"-config", "-configFile"}, description =
-      "PinotFS Config file.")
+  @CommandLine.Option(names = {"-conf", "-config", "-configFile", "-config-file"}, scope =
+      CommandLine.ScopeType.INHERIT, description = "PinotFS Config file.")
   private String _configFile;
 
-  @CommandLine.Option(names = {"-command"}, required = true, arity = "1..*", description = "File system command, e.g."
-      + " EXISTS, IS_DIR, LAST_MODIFIED, LENGTH, LIST_FILE, LIST_FILE_RECURSIVE, CP, COPY_DIR, COPY_FROM_LOCAL_FILE, "
-      + "COPY_FROM_LOCAL_DIR, COPY_TO_LOCAL_FILE, MV, DELETE")
-  private String[] _command;
-
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, usageHelp = true, description = "Print this message.")
+  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, usageHelp = true, description = "Print this message.",
+      scope = CommandLine.ScopeType.INHERIT)
   private boolean _help = false;
 
-  public FileSystemCommand setScheme(String scheme) {
-    _scheme = scheme;
-    return this;
-  }
+  @CommandLine.Parameters
+  private String[] _parameters;
 
   public FileSystemCommand setConfigFile(String configFile) {
     _configFile = configFile;
-    return this;
-  }
-
-  public FileSystemCommand setCommand(String[] command) {
-    _command = command;
     return this;
   }
 
@@ -85,16 +60,13 @@ public class FileSystemCommand extends AbstractBaseAdminCommand implements Comma
     return this;
   }
 
-  public String getScheme() {
-    return _scheme;
-  }
-
   public String getConfigFile() {
     return _configFile;
   }
 
-  public String[] getCommand() {
-    return _command;
+  public FileSystemCommand setParameters(String[] parameters) {
+    _parameters = parameters;
+    return this;
   }
 
   @Override
@@ -109,8 +81,7 @@ public class FileSystemCommand extends AbstractBaseAdminCommand implements Comma
 
   @Override
   public String toString() {
-    return ("FileSystem --scheme " + _scheme + " -configFileName " + _configFile + " -command " + Arrays.toString(
-        _command));
+    return "FileSystem -configFile " + _configFile;
   }
 
   @Override
@@ -122,106 +93,19 @@ public class FileSystemCommand extends AbstractBaseAdminCommand implements Comma
     return "Pinot File system operation.";
   }
 
-  public String run()
-      throws Exception {
-    LOGGER.info("Executing command: " + this);
-    Map<String, Object> configs =
-        getConfigFile() == null ? new HashMap<>() : PinotConfigUtils.readConfigFromFile(getConfigFile());
-    PinotFSFactory.init(new PinotConfiguration(configs));
-    registerDefaultPinotFS();
-
-    PinotFS pinotFS = PinotFSFactory.create(getScheme());
-    String output = "DONE";
-    String fsOp = _command[0].replace("_", "").toUpperCase();
-    String[] arguments = Arrays.copyOfRange(_command, 1, _command.length);
-    try {
-      switch (fsOp) {
-        case "LSFILE":
-        case "LISTFILE":
-          output = StringUtil.join("\n", pinotFS.listFiles(URI.create(arguments[0]), false));
-          break;
-        case "LISTFILERECURSIVE":
-          output = StringUtil.join("\n", pinotFS.listFiles(URI.create(arguments[0]), true));
-          break;
-        case "CP":
-        case "COPY":
-          output = String.valueOf(pinotFS.copy(URI.create(arguments[0]), URI.create(arguments[1])));
-          break;
-        case "COPYDIR":
-          pinotFS.copyDir(URI.create(arguments[0]), URI.create(arguments[1]));
-          break;
-        case "COPYFROMLOCALDIR":
-          pinotFS.copyFromLocalDir(new File(arguments[0]), URI.create(arguments[1]));
-          break;
-        case "COPYFROMLOCALFILE":
-          pinotFS.copyFromLocalFile(new File(arguments[0]), URI.create(arguments[1]));
-          break;
-        case "COPYTOLOCALFILE":
-          pinotFS.copyToLocalFile(URI.create(arguments[0]), new File(arguments[1]));
-          break;
-        case "EXISTS":
-          output = String.valueOf(pinotFS.exists(URI.create(arguments[0])));
-          break;
-        case "DELETE":
-          pinotFS.delete(URI.create(arguments[0]), true);
-          break;
-        case "ISDIR":
-        case "ISDIRECTORY":
-          output = String.valueOf(pinotFS.isDirectory(URI.create(arguments[0])));
-          break;
-        case "LASTMODIFIED":
-          output = String.valueOf(pinotFS.lastModified(URI.create(arguments[0])));
-          break;
-        case "LENGTH":
-          output = String.valueOf(pinotFS.length(URI.create(arguments[0])));
-          break;
-        case "MV":
-        case "MOVE":
-          output = String.valueOf(pinotFS.move(URI.create(arguments[0]), URI.create(arguments[1]), true));
-          break;
-        case "MKDIR":
-          output = String.valueOf(pinotFS.mkdir(URI.create(arguments[0])));
-          break;
-        default:
-          output = "Unsupported file system op: " + fsOp + ". Current supported operations are: "
-              + StringUtil.join(", ", SUPPORTED_FS_COMMANDS);
-          break;
-      }
-    } catch (Exception e) {
-      e.printStackTrace(new PrintStream(output));
-    }
-    return output;
-  }
-
-  private void registerDefaultPinotFS() {
-    registerPinotFS("s3", "org.apache.pinot.plugin.filesystem.S3PinotFS",
-        ImmutableMap.of("region", System.getProperty("AWS_REGION", "us-west-2")));
-  }
-
-  public static void registerPinotFS(String scheme, String fsClassName, Map<String, Object> configs) {
-    if (PinotFSFactory.isSchemeSupported(scheme)) {
-      LOGGER.info("PinotFS for scheme: {} is already registered.", scheme);
-      return;
-    }
-    try {
-      PinotFSFactory.register(scheme, fsClassName, new PinotConfiguration(configs));
-      LOGGER.info("Registered PinotFS for scheme: {}", scheme);
-    } catch (Exception e) {
-      LOGGER.error("Unable to init PinotFS for scheme: {}, class name: {}, configs: {}", scheme, fsClassName, configs,
-          e);
-    }
-  }
-
   @Override
   public boolean execute()
       throws Exception {
-    String result = run();
-    LOGGER.info(result);
-    return true;
+    // All FileSystem commands should go to SubCommand class.
+    System.out.println("Unsupported subcommand: " + Arrays.toString(_parameters));
+    return false;
   }
 
   public static void main(String[] args) {
     PluginManager.get().init();
-    new CommandLine(new FileSystemCommand()).execute(args);
+    int exitCode = new CommandLine(new FileSystemCommand()).execute(args);
+    if (exitCode != 0 && Boolean.parseBoolean(System.getProperties().getProperty("pinot.admin.system.exit", "true"))) {
+      System.exit(exitCode);
+    }
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/FileSystemCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/FileSystemCommand.java
@@ -1,0 +1,227 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.admin.command;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.io.PrintStream;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.plugin.PluginManager;
+import org.apache.pinot.spi.utils.StringUtil;
+import org.apache.pinot.tools.Command;
+import org.apache.pinot.tools.utils.PinotConfigUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+
+@CommandLine.Command(name = "FileSystem")
+public class FileSystemCommand extends AbstractBaseAdminCommand implements Command {
+  private static final Logger LOGGER = LoggerFactory.getLogger(FileSystemCommand.class.getName());
+
+  private static final String[] SUPPORTED_FS_COMMANDS = new String[]{
+      "EXISTS", "IS_DIR", "LAST_MODIFIED", "LENGTH",
+      "LIST_FILE", "LIST_FILE_RECURSIVE",
+      "CP", "COPY_DIR",
+      "COPY_FROM_LOCAL_FILE", "COPY_FROM_LOCAL_DIR", "COPY_TO_LOCAL_FILE",
+      "MV", "DELETE"
+  };
+
+  @CommandLine.Option(names = {"-scheme"}, required = true, description = "PinotFS scheme name, e.g. "
+      + "file/s3/adls/gcs/hdfs.")
+  private String _scheme;
+
+  @CommandLine.Option(names = {"-config", "-configFile"}, description =
+      "PinotFS Config file.")
+  private String _configFile;
+
+  @CommandLine.Option(names = {"-command"}, required = true, arity = "1..*", description = "File system command, e.g."
+      + " EXISTS, IS_DIR, LAST_MODIFIED, LENGTH, LIST_FILE, LIST_FILE_RECURSIVE, CP, COPY_DIR, COPY_FROM_LOCAL_FILE, "
+      + "COPY_FROM_LOCAL_DIR, COPY_TO_LOCAL_FILE, MV, DELETE")
+  private String[] _command;
+
+  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, usageHelp = true, description = "Print this message.")
+  private boolean _help = false;
+
+  public FileSystemCommand setScheme(String scheme) {
+    _scheme = scheme;
+    return this;
+  }
+
+  public FileSystemCommand setConfigFile(String configFile) {
+    _configFile = configFile;
+    return this;
+  }
+
+  public FileSystemCommand setCommand(String[] command) {
+    _command = command;
+    return this;
+  }
+
+  public FileSystemCommand setHelp(boolean help) {
+    _help = help;
+    return this;
+  }
+
+  public String getScheme() {
+    return _scheme;
+  }
+
+  public String getConfigFile() {
+    return _configFile;
+  }
+
+  public String[] getCommand() {
+    return _command;
+  }
+
+  @Override
+  public boolean getHelp() {
+    return _help;
+  }
+
+  @Override
+  public String getName() {
+    return "FileSystem";
+  }
+
+  @Override
+  public String toString() {
+    return ("FileSystem --scheme " + _scheme + " -configFileName " + _configFile + " -command " + Arrays.toString(
+        _command));
+  }
+
+  @Override
+  public void cleanup() {
+  }
+
+  @Override
+  public String description() {
+    return "Pinot File system operation.";
+  }
+
+  public String run()
+      throws Exception {
+    LOGGER.info("Executing command: " + this);
+    Map<String, Object> configs =
+        getConfigFile() == null ? new HashMap<>() : PinotConfigUtils.readConfigFromFile(getConfigFile());
+    PinotFSFactory.init(new PinotConfiguration(configs));
+    registerDefaultPinotFS();
+
+    PinotFS pinotFS = PinotFSFactory.create(getScheme());
+    String output = "DONE";
+    String fsOp = _command[0].replace("_", "").toUpperCase();
+    String[] arguments = Arrays.copyOfRange(_command, 1, _command.length);
+    try {
+      switch (fsOp) {
+        case "LSFILE":
+        case "LISTFILE":
+          output = StringUtil.join("\n", pinotFS.listFiles(URI.create(arguments[0]), false));
+          break;
+        case "LISTFILERECURSIVE":
+          output = StringUtil.join("\n", pinotFS.listFiles(URI.create(arguments[0]), true));
+          break;
+        case "CP":
+        case "COPY":
+          output = String.valueOf(pinotFS.copy(URI.create(arguments[0]), URI.create(arguments[1])));
+          break;
+        case "COPYDIR":
+          pinotFS.copyDir(URI.create(arguments[0]), URI.create(arguments[1]));
+          break;
+        case "COPYFROMLOCALDIR":
+          pinotFS.copyFromLocalDir(new File(arguments[0]), URI.create(arguments[1]));
+          break;
+        case "COPYFROMLOCALFILE":
+          pinotFS.copyFromLocalFile(new File(arguments[0]), URI.create(arguments[1]));
+          break;
+        case "COPYTOLOCALFILE":
+          pinotFS.copyToLocalFile(URI.create(arguments[0]), new File(arguments[1]));
+          break;
+        case "EXISTS":
+          output = String.valueOf(pinotFS.exists(URI.create(arguments[0])));
+          break;
+        case "DELETE":
+          pinotFS.delete(URI.create(arguments[0]), true);
+          break;
+        case "ISDIR":
+        case "ISDIRECTORY":
+          output = String.valueOf(pinotFS.isDirectory(URI.create(arguments[0])));
+          break;
+        case "LASTMODIFIED":
+          output = String.valueOf(pinotFS.lastModified(URI.create(arguments[0])));
+          break;
+        case "LENGTH":
+          output = String.valueOf(pinotFS.length(URI.create(arguments[0])));
+          break;
+        case "MV":
+        case "MOVE":
+          output = String.valueOf(pinotFS.move(URI.create(arguments[0]), URI.create(arguments[1]), true));
+          break;
+        case "MKDIR":
+          output = String.valueOf(pinotFS.mkdir(URI.create(arguments[0])));
+          break;
+        default:
+          output = "Unsupported file system op: " + fsOp + ". Current supported operations are: "
+              + StringUtil.join(", ", SUPPORTED_FS_COMMANDS);
+          break;
+      }
+    } catch (Exception e) {
+      e.printStackTrace(new PrintStream(output));
+    }
+    return output;
+  }
+
+  private void registerDefaultPinotFS() {
+    registerPinotFS("s3", "org.apache.pinot.plugin.filesystem.S3PinotFS",
+        ImmutableMap.of("region", System.getProperty("AWS_REGION", "us-west-2")));
+  }
+
+  public static void registerPinotFS(String scheme, String fsClassName, Map<String, Object> configs) {
+    if (PinotFSFactory.isSchemeSupported(scheme)) {
+      LOGGER.info("PinotFS for scheme: {} is already registered.", scheme);
+      return;
+    }
+    try {
+      PinotFSFactory.register(scheme, fsClassName, new PinotConfiguration(configs));
+      LOGGER.info("Registered PinotFS for scheme: {}", scheme);
+    } catch (Exception e) {
+      LOGGER.error("Unable to init PinotFS for scheme: {}, class name: {}, configs: {}", scheme, fsClassName, configs,
+          e);
+    }
+  }
+
+  @Override
+  public boolean execute()
+      throws Exception {
+    String result = run();
+    LOGGER.info(result);
+    return true;
+  }
+
+  public static void main(String[] args) {
+    PluginManager.get().init();
+    new CommandLine(new FileSystemCommand()).execute(args);
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/filesystem/BaseFileOperation.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/filesystem/BaseFileOperation.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.admin.command.filesystem;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.tools.Command;
+import org.apache.pinot.tools.admin.command.FileSystemCommand;
+import org.apache.pinot.tools.admin.command.QuickstartRunner;
+import org.apache.pinot.tools.utils.PinotConfigUtils;
+import picocli.CommandLine;
+
+
+/**
+ * Base class for file operation classes
+ */
+public abstract class BaseFileOperation implements Command {
+
+  @CommandLine.ParentCommand
+  protected FileSystemCommand _parent;
+
+  public BaseFileOperation setParent(FileSystemCommand parent) {
+    _parent = parent;
+    return this;
+  }
+
+  protected void initialPinotFS()
+      throws Exception {
+    String configFile = _parent.getConfigFile();
+    Map<String, Object> configs =
+        configFile == null ? new HashMap<>() : PinotConfigUtils.readConfigFromFile(configFile);
+    PinotFSFactory.init(new PinotConfiguration(configs));
+    QuickstartRunner.registerDefaultPinotFS();
+  }
+
+  @Override
+  public boolean getHelp() {
+    return _parent.getHelp();
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/filesystem/CopyFiles.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/filesystem/CopyFiles.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.admin.command.filesystem;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import org.apache.pinot.spi.filesystem.LocalPinotFS;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import picocli.CommandLine;
+
+
+@CommandLine.Command(name = "cp", aliases = {"copy"}, description = "Copy file from source to destination")
+public class CopyFiles extends BaseFileOperation {
+  @CommandLine.Parameters(index = "0", description = "Source file")
+  private String _source;
+
+  @CommandLine.Parameters(index = "1", description = "Destination file")
+  private String _destination;
+
+  public CopyFiles setSource(String source) {
+    _source = source;
+    return this;
+  }
+
+  public CopyFiles setDestination(String destination) {
+    _destination = destination;
+    return this;
+  }
+
+  @Override
+  public boolean execute()
+      throws Exception {
+    try {
+      super.initialPinotFS();
+    } catch (Exception e) {
+      System.err.println("Failed to initialize PinotFS, exception: " + e.getMessage());
+      return false;
+    }
+
+    URI sourceURI = URI.create(_source);
+    PinotFS sourcePinotFS = Utils.getPinotFS(sourceURI);
+
+    URI destinationURI = URI.create(_destination);
+    PinotFS destinationPinotFS = Utils.getPinotFS(destinationURI);
+
+    if (sourcePinotFS == destinationPinotFS) {
+      try {
+        sourcePinotFS.copy(sourceURI, destinationURI);
+        return true;
+      } catch (IOException e) {
+        System.err.println(
+            "Unable to copy files from " + _source + " to " + _destination + ", exception: " + e.getMessage());
+      }
+    } else if (sourcePinotFS instanceof LocalPinotFS) {
+      File localFile = new File(_source);
+      if (localFile.isDirectory()) {
+        try {
+          destinationPinotFS.copyFromLocalDir(localFile, destinationURI);
+          return true;
+        } catch (Exception e) {
+          System.err.println(
+              "Failed to copy local directory " + _source + " to " + _destination + ", exception: " + e.getMessage());
+        }
+      } else {
+        try {
+          destinationPinotFS.copyFromLocalFile(localFile, destinationURI);
+          return true;
+        } catch (Exception e) {
+          System.err.println(
+              "Failed to copy local file " + _source + " to " + _destination + ", exception: " + e.getMessage());
+        }
+      }
+    } else if (destinationPinotFS instanceof LocalPinotFS) {
+      try {
+        sourcePinotFS.copyToLocalFile(sourceURI, new File(_destination));
+        return true;
+      } catch (Exception e) {
+        System.err.println(
+            "Failed to copy remote " + _source + " to local file " + _destination + ", exception: " + e.getMessage());
+      }
+    } else {
+      System.err.println("Copying files between two different remote PinotFS is not supported");
+    }
+    return false;
+  }
+
+  @Override
+  public void printUsage() {
+    System.out.println("cp <source-uri> <destination-uri>");
+  }
+
+  @Override
+  public String description() {
+    return "Copy file from source to destination, copying from two different remote PinotFS is not supported.";
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/filesystem/DeleteFiles.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/filesystem/DeleteFiles.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.admin.command.filesystem;
+
+import java.io.IOException;
+import java.net.URI;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import picocli.CommandLine;
+
+
+@CommandLine.Command(name = "rm", aliases = {"delete", "del"}, description = "Delete files")
+public class DeleteFiles extends BaseFileOperation {
+  @CommandLine.Option(names = {"-f", "--force"},
+      description = "Force delete if possible")
+  private boolean _force;
+
+  @CommandLine.Parameters(arity = "1..*", description = "File paths to delete")
+  private String[] _filePaths;
+
+  public DeleteFiles setForce(boolean force) {
+    _force = force;
+    return this;
+  }
+
+  public DeleteFiles setFilePaths(String[] filePaths) {
+    _filePaths = filePaths;
+    return this;
+  }
+
+  @Override
+  public boolean execute()
+      throws Exception {
+    try {
+      super.initialPinotFS();
+    } catch (Exception e) {
+      System.err.println("Failed to initialize PinotFS, exception: " + e.getMessage());
+      return false;
+    }
+    for (String filePath : _filePaths) {
+      URI pathURI = URI.create(filePath);
+      String scheme = Utils.getScheme(pathURI);
+      if (!PinotFSFactory.isSchemeSupported(scheme)) {
+        System.err.println("Scheme: " + scheme + " is not registered.");
+        return false;
+      }
+      try {
+        PinotFSFactory.create(scheme).delete(pathURI, _force);
+      } catch (IOException e) {
+        System.err.println("Unable to delete files under: " + pathURI + ", exception: " + e.getMessage());
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public void printUsage() {
+    System.out.println("rm [-f] <path-uri>...");
+  }
+
+  @Override
+  public String description() {
+    return "Delete files";
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/filesystem/ListFiles.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/filesystem/ListFiles.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.admin.command.filesystem;
+
+import java.io.IOException;
+import java.net.URI;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.utils.StringUtil;
+import picocli.CommandLine;
+
+
+@CommandLine.Command(name = "ls", aliases = {"list"}, description = "List files")
+public class ListFiles extends BaseFileOperation {
+  @CommandLine.Option(names = {"-r", "--recursive"},
+      description = "Recursively list subdirectories")
+  private boolean _recursive;
+
+  @CommandLine.Parameters(arity = "1..*", description = "File paths to list")
+  private String[] _filePaths;
+
+  public ListFiles setRecursive(boolean recursive) {
+    _recursive = recursive;
+    return this;
+  }
+
+  public ListFiles setFilePaths(String[] filePaths) {
+    _filePaths = filePaths;
+    return this;
+  }
+
+  @Override
+  public boolean execute()
+      throws Exception {
+    try {
+      super.initialPinotFS();
+    } catch (Exception e) {
+      System.err.println("Failed to initialize PinotFS, exception: " + e.getMessage());
+      return false;
+    }
+
+    for (String filePath : _filePaths) {
+      URI pathURI = URI.create(filePath);
+      String scheme = Utils.getScheme(pathURI);
+      if (!PinotFSFactory.isSchemeSupported(scheme)) {
+        System.err.println("Scheme: " + scheme + " is not registered.");
+        return false;
+      }
+      try {
+        PinotFS pinotFS = PinotFSFactory.create(scheme);
+        if (pinotFS.isDirectory(pathURI)) {
+          System.out.println(filePath + ":\n");
+          System.out.println(StringUtil.join("\n", pinotFS.listFiles(pathURI, _recursive)) + "\n");
+        } else if (pinotFS.exists(pathURI)) {
+          System.out.println(pathURI + "\n");
+        } else {
+          System.out.println("ls: " + pathURI + ": No such file or directory");
+          return false;
+        }
+      } catch (IOException e) {
+        System.err.println("Unable to list files under: " + pathURI + ", exception: " + e.getMessage());
+        return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public void printUsage() {
+    System.out.println("ls [-r] <path-uri>...");
+  }
+
+  @Override
+  public String description() {
+    return "List all files under a given URI";
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/filesystem/MoveFiles.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/filesystem/MoveFiles.java
@@ -1,0 +1,93 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.admin.command.filesystem;
+
+import java.io.IOException;
+import java.net.URI;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import picocli.CommandLine;
+
+
+@CommandLine.Command(name = "mv", aliases = {"move"}, description = "Move file from source to destination")
+public class MoveFiles extends BaseFileOperation {
+  @CommandLine.Option(names = {"-o", "--overwrite"},
+      description = "Overwrite if destination already exists")
+  private boolean _overwrite;
+
+  @CommandLine.Parameters(index = "0", description = "Source file")
+  private String _source;
+
+  @CommandLine.Parameters(index = "1", description = "Destination file")
+  private String _destination;
+
+  public MoveFiles setOverwrite(boolean overwrite) {
+    _overwrite = overwrite;
+    return this;
+  }
+
+  public MoveFiles setSource(String source) {
+    _source = source;
+    return this;
+  }
+
+  public MoveFiles setDestination(String destination) {
+    _destination = destination;
+    return this;
+  }
+
+  @Override
+  public boolean execute()
+      throws Exception {
+    try {
+      super.initialPinotFS();
+    } catch (Exception e) {
+      System.err.println("Failed to initialize PinotFS, exception: " + e.getMessage());
+      return false;
+    }
+
+    URI sourceURI = URI.create(_source);
+    PinotFS sourcePinotFS = Utils.getPinotFS(sourceURI);
+
+    URI destinationURI = URI.create(_destination);
+    PinotFS destinationPinotFS = Utils.getPinotFS(destinationURI);
+
+    if (sourcePinotFS == destinationPinotFS) {
+      try {
+        sourcePinotFS.move(sourceURI, destinationURI, _overwrite);
+        return true;
+      } catch (IOException e) {
+        System.err.println(
+            "Unable to move files from " + _source + " to " + _destination + ", exception: " + e.getMessage());
+      }
+    } else {
+      System.err.println("Moving files between two different PinotFS is not supported");
+    }
+    return false;
+  }
+
+  @Override
+  public void printUsage() {
+    System.out.println("mv [-o] <source-uri> <destination-uri>");
+  }
+
+  @Override
+  public String description() {
+    return "Move file from source to destination, moving from two different PinotFS is not supported.";
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/filesystem/Utils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/filesystem/Utils.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.admin.command.filesystem;
+
+import java.net.URI;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+
+
+public class Utils {
+  private Utils() {
+  }
+
+  public static String getScheme(URI uri) {
+    if (uri.getScheme() != null) {
+      return uri.getScheme();
+    }
+    return PinotFSFactory.LOCAL_PINOT_FS_SCHEME;
+  }
+
+  public static PinotFS getPinotFS(URI uri) {
+    String scheme = getScheme(uri);
+    if (!PinotFSFactory.isSchemeSupported(scheme)) {
+      System.err.println("File scheme " + scheme + " is not supported.");
+      throw new RuntimeException("File scheme " + scheme + " is not supported.");
+    }
+    return PinotFSFactory.create(scheme);
+  }
+}


### PR DESCRIPTION
Adding Pinot FS command into toolings for quickly testing if the filesystem configs and settings credentials are correct. Also, users can perform some simple actions if needed.

Usage:
```
pinot-admins.sh FileSystem <sub-command> <sub-command parameters>
```
There is also a separate script for it:
```
pinot-fs-util.sh <sub-command> <sub-command parameters>
```

Currently, supported sub-command operations are coming from PinotFS interfaces:
```
ls
cp
mv
rm
```

Default loaded PinotFS are `org.apache.pinot.spi.filesystem.LocalPinotFS` and `org.apache.pinot.plugin.filesystem.S3PinotFS` if scheme is not registered by the config file.

Example:

List files recursively on s3 when AWS is configured:
```
pinot-admin.sh FileSystem ls -r s3://<my-bucket>/
```

List files recursively on s3 with the pinot fs config:
```
pinot-admin.sh  FileSystem -config /tmp/fs.conf  -command ls -r s3://<my-bucket>/
```

The content of `fs.conf` will be deserailize to `org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec`
```
class.s3=org.apache.pinot.plugin.filesystem.S3PinotFS
s3.region=us-west-2
s3.accessKey=<my-access-key>
s3.secretKey=<my-secret-key>
```

Examples of no access for s3:
```
bin/pinot-admin.sh  FileSystem ls  s3://<my-bucket>

Unable to list files under: s3://<my-bucket>, exception: software.amazon.awssdk.services.s3.model.S3Exception: Access Denied (Service: S3, Status Code: 403, Request ID: 33KA59XA0ZPBDPN2, Extended Request ID: TILm5sJyqoQttVTNgSS5Hs1N89cQa9MtxRAh5oQSH8Jm9DpOG/yI/raYIw/7FU3fYzARba6qQBA=)
```