### PR TITLE
Add pluggable client auth provider

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/auth/AuthConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/auth/AuthConfig.java
@@ -16,19 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.spi.auth;
+package org.apache.pinot.common.auth;
+
+import java.util.Map;
+import org.apache.pinot.spi.env.PinotConfiguration;
+
 
 /**
- * Container for all auth related info
+ * Standardized auth config container for AuthProvider
+ * @see AuthProviderUtils#extractAuthConfig(PinotConfiguration, String)
  */
-public class AuthContext {
-  private final String _authToken;
+public class AuthConfig {
+  public static final String PROVIDER_CLASS = "provider.class";
 
-  public AuthContext(String authToken) {
-    _authToken = authToken;
+  protected Map<String, Object> _properties;
+
+  public AuthConfig(Map<String, Object> properties) {
+    _properties = properties;
   }
 
-  public String getAuthToken() {
-    return _authToken;
+  public Map<String, Object> getProperties() {
+    return _properties;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/auth/AuthProviderUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/auth/AuthProviderUtils.java
@@ -1,0 +1,171 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.auth;
+
+import java.lang.reflect.Constructor;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.Header;
+import org.apache.http.message.BasicHeader;
+import org.apache.pinot.spi.auth.AuthProvider;
+import org.apache.pinot.spi.env.PinotConfiguration;
+
+
+/**
+ * Utility class to wrap inference of optimal auth provider from component configs.
+ */
+public final class AuthProviderUtils {
+  private AuthProviderUtils() {
+    // left blank
+  }
+
+  /**
+   * Extract an AuthConfig from a pinot configuration subset namespace.
+   *
+   * @param pinotConfig pinot configuration
+   * @param namespace subset namespace
+   * @return auth config
+   */
+  public static AuthConfig extractAuthConfig(PinotConfiguration pinotConfig, String namespace) {
+    if (namespace == null) {
+      return new AuthConfig(pinotConfig.toMap());
+    }
+    return new AuthConfig(pinotConfig.subset(namespace).toMap());
+  }
+
+  /**
+   * Create an AuthProvider after extracting a config from a pinot configuration subset namespace
+   * @see AuthProviderUtils#extractAuthConfig(PinotConfiguration, String)
+   *
+   * @param pinotConfig pinot configuration
+   * @param namespace subset namespace
+   * @return auth provider
+   */
+  public static AuthProvider extractAuthProvider(PinotConfiguration pinotConfig, String namespace) {
+    return makeAuthProvider(extractAuthConfig(pinotConfig, namespace));
+  }
+
+  /**
+   * Create auth provider based on the availability of a static token only, if any. This typically applies to task specs
+   *
+   * @param authToken static auth token
+   * @return auth provider
+   */
+  public static AuthProvider makeAuthProvider(String authToken) {
+    if (StringUtils.isBlank(authToken)) {
+      return new NullAuthProvider();
+    }
+    return new StaticTokenAuthProvider(authToken);
+  }
+
+  /**
+   * Create auth provider based on an auth config. Mimics legacy behavior for static tokens if provided, or dynamic auth
+   * providers if additional configs are given.
+   *
+   * @param authConfig auth config
+   * @return auth provider
+   */
+  public static AuthProvider makeAuthProvider(AuthConfig authConfig) {
+    if (authConfig == null) {
+      return new NullAuthProvider();
+    }
+
+    Object providerClassValue = authConfig.getProperties().get(AuthConfig.PROVIDER_CLASS);
+    if (providerClassValue != null) {
+      try {
+        Class<?> providerClass = Class.forName(providerClassValue.toString());
+        Constructor<?> constructor = providerClass.getConstructor(AuthConfig.class);
+        return (AuthProvider) constructor.newInstance(authConfig);
+      } catch (Exception e) {
+        throw new IllegalStateException("Could not create AuthProvider " + providerClassValue, e);
+      }
+    }
+
+    // mimic legacy behavior for "auth.token" property
+    if (authConfig.getProperties().containsKey(StaticTokenAuthProvider.TOKEN)) {
+      return new StaticTokenAuthProvider(authConfig);
+    }
+
+    if (!authConfig.getProperties().isEmpty()) {
+      throw new IllegalArgumentException("Some auth properties defined, but no provider created. Aborting.");
+    }
+
+    return new NullAuthProvider();
+  }
+
+  /**
+   * Convenience helper to convert Map to list of Http Headers
+   * @param headers header map
+   * @return list of http headers
+   */
+  public static List<Header> toRequestHeaders(@Nullable Map<String, Object> headers) {
+    if (headers == null) {
+      return Collections.emptyList();
+    }
+    return headers.entrySet().stream().filter(entry -> Objects.nonNull(entry.getValue()))
+        .map(entry -> new BasicHeader(entry.getKey(), entry.getValue().toString())).collect(Collectors.toList());
+  }
+
+  /**
+   * Convenience helper to convert an optional authProvider to a list of http headers
+   * @param authProvider auth provider
+   * @return list of http headers
+   */
+  public static List<Header> toRequestHeaders(@Nullable AuthProvider authProvider) {
+    if (authProvider == null) {
+      return Collections.emptyList();
+    }
+    return toRequestHeaders(authProvider.getRequestHeaders());
+  }
+
+  /**
+   * Convenience helper to convert an optional authProvider to a static job spec token
+   * @param authProvider auth provider
+   * @return static token
+   */
+  public static String toStaticToken(@Nullable AuthProvider authProvider) {
+    if (authProvider == null) {
+      return null;
+    }
+    return authProvider.getTaskToken();
+  }
+
+  /**
+   * Helper to extract string values from complex AuthConfig instance.
+   *
+   * @param config auth config
+   * @param key config key
+   * @param defaultValue default value
+   * @return config value
+   */
+  static String getOrDefault(AuthConfig config, String key, String defaultValue) {
+    if (config == null || !config.getProperties().containsKey(key)) {
+      return defaultValue;
+    }
+    if (config.getProperties().get(key) instanceof String) {
+      return (String) config.getProperties().get(key);
+    }
+    throw new IllegalArgumentException("Expected String but got " + config.getProperties().get(key).getClass());
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/auth/NullAuthProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/auth/NullAuthProvider.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.auth;
+
+import java.util.Collections;
+import java.util.Map;
+import org.apache.pinot.spi.auth.AuthProvider;
+
+
+/**
+ * Noop auth provider
+ */
+public class NullAuthProvider implements AuthProvider {
+  public NullAuthProvider() {
+    // left blank
+  }
+
+  public NullAuthProvider(AuthConfig ignore) {
+    // left blank
+  }
+
+  @Override
+  public Map<String, Object> getRequestHeaders() {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public String getTaskToken() {
+    return null;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/auth/StaticTokenAuthProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/auth/StaticTokenAuthProvider.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.auth;
+
+import java.util.Collections;
+import java.util.Map;
+import javax.ws.rs.core.HttpHeaders;
+import org.apache.pinot.spi.auth.AuthProvider;
+
+
+/**
+ * Auth provider for static client tokens, typically used for job specs or when mimicking legacy behavior.
+ */
+public class StaticTokenAuthProvider implements AuthProvider {
+  public static final String HEADER = "header";
+  public static final String PREFIX = "prefix";
+  public static final String TOKEN = "token";
+
+  protected final String _taskToken;
+  protected final Map<String, Object> _requestHeaders;
+
+  public StaticTokenAuthProvider(String token) {
+    _taskToken = token;
+    _requestHeaders = Collections.singletonMap(HttpHeaders.AUTHORIZATION, token);
+  }
+
+  public StaticTokenAuthProvider(AuthConfig authConfig) {
+    String header = AuthProviderUtils.getOrDefault(authConfig, HEADER, HttpHeaders.AUTHORIZATION);
+    String prefix = AuthProviderUtils.getOrDefault(authConfig, PREFIX, "Basic");
+    String userToken = authConfig.getProperties().get(TOKEN).toString();
+
+    _taskToken = makeToken(prefix, userToken);
+    _requestHeaders = Collections.singletonMap(header, _taskToken);
+  }
+
+  @Override
+  public Map<String, Object> getRequestHeaders() {
+    return _requestHeaders;
+  }
+
+  @Override
+  public String getTaskToken() {
+    return _taskToken;
+  }
+
+  private static String makeToken(String prefix, String token) {
+    if (token.startsWith(prefix)) {
+      return token;
+    }
+    return prefix + " " + token;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/auth/UrlAuthProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/auth/UrlAuthProvider.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.auth;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+import javax.ws.rs.core.HttpHeaders;
+import org.apache.commons.io.IOUtils;
+import org.apache.pinot.spi.auth.AuthProvider;
+
+
+/**
+ * Auth provider with dynamic loading support, typically used for rotating tokens such as those injected by kubernetes.
+ * UrlAuthProvider will re-read the source on every invocation, so beware of long round-trip times if the source is
+ * remote.
+ */
+public class UrlAuthProvider implements AuthProvider {
+  public static final String HEADER = "header";
+  public static final String PREFIX = "prefix";
+  public static final String URL = "url";
+
+  protected final String _header;
+  protected final String _prefix;
+  protected final URL _url;
+
+  public UrlAuthProvider(String url) {
+    try {
+      _header = HttpHeaders.AUTHORIZATION;
+      _prefix = "Bearer";
+      _url = new URL(url);
+    } catch (MalformedURLException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  public UrlAuthProvider(AuthConfig authConfig) {
+    try {
+      _header = AuthProviderUtils.getOrDefault(authConfig, HEADER, HttpHeaders.AUTHORIZATION);
+      _prefix = AuthProviderUtils.getOrDefault(authConfig, PREFIX, "Bearer");
+      _url = new URL(authConfig.getProperties().get(URL).toString());
+    } catch (MalformedURLException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  @Override
+  public Map<String, Object> getRequestHeaders() {
+    return Collections.singletonMap(_header, makeToken());
+  }
+
+  @Override
+  public String getTaskToken() {
+    return makeToken();
+  }
+
+  private String makeToken() {
+    try {
+      String token = IOUtils.toString(_url, StandardCharsets.UTF_8);
+      if (token.startsWith(_prefix)) {
+        return token;
+      }
+      return _prefix + " " + token;
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Could not resolve auth url " + _url, e);
+    }
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/BaseSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/BaseSegmentFetcher.java
@@ -22,6 +22,8 @@ import java.io.File;
 import java.net.URI;
 import java.util.List;
 import java.util.Random;
+import org.apache.pinot.common.auth.AuthProviderUtils;
+import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
@@ -36,7 +38,6 @@ public abstract class BaseSegmentFetcher implements SegmentFetcher {
   public static final String RETRY_COUNT_CONFIG_KEY = "retry.count";
   public static final String RETRY_WAIT_MS_CONFIG_KEY = "retry.wait.ms";
   public static final String RETRY_DELAY_SCALE_FACTOR_CONFIG_KEY = "retry.delay.scale.factor";
-  public static final String AUTH_TOKEN = CommonConstants.KEY_OF_AUTH_TOKEN;
   public static final int DEFAULT_RETRY_COUNT = 3;
   public static final int DEFAULT_RETRY_WAIT_MS = 100;
   public static final int DEFAULT_RETRY_DELAY_SCALE_FACTOR = 5;
@@ -46,14 +47,14 @@ public abstract class BaseSegmentFetcher implements SegmentFetcher {
   protected int _retryCount;
   protected int _retryWaitMs;
   protected int _retryDelayScaleFactor;
-  protected String _authToken;
+  protected AuthProvider _authProvider;
 
   @Override
   public void init(PinotConfiguration config) {
     _retryCount = config.getProperty(RETRY_COUNT_CONFIG_KEY, DEFAULT_RETRY_COUNT);
     _retryWaitMs = config.getProperty(RETRY_WAIT_MS_CONFIG_KEY, DEFAULT_RETRY_WAIT_MS);
     _retryDelayScaleFactor = config.getProperty(RETRY_DELAY_SCALE_FACTOR_CONFIG_KEY, DEFAULT_RETRY_DELAY_SCALE_FACTOR);
-    _authToken = config.getProperty(AUTH_TOKEN);
+    _authProvider = AuthProviderUtils.extractAuthProvider(config, CommonConstants.KEY_OF_AUTH);
     doInit(config);
     _logger
         .info("Initialized with retryCount: {}, retryWaitMs: {}, retryDelayScaleFactor: {}", _retryCount, _retryWaitMs,

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
@@ -63,7 +63,7 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
         if (!InetAddresses.isInetAddress(hostName)) {
           httpHeaders.add(new BasicHeader(HttpHeaders.HOST, hostName + ":" + port));
         }
-        int statusCode = _httpClient.downloadFile(uri, dest, _authToken, httpHeaders);
+        int statusCode = _httpClient.downloadFile(uri, dest, _authProvider, httpHeaders);
         _logger
             .info("Downloaded segment from: {} to: {} of size: {}; Response status code: {}", uri, dest, dest.length(),
                 statusCode);
@@ -94,7 +94,7 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
   public void fetchSegmentToLocalWithoutRetry(URI uri, File dest)
       throws Exception {
     try {
-      int statusCode = _httpClient.downloadFile(uri, dest, _authToken);
+      int statusCode = _httpClient.downloadFile(uri, dest, _authProvider);
       _logger.info("Downloaded segment from: {} to: {} of size: {}; Response status code: {}", uri, dest, dest.length(),
           statusCode);
     } catch (Exception e) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
@@ -37,6 +37,7 @@ import javax.ws.rs.container.AsyncResponse;
 import javax.ws.rs.container.Suspended;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AccessType;
 import org.apache.pinot.controller.api.access.Authenticate;
@@ -44,6 +45,7 @@ import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.FileIngestionHelper;
 import org.apache.pinot.controller.util.FileIngestionHelper.DataPayload;
+import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
@@ -202,15 +204,13 @@ public class PinotIngestionRestletResource {
         });
     Schema schema = _pinotHelixResourceManager.getTableSchema(tableNameWithType);
 
+    AuthProvider authProvider = AuthProviderUtils.extractAuthProvider(_controllerConf,
+        CommonConstants.Controller.PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY + ".auth");
+
     FileIngestionHelper fileIngestionHelper =
         new FileIngestionHelper(tableConfig, schema, batchConfigMap, getControllerUri(),
-            new File(_controllerConf.getDataDir(), UPLOAD_DIR), getAuthToken());
+            new File(_controllerConf.getDataDir(), UPLOAD_DIR), authProvider);
     return fileIngestionHelper.buildSegmentAndPush(payload);
-  }
-
-  private String getAuthToken() {
-    return _controllerConf
-        .getProperty(CommonConstants.Controller.PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY + ".auth.token");
   }
 
   private URI getControllerUri() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
@@ -35,7 +35,7 @@ import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.controller.api.resources.SuccessResponse;
 import org.apache.pinot.segment.local.utils.IngestionUtils;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
-import org.apache.pinot.spi.auth.AuthContext;
+import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
@@ -71,16 +71,16 @@ public class FileIngestionHelper {
   private final Map<String, String> _batchConfigMap;
   private final URI _controllerUri;
   private final File _uploadDir;
-  private final AuthContext _authContext;
+  private final AuthProvider _authProvider;
 
   public FileIngestionHelper(TableConfig tableConfig, Schema schema, Map<String, String> batchConfigMap,
-      URI controllerUri, File uploadDir, String authToken) {
+      URI controllerUri, File uploadDir, AuthProvider authProvider) {
     _tableConfig = tableConfig;
     _schema = schema;
     _batchConfigMap = batchConfigMap;
     _controllerUri = controllerUri;
     _uploadDir = uploadDir;
-    _authContext = new AuthContext(authToken);
+    _authProvider = authProvider;
   }
 
   /**
@@ -154,7 +154,7 @@ public class FileIngestionHelper {
               .setIngestionConfig(ingestionConfigOverride).build();
       SegmentUploader segmentUploader = PluginManager.get().createInstance(SEGMENT_UPLOADER_CLASS);
       segmentUploader.init(tableConfigOverride);
-      segmentUploader.uploadSegment(segmentTarFile.toURI(), _authContext);
+      segmentUploader.uploadSegment(segmentTarFile.toURI(), _authProvider);
       LOGGER.info("Uploaded tar: {} to table: {}", segmentTarFile.getAbsolutePath(), tableNameWithType);
 
       return new SuccessResponse(

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -636,6 +636,9 @@ public abstract class BaseTableDataManager implements TableDataManager {
   }
 
   private static PinotConfiguration toPinotConfiguration(Configuration configuration) {
+    if (configuration == null) {
+      return new PinotConfiguration();
+    }
     return new PinotConfiguration((Map<String, Object>) (Map) ConfigurationConverter.getMap(configuration));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
@@ -64,7 +64,7 @@ public class SegmentCommitterFactory {
     segmentUploader = new Server2ControllerSegmentUploader(_logger, _protocolHandler.getFileUploadDownloadClient(),
         _protocolHandler.getSegmentCommitUploadURL(params, controllerVipUrl), params.getSegmentName(),
         ServerSegmentCompletionProtocolHandler.getSegmentUploadRequestTimeoutMs(), _serverMetrics,
-        _protocolHandler.getAuthToken());
+        _protocolHandler.getAuthProvider());
     return new SplitSegmentCommitter(_logger, _protocolHandler, params, segmentUploader);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
@@ -24,13 +24,14 @@ import java.net.URISyntaxException;
 import java.util.Map;
 import javax.net.ssl.SSLContext;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.common.utils.ClientSSLContextGenerator;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
-import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.core.data.manager.realtime.Server2ControllerSegmentUploader;
 import org.apache.pinot.core.util.SegmentCompletionProtocolUtils;
+import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
@@ -53,7 +54,7 @@ public class ServerSegmentCompletionProtocolHandler {
   private static SSLContext _sslContext;
   private static Integer _controllerHttpsPort;
   private static int _segmentUploadRequestTimeoutMs;
-  private static String _authToken;
+  private static AuthProvider _authProvider;
   private static String _protocol = HTTP_PROTOCOL;
 
   private final FileUploadDownloadClient _fileUploadDownloadClient;
@@ -73,7 +74,8 @@ public class ServerSegmentCompletionProtocolHandler {
     _protocol = uploaderConfig.getProperty(CONFIG_OF_PROTOCOL, HTTP_PROTOCOL);
     _segmentUploadRequestTimeoutMs = uploaderConfig
         .getProperty(CONFIG_OF_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS, DEFAULT_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS);
-    _authToken = uploaderConfig.getProperty(CONFIG_OF_SEGMENT_UPLOADER_AUTH_TOKEN);
+
+    _authProvider = AuthProviderUtils.extractAuthProvider(uploaderConfig, CONFIG_OF_SEGMENT_UPLOADER_AUTH);
   }
 
   public ServerSegmentCompletionProtocolHandler(ServerMetrics serverMetrics, String tableNameWithType) {
@@ -90,8 +92,8 @@ public class ServerSegmentCompletionProtocolHandler {
     return _fileUploadDownloadClient;
   }
 
-  public String getAuthToken() {
-    return _authToken;
+  public AuthProvider getAuthProvider() {
+    return _authProvider;
   }
 
   public SegmentCompletionProtocol.Response segmentCommitStart(SegmentCompletionProtocol.Request.Params params) {
@@ -157,7 +159,7 @@ public class ServerSegmentCompletionProtocolHandler {
     try {
       segmentUploader =
           new Server2ControllerSegmentUploader(LOGGER, _fileUploadDownloadClient, url, params.getSegmentName(),
-              _segmentUploadRequestTimeoutMs, _serverMetrics, _authToken);
+              _segmentUploadRequestTimeoutMs, _serverMetrics, _authProvider);
     } catch (URISyntaxException e) {
       LOGGER.error("Segment commit upload url error: ", e);
       return SegmentCompletionProtocol.RESP_NOT_SENT;
@@ -212,7 +214,7 @@ public class ServerSegmentCompletionProtocolHandler {
     SegmentCompletionProtocol.Response response;
     try {
       String responseStr = _fileUploadDownloadClient
-          .sendSegmentCompletionProtocolRequest(new URI(url), HttpClient.makeAuthHeader(_authToken), null,
+          .sendSegmentCompletionProtocolRequest(new URI(url), AuthProviderUtils.toRequestHeaders(_authProvider), null,
               DEFAULT_OTHER_REQUESTS_TIMEOUT).getResponse();
       response = SegmentCompletionProtocol.Response.fromJsonString(responseStr);
       LOGGER.info("Controller response {} for {}", response.toJsonString(), url);
@@ -237,7 +239,7 @@ public class ServerSegmentCompletionProtocolHandler {
     SegmentCompletionProtocol.Response response;
     try {
       String responseStr = _fileUploadDownloadClient
-          .uploadSegmentMetadataFiles(new URI(url), metadataFiles, HttpClient.makeAuthHeader(_authToken),
+          .uploadSegmentMetadataFiles(new URI(url), metadataFiles, AuthProviderUtils.toRequestHeaders(_authProvider),
               null, _segmentUploadRequestTimeoutMs).getResponse();
       response = SegmentCompletionProtocol.Response.fromJsonString(responseStr);
       LOGGER.info("Controller response {} for {}", response.toJsonString(), url);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerAcquireSegmentTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerAcquireSegmentTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -29,6 +30,7 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.commons.configuration.MapConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixManager;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -117,6 +119,7 @@ public class BaseTableDataManagerAcquireSegmentTest {
       config = mock(TableDataManagerConfig.class);
       when(config.getTableName()).thenReturn(TABLE_NAME);
       when(config.getDataDir()).thenReturn(_tmpDir.getAbsolutePath());
+      when(config.getAuthConfig()).thenReturn(new MapConfiguration(new HashMap<>()));
     }
     tableDataManager.init(config, "dummyInstance", mock(ZkHelixPropertyStore.class),
         new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class), null, 0);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -24,10 +24,12 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.configuration.MapConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixManager;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -526,6 +528,7 @@ public class BaseTableDataManagerTest {
     TableDataManagerConfig config = mock(TableDataManagerConfig.class);
     when(config.getTableName()).thenReturn(TABLE_NAME);
     when(config.getDataDir()).thenReturn(TABLE_DATA_DIR.getAbsolutePath());
+    when(config.getAuthConfig()).thenReturn(new MapConfiguration(Collections.emptyMap()));
 
     OfflineTableDataManager tableDataManager = new OfflineTableDataManager();
     tableDataManager.init(config, "dummyInstance", mock(ZkHelixPropertyStore.class),

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthBatchIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthBatchIntegrationTest.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.controller.helix.core.minion.generator.PinotTaskGenerator;
 import org.apache.pinot.minion.executor.PinotTaskExecutor;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -158,7 +159,8 @@ public class BasicAuthBatchIntegrationTest extends ClusterTest {
     IOUtils
         .write(jobFileContents.replaceAll("9000", String.valueOf(getControllerPort())), new FileOutputStream(jobFile));
 
-    new BootstrapTableTool("http", "localhost", getControllerPort(), baseDir.getAbsolutePath(), AUTH_TOKEN).execute();
+    new BootstrapTableTool("http", "localhost", getControllerPort(), baseDir.getAbsolutePath(),
+        AuthProviderUtils.makeAuthProvider(AUTH_TOKEN)).execute();
 
     Thread.sleep(5000);
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
@@ -465,6 +465,13 @@ public class TlsIntegrationTest extends BaseClusterIntegrationTest {
     }
   }
 
+  @Test(expectedExceptions = IOException.class)
+  public void testUnauthenticatedFailure()
+      throws IOException {
+    sendDeleteRequest(
+        _controllerRequestURLBuilder.forTableDelete(TableNameBuilder.REALTIME.tableNameWithType("mytable")));
+  }
+
   @Test
   public void testRealtimeSegmentUploadDownload()
       throws Exception {

--- a/pinot-integration-tests/src/test/resources/url-auth-token-prefixed.txt
+++ b/pinot-integration-tests/src/test/resources/url-auth-token-prefixed.txt
@@ -1,0 +1,1 @@
+Basic YWRtaW46dmVyeXNlY3JldA==

--- a/pinot-integration-tests/src/test/resources/url-auth-token.txt
+++ b/pinot-integration-tests/src/test/resources/url-auth-token.txt
@@ -1,0 +1,1 @@
+YWRtaW46dmVyeXNlY3JldA==

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
@@ -33,16 +33,17 @@ import org.apache.http.Header;
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicNameValuePair;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
 import org.apache.pinot.common.restlet.resources.StartReplaceSegmentsRequest;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
-import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.minion.MinionConf;
 import org.apache.pinot.minion.exception.TaskCancelledException;
+import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -105,7 +106,7 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
               .collect(Collectors.toList());
       String lineageEntryId =
           SegmentConversionUtils.startSegmentReplace(context.getTableNameWithType(), context.getUploadURL(),
-              new StartReplaceSegmentsRequest(segmentsFrom, segmentsTo), context.getAuthToken());
+              new StartReplaceSegmentsRequest(segmentsFrom, segmentsTo), context.getAuthProvider());
       context.setCustomContext(CUSTOM_SEGMENT_UPLOAD_CONTEXT_LINEAGE_ENTRY_ID, lineageEntryId);
     }
   }
@@ -116,7 +117,7 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
     if (context.isReplaceSegmentsEnabled()) {
       String lineageEntryId = (String) context.getCustomContext(CUSTOM_SEGMENT_UPLOAD_CONTEXT_LINEAGE_ENTRY_ID);
       SegmentConversionUtils.endSegmentReplace(context.getTableNameWithType(), context.getUploadURL(), lineageEntryId,
-          _minionConf.getEndReplaceSegmentsTimeoutMs(), context.getAuthToken());
+          _minionConf.getEndReplaceSegmentsTimeoutMs(), context.getAuthProvider());
     }
   }
 
@@ -132,7 +133,7 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
     String downloadURLString = configs.get(MinionConstants.DOWNLOAD_URL_KEY);
     String[] downloadURLs = downloadURLString.split(MinionConstants.URL_SEPARATOR);
     String uploadURL = configs.get(MinionConstants.UPLOAD_URL_KEY);
-    String authToken = configs.get(MinionConstants.AUTH_TOKEN);
+    AuthProvider authProvider = AuthProviderUtils.makeAuthProvider(configs.get(MinionConstants.AUTH_TOKEN));
 
     LOGGER.info("Start executing {} on table: {}, input segments: {} with downloadURLs: {}, uploadURL: {}", taskType,
         tableNameWithType, inputSegmentNames, downloadURLString, uploadURL);
@@ -215,7 +216,7 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
 
         List<Header> httpHeaders = new ArrayList<>();
         httpHeaders.add(segmentZKMetadataCustomMapModifierHeader);
-        httpHeaders.addAll(HttpClient.makeAuthHeader(authToken));
+        httpHeaders.addAll(AuthProviderUtils.toRequestHeaders(authProvider));
 
         // Set parameters for upload request
         NameValuePair enableParallelPushProtectionParameter =
@@ -255,7 +256,7 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
 
     private final String _tableNameWithType;
     private final String _uploadURL;
-    private final String _authToken;
+    private final AuthProvider _authProvider;
     private final String _inputSegmentNames;
     private final boolean _replaceSegmentsEnabled;
     private final Map<String, Object> _customMap;
@@ -268,7 +269,7 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
       Map<String, String> configs = pinotTaskConfig.getConfigs();
       _tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
       _uploadURL = configs.get(MinionConstants.UPLOAD_URL_KEY);
-      _authToken = configs.get(MinionConstants.AUTH_TOKEN);
+      _authProvider = AuthProviderUtils.makeAuthProvider(configs.get(MinionConstants.AUTH_TOKEN));
       _inputSegmentNames = configs.get(MinionConstants.SEGMENT_NAME_KEY);
       String replaceSegmentsString = configs.get(MinionConstants.ENABLE_REPLACE_SEGMENTS_KEY);
       _replaceSegmentsEnabled = Boolean.parseBoolean(replaceSegmentsString);
@@ -291,8 +292,8 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
       return _uploadURL;
     }
 
-    public String getAuthToken() {
-      return _authToken;
+    public AuthProvider getAuthProvider() {
+      return _authProvider;
     }
 
     public String getInputSegmentNames() {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseSingleSegmentConversionExecutor.java
@@ -31,14 +31,15 @@ import org.apache.http.HttpHeaders;
 import org.apache.http.NameValuePair;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicNameValuePair;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
-import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.minion.exception.TaskCancelledException;
+import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -69,7 +70,7 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
     String downloadURL = configs.get(MinionConstants.DOWNLOAD_URL_KEY);
     String uploadURL = configs.get(MinionConstants.UPLOAD_URL_KEY);
     String originalSegmentCrc = configs.get(MinionConstants.ORIGINAL_SEGMENT_CRC_KEY);
-    String authToken = configs.get(MinionConstants.AUTH_TOKEN);
+    AuthProvider authProvider = AuthProviderUtils.makeAuthProvider(configs.get(MinionConstants.AUTH_TOKEN));
 
     long currentSegmentCrc = getSegmentCrc(tableNameWithType, segmentName);
     if (Long.parseLong(originalSegmentCrc) != currentSegmentCrc) {
@@ -150,7 +151,7 @@ public abstract class BaseSingleSegmentConversionExecutor extends BaseTaskExecut
       httpHeaders.add(ifMatchHeader);
       httpHeaders.add(refreshOnlyHeader);
       httpHeaders.add(segmentZKMetadataCustomMapModifierHeader);
-      httpHeaders.addAll(HttpClient.makeAuthHeader(authToken));
+      httpHeaders.addAll(AuthProviderUtils.toRequestHeaders(authProvider));
 
       // Set parameters for upload request.
       NameValuePair enableParallelPushProtectionParameter =

--- a/pinot-plugins/pinot-segment-uploader/pinot-segment-uploader-default/src/main/java/org/apache/pinot/plugin/segmentuploader/SegmentUploaderDefault.java
+++ b/pinot-plugins/pinot-segment-uploader/pinot-segment-uploader-default/src/main/java/org/apache/pinot/plugin/segmentuploader/SegmentUploaderDefault.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.segment.local.utils.IngestionUtils;
-import org.apache.pinot.spi.auth.AuthContext;
+import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.ingestion.batch.BatchConfig;
@@ -86,15 +86,15 @@ public class SegmentUploaderDefault implements SegmentUploader {
   }
 
   @Override
-  public void uploadSegment(URI segmentTarURI, @Nullable AuthContext authContext)
+  public void uploadSegment(URI segmentTarURI, @Nullable AuthProvider authProvider)
       throws Exception {
     IngestionUtils
-        .uploadSegment(_tableNameWithType, _batchConfig, Collections.singletonList(segmentTarURI), authContext);
+        .uploadSegment(_tableNameWithType, _batchConfig, Collections.singletonList(segmentTarURI), authProvider);
     LOGGER.info("Successfully uploaded segment: {} to table: {}", segmentTarURI, _tableNameWithType);
   }
 
   @Override
-  public void uploadSegmentsFromDir(URI segmentDir, @Nullable AuthContext authContext)
+  public void uploadSegmentsFromDir(URI segmentDir, @Nullable AuthProvider authProvider)
       throws Exception {
 
     List<URI> segmentTarURIs = new ArrayList<>();
@@ -106,7 +106,7 @@ public class SegmentUploaderDefault implements SegmentUploader {
         segmentTarURIs.add(uri);
       }
     }
-    IngestionUtils.uploadSegment(_tableNameWithType, _batchConfig, segmentTarURIs, authContext);
+    IngestionUtils.uploadSegment(_tableNameWithType, _batchConfig, segmentTarURIs, authProvider);
     LOGGER.info("Successfully uploaded segments: {} to table: {}", segmentTarURIs, _tableNameWithType);
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManagerConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManagerConfig.java
@@ -36,7 +36,7 @@ public class TableDataManagerConfig {
   private static final String TABLE_DATA_MANAGER_CONSUMER_DIRECTORY = "consumerDirectory";
   private static final String TABLE_DATA_MANAGER_NAME = "name";
   private static final String TABLE_IS_DIMENSION = "isDimTable";
-  private static final String TABLE_DATA_MANGER_AUTH_TOKEN = "authToken";
+  private static final String TABLE_DATA_MANAGER_AUTH = "auth";
 
   private final Configuration _tableDataManagerConfig;
 
@@ -68,8 +68,8 @@ public class TableDataManagerConfig {
     return _tableDataManagerConfig.getBoolean(TABLE_IS_DIMENSION);
   }
 
-  public String getAuthToken() {
-    return _tableDataManagerConfig.getString(TABLE_DATA_MANGER_AUTH_TOKEN);
+  public Configuration getAuthConfig() {
+    return _tableDataManagerConfig.subset(TABLE_DATA_MANAGER_AUTH);
   }
 
   public static TableDataManagerConfig getDefaultHelixTableDataManagerConfig(
@@ -82,16 +82,18 @@ public class TableDataManagerConfig {
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
     Preconditions.checkNotNull(tableType);
     defaultConfig.addProperty(TABLE_DATA_MANAGER_TYPE, tableType.name());
-    defaultConfig.addProperty(TABLE_DATA_MANGER_AUTH_TOKEN, instanceDataManagerConfig.getAuthToken());
+
+    // copy auth-related configs
+    instanceDataManagerConfig.getConfig().subset(TABLE_DATA_MANAGER_AUTH).toMap()
+        .forEach((key, value) -> defaultConfig.setProperty(TABLE_DATA_MANAGER_AUTH + "." + key, value));
 
     return new TableDataManagerConfig(defaultConfig);
   }
 
-  public void overrideConfigs(TableConfig tableConfig, String authToken) {
+  public void overrideConfigs(TableConfig tableConfig) {
     // Override table level configs
 
     _tableDataManagerConfig.addProperty(TABLE_IS_DIMENSION, tableConfig.isDimTable());
-    _tableDataManagerConfig.addProperty(TABLE_DATA_MANGER_AUTH_TOKEN, authToken);
 
     // If we wish to override some table level configs using table config, override them here
     // Note: the configs in TableDataManagerConfig is immutable once the table is created, which mean it will not pick

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
@@ -37,12 +37,14 @@ import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
 import org.apache.http.message.BasicHeader;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.exception.HttpErrorStatusException;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.SimpleHttpResponse;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
@@ -105,6 +107,7 @@ public class SegmentPushUtils implements Serializable {
       String fileName = tarFile.getName();
       Preconditions.checkArgument(fileName.endsWith(Constants.TAR_GZ_FILE_EXT));
       String segmentName = fileName.substring(0, fileName.length() - Constants.TAR_GZ_FILE_EXT.length());
+      AuthProvider authProvider = AuthProviderUtils.makeAuthProvider(spec.getAuthToken());
       for (PinotClusterSpec pinotClusterSpec : spec.getPinotClusterSpecs()) {
         URI controllerURI;
         try {
@@ -125,7 +128,7 @@ public class SegmentPushUtils implements Serializable {
           try (InputStream inputStream = fileSystem.open(tarFileURI)) {
             SimpleHttpResponse response =
                 FILE_UPLOAD_DOWNLOAD_CLIENT.uploadSegment(FileUploadDownloadClient.getUploadSegmentURI(controllerURI),
-                    segmentName, inputStream, HttpClient.makeAuthHeader(spec.getAuthToken()),
+                    segmentName, inputStream, AuthProviderUtils.toRequestHeaders(authProvider),
                     FileUploadDownloadClient.makeTableParam(tableName), tableName, tableType);
             LOGGER.info("Response for pushing table {} segment {} to location {} - {}: {}", tableName, segmentName,
                 controllerURI, response.getStatusCode(), response.getResponse());
@@ -162,6 +165,7 @@ public class SegmentPushUtils implements Serializable {
     for (String segmentUri : segmentUris) {
       URI segmentURI = URI.create(segmentUri);
       PinotFS outputDirFS = PinotFSFactory.create(segmentURI.getScheme());
+      AuthProvider authProvider = AuthProviderUtils.makeAuthProvider(spec.getAuthToken());
       for (PinotClusterSpec pinotClusterSpec : spec.getPinotClusterSpecs()) {
         URI controllerURI;
         try {
@@ -182,9 +186,8 @@ public class SegmentPushUtils implements Serializable {
           try {
             SimpleHttpResponse response = FILE_UPLOAD_DOWNLOAD_CLIENT
                 .sendSegmentUri(FileUploadDownloadClient.getUploadSegmentURI(controllerURI), segmentUri,
-                    HttpClient.makeAuthHeader(spec.getAuthToken()),
-                    FileUploadDownloadClient.makeTableParam(tableName),
-                    HttpClient.DEFAULT_SOCKET_TIMEOUT_MS);
+                    AuthProviderUtils.toRequestHeaders(authProvider),
+                    FileUploadDownloadClient.makeTableParam(tableName), HttpClient.DEFAULT_SOCKET_TIMEOUT_MS);
             LOGGER.info("Response for pushing table {} segment uri {} to location {} - {}: {}", tableName, segmentUri,
                 controllerURI, response.getStatusCode(), response.getResponse());
             return true;
@@ -237,6 +240,7 @@ public class SegmentPushUtils implements Serializable {
       Preconditions.checkArgument(fileName.endsWith(Constants.TAR_GZ_FILE_EXT));
       String segmentName = fileName.substring(0, fileName.length() - Constants.TAR_GZ_FILE_EXT.length());
       File segmentMetadataFile = generateSegmentMetadataFile(fileSystem, URI.create(tarFilePath));
+      AuthProvider authProvider = AuthProviderUtils.makeAuthProvider(spec.getAuthToken());
       try {
         for (PinotClusterSpec pinotClusterSpec : spec.getPinotClusterSpecs()) {
           URI controllerURI;
@@ -260,7 +264,7 @@ public class SegmentPushUtils implements Serializable {
               headers.add(new BasicHeader(FileUploadDownloadClient.CustomHeaders.DOWNLOAD_URI, segmentUriPath));
               headers.add(new BasicHeader(FileUploadDownloadClient.CustomHeaders.UPLOAD_TYPE,
                   FileUploadDownloadClient.FileUploadType.METADATA.toString()));
-              headers.addAll(HttpClient.makeAuthHeader(spec.getAuthToken()));
+              headers.addAll(AuthProviderUtils.toRequestHeaders(authProvider));
 
               SimpleHttpResponse response = FILE_UPLOAD_DOWNLOAD_CLIENT
                   .uploadSegmentMetadata(FileUploadDownloadClient.getUploadSegmentURI(controllerURI), segmentName,

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -64,7 +64,6 @@ import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.utils.CommonConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -86,7 +85,6 @@ public class HelixInstanceDataManager implements InstanceDataManager {
   private HelixManager _helixManager;
   private ServerMetrics _serverMetrics;
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;
-  private String _authToken;
   private SegmentUploader _segmentUploader;
 
   // Fixed size LRU cache for storing last N errors on the instance.
@@ -103,7 +101,6 @@ public class HelixInstanceDataManager implements InstanceDataManager {
     _instanceId = _instanceDataManagerConfig.getInstanceId();
     _helixManager = helixManager;
     _serverMetrics = serverMetrics;
-    _authToken = config.getProperty(CommonConstants.Server.CONFIG_OF_AUTH_TOKEN);
     _segmentUploader = new PinotFSSegmentUploader(_instanceDataManagerConfig.getSegmentStoreUri(),
         PinotFSSegmentUploader.DEFAULT_SEGMENT_UPLOAD_TIMEOUT_MILLIS);
 
@@ -180,7 +177,7 @@ public class HelixInstanceDataManager implements InstanceDataManager {
     LOGGER.info("Creating table data manager for table: {}", tableNameWithType);
     TableDataManagerConfig tableDataManagerConfig =
         TableDataManagerConfig.getDefaultHelixTableDataManagerConfig(_instanceDataManagerConfig, tableNameWithType);
-    tableDataManagerConfig.overrideConfigs(tableConfig, _authToken);
+    tableDataManagerConfig.overrideConfigs(tableConfig);
     TableDataManager tableDataManager =
         TableDataManagerProvider.getTableDataManager(tableDataManagerConfig, _instanceId, _propertyStore,
             _serverMetrics, _helixManager, _errorCache);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -62,8 +62,6 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   public static final String SEGMENT_FORMAT_VERSION = "segment.format.version";
   // Key of whether to enable reloading consuming segments
   public static final String INSTANCE_RELOAD_CONSUMING_SEGMENT = "reload.consumingSegment";
-  // Key of the auth token
-  public static final String AUTH_TOKEN = "auth.token";
   // Key of segment directory loader
   public static final String SEGMENT_DIRECTORY_LOADER = "segment.directory.loader";
 
@@ -224,12 +222,6 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
         DEFAULT_MAX_PARALLEL_SEGMENT_DOWNLOADS);
   }
 
-  @Override
-  public String getAuthToken() {
-    return _instanceDataManagerConfiguration.getProperty(AUTH_TOKEN);
-  }
-
-  @Override
   public String getSegmentDirectoryLoader() {
     return _instanceDataManagerConfiguration.getProperty(SEGMENT_DIRECTORY_LOADER,
         SegmentDirectoryLoaderRegistry.DEFAULT_SEGMENT_DIRECTORY_LOADER_NAME);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/auth/AuthProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/auth/AuthProvider.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.auth;
+
+import java.util.Map;
+
+
+/**
+ * Pluggable auth provider interface to augment authentication information in requests issued by pinot.
+ *
+ * Comes with several default implementation, including noop, static tokens, and token loaded from external urls.
+ * The purpose of AuthProvider is enabling dynamic reconfiguration of pinot's internal auth tokens, for example with
+ * expiring JWTs and other token rotation mechanisms.
+ */
+public interface AuthProvider {
+  Map<String, Object> getRequestHeaders();
+
+  String getTaskToken();
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
@@ -55,8 +55,6 @@ public interface InstanceDataManagerConfig {
 
   int getMaxParallelSegmentDownloads();
 
-  String getAuthToken();
-
   String getSegmentDirectoryLoader();
 
   long getErrorCacheSize();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
@@ -124,6 +124,12 @@ public class SegmentGenerationJobSpec implements Serializable {
 
   /**
    * Controller auth token
+   *
+   * <br/>NOTE: jobs MUST NOT allow references to external tokens via URL or path to prevent:
+   * (a) file system crawling
+   * (b) unauthorized injection of system tokens from the server's local file system.
+   *
+   * Instead, resolve tokens right when the job command is run. This allows injection of client-local credentials.
    */
   private String _authToken;
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/segment/uploader/SegmentUploader.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/segment/uploader/SegmentUploader.java
@@ -22,7 +22,7 @@ import java.net.URI;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.annotations.InterfaceStability;
-import org.apache.pinot.spi.auth.AuthContext;
+import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.config.table.TableConfig;
 
 
@@ -49,17 +49,17 @@ public interface SegmentUploader {
   /**
    * Uploads the segment tar file to the cluster
    * @param segmentTarFile URI of segment tar file
-   * @param authContext auth details required to upload pinot segment to controller
+   * @param authProvider auth provider
    */
-  void uploadSegment(URI segmentTarFile, @Nullable AuthContext authContext)
+  void uploadSegment(URI segmentTarFile, @Nullable AuthProvider authProvider)
       throws Exception;
 
   /**
    * Uploads the segments from the segmentDir to the cluster.
    * Looks for segmentTar files recursively, with suffix .tar.gz
    * @param segmentDir URI of directory containing segment tar files
-   * @param authContext auth details required to upload pinot segment to controller
+   * @param authProvider auth auth provider
    */
-  void uploadSegmentsFromDir(URI segmentDir, @Nullable AuthContext authContext)
+  void uploadSegmentsFromDir(URI segmentDir, @Nullable AuthProvider authProvider)
       throws Exception;
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -33,7 +33,7 @@ public class CommonConstants {
   public static final String HTTP_PROTOCOL = "http";
   public static final String HTTPS_PROTOCOL = "https";
 
-  public static final String KEY_OF_AUTH_TOKEN = "auth.token";
+  public static final String KEY_OF_AUTH = "auth";
 
   public static final String TABLE_NAME = "tableName";
 
@@ -336,7 +336,7 @@ public class CommonConstants {
      * Service token for accessing protected controller APIs.
      * E.g. null (auth disabled), "Basic abcdef..." (basic auth), "Bearer 123def..." (oauth2)
      */
-    public static final String CONFIG_OF_AUTH_TOKEN = KEY_OF_AUTH_TOKEN;
+    public static final String CONFIG_OF_AUTH = KEY_OF_AUTH;
 
     // Configuration to consider the server ServiceStatus as being STARTED if the percent of resources (tables) that
     // are ONLINE for this this server has crossed the threshold percentage of the total number of tables
@@ -437,7 +437,7 @@ public class CommonConstants {
        * Service token for accessing protected controller APIs.
        * E.g. null (auth disabled), "Basic abcdef..." (basic auth), "Bearer 123def..." (oauth2)
        */
-      public static final String CONFIG_OF_SEGMENT_UPLOADER_AUTH_TOKEN = KEY_OF_AUTH_TOKEN;
+      public static final String CONFIG_OF_SEGMENT_UPLOADER_AUTH = KEY_OF_AUTH;
 
       public static final int DEFAULT_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS = 300_000;
       public static final int DEFAULT_OTHER_REQUESTS_TIMEOUT = 10_000;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
@@ -22,7 +22,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.core.auth.BasicAuthUtils;
+import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.plugin.PluginManager;
 
 
@@ -33,8 +35,8 @@ public class AuthQuickstart extends Quickstart {
   }
 
   @Override
-  public String getAuthToken() {
-    return BasicAuthUtils.toBasicAuthToken("admin", "verysecret");
+  public AuthProvider getAuthProvider() {
+    return AuthProviderUtils.makeAuthProvider(BasicAuthUtils.toBasicAuthToken("admin", "verysecret"));
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/BootstrapTableTool.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/BootstrapTableTool.java
@@ -30,9 +30,11 @@ import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.minion.MinionClient;
 import org.apache.pinot.common.utils.TlsUtils;
 import org.apache.pinot.core.common.MinionConstants;
+import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.ingestion.batch.IngestionJobLauncher;
@@ -53,12 +55,12 @@ public class BootstrapTableTool {
   private final String _controllerProtocol;
   private final String _controllerHost;
   private final int _controllerPort;
-  private final String _authToken;
+  private final AuthProvider _authProvider;
   private final String _tableDir;
   private final MinionClient _minionClient;
 
   public BootstrapTableTool(String controllerProtocol, String controllerHost, int controllerPort, String tableDir,
-      String authToken) {
+      AuthProvider authProvider) {
     Preconditions.checkNotNull(controllerProtocol);
     Preconditions.checkNotNull(controllerHost);
     Preconditions.checkNotNull(tableDir);
@@ -67,7 +69,7 @@ public class BootstrapTableTool {
     _controllerPort = controllerPort;
     _tableDir = tableDir;
     _minionClient = new MinionClient(controllerHost, String.valueOf(controllerPort));
-    _authToken = authToken;
+    _authProvider = authProvider;
   }
 
   public boolean execute()
@@ -117,7 +119,7 @@ public class BootstrapTableTool {
     return new AddTableCommand().setSchemaFile(schemaFile.getAbsolutePath())
         .setTableConfigFile(tableConfigFile.getAbsolutePath()).setControllerProtocol(_controllerProtocol)
         .setControllerHost(_controllerHost).setControllerPort(String.valueOf(_controllerPort)).setExecute(true)
-        .setAuthToken(_authToken).execute();
+        .setAuthProvider(_authProvider).execute();
   }
 
   private boolean bootstrapOfflineTable(File setupTableTmpDir, String tableName, File schemaFile,
@@ -179,7 +181,8 @@ public class BootstrapTableTool {
                 tlsSpec.getTrustStorePassword());
           }
 
-          spec.setAuthToken(_authToken);
+          // url-based token needs to be resolved before job run
+          spec.setAuthToken(AuthProviderUtils.toStaticToken(_authProvider));
 
           IngestionJobLauncher.runIngestionJob(spec);
         }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/EmptyQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/EmptyQuickstart.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 
@@ -32,7 +33,7 @@ public class EmptyQuickstart extends QuickStartBase {
     return Arrays.asList("EMPTY", "DEFAULT");
   }
 
-  public String getAuthToken() {
+  public AuthProvider getAuthProvider() {
     return null;
   }
 
@@ -48,7 +49,7 @@ public class EmptyQuickstart extends QuickStartBase {
 
     QuickstartRunner runner =
         new QuickstartRunner(new ArrayList<>(), 1, 1, 1, 1,
-            dataDir, true, getAuthToken(), getConfigOverrides(), _zkExternalAddress, false);
+            dataDir, true, getAuthProvider(), getConfigOverrides(), _zkExternalAddress, false);
 
     if (_zkExternalAddress != null) {
       printStatus(Quickstart.Color.CYAN, "***** Starting controller, broker and server *****");

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.tools.admin.PinotAdministrator;
 import org.apache.pinot.tools.admin.command.QuickstartRunner;
 
@@ -56,7 +57,7 @@ public class Quickstart extends QuickStartBase {
     }
   }
 
-  public String getAuthToken() {
+  public AuthProvider getAuthProvider() {
     return null;
   }
 
@@ -99,7 +100,7 @@ public class Quickstart extends QuickStartBase {
 
     QuickstartTableRequest request = new QuickstartTableRequest(baseDir.getAbsolutePath());
     QuickstartRunner runner =
-        new QuickstartRunner(Lists.newArrayList(request), 1, 1, 1, 1, dataDir, true, getAuthToken(),
+        new QuickstartRunner(Lists.newArrayList(request), 1, 1, 1, 1, dataDir, true, getAuthProvider(),
             getConfigOverrides(), null, true);
 
     printStatus(Color.CYAN, "***** Starting Zookeeper, controller, broker and server *****");

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddSchemaCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddSchemaCommand.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.Collections;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
+import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.NetUtils;
@@ -59,9 +60,14 @@ public class AddSchemaCommand extends AbstractBaseAdminCommand implements Comman
   @CommandLine.Option(names = {"-authToken"}, required = false, description = "Http auth token.")
   private String _authToken;
 
+  @CommandLine.Option(names = {"-authTokenUrl"}, required = false, description = "Http auth token url.")
+  private String _authTokenUrl;
+
   @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
       description = "Print this message.")
   private boolean _help = false;
+
+  private AuthProvider _authProvider;
 
   @Override
   public boolean getHelp() {
@@ -119,8 +125,8 @@ public class AddSchemaCommand extends AbstractBaseAdminCommand implements Comman
     _password = password;
   }
 
-  public void setAuthToken(String authToken) {
-    _authToken = authToken;
+  public void setAuthProvider(AuthProvider authProvider) {
+    _authProvider = authProvider;
   }
 
   public AddSchemaCommand setExecute(boolean exec) {
@@ -151,8 +157,8 @@ public class AddSchemaCommand extends AbstractBaseAdminCommand implements Comman
     try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient()) {
       fileUploadDownloadClient.addSchema(FileUploadDownloadClient
               .getUploadSchemaURI(_controllerProtocol, _controllerHost, Integer.parseInt(_controllerPort)),
-          schema.getSchemaName(), schemaFile, makeAuthHeader(makeAuthToken(_authToken, _user, _password)),
-          Collections.emptyList());
+          schema.getSchemaName(), schemaFile, makeAuthHeaders(makeAuthProvider(_authProvider, _authTokenUrl, _authToken,
+              _user, _password)), Collections.emptyList());
     } catch (Exception e) {
       LOGGER.error("Got Exception to upload Pinot Schema: " + schema.getSchemaName(), e);
       return false;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTenantCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTenantCommand.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.tools.admin.command;
 
+import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.config.tenant.Tenant;
 import org.apache.pinot.spi.config.tenant.TenantRole;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -71,11 +72,16 @@ public class AddTenantCommand extends AbstractBaseAdminCommand implements Comman
   @CommandLine.Option(names = {"-authToken"}, required = false, description = "Http auth token.")
   private String _authToken;
 
+  @CommandLine.Option(names = {"-authTokenUrl"}, required = false, description = "Http auth token url.")
+  private String _authTokenUrl;
+
   @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
       description = "Print this message.")
   private boolean _help = false;
 
   private String _controllerAddress;
+
+  private AuthProvider _authProvider;
 
   public AddTenantCommand setControllerUrl(String url) {
     _controllerAddress = url;
@@ -117,13 +123,13 @@ public class AddTenantCommand extends AbstractBaseAdminCommand implements Comman
     return this;
   }
 
-  public AddTenantCommand setAuthToken(String authToken) {
-    _authToken = authToken;
+  public AddTenantCommand setExecute(boolean exec) {
+    _exec = exec;
     return this;
   }
 
-  public AddTenantCommand setExecute(boolean exec) {
-    _exec = exec;
+  public AddTenantCommand setAuthProvider(AuthProvider authProvider) {
+    _authProvider = authProvider;
     return this;
   }
 
@@ -147,7 +153,8 @@ public class AddTenantCommand extends AbstractBaseAdminCommand implements Comman
     Tenant tenant = new Tenant(_role, _name, _instanceCount, _offlineInstanceCount, _realtimeInstanceCount);
     String res = AbstractBaseAdminCommand
         .sendRequest("POST", ControllerRequestURLBuilder.baseUrl(_controllerAddress).forTenantCreate(),
-            tenant.toJsonString(), makeAuthHeader(makeAuthToken(_authToken, _user, _password)));
+            tenant.toJsonString(), makeAuthHeaders(makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user,
+                _password)));
 
     LOGGER.info(res);
     System.out.print(res);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/BootstrapTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/BootstrapTableCommand.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.tools.admin.command;
 
+import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.NetUtils;
@@ -87,9 +88,14 @@ public class BootstrapTableCommand extends AbstractBaseAdminCommand implements C
   @CommandLine.Option(names = {"-authToken"}, required = false, description = "Http auth token.")
   private String _authToken;
 
+  @CommandLine.Option(names = {"-authTokenUrl"}, required = false, description = "Http auth token url.")
+  private String _authTokenUrl;
+
   @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
       description = "Print this message.")
   private boolean _help = false;
+
+  private AuthProvider _authProvider;
 
   @Override
   public boolean getHelp() {
@@ -103,6 +109,11 @@ public class BootstrapTableCommand extends AbstractBaseAdminCommand implements C
 
   public BootstrapTableCommand setDir(String dir) {
     _dir = dir;
+    return this;
+  }
+
+  public BootstrapTableCommand setAuthProvider(AuthProvider authProvider) {
+    _authProvider = authProvider;
     return this;
   }
 
@@ -127,8 +138,7 @@ public class BootstrapTableCommand extends AbstractBaseAdminCommand implements C
     if (_controllerHost == null) {
       _controllerHost = NetUtils.getHostAddress();
     }
-    String token = makeAuthToken(_authToken, _user, _password);
-    return new BootstrapTableTool(_controllerProtocol, _controllerHost, Integer.parseInt(_controllerPort), _dir, token)
-        .execute();
+    return new BootstrapTableTool(_controllerProtocol, _controllerHost, Integer.parseInt(_controllerPort), _dir,
+        makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password)).execute();
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ImportDataCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ImportDataCommand.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
@@ -85,6 +86,9 @@ public class ImportDataCommand extends AbstractBaseAdminCommand implements Comma
   @CommandLine.Option(names = {"-authToken"}, required = false, description = "Http auth token.")
   private String _authToken;
 
+  @CommandLine.Option(names = {"-authTokenUrl"}, required = false, description = "Http auth token url.")
+  private String _authTokenUrl;
+
   @CommandLine.Option(names = {"-tempDir"},
       description = "Temporary directory used to hold data during segment creation.")
   private String _tempDir = new File(FileUtils.getTempDirectory(), getClass().getSimpleName()).getAbsolutePath();
@@ -95,6 +99,8 @@ public class ImportDataCommand extends AbstractBaseAdminCommand implements Comma
   @SuppressWarnings("FieldCanBeLocal")
   @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, help = true, description = "Print this message.")
   private boolean _help = false;
+
+  private AuthProvider _authProvider;
 
   public ImportDataCommand setDataFilePath(String dataFilePath) {
     _dataFilePath = dataFilePath;
@@ -143,8 +149,8 @@ public class ImportDataCommand extends AbstractBaseAdminCommand implements Comma
     return this;
   }
 
-  public ImportDataCommand setAuthToken(String authToken) {
-    _authToken = authToken;
+  public ImportDataCommand setAuthProvider(AuthProvider authProvider) {
+    _authProvider = authProvider;
     return this;
   }
 
@@ -253,7 +259,7 @@ public class ImportDataCommand extends AbstractBaseAdminCommand implements Comma
     spec.setCleanUpOutputDir(true);
     spec.setOverwriteOutput(true);
     spec.setJobType("SegmentCreationAndTarPush");
-    spec.setAuthToken(makeAuthToken(_authToken, _user, _password));
+    spec.setAuthToken(makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password).getTaskToken());
 
     // set ExecutionFrameworkSpec
     ExecutionFrameworkSpec executionFrameworkSpec = new ExecutionFrameworkSpec();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchDataIngestionJobCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchDataIngestionJobCommand.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.TlsUtils;
+import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.ingestion.batch.IngestionJobLauncher;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.TlsSpec;
@@ -58,6 +59,10 @@ public class LaunchDataIngestionJobCommand extends AbstractBaseAdminCommand impl
   private String _password;
   @CommandLine.Option(names = {"-authToken"}, required = false, description = "Http auth token.")
   private String _authToken;
+  @CommandLine.Option(names = {"-authTokenUrl"}, required = false, description = "Http auth token url.")
+  private String _authTokenUrl;
+
+  private AuthProvider _authProvider;
 
   public String getJobSpecFile() {
     return _jobSpecFile;
@@ -81,6 +86,10 @@ public class LaunchDataIngestionJobCommand extends AbstractBaseAdminCommand impl
 
   public void setPropertyFile(String propertyFile) {
     _propertyFile = propertyFile;
+  }
+
+  public void setAuthProvider(AuthProvider authProvider) {
+    _authProvider = authProvider;
   }
 
   @Override
@@ -114,7 +123,7 @@ public class LaunchDataIngestionJobCommand extends AbstractBaseAdminCommand impl
     }
 
     if (StringUtils.isBlank(spec.getAuthToken())) {
-      spec.setAuthToken(makeAuthToken(_authToken, _user, _password));
+      spec.setAuthToken(makeAuthProvider(_authProvider, _authToken, _user, _password, _authTokenUrl).getTaskToken());
     }
 
     try {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/OperateClusterConfigCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/OperateClusterConfigCommand.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.Header;
+import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.NetUtils;
@@ -55,6 +56,9 @@ public class OperateClusterConfigCommand extends AbstractBaseAdminCommand implem
   @CommandLine.Option(names = {"-authToken"}, required = false, description = "Http auth token.")
   private String _authToken;
 
+  @CommandLine.Option(names = {"-authTokenUrl"}, required = false, description = "Http auth token url.")
+  private String _authTokenUrl;
+
   @CommandLine.Option(names = {"-config"}, description = "Cluster config to operate.")
   private String _config;
 
@@ -65,6 +69,8 @@ public class OperateClusterConfigCommand extends AbstractBaseAdminCommand implem
   @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
       description = "Print this message.")
   private boolean _help = false;
+
+  private AuthProvider _authProvider;
 
   @Override
   public boolean getHelp() {
@@ -122,11 +128,6 @@ public class OperateClusterConfigCommand extends AbstractBaseAdminCommand implem
     return this;
   }
 
-  public OperateClusterConfigCommand setAuthToken(String authToken) {
-    _authToken = authToken;
-    return this;
-  }
-
   public OperateClusterConfigCommand setConfig(String config) {
     _config = config;
     return this;
@@ -134,6 +135,11 @@ public class OperateClusterConfigCommand extends AbstractBaseAdminCommand implem
 
   public OperateClusterConfigCommand setOperation(String operation) {
     _operation = operation;
+    return this;
+  }
+
+  public OperateClusterConfigCommand setAuthProvider(AuthProvider authProvider) {
+    _authProvider = authProvider;
     return this;
   }
 
@@ -148,7 +154,8 @@ public class OperateClusterConfigCommand extends AbstractBaseAdminCommand implem
     }
     String clusterConfigUrl =
         _controllerProtocol + "://" + _controllerHost + ":" + _controllerPort + "/cluster/configs";
-    List<Header> headers = makeAuthHeader(makeAuthToken(_authToken, _user, _password));
+    List<Header> headers = makeAuthHeaders(makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user,
+        _password));
     switch (_operation.toUpperCase()) {
       case "ADD":
       case "UPDATE":

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.tools.admin.command;
 
 import java.util.Collections;
+import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -54,9 +55,14 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
   @CommandLine.Option(names = {"-authToken"}, required = false, description = "Http auth token.")
   private String _authToken;
 
+  @CommandLine.Option(names = {"-authTokenUrl"}, required = false, description = "Http auth token url.")
+  private String _authTokenUrl;
+
   @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true, description = "Print "
       + "this message.")
   private boolean _help = false;
+
+  private AuthProvider _authProvider;
 
   @Override
   public boolean getHelp() {
@@ -108,13 +114,13 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
     return this;
   }
 
-  public PostQueryCommand setAuthToken(String authToken) {
-    _authToken = authToken;
+  public PostQueryCommand setQuery(String query) {
+    _query = query;
     return this;
   }
 
-  public PostQueryCommand setQuery(String query) {
-    _query = query;
+  public PostQueryCommand setAuthProvider(AuthProvider authProvider) {
+    _authProvider = authProvider;
     return this;
   }
 
@@ -126,7 +132,8 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
     LOGGER.info("Executing command: " + this);
     String url = _brokerProtocol + "://" + _brokerHost + ":" + _brokerPort + "/query/sql";
     String request = JsonUtils.objectToString(Collections.singletonMap(Request.SQL, _query));
-    return sendRequest("POST", url, request, makeAuthHeader(makeAuthToken(_authToken, _user, _password)));
+    return sendRequest("POST", url, request, makeAuthHeaders(makeAuthProvider(_authProvider,
+            _authTokenUrl, _authToken, _user, _password)));
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
@@ -27,6 +27,7 @@ import org.apache.http.message.BasicNameValuePair;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.common.utils.http.HttpClient;
+import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.tools.Command;
@@ -63,6 +64,9 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
   @CommandLine.Option(names = {"-authToken"}, required = false, description = "Http auth token.")
   private String _authToken;
 
+  @CommandLine.Option(names = {"-authTokenUrl"}, required = false, description = "Http auth token url.")
+  private String _authTokenUrl;
+
   @CommandLine.Option(names = {"-segmentDir"}, required = true, description = "Path to segment directory.")
   private String _segmentDir = null;
 
@@ -73,6 +77,8 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
   @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
       description = "Print this message.")
   private boolean _help = false;
+
+  private AuthProvider _authProvider;
 
   @Override
   public boolean getHelp() {
@@ -124,13 +130,13 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
     return this;
   }
 
-  public UploadSegmentCommand setAuthToken(String authToken) {
-    _authToken = authToken;
+  public UploadSegmentCommand setSegmentDir(String segmentDir) {
+    _segmentDir = segmentDir;
     return this;
   }
 
-  public UploadSegmentCommand setSegmentDir(String segmentDir) {
-    _segmentDir = segmentDir;
+  public UploadSegmentCommand setAuthProvider(AuthProvider authProvider) {
+    _authProvider = authProvider;
     return this;
   }
 
@@ -168,9 +174,9 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
 
         LOGGER.info("Uploading segment tar file: {}", segmentTarFile);
         fileUploadDownloadClient.uploadSegment(uploadSegmentHttpURI, segmentTarFile.getName(), segmentTarFile,
-            makeAuthHeader(makeAuthToken(_authToken, _user, _password)), Collections
-                .singletonList(new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_NAME, _tableName)),
-            HttpClient.DEFAULT_SOCKET_TIMEOUT_MS);
+            makeAuthHeaders(makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password)),
+            Collections.singletonList(new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_NAME,
+                _tableName)), HttpClient.DEFAULT_SOCKET_TIMEOUT_MS);
       }
     } finally {
       // Delete the temporary working directory.


### PR DESCRIPTION
This PR adds support for pluggable client auth providers, which enables pinot components (controller, server, minion) to use dynamically changing tokens, such as kubernetes service account JWTs. The implementation is generic and enables the addition of third-party auth providers to support virtually any environment.

Previously, pinot components were stuck with statically pre-configured client auth tokens. While authentication for the server-side (e.g. restlets responses) was pluggable already, the client-side (e.g. segment fetcher http requests) was configured statically. This would require a full restart of pinot components to address token changes (e.g. rotation). This PR removes this limitation while preserving legacy behavior for static `auth.token` values, if configured.

*Potentially backwards-incompatible changes:*

`AddTableCommand.setAuthToken()` removed (same for other commands)
`FileUploadDownloadClient` removes several methods specific to auth tokens in favor of header-based method signatures

*Release Notes:*

Add pluggable auth providers to pinot to enable dynamic client token rotation:
- `StaticTokenAuthProvider` legacy behavior, job specs
- `UrlTokenAuthProvider` dynamic file- or url-based token retrieval
- `AuthProvider` interface for generic third-party implementations

Add support for pinot admin command to inject tokens from a URL using a `-authTokenUrl` param

New configuration options:
`...auth.provider.class` provider class name for dynamic loading
`...auth.token` StaticTokenAuthProvider token, legacy behavior
`...auth.url` UrlTokenAuthProvider source URL
`...auth.prefix` StaticTokenAuthProvider and UrlTokenAuthProvider token prefix (typically `Basic` or `Bearer`)
`...auth.header` StaticTokenAuthProvider and UrlTokenAuthProvider http header name (typically `Authorization`)
