### PR TITLE
Remove segments using valid doc ids instead of primary key

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -135,8 +135,9 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     try {
       _statsHistory = RealtimeSegmentStatsHistory.deserialzeFrom(statsFile);
     } catch (IOException | ClassNotFoundException e) {
-      _logger.error("Error reading history object for table {} from {}", _tableNameWithType,
-          statsFile.getAbsolutePath(), e);
+      _logger
+          .error("Error reading history object for table {} from {}", _tableNameWithType, statsFile.getAbsolutePath(),
+              e);
       File savedFile = new File(_tableDataDir, STATS_FILE_NAME + "." + UUID.randomUUID());
       try {
         FileUtils.moveFile(statsFile, savedFile);
@@ -334,17 +335,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
           throw new RuntimeException("Failed to find local copy for committed HLC segment: " + segmentName);
         }
       }
-
       // Local segment doesn't exist or cannot load, download a new copy
       downloadAndReplaceSegment(segmentName, segmentZKMetadata, indexLoadingConfig, tableConfig);
-
-    } else if (segmentZKMetadata.getStatus() == Status.UPLOADED) {
-      // The segment is uploaded to an upsert enabled realtime table. Download the segment and load.
-      String downloadUrl = segmentZKMetadata.getDownloadUrl();
-      Preconditions.checkNotNull(downloadUrl, "Upload segment metadata has no download url");
-      downloadSegmentFromDeepStore(segmentName, indexLoadingConfig, downloadUrl);
-      _logger.info("Downloaded, untarred and add segment {} of table {} from {}", segmentName,
-          tableConfig.getTableName(), downloadUrl);
       return;
     } else {
       // Metadata has not been committed, delete the local segment if exists
@@ -366,7 +358,6 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       PartitionUpsertMetadataManager partitionUpsertMetadataManager =
           _tableUpsertMetadataManager != null ? _tableUpsertMetadataManager.getOrCreatePartitionManager(
               partitionGroupId) : null;
-
       PartitionDedupMetadataManager partitionDedupMetadataManager =
           _tableDedupMetadataManager != null ? _tableDedupMetadataManager.getOrCreatePartitionManager(partitionGroupId)
               : null;
@@ -441,8 +432,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     for (String primaryKeyColumn : _primaryKeyColumns) {
       columnToReaderMap.put(primaryKeyColumn, new PinotSegmentColumnReader(immutableSegment, primaryKeyColumn));
     }
-    columnToReaderMap.put(_upsertComparisonColumn,
-        new PinotSegmentColumnReader(immutableSegment, _upsertComparisonColumn));
+    columnToReaderMap
+        .put(_upsertComparisonColumn, new PinotSegmentColumnReader(immutableSegment, _upsertComparisonColumn));
     int numTotalDocs = immutableSegment.getSegmentMetadata().getTotalDocs();
     int numPrimaryKeyColumns = _primaryKeyColumns.size();
     Iterator<RecordInfo> recordInfoIterator = new Iterator<RecordInfo>() {
@@ -548,8 +539,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   private boolean isPeerSegmentDownloadEnabled(TableConfig tableConfig) {
     return
         CommonConstants.HTTP_PROTOCOL.equalsIgnoreCase(tableConfig.getValidationConfig().getPeerSegmentDownloadScheme())
-            || CommonConstants.HTTPS_PROTOCOL.equalsIgnoreCase(
-            tableConfig.getValidationConfig().getPeerSegmentDownloadScheme());
+            || CommonConstants.HTTPS_PROTOCOL
+            .equalsIgnoreCase(tableConfig.getValidationConfig().getPeerSegmentDownloadScheme());
   }
 
   private void downloadSegmentFromPeer(String segmentName, String downloadScheme,

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -68,7 +68,6 @@ import org.apache.pinot.segment.local.utils.tablestate.TableStateUtils;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.spi.config.table.DedupConfig;
-import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
@@ -125,7 +126,7 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     _upsertIndexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
     ((ImmutableSegmentImpl) _upsertIndexSegment).enableUpsert(
         new PartitionUpsertMetadataManager("testTable_REALTIME", 0, serverMetrics, null,
-            HashFunction.NONE), new ThreadSafeMutableRoaringBitmap());
+            HashFunction.NONE, Collections.emptyList()), new ThreadSafeMutableRoaringBitmap());
   }
 
   @AfterClass

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/QueryOverrideWithHintsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/QueryOverrideWithHintsTest.java
@@ -42,6 +42,7 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.testng.annotations.Test;
 
