### PR TITLE
[bugfix] Explain plan improvements

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -26,7 +26,6 @@ import com.google.common.util.concurrent.RateLimiter;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataTable.java
@@ -111,7 +111,9 @@ public interface DataTable {
     RESIZE_TIME_MS("resizeTimeMs", MetadataValueType.LONG),
     THREAD_CPU_TIME_NS("threadCpuTimeNs", MetadataValueType.LONG),
     SYSTEM_ACTIVITIES_CPU_TIME_NS("systemActivitiesCpuTimeNs", MetadataValueType.LONG),
-    RESPONSE_SER_CPU_TIME_NS("responseSerializationCpuTimeNs", MetadataValueType.LONG);
+    RESPONSE_SER_CPU_TIME_NS("responseSerializationCpuTimeNs", MetadataValueType.LONG),
+    EXPLAIN_PLAN_NUM_EMPTY_FILTER_SEGMENTS("explainPlanNumEmptyFilterSegments", MetadataValueType.INT),
+    EXPLAIN_PLAN_NUM_MATCH_ALL_FILTER_SEGMENTS("explainPlanNumMatchAllFilterSegments", MetadataValueType.INT);
 
     private static final MetadataKey[] VALUES;
     private static final Map<String, MetadataKey> NAME_TO_ENUM_KEY_MAP = new HashMap<>();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/EmptyFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/EmptyFilterOperator.java
@@ -33,7 +33,7 @@ public final class EmptyFilterOperator extends BaseFilterOperator {
   }
 
 
-  private static final String EXPLAIN_NAME = "FILTER_EMPTY";
+  public static final String EXPLAIN_NAME = "FILTER_EMPTY";
 
   private static final EmptyFilterOperator INSTANCE = new EmptyFilterOperator();
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MatchAllFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MatchAllFilterOperator.java
@@ -26,7 +26,7 @@ import org.apache.pinot.core.operator.docidsets.MatchAllDocIdSet;
 
 
 public class MatchAllFilterOperator extends BaseFilterOperator {
-  private static final String EXPLAIN_NAME = "FILTER_MATCH_ENTIRE_SEGMENT";
+  public static final String EXPLAIN_NAME = "FILTER_MATCH_ENTIRE_SEGMENT";
   private final int _numDocs;
 
   public MatchAllFilterOperator(int numDocs) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -386,7 +386,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
     int maxDepthMatchAllIdx = -1;
     int maxDepthOther = -1;
     int maxDepthOtherIdx = -1;
-    for (int i = 0; i < children.size(); ++i) {
+    for (int i = 0; i < children.size(); i++) {
       int[] numOperators = {0};
       boolean[] isEmptyFilter = {false};
       boolean[] isMatchAllFilter = {false};
@@ -418,7 +418,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       segmentIdxForExplainPlanQuery = maxDepthOtherIdx;
     } else if (maxDepthMatchAll > -1) {
       segmentIdxForExplainPlanQuery = maxDepthMatchAllIdx;
-    } else if (maxDepthEmpty > -1){
+    } else if (maxDepthEmpty > -1) {
       segmentIdxForExplainPlanQuery = maxDepthEmptyIdx;
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExplainPlanDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExplainPlanDataTableReducer.java
@@ -28,6 +28,8 @@ import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataTable;
+import org.apache.pinot.core.operator.filter.EmptyFilterOperator;
+import org.apache.pinot.core.operator.filter.MatchAllFilterOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextUtils;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
@@ -50,7 +52,7 @@ public class ExplainPlanDataTableReducer implements DataTableReducer {
       Map<ServerRoutingInstance, DataTable> dataTableMap, BrokerResponseNative brokerResponseNative,
       DataTableReducerContext reducerContext, BrokerMetrics brokerMetrics) {
 
-    Map.Entry<ServerRoutingInstance, DataTable> entry = dataTableMap.entrySet().iterator().next();
+    Map.Entry<ServerRoutingInstance, DataTable> entry = selectBestServerDataTableResultToUse(dataTableMap);
     DataTable dataTable = entry.getValue();
     List<Object[]> reducedRows = new ArrayList<>();
 
@@ -67,10 +69,65 @@ public class ExplainPlanDataTableReducer implements DataTableReducer {
     brokerResponseNative.setResultTable(resultTable);
   }
 
+  private Map.Entry<ServerRoutingInstance, DataTable> selectBestServerDataTableResultToUse(
+      Map<ServerRoutingInstance, DataTable> dataTableMap) {
+    int maxOtherDepth = -1;
+    int maxEmptyFilterDepth = -1;
+    int maxMatchAllFilterDepth = -1;
+    Map.Entry<ServerRoutingInstance, DataTable> maxOtherEntry = null;
+    Map.Entry<ServerRoutingInstance, DataTable> maxEmptyFilterEntry = null;
+    Map.Entry<ServerRoutingInstance, DataTable> maxMatchAllFilterEntry = null;
+    for (Map.Entry<ServerRoutingInstance, DataTable> entry : dataTableMap.entrySet()) {
+      DataTable dataTable = entry.getValue();
+      boolean hasEmptyFilter = false;
+      boolean hasMatchAllFilter = false;
+      int numRows = dataTable.getNumberOfRows();
+
+      for (int rowId = 0; rowId < numRows; rowId++) {
+        Object[] row = SelectionOperatorUtils.extractRowFromDataTable(dataTable, rowId);
+        if (row[0].toString().contains(EmptyFilterOperator.EXPLAIN_NAME)) {
+          hasEmptyFilter = true;
+          break;
+        }
+        if (row[0].toString().contains(MatchAllFilterOperator.EXPLAIN_NAME)) {
+          hasMatchAllFilter = true;
+          break;
+        }
+      }
+
+      if (hasEmptyFilter) {
+        if (numRows > maxEmptyFilterDepth) {
+          maxEmptyFilterDepth = numRows;
+          maxEmptyFilterEntry = entry;
+        }
+      } else if (hasMatchAllFilter) {
+        if (numRows > maxMatchAllFilterDepth) {
+          maxMatchAllFilterDepth = numRows;
+          maxMatchAllFilterEntry = entry;
+        }
+      } else {
+        if (numRows > maxOtherDepth) {
+          maxOtherDepth = numRows;
+          maxOtherEntry = entry;
+        }
+      }
+    }
+
+    Map.Entry<ServerRoutingInstance, DataTable> finalEntry;
+    if (maxOtherEntry != null) {
+      finalEntry = maxOtherEntry;
+    } else if (maxMatchAllFilterEntry != null) {
+      finalEntry = maxMatchAllFilterEntry;
+    } else {
+      finalEntry = maxEmptyFilterEntry;
+    }
+
+    return finalEntry;
+  }
+
   private void addBrokerReduceOperation(List<Object[]> resultRows) {
 
     Set<String> postAggregations = new HashSet<>();
-    Set<String> regularTransforms = new HashSet<>();
     QueryContextUtils.collectPostAggregations(_queryContext, postAggregations);
     StringBuilder stringBuilder = new StringBuilder("BROKER_REDUCE").append('(');
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
@@ -681,7 +681,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result5.add(new Object[]{"COMBINE_AGGREGATE", 1, 0});
     result5.add(new Object[]{"FAST_FILTERED_COUNT", 2, 1});
     result5.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:"
-        +"invertedIndexCol1 = '1.5')", 3, 2});
+        + "invertedIndexCol1 = '1.5')", 3, 2});
     check(query5, new ResultTable(DATA_SCHEMA, result5));
 
     // All segments have a EmptyFilterOperator plan for this query, ensure we get that plan
@@ -709,7 +709,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // uses an inverted index. Ensure we get the one with the inverted index plan.
     String query8 =
         "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol3 = 'pluto' OR "
-            +"invertedIndexCol3 = 'minnie' LIMIT 100";
+            + "invertedIndexCol3 = 'minnie' LIMIT 100";
     List<Object[]> result8 = new ArrayList<>();
     result8.add(new Object[]{"BROKER_REDUCE(limit:100)", 0, -1});
     result8.add(new Object[]{"COMBINE_AGGREGATE", 1, 0});


### PR DESCRIPTION
Improve the accuracy of the Explain plan output. Today Explain plan selects a single segment to send the request to on the Server side. This segment may be pruned on the server side or may not match the filters if any. This changes addresses this shortcoming by doing the following:
- Sending the Explain Plan query to all segments across all Servers (only OFFLINE servers in case of hybrid tables)
- Each Server calculates the segment with the maximum operators as a heuristic for accuracy and returns the Explain Plan output for this segment. Each Server also ignores segments with EmptyFilterOperator or MatchAllFilterOperator if a segment without these operators is present. If no segment without these two operators are present then the one with the most operators is returned.
- Each Broker now receives a single plan from each Server. It walks through all the results and finds the one with the maximum number of rows and returns that as the final Explain plan output. If all results have the EmptyFilter or MatchAllFilter then that is returned, otherwise these results are pruned by the Broker.


Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
