### PR TITLE
[Bugfixing] Don't remove Timestamp index during server restart.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -54,6 +54,7 @@ import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.index.loader.LoaderUtils;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoader;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderContext;
@@ -527,6 +528,9 @@ public abstract class BaseTableDataManager implements TableDataManager {
     recoverReloadFailureQuietly(_tableNameWithType, segmentName, indexDir);
 
     Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
+    schema = SegmentGeneratorConfig.updateSchemaWithTimestampIndexes(schema,
+        SegmentGeneratorConfig.extractTimestampIndexConfigsFromTableConfig(indexLoadingConfig.getTableConfig()));
+
     // Creates the SegmentDirectory object to access the segment metadata.
     // The metadata is null if the segment doesn't exist yet.
     SegmentDirectory segmentDirectory =


### PR DESCRIPTION
Tested: 

- [x] Scenario I. Server start w/o ts index in table config, on-disk segments w/o index:

1. Update table config to add ts index
2. Reload segments to create ts index

- [x] Scenario II. Server start w/ ts index in table config, on-disk segments w/o index:
1. Server builds ts index during the start

- [x] Scenario III. Server start w/ ts index in table config, on-disk segments w/ index:
1. Ensure ts index is loaded after server start.
2. Remove ts index from table config
3. Reload segments to remove ts index on-disk

- [x] Scenario IV. Server start w/o ts index in table config, on-disk segments w/ index:
1. Start server to ensure segments to remove ts index on-disk
