### PR TITLE
throw when integer overflow occurs

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/BaseChunkSVForwardIndexWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/BaseChunkSVForwardIndexWriter.java
@@ -183,6 +183,7 @@ public abstract class BaseChunkSVForwardIndexWriter implements Closeable {
     }
 
     if (_headerEntryChunkOffsetSize == Integer.BYTES) {
+      Preconditions.checkState(_dataOffset <= Integer.MAX_VALUE, "Integer overflow detected");
       _header.putInt((int) _dataOffset);
     } else if (_headerEntryChunkOffsetSize == Long.BYTES) {
       _header.putLong(_dataOffset);


### PR DESCRIPTION
Fixes #8701 by throwing early. The workaround is to start using V3 or V4.