### PR TITLE
[hotfix] multi stage engine serde

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/parser/CalciteRexExpressionParser.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/parser/CalciteRexExpressionParser.java
@@ -22,7 +22,6 @@ import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
@@ -139,11 +138,7 @@ public class CalciteRexExpressionParser {
   }
 
   private static Expression rexLiteralToExpression(RexExpression.Literal rexLiteral) {
-    RelDataType type = rexLiteral.getDataType();
-    switch (type.getSqlTypeName()) {
-      default:
-        return RequestUtils.getLiteralExpression(rexLiteral.getValue());
-    }
+    return RequestUtils.getLiteralExpression(rexLiteral.getValue());
   }
 
   private static Expression inputRefToIdentifier(RexExpression.InputRef inputRef, PinotQuery pinotQuery) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToStageConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToStageConverter.java
@@ -73,18 +73,18 @@ public final class RelToStageConverter {
   }
 
   private static StageNode convertLogicalProject(LogicalProject node, int currentStageId) {
-    return new ProjectNode(currentStageId, RexExpression.toDataType(node.getRowType()), node.getProjects());
+    return new ProjectNode(currentStageId, node.getProjects());
   }
 
   private static StageNode convertLogicalFilter(LogicalFilter node, int currentStageId) {
-    return new FilterNode(currentStageId, RexExpression.toDataType(node.getRowType()), node.getCondition());
+    return new FilterNode(currentStageId, node.getCondition());
   }
 
   private static StageNode convertLogicalTableScan(LogicalTableScan node, int currentStageId) {
     String tableName = node.getTable().getQualifiedName().get(0);
     List<String> columnNames = node.getRowType().getFieldList().stream()
         .map(RelDataTypeField::getName).collect(Collectors.toList());
-    return new TableScanNode(currentStageId, RexExpression.toDataType(node.getRowType()), tableName, columnNames);
+    return new TableScanNode(currentStageId, tableName, columnNames);
   }
 
   private static StageNode convertLogicalJoin(LogicalJoin node, int currentStageId) {
@@ -102,8 +102,7 @@ public final class RelToStageConverter {
     FieldSelectionKeySelector leftFieldSelectionKeySelector = new FieldSelectionKeySelector(leftOperandIndex);
     FieldSelectionKeySelector rightFieldSelectionKeySelector =
           new FieldSelectionKeySelector(rightOperandIndex - leftRowType.getFieldNames().size());
-    return new JoinNode(currentStageId, RexExpression.toDataType(node.getRowType()), joinType,
-        Collections.singletonList(new JoinNode.JoinClause(
-            leftFieldSelectionKeySelector, rightFieldSelectionKeySelector)));
+    return new JoinNode(currentStageId, joinType, Collections.singletonList(new JoinNode.JoinClause(
+        leftFieldSelectionKeySelector, rightFieldSelectionKeySelector)));
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToStageConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToStageConverter.java
@@ -73,18 +73,18 @@ public final class RelToStageConverter {
   }
 
   private static StageNode convertLogicalProject(LogicalProject node, int currentStageId) {
-    return new ProjectNode(currentStageId, node.getRowType(), node.getProjects());
+    return new ProjectNode(currentStageId, RexExpression.toDataType(node.getRowType()), node.getProjects());
   }
 
   private static StageNode convertLogicalFilter(LogicalFilter node, int currentStageId) {
-    return new FilterNode(currentStageId, node.getRowType(), node.getCondition());
+    return new FilterNode(currentStageId, RexExpression.toDataType(node.getRowType()), node.getCondition());
   }
 
   private static StageNode convertLogicalTableScan(LogicalTableScan node, int currentStageId) {
     String tableName = node.getTable().getQualifiedName().get(0);
     List<String> columnNames = node.getRowType().getFieldList().stream()
         .map(RelDataTypeField::getName).collect(Collectors.toList());
-    return new TableScanNode(currentStageId, node.getRowType(), tableName, columnNames);
+    return new TableScanNode(currentStageId, RexExpression.toDataType(node.getRowType()), tableName, columnNames);
   }
 
   private static StageNode convertLogicalJoin(LogicalJoin node, int currentStageId) {
@@ -102,7 +102,8 @@ public final class RelToStageConverter {
     FieldSelectionKeySelector leftFieldSelectionKeySelector = new FieldSelectionKeySelector(leftOperandIndex);
     FieldSelectionKeySelector rightFieldSelectionKeySelector =
           new FieldSelectionKeySelector(rightOperandIndex - leftRowType.getFieldNames().size());
-    return new JoinNode(currentStageId, node.getRowType(), joinType, Collections.singletonList(new JoinNode.JoinClause(
-        leftFieldSelectionKeySelector, rightFieldSelectionKeySelector)));
+    return new JoinNode(currentStageId, RexExpression.toDataType(node.getRowType()), joinType,
+        Collections.singletonList(new JoinNode.JoinClause(
+            leftFieldSelectionKeySelector, rightFieldSelectionKeySelector)));
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/StagePlanner.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/StagePlanner.java
@@ -72,10 +72,8 @@ public class StagePlanner {
     // global root needs to send results back to the ROOT, a.k.a. the client response node. the last stage only has one
     // receiver so doesn't matter what the exchange type is. setting it to SINGLETON by default.
     StageNode globalReceiverNode =
-        new MailboxReceiveNode(0, RexExpression.toDataType(relRoot.getRowType()), globalStageRoot.getStageId(),
-            RelDistribution.Type.SINGLETON);
-    StageNode globalSenderNode = new MailboxSendNode(globalStageRoot.getStageId(),
-        RexExpression.toDataType(relRoot.getRowType()), globalReceiverNode.getStageId(),
+        new MailboxReceiveNode(0, globalStageRoot.getStageId(), RelDistribution.Type.SINGLETON);
+    StageNode globalSenderNode = new MailboxSendNode(globalStageRoot.getStageId(), globalReceiverNode.getStageId(),
         RelDistribution.Type.SINGLETON);
     globalSenderNode.addInput(globalStageRoot);
     _queryStageMap.put(globalSenderNode.getStageId(), globalSenderNode);
@@ -104,12 +102,10 @@ public class StagePlanner {
       RelDistribution.Type exchangeType = distribution.getType();
 
       // 2. make an exchange sender and receiver node pair
-      StageNode mailboxReceiver = new MailboxReceiveNode(currentStageId, RexExpression.toDataType(node.getRowType()),
-          nextStageRoot.getStageId(), exchangeType);
-      StageNode mailboxSender = new MailboxSendNode(nextStageRoot.getStageId(),
-          RexExpression.toDataType(node.getRowType()), mailboxReceiver.getStageId(), exchangeType,
-          exchangeType == RelDistribution.Type.HASH_DISTRIBUTED
-              ? new FieldSelectionKeySelector(distribution.getKeys().get(0)) : null);
+      StageNode mailboxReceiver = new MailboxReceiveNode(currentStageId, nextStageRoot.getStageId(), exchangeType);
+      StageNode mailboxSender = new MailboxSendNode(nextStageRoot.getStageId(), mailboxReceiver.getStageId(),
+          exchangeType, exchangeType == RelDistribution.Type.HASH_DISTRIBUTED
+          ? new FieldSelectionKeySelector(distribution.getKeys().get(0)) : null);
       mailboxSender.addInput(nextStageRoot);
 
       // 3. put the sender side as a completed stage.

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/StagePlanner.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/StagePlanner.java
@@ -72,10 +72,11 @@ public class StagePlanner {
     // global root needs to send results back to the ROOT, a.k.a. the client response node. the last stage only has one
     // receiver so doesn't matter what the exchange type is. setting it to SINGLETON by default.
     StageNode globalReceiverNode =
-        new MailboxReceiveNode(0, relRoot.getRowType(), globalStageRoot.getStageId(),
+        new MailboxReceiveNode(0, RexExpression.toDataType(relRoot.getRowType()), globalStageRoot.getStageId(),
             RelDistribution.Type.SINGLETON);
-    StageNode globalSenderNode = new MailboxSendNode(globalStageRoot.getStageId(), relRoot.getRowType(),
-        globalReceiverNode.getStageId(), RelDistribution.Type.SINGLETON);
+    StageNode globalSenderNode = new MailboxSendNode(globalStageRoot.getStageId(),
+        RexExpression.toDataType(relRoot.getRowType()), globalReceiverNode.getStageId(),
+        RelDistribution.Type.SINGLETON);
     globalSenderNode.addInput(globalStageRoot);
     _queryStageMap.put(globalSenderNode.getStageId(), globalSenderNode);
     StageMetadata stageMetadata = _stageMetadataMap.get(globalSenderNode.getStageId());
@@ -103,11 +104,12 @@ public class StagePlanner {
       RelDistribution.Type exchangeType = distribution.getType();
 
       // 2. make an exchange sender and receiver node pair
-      StageNode mailboxReceiver = new MailboxReceiveNode(currentStageId, node.getRowType(), nextStageRoot.getStageId(),
-          exchangeType);
-      StageNode mailboxSender = new MailboxSendNode(nextStageRoot.getStageId(), node.getRowType(),
-          mailboxReceiver.getStageId(), exchangeType, exchangeType == RelDistribution.Type.HASH_DISTRIBUTED
-          ? new FieldSelectionKeySelector(distribution.getKeys().get(0)) : null);
+      StageNode mailboxReceiver = new MailboxReceiveNode(currentStageId, RexExpression.toDataType(node.getRowType()),
+          nextStageRoot.getStageId(), exchangeType);
+      StageNode mailboxSender = new MailboxSendNode(nextStageRoot.getStageId(),
+          RexExpression.toDataType(node.getRowType()), mailboxReceiver.getStageId(), exchangeType,
+          exchangeType == RelDistribution.Type.HASH_DISTRIBUTED
+              ? new FieldSelectionKeySelector(distribution.getKeys().get(0)) : null);
       mailboxSender.addInput(nextStageRoot);
 
       // 3. put the sender side as a completed stage.

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/AbstractStageNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/AbstractStageNode.java
@@ -20,21 +20,15 @@ package org.apache.pinot.query.planner.stage;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.calcite.rel.type.RelDataType;
 import org.apache.pinot.common.proto.Plan;
-import org.apache.pinot.query.planner.serde.ProtoProperties;
 import org.apache.pinot.query.planner.serde.ProtoSerializable;
 import org.apache.pinot.query.planner.serde.ProtoSerializationUtils;
 
 
 public abstract class AbstractStageNode implements StageNode, ProtoSerializable {
 
-  @ProtoProperties
   protected final int _stageId;
-  @ProtoProperties
   protected final List<StageNode> _inputs;
-  @ProtoProperties
-  protected RelDataType _rowType;
 
   public AbstractStageNode(int stageId) {
     _stageId = stageId;
@@ -64,9 +58,5 @@ public abstract class AbstractStageNode implements StageNode, ProtoSerializable 
   @Override
   public Plan.ObjectField toObjectField() {
     return ProtoSerializationUtils.convertObjectToObjectField(this);
-  }
-
-  public RelDataType getRowType() {
-    return _rowType;
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/FilterNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/FilterNode.java
@@ -21,22 +21,18 @@ package org.apache.pinot.query.planner.stage;
 import org.apache.calcite.rex.RexNode;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.planner.serde.ProtoProperties;
-import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class FilterNode extends AbstractStageNode {
   @ProtoProperties
   private RexExpression _condition;
-  @ProtoProperties
-  private FieldSpec.DataType _rowType;
 
   public FilterNode(int stageId) {
     super(stageId);
   }
 
-  public FilterNode(int currentStageId, FieldSpec.DataType rowType, RexNode condition) {
+  public FilterNode(int currentStageId, RexNode condition) {
     super(currentStageId);
-    _rowType = rowType;
     _condition = RexExpression.toRexExpression(condition);
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/FilterNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/FilterNode.java
@@ -18,23 +18,25 @@
  */
 package org.apache.pinot.query.planner.stage;
 
-import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.planner.serde.ProtoProperties;
+import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class FilterNode extends AbstractStageNode {
   @ProtoProperties
   private RexExpression _condition;
+  @ProtoProperties
+  private FieldSpec.DataType _rowType;
 
   public FilterNode(int stageId) {
     super(stageId);
   }
 
-  public FilterNode(int currentStageId, RelDataType rowType, RexNode condition) {
+  public FilterNode(int currentStageId, FieldSpec.DataType rowType, RexNode condition) {
     super(currentStageId);
-    super._rowType = rowType;
+    _rowType = rowType;
     _condition = RexExpression.toRexExpression(condition);
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/JoinNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/JoinNode.java
@@ -20,10 +20,10 @@ package org.apache.pinot.query.planner.stage;
 
 import java.util.List;
 import org.apache.calcite.rel.core.JoinRelType;
-import org.apache.calcite.rel.type.RelDataType;
 import org.apache.pinot.query.planner.partitioning.FieldSelectionKeySelector;
 import org.apache.pinot.query.planner.partitioning.KeySelector;
 import org.apache.pinot.query.planner.serde.ProtoProperties;
+import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class JoinNode extends AbstractStageNode {
@@ -31,14 +31,16 @@ public class JoinNode extends AbstractStageNode {
   private JoinRelType _joinRelType;
   @ProtoProperties
   private List<JoinClause> _criteria;
+  @ProtoProperties
+  private FieldSpec.DataType _rowType;
 
   public JoinNode(int stageId) {
     super(stageId);
   }
 
-  public JoinNode(int stageId, RelDataType rowType, JoinRelType joinRelType, List<JoinClause> criteria) {
+  public JoinNode(int stageId, FieldSpec.DataType rowType, JoinRelType joinRelType, List<JoinClause> criteria) {
     super(stageId);
-    super._rowType = rowType;
+    _rowType = rowType;
     _joinRelType = joinRelType;
     _criteria = criteria;
   }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/JoinNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/JoinNode.java
@@ -23,7 +23,6 @@ import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.pinot.query.planner.partitioning.FieldSelectionKeySelector;
 import org.apache.pinot.query.planner.partitioning.KeySelector;
 import org.apache.pinot.query.planner.serde.ProtoProperties;
-import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class JoinNode extends AbstractStageNode {
@@ -31,16 +30,13 @@ public class JoinNode extends AbstractStageNode {
   private JoinRelType _joinRelType;
   @ProtoProperties
   private List<JoinClause> _criteria;
-  @ProtoProperties
-  private FieldSpec.DataType _rowType;
 
   public JoinNode(int stageId) {
     super(stageId);
   }
 
-  public JoinNode(int stageId, FieldSpec.DataType rowType, JoinRelType joinRelType, List<JoinClause> criteria) {
+  public JoinNode(int stageId, JoinRelType joinRelType, List<JoinClause> criteria) {
     super(stageId);
-    _rowType = rowType;
     _joinRelType = joinRelType;
     _criteria = criteria;
   }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/MailboxReceiveNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/MailboxReceiveNode.java
@@ -20,7 +20,6 @@ package org.apache.pinot.query.planner.stage;
 
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.pinot.query.planner.serde.ProtoProperties;
-import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class MailboxReceiveNode extends AbstractStageNode {
@@ -28,17 +27,14 @@ public class MailboxReceiveNode extends AbstractStageNode {
   private int _senderStageId;
   @ProtoProperties
   private RelDistribution.Type _exchangeType;
-  @ProtoProperties
-  private FieldSpec.DataType _rowType;
 
   public MailboxReceiveNode(int stageId) {
     super(stageId);
   }
 
-  public MailboxReceiveNode(int stageId, FieldSpec.DataType rowType, int senderStageId,
+  public MailboxReceiveNode(int stageId, int senderStageId,
       RelDistribution.Type exchangeType) {
     super(stageId);
-    _rowType = rowType;
     _senderStageId = senderStageId;
     _exchangeType = exchangeType;
   }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/MailboxReceiveNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/MailboxReceiveNode.java
@@ -19,8 +19,8 @@
 package org.apache.pinot.query.planner.stage;
 
 import org.apache.calcite.rel.RelDistribution;
-import org.apache.calcite.rel.type.RelDataType;
 import org.apache.pinot.query.planner.serde.ProtoProperties;
+import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class MailboxReceiveNode extends AbstractStageNode {
@@ -28,14 +28,17 @@ public class MailboxReceiveNode extends AbstractStageNode {
   private int _senderStageId;
   @ProtoProperties
   private RelDistribution.Type _exchangeType;
+  @ProtoProperties
+  private FieldSpec.DataType _rowType;
 
   public MailboxReceiveNode(int stageId) {
     super(stageId);
   }
 
-  public MailboxReceiveNode(int stageId, RelDataType rowType, int senderStageId, RelDistribution.Type exchangeType) {
+  public MailboxReceiveNode(int stageId, FieldSpec.DataType rowType, int senderStageId,
+      RelDistribution.Type exchangeType) {
     super(stageId);
-    super._rowType = rowType;
+    _rowType = rowType;
     _senderStageId = senderStageId;
     _exchangeType = exchangeType;
   }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/MailboxSendNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/MailboxSendNode.java
@@ -22,7 +22,6 @@ import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.pinot.query.planner.partitioning.KeySelector;
 import org.apache.pinot.query.planner.serde.ProtoProperties;
-import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class MailboxSendNode extends AbstractStageNode {
@@ -32,23 +31,20 @@ public class MailboxSendNode extends AbstractStageNode {
   private RelDistribution.Type _exchangeType;
   @ProtoProperties
   private KeySelector<Object[], Object> _partitionKeySelector;
-  @ProtoProperties
-  private FieldSpec.DataType _rowType;
 
   public MailboxSendNode(int stageId) {
     super(stageId);
   }
 
-  public MailboxSendNode(int stageId, FieldSpec.DataType rowType, int receiverStageId,
+  public MailboxSendNode(int stageId, int receiverStageId,
       RelDistribution.Type exchangeType) {
     // When exchangeType is not HASH_DISTRIBUTE, no partitionKeySelector is needed.
-    this(stageId, rowType, receiverStageId, exchangeType, null);
+    this(stageId, receiverStageId, exchangeType, null);
   }
 
-  public MailboxSendNode(int stageId, FieldSpec.DataType rowType, int receiverStageId,
+  public MailboxSendNode(int stageId, int receiverStageId,
       RelDistribution.Type exchangeType, @Nullable KeySelector<Object[], Object> partitionKeySelector) {
     super(stageId);
-    _rowType = rowType;
     _receiverStageId = receiverStageId;
     _exchangeType = exchangeType;
     _partitionKeySelector = partitionKeySelector;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/MailboxSendNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/MailboxSendNode.java
@@ -20,9 +20,9 @@ package org.apache.pinot.query.planner.stage;
 
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelDistribution;
-import org.apache.calcite.rel.type.RelDataType;
 import org.apache.pinot.query.planner.partitioning.KeySelector;
 import org.apache.pinot.query.planner.serde.ProtoProperties;
+import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class MailboxSendNode extends AbstractStageNode {
@@ -32,20 +32,23 @@ public class MailboxSendNode extends AbstractStageNode {
   private RelDistribution.Type _exchangeType;
   @ProtoProperties
   private KeySelector<Object[], Object> _partitionKeySelector;
+  @ProtoProperties
+  private FieldSpec.DataType _rowType;
 
   public MailboxSendNode(int stageId) {
     super(stageId);
   }
 
-  public MailboxSendNode(int stageId, RelDataType rowType, int receiverStageId, RelDistribution.Type exchangeType) {
+  public MailboxSendNode(int stageId, FieldSpec.DataType rowType, int receiverStageId,
+      RelDistribution.Type exchangeType) {
     // When exchangeType is not HASH_DISTRIBUTE, no partitionKeySelector is needed.
     this(stageId, rowType, receiverStageId, exchangeType, null);
   }
 
-  public MailboxSendNode(int stageId, RelDataType rowType, int receiverStageId, RelDistribution.Type exchangeType,
-      @Nullable KeySelector<Object[], Object> partitionKeySelector) {
+  public MailboxSendNode(int stageId, FieldSpec.DataType rowType, int receiverStageId,
+      RelDistribution.Type exchangeType, @Nullable KeySelector<Object[], Object> partitionKeySelector) {
     super(stageId);
-    super._rowType = rowType;
+    _rowType = rowType;
     _receiverStageId = receiverStageId;
     _exchangeType = exchangeType;
     _partitionKeySelector = partitionKeySelector;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/ProjectNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/ProjectNode.java
@@ -20,30 +20,28 @@ package org.apache.pinot.query.planner.stage;
 
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexNode;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.planner.serde.ProtoProperties;
+import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class ProjectNode extends AbstractStageNode {
   @ProtoProperties
   private List<RexExpression> _projects;
+  @ProtoProperties
+  private FieldSpec.DataType _rowType;
 
   public ProjectNode(int stageId) {
     super(stageId);
   }
-  public ProjectNode(int currentStageId, RelDataType rowType, List<RexNode> projects) {
+  public ProjectNode(int currentStageId, FieldSpec.DataType rowType, List<RexNode> projects) {
     super(currentStageId);
-    super._rowType = rowType;
+    _rowType = rowType;
     _projects = projects.stream().map(RexExpression::toRexExpression).collect(Collectors.toList());
   }
 
   public List<RexExpression> getProjects() {
     return _projects;
-  }
-
-  public RelDataType getRowType() {
-    return _rowType;
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/ProjectNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/ProjectNode.java
@@ -23,21 +23,17 @@ import java.util.stream.Collectors;
 import org.apache.calcite.rex.RexNode;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.planner.serde.ProtoProperties;
-import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class ProjectNode extends AbstractStageNode {
   @ProtoProperties
   private List<RexExpression> _projects;
-  @ProtoProperties
-  private FieldSpec.DataType _rowType;
 
   public ProjectNode(int stageId) {
     super(stageId);
   }
-  public ProjectNode(int currentStageId, FieldSpec.DataType rowType, List<RexNode> projects) {
+  public ProjectNode(int currentStageId, List<RexNode> projects) {
     super(currentStageId);
-    _rowType = rowType;
     _projects = projects.stream().map(RexExpression::toRexExpression).collect(Collectors.toList());
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/TableScanNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/TableScanNode.java
@@ -19,8 +19,8 @@
 package org.apache.pinot.query.planner.stage;
 
 import java.util.List;
-import org.apache.calcite.rel.type.RelDataType;
 import org.apache.pinot.query.planner.serde.ProtoProperties;
+import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class TableScanNode extends AbstractStageNode {
@@ -28,14 +28,16 @@ public class TableScanNode extends AbstractStageNode {
   private String _tableName;
   @ProtoProperties
   private List<String> _tableScanColumns;
+  @ProtoProperties
+  private FieldSpec.DataType _rowType;
 
   public TableScanNode(int stageId) {
     super(stageId);
   }
 
-  public TableScanNode(int stageId, RelDataType rowType, String tableName, List<String> tableScanColumns) {
+  public TableScanNode(int stageId, FieldSpec.DataType rowType, String tableName, List<String> tableScanColumns) {
     super(stageId);
-    super._rowType = rowType;
+    _rowType = rowType;
     _tableName = tableName;
     _tableScanColumns = tableScanColumns;
   }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/TableScanNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/TableScanNode.java
@@ -20,7 +20,6 @@ package org.apache.pinot.query.planner.stage;
 
 import java.util.List;
 import org.apache.pinot.query.planner.serde.ProtoProperties;
-import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class TableScanNode extends AbstractStageNode {
@@ -28,16 +27,13 @@ public class TableScanNode extends AbstractStageNode {
   private String _tableName;
   @ProtoProperties
   private List<String> _tableScanColumns;
-  @ProtoProperties
-  private FieldSpec.DataType _rowType;
 
   public TableScanNode(int stageId) {
     super(stageId);
   }
 
-  public TableScanNode(int stageId, FieldSpec.DataType rowType, String tableName, List<String> tableScanColumns) {
+  public TableScanNode(int stageId, String tableName, List<String> tableScanColumns) {
     super(stageId);
-    _rowType = rowType;
     _tableName = tableName;
     _tableScanColumns = tableScanColumns;
   }

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/stage/SerDeUtilsTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/stage/SerDeUtilsTest.java
@@ -46,35 +46,41 @@ public class SerDeUtilsTest extends QueryEnvironmentTestBase {
   private boolean isObjectEqual(Object left, Object right)
       throws IllegalAccessException {
     Class<?> clazz = left.getClass();
-    for (Field field : clazz.getDeclaredFields()) {
-      if (field.isAnnotationPresent(ProtoProperties.class)) {
-        field.setAccessible(true);
-        Object l = field.get(left);
-        Object r = field.get(right);
-        if (l instanceof List) {
-          if (((List) l).size() != ((List) r).size()) {
-            return false;
-          }
-          for (int i = 0; i < ((List) l).size(); i++) {
-            if (!isObjectEqual(((List) l).get(i), ((List) r).get(i))) {
+    while (Object.class != clazz) {
+      for (Field field : clazz.getDeclaredFields()) {
+        if (field.isAnnotationPresent(ProtoProperties.class)) {
+          field.setAccessible(true);
+          Object l = field.get(left);
+          Object r = field.get(right);
+          if (l instanceof List) {
+            if (((List) l).size() != ((List) r).size()) {
               return false;
             }
-          }
-        } else if (l instanceof Map) {
-          if (((Map) l).size() != ((Map) r).size()) {
-            return false;
-          }
-          for (Object key : ((Map) l).keySet()) {
-            if (!isObjectEqual(((Map) l).get(key), ((Map) r).get(key))) {
+            for (int i = 0; i < ((List) l).size(); i++) {
+              if (!isObjectEqual(((List) l).get(i), ((List) r).get(i))) {
+                return false;
+              }
+            }
+          } else if (l instanceof Map) {
+            if (((Map) l).size() != ((Map) r).size()) {
               return false;
             }
-          }
-        } else {
-          if (!(l == null && r == null || l != null && l.equals(r) || isObjectEqual(l, r))) {
-            return false;
+            for (Object key : ((Map) l).keySet()) {
+              if (!isObjectEqual(((Map) l).get(key), ((Map) r).get(key))) {
+                return false;
+              }
+            }
+          } else {
+            if (l == null && r != null || l != null && r == null) {
+              return false;
+            }
+            if (!(l == null && r == null || l != null && l.equals(r) || isObjectEqual(l, r))) {
+              return false;
+            }
           }
         }
       }
+      clazz = clazz.getSuperclass();
     }
     return true;
   }


### PR DESCRIPTION
SerDeUtils has 2 limitations

1. annotated rowType field is of Calcite's relational data type and cannot be understood.
2. `@ProtoProperites` field lookup doesn't extend into superClass

change to use RexExpression from pinot that's proto serializable. to fix item 1, item 2 will be address separately 