### PR TITLE
Upgrade jersey to fix parallel segment upload

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -526,21 +526,19 @@ Common Development and Distribution License (CDDL) 1.0
 (see licenses/LICENSE-cddl-1.0.txt)
 
 javax.activation:activation:1.1.1
+javax.annotation:javax.annotation-api:1.3.2
+javax.servlet:javax.servlet-api:3.0.1
+org.glassfish.jersey.containers:jersey-container-servlet-core:2.25.1
 
 
 Common Development and Distribution License (CDDL) 1.1
 ------------------------------------------------------
 (see licenses/LICENSE-cddl-1.1.txt)
 
-com.sun.activation:javax.activation:1.2.0
 com.sun.xml.bind:jaxb-core:2.3.0
 com.sun.xml.bind:jaxb-impl:2.3.0
-javax.annotation:javax.annotation-api:1.2
-javax.servlet:javax.servlet-api:3.0.1
 javax.ws.rs:javax.ws.rs-api:2.0.1
 javax.xml.bind:jaxb-api:2.3.0
-org.glassfish.hk2:osgi-resource-locator:1.0.1
-org.glassfish.jersey.containers:jersey-container-servlet:2.22.2
 
 
 Eclipse Public License (EPL) 1.0
@@ -557,26 +555,26 @@ Eclipse Public License (EPL) 2.0
 -------------------------------
 (see licenses/LICENSE-epl-2.0.txt)
 
-jakarta.annotation:jakarta.annotation-api:1.3.4
-jakarta.ws.rs:jakarta.ws.rs-api:2.1.5
+jakarta.annotation:jakarta.annotation-api:1.3.5
+jakarta.ws.rs:jakarta.ws.rs-api:2.1.6
 org.glassfish.grizzly:grizzly-framework:2.4.4
 org.glassfish.grizzly:grizzly-http-server:2.4.4
 org.glassfish.grizzly:grizzly-http:2.4.4
-org.glassfish.hk2.external:aopalliance-repackaged:2.5.0
-org.glassfish.hk2.external:jakarta.inject:2.5.0
-org.glassfish.hk2:hk2-api:2.5.0
-org.glassfish.hk2:hk2-locator:2.5.0
-org.glassfish.hk2:hk2-utils:2.5.0
-org.glassfish.jersey.containers:jersey-container-grizzly2-http:2.28
-org.glassfish.jersey.containers:jersey-container-servlet-core:2.28
-org.glassfish.jersey.core:jersey-client:2.28
-org.glassfish.jersey.core:jersey-common:2.28
-org.glassfish.jersey.core:jersey-server:2.28
-org.glassfish.jersey.ext:jersey-entity-filtering:2.28
-org.glassfish.jersey.inject:jersey-hk2:2.28
-org.glassfish.jersey.media:jersey-media-jaxb:2.28
-org.glassfish.jersey.media:jersey-media-json-jackson:2.28
-org.glassfish.jersey.media:jersey-media-multipart:2.28
+org.glassfish.hk2.external:aopalliance-repackaged:2.6.1
+org.glassfish.hk2.external:jakarta.inject:2.6.1
+org.glassfish.hk2:hk2-api:2.6.1
+org.glassfish.hk2:hk2-locator:2.6.1
+org.glassfish.hk2:hk2-utils:2.6.1
+org.glassfish.hk2:osgi-resource-locator:1.0.3
+org.glassfish.jersey.containers:jersey-container-grizzly2-http:2.35
+org.glassfish.jersey.core:jersey-client:2.35
+org.glassfish.jersey.core:jersey-common:2.35
+org.glassfish.jersey.core:jersey-server:2.35
+org.glassfish.jersey.ext:jersey-entity-filtering:2.35
+org.glassfish.jersey.inject:jersey-hk2:2.35
+org.glassfish.jersey.media:jersey-media-jaxb:2.35
+org.glassfish.jersey.media:jersey-media-json-jackson:2.35
+org.glassfish.jersey.media:jersey-media-multipart:2.35
 org.glassfish.tyrus.bundles:tyrus-standalone-client:1.15
 
 

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -199,6 +199,18 @@
       <groupId>org.glassfish.hk2</groupId>
       <artifactId>hk2-locator</artifactId>
     </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
 
     <!-- test -->
     <dependency>

--- a/pinot-distribution/pom.xml
+++ b/pinot-distribution/pom.xml
@@ -110,18 +110,6 @@
       <groupId>javax.activation</groupId>
       <artifactId>activation</artifactId>
     </dependency>
-    <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -230,6 +230,10 @@
       <artifactId>hk2-locator</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.hk2</groupId>
+      <artifactId>hk2-metadata-generator</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-server</artifactId>
       <version>${project.version}</version>
@@ -372,11 +376,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.glassfish.hk2</groupId>
-      <artifactId>hk2-metadata-generator</artifactId>
-      <version>${hk2.version}</version>
     </dependency>
   </dependencies>
 </project>

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/pom.xml
@@ -208,18 +208,6 @@
       <groupId>org.apache.orc</groupId>
       <artifactId>orc-mapreduce</artifactId>
     </dependency>
-    <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-impl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.sun.xml.bind</groupId>
-      <artifactId>jaxb-core</artifactId>
-    </dependency>
 
     <!--Test-->
     <dependency>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/pom.xml
@@ -41,7 +41,7 @@
     <jetty-server.version>9.4.45.v20220203</jetty-server.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     <javax.ws.rs-api.version>2.1</javax.ws.rs-api.version>
-    <jersey-container-grizzly2-http.version>2.28</jersey-container-grizzly2-http.version>
+    <jersey-container-grizzly2-http.version>2.35</jersey-container-grizzly2-http.version>
     <simpleclient_common.version>0.8.1</simpleclient_common.version>
     <grpc-proto.version>1.12.0</grpc-proto.version>
     <grpc-context.version>1.14.0</grpc-context.version>

--- a/pom.xml
+++ b/pom.xml
@@ -125,9 +125,9 @@
     <jackson.version>2.10.0</jackson.version>
     <zookeeper.version>3.5.8</zookeeper.version>
     <async-http-client.version>2.12.3</async-http-client.version>
-    <jersey.version>2.28</jersey.version>
+    <jersey.version>2.35</jersey.version>
     <grizzly.version>2.4.4</grizzly.version>
-    <hk2.version>2.5.0</hk2.version>
+    <hk2.version>2.6.1</hk2.version>
     <swagger.version>1.5.16</swagger.version>
     <hadoop.version>2.10.1</hadoop.version>
     <antlr.version>4.6</antlr.version>
@@ -1075,6 +1075,31 @@
         <groupId>org.glassfish.hk2</groupId>
         <artifactId>hk2-locator</artifactId>
         <version>${hk2.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
+        <groupId>org.glassfish.hk2</groupId>
+        <artifactId>hk2-metadata-generator</artifactId>
+        <version>${hk2.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>jakarta.annotation</groupId>
+            <artifactId>jakarta.annotation-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.media</groupId>


### PR DESCRIPTION
Caught by #8265 

The root cause is a bug in the `metro-mimepull` library
Upgrade jersey to the latest commonly used version to include the fix
Note that the current jersey version has [vulnerability](https://mvnrepository.com/artifact/org.glassfish.jersey.core/jersey-common), so we should upgrade it anyway