### PR TITLE
track group by evaluation statistics

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationGroupByOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationGroupByOrderByOperator.java
@@ -37,6 +37,7 @@ import org.apache.pinot.core.query.aggregation.groupby.GroupByExecutor;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.startree.executor.StarTreeGroupByExecutor;
 import org.apache.pinot.core.util.GroupByUtils;
+import org.apache.pinot.spi.trace.Tracing;
 
 
 /**
@@ -110,6 +111,7 @@ public class AggregationGroupByOrderByOperator extends BaseOperator<Intermediate
 
     // Check if the groups limit is reached
     boolean numGroupsLimitReached = groupByExecutor.getNumGroups() >= _queryContext.getNumGroupsLimit();
+    Tracing.activeRecording().setNumGroups(_queryContext.getNumGroupsLimit(), groupByExecutor.getNumGroups());
 
     // Trim the groups when iff:
     // - Query has ORDER BY clause

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/InvocationRecording.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/InvocationRecording.java
@@ -29,6 +29,15 @@ import org.apache.pinot.spi.data.FieldSpec;
 public interface InvocationRecording {
 
   /**
+   * Sets the upper bound for the number of groups in a group by evaluation, along with the actual number of groups.
+   * The ratio of these two quantities indicates how efficient the group by was, and if truncation has occurred.
+   * @param numGroupsLimit the upper bound for the number of groups
+   * @param numGroups the actual number of groups
+   */
+  default void setNumGroups(int numGroupsLimit, int numGroups) {
+  }
+
+  /**
    * Sets the number of docs scanned by the operator.
    * @param numDocsScanned how many docs were scanned.
    */


### PR DESCRIPTION
Tracks statistics about how efficient group by evaluation is as the estimate of the upper bound appears to be too high when there is a selective filter.