### PR TITLE
Upgrade h3 to 3.7.2 for M1 Mac support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <netty.version>4.1.74.Final</netty.version>
     <reactivestreams.version>1.0.3</reactivestreams.version>
     <jts.version>1.16.1</jts.version>
-    <h3.version>3.7.0</h3.version>
+    <h3.version>3.7.2</h3.version>
     <jmh.version>1.26</jmh.version>
     <audienceannotations.version>0.13.0</audienceannotations.version>
 


### PR DESCRIPTION
H3 Java 3.7.2 contains binaries for darwin arm64. It simply throws runtime exception when running with the current version. Currently used by `meetupRsvp` table in  `PartialUpsertQuickStart`