### PR TITLE
Fix dimension table load when server restart or reload table

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
@@ -20,134 +20,129 @@ package org.apache.pinot.core.data.manager.offline;
 
 import java.io.File;
 import java.net.URL;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.AccessOption;
 import org.apache.helix.HelixManager;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.PinotMetricUtils;
 import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.utils.SchemaUtils;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManagerConfig;
 import org.apache.pinot.segment.local.segment.creator.SegmentTestUtils;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentCreationDriverFactory;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.index.loader.LoaderTest;
+import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
-import org.apache.pinot.segment.spi.creator.SegmentVersion;
+import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
-import org.apache.pinot.spi.utils.ReadMode;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
 
+@SuppressWarnings("unchecked")
 public class DimensionTableDataManagerTest {
+  private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), LoaderTest.class.getName());
   private static final String TABLE_NAME = "dimBaseballTeams";
-  private static final File INDEX_DIR = new File(LoaderTest.class.getName());
   private static final String AVRO_DATA_PATH = "data/dimBaseballTeams.avro";
 
   private File _indexDir;
   private IndexLoadingConfig _indexLoadingConfig;
+  private SegmentMetadata _segmentMetadata;
+  private SegmentZKMetadata _segmentZKMetadata;
 
   @BeforeClass
   public void setUp()
       throws Exception {
     // prepare segment data
     URL resourceUrl = getClass().getClassLoader().getResource(AVRO_DATA_PATH);
-    Assert.assertNotNull(resourceUrl);
+    assertNotNull(resourceUrl);
     File avroFile = new File(resourceUrl.getFile());
 
     // create segment
     SegmentGeneratorConfig segmentGeneratorConfig =
-        SegmentTestUtils.getSegmentGeneratorConfigWithoutTimeColumn(avroFile, INDEX_DIR, TABLE_NAME);
-    segmentGeneratorConfig.setSegmentVersion(SegmentVersion.v3);
+        SegmentTestUtils.getSegmentGeneratorConfigWithoutTimeColumn(avroFile, TEMP_DIR, TABLE_NAME);
     SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(segmentGeneratorConfig);
     driver.build();
-    _indexDir = new File(INDEX_DIR, driver.getSegmentName());
 
+    String segmentName = driver.getSegmentName();
+    _indexDir = new File(TEMP_DIR, segmentName);
     _indexLoadingConfig = new IndexLoadingConfig();
-    _indexLoadingConfig.setReadMode(ReadMode.mmap);
-    _indexLoadingConfig.setSegmentVersion(SegmentVersion.v3);
+    _segmentMetadata = new SegmentMetadataImpl(_indexDir);
+    _segmentZKMetadata = new SegmentZKMetadata(segmentName);
+    _segmentZKMetadata.setCrc(Long.parseLong(_segmentMetadata.getCrc()));
   }
 
   @AfterClass
   public void tearDown() {
-    FileUtils.deleteQuietly(INDEX_DIR);
+    FileUtils.deleteQuietly(TEMP_DIR);
   }
 
