### PR TITLE
[CI] Reduce quickstart testing to only LTS

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -186,7 +186,7 @@ jobs:
       matrix:
         # We only test LTS Java versions
         # TODO: add JDK 17 once ready. see: https://github.com/apache/pinot/issues/8529
-        java: [ 1.8, 11, 16 ]
+        java: [ 1.8, 11, 15 ]
     name: Pinot Quickstart on JDK ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -184,7 +184,9 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 1.8, 10, 11, 12, 13, 14, 15 ]
+        # We only test LTS Java versions
+        # TODO: add JDK 17 once ready. see: https://github.com/apache/pinot/issues/8529
+        java: [ 1.8, 11, 16 ]
     name: Pinot Quickstart on JDK ${{ matrix.java }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
There's no need to test quickstart on every JDK version. reduce to only test LTS versions.

See: https://www.oracle.com/java/technologies/java-se-support-roadmap.html