### PR TITLE
Allow table name with dots by a PinotConfiguration switch

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -763,9 +763,6 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
    * - Case-insensitive cluster
    * - Table name in the format of [database_name].[table_name]
    *
-   * If the PinotConfiguration does not allow dots in table name, will do the below:
-   * Drop the prefix part for the format of [database_name].[table_name], keep only [table_name].
-   * If the PinotConfiguration allows dots in table name, we will not do the split
    * @param tableName the table name in the query
    * @param tableCache the table case-sensitive cache
    * @return the table name in the format of [database_name].[table_name]

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1451,7 +1451,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       columnNameToCheck = isCaseInsensitive ? columnName.substring(rawTableName.length() + 1).toLowerCase()
           : columnName.substring(rawTableName.length() + 1);
     } else {
-      columnNameToCheck = isCaseInsensitive? columnName.toLowerCase() : columnName;
+      columnNameToCheck = isCaseInsensitive ? columnName.toLowerCase() : columnName;
     }
     if (columnNameMap != null) {
       String actualColumnName = columnNameMap.get(columnNameToCheck);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1451,7 +1451,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       columnNameToCheck = isCaseInsensitive ? columnName.substring(rawTableName.length() + 1).toLowerCase()
           : columnName.substring(rawTableName.length() + 1);
     } else {
-      columnNameToCheck = columnName;
+      columnNameToCheck = isCaseInsensitive? columnName.toLowerCase() : columnName;
     }
     if (columnNameMap != null) {
       String actualColumnName = columnNameMap.get(columnNameToCheck);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -776,8 +776,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   static String getActualTableName(String tableName, TableCache tableCache, BrokerRoutingManager routingManager,
       PinotConfiguration config) {
     // Use TableCache to handle case-insensitive table name
-    boolean allowDots = config.getProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS,
-        CommonConstants.Helix.DEFAULT_ALLOW_TABLE_NAME_DOTS);
+    boolean allowDots = config.getProperty(CommonConstants.Helix.ALLOW_TABLE_NAME_WITH_DATABASE,
+        CommonConstants.Helix.DEFAULT_ALLOW_TABLE_NAME_WITH_DATABASE);
 
     if (tableCache.isIgnoreCase()) {
       String actualTableName = tableCache.getActualTableName(tableName);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -765,7 +765,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
    *
    * @param tableName the table name in the query
    * @param tableCache the table case-sensitive cache
-   * @return the table name in the format of [database_name].[table_name]
+   * @return table name if the table name is found in Pinot registry, drop the database_name in the format
+   *  of [database_name].[table_name] if only [table_name] is found in Pinot registry.
    */
   @VisibleForTesting
   static String getActualTableName(String tableName, TableCache tableCache) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -243,7 +243,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     }
 
     String tableName =
-        getActualTableName(serverPinotQuery.getDataSource().getTableName(), _tableCache, _routingManager);
+        getActualTableName(serverPinotQuery.getDataSource().getTableName(), _tableCache);
     serverPinotQuery.getDataSource().setTableName(tableName);
     String rawTableName = TableNameBuilder.extractRawTableName(tableName);
     requestContext.setTableName(rawTableName);
@@ -768,52 +768,22 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
    * If the PinotConfiguration allows dots in table name, we will not do the split
    * @param tableName the table name in the query
    * @param tableCache the table case-sensitive cache
-   * @param routingManager the routing mananger for testing whether a route exists
    * @return the table name in the format of [database_name].[table_name]
    */
   @VisibleForTesting
-  static String getActualTableName(String tableName, TableCache tableCache, BrokerRoutingManager routingManager) {
-    // Use TableCache to handle case-insensitive table name
-    if (tableCache.isIgnoreCase()) {
-      String actualTableName = tableCache.getActualTableName(tableName);
+  static String getActualTableName(String tableName, TableCache tableCache) {
+    String actualTableName = tableCache.getActualTableName(tableName);
+    if (actualTableName != null) {
+      return actualTableName;
+    }
+
+    // Check if table is in the format of [database_name].[table_name]
+    String[] tableNameSplits = StringUtils.split(tableName, ".", 2);
+    if (tableNameSplits.length == 2) {
+      actualTableName = tableCache.getActualTableName(tableNameSplits[1]);
       if (actualTableName != null) {
         return actualTableName;
       }
-
-      // Check if table is in the format of [database_name].[table_name]
-      String[] tableNameSplits = StringUtils.split(tableName, ".", 2);
-      if (tableNameSplits.length == 2) {
-        actualTableName = tableCache.getActualTableName(tableNameSplits[1]);
-        if (actualTableName != null) {
-          return actualTableName;
-        }
-      }
-
-      return tableName;
-    }
-    // Check if table is in the format of [database_name].[table_name]
-    String[] tableNameSplits = StringUtils.split(tableName, ".", 2);
-    if (tableNameSplits.length != 2) {
-      return tableName;
-    }
-
-    // Use RoutingManager to handle case-sensitive table name
-    // Update table name if there is no existing table in the format of [database_name].[table_name] but only
-    // [table_name]
-    if (TableNameBuilder.isTableResource(tableName)) {
-      if (routingManager.routingExists(tableNameSplits[1]) && !routingManager.routingExists(tableName)) {
-        return tableNameSplits[1];
-      } else {
-        return tableName;
-      }
-    }
-    if (routingManager.routingExists(TableNameBuilder.OFFLINE.tableNameWithType(tableNameSplits[1]))
-        && !routingManager.routingExists(TableNameBuilder.OFFLINE.tableNameWithType(tableName))) {
-      return tableNameSplits[1];
-    }
-    if (routingManager.routingExists(TableNameBuilder.REALTIME.tableNameWithType(tableNameSplits[1]))
-        && !routingManager.routingExists(TableNameBuilder.REALTIME.tableNameWithType(tableName))) {
-      return tableNameSplits[1];
     }
     return tableName;
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -761,10 +761,10 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   /**
    * Resolves the actual table name for:
    * - Case-insensitive cluster
-   * - Table name in the format of [database_name].[namespace].[table_name]
+   * - Table name in the format of [database_name].[table_name]
    *
    * If the PinotConfiguration does not allow dots in table name, will do the below:
-   * Drop the prefix part for the format of [database_name].[namespace].[table_name], keep only [table_name].
+   * Drop the prefix part for the format of [database_name].[table_name], keep only [table_name].
    * If the PinotConfiguration allows dots in table name, we will not do the split
    * @param tableName the table name in the query
    * @param tableCache the table case-sensitive cache
@@ -832,7 +832,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   static String[] splitTableNameByConfig(String tableName, PinotConfiguration config) {
     if (!config.getProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS,
         CommonConstants.Helix.DEFAULT_ALLOW_TABLE_NAME_DOTS)) {
-      return splitByLastDot(tableName);
+      return StringUtils.split(tableName, ".", 2);
     }
     return new String[]{tableName};
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1470,27 +1470,6 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     throw new BadQueryRequestException("Unknown columnName '" + columnName + "' found in the query");
   }
 
-  /**
-   * Split the column/table name by its last dot. In this way we can extract column name from format like
-   * select [database].[schema].[tableName].[columnName] from ....
-   * <code>
-   * splitByLastDot("db.schema.table.column") == {"db.schema.table", "column"};
-   * splitByLastDot("") == {""};
-   * splitByLastDot(".") == {"", ""}
-   * </code>
-   * @param columnOrTableName the column name with dots
-   * @return Array of one or two elements, by splitting results
-   */
-  @VisibleForTesting
-  static String[] splitByLastDot(String columnOrTableName) {
-    int lastDot = columnOrTableName.lastIndexOf(".");
-    if (lastDot >= 0) {
-      return new String[]{columnOrTableName.substring(0, lastDot), columnOrTableName.substring(lastDot + 1)};
-    } else {
-      return new String[]{columnOrTableName};
-    }
-  }
-
   private static Map<String, String> getOptionsFromJson(JsonNode request, String optionsKey) {
     return Splitter.on(';').omitEmptyStrings().trimResults().withKeyValueSeparator('=')
         .split(request.get(optionsKey).asText());

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTest.java
@@ -106,9 +106,6 @@ public class BaseBrokerRequestHandlerTest {
     Assert.assertEquals(
         BaseBrokerRequestHandler.getActualTableName("db.mytable", tableCache, routingManager, configuration),
         "mytable");
-    Assert.assertEquals(
-        BaseBrokerRequestHandler.getActualTableName("db.namespace.mytable", tableCache, routingManager, configuration),
-        "mytable");
   }
 
   @Test
@@ -154,8 +151,8 @@ public class BaseBrokerRequestHandlerTest {
   public void testSplitTableNameByConfig() {
     PinotConfiguration configuration = new PinotConfiguration();
     configuration.setProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS, false);
-    String[] split = BaseBrokerRequestHandler.splitTableNameByConfig("db.schema.table", configuration);
-    Assert.assertEquals(split, new String[]{"db.schema", "table"});
+    String[] split = BaseBrokerRequestHandler.splitTableNameByConfig("db.table", configuration);
+    Assert.assertEquals(split, new String[]{"db", "table"});
 
     configuration.setProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS, true);
     split = BaseBrokerRequestHandler.splitTableNameByConfig("db.schema.table", configuration);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTest.java
@@ -1,0 +1,167 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.Map;
+import org.apache.pinot.broker.routing.BrokerRoutingManager;
+import org.apache.pinot.common.config.provider.TableCache;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.when;
+
+
+public class BaseBrokerRequestHandlerTest {
+
+  @Test
+  public void testUpdateColumnNames() {
+    String query = "SELECT database.my_table.column_name_1st, column_name_2nd from database.my_table";
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    Map<String, String> columnNameMap =
+        ImmutableMap.of("column_name_1st", "column_name_1st", "column_name_2nd", "column_name_2nd");
+    BaseBrokerRequestHandler.updateColumnNames("database.my_table", pinotQuery, false, columnNameMap);
+    Assert.assertEquals(pinotQuery.getSelectList().size(), 2);
+    for (Expression expression : pinotQuery.getSelectList()) {
+      String columnName = expression.getIdentifier().getName();
+      if (columnName.endsWith("column_name_1st")) {
+        Assert.assertEquals(columnName, "column_name_1st");
+      } else if (columnName.endsWith("column_name_2nd")) {
+        Assert.assertEquals(columnName, "column_name_2nd");
+      } else {
+        Assert.fail("rewritten column name should be column_name_1st or column_name_1st, but is " + columnName);
+      }
+    }
+  }
+
+  @Test
+  public void testSplitByLastDot() {
+    String[] res = BaseBrokerRequestHandler.splitByLastDot("db.table.column_name");
+    Assert.assertEquals(res.length, 2);
+    Assert.assertEquals(res[0], "db.table");
+    Assert.assertEquals(res[1], "column_name");
+
+    res = BaseBrokerRequestHandler.splitByLastDot("table.column_name");
+    Assert.assertEquals(res.length, 2);
+    Assert.assertEquals(res[0], "table");
+    Assert.assertEquals(res[1], "column_name");
+
+    res = BaseBrokerRequestHandler.splitByLastDot("");
+    Assert.assertEquals(res.length, 1);
+    Assert.assertEquals(res[0], "");
+
+    res = BaseBrokerRequestHandler.splitByLastDot(".");
+    Assert.assertEquals(res.length, 2);
+    Assert.assertEquals(res[0], "");
+    Assert.assertEquals(res[0], "");
+
+    res = BaseBrokerRequestHandler.splitByLastDot(".column_name");
+    Assert.assertEquals(res.length, 2);
+    Assert.assertEquals(res[0], "");
+    Assert.assertEquals(res[1], "column_name");
+  }
+
+  @Test
+  public void testGetActualTableNameBanningDots() {
+    // not allowing dots
+    PinotConfiguration configuration = new PinotConfiguration();
+    configuration.setProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS, false);
+
+    TableCache tableCache = Mockito.mock(TableCache.class);
+    BrokerRoutingManager routingManager = Mockito.mock(BrokerRoutingManager.class);
+    when(tableCache.isCaseInsensitive()).thenReturn(true);
+    when(tableCache.getActualTableName("mytable")).thenReturn("mytable");
+    Assert.assertEquals(
+        BaseBrokerRequestHandler.getActualTableName("mytable", tableCache, routingManager, configuration), "mytable");
+    when(tableCache.getActualTableName("db.mytable")).thenReturn(null);
+    Assert.assertEquals(
+        BaseBrokerRequestHandler.getActualTableName("db.mytable", tableCache, routingManager, configuration),
+        "mytable");
+
+    when(tableCache.isCaseInsensitive()).thenReturn(false);
+    when(routingManager.routingExists("mytable_OFFLINE")).thenReturn(true);
+    when(routingManager.routingExists("mytable_REALTIME")).thenReturn(true);
+    Assert.assertEquals(
+        BaseBrokerRequestHandler.getActualTableName("db.mytable", tableCache, routingManager, configuration),
+        "mytable");
+    Assert.assertEquals(
+        BaseBrokerRequestHandler.getActualTableName("db.namespace.mytable", tableCache, routingManager, configuration),
+        "mytable");
+  }
+
+  @Test
+  public void testGetActualTableNameAllowingDots() {
+    // not allowing dots
+    PinotConfiguration configuration = new PinotConfiguration();
+    configuration.setProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS, true);
+
+    TableCache tableCache = Mockito.mock(TableCache.class);
+    BrokerRoutingManager routingManager = Mockito.mock(BrokerRoutingManager.class);
+    when(tableCache.isCaseInsensitive()).thenReturn(true);
+    // the tableCache should have only "db.mytable" in it since this is the only table
+    when(tableCache.getActualTableName("mytable")).thenReturn(null);
+    when(tableCache.getActualTableName("db.mytable")).thenReturn("db.mytable");
+    when(tableCache.getActualTableName("other.mytable")).thenReturn(null);
+    when(tableCache.getActualTableName("test_table")).thenReturn(null);
+
+    Assert.assertEquals(
+        BaseBrokerRequestHandler.getActualTableName("test_table", tableCache, routingManager, configuration), "test_table");
+    Assert.assertEquals(
+        BaseBrokerRequestHandler.getActualTableName("mytable", tableCache, routingManager, configuration), "mytable");
+
+    Assert.assertEquals(
+        BaseBrokerRequestHandler.getActualTableName("db.mytable", tableCache, routingManager, configuration),
+        "db.mytable");
+    Assert.assertEquals(
+        BaseBrokerRequestHandler.getActualTableName("other.mytable", tableCache, routingManager, configuration),
+        "other.mytable");
+
+    when(tableCache.isCaseInsensitive()).thenReturn(false);
+    when(routingManager.routingExists("db.namespace.mytable_OFFLINE")).thenReturn(true);
+    when(routingManager.routingExists("db.namespace.mytable_REALTIME")).thenReturn(true);
+    Assert.assertEquals(
+        BaseBrokerRequestHandler.getActualTableName("db.mytable", tableCache, routingManager, configuration),
+        "db.mytable");
+    Assert.assertEquals(
+        BaseBrokerRequestHandler.getActualTableName("db.namespace.mytable", tableCache, routingManager, configuration),
+        "db.namespace.mytable");
+  }
+
+  @Test
+  public void testSplitTableNameByConfig() {
+    PinotConfiguration configuration = new PinotConfiguration();
+    configuration.setProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS, false);
+    String[] split = BaseBrokerRequestHandler.splitTableNameByConfig("db.schema.table", configuration);
+    Assert.assertEquals(split, new String[]{"db.schema", "table"});
+
+    configuration.setProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS, true);
+    split = BaseBrokerRequestHandler.splitTableNameByConfig("db.schema.table", configuration);
+    Assert.assertEquals(split, new String[]{"db.schema.table"});
+
+    configuration.setProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS, false);
+    split = BaseBrokerRequestHandler.splitTableNameByConfig("db.table", configuration);
+    Assert.assertEquals(split, new String[]{"db", "table"});
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTest.java
@@ -127,7 +127,8 @@ public class BaseBrokerRequestHandlerTest {
     when(tableCache.getActualTableName("test_table")).thenReturn(null);
 
     Assert.assertEquals(
-        BaseBrokerRequestHandler.getActualTableName("test_table", tableCache, routingManager, configuration), "test_table");
+        BaseBrokerRequestHandler.getActualTableName("test_table", tableCache, routingManager, configuration),
+        "test_table");
     Assert.assertEquals(
         BaseBrokerRequestHandler.getActualTableName("mytable", tableCache, routingManager, configuration), "mytable");
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTest.java
@@ -178,17 +178,13 @@ public class BaseBrokerRequestHandlerTest {
 
   @Test
   public void testSplitTableNameByConfig() {
-    PinotConfiguration configuration = new PinotConfiguration();
-    configuration.setProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS, false);
-    String[] split = BaseBrokerRequestHandler.splitTableNameByConfig("db.table", configuration);
+    String[] split = BaseBrokerRequestHandler.splitTableNameByConfig("db.table", false);
     Assert.assertEquals(split, new String[]{"db", "table"});
 
-    configuration.setProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS, true);
-    split = BaseBrokerRequestHandler.splitTableNameByConfig("db.schema.table", configuration);
+    split = BaseBrokerRequestHandler.splitTableNameByConfig("db.schema.table", true);
     Assert.assertEquals(split, new String[]{"db.schema.table"});
 
-    configuration.setProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS, false);
-    split = BaseBrokerRequestHandler.splitTableNameByConfig("db.table", configuration);
+    split = BaseBrokerRequestHandler.splitTableNameByConfig("db.table", false);
     Assert.assertEquals(split, new String[]{"db", "table"});
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTest.java
@@ -129,25 +129,22 @@ public class BaseBrokerRequestHandlerTest {
     when(tableCache.isIgnoreCase()).thenReturn(true);
     when(tableCache.getActualTableName("mytable")).thenReturn("mytable");
     Assert.assertEquals(
-        BaseBrokerRequestHandler.getActualTableName("mytable", tableCache, routingManager, configuration), "mytable");
+        BaseBrokerRequestHandler.getActualTableName("mytable", tableCache, routingManager), "mytable");
     when(tableCache.getActualTableName("db.mytable")).thenReturn(null);
     Assert.assertEquals(
-        BaseBrokerRequestHandler.getActualTableName("db.mytable", tableCache, routingManager, configuration),
+        BaseBrokerRequestHandler.getActualTableName("db.mytable", tableCache, routingManager),
         "mytable");
 
     when(tableCache.isIgnoreCase()).thenReturn(false);
     when(routingManager.routingExists("mytable_OFFLINE")).thenReturn(true);
     when(routingManager.routingExists("mytable_REALTIME")).thenReturn(true);
     Assert.assertEquals(
-        BaseBrokerRequestHandler.getActualTableName("db.mytable", tableCache, routingManager, configuration),
+        BaseBrokerRequestHandler.getActualTableName("db.mytable", tableCache, routingManager),
         "mytable");
   }
 
   @Test
   public void testGetActualTableNameAllowingDots() {
-    // not allowing dots
-    PinotConfiguration configuration = new PinotConfiguration();
-    configuration.setProperty(CommonConstants.Helix.ALLOW_TABLE_NAME_WITH_DATABASE, true);
 
     TableCache tableCache = Mockito.mock(TableCache.class);
     BrokerRoutingManager routingManager = Mockito.mock(BrokerRoutingManager.class);
@@ -159,38 +156,26 @@ public class BaseBrokerRequestHandlerTest {
     when(tableCache.getActualTableName("test_table")).thenReturn(null);
 
     Assert.assertEquals(
-        BaseBrokerRequestHandler.getActualTableName("test_table", tableCache, routingManager, configuration),
+        BaseBrokerRequestHandler.getActualTableName("test_table", tableCache, routingManager),
         "test_table");
     Assert.assertEquals(
-        BaseBrokerRequestHandler.getActualTableName("mytable", tableCache, routingManager, configuration), "mytable");
+        BaseBrokerRequestHandler.getActualTableName("mytable", tableCache, routingManager), "mytable");
 
     Assert.assertEquals(
-        BaseBrokerRequestHandler.getActualTableName("db.mytable", tableCache, routingManager, configuration),
+        BaseBrokerRequestHandler.getActualTableName("db.mytable", tableCache, routingManager),
         "db.mytable");
     Assert.assertEquals(
-        BaseBrokerRequestHandler.getActualTableName("other.mytable", tableCache, routingManager, configuration),
+        BaseBrokerRequestHandler.getActualTableName("other.mytable", tableCache, routingManager),
         "other.mytable");
 
     when(tableCache.isIgnoreCase()).thenReturn(false);
     when(routingManager.routingExists("db.namespace.mytable_OFFLINE")).thenReturn(true);
     when(routingManager.routingExists("db.namespace.mytable_REALTIME")).thenReturn(true);
     Assert.assertEquals(
-        BaseBrokerRequestHandler.getActualTableName("db.mytable", tableCache, routingManager, configuration),
+        BaseBrokerRequestHandler.getActualTableName("db.mytable", tableCache, routingManager),
         "db.mytable");
     Assert.assertEquals(
-        BaseBrokerRequestHandler.getActualTableName("db.namespace.mytable", tableCache, routingManager, configuration),
+        BaseBrokerRequestHandler.getActualTableName("db.namespace.mytable", tableCache, routingManager),
         "db.namespace.mytable");
-  }
-
-  @Test
-  public void testSplitTableNameByConfig() {
-    String[] split = BaseBrokerRequestHandler.splitTableNameByConfig("db.table", false);
-    Assert.assertEquals(split, new String[]{"db", "table"});
-
-    split = BaseBrokerRequestHandler.splitTableNameByConfig("db.schema.table", true);
-    Assert.assertEquals(split, new String[]{"db.schema.table"});
-
-    split = BaseBrokerRequestHandler.splitTableNameByConfig("db.table", false);
-    Assert.assertEquals(split, new String[]{"db", "table"});
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTest.java
@@ -119,33 +119,6 @@ public class BaseBrokerRequestHandlerTest {
   }
 
   @Test
-  public void testSplitByLastDot() {
-    String[] res = BaseBrokerRequestHandler.splitByLastDot("db.table.column_name");
-    Assert.assertEquals(res.length, 2);
-    Assert.assertEquals(res[0], "db.table");
-    Assert.assertEquals(res[1], "column_name");
-
-    res = BaseBrokerRequestHandler.splitByLastDot("table.column_name");
-    Assert.assertEquals(res.length, 2);
-    Assert.assertEquals(res[0], "table");
-    Assert.assertEquals(res[1], "column_name");
-
-    res = BaseBrokerRequestHandler.splitByLastDot("");
-    Assert.assertEquals(res.length, 1);
-    Assert.assertEquals(res[0], "");
-
-    res = BaseBrokerRequestHandler.splitByLastDot(".");
-    Assert.assertEquals(res.length, 2);
-    Assert.assertEquals(res[0], "");
-    Assert.assertEquals(res[0], "");
-
-    res = BaseBrokerRequestHandler.splitByLastDot(".column_name");
-    Assert.assertEquals(res.length, 2);
-    Assert.assertEquals(res[0], "");
-    Assert.assertEquals(res[1], "column_name");
-  }
-
-  @Test
   public void testGetActualTableNameBanningDots() {
     // not allowing dots
     PinotConfiguration configuration = new PinotConfiguration();

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.broker.requesthandler;
 import com.google.common.collect.ImmutableMap;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.pinot.broker.routing.BrokerRoutingManager;
 import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.PinotQuery;
@@ -125,29 +124,20 @@ public class BaseBrokerRequestHandlerTest {
     configuration.setProperty(CommonConstants.Helix.ALLOW_TABLE_NAME_WITH_DATABASE, false);
 
     TableCache tableCache = Mockito.mock(TableCache.class);
-    BrokerRoutingManager routingManager = Mockito.mock(BrokerRoutingManager.class);
     when(tableCache.isIgnoreCase()).thenReturn(true);
     when(tableCache.getActualTableName("mytable")).thenReturn("mytable");
-    Assert.assertEquals(
-        BaseBrokerRequestHandler.getActualTableName("mytable", tableCache, routingManager), "mytable");
+    Assert.assertEquals(BaseBrokerRequestHandler.getActualTableName("mytable", tableCache), "mytable");
     when(tableCache.getActualTableName("db.mytable")).thenReturn(null);
-    Assert.assertEquals(
-        BaseBrokerRequestHandler.getActualTableName("db.mytable", tableCache, routingManager),
-        "mytable");
+    Assert.assertEquals(BaseBrokerRequestHandler.getActualTableName("db.mytable", tableCache), "mytable");
 
     when(tableCache.isIgnoreCase()).thenReturn(false);
-    when(routingManager.routingExists("mytable_OFFLINE")).thenReturn(true);
-    when(routingManager.routingExists("mytable_REALTIME")).thenReturn(true);
-    Assert.assertEquals(
-        BaseBrokerRequestHandler.getActualTableName("db.mytable", tableCache, routingManager),
-        "mytable");
+    Assert.assertEquals(BaseBrokerRequestHandler.getActualTableName("db.mytable", tableCache), "mytable");
   }
 
   @Test
   public void testGetActualTableNameAllowingDots() {
 
     TableCache tableCache = Mockito.mock(TableCache.class);
-    BrokerRoutingManager routingManager = Mockito.mock(BrokerRoutingManager.class);
     when(tableCache.isIgnoreCase()).thenReturn(true);
     // the tableCache should have only "db.mytable" in it since this is the only table
     when(tableCache.getActualTableName("mytable")).thenReturn(null);
@@ -155,27 +145,15 @@ public class BaseBrokerRequestHandlerTest {
     when(tableCache.getActualTableName("other.mytable")).thenReturn(null);
     when(tableCache.getActualTableName("test_table")).thenReturn(null);
 
-    Assert.assertEquals(
-        BaseBrokerRequestHandler.getActualTableName("test_table", tableCache, routingManager),
-        "test_table");
-    Assert.assertEquals(
-        BaseBrokerRequestHandler.getActualTableName("mytable", tableCache, routingManager), "mytable");
+    Assert.assertEquals(BaseBrokerRequestHandler.getActualTableName("test_table", tableCache), "test_table");
+    Assert.assertEquals(BaseBrokerRequestHandler.getActualTableName("mytable", tableCache), "mytable");
 
-    Assert.assertEquals(
-        BaseBrokerRequestHandler.getActualTableName("db.mytable", tableCache, routingManager),
-        "db.mytable");
-    Assert.assertEquals(
-        BaseBrokerRequestHandler.getActualTableName("other.mytable", tableCache, routingManager),
-        "other.mytable");
+    Assert.assertEquals(BaseBrokerRequestHandler.getActualTableName("db.mytable", tableCache), "db.mytable");
+    Assert.assertEquals(BaseBrokerRequestHandler.getActualTableName("other.mytable", tableCache), "other.mytable");
 
     when(tableCache.isIgnoreCase()).thenReturn(false);
-    when(routingManager.routingExists("db.namespace.mytable_OFFLINE")).thenReturn(true);
-    when(routingManager.routingExists("db.namespace.mytable_REALTIME")).thenReturn(true);
-    Assert.assertEquals(
-        BaseBrokerRequestHandler.getActualTableName("db.mytable", tableCache, routingManager),
-        "db.mytable");
-    Assert.assertEquals(
-        BaseBrokerRequestHandler.getActualTableName("db.namespace.mytable", tableCache, routingManager),
+    Assert.assertEquals(BaseBrokerRequestHandler.getActualTableName("db.mytable", tableCache), "db.mytable");
+    Assert.assertEquals(BaseBrokerRequestHandler.getActualTableName("db.namespace.mytable", tableCache),
         "db.namespace.mytable");
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTest.java
@@ -149,7 +149,7 @@ public class BaseBrokerRequestHandlerTest {
   public void testGetActualTableNameBanningDots() {
     // not allowing dots
     PinotConfiguration configuration = new PinotConfiguration();
-    configuration.setProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS, false);
+    configuration.setProperty(CommonConstants.Helix.ALLOW_TABLE_NAME_WITH_DATABASE, false);
 
     TableCache tableCache = Mockito.mock(TableCache.class);
     BrokerRoutingManager routingManager = Mockito.mock(BrokerRoutingManager.class);
@@ -174,7 +174,7 @@ public class BaseBrokerRequestHandlerTest {
   public void testGetActualTableNameAllowingDots() {
     // not allowing dots
     PinotConfiguration configuration = new PinotConfiguration();
-    configuration.setProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS, true);
+    configuration.setProperty(CommonConstants.Helix.ALLOW_TABLE_NAME_WITH_DATABASE, true);
 
     TableCache tableCache = Mockito.mock(TableCache.class);
     BrokerRoutingManager routingManager = Mockito.mock(BrokerRoutingManager.class);

--- a/pinot-common/src/main/java/org/apache/pinot/common/config/provider/TableCache.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/provider/TableCache.java
@@ -76,7 +76,7 @@ public class TableCache implements PinotConfigProvider {
   private final Set<SchemaChangeListener> _schemaChangeListeners = new HashSet<>();
 
   private final ZkHelixPropertyStore<ZNRecord> _propertyStore;
-  private final boolean _caseInsensitive;
+  private final boolean _ignoreCase;
 
   private final ZkTableConfigChangeListener _zkTableConfigChangeListener = new ZkTableConfigChangeListener();
   // Key is table name with type suffix, value is table config info
@@ -92,9 +92,9 @@ public class TableCache implements PinotConfigProvider {
   // Key is schema name, value is schema info
   private final Map<String, SchemaInfo> _schemaInfoMap = new ConcurrentHashMap<>();
 
-  public TableCache(ZkHelixPropertyStore<ZNRecord> propertyStore, boolean caseInsensitive) {
+  public TableCache(ZkHelixPropertyStore<ZNRecord> propertyStore, boolean ignoreCase) {
     _propertyStore = propertyStore;
-    _caseInsensitive = caseInsensitive;
+    _ignoreCase = ignoreCase;
 
     synchronized (_zkTableConfigChangeListener) {
       // Subscribe child changes before reading the data to avoid missing changes
@@ -124,14 +124,14 @@ public class TableCache implements PinotConfigProvider {
       }
     }
 
-    LOGGER.info("Initialized TableCache with caseInsensitive: {}", caseInsensitive);
+    LOGGER.info("Initialized TableCache with IgnoreCase: {}", ignoreCase);
   }
 
   /**
    * Returns {@code true} if the TableCache is case-insensitive, {@code false} otherwise.
    */
-  public boolean isCaseInsensitive() {
-    return _caseInsensitive;
+  public boolean isIgnoreCase() {
+    return _ignoreCase;
   }
 
   /**
@@ -140,7 +140,7 @@ public class TableCache implements PinotConfigProvider {
    */
   @Nullable
   public String getActualTableName(String tableName) {
-    if (_caseInsensitive) {
+    if (_ignoreCase) {
       return _tableNameMap.get(tableName.toLowerCase());
     } else {
       return _tableNameMap.get(tableName);
@@ -259,7 +259,7 @@ public class TableCache implements PinotConfigProvider {
       removeSchemaName(tableNameWithType);
     }
 
-    if (_caseInsensitive) {
+    if (_ignoreCase) {
       _tableNameMap.put(tableNameWithType.toLowerCase(), tableNameWithType);
       _tableNameMap.put(rawTableName.toLowerCase(), rawTableName);
     } else {
@@ -274,7 +274,7 @@ public class TableCache implements PinotConfigProvider {
     String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
     _tableConfigInfoMap.remove(tableNameWithType);
     removeSchemaName(tableNameWithType);
-    if (_caseInsensitive) {
+    if (_ignoreCase) {
       _tableNameMap.remove(tableNameWithType.toLowerCase());
       String lowerCaseRawTableName = rawTableName.toLowerCase();
       if (TableNameBuilder.isOfflineTableResource(tableNameWithType)) {
@@ -338,7 +338,7 @@ public class TableCache implements PinotConfigProvider {
     addBuiltInVirtualColumns(schema);
     String schemaName = schema.getSchemaName();
     Map<String, String> columnNameMap = new HashMap<>();
-    if (_caseInsensitive) {
+    if (_ignoreCase) {
       for (String columnName : schema.getColumnNames()) {
         columnNameMap.put(columnName.toLowerCase(), columnName);
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -183,7 +183,7 @@ public class PinotTableRestletResource {
       TableConfigUtils.validate(tableConfig, schema, typesToSkip, _controllerConf.isDisableIngestionGroovy());
       // TableConfigUtils.validateTableName(...) checks table name rules.
       // So it won't effect already created tables.
-      TableConfigUtils.validateTableName(tableConfig);
+      TableConfigUtils.validateTableName(tableConfig, _controllerConf);
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -88,6 +88,7 @@ import org.apache.pinot.spi.config.table.TableStats;
 import org.apache.pinot.spi.config.table.TableStatus;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.RebalanceConfigConstants;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
@@ -183,7 +184,9 @@ public class PinotTableRestletResource {
       TableConfigUtils.validate(tableConfig, schema, typesToSkip, _controllerConf.isDisableIngestionGroovy());
       // TableConfigUtils.validateTableName(...) checks table name rules.
       // So it won't effect already created tables.
-      TableConfigUtils.validateTableName(tableConfig, _controllerConf);
+      boolean allowDots = _controllerConf.getProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS,
+          CommonConstants.Helix.DEFAULT_ALLOW_TABLE_NAME_DOTS);
+        TableConfigUtils.validateTableName(tableConfig, allowDots);
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -183,10 +183,11 @@ public class PinotTableRestletResource {
       // TableConfigUtils.validate(...) is used across table create/update.
       TableConfigUtils.validate(tableConfig, schema, typesToSkip, _controllerConf.isDisableIngestionGroovy());
       // TableConfigUtils.validateTableName(...) checks table name rules.
-      // So it won't effect already created tables.
-      boolean allowDots = _controllerConf.getProperty(CommonConstants.Helix.ALLOW_TABLE_NAME_WITH_DATABASE,
+      // So it won't affect already created tables.
+      boolean allowTableNameWithDatabase = _controllerConf.getProperty(
+          CommonConstants.Helix.ALLOW_TABLE_NAME_WITH_DATABASE,
           CommonConstants.Helix.DEFAULT_ALLOW_TABLE_NAME_WITH_DATABASE);
-        TableConfigUtils.validateTableName(tableConfig, allowDots);
+        TableConfigUtils.validateTableName(tableConfig, allowTableNameWithDatabase);
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -184,8 +184,8 @@ public class PinotTableRestletResource {
       TableConfigUtils.validate(tableConfig, schema, typesToSkip, _controllerConf.isDisableIngestionGroovy());
       // TableConfigUtils.validateTableName(...) checks table name rules.
       // So it won't effect already created tables.
-      boolean allowDots = _controllerConf.getProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS,
-          CommonConstants.Helix.DEFAULT_ALLOW_TABLE_NAME_DOTS);
+      boolean allowDots = _controllerConf.getProperty(CommonConstants.Helix.ALLOW_TABLE_NAME_WITH_DATABASE,
+          CommonConstants.Helix.DEFAULT_ALLOW_TABLE_NAME_WITH_DATABASE);
         TableConfigUtils.validateTableName(tableConfig, allowDots);
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -62,6 +62,7 @@ import org.apache.pinot.segment.local.utils.TableConfigUtils;
 import org.apache.pinot.spi.config.TableConfigs;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.glassfish.grizzly.http.server.Request;
@@ -408,19 +409,20 @@ public class TableConfigsRestletResource {
       Preconditions.checkState(rawTableName.equals(schema.getSchemaName()),
           "'tableName': %s must be equal to 'schemaName' from 'schema': %s", rawTableName, schema.getSchemaName());
       SchemaUtils.validate(schema);
-
+      boolean allowDots = _controllerConf.getProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS,
+          CommonConstants.Helix.DEFAULT_ALLOW_TABLE_NAME_DOTS);
       if (offlineTableConfig != null) {
         String offlineRawTableName = TableNameBuilder.extractRawTableName(offlineTableConfig.getTableName());
         Preconditions.checkState(offlineRawTableName.equals(rawTableName),
             "Name in 'offline' table config: %s must be equal to 'tableName': %s", offlineRawTableName, rawTableName);
-        TableConfigUtils.validateTableName(offlineTableConfig, _controllerConf);
+        TableConfigUtils.validateTableName(offlineTableConfig, allowDots);
         TableConfigUtils.validate(offlineTableConfig, schema, typesToSkip, _controllerConf.isDisableIngestionGroovy());
       }
       if (realtimeTableConfig != null) {
         String realtimeRawTableName = TableNameBuilder.extractRawTableName(realtimeTableConfig.getTableName());
         Preconditions.checkState(realtimeRawTableName.equals(rawTableName),
             "Name in 'realtime' table config: %s must be equal to 'tableName': %s", realtimeRawTableName, rawTableName);
-        TableConfigUtils.validateTableName(realtimeTableConfig, _controllerConf);
+        TableConfigUtils.validateTableName(realtimeTableConfig, allowDots);
         TableConfigUtils.validate(realtimeTableConfig, schema, typesToSkip, _controllerConf.isDisableIngestionGroovy());
       }
       if (offlineTableConfig != null && realtimeTableConfig != null) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -413,14 +413,14 @@ public class TableConfigsRestletResource {
         String offlineRawTableName = TableNameBuilder.extractRawTableName(offlineTableConfig.getTableName());
         Preconditions.checkState(offlineRawTableName.equals(rawTableName),
             "Name in 'offline' table config: %s must be equal to 'tableName': %s", offlineRawTableName, rawTableName);
-        TableConfigUtils.validateTableName(offlineTableConfig);
+        TableConfigUtils.validateTableName(offlineTableConfig, _controllerConf);
         TableConfigUtils.validate(offlineTableConfig, schema, typesToSkip, _controllerConf.isDisableIngestionGroovy());
       }
       if (realtimeTableConfig != null) {
         String realtimeRawTableName = TableNameBuilder.extractRawTableName(realtimeTableConfig.getTableName());
         Preconditions.checkState(realtimeRawTableName.equals(rawTableName),
             "Name in 'realtime' table config: %s must be equal to 'tableName': %s", realtimeRawTableName, rawTableName);
-        TableConfigUtils.validateTableName(realtimeTableConfig);
+        TableConfigUtils.validateTableName(realtimeTableConfig, _controllerConf);
         TableConfigUtils.validate(realtimeTableConfig, schema, typesToSkip, _controllerConf.isDisableIngestionGroovy());
       }
       if (offlineTableConfig != null && realtimeTableConfig != null) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -409,8 +409,8 @@ public class TableConfigsRestletResource {
       Preconditions.checkState(rawTableName.equals(schema.getSchemaName()),
           "'tableName': %s must be equal to 'schemaName' from 'schema': %s", rawTableName, schema.getSchemaName());
       SchemaUtils.validate(schema);
-      boolean allowDots = _controllerConf.getProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS,
-          CommonConstants.Helix.DEFAULT_ALLOW_TABLE_NAME_DOTS);
+      boolean allowDots = _controllerConf.getProperty(CommonConstants.Helix.ALLOW_TABLE_NAME_WITH_DATABASE,
+          CommonConstants.Helix.DEFAULT_ALLOW_TABLE_NAME_WITH_DATABASE);
       if (offlineTableConfig != null) {
         String offlineRawTableName = TableNameBuilder.extractRawTableName(offlineTableConfig.getTableName());
         Preconditions.checkState(offlineRawTableName.equals(rawTableName),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -409,20 +409,21 @@ public class TableConfigsRestletResource {
       Preconditions.checkState(rawTableName.equals(schema.getSchemaName()),
           "'tableName': %s must be equal to 'schemaName' from 'schema': %s", rawTableName, schema.getSchemaName());
       SchemaUtils.validate(schema);
-      boolean allowDots = _controllerConf.getProperty(CommonConstants.Helix.ALLOW_TABLE_NAME_WITH_DATABASE,
+      boolean allowTableNameWithDatabase = _controllerConf.getProperty(
+          CommonConstants.Helix.ALLOW_TABLE_NAME_WITH_DATABASE,
           CommonConstants.Helix.DEFAULT_ALLOW_TABLE_NAME_WITH_DATABASE);
       if (offlineTableConfig != null) {
         String offlineRawTableName = TableNameBuilder.extractRawTableName(offlineTableConfig.getTableName());
         Preconditions.checkState(offlineRawTableName.equals(rawTableName),
             "Name in 'offline' table config: %s must be equal to 'tableName': %s", offlineRawTableName, rawTableName);
-        TableConfigUtils.validateTableName(offlineTableConfig, allowDots);
+        TableConfigUtils.validateTableName(offlineTableConfig, allowTableNameWithDatabase);
         TableConfigUtils.validate(offlineTableConfig, schema, typesToSkip, _controllerConf.isDisableIngestionGroovy());
       }
       if (realtimeTableConfig != null) {
         String realtimeRawTableName = TableNameBuilder.extractRawTableName(realtimeTableConfig.getTableName());
         Preconditions.checkState(realtimeRawTableName.equals(rawTableName),
             "Name in 'realtime' table config: %s must be equal to 'tableName': %s", realtimeRawTableName, rawTableName);
-        TableConfigUtils.validateTableName(realtimeTableConfig, allowDots);
+        TableConfigUtils.validateTableName(realtimeTableConfig, allowTableNameWithDatabase);
         TableConfigUtils.validate(realtimeTableConfig, schema, typesToSkip, _controllerConf.isDisableIngestionGroovy());
       }
       if (offlineTableConfig != null && realtimeTableConfig != null) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -1612,8 +1612,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
     //@formatter:off
     String[] origins = new String[]{
-        "ATL", "ORD", "DFW", "DEN", "LAX", "IAH", "SFO", "PHX", "LAS", "EWR", "MCO", "BOS", "SLC", "SEA", "MSP", "CLT"
-        , "LGA", "DTW", "JFK", "BWI"
+        "ATL", "ORD", "DFW", "DEN", "LAX", "IAH", "SFO", "PHX", "LAS", "EWR", "MCO", "BOS", "SLC", "SEA", "MSP", "CLT",
+        "LGA", "DTW", "JFK", "BWI"
     };
     //@formatter:on
     for (String origin : origins) {
@@ -1951,7 +1951,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         q -> queries.add(q.replace("mytable", "MYTABLE").replace("DaysSinceEpoch", "MYTABLE.DAYSSinceEpOch")));
     // something like "SELECT MYDB.MYTABLE.DAYSSinceEpOch from MYDB.MYTABLE where MYDB.MYTABLE.DAYSSinceEpOch = 16138"
     baseQueries.forEach(q -> queries.add(
-        q.replace("mytable", "MYDB.MYTABLE").replace("DaysSinceEpoch", "MYDB.MYTABLE.DAYSSinceEpOch")));
+        q.replace("mytable", "MYDB.MYTABLE").replace("DaysSinceEpoch", "MYTABLE.DAYSSinceEpOch")));
 
     for (String query : queries) {
       JsonNode response = postQuery(query);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -1612,8 +1612,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
     //@formatter:off
     String[] origins = new String[]{
-        "ATL", "ORD", "DFW", "DEN", "LAX", "IAH", "SFO", "PHX", "LAS", "EWR", "MCO", "BOS", "SLC", "SEA", "MSP", "CLT",
-        "LGA", "DTW", "JFK", "BWI"
+        "ATL", "ORD", "DFW", "DEN", "LAX", "IAH", "SFO", "PHX", "LAS", "EWR", "MCO", "BOS", "SLC", "SEA", "MSP", "CLT"
+        , "LGA", "DTW", "JFK", "BWI"
     };
     //@formatter:on
     for (String origin : origins) {
@@ -1949,8 +1949,9 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     List<String> queries = new ArrayList<>();
     baseQueries.forEach(
         q -> queries.add(q.replace("mytable", "MYTABLE").replace("DaysSinceEpoch", "MYTABLE.DAYSSinceEpOch")));
-    baseQueries.forEach(
-        q -> queries.add(q.replace("mytable", "MYDB.MYTABLE").replace("DaysSinceEpoch", "MYTABLE.DAYSSinceEpOch")));
+    // something like "SELECT MYDB.MYTABLE.DAYSSinceEpOch from MYDB.MYTABLE where MYDB.MYTABLE.DAYSSinceEpOch = 16138"
+    baseQueries.forEach(q -> queries.add(
+        q.replace("mytable", "MYDB.MYTABLE").replace("DaysSinceEpoch", "MYDB.MYTABLE.DAYSSinceEpOch")));
 
     for (String query : queries) {
       JsonNode response = postQuery(query);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -65,7 +65,6 @@ import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.ingestion.batch.BatchConfig;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
@@ -154,13 +153,10 @@ public final class TableConfigUtils {
    *   <li>Table name shouldn't contain dot or space in it</li>
    * </ul>
    */
-  public static void validateTableName(TableConfig tableConfig, PinotConfiguration pinotConfiguration) {
+  public static void validateTableName(TableConfig tableConfig, boolean allowDots) {
     String tableName = tableConfig.getTableName();
-    if (!pinotConfiguration.getProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS,
-        CommonConstants.Helix.DEFAULT_ALLOW_TABLE_NAME_DOTS)) {
-      if (tableName.contains(".")) {
-        throw new IllegalStateException("Table name: '" + tableName + "' containing '.' is not allowed");
-      }
+    if (tableName.contains(".") && !allowDots) {
+      throw new IllegalStateException("Table name: '" + tableName + "' containing '.' is not allowed");
     }
     if (tableName.contains(" ")) {
       throw new IllegalStateException("Table name: '" + tableName + "' containing space is not allowed");

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -155,7 +155,11 @@ public final class TableConfigUtils {
    */
   public static void validateTableName(TableConfig tableConfig, boolean allowDots) {
     String tableName = tableConfig.getTableName();
-    if (tableName.contains(".") && !allowDots) {
+    int dotCount = StringUtils.countMatches(tableName,'.');
+    if (allowDots && dotCount > 1) {
+      throw new IllegalStateException("Table name: '" + tableName + "' containing more than one '.' is not allowed");
+    }
+    if (!allowDots && dotCount > 0) {
       throw new IllegalStateException("Table name: '" + tableName + "' containing '.' is not allowed");
     }
     if (tableName.contains(" ")) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -143,9 +143,9 @@ public final class TableConfigUtils {
   }
 
   private static Set<ValidationType> parseTypesToSkipString(@Nullable String typesToSkip) {
-    return typesToSkip == null ? Collections.emptySet()
-        : Arrays.stream(typesToSkip.split(",")).map(s -> ValidationType.valueOf(s.toUpperCase()))
-            .collect(Collectors.toSet());
+    return typesToSkip == null ? Collections.emptySet() : Arrays.stream(typesToSkip.split(","))
+        .map(s -> ValidationType.valueOf(s.toUpperCase()))
+        .collect(Collectors.toSet());
   }
 
   /**
@@ -237,8 +237,8 @@ public final class TableConfigUtils {
 
     String peerSegmentDownloadScheme = validationConfig.getPeerSegmentDownloadScheme();
     if (peerSegmentDownloadScheme != null) {
-      if (!CommonConstants.HTTP_PROTOCOL.equalsIgnoreCase(peerSegmentDownloadScheme)
-          && !CommonConstants.HTTPS_PROTOCOL.equalsIgnoreCase(peerSegmentDownloadScheme)) {
+      if (!CommonConstants.HTTP_PROTOCOL.equalsIgnoreCase(peerSegmentDownloadScheme) && !CommonConstants.HTTPS_PROTOCOL
+          .equalsIgnoreCase(peerSegmentDownloadScheme)) {
         throw new IllegalStateException("Invalid value '" + peerSegmentDownloadScheme
             + "' for peerSegmentDownloadScheme. Must be one of http or https");
       }
@@ -427,8 +427,8 @@ public final class TableConfigUtils {
           for (String prefix : prefixesToRename.keySet()) {
             for (String field : fieldNames) {
               Preconditions.checkState(!field.startsWith(prefix),
-                  "Fields in the schema may not begin with any prefix specified in the prefixesToRename"
-                      + " config. Name conflict with field: " + field + " and prefix: " + prefix);
+                      "Fields in the schema may not begin with any prefix specified in the prefixesToRename"
+                              + " config. Name conflict with field: " + field + " and prefix: " + prefix);
             }
           }
         }
@@ -469,8 +469,8 @@ public final class TableConfigUtils {
           try {
             CronScheduleBuilder.cronSchedule(cronExprStr);
           } catch (Exception e) {
-            throw new IllegalStateException(
-                String.format("Task %s contains an invalid cron schedule: %s", taskTypeConfigName, cronExprStr), e);
+            throw new IllegalStateException(String.format(
+                "Task %s contains an invalid cron schedule: %s", taskTypeConfigName, cronExprStr), e);
           }
         }
         // Task Specific validation for REALTIME_TO_OFFLINE_TASK_TYPE
@@ -484,14 +484,15 @@ public final class TableConfigUtils {
           TimeUtils.convertPeriodToMillis(taskTypeConfig.getOrDefault("bucketTimePeriod", "1d"));
           TimeUtils.convertPeriodToMillis(taskTypeConfig.getOrDefault("roundBucketTimePeriod", "1s"));
           // check mergeType is correct
-          Preconditions.checkState(ImmutableSet.of("CONCAT", "ROLLUP", "DEDUP")
-                  .contains(taskTypeConfig.getOrDefault("mergeType", "CONCAT").toUpperCase()),
+          Preconditions.checkState(ImmutableSet.of("CONCAT", "ROLLUP", "DEDUP").contains(
+              taskTypeConfig.getOrDefault("mergeType", "CONCAT").toUpperCase()),
               "MergeType must be one of [CONCAT, ROLLUP, DEDUP]!");
           // check no mis-configured columns
           Set<String> columnNames = schema.getColumnNames();
           for (Map.Entry<String, String> entry : taskTypeConfig.entrySet()) {
             if (entry.getKey().endsWith(".aggregationType")) {
-              Preconditions.checkState(columnNames.contains(StringUtils.removeEnd(entry.getKey(), ".aggregationType")),
+              Preconditions.checkState(
+                  columnNames.contains(StringUtils.removeEnd(entry.getKey(), ".aggregationType")),
                   String.format("Column \"%s\" not found in schema!", entry.getKey()));
               Preconditions.checkState(ImmutableSet.of("SUM", "MAX", "MIN").contains(entry.getValue().toUpperCase()),
                   String.format("Column \"%s\" has invalid aggregate type: %s", entry.getKey(), entry.getValue()));
@@ -516,8 +517,8 @@ public final class TableConfigUtils {
       return;
     }
     // check table type is realtime
-    Preconditions.checkState(tableConfig.getTableType() == TableType.REALTIME,
-        "Upsert table is for realtime table only.");
+    Preconditions
+        .checkState(tableConfig.getTableType() == TableType.REALTIME, "Upsert table is for realtime table only.");
     // primary key exists
     Preconditions.checkState(CollectionUtils.isNotEmpty(schema.getPrimaryKeyColumns()),
         "Upsert table must have primary key columns in the schema");
@@ -527,13 +528,14 @@ public final class TableConfigUtils {
     Preconditions.checkState(streamConfig.hasLowLevelConsumerType() && !streamConfig.hasHighLevelConsumerType(),
         "Upsert table must use low-level streaming consumer type");
     // replica group is configured for routing
-    Preconditions.checkState(tableConfig.getRoutingConfig() != null
-            && RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE.equalsIgnoreCase(
-            tableConfig.getRoutingConfig().getInstanceSelectorType()),
+    Preconditions.checkState(
+        tableConfig.getRoutingConfig() != null && RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE
+            .equalsIgnoreCase(tableConfig.getRoutingConfig().getInstanceSelectorType()),
         "Upsert table must use strict replica-group (i.e. strictReplicaGroup) based routing");
     // no startree index
-    Preconditions.checkState(CollectionUtils.isEmpty(tableConfig.getIndexingConfig().getStarTreeIndexConfigs())
-        && !tableConfig.getIndexingConfig().isEnableDefaultStarTree(), "The upsert table cannot have star-tree index.");
+    Preconditions.checkState(
+        CollectionUtils.isEmpty(tableConfig.getIndexingConfig().getStarTreeIndexConfigs()) && !tableConfig
+            .getIndexingConfig().isEnableDefaultStarTree(), "The upsert table cannot have star-tree index.");
     // comparison column exists
     if (tableConfig.getUpsertConfig().getComparisonColumn() != null) {
       String comparisonCol = tableConfig.getUpsertConfig().getComparisonColumn();
@@ -586,8 +588,9 @@ public final class TableConfigUtils {
         Preconditions.checkState(!schema.getDateTimeNames().contains(column),
             "INCREMENT merger cannot be applied to date time column: %s", column);
       } else if (columnStrategy == UpsertConfig.Strategy.APPEND || columnStrategy == UpsertConfig.Strategy.UNION) {
-        Preconditions.checkState(!fieldSpec.isSingleValueField(),
-            "%s merger cannot be applied to single-value column: %s", columnStrategy.toString(), column);
+        Preconditions
+            .checkState(!fieldSpec.isSingleValueField(), "%s merger cannot be applied to single-value column: %s",
+                columnStrategy.toString(), column);
       }
     }
   }
@@ -611,8 +614,9 @@ public final class TableConfigUtils {
       String segmentSelectorType = tierConfig.getSegmentSelectorType();
       String segmentAge = tierConfig.getSegmentAge();
       if (segmentSelectorType.equalsIgnoreCase(TierFactory.TIME_SEGMENT_SELECTOR_TYPE)) {
-        Preconditions.checkState(segmentAge != null,
-            "Must provide 'segmentAge' for segmentSelectorType: %s in tier: %s", segmentSelectorType, tierName);
+        Preconditions
+            .checkState(segmentAge != null, "Must provide 'segmentAge' for segmentSelectorType: %s in tier: %s",
+                segmentSelectorType, tierName);
         Preconditions.checkState(TimeUtils.isPeriodValid(segmentAge),
             "segmentAge: %s must be a valid period string (eg. 30d, 24h) in tier: %s", segmentAge, tierName);
       } else if (!segmentSelectorType.equalsIgnoreCase(TierFactory.FIXED_SEGMENT_SELECTOR_TYPE)) {
@@ -623,8 +627,9 @@ public final class TableConfigUtils {
       String storageType = tierConfig.getStorageType();
       String serverTag = tierConfig.getServerTag();
       if (storageType.equalsIgnoreCase(TierFactory.PINOT_SERVER_STORAGE_TYPE)) {
-        Preconditions.checkState(serverTag != null, "Must provide 'serverTag' for storageType: %s in tier: %s",
-            storageType, tierName);
+        Preconditions
+            .checkState(serverTag != null, "Must provide 'serverTag' for storageType: %s in tier: %s", storageType,
+                tierName);
         Preconditions.checkState(TagNameUtils.isServerTag(serverTag),
             "serverTag: %s must have a valid server tag format (<tenantName>_OFFLINE or <tenantName>_REALTIME) in "
                 + "tier: %s", serverTag, tierName);
@@ -756,8 +761,9 @@ public final class TableConfigUtils {
     if (indexingConfig.getRangeIndexColumns() != null) {
       for (String rangeIndexCol : indexingConfig.getRangeIndexColumns()) {
         Preconditions.checkState(
-            schema.getFieldSpecFor(rangeIndexCol).getDataType().isNumeric() || !noDictionaryColumnsSet.contains(
-                rangeIndexCol), "Cannot create a range index on non-numeric/no-dictionary column " + rangeIndexCol);
+            schema.getFieldSpecFor(rangeIndexCol).getDataType().isNumeric() || !noDictionaryColumnsSet
+                .contains(rangeIndexCol),
+            "Cannot create a range index on non-numeric/no-dictionary column " + rangeIndexCol);
       }
     }
 
@@ -780,9 +786,9 @@ public final class TableConfigUtils {
     if (indexingConfig.getJsonIndexColumns() != null) {
       for (String jsonIndexCol : indexingConfig.getJsonIndexColumns()) {
         FieldSpec fieldSpec = schema.getFieldSpecFor(jsonIndexCol);
-        Preconditions.checkState(
-            fieldSpec.isSingleValueField() && fieldSpec.getDataType().getStoredType() == DataType.STRING,
-            "Json index can only be created for single value String column. Invalid for column: %s", jsonIndexCol);
+        Preconditions
+            .checkState(fieldSpec.isSingleValueField() && fieldSpec.getDataType().getStoredType() == DataType.STRING,
+                "Json index can only be created for single value String column. Invalid for column: %s", jsonIndexCol);
       }
     }
   }
@@ -855,8 +861,8 @@ public final class TableConfigUtils {
     indexingConfig.setNoDictionaryColumns(sanitizeListBasedIndexingColumns(indexingConfig.getNoDictionaryColumns()));
     indexingConfig.setSortedColumn(sanitizeListBasedIndexingColumns(indexingConfig.getSortedColumn()));
     indexingConfig.setBloomFilterColumns(sanitizeListBasedIndexingColumns(indexingConfig.getBloomFilterColumns()));
-    indexingConfig.setOnHeapDictionaryColumns(
-        sanitizeListBasedIndexingColumns(indexingConfig.getOnHeapDictionaryColumns()));
+    indexingConfig
+        .setOnHeapDictionaryColumns(sanitizeListBasedIndexingColumns(indexingConfig.getOnHeapDictionaryColumns()));
     indexingConfig.setRangeIndexColumns(sanitizeListBasedIndexingColumns(indexingConfig.getRangeIndexColumns()));
     indexingConfig.setVarLengthDictionaryColumns(
         sanitizeListBasedIndexingColumns(indexingConfig.getVarLengthDictionaryColumns()));
@@ -945,8 +951,8 @@ public final class TableConfigUtils {
               tableConfig.getTableName());
         } else {
           if (quotaConfig.getStorageInBytes() > maxAllowedSizeInBytes) {
-            throw new IllegalStateException(
-                String.format("Invalid storage quota: %d, max allowed size: %d", quotaConfig.getStorageInBytes(),
+            throw new IllegalStateException(String
+                .format("Invalid storage quota: %d, max allowed size: %d", quotaConfig.getStorageInBytes(),
                     maxAllowedSizeInBytes));
           }
         }
@@ -959,10 +965,12 @@ public final class TableConfigUtils {
    */
   public static void verifyHybridTableConfigs(String rawTableName, TableConfig offlineTableConfig,
       TableConfig realtimeTableConfig) {
-    Preconditions.checkNotNull(offlineTableConfig,
-        "Found null offline table config in hybrid table check for table: %s", rawTableName);
-    Preconditions.checkNotNull(realtimeTableConfig,
-        "Found null realtime table config in hybrid table check for table: %s", rawTableName);
+    Preconditions
+        .checkNotNull(offlineTableConfig, "Found null offline table config in hybrid table check for table: %s",
+            rawTableName);
+    Preconditions
+        .checkNotNull(realtimeTableConfig, "Found null realtime table config in hybrid table check for table: %s",
+            rawTableName);
     LOGGER.info("Validating realtime and offline configs for the hybrid table: {}", rawTableName);
     SegmentsValidationAndRetentionConfig offlineSegmentConfig = offlineTableConfig.getValidationConfig();
     SegmentsValidationAndRetentionConfig realtimeSegmentConfig = realtimeTableConfig.getValidationConfig();
@@ -1013,7 +1021,8 @@ public final class TableConfigUtils {
     IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
     if (indexingConfig != null) {
       Map<String, String> streamConfig = indexingConfig.getStreamConfigs();
-      if (streamConfig != null && KINESIS_STREAM_TYPE.equals(streamConfig.get(StreamConfigProperties.STREAM_TYPE))) {
+      if (streamConfig != null && KINESIS_STREAM_TYPE.equals(
+          streamConfig.get(StreamConfigProperties.STREAM_TYPE))) {
         return true;
       }
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -65,6 +65,7 @@ import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.ingestion.batch.BatchConfig;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
@@ -142,9 +143,9 @@ public final class TableConfigUtils {
   }
 
   private static Set<ValidationType> parseTypesToSkipString(@Nullable String typesToSkip) {
-    return typesToSkip == null ? Collections.emptySet() : Arrays.stream(typesToSkip.split(","))
-        .map(s -> ValidationType.valueOf(s.toUpperCase()))
-        .collect(Collectors.toSet());
+    return typesToSkip == null ? Collections.emptySet()
+        : Arrays.stream(typesToSkip.split(",")).map(s -> ValidationType.valueOf(s.toUpperCase()))
+            .collect(Collectors.toSet());
   }
 
   /**
@@ -153,10 +154,16 @@ public final class TableConfigUtils {
    *   <li>Table name shouldn't contain dot or space in it</li>
    * </ul>
    */
-  public static void validateTableName(TableConfig tableConfig) {
+  public static void validateTableName(TableConfig tableConfig, PinotConfiguration pinotConfiguration) {
     String tableName = tableConfig.getTableName();
-    if (tableName.contains(".") || tableName.contains(" ")) {
-      throw new IllegalStateException("Table name: '" + tableName + "' containing '.' or space is not allowed");
+    if (!pinotConfiguration.getProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS,
+        CommonConstants.Helix.DEFAULT_ALLOW_TABLE_NAME_DOTS)) {
+      if (tableName.contains(".")) {
+        throw new IllegalStateException("Table name: '" + tableName + "' containing '.' is not allowed");
+      }
+    }
+    if (tableName.contains(" ")) {
+      throw new IllegalStateException("Table name: '" + tableName + "' containing space is not allowed");
     }
   }
 
@@ -230,8 +237,8 @@ public final class TableConfigUtils {
 
     String peerSegmentDownloadScheme = validationConfig.getPeerSegmentDownloadScheme();
     if (peerSegmentDownloadScheme != null) {
-      if (!CommonConstants.HTTP_PROTOCOL.equalsIgnoreCase(peerSegmentDownloadScheme) && !CommonConstants.HTTPS_PROTOCOL
-          .equalsIgnoreCase(peerSegmentDownloadScheme)) {
+      if (!CommonConstants.HTTP_PROTOCOL.equalsIgnoreCase(peerSegmentDownloadScheme)
+          && !CommonConstants.HTTPS_PROTOCOL.equalsIgnoreCase(peerSegmentDownloadScheme)) {
         throw new IllegalStateException("Invalid value '" + peerSegmentDownloadScheme
             + "' for peerSegmentDownloadScheme. Must be one of http or https");
       }
@@ -420,8 +427,8 @@ public final class TableConfigUtils {
           for (String prefix : prefixesToRename.keySet()) {
             for (String field : fieldNames) {
               Preconditions.checkState(!field.startsWith(prefix),
-                      "Fields in the schema may not begin with any prefix specified in the prefixesToRename"
-                              + " config. Name conflict with field: " + field + " and prefix: " + prefix);
+                  "Fields in the schema may not begin with any prefix specified in the prefixesToRename"
+                      + " config. Name conflict with field: " + field + " and prefix: " + prefix);
             }
           }
         }
@@ -462,8 +469,8 @@ public final class TableConfigUtils {
           try {
             CronScheduleBuilder.cronSchedule(cronExprStr);
           } catch (Exception e) {
-            throw new IllegalStateException(String.format(
-                "Task %s contains an invalid cron schedule: %s", taskTypeConfigName, cronExprStr), e);
+            throw new IllegalStateException(
+                String.format("Task %s contains an invalid cron schedule: %s", taskTypeConfigName, cronExprStr), e);
           }
         }
         // Task Specific validation for REALTIME_TO_OFFLINE_TASK_TYPE
@@ -477,15 +484,14 @@ public final class TableConfigUtils {
           TimeUtils.convertPeriodToMillis(taskTypeConfig.getOrDefault("bucketTimePeriod", "1d"));
           TimeUtils.convertPeriodToMillis(taskTypeConfig.getOrDefault("roundBucketTimePeriod", "1s"));
           // check mergeType is correct
-          Preconditions.checkState(ImmutableSet.of("CONCAT", "ROLLUP", "DEDUP").contains(
-              taskTypeConfig.getOrDefault("mergeType", "CONCAT").toUpperCase()),
+          Preconditions.checkState(ImmutableSet.of("CONCAT", "ROLLUP", "DEDUP")
+                  .contains(taskTypeConfig.getOrDefault("mergeType", "CONCAT").toUpperCase()),
               "MergeType must be one of [CONCAT, ROLLUP, DEDUP]!");
           // check no mis-configured columns
           Set<String> columnNames = schema.getColumnNames();
           for (Map.Entry<String, String> entry : taskTypeConfig.entrySet()) {
             if (entry.getKey().endsWith(".aggregationType")) {
-              Preconditions.checkState(
-                  columnNames.contains(StringUtils.removeEnd(entry.getKey(), ".aggregationType")),
+              Preconditions.checkState(columnNames.contains(StringUtils.removeEnd(entry.getKey(), ".aggregationType")),
                   String.format("Column \"%s\" not found in schema!", entry.getKey()));
               Preconditions.checkState(ImmutableSet.of("SUM", "MAX", "MIN").contains(entry.getValue().toUpperCase()),
                   String.format("Column \"%s\" has invalid aggregate type: %s", entry.getKey(), entry.getValue()));
@@ -510,8 +516,8 @@ public final class TableConfigUtils {
       return;
     }
     // check table type is realtime
-    Preconditions
-        .checkState(tableConfig.getTableType() == TableType.REALTIME, "Upsert table is for realtime table only.");
+    Preconditions.checkState(tableConfig.getTableType() == TableType.REALTIME,
+        "Upsert table is for realtime table only.");
     // primary key exists
     Preconditions.checkState(CollectionUtils.isNotEmpty(schema.getPrimaryKeyColumns()),
         "Upsert table must have primary key columns in the schema");
@@ -521,14 +527,13 @@ public final class TableConfigUtils {
     Preconditions.checkState(streamConfig.hasLowLevelConsumerType() && !streamConfig.hasHighLevelConsumerType(),
         "Upsert table must use low-level streaming consumer type");
     // replica group is configured for routing
-    Preconditions.checkState(
-        tableConfig.getRoutingConfig() != null && RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE
-            .equalsIgnoreCase(tableConfig.getRoutingConfig().getInstanceSelectorType()),
+    Preconditions.checkState(tableConfig.getRoutingConfig() != null
+            && RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE.equalsIgnoreCase(
+            tableConfig.getRoutingConfig().getInstanceSelectorType()),
         "Upsert table must use strict replica-group (i.e. strictReplicaGroup) based routing");
     // no startree index
-    Preconditions.checkState(
-        CollectionUtils.isEmpty(tableConfig.getIndexingConfig().getStarTreeIndexConfigs()) && !tableConfig
-            .getIndexingConfig().isEnableDefaultStarTree(), "The upsert table cannot have star-tree index.");
+    Preconditions.checkState(CollectionUtils.isEmpty(tableConfig.getIndexingConfig().getStarTreeIndexConfigs())
+        && !tableConfig.getIndexingConfig().isEnableDefaultStarTree(), "The upsert table cannot have star-tree index.");
     // comparison column exists
     if (tableConfig.getUpsertConfig().getComparisonColumn() != null) {
       String comparisonCol = tableConfig.getUpsertConfig().getComparisonColumn();
@@ -581,9 +586,8 @@ public final class TableConfigUtils {
         Preconditions.checkState(!schema.getDateTimeNames().contains(column),
             "INCREMENT merger cannot be applied to date time column: %s", column);
       } else if (columnStrategy == UpsertConfig.Strategy.APPEND || columnStrategy == UpsertConfig.Strategy.UNION) {
-        Preconditions
-            .checkState(!fieldSpec.isSingleValueField(), "%s merger cannot be applied to single-value column: %s",
-                columnStrategy.toString(), column);
+        Preconditions.checkState(!fieldSpec.isSingleValueField(),
+            "%s merger cannot be applied to single-value column: %s", columnStrategy.toString(), column);
       }
     }
   }
@@ -607,9 +611,8 @@ public final class TableConfigUtils {
       String segmentSelectorType = tierConfig.getSegmentSelectorType();
       String segmentAge = tierConfig.getSegmentAge();
       if (segmentSelectorType.equalsIgnoreCase(TierFactory.TIME_SEGMENT_SELECTOR_TYPE)) {
-        Preconditions
-            .checkState(segmentAge != null, "Must provide 'segmentAge' for segmentSelectorType: %s in tier: %s",
-                segmentSelectorType, tierName);
+        Preconditions.checkState(segmentAge != null,
+            "Must provide 'segmentAge' for segmentSelectorType: %s in tier: %s", segmentSelectorType, tierName);
         Preconditions.checkState(TimeUtils.isPeriodValid(segmentAge),
             "segmentAge: %s must be a valid period string (eg. 30d, 24h) in tier: %s", segmentAge, tierName);
       } else if (!segmentSelectorType.equalsIgnoreCase(TierFactory.FIXED_SEGMENT_SELECTOR_TYPE)) {
@@ -620,9 +623,8 @@ public final class TableConfigUtils {
       String storageType = tierConfig.getStorageType();
       String serverTag = tierConfig.getServerTag();
       if (storageType.equalsIgnoreCase(TierFactory.PINOT_SERVER_STORAGE_TYPE)) {
-        Preconditions
-            .checkState(serverTag != null, "Must provide 'serverTag' for storageType: %s in tier: %s", storageType,
-                tierName);
+        Preconditions.checkState(serverTag != null, "Must provide 'serverTag' for storageType: %s in tier: %s",
+            storageType, tierName);
         Preconditions.checkState(TagNameUtils.isServerTag(serverTag),
             "serverTag: %s must have a valid server tag format (<tenantName>_OFFLINE or <tenantName>_REALTIME) in "
                 + "tier: %s", serverTag, tierName);
@@ -754,9 +756,8 @@ public final class TableConfigUtils {
     if (indexingConfig.getRangeIndexColumns() != null) {
       for (String rangeIndexCol : indexingConfig.getRangeIndexColumns()) {
         Preconditions.checkState(
-            schema.getFieldSpecFor(rangeIndexCol).getDataType().isNumeric() || !noDictionaryColumnsSet
-                .contains(rangeIndexCol),
-            "Cannot create a range index on non-numeric/no-dictionary column " + rangeIndexCol);
+            schema.getFieldSpecFor(rangeIndexCol).getDataType().isNumeric() || !noDictionaryColumnsSet.contains(
+                rangeIndexCol), "Cannot create a range index on non-numeric/no-dictionary column " + rangeIndexCol);
       }
     }
 
@@ -779,9 +780,9 @@ public final class TableConfigUtils {
     if (indexingConfig.getJsonIndexColumns() != null) {
       for (String jsonIndexCol : indexingConfig.getJsonIndexColumns()) {
         FieldSpec fieldSpec = schema.getFieldSpecFor(jsonIndexCol);
-        Preconditions
-            .checkState(fieldSpec.isSingleValueField() && fieldSpec.getDataType().getStoredType() == DataType.STRING,
-                "Json index can only be created for single value String column. Invalid for column: %s", jsonIndexCol);
+        Preconditions.checkState(
+            fieldSpec.isSingleValueField() && fieldSpec.getDataType().getStoredType() == DataType.STRING,
+            "Json index can only be created for single value String column. Invalid for column: %s", jsonIndexCol);
       }
     }
   }
@@ -854,8 +855,8 @@ public final class TableConfigUtils {
     indexingConfig.setNoDictionaryColumns(sanitizeListBasedIndexingColumns(indexingConfig.getNoDictionaryColumns()));
     indexingConfig.setSortedColumn(sanitizeListBasedIndexingColumns(indexingConfig.getSortedColumn()));
     indexingConfig.setBloomFilterColumns(sanitizeListBasedIndexingColumns(indexingConfig.getBloomFilterColumns()));
-    indexingConfig
-        .setOnHeapDictionaryColumns(sanitizeListBasedIndexingColumns(indexingConfig.getOnHeapDictionaryColumns()));
+    indexingConfig.setOnHeapDictionaryColumns(
+        sanitizeListBasedIndexingColumns(indexingConfig.getOnHeapDictionaryColumns()));
     indexingConfig.setRangeIndexColumns(sanitizeListBasedIndexingColumns(indexingConfig.getRangeIndexColumns()));
     indexingConfig.setVarLengthDictionaryColumns(
         sanitizeListBasedIndexingColumns(indexingConfig.getVarLengthDictionaryColumns()));
@@ -944,8 +945,8 @@ public final class TableConfigUtils {
               tableConfig.getTableName());
         } else {
           if (quotaConfig.getStorageInBytes() > maxAllowedSizeInBytes) {
-            throw new IllegalStateException(String
-                .format("Invalid storage quota: %d, max allowed size: %d", quotaConfig.getStorageInBytes(),
+            throw new IllegalStateException(
+                String.format("Invalid storage quota: %d, max allowed size: %d", quotaConfig.getStorageInBytes(),
                     maxAllowedSizeInBytes));
           }
         }
@@ -958,12 +959,10 @@ public final class TableConfigUtils {
    */
   public static void verifyHybridTableConfigs(String rawTableName, TableConfig offlineTableConfig,
       TableConfig realtimeTableConfig) {
-    Preconditions
-        .checkNotNull(offlineTableConfig, "Found null offline table config in hybrid table check for table: %s",
-            rawTableName);
-    Preconditions
-        .checkNotNull(realtimeTableConfig, "Found null realtime table config in hybrid table check for table: %s",
-            rawTableName);
+    Preconditions.checkNotNull(offlineTableConfig,
+        "Found null offline table config in hybrid table check for table: %s", rawTableName);
+    Preconditions.checkNotNull(realtimeTableConfig,
+        "Found null realtime table config in hybrid table check for table: %s", rawTableName);
     LOGGER.info("Validating realtime and offline configs for the hybrid table: {}", rawTableName);
     SegmentsValidationAndRetentionConfig offlineSegmentConfig = offlineTableConfig.getValidationConfig();
     SegmentsValidationAndRetentionConfig realtimeSegmentConfig = realtimeTableConfig.getValidationConfig();
@@ -1014,8 +1013,7 @@ public final class TableConfigUtils {
     IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
     if (indexingConfig != null) {
       Map<String, String> streamConfig = indexingConfig.getStreamConfigs();
-      if (streamConfig != null && KINESIS_STREAM_TYPE.equals(
-          streamConfig.get(StreamConfigProperties.STREAM_TYPE))) {
+      if (streamConfig != null && KINESIS_STREAM_TYPE.equals(streamConfig.get(StreamConfigProperties.STREAM_TYPE))) {
         return true;
       }
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -155,7 +155,7 @@ public final class TableConfigUtils {
    */
   public static void validateTableName(TableConfig tableConfig, boolean allowDots) {
     String tableName = tableConfig.getTableName();
-    int dotCount = StringUtils.countMatches(tableName,'.');
+    int dotCount = StringUtils.countMatches(tableName, '.');
     // For transitioning into full [database_name].[table_name] support, we allow the table name
     // with one dot at max, so the admin may create mydb.mytable with a feature knob.
     if (allowDots && dotCount > 1) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -156,6 +156,8 @@ public final class TableConfigUtils {
   public static void validateTableName(TableConfig tableConfig, boolean allowDots) {
     String tableName = tableConfig.getTableName();
     int dotCount = StringUtils.countMatches(tableName,'.');
+    // For transitioning into full [database_name].[table_name] support, we allow the table name
+    // with one dot at max, so the admin may create mydb.mytable with a feature knob.
     if (allowDots && dotCount > 1) {
       throw new IllegalStateException("Table name: '" + tableName + "' containing more than one '.' is not allowed");
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -150,7 +150,8 @@ public final class TableConfigUtils {
   /**
    * Validates the table name with the following rules:
    * <ul>
-   *   <li>Table name can either have no dots, or have only one dot or there is a flag allowing database name in it</li>
+   *   <li>If there is a flag allowing database name in it, table name can have one dot in it.
+   *   <li>Otherwise, there is no dot allowed in table name.</li>
    * </ul>
    */
   public static void validateTableName(TableConfig tableConfig, boolean allowTableNameWithDatabase) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -150,21 +150,21 @@ public final class TableConfigUtils {
   /**
    * Validates the table name with the following rules:
    * <ul>
-   *   <li>Table name shouldn't contain dot or space in it</li>
+   *   <li>Table name can either have no dots, or have only one dot or there is a flag allowing database name in it</li>
    * </ul>
    */
-  public static void validateTableName(TableConfig tableConfig, boolean allowDots) {
+  public static void validateTableName(TableConfig tableConfig, boolean allowTableNameWithDatabase) {
     String tableName = tableConfig.getTableName();
     int dotCount = StringUtils.countMatches(tableName, '.');
     // For transitioning into full [database_name].[table_name] support, we allow the table name
     // with one dot at max, so the admin may create mydb.mytable with a feature knob.
-    if (allowDots && dotCount > 1) {
+    if (allowTableNameWithDatabase && dotCount > 1) {
       throw new IllegalStateException("Table name: '" + tableName + "' containing more than one '.' is not allowed");
     }
-    if (!allowDots && dotCount > 0) {
+    if (!allowTableNameWithDatabase && dotCount > 0) {
       throw new IllegalStateException("Table name: '" + tableName + "' containing '.' is not allowed");
     }
-    if (tableName.contains(" ")) {
+    if (StringUtils.containsWhitespace(tableName)) {
       throw new IllegalStateException("Table name: '" + tableName + "' containing space is not allowed");
     }
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -781,7 +781,6 @@ public class TableConfigUtilsTest {
     } catch (IllegalStateException e) {
       // expected
     }
-
   }
 
   @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -759,7 +759,7 @@ public class TableConfigUtilsTest {
       String tableName = malformedTableName[i];
       TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(tableName).build();
       try {
-        TableConfigUtils.validateTableName(tableConfig, new PinotConfiguration());
+        TableConfigUtils.validateTableName(tableConfig, CommonConstants.Helix.DEFAULT_ALLOW_TABLE_NAME_DOTS);
         Assert.fail("Should fail for malformed table name : " + tableName);
       } catch (IllegalStateException e) {
         // expected
@@ -768,10 +768,9 @@ public class TableConfigUtilsTest {
 
     PinotConfiguration configuration = new PinotConfiguration();
     String allowedWitConfig = "test.table";
-    configuration.setProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS, true);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(allowedWitConfig).build();
     try {
-      TableConfigUtils.validateTableName(tableConfig, configuration);
+      TableConfigUtils.validateTableName(tableConfig, true);
     } catch (IllegalStateException e) {
       Assert.fail("Should allow table name with dot if configuration is turned on");
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -49,8 +49,10 @@ import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -757,11 +759,21 @@ public class TableConfigUtilsTest {
       String tableName = malformedTableName[i];
       TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(tableName).build();
       try {
-        TableConfigUtils.validateTableName(tableConfig);
+        TableConfigUtils.validateTableName(tableConfig, new PinotConfiguration());
         Assert.fail("Should fail for malformed table name : " + tableName);
       } catch (IllegalStateException e) {
         // expected
       }
+    }
+
+    PinotConfiguration configuration = new PinotConfiguration();
+    String allowedWitConfig = "test.table";
+    configuration.setProperty(CommonConstants.Helix.CONFIG_OF_ALLOW_TABLE_NAME_DOTS, true);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(allowedWitConfig).build();
+    try {
+      TableConfigUtils.validateTableName(tableConfig, configuration);
+    } catch (IllegalStateException e) {
+      Assert.fail("Should allow table name with dot if configuration is turned on");
     }
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -49,7 +49,6 @@ import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -759,21 +758,30 @@ public class TableConfigUtilsTest {
       String tableName = malformedTableName[i];
       TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(tableName).build();
       try {
-        TableConfigUtils.validateTableName(tableConfig, CommonConstants.Helix.DEFAULT_ALLOW_TABLE_NAME_DOTS);
+        TableConfigUtils.validateTableName(tableConfig, CommonConstants.Helix.DEFAULT_ALLOW_TABLE_NAME_WITH_DATABASE);
         Assert.fail("Should fail for malformed table name : " + tableName);
       } catch (IllegalStateException e) {
         // expected
       }
     }
 
-    PinotConfiguration configuration = new PinotConfiguration();
-    String allowedWitConfig = "test.table";
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(allowedWitConfig).build();
+    String allowedWithConfig = "test.table";
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(allowedWithConfig).build();
     try {
       TableConfigUtils.validateTableName(tableConfig, true);
     } catch (IllegalStateException e) {
       Assert.fail("Should allow table name with dot if configuration is turned on");
     }
+
+    String rejected = "test.another.table";
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(rejected).build();
+    try {
+      TableConfigUtils.validateTableName(tableConfig, true);
+      Assert.fail("Should fail for malformed table name : " + rejected);
+    } catch (IllegalStateException e) {
+      // expected
+    }
+
   }
 
   @Test

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -172,6 +172,8 @@ public class CommonConstants {
     public static final String CONFIG_OF_PINOT_BROKER_STARTABLE_CLASS = "pinot.broker.startable.class";
     public static final String CONFIG_OF_PINOT_SERVER_STARTABLE_CLASS = "pinot.server.startable.class";
     public static final String CONFIG_OF_PINOT_MINION_STARTABLE_CLASS = "pinot.minion.startable.class";
+    public static final String CONFIG_OF_ALLOW_TABLE_NAME_DOTS = "pinot.table.name.dots.enabled";
+    public static final boolean DEFAULT_ALLOW_TABLE_NAME_DOTS = false;
   }
 
   public static class Broker {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -78,6 +78,8 @@ public class CommonConstants {
     public static final String LEAD_CONTROLLER_RESOURCE_ENABLED_KEY = "RESOURCE_ENABLED";
 
     public static final String ENABLE_CASE_INSENSITIVE_KEY = "enable.case.insensitive";
+    public static final String CONFIG_OF_ALLOW_TABLE_NAME_DOTS = "allow.table.name.dots";
+    public static final boolean DEFAULT_ALLOW_TABLE_NAME_DOTS = false;
     @Deprecated
     public static final String DEPRECATED_ENABLE_CASE_INSENSITIVE_KEY = "enable.case.insensitive.pql";
 
@@ -172,8 +174,6 @@ public class CommonConstants {
     public static final String CONFIG_OF_PINOT_BROKER_STARTABLE_CLASS = "pinot.broker.startable.class";
     public static final String CONFIG_OF_PINOT_SERVER_STARTABLE_CLASS = "pinot.server.startable.class";
     public static final String CONFIG_OF_PINOT_MINION_STARTABLE_CLASS = "pinot.minion.startable.class";
-    public static final String CONFIG_OF_ALLOW_TABLE_NAME_DOTS = "pinot.table.name.dots.enabled";
-    public static final boolean DEFAULT_ALLOW_TABLE_NAME_DOTS = false;
   }
 
   public static class Broker {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -78,8 +78,8 @@ public class CommonConstants {
     public static final String LEAD_CONTROLLER_RESOURCE_ENABLED_KEY = "RESOURCE_ENABLED";
 
     public static final String ENABLE_CASE_INSENSITIVE_KEY = "enable.case.insensitive";
-    public static final String CONFIG_OF_ALLOW_TABLE_NAME_DOTS = "allow.table.name.dots";
-    public static final boolean DEFAULT_ALLOW_TABLE_NAME_DOTS = false;
+    public static final String ALLOW_TABLE_NAME_WITH_DATABASE = "allow.table.name.with.database";
+    public static final boolean DEFAULT_ALLOW_TABLE_NAME_WITH_DATABASE = false;
     @Deprecated
     public static final String DEPRECATED_ENABLE_CASE_INSENSITIVE_KEY = "enable.case.insensitive.pql";
 


### PR DESCRIPTION
## Description
Following changes in https://github.com/apache/pinot/pull/5734, 
Allows table name with dots by a shared pinot property. This will allow table name format like `namespace.table_name` to avoid table_name conflict while **providing some mitigation/middle ground before Pinot table goes true multi-tenant**.

The use case this one PR enabled will be for some users sharing a same Pinot Cluster, with the below **Example** rules (not in Pinot, but only with the wrapper/UI or some toolset visible to user):
1. The Admin enforces the rule that the users cannot use dots in their own table_name like `test`;
2. The Admin also enforces the rule that the users will be given a unique "namespace" as prefix to table;
3. The users can create a table named `test` and write query freely/naturally with table name like `user_namespace.test`
4. Pinot can delegate the authorization of table access via its plugin properly in the query

## Extended feature
Extract column name only after the last dot in cases like `SELECT db.namespace.table.column_name from db.namespace.table`. In the example the table name will be `db.namespace.table`

## Tests Done
Many Unit tests

## Release Notes
- Added `pinot.table.name.dots.enabled` config to Controllers and Brokers to allow table name with dots.
- Extract column name from queries like "SELECT db.namespace.table.column_name" properly