-  private ZkHelixPropertyStore mockPropertyStore() {
-    String baseballTeamsSchemaStr =
-        "{\"schemaName\":\"dimBaseballTeams\",\"dimensionFieldSpecs\":[{\"name\":\"teamID\",\"dataType\":\"STRING\"},"
-            + "{\"name\":\"teamName\",\"dataType\":\"STRING\"}],\"primaryKeyColumns\":[\"teamID\"]}";
-    ZNRecord zkSchemaRec = new ZNRecord("dimBaseballTeams");
-    zkSchemaRec.setSimpleField("schemaJSON", baseballTeamsSchemaStr);
-
-    ZkHelixPropertyStore propertyStore = mock(ZkHelixPropertyStore.class);
-    when(propertyStore.get("/SCHEMAS/dimBaseballTeams", null, AccessOption.PERSISTENT)).
-        thenReturn(zkSchemaRec);
-
-    return propertyStore;
+  private Schema getSchema() {
+    return new Schema.SchemaBuilder().setSchemaName("dimBaseballTeams")
+        .addSingleValueDimension("teamID", DataType.STRING).addSingleValueDimension("teamName", DataType.STRING)
+        .setPrimaryKeyColumns(Collections.singletonList("teamID")).build();
   }
 
-  private ZkHelixPropertyStore mockPropertyStoreWithNewColumn() {
-    String baseballTeamsSchemaStr =
-        "{\"schemaName\":\"dimBaseballTeams\",\"dimensionFieldSpecs\":[{\"name\":\"teamID\",\"dataType\":\"STRING\"},"
-            + "{\"name\":\"teamName\",\"dataType\":\"STRING\"}, {\"name\":\"teamCity\",\"dataType\":\"STRING\"}],"
-            + "\"primaryKeyColumns\":[\"teamID\"]}";
-    ZNRecord zkSchemaRec = new ZNRecord("dimBaseballTeams");
-    zkSchemaRec.setSimpleField("schemaJSON", baseballTeamsSchemaStr);
-
-    ZkHelixPropertyStore propertyStore = mock(ZkHelixPropertyStore.class);
-    when(propertyStore.get("/SCHEMAS/dimBaseballTeams", null, AccessOption.PERSISTENT)).
-        thenReturn(zkSchemaRec);
-
-    return propertyStore;
+  private Schema getSchemaWithExtraColumn() {
+    return new Schema.SchemaBuilder().setSchemaName("dimBaseballTeams")
+        .addSingleValueDimension("teamID", DataType.STRING).addSingleValueDimension("teamName", DataType.STRING)
+        .addSingleValueDimension("teamCity", DataType.STRING).setPrimaryKeyColumns(Collections.singletonList("teamID"))
+        .build();
   }
 
-  private DimensionTableDataManager makeTestableManager(HelixManager helixManager) {
+  private DimensionTableDataManager makeTableDataManager(HelixManager helixManager) {
     DimensionTableDataManager tableDataManager = DimensionTableDataManager.createInstanceByTableName(TABLE_NAME);
     TableDataManagerConfig config;
     {
       config = mock(TableDataManagerConfig.class);
       when(config.getTableName()).thenReturn(TABLE_NAME);
-      when(config.getDataDir()).thenReturn(INDEX_DIR.getAbsolutePath());
+      when(config.getDataDir()).thenReturn(TEMP_DIR.getAbsolutePath());
     }
-    tableDataManager.init(config, "dummyInstance", mockPropertyStore(),
+    tableDataManager.init(config, "dummyInstance", helixManager.getHelixPropertyStore(),
         new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), helixManager, null, 0);
     tableDataManager.start();
-
     return tableDataManager;
   }
 
   @Test
-  public void instantiationTests()
+  public void testInstantiation()
       throws Exception {
     HelixManager helixManager = mock(HelixManager.class);
-    ZkHelixPropertyStore propertyStore = mockPropertyStore();
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(propertyStore.get("/SCHEMAS/dimBaseballTeams", null, AccessOption.PERSISTENT)).thenReturn(
+        SchemaUtils.toZNRecord(getSchema()));
     when(helixManager.getHelixPropertyStore()).thenReturn(propertyStore);
-    DimensionTableDataManager mgr = makeTestableManager(helixManager);
-    Assert.assertEquals(mgr.getTableName(), TABLE_NAME);
+    DimensionTableDataManager tableDataManager = makeTableDataManager(helixManager);
+    assertEquals(tableDataManager.getTableName(), TABLE_NAME);
 
     // fetch the same instance via static method
     DimensionTableDataManager returnedManager = DimensionTableDataManager.getInstanceByTableName(TABLE_NAME);
-    Assert.assertNotNull(returnedManager, "Manager should find instance");
-    Assert.assertEquals(mgr, returnedManager, "Manager should return already created instance");
+    assertNotNull(returnedManager, "Manager should find instance");
+    assertEquals(tableDataManager, returnedManager, "Manager should return already created instance");
 
     // assert that segments are released after loading data
-    mgr.addSegment(_indexDir, _indexLoadingConfig);
+    tableDataManager.addSegment(_indexDir, _indexLoadingConfig);
     for (SegmentDataManager segmentManager : returnedManager.acquireAllSegments()) {
-      Assert.assertEquals(segmentManager.getReferenceCount() - 1, // Subtract this acquisition
+      assertEquals(segmentManager.getReferenceCount() - 1, // Subtract this acquisition
           1, // Default ref count
           "Reference counts should be same before and after segment loading.");
       returnedManager.releaseSegment(segmentManager);
@@ -156,73 +151,90 @@ public class DimensionTableDataManagerTest {
 
     // try fetching non-existent table
     returnedManager = DimensionTableDataManager.getInstanceByTableName("doesNotExist");
-    Assert.assertNull(returnedManager, "Manager should return null for non-existent table");
+    assertNull(returnedManager, "Manager should return null for non-existent table");
   }
 
   @Test
-  public void lookupTests()
+  public void testLookup()
       throws Exception {
     HelixManager helixManager = mock(HelixManager.class);
-    ZkHelixPropertyStore propertyStore = mockPropertyStore();
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(propertyStore.get("/SCHEMAS/dimBaseballTeams", null, AccessOption.PERSISTENT)).thenReturn(
+        SchemaUtils.toZNRecord(getSchema()));
     when(helixManager.getHelixPropertyStore()).thenReturn(propertyStore);
-    DimensionTableDataManager mgr = makeTestableManager(helixManager);
+    DimensionTableDataManager tableDataManager = makeTableDataManager(helixManager);
 
     // try fetching data BEFORE loading segment
-    GenericRow resp = mgr.lookupRowByPrimaryKey(new PrimaryKey(new String[]{"SF"}));
-    Assert.assertNull(resp, "Response should be null if no segment is loaded");
+    GenericRow resp = tableDataManager.lookupRowByPrimaryKey(new PrimaryKey(new String[]{"SF"}));
+    assertNull(resp, "Response should be null if no segment is loaded");
 
-    mgr.addSegment(_indexDir, _indexLoadingConfig);
+    tableDataManager.addSegment(_indexDir, _indexLoadingConfig);
 
     // Confirm table is loaded and available for lookup
-    resp = mgr.lookupRowByPrimaryKey(new PrimaryKey(new String[]{"SF"}));
-    Assert.assertNotNull(resp, "Should return response after segment load");
-    Assert.assertEquals(resp.getValue("teamName"), "San Francisco Giants");
+    resp = tableDataManager.lookupRowByPrimaryKey(new PrimaryKey(new String[]{"SF"}));
+    assertNotNull(resp, "Should return response after segment load");
+    assertEquals(resp.getFieldToValueMap().size(), 2);
+    assertEquals(resp.getValue("teamID"), "SF");
+    assertEquals(resp.getValue("teamName"), "San Francisco Giants");
 
     // Confirm we can get FieldSpec for loaded tables columns.
-    FieldSpec spec = mgr.getColumnFieldSpec("teamName");
-    Assert.assertNotNull(spec, "Should return spec for existing column");
-    Assert.assertEquals(spec.getDataType(), FieldSpec.DataType.STRING,
-        "Should return correct data type for teamName column");
+    FieldSpec spec = tableDataManager.getColumnFieldSpec("teamName");
+    assertNotNull(spec, "Should return spec for existing column");
+    assertEquals(spec.getDataType(), DataType.STRING, "Should return correct data type for teamName column");
 
     // Confirm we can read primary column list
-    List<String> pkColumns = mgr.getPrimaryKeyColumns();
-    Assert.assertEquals(pkColumns, Arrays.asList("teamID"), "Should return PK column list");
+    List<String> pkColumns = tableDataManager.getPrimaryKeyColumns();
+    assertEquals(pkColumns, Collections.singletonList("teamID"), "Should return PK column list");
 
     // Remove the segment
-    List<SegmentDataManager> segmentManagers = mgr.acquireAllSegments();
-    Assert.assertEquals(segmentManagers.size(), 1, "Should have exactly one segment manager");
+    List<SegmentDataManager> segmentManagers = tableDataManager.acquireAllSegments();
+    assertEquals(segmentManagers.size(), 1, "Should have exactly one segment manager");
     SegmentDataManager segMgr = segmentManagers.get(0);
     String segmentName = segMgr.getSegmentName();
-    mgr.removeSegment(segmentName);
+    tableDataManager.removeSegment(segmentName);
     // confirm table is cleaned up
-    resp = mgr.lookupRowByPrimaryKey(new PrimaryKey(new String[]{"SF"}));
-    Assert.assertNull(resp, "Response should be null if no segment is loaded");
+    resp = tableDataManager.lookupRowByPrimaryKey(new PrimaryKey(new String[]{"SF"}));
+    assertNull(resp, "Response should be null if no segment is loaded");
   }
 
   @Test
-  public void onRefreshDimensionTable()
+  public void testReloadTable()
       throws Exception {
     HelixManager helixManager = mock(HelixManager.class);
-    ZkHelixPropertyStore<ZNRecord> propertyStore = mockPropertyStoreWithNewColumn();
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(propertyStore.get("/SCHEMAS/dimBaseballTeams", null, AccessOption.PERSISTENT)).thenReturn(
+        SchemaUtils.toZNRecord(getSchema()));
     when(helixManager.getHelixPropertyStore()).thenReturn(propertyStore);
+    DimensionTableDataManager tableDataManager = makeTableDataManager(helixManager);
 
-    DimensionTableDataManager mgr = makeTestableManager(helixManager);
-
-    mgr.addSegment(_indexDir, _indexLoadingConfig);
+    tableDataManager.addSegment(_indexDir, _indexLoadingConfig);
 
     // Confirm table is loaded and available for lookup
-    GenericRow resp = mgr.lookupRowByPrimaryKey(new PrimaryKey(new String[]{"SF"}));
-    Assert.assertNotNull(resp, "Should return response after segment load");
-    Assert.assertEquals(resp.getValue("teamName"), "San Francisco Giants");
+    GenericRow resp = tableDataManager.lookupRowByPrimaryKey(new PrimaryKey(new String[]{"SF"}));
+    assertNotNull(resp, "Should return response after segment load");
+    assertEquals(resp.getFieldToValueMap().size(), 2);
+    assertEquals(resp.getValue("teamID"), "SF");
+    assertEquals(resp.getValue("teamName"), "San Francisco Giants");
 
-    // WHEN (segment is refreshed)
+    // Confirm the new column does not exist
+    FieldSpec teamCitySpec = tableDataManager.getColumnFieldSpec("teamCity");
+    assertNull(teamCitySpec, "Should not return spec for non-existing column");
 
-    mgr.addSegment(_indexDir, _indexLoadingConfig);
+    // Reload the segment with a new column
+    Schema schemaWithExtraColumn = getSchemaWithExtraColumn();
+    when(propertyStore.get("/SCHEMAS/dimBaseballTeams", null, AccessOption.PERSISTENT)).thenReturn(
+        SchemaUtils.toZNRecord(schemaWithExtraColumn));
+    tableDataManager.reloadSegment(_segmentZKMetadata.getSegmentName(), _indexLoadingConfig, _segmentZKMetadata,
+        _segmentMetadata, schemaWithExtraColumn, false);
 
-    // THEN
-    FieldSpec teamCitySpec = mgr.getColumnFieldSpec("teamCity");
-    Assert.assertNotNull(teamCitySpec, "Should return spec for existing column");
-    Assert.assertEquals(teamCitySpec.getDataType(), FieldSpec.DataType.STRING,
-        "Should return correct data type for teamCity column");
+    // Confirm the new column is available for lookup
+    teamCitySpec = tableDataManager.getColumnFieldSpec("teamCity");
+    assertNotNull(teamCitySpec, "Should return spec for existing column");
+    assertEquals(teamCitySpec.getDataType(), DataType.STRING, "Should return correct data type for teamCity column");
+    resp = tableDataManager.lookupRowByPrimaryKey(new PrimaryKey(new String[]{"SF"}));
+    assertEquals(resp.getFieldToValueMap().size(), 3);
+    assertEquals(resp.getValue("teamID"), "SF");
+    assertEquals(resp.getValue("teamName"), "San Francisco Giants");
+    assertEquals(resp.getValue("teamCity"), "null");
   }
 }


### PR DESCRIPTION
Currently `DimensionTableDataManager` overrides the `addSegment(File indexDir, IndexLoadingConfig indexLoadingConfig)` method to reload the lookup table, but this method is not always invoked when adding the segment. Fix the issue by overriding `addSegment(ImmutableSegment immutableSegment)` which is always invoked when adding the segment.

Other changes:
- Enhance the validation for schema and primary key and fail with proper exception message
- Enhance the test to mimic the actual flow of reloading the segment