### PR TITLE
Set max number of parallel segment downloads per table in pinot-server

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/TableDataManagerProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/TableDataManagerProvider.java
@@ -38,6 +38,7 @@ import org.apache.pinot.spi.utils.Pair;
  */
 public class TableDataManagerProvider {
   private static Semaphore _segmentBuildSemaphore;
+  private static int _maxParallelSegmentDownloads;
 
   private TableDataManagerProvider() {
   }
@@ -47,6 +48,7 @@ public class TableDataManagerProvider {
     if (maxParallelBuilds > 0) {
       _segmentBuildSemaphore = new Semaphore(maxParallelBuilds, true);
     }
+    _maxParallelSegmentDownloads = instanceDataManagerConfig.getMaxParallelSegmentDownloads();
   }
 
   public static TableDataManager getTableDataManager(TableDataManagerConfig tableDataManagerConfig, String instanceId,
@@ -67,7 +69,8 @@ public class TableDataManagerProvider {
       default:
         throw new IllegalStateException();
     }
-    tableDataManager.init(tableDataManagerConfig, instanceId, propertyStore, serverMetrics, helixManager, errorCache);
+    tableDataManager.init(tableDataManagerConfig, instanceId, propertyStore, serverMetrics, helixManager, errorCache,
+        _maxParallelSegmentDownloads);
     return tableDataManager;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerAcquireSegmentTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerAcquireSegmentTest.java
@@ -119,7 +119,7 @@ public class BaseTableDataManagerAcquireSegmentTest {
       when(config.getDataDir()).thenReturn(_tmpDir.getAbsolutePath());
     }
     tableDataManager.init(config, "dummyInstance", mock(ZkHelixPropertyStore.class),
-        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class), null);
+        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class), null, 0);
     tableDataManager.start();
     Field segsMapField = BaseTableDataManager.class.getDeclaredField("_segmentDataManagerMap");
     segsMapField.setAccessible(true);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -529,7 +529,7 @@ public class BaseTableDataManagerTest {
 
     OfflineTableDataManager tableDataManager = new OfflineTableDataManager();
     tableDataManager.init(config, "dummyInstance", mock(ZkHelixPropertyStore.class),
-        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class), null);
+        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class), null, 0);
     tableDataManager.start();
     return tableDataManager;
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
@@ -124,7 +124,7 @@ public class DimensionTableDataManagerTest {
       when(config.getDataDir()).thenReturn(INDEX_DIR.getAbsolutePath());
     }
     tableDataManager.init(config, "dummyInstance", mockPropertyStore(),
-        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), helixManager, null);
+        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), helixManager, null, 0);
     tableDataManager.start();
 
     return tableDataManager;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -49,7 +49,7 @@ public interface TableDataManager {
    */
   void init(TableDataManagerConfig tableDataManagerConfig, String instanceId,
       ZkHelixPropertyStore<ZNRecord> propertyStore, ServerMetrics serverMetrics, HelixManager helixManager,
-      LoadingCache<Pair<String, String>, SegmentErrorInfo> errorCache);
+      LoadingCache<Pair<String, String>, SegmentErrorInfo> errorCache, int maxParallelSegmentDownloads);
 
   /**
    * Starts the table data manager. Should be called only once after table data manager gets initialized but before

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -74,6 +74,13 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   private static final String MAX_PARALLEL_SEGMENT_BUILDS = "realtime.max.parallel.segment.builds";
   private static final int DEFAULT_MAX_PARALLEL_SEGMENT_BUILDS = 4;
 
+  // Key of how many parallel segment downloads can be made per table.
+  // A value of <= 0 indicates unlimited.
+  // Unlimited parallel downloads can make Pinot controllers receive high burst of download requests,
+  // causing controllers unavailable for that period of time.
+  private static final String MAX_PARALLEL_SEGMENT_DOWNLOADS = "table.level.max.parallel.segment.downloads";
+  private static final int DEFAULT_MAX_PARALLEL_SEGMENT_DOWNLOADS = -1;
+
   // Key of whether to enable split commit
   private static final String ENABLE_SPLIT_COMMIT = "enable.split.commit";
   // Key of whether to enable split commit end with segment metadata files.
@@ -209,6 +216,12 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   public int getMaxParallelSegmentBuilds() {
     return _instanceDataManagerConfiguration
         .getProperty(MAX_PARALLEL_SEGMENT_BUILDS, DEFAULT_MAX_PARALLEL_SEGMENT_BUILDS);
+  }
+
+  @Override
+  public int getMaxParallelSegmentDownloads() {
+    return _instanceDataManagerConfiguration.getProperty(MAX_PARALLEL_SEGMENT_DOWNLOADS,
+        DEFAULT_MAX_PARALLEL_SEGMENT_DOWNLOADS);
   }
 
   @Override

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
@@ -193,7 +193,7 @@ public abstract class BaseResourceTest {
     TableDataManager tableDataManager = new OfflineTableDataManager();
     tableDataManager
         .init(tableDataManagerConfig, "testInstance", mock(ZkHelixPropertyStore.class), mock(ServerMetrics.class),
-            mock(HelixManager.class), null);
+            mock(HelixManager.class), null, 0);
     tableDataManager.start();
     _tableDataManagerMap.put(tableNameWithType, tableDataManager);
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
@@ -53,6 +53,8 @@ public interface InstanceDataManagerConfig {
 
   int getMaxParallelSegmentBuilds();
 
+  int getMaxParallelSegmentDownloads();
+
   String getAuthToken();
 
   String getSegmentDirectoryLoader();


### PR DESCRIPTION
This PR adds the ability to set the max number of parallel segment downloads per table in pinot-server. There are a couple of reasons:

* Currently there is no upper limit on how many segment download requests that server can send to controllers. In some cases like table rebalance, if the number of download requests is high, this burst of download requests will affect the availability of pinot controllers to serve other requests.
* By default there is no timeout on helix state transition. As long as the transition hasn't finished, the segment won't be online for serving queries. Thus, there is no side effect on querying part.

