### PR TITLE
Change minion's default port, enable minion health and readiness probe via helm chart

### DIFF
--- a/kubernetes/helm/pinot/values.yaml
+++ b/kubernetes/helm/pinot/values.yaml
@@ -341,8 +341,8 @@ minion:
 
   probes:
     endpoint: "/health"
-    livenessEnabled: false
-    readinessEnabled: false
+    livenessEnabled: true
+    readinessEnabled: true
 
   dataDir: /var/pinot/minion/data
   jvmOpts: "-Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-minion.log"

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/ListenerConfigUtil.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/ListenerConfigUtil.java
@@ -155,22 +155,13 @@ public final class ListenerConfigUtil {
   public static List<ListenerConfig> buildMinionAdminConfigs(PinotConfiguration minionConf) {
     List<ListenerConfig> listeners = new ArrayList<>();
 
-    String adminApiPortString = minionConf.getProperty(CommonConstants.Minion.CONFIG_OF_ADMIN_API_PORT);
-    if (adminApiPortString != null) {
-      listeners.add(
-          new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST, Integer.parseInt(adminApiPortString),
-              CommonConstants.HTTP_PROTOCOL, new TlsConfig()));
-    }
+    int port = minionConf.getProperty(CommonConstants.Helix.KEY_OF_MINION_PORT,
+        CommonConstants.Minion.DEFAULT_HELIX_PORT);
+    listeners.add(new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST, port,
+        CommonConstants.HTTP_PROTOCOL, new TlsConfig()));
 
     TlsConfig tlsDefaults = TlsUtils.extractTlsConfig(minionConf, CommonConstants.Minion.MINION_TLS_PREFIX);
     listeners.addAll(buildListenerConfigs(minionConf, "pinot.minion.adminapi", tlsDefaults));
-
-    // support legacy behavior < 0.7.0
-    if (listeners.isEmpty()) {
-      listeners.add(
-          new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST, CommonConstants.Minion.DEFAULT_ADMIN_API_PORT,
-              CommonConstants.HTTP_PROTOCOL, new TlsConfig()));
-    }
 
     return listeners;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/ListenerConfigUtil.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/ListenerConfigUtil.java
@@ -152,7 +152,7 @@ public final class ListenerConfigUtil {
     return listeners;
   }
 
-  public static List<ListenerConfig> buildMinionAdminConfigs(PinotConfiguration minionConf) {
+  public static List<ListenerConfig> buildMinionConfigs(PinotConfiguration minionConf) {
     List<ListenerConfig> listeners = new ArrayList<>();
 
     int port = minionConf.getProperty(CommonConstants.Helix.KEY_OF_MINION_PORT,

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
@@ -101,7 +101,7 @@ public abstract class BaseMinionStarter implements ServiceStartable {
     } else {
       _instanceId = CommonConstants.Helix.PREFIX_OF_MINION_INSTANCE + _hostname + "_" + _port;
     }
-    _listenerConfigs = ListenerConfigUtil.buildMinionAdminConfigs(_config);
+    _listenerConfigs = ListenerConfigUtil.buildMinionConfigs(_config);
     _helixManager = new ZKHelixManager(helixClusterName, _instanceId, InstanceType.PARTICIPANT, zkAddress);
     MinionTaskZkMetadataManager minionTaskZkMetadataManager = new MinionTaskZkMetadataManager(_helixManager);
     _taskExecutorFactoryRegistry = new TaskExecutorFactoryRegistry(minionTaskZkMetadataManager, _config);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -525,9 +525,7 @@ public class CommonConstants {
      * E.g. null (auth disabled), "Basic abcdef..." (basic auth), "Bearer 123def..." (oauth2)
      */
     public static final String CONFIG_OF_TASK_AUTH_TOKEN = "task.auth.token";
-    public static final String CONFIG_OF_ADMIN_API_PORT = "pinot.minion.adminapi.port";
     public static final String MINION_TLS_PREFIX = "pinot.minion.tls";
-    public static final int DEFAULT_ADMIN_API_PORT = 9514;
     public static final String CONFIG_OF_MINION_QUERY_REWRITER_CLASS_NAMES = "pinot.minion.query.rewriter.class.names";
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -527,7 +527,7 @@ public class CommonConstants {
     public static final String CONFIG_OF_TASK_AUTH_TOKEN = "task.auth.token";
     public static final String CONFIG_OF_ADMIN_API_PORT = "pinot.minion.adminapi.port";
     public static final String MINION_TLS_PREFIX = "pinot.minion.tls";
-    public static final int DEFAULT_ADMIN_API_PORT = 6500;
+    public static final int DEFAULT_ADMIN_API_PORT = 9514;
     public static final String CONFIG_OF_MINION_QUERY_REWRITER_CLASS_NAMES = "pinot.minion.query.rewriter.class.names";
   }
 

--- a/pinot-tools/src/main/resources/conf/pinot-minion.conf
+++ b/pinot-tools/src/main/resources/conf/pinot-minion.conf
@@ -33,7 +33,4 @@ pinot.set.instance.id.to.hostname=true
 # pinot.minion.host=localhost
 
 # Pinot Minion Port
-pinot.minion.port=9154
-
-# Pinot Minion Admin API Port
-pinot.minion.adminapi.port=6500
+pinot.minion.port=9514

--- a/pinot-tools/src/main/resources/conf/pinot-minion.conf
+++ b/pinot-tools/src/main/resources/conf/pinot-minion.conf
@@ -33,7 +33,7 @@ pinot.set.instance.id.to.hostname=true
 # pinot.minion.host=localhost
 
 # Pinot Minion Port
-pinot.minion.port=8098
+pinot.minion.port=9154
 
 # Pinot Minion Admin API Port
 pinot.minion.adminapi.port=6500


### PR DESCRIPTION
This PR adds support for minion's health and readiness probe when deploying using helm charts