@@ -90,6 +91,11 @@ public class QueryOverrideWithHintsTest {
 
     @Override
     public GenericRow getRecord(int docId, GenericRow reuse) {
+      return null;
+    }
+
+    @Override
+    public PrimaryKey getPrimaryKey(int docId, PrimaryKey reuse) {
       return null;
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/QueryOverrideWithHintsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/QueryOverrideWithHintsTest.java
@@ -95,8 +95,7 @@ public class QueryOverrideWithHintsTest {
     }
 
     @Override
-    public PrimaryKey getPrimaryKey(int docId, PrimaryKey reuse) {
-      return null;
+    public void getPrimaryKey(int docId, PrimaryKey reuse) {
     }
 
     @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/EmptyIndexSegment.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/EmptyIndexSegment.java
@@ -33,6 +33,7 @@ import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.PrimaryKey;
 
 
 /**
@@ -92,6 +93,11 @@ public class EmptyIndexSegment implements ImmutableSegment {
   @Override
   public GenericRow getRecord(int docId, GenericRow reuse) {
     throw new UnsupportedOperationException("Cannot read record from empty segment");
+  }
+
+  @Override
+  public PrimaryKey getPrimaryKey(int docId, PrimaryKey reuse) {
+    throw new UnsupportedOperationException("Cannot read primary key from empty segment");
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/EmptyIndexSegment.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/EmptyIndexSegment.java
@@ -96,7 +96,7 @@ public class EmptyIndexSegment implements ImmutableSegment {
   }
 
   @Override
-  public PrimaryKey getPrimaryKey(int docId, PrimaryKey reuse) {
+  public void getPrimaryKey(int docId, PrimaryKey reuse) {
     throw new UnsupportedOperationException("Cannot read primary key from empty segment");
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -44,6 +44,7 @@ import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -231,6 +232,20 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
       return reuse;
     } catch (Exception e) {
       throw new RuntimeException("Failed to use PinotSegmentRecordReader to read immutable segment");
+    }
+  }
+
+  @Override
+  public PrimaryKey getPrimaryKey(int docId, PrimaryKey reuse) {
+    try {
+      if (_pinotSegmentRecordReader == null) {
+        _pinotSegmentRecordReader = new PinotSegmentRecordReader();
+        _pinotSegmentRecordReader.init(this);
+      }
+      return _pinotSegmentRecordReader.getPrimaryKey(docId, _partitionUpsertMetadataManager.getPrimaryKeyColumns());
+    } catch (Exception e) {
+      e.printStackTrace();
+      throw new RuntimeException("Failed to use PinotSegmentRecordReader to read primary key from immutable segment");
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -236,15 +236,14 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
   }
 
   @Override
-  public PrimaryKey getPrimaryKey(int docId, PrimaryKey reuse) {
+  public void getPrimaryKey(int docId, PrimaryKey reuse) {
     try {
       if (_pinotSegmentRecordReader == null) {
         _pinotSegmentRecordReader = new PinotSegmentRecordReader();
         _pinotSegmentRecordReader.init(this);
       }
-      return _pinotSegmentRecordReader.getPrimaryKey(docId, _partitionUpsertMetadataManager.getPrimaryKeyColumns());
+      _pinotSegmentRecordReader.getPrimaryKey(docId, _partitionUpsertMetadataManager.getPrimaryKeyColumns(), reuse);
     } catch (Exception e) {
-      e.printStackTrace();
       throw new RuntimeException("Failed to use PinotSegmentRecordReader to read primary key from immutable segment");
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/IntermediateSegment.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/IntermediateSegment.java
@@ -226,7 +226,7 @@ public class IntermediateSegment implements MutableSegment {
   }
 
   @Override
-  public PrimaryKey getPrimaryKey(int docId, PrimaryKey reuse) {
+  public void getPrimaryKey(int docId, PrimaryKey reuse) {
     int numPrimaryKeyColumns = _schema.getPrimaryKeyColumns().size();
     Object[] values = new Object[numPrimaryKeyColumns];;
     for (int i = 0; i < numPrimaryKeyColumns; i++) {
@@ -236,7 +236,7 @@ public class IntermediateSegment implements MutableSegment {
           indexContainer.getNumValuesInfo().getMaxNumValuesPerMVEntry());
       values[i] = value;
     }
-    return new PrimaryKey(values);
+    reuse.setValues(values);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/IntermediateSegment.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/IntermediateSegment.java
@@ -228,7 +228,7 @@ public class IntermediateSegment implements MutableSegment {
   @Override
   public void getPrimaryKey(int docId, PrimaryKey reuse) {
     int numPrimaryKeyColumns = _schema.getPrimaryKeyColumns().size();
-    Object[] values = new Object[numPrimaryKeyColumns];;
+    Object[] values = reuse.getValues();
     for (int i = 0; i < numPrimaryKeyColumns; i++) {
       IntermediateIndexContainer indexContainer = _indexContainerMap.get(
           _schema.getPrimaryKeyColumns().get(i));
@@ -236,7 +236,6 @@ public class IntermediateSegment implements MutableSegment {
           indexContainer.getNumValuesInfo().getMaxNumValuesPerMVEntry());
       values[i] = value;
     }
-    reuse.setValues(values);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/IntermediateSegment.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/IntermediateSegment.java
@@ -55,6 +55,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.apache.pinot.spi.stream.RowMetadata;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.slf4j.Logger;
@@ -222,6 +223,20 @@ public class IntermediateSegment implements MutableSegment {
       reuse.putValue(column, value);
     }
     return reuse;
+  }
+
+  @Override
+  public PrimaryKey getPrimaryKey(int docId, PrimaryKey reuse) {
+    int numPrimaryKeyColumns = _schema.getPrimaryKeyColumns().size();
+    Object[] values = new Object[numPrimaryKeyColumns];;
+    for (int i = 0; i < numPrimaryKeyColumns; i++) {
+      IntermediateIndexContainer indexContainer = _indexContainerMap.get(
+          _schema.getPrimaryKeyColumns().get(i));
+      Object value = getValue(docId, indexContainer.getForwardIndex(), indexContainer.getDictionary(),
+          indexContainer.getNumValuesInfo().getMaxNumValuesPerMVEntry());
+      values[i] = value;
+    }
+    return new PrimaryKey(values);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -573,7 +573,7 @@ public class MutableSegmentImpl implements MutableSegment {
   @Override
   public void getPrimaryKey(int docId, PrimaryKey reuse) {
     int numPrimaryKeyColumns = _partitionUpsertMetadataManager.getPrimaryKeyColumns().size();
-    Object[] values = new Object[numPrimaryKeyColumns];;
+    Object[] values = reuse.getValues();
     for (int i = 0; i < numPrimaryKeyColumns; i++) {
       IndexContainer indexContainer = _indexContainerMap.get(
           _partitionUpsertMetadataManager.getPrimaryKeyColumns().get(i));
@@ -581,7 +581,6 @@ public class MutableSegmentImpl implements MutableSegment {
           indexContainer._numValuesInfo._maxNumValuesPerMVEntry);
       values[i] = value;
     }
-    reuse.setValues(values);
   }
 
   private void updateDictionary(GenericRow row) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -570,19 +570,6 @@ public class MutableSegmentImpl implements MutableSegment {
     return new RecordInfo(primaryKey, docId, null);
   }
 
-  @Override
-  public void getPrimaryKey(int docId, PrimaryKey reuse) {
-    int numPrimaryKeyColumns = _partitionUpsertMetadataManager.getPrimaryKeyColumns().size();
-    Object[] values = reuse.getValues();
-    for (int i = 0; i < numPrimaryKeyColumns; i++) {
-      IndexContainer indexContainer = _indexContainerMap.get(
-          _partitionUpsertMetadataManager.getPrimaryKeyColumns().get(i));
-      Object value = getValue(docId, indexContainer._forwardIndex, indexContainer._dictionary,
-          indexContainer._numValuesInfo._maxNumValuesPerMVEntry);
-      values[i] = value;
-    }
-  }
-
   private void updateDictionary(GenericRow row) {
     for (Map.Entry<String, IndexContainer> entry : _indexContainerMap.entrySet()) {
       IndexContainer indexContainer = entry.getValue();
@@ -1028,6 +1015,19 @@ public class MutableSegmentImpl implements MutableSegment {
       }
     }
     return reuse;
+  }
+
+  @Override
+  public void getPrimaryKey(int docId, PrimaryKey reuse) {
+    int numPrimaryKeyColumns = _partitionUpsertMetadataManager.getPrimaryKeyColumns().size();
+    Object[] values = reuse.getValues();
+    for (int i = 0; i < numPrimaryKeyColumns; i++) {
+      IndexContainer indexContainer = _indexContainerMap.get(
+          _partitionUpsertMetadataManager.getPrimaryKeyColumns().get(i));
+      Object value = getValue(docId, indexContainer._forwardIndex, indexContainer._dictionary,
+          indexContainer._numValuesInfo._maxNumValuesPerMVEntry);
+      values[i] = value;
+    }
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -570,6 +570,20 @@ public class MutableSegmentImpl implements MutableSegment {
     return new RecordInfo(primaryKey, docId, null);
   }
 
+  @Override
+  public PrimaryKey getPrimaryKey(int docId, PrimaryKey reuse) {
+    int numPrimaryKeyColumns = _partitionUpsertMetadataManager.getPrimaryKeyColumns().size();
+    Object[] values = new Object[numPrimaryKeyColumns];;
+    for (int i = 0; i < numPrimaryKeyColumns; i++) {
+      IndexContainer indexContainer = _indexContainerMap.get(
+          _partitionUpsertMetadataManager.getPrimaryKeyColumns().get(i));
+      Object value = getValue(docId, indexContainer._forwardIndex, indexContainer._dictionary,
+          indexContainer._numValuesInfo._maxNumValuesPerMVEntry);
+      values[i] = value;
+    }
+    return new PrimaryKey(values);
+  }
+
   private void updateDictionary(GenericRow row) {
     for (Map.Entry<String, IndexContainer> entry : _indexContainerMap.entrySet()) {
       IndexContainer indexContainer = entry.getValue();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -571,7 +571,7 @@ public class MutableSegmentImpl implements MutableSegment {
   }
 
   @Override
-  public PrimaryKey getPrimaryKey(int docId, PrimaryKey reuse) {
+  public void getPrimaryKey(int docId, PrimaryKey reuse) {
     int numPrimaryKeyColumns = _partitionUpsertMetadataManager.getPrimaryKeyColumns().size();
     Object[] values = new Object[numPrimaryKeyColumns];;
     for (int i = 0; i < numPrimaryKeyColumns; i++) {
@@ -581,7 +581,7 @@ public class MutableSegmentImpl implements MutableSegment {
           indexContainer._numValuesInfo._maxNumValuesPerMVEntry);
       values[i] = value;
     }
-    return new PrimaryKey(values);
+    reuse.setValues(values);
   }
 
   private void updateDictionary(GenericRow row) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentRecordReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentRecordReader.java
@@ -234,7 +234,7 @@ public class PinotSegmentRecordReader implements RecordReader {
 
   public void getPrimaryKey(int docId, List<String> primaryKeyColumns, PrimaryKey reuse) {
     int numPrimaryKeyColumns = primaryKeyColumns.size();
-    Object[] values = new Object[numPrimaryKeyColumns];;
+    Object[] values = reuse.getValues();
     for (int i = 0; i < numPrimaryKeyColumns; i++) {
       PinotSegmentColumnReader columnReader = _columnReaderMap.get(primaryKeyColumns.get(i));
       Object value = columnReader.getValue(docId);
@@ -243,7 +243,6 @@ public class PinotSegmentRecordReader implements RecordReader {
       }
       values[i] = value;
     }
-    reuse.setValues(values);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentRecordReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentRecordReader.java
@@ -33,8 +33,10 @@ import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
+import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -228,6 +230,20 @@ public class PinotSegmentRecordReader implements RecordReader {
         reuse.putDefaultNullValue(column, columnReader.getValue(docId));
       }
     }
+  }
+
+  public PrimaryKey getPrimaryKey(int docId, List<String> primaryKeyColumns) {
+    int numPrimaryKeyColumns = primaryKeyColumns.size();
+    Object[] values = new Object[numPrimaryKeyColumns];;
+    for (int i = 0; i < numPrimaryKeyColumns; i++) {
+      PinotSegmentColumnReader columnReader = _columnReaderMap.get(primaryKeyColumns.get(i));
+      Object value = columnReader.getValue(docId);
+      if (value instanceof byte[]) {
+        value = new ByteArray((byte[]) value);
+      }
+      values[i] = value;
+    }
+    return new PrimaryKey(values);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentRecordReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentRecordReader.java
@@ -232,7 +232,7 @@ public class PinotSegmentRecordReader implements RecordReader {
     }
   }
 
-  public PrimaryKey getPrimaryKey(int docId, List<String> primaryKeyColumns) {
+  public void getPrimaryKey(int docId, List<String> primaryKeyColumns, PrimaryKey reuse) {
     int numPrimaryKeyColumns = primaryKeyColumns.size();
     Object[] values = new Object[numPrimaryKeyColumns];;
     for (int i = 0; i < numPrimaryKeyColumns; i++) {
@@ -243,7 +243,7 @@ public class PinotSegmentRecordReader implements RecordReader {
       }
       values[i] = value;
     }
-    return new PrimaryKey(values);
+    reuse.setValues(values);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
@@ -264,11 +264,12 @@ public class PartitionUpsertMetadataManager {
       while (iterator.hasNext()) {
         int docId = iterator.next();
         segment.getPrimaryKey(docId, reuse);
-        _primaryKeyToRecordLocationMap.computeIfPresent(hashPrimaryKey(reuse, _hashFunction), (pk, recordLocation) -> {
-          if (recordLocation.getSegment() == segment) {
-            return null;
-          }
-          return recordLocation;
+        _primaryKeyToRecordLocationMap.computeIfPresent(HashUtils.hashPrimaryKey(reuse, _hashFunction),
+            (pk, recordLocation) -> {
+              if (recordLocation.getSegment() == segment) {
+                return null;
+              }
+              return recordLocation;
         });
       }
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
@@ -261,11 +261,12 @@ public class PartitionUpsertMetadataManager {
         int docId = iterator.next();
         GenericRow record = segment.getRecord(docId, _reuse);
         PrimaryKey primaryKey = record.getPrimaryKey(_primaryKeyColumns);
-        if (_primaryKeyToRecordLocationMap.containsKey(primaryKey)
-            && _primaryKeyToRecordLocationMap.get(primaryKey).getSegment() == segment
-            && _primaryKeyToRecordLocationMap.get(primaryKey).getDocId() == docId) {
-          _primaryKeyToRecordLocationMap.remove(primaryKey);
-        }
+        _primaryKeyToRecordLocationMap.computeIfPresent(primaryKey, (pk, recordLocation) -> {
+          if (recordLocation.getSegment() == segment) {
+            return null;
+          }
+          return recordLocation;
+        });
       }
     }
     // Update metrics

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
@@ -101,6 +101,10 @@ public class PartitionUpsertMetadataManager {
     _primaryKeyColumns = primaryKeyColumns;
   }
 
+  public List<String> getPrimaryKeyColumns() {
+    return _primaryKeyColumns;
+  }
+
   /**
    * Initializes the upsert metadata for the given immutable segment.
    */
@@ -255,12 +259,11 @@ public class PartitionUpsertMetadataManager {
     LOGGER.info("Removing upsert metadata for segment: {}", segmentName);
 
     if (!Objects.requireNonNull(segment.getValidDocIds()).getMutableRoaringBitmap().isEmpty()) {
+      PrimaryKey reuse = new PrimaryKey(new Object[]{});
       PeekableIntIterator iterator = segment.getValidDocIds().getMutableRoaringBitmap().getIntIterator();
       while (iterator.hasNext()) {
-        _reuse.clear();
         int docId = iterator.next();
-        GenericRow record = segment.getRecord(docId, _reuse);
-        PrimaryKey primaryKey = record.getPrimaryKey(_primaryKeyColumns);
+        PrimaryKey primaryKey = segment.getPrimaryKey(docId, reuse);
         _primaryKeyToRecordLocationMap.computeIfPresent(primaryKey, (pk, recordLocation) -> {
           if (recordLocation.getSegment() == segment) {
             return null;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
@@ -259,12 +259,12 @@ public class PartitionUpsertMetadataManager {
     LOGGER.info("Removing upsert metadata for segment: {}", segmentName);
 
     if (!Objects.requireNonNull(segment.getValidDocIds()).getMutableRoaringBitmap().isEmpty()) {
-      PrimaryKey reuse = new PrimaryKey(new Object[]{});
+      PrimaryKey reuse = new PrimaryKey(new Object[_primaryKeyColumns.size()]);
       PeekableIntIterator iterator = segment.getValidDocIds().getMutableRoaringBitmap().getIntIterator();
       while (iterator.hasNext()) {
         int docId = iterator.next();
-        PrimaryKey primaryKey = segment.getPrimaryKey(docId, reuse);
-        _primaryKeyToRecordLocationMap.computeIfPresent(primaryKey, (pk, recordLocation) -> {
+        segment.getPrimaryKey(docId, reuse);
+        _primaryKeyToRecordLocationMap.computeIfPresent(reuse, (pk, recordLocation) -> {
           if (recordLocation.getSegment() == segment) {
             return null;
           }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
@@ -38,6 +38,7 @@ import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.roaringbitmap.PeekableIntIterator;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -258,9 +259,12 @@ public class PartitionUpsertMetadataManager {
     String segmentName = segment.getSegmentName();
     LOGGER.info("Removing upsert metadata for segment: {}", segmentName);
 
-    if (!Objects.requireNonNull(segment.getValidDocIds()).getMutableRoaringBitmap().isEmpty()) {
+    MutableRoaringBitmap mutableRoaringBitmap =
+        Objects.requireNonNull(segment.getValidDocIds()).getMutableRoaringBitmap();
+
+    if (!mutableRoaringBitmap.isEmpty()) {
       PrimaryKey reuse = new PrimaryKey(new Object[_primaryKeyColumns.size()]);
-      PeekableIntIterator iterator = segment.getValidDocIds().getMutableRoaringBitmap().getIntIterator();
+      PeekableIntIterator iterator = mutableRoaringBitmap.getIntIterator();
       while (iterator.hasNext()) {
         int docId = iterator.next();
         segment.getPrimaryKey(docId, reuse);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
@@ -264,7 +264,7 @@ public class PartitionUpsertMetadataManager {
       while (iterator.hasNext()) {
         int docId = iterator.next();
         segment.getPrimaryKey(docId, reuse);
-        _primaryKeyToRecordLocationMap.computeIfPresent(reuse, (pk, recordLocation) -> {
+        _primaryKeyToRecordLocationMap.computeIfPresent(hashPrimaryKey(reuse, _hashFunction), (pk, recordLocation) -> {
           if (recordLocation.getSegment() == segment) {
             return null;
           }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.upsert;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
@@ -36,19 +37,22 @@ public class TableUpsertMetadataManager {
   private final ServerMetrics _serverMetrics;
   private final PartialUpsertHandler _partialUpsertHandler;
   private final HashFunction _hashFunction;
+  private final List<String> _primaryKeyColumns;
 
   public TableUpsertMetadataManager(String tableNameWithType, ServerMetrics serverMetrics,
-      @Nullable PartialUpsertHandler partialUpsertHandler, HashFunction hashFunction) {
+      @Nullable PartialUpsertHandler partialUpsertHandler, HashFunction hashFunction,
+      List<String> primaryKeyColumns) {
     _tableNameWithType = tableNameWithType;
     _serverMetrics = serverMetrics;
     _partialUpsertHandler = partialUpsertHandler;
     _hashFunction = hashFunction;
+    _primaryKeyColumns = primaryKeyColumns;
   }
 
   public PartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId) {
     return _partitionMetadataManagerMap.computeIfAbsent(partitionId,
         k -> new PartitionUpsertMetadataManager(_tableNameWithType, k, _serverMetrics, _partialUpsertHandler,
-            _hashFunction));
+            _hashFunction, _primaryKeyColumns));
   }
 
   public boolean isPartialUpsertEnabled() {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
@@ -63,7 +63,7 @@ public class MutableSegmentImplUpsertComparisonColTest {
     File jsonFile = new File(dataResourceUrl.getFile());
     _partitionUpsertMetadataManager =
         new TableUpsertMetadataManager("testTable_REALTIME", Mockito.mock(ServerMetrics.class), null,
-            HashFunction.NONE).getOrCreatePartitionManager(0);
+            HashFunction.NONE, _schema.getPrimaryKeyColumns()).getOrCreatePartitionManager(0);
     _mutableSegmentImpl = MutableSegmentImplTestUtils
         .createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(), Collections.emptySet(),
             false, true, new UpsertConfig(UpsertConfig.Mode.FULL, null, null, "offset", null), "secondsSinceEpoch",

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
@@ -60,15 +60,17 @@ public class MutableSegmentImplUpsertTest {
     _recordTransformer = CompositeTransformer.getDefaultTransformer(_tableConfig, _schema);
     File jsonFile = new File(dataResourceUrl.getFile());
     _partitionUpsertMetadataManager =
-        new TableUpsertMetadataManager("testTable_REALTIME", Mockito.mock(ServerMetrics.class), null, hashFunction)
+        new TableUpsertMetadataManager("testTable_REALTIME", Mockito.mock(ServerMetrics.class), null, hashFunction,
+            _schema.getPrimaryKeyColumns())
             .getOrCreatePartitionManager(0);
     _mutableSegmentImpl = MutableSegmentImplTestUtils
         .createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(), Collections.emptySet(),
             false, true, new UpsertConfig(UpsertConfig.Mode.FULL, null, null, null, hashFunction), "secondsSinceEpoch",
             _partitionUpsertMetadataManager, null);
+
     GenericRow reuse = new GenericRow();
-    try (RecordReader recordReader = RecordReaderFactory
-        .getRecordReader(FileFormat.JSON, jsonFile, _schema.getColumnNames(), null)) {
+    try (RecordReader recordReader = RecordReaderFactory.getRecordReader(FileFormat.JSON, jsonFile,
+        _schema.getColumnNames(), null)) {
       while (recordReader.hasNext()) {
         recordReader.next(reuse);
         GenericRow transformedRow = _recordTransformer.transform(reuse);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManagerTest.java
@@ -167,9 +167,12 @@ public class PartitionUpsertMetadataManagerTest {
     when(segment.getSegmentName()).thenReturn(segmentName);
     when(segment.getValidDocIds()).thenReturn(validDocIds);
     doAnswer((invocation) -> {
-        PrimaryKey pk = primaryKeys.get(invocation.getArgument(0));
-        PrimaryKey reuse = invocation.getArgument(1, PrimaryKey.class);
-        reuse.setValues(pk.getValues());
+      PrimaryKey pk = primaryKeys.get(invocation.getArgument(0));
+      PrimaryKey reuse = invocation.getArgument(1, PrimaryKey.class);
+      Object[] reuseValues = reuse.getValues();
+      for (int i = 0; i < reuseValues.length; i++) {
+        reuseValues[i] = pk.getValues()[i];
+      }
         return null;
       }).when(segment).getPrimaryKey(anyInt(), any(PrimaryKey.class));
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManagerTest.java
@@ -41,6 +41,7 @@ import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -165,7 +166,13 @@ public class PartitionUpsertMetadataManagerTest {
     String segmentName = getSegmentName(sequenceNumber);
     when(segment.getSegmentName()).thenReturn(segmentName);
     when(segment.getValidDocIds()).thenReturn(validDocIds);
-    when(segment.getPrimaryKey(anyInt(), any())).thenAnswer(i -> primaryKeys.get(i.getArgument(0)));
+    doAnswer((invocation) -> {
+        PrimaryKey pk = primaryKeys.get(invocation.getArgument(0));
+        PrimaryKey reuse = invocation.getArgument(1, PrimaryKey.class);
+        reuse.setValues(pk.getValues());
+        return null;
+      }).when(segment).getPrimaryKey(anyInt(), any(PrimaryKey.class));
+
     return segment;
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/IndexSegment.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/IndexSegment.java
@@ -26,6 +26,7 @@ import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.PrimaryKey;
 
 
 @InterfaceAudience.Private
@@ -85,6 +86,15 @@ public interface IndexSegment {
    * @return Record for the given document Id
    */
   GenericRow getRecord(int docId, GenericRow reuse);
+
+  /**
+   * Returns the primaryKey for a given docId
+   *
+   * @param docId Document Id
+   * @param reuse Reusable buffer for the primary key
+   * @return Primary key for the given document Id
+   */
+  PrimaryKey getPrimaryKey(int docId, PrimaryKey reuse);
 
   /**
    * Hints the segment to begin prefetching buffers for specified columns.

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/IndexSegment.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/IndexSegment.java
@@ -94,7 +94,7 @@ public interface IndexSegment {
    * @param reuse Reusable buffer for the primary key
    * @return Primary key for the given document Id
    */
-  PrimaryKey getPrimaryKey(int docId, PrimaryKey reuse);
+  void getPrimaryKey(int docId, PrimaryKey reuse);
 
   /**
    * Hints the segment to begin prefetching buffers for specified columns.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/PrimaryKey.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/PrimaryKey.java
@@ -26,9 +26,13 @@ import org.apache.commons.lang3.SerializationUtils;
  * The primary key of a record. Note that the value used in the primary key must be single-value.
  */
 public class PrimaryKey {
-  private final Object[] _values;
+  private Object[] _values;
 
   public PrimaryKey(Object[] values) {
+    _values = values;
+  }
+
+  public void setValues(Object[] values) {
     _values = values;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/PrimaryKey.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/PrimaryKey.java
@@ -26,13 +26,9 @@ import org.apache.commons.lang3.SerializationUtils;
  * The primary key of a record. Note that the value used in the primary key must be single-value.
  */
 public class PrimaryKey {
-  private Object[] _values;
+  private final Object[] _values;
 
   public PrimaryKey(Object[] values) {
-    _values = values;
-  }
-
-  public void setValues(Object[] values) {
     _values = values;
   }
 


### PR DESCRIPTION
This PR improves the performance segment removal from upsert metadata. Currently, we iterate upon whole state to check for matching primary keys to doc ids in segment. We can improve this by iterating upon valid doc ids from the segment instead. The valid doc are less than than the number of primary keys present in the metadata.