### PR TITLE
Handle partial update for comparison columns

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -457,13 +457,12 @@ public class MutableSegmentImpl implements MutableSegment {
     if (isUpsertEnabled()) {
       PartitionUpsertMetadataManager.RecordInfo recordInfo = getRecordInfo(row, numDocsIndexed);
       GenericRow updatedRow = _partitionUpsertMetadataManager.updateRecord(row, recordInfo);
-      PartitionUpsertMetadataManager.RecordInfo updatedRecordInfo = getRecordInfo(updatedRow, numDocsIndexed);
       updateDictionary(updatedRow);
       addNewRow(numDocsIndexed, updatedRow);
       // Update number of documents indexed before handling the upsert metadata so that the record becomes queryable
       // once validated
       canTakeMore = numDocsIndexed++ < _capacity;
-      _partitionUpsertMetadataManager.addRecord(this, updatedRecordInfo);
+      _partitionUpsertMetadataManager.addRecord(this, recordInfo);
     } else {
       // Update dictionary first
       updateDictionary(row);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -457,12 +457,13 @@ public class MutableSegmentImpl implements MutableSegment {
     if (isUpsertEnabled()) {
       PartitionUpsertMetadataManager.RecordInfo recordInfo = getRecordInfo(row, numDocsIndexed);
       GenericRow updatedRow = _partitionUpsertMetadataManager.updateRecord(row, recordInfo);
+      PartitionUpsertMetadataManager.RecordInfo updatedRecordInfo = getRecordInfo(updatedRow, numDocsIndexed);
       updateDictionary(updatedRow);
       addNewRow(numDocsIndexed, updatedRow);
       // Update number of documents indexed before handling the upsert metadata so that the record becomes queryable
       // once validated
       canTakeMore = numDocsIndexed++ < _capacity;
-      _partitionUpsertMetadataManager.addRecord(this, recordInfo);
+      _partitionUpsertMetadataManager.addRecord(this, updatedRecordInfo);
     } else {
       // Update dictionary first
       updateDictionary(row);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -482,10 +482,10 @@ public final class TableConfigUtils {
       Preconditions.checkState(!primaryKeyColumns.contains(column), "Merger cannot be applied to primary key columns");
 
       if (upsertConfig.getComparisonColumn() != null) {
-        Preconditions.checkState(upsertConfig.getComparisonColumn().compareTo(column) != 0,
+        Preconditions.checkState(!upsertConfig.getComparisonColumn().equals(column),
             "Merger cannot be applied to comparison column");
       } else {
-        Preconditions.checkState(tableConfig.getValidationConfig().getTimeColumnName().compareTo(column) != 0,
+        Preconditions.checkState(!tableConfig.getValidationConfig().getTimeColumnName().equals(column),
             "Merger cannot be applied to time column");
       }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -481,6 +481,14 @@ public final class TableConfigUtils {
       UpsertConfig.Strategy columnStrategy = entry.getValue();
       Preconditions.checkState(!primaryKeyColumns.contains(column), "Merger cannot be applied to primary key columns");
 
+      if (upsertConfig.getComparisonColumn() != null) {
+        Preconditions.checkState(upsertConfig.getComparisonColumn().compareTo(column) != 0,
+            "Merger cannot be applied to comparison column");
+      } else {
+        Preconditions.checkState(tableConfig.getValidationConfig().getTimeColumnName().compareTo(column) != 0,
+            "Merger cannot be applied to time column");
+      }
+
       FieldSpec fieldSpec = schema.getFieldSpecFor(column);
       Preconditions.checkState(fieldSpec != null, "Merger cannot be applied to non-existing column: %s", column);
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -1194,9 +1194,10 @@ public class TableConfigUtilsTest {
     }
 
     partialUpsertStratgies.put("myCol1", UpsertConfig.Strategy.INCREMENT);
-    tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(
-        new UpsertConfig(UpsertConfig.Mode.PARTIAL, partialUpsertStratgies, UpsertConfig.Strategy.OVERWRITE, null,
-            null)).setNullHandlingEnabled(false)
+    tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName("timeCol").setUpsertConfig(
+            new UpsertConfig(UpsertConfig.Mode.PARTIAL, partialUpsertStratgies, UpsertConfig.Strategy.OVERWRITE, null,
+                null)).setNullHandlingEnabled(false)
         .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
         .setStreamConfigs(streamConfigs).build();
     try {


### PR DESCRIPTION
use the following `upsertConfig` inside any table config to reproduce the issue
```
      "partialUpsertStrategies":{
        "columnA": "IGNORE"
      },
      "comparisonColumn": "columnA"
```

IMO, comparison columns should not have `IGNORE` update strategy ever since we need the latest value for comparison. So there should be no need for this patch.

Primary motivation for creating is to discuss if we even need this change or not. If not, we should add a validation in table config and fail at the time of table creation itself.