### PR TITLE
Disable Groovy function by default

### DIFF
--- a/compatibility-verifier/sample-test-suite/config/BrokerConfig.properties
+++ b/compatibility-verifier/sample-test-suite/config/BrokerConfig.properties
@@ -20,3 +20,4 @@
 pinot.broker.client.queryPort = 8099
 pinot.zk.server = localhost:2181
 pinot.cluster.name = PinotCluster
+pinot.broker.disable.query.groovy=false

--- a/compatibility-verifier/sample-test-suite/config/ControllerConfig.properties
+++ b/compatibility-verifier/sample-test-suite/config/ControllerConfig.properties
@@ -22,3 +22,4 @@ controller.port = 9000
 controller.zk.str = localhost:2181
 controller.data.dir = /tmp/PinotController
 controller.helix.cluster.name = PinotCluster
+controller.disable.ingestion.groovy = false

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -255,7 +255,9 @@ public class ControllerConf extends PinotConfiguration {
   private static final String DEFAULT_DIM_TABLE_MAX_SIZE = "200M";
 
   private static final String DEFAULT_PINOT_FS_FACTORY_CLASS_LOCAL = LocalPinotFS.class.getName();
-  private static final String DISABLE_GROOVY = "controller.disable.ingestion.groovy";
+
+  public static final String DISABLE_GROOVY = "controller.disable.ingestion.groovy";
+  public static final boolean DEFAULT_DISABLE_GROOVY = true;
 
   public ControllerConf() {
     super(new HashMap<>());
@@ -867,7 +869,7 @@ public class ControllerConf extends PinotConfiguration {
    * @return true if Groovy functions are disabled in controller config, otherwise returns false.
    */
   public boolean isDisableIngestionGroovy() {
-    return getProperty(DISABLE_GROOVY, false);
+    return getProperty(DISABLE_GROOVY, DEFAULT_DISABLE_GROOVY);
   }
 
   private long convertPeriodToUnit(String period, TimeUnit timeUnitToConvertTo) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -161,7 +161,8 @@ public abstract class ControllerTest {
     properties.put(ControllerConf.DATA_DIR, DEFAULT_DATA_DIR);
     properties.put(ControllerConf.ZK_STR, getZkUrl());
     properties.put(ControllerConf.HELIX_CLUSTER_NAME, getHelixClusterName());
-
+    // Enable groovy on the controller
+    properties.put(ControllerConf.DISABLE_GROOVY, false);
     return properties;
   }
 

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -39,6 +39,7 @@ import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.plugin.stream.kafka.KafkaStreamConfigProperties;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.QueryConfig;
 import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;
 import org.apache.pinot.spi.config.table.RoutingConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
@@ -256,6 +257,11 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
     return null;
   }
 
+  protected QueryConfig getQueryconfig() {
+    // Enable groovy for tables used in the tests
+    return new QueryConfig(null, false, null, null);
+  }
+
   protected boolean getNullHandlingEnabled() {
     return DEFAULT_NULL_HANDLING_ENABLED;
   }
@@ -298,8 +304,9 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
         .setRangeIndexColumns(getRangeIndexColumns()).setBloomFilterColumns(getBloomFilterColumns())
         .setFieldConfigList(getFieldConfigs()).setNumReplicas(getNumReplicas()).setSegmentVersion(getSegmentVersion())
         .setLoadMode(getLoadMode()).setTaskConfig(getTaskConfig()).setBrokerTenant(getBrokerTenant())
-        .setServerTenant(getServerTenant()).setIngestionConfig(getIngestionConfig())
-        .setNullHandlingEnabled(getNullHandlingEnabled()).setSegmentPartitionConfig(getSegmentPartitionConfig()).build();
+        .setServerTenant(getServerTenant()).setIngestionConfig(getIngestionConfig()).setQueryConfig(getQueryconfig())
+        .setNullHandlingEnabled(getNullHandlingEnabled()).setSegmentPartitionConfig(getSegmentPartitionConfig())
+        .build();
   }
 
   /**
@@ -368,8 +375,8 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
         .setRangeIndexColumns(getRangeIndexColumns()).setBloomFilterColumns(getBloomFilterColumns())
         .setFieldConfigList(getFieldConfigs()).setNumReplicas(getNumReplicas()).setSegmentVersion(getSegmentVersion())
         .setLoadMode(getLoadMode()).setTaskConfig(getTaskConfig()).setBrokerTenant(getBrokerTenant())
-        .setServerTenant(getServerTenant()).setIngestionConfig(getIngestionConfig()).setLLC(useLlc())
-        .setStreamConfigs(getStreamConfigs()).setNullHandlingEnabled(getNullHandlingEnabled()).build();
+        .setServerTenant(getServerTenant()).setIngestionConfig(getIngestionConfig()).setQueryConfig(getQueryconfig())
+        .setLLC(useLlc()).setStreamConfigs(getStreamConfigs()).setNullHandlingEnabled(getNullHandlingEnabled()).build();
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -909,7 +909,21 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     String groovyQuery = "SELECT GROOVY('{\"returnType\":\"STRING\",\"isSingleValue\":true}', "
         + "'arg0 + arg1', FlightNum, Origin) FROM myTable";
     TableConfig tableConfig = getOfflineTableConfig();
-    tableConfig.setQueryConfig(new QueryConfig(null, true, null, null));
+    tableConfig.setQueryConfig(new QueryConfig(null, false, null, null));
+    updateTableConfig(tableConfig);
+
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        // Query should not throw exception
+        postQuery(groovyQuery);
+        return true;
+      } catch (Exception e) {
+        return false;
+      }
+    }, 60_000L, "Failed to accept Groovy query with table override");
+
+    // Remove query config
+    tableConfig.setQueryConfig(null);
     updateTableConfig(tableConfig);
 
     TestUtils.waitForCondition(aVoid -> {
@@ -920,21 +934,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         // expected
         return true;
       }
-    }, 60_000L, "Failed to reject Groovy query with table override");
-
-    // Remove query config
-    tableConfig.setQueryConfig(null);
-    updateTableConfig(tableConfig);
-
-    TestUtils.waitForCondition(aVoid -> {
-      try {
-        postQuery(groovyQuery);
-        // Query should not throw exception
-        return true;
-      } catch (Exception e) {
-        return false;
-      }
-    }, 60_000L, "Failed to accept Groovy query without query table config override");
+    }, 60_000L, "Failed to reject Groovy query without query table config override");
   }
 
   private void reloadWithExtraColumns()

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -230,6 +230,7 @@ public class CommonConstants {
     public static final String BROKER_SERVICE_AUTO_DISCOVERY = "pinot.broker.service.auto.discovery";
 
     public static final String DISABLE_GROOVY = "pinot.broker.disable.query.groovy";
+    public static final boolean DEFAULT_DISABLE_GROOVY = true;
 
     // Rewrite potential expensive functions to their approximation counterparts
     // - DISTINCT_COUNT -> DISTINCT_COUNT_SMART_HLL


### PR DESCRIPTION
This is the last step for #7966 to disable groovy function by default.

Release Notes: We are disabling groovy function by default due to the potential security issues. To enable back the functionality, users can choose to use table-level config override or broker/controller config to turn it on globally.
```
# Enable Groovy globally on Pinot broker
pinot.broker.disable.query.groovy=false

# Enable Groovy globally on Pinot controller
controller.disable.ingestion.groovy=false

# Table override
{
  "tableName": "myTable",
  "tableType": "OFFLINE",
 
  "query" : {
    "disableGroovy": false
  }
}

```