### PR TITLE
[Draft] E2E QuickStart for Multi-stage Query Engine

### DIFF
--- a/pinot-tools/src/main/resources/conf/pinot-broker.conf
+++ b/pinot-tools/src/main/resources/conf/pinot-broker.conf
@@ -34,3 +34,7 @@ pinot.broker.client.queryPort=8099
 
 # Pinot Routing table builder class
 pinot.broker.routing.table.builder.class=random
+
+pinot.multistage.engine.enabled=true
+
+pinot.query.runner.port=8421

--- a/pinot-tools/src/main/resources/conf/pinot-server.conf
+++ b/pinot-tools/src/main/resources/conf/pinot-server.conf
@@ -41,9 +41,7 @@ pinot.server.instance.dataDir=/tmp/pinot/data/server/index
 # Pinot Server Temporary Segment Tar Directory
 pinot.server.instance.segmentTarDir=/tmp/pinot/data/server/segmentTar
 
-// pinot multi_stage query engine configs, in order to reuse ServerInstance ZkMetadata, we:
-// reused server GRPC port for mailbox port
-// reused server netty port for worker service request port
+// pinot multi_stage query engine configs
 pinot.multistage.engine.enabled=true
 
 pinot.query.runner.port=8422

--- a/pinot-tools/src/main/resources/conf/pinot-server.conf
+++ b/pinot-tools/src/main/resources/conf/pinot-server.conf
@@ -40,3 +40,12 @@ pinot.server.instance.dataDir=/tmp/pinot/data/server/index
 
 # Pinot Server Temporary Segment Tar Directory
 pinot.server.instance.segmentTarDir=/tmp/pinot/data/server/segmentTar
+
+// pinot multi_stage query engine configs, in order to reuse ServerInstance ZkMetadata, we:
+// reused server GRPC port for mailbox port
+// reused server netty port for worker service request port
+pinot.multistage.engine.enabled=true
+
+pinot.query.runner.port=8422
+
+pinot.query.server.port=8842


### PR DESCRIPTION
Overview
===
Master PR for trying out the new mulit-stage-query-engine. See: https://www.startree.ai/blogs/apache-pinot-native-join-support

Since the feature branch is not merged back to main branch. Please read the instruction below to try it out. 

Try the new engine
===
[UPDATE 06/10/2022] 
**Multi-stage query engine is fully merged back to master, please read the following instruction carefully as the quickstart steps has changed**

1. run `mvn install -Pbin-dist -pl pinot-distribution -am -DskipTests` to build pinot
2. run regular quickstart with the configuration files in this PR applied
    - run `gh pr checkout 8662` to checkout this PR's change.
    - run `cd build; bin/pinot-admin.sh StartZookeeper & bin/pinot-admin.sh StartServiceManager -bootstrapConfigPaths conf/pinot-controller.conf conf/pinot-broker.conf conf/pinot-server.conf&`
3. load your tables normally. for example: 
    - `bin/pinot-admin.sh AddTable -tableConfigFile examples/batch/baseballStats/baseballStats_offline_table_config.json -schemaFile examples/batch/baseballStats/baseballStats_schema.json -exec`
    - `bin/pinot-admin.sh LaunchDataIngestionJob -jobSpecFile examples/batch/baseballStats/ingestionJobSpec.yaml`
4. run the broker query: `curl -X POST http://localhost:8099/query/sql -d '{"sql": "SELECT * FROM baseballStats_OFFLINE", "useMultistageEngine": true}'`

Noted that there are several limitations, please see limitation section below.

Limitations
===
The feature branch is still under development so please check back to see any updates on this limitation section

- controller endpoint is not supported. only broker endpoint can invoke mulit-stage engine
- generic table are not supported; `_OFFLINE` or `_REALTIME` suffix must be attached to the query table name
- schema name has to match table name
  - for example the baseballStats example above, one need to edit the table schema to rename `schemaName` to `baseballStats`
- [will be supported soon] aggregation is not supported, so count(*) or group by cannot run. 
- [will be supported soon] some data types are not backward compatible with old Pinot datatable byte format so data type float/bytes are not supported.

Share your feedback
===
Please share your feedback on Slack channel: https://apache-pinot.slack.com/archives/C013WKLT5T7


