### PR TITLE
avoid putting null into segment download uri

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
@@ -88,7 +88,8 @@ public class SegmentPushUtils implements Serializable {
         return fileURI;
       }
     }
-    return URI.create(String.format("%s%s%s", prefix, fileURI.getRawPath(), suffix));
+    return URI.create(
+        String.format("%s%s%s", (prefix != null) ? prefix : "", fileURI.getRawPath(), (suffix != null) ? suffix : ""));
   }
 
   public static void pushSegments(SegmentGenerationJobSpec spec, PinotFS fileSystem, List<String> tarFilePaths)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
@@ -88,8 +88,7 @@ public class SegmentPushUtils implements Serializable {
         return fileURI;
       }
     }
-    return URI.create(
-        String.format("%s%s%s", (prefix != null) ? prefix : "", fileURI.getRawPath(), (suffix != null) ? suffix : ""));
+    return URI.create((prefix != null ? prefix : "") + fileURI.getRawPath() + (suffix != null ? suffix : ""));
   }
 
   public static void pushSegments(SegmentGenerationJobSpec spec, PinotFS fileSystem, List<String> tarFilePaths)


### PR DESCRIPTION
If one of the segmentUriPrefix/Suffix config fields in PushJobSpec is not set, its value is null and 'null' is put in the segment uri like `....tar.gznull`.  

