### PR TITLE
Improve the range evaluation for raw values without range index

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/RangeIndexBasedFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/RangeIndexBasedFilterOperator.java
@@ -175,14 +175,12 @@ public class RangeIndexBasedFilterOperator extends BaseFilterOperator {
       _max = max;
     }
 
-    IntRangeEvaluator(
-        RangeIndexReader<ImmutableRoaringBitmap> rangeIndexReader,
+    IntRangeEvaluator(RangeIndexReader<ImmutableRoaringBitmap> rangeIndexReader,
         IntRawValueBasedRangePredicateEvaluator predicateEvaluator) {
-      this(rangeIndexReader, predicateEvaluator.getLowerBound(), predicateEvaluator.getUpperBound());
+      this(rangeIndexReader, predicateEvaluator.getInclusiveLowerBound(), predicateEvaluator.getInclusiveUpperBound());
     }
 
-    IntRangeEvaluator(
-        RangeIndexReader<ImmutableRoaringBitmap> rangeIndexReader,
+    IntRangeEvaluator(RangeIndexReader<ImmutableRoaringBitmap> rangeIndexReader,
         SortedDictionaryBasedRangePredicateEvaluator predicateEvaluator) {
       // NOTE: End dictionary id is exclusive in OfflineDictionaryBasedRangePredicateEvaluator.
       this(rangeIndexReader, predicateEvaluator.getStartDictId(), predicateEvaluator.getEndDictId() - 1);
@@ -217,8 +215,8 @@ public class RangeIndexBasedFilterOperator extends BaseFilterOperator {
     LongRangeEvaluator(RangeIndexReader<ImmutableRoaringBitmap> rangeIndexReader,
         LongRawValueBasedRangePredicateEvaluator predicateEvaluator) {
       _rangeIndexReader = rangeIndexReader;
-      _min = predicateEvaluator.getLowerBound();
-      _max = predicateEvaluator.getUpperBound();
+      _min = predicateEvaluator.getInclusiveLowerBound();
+      _max = predicateEvaluator.getInclusiveUpperBound();
     }
 
     @Override
@@ -250,8 +248,8 @@ public class RangeIndexBasedFilterOperator extends BaseFilterOperator {
     FloatRangeEvaluator(RangeIndexReader<ImmutableRoaringBitmap> rangeIndexReader,
         FloatRawValueBasedRangePredicateEvaluator predicateEvaluator) {
       _rangeIndexReader = rangeIndexReader;
-      _min = predicateEvaluator.getLowerBound();
-      _max = predicateEvaluator.getUpperBound();
+      _min = predicateEvaluator.getInclusiveLowerBound();
+      _max = predicateEvaluator.getInclusiveUpperBound();
     }
 
     @Override
@@ -283,8 +281,8 @@ public class RangeIndexBasedFilterOperator extends BaseFilterOperator {
     DoubleRangeEvaluator(RangeIndexReader<ImmutableRoaringBitmap> rangeIndexReader,
         DoubleRawValueBasedRangePredicateEvaluator predicateEvaluator) {
       _rangeIndexReader = rangeIndexReader;
-      _min = predicateEvaluator.getLowerBound();
-      _max = predicateEvaluator.getUpperBound();
+      _min = predicateEvaluator.getInclusiveLowerBound();
+      _max = predicateEvaluator.getInclusiveUpperBound();
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.filter.predicate;
 
+import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import java.math.BigDecimal;
 import org.apache.pinot.common.request.context.predicate.RangePredicate;
@@ -88,8 +89,8 @@ public class RangePredicateEvaluatorFactory {
             upperUnbounded ? Double.POSITIVE_INFINITY : Double.parseDouble(upperBound), lowerInclusive, upperInclusive);
       case BIG_DECIMAL:
         return new BigDecimalRawValueBasedRangePredicateEvaluator(rangePredicate,
-            lowerUnbounded ? null : new BigDecimal(lowerBound),
-            upperUnbounded ? null : new BigDecimal(upperBound), lowerInclusive, upperInclusive);
+            lowerUnbounded ? null : new BigDecimal(lowerBound), upperUnbounded ? null : new BigDecimal(upperBound),
+            lowerInclusive, upperInclusive);
       case BOOLEAN:
         return new IntRawValueBasedRangePredicateEvaluator(rangePredicate,
             lowerUnbounded ? Integer.MIN_VALUE : BooleanUtils.toInt(lowerBound),
@@ -271,32 +272,32 @@ public class RangePredicateEvaluatorFactory {
   }
 
   public static final class IntRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
-    final int _lowerBound;
-    final int _upperBound;
-    final boolean _lowerInclusive;
-    final boolean _upperInclusive;
+    final int _inclusiveLowerBound;
+    final int _inclusiveUpperBound;
 
     IntRawValueBasedRangePredicateEvaluator(RangePredicate rangePredicate, int lowerBound, int upperBound,
         boolean lowerInclusive, boolean upperInclusive) {
       super(rangePredicate);
-      _lowerBound = lowerBound;
-      _upperBound = upperBound;
-      _lowerInclusive = lowerInclusive;
-      _upperInclusive = upperInclusive;
+      if (lowerInclusive) {
+        _inclusiveLowerBound = lowerBound;
+      } else {
+        _inclusiveLowerBound = lowerBound + 1;
+        Preconditions.checkArgument(_inclusiveLowerBound > lowerBound, "Invalid range: %s", rangePredicate);
+      }
+      if (upperInclusive) {
+        _inclusiveUpperBound = upperBound;
+      } else {
+        _inclusiveUpperBound = upperBound - 1;
+        Preconditions.checkArgument(_inclusiveUpperBound < upperBound, "Invalid range: %s", rangePredicate);
+      }
     }
 
-    /**
-     * Returns the inclusive lower bound of the range.
-     */
-    public int getLowerBound() {
-      return _lowerInclusive ? _lowerBound : _lowerBound + 1;
+    public int getInclusiveLowerBound() {
+      return _inclusiveLowerBound;
     }
 
-    /**
-     * Returns the inclusive upper bound of the range.
-     */
-    public int getUpperBound() {
-      return _upperInclusive ? _upperBound : _upperBound - 1;
+    public int getInclusiveUpperBound() {
+      return _inclusiveUpperBound;
     }
 
     @Override
@@ -306,48 +307,37 @@ public class RangePredicateEvaluatorFactory {
 
     @Override
     public boolean applySV(int value) {
-      boolean result;
-      if (_lowerInclusive) {
-        result = _lowerBound <= value;
-      } else {
-        result = _lowerBound < value;
-      }
-      if (_upperInclusive) {
-        result &= _upperBound >= value;
-      } else {
-        result &= _upperBound > value;
-      }
-      return result;
+      return value >= _inclusiveLowerBound && value <= _inclusiveUpperBound;
     }
   }
 
   public static final class LongRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
-    final long _lowerBound;
-    final long _upperBound;
-    final boolean _lowerInclusive;
-    final boolean _upperInclusive;
+    final long _inclusiveLowerBound;
+    final long _inclusiveUpperBound;
 
     LongRawValueBasedRangePredicateEvaluator(RangePredicate rangePredicate, long lowerBound, long upperBound,
         boolean lowerInclusive, boolean upperInclusive) {
       super(rangePredicate);
-      _lowerBound = lowerBound;
-      _upperBound = upperBound;
-      _lowerInclusive = lowerInclusive;
-      _upperInclusive = upperInclusive;
+      if (lowerInclusive) {
+        _inclusiveLowerBound = lowerBound;
+      } else {
+        _inclusiveLowerBound = lowerBound + 1;
+        Preconditions.checkArgument(_inclusiveLowerBound > lowerBound, "Invalid range: %s", rangePredicate);
+      }
+      if (upperInclusive) {
+        _inclusiveUpperBound = upperBound;
+      } else {
+        _inclusiveUpperBound = upperBound - 1;
+        Preconditions.checkArgument(_inclusiveUpperBound < upperBound, "Invalid range: %s", rangePredicate);
+      }
     }
 
-    /**
-     * Returns the inclusive lower bound of the range.
-     */
-    public long getLowerBound() {
-      return _lowerInclusive ? _lowerBound : _lowerBound + 1;
+    public long getInclusiveLowerBound() {
+      return _inclusiveLowerBound;
     }
 
-    /**
-     * Returns the inclusive upper bound of the range.
-     */
-    public long getUpperBound() {
-      return _upperInclusive ? _upperBound : _upperBound - 1;
+    public long getInclusiveUpperBound() {
+      return _inclusiveUpperBound;
     }
 
     @Override
@@ -357,48 +347,37 @@ public class RangePredicateEvaluatorFactory {
 
     @Override
     public boolean applySV(long value) {
-      boolean result;
-      if (_lowerInclusive) {
-        result = _lowerBound <= value;
-      } else {
-        result = _lowerBound < value;
-      }
-      if (_upperInclusive) {
-        result &= _upperBound >= value;
-      } else {
-        result &= _upperBound > value;
-      }
-      return result;
+      return value >= _inclusiveLowerBound && value <= _inclusiveUpperBound;
     }
   }
 
   public static final class FloatRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
-    final float _lowerBound;
-    final float _upperBound;
-    final boolean _lowerInclusive;
-    final boolean _upperInclusive;
+    final float _inclusiveLowerBound;
+    final float _inclusiveUpperBound;
 
     FloatRawValueBasedRangePredicateEvaluator(RangePredicate rangePredicate, float lowerBound, float upperBound,
         boolean lowerInclusive, boolean upperInclusive) {
       super(rangePredicate);
-      _lowerBound = lowerBound;
-      _upperBound = upperBound;
-      _lowerInclusive = lowerInclusive;
-      _upperInclusive = upperInclusive;
+      if (lowerInclusive) {
+        _inclusiveLowerBound = lowerBound;
+      } else {
+        _inclusiveLowerBound = Math.nextUp(lowerBound);
+        Preconditions.checkArgument(_inclusiveLowerBound > lowerBound, "Invalid range: %s", rangePredicate);
+      }
+      if (upperInclusive) {
+        _inclusiveUpperBound = upperBound;
+      } else {
+        _inclusiveUpperBound = Math.nextDown(upperBound);
+        Preconditions.checkArgument(_inclusiveUpperBound < upperBound, "Invalid range: %s", rangePredicate);
+      }
     }
 
-    /**
-     * Returns the inclusive lower bound of the range.
-     */
-    public float getLowerBound() {
-      return _lowerInclusive ? _lowerBound : _lowerBound + Float.MIN_VALUE;
+    public float getInclusiveLowerBound() {
+      return _inclusiveLowerBound;
     }
 
-    /**
-     * Returns the inclusive upper bound of the range.
-     */
-    public float getUpperBound() {
-      return _upperInclusive ? _upperBound : _upperBound - Float.MIN_VALUE;
+    public float getInclusiveUpperBound() {
+      return _inclusiveUpperBound;
     }
 
     @Override
@@ -408,48 +387,37 @@ public class RangePredicateEvaluatorFactory {
 
     @Override
     public boolean applySV(float value) {
-      boolean result;
-      if (_lowerInclusive) {
-        result = _lowerBound <= value;
-      } else {
-        result = _lowerBound < value;
-      }
-      if (_upperInclusive) {
-        result &= _upperBound >= value;
-      } else {
-        result &= _upperBound > value;
-      }
-      return result;
+      return value >= _inclusiveLowerBound && value <= _inclusiveUpperBound;
     }
   }
 
   public static final class DoubleRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
-    final double _lowerBound;
-    final double _upperBound;
-    final boolean _lowerInclusive;
-    final boolean _upperInclusive;
+    final double _inclusiveLowerBound;
+    final double _inclusiveUpperBound;
 
     DoubleRawValueBasedRangePredicateEvaluator(RangePredicate rangePredicate, double lowerBound, double upperBound,
         boolean lowerInclusive, boolean upperInclusive) {
       super(rangePredicate);
-      _lowerBound = lowerBound;
-      _upperBound = upperBound;
-      _lowerInclusive = lowerInclusive;
-      _upperInclusive = upperInclusive;
+      if (lowerInclusive) {
+        _inclusiveLowerBound = lowerBound;
+      } else {
+        _inclusiveLowerBound = Math.nextUp(lowerBound);
+        Preconditions.checkArgument(_inclusiveLowerBound > lowerBound, "Invalid range: %s", rangePredicate);
+      }
+      if (upperInclusive) {
+        _inclusiveUpperBound = upperBound;
+      } else {
+        _inclusiveUpperBound = Math.nextDown(upperBound);
+        Preconditions.checkArgument(_inclusiveUpperBound < upperBound, "Invalid range: %s", rangePredicate);
+      }
     }
 
-    /**
-     * Returns the inclusive lower bound of the range.
-     */
-    public double getLowerBound() {
-      return _lowerInclusive ? _lowerBound : _lowerBound + Double.MIN_VALUE;
+    public double getInclusiveLowerBound() {
+      return _inclusiveLowerBound;
     }
 
-    /**
-     * Returns the inclusive upper bound of the range.
-     */
-    public double getUpperBound() {
-      return _upperInclusive ? _upperBound : _upperBound - Double.MIN_VALUE;
+    public double getInclusiveUpperBound() {
+      return _inclusiveUpperBound;
     }
 
     @Override
@@ -459,34 +427,23 @@ public class RangePredicateEvaluatorFactory {
 
     @Override
     public boolean applySV(double value) {
-      boolean result;
-      if (_lowerInclusive) {
-        result = _lowerBound <= value;
-      } else {
-        result = _lowerBound < value;
-      }
-      if (_upperInclusive) {
-        result &= _upperBound >= value;
-      } else {
-        result &= _upperBound > value;
-      }
-      return result;
+      return value >= _inclusiveLowerBound && value <= _inclusiveUpperBound;
     }
   }
 
   public static final class BigDecimalRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
     final BigDecimal _lowerBound;
     final BigDecimal _upperBound;
-    final boolean _lowerInclusive;
-    final boolean _upperInclusive;
+    final int _lowerComparisonValue;
+    final int _upperComparisonValue;
 
     BigDecimalRawValueBasedRangePredicateEvaluator(RangePredicate rangePredicate, BigDecimal lowerBound,
         BigDecimal upperBound, boolean lowerInclusive, boolean upperInclusive) {
       super(rangePredicate);
       _lowerBound = lowerBound;
       _upperBound = upperBound;
-      _lowerInclusive = lowerInclusive;
-      _upperInclusive = upperInclusive;
+      _lowerComparisonValue = lowerInclusive ? 0 : 1;
+      _upperComparisonValue = upperInclusive ? 0 : -1;
     }
 
     @Override
@@ -496,30 +453,24 @@ public class RangePredicateEvaluatorFactory {
 
     @Override
     public boolean applySV(BigDecimal value) {
-      boolean result = true;
-      if (_lowerBound != null) {
-        result = _lowerInclusive ? _lowerBound.compareTo(value) <= 0 : _lowerBound.compareTo(value) < 0;
-      }
-      if (_upperBound != null) {
-        result &= _upperInclusive ? _upperBound.compareTo(value) >= 0 : _upperBound.compareTo(value) > 0;
-      }
-      return result;
+      return (_lowerBound == null || value.compareTo(_lowerBound) >= _lowerComparisonValue) && (_upperBound == null
+          || value.compareTo(_upperBound) <= _upperComparisonValue);
     }
   }
 
   private static final class StringRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
     final String _lowerBound;
     final String _upperBound;
-    final boolean _lowerInclusive;
-    final boolean _upperInclusive;
+    final int _lowerComparisonValue;
+    final int _upperComparisonValue;
 
     StringRawValueBasedRangePredicateEvaluator(RangePredicate rangePredicate, String lowerBound, String upperBound,
         boolean lowerInclusive, boolean upperInclusive) {
       super(rangePredicate);
       _lowerBound = lowerBound;
       _upperBound = upperBound;
-      _lowerInclusive = lowerInclusive;
-      _upperInclusive = upperInclusive;
+      _lowerComparisonValue = lowerInclusive ? 0 : 1;
+      _upperComparisonValue = upperInclusive ? 0 : -1;
     }
 
     @Override
@@ -529,38 +480,24 @@ public class RangePredicateEvaluatorFactory {
 
     @Override
     public boolean applySV(String value) {
-      boolean result = true;
-      if (_lowerBound != null) {
-        if (_lowerInclusive) {
-          result = _lowerBound.compareTo(value) <= 0;
-        } else {
-          result = _lowerBound.compareTo(value) < 0;
-        }
-      }
-      if (_upperBound != null) {
-        if (_upperInclusive) {
-          result &= _upperBound.compareTo(value) >= 0;
-        } else {
-          result &= _upperBound.compareTo(value) > 0;
-        }
-      }
-      return result;
+      return (_lowerBound == null || value.compareTo(_lowerBound) >= _lowerComparisonValue) && (_upperBound == null
+          || value.compareTo(_upperBound) <= _upperComparisonValue);
     }
   }
 
   private static final class BytesRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
     final byte[] _lowerBound;
     final byte[] _upperBound;
-    final boolean _lowerInclusive;
-    final boolean _upperInclusive;
+    final int _lowerComparisonValue;
+    final int _upperComparisonValue;
 
     BytesRawValueBasedRangePredicateEvaluator(RangePredicate rangePredicate, byte[] lowerBound, byte[] upperBound,
         boolean lowerInclusive, boolean upperInclusive) {
       super(rangePredicate);
       _lowerBound = lowerBound;
       _upperBound = upperBound;
-      _lowerInclusive = lowerInclusive;
-      _upperInclusive = upperInclusive;
+      _lowerComparisonValue = lowerInclusive ? 0 : 1;
+      _upperComparisonValue = upperInclusive ? 0 : -1;
     }
 
     @Override
@@ -570,22 +507,8 @@ public class RangePredicateEvaluatorFactory {
 
     @Override
     public boolean applySV(byte[] value) {
-      boolean result = true;
-      if (_lowerBound != null) {
-        if (_lowerInclusive) {
-          result = ByteArray.compare(_lowerBound, value) <= 0;
-        } else {
-          result = ByteArray.compare(_lowerBound, value) < 0;
-        }
-      }
-      if (_upperBound != null) {
-        if (_upperInclusive) {
-          result &= ByteArray.compare(_upperBound, value) >= 0;
-        } else {
-          result &= ByteArray.compare(_upperBound, value) > 0;
-        }
-      }
-      return result;
+      return (_lowerBound == null || ByteArray.compare(value, _lowerBound) >= _lowerComparisonValue) && (
+          _upperBound == null || ByteArray.compare(value, _upperBound) <= _upperComparisonValue);
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/RangeQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/RangeQueriesTest.java
@@ -143,8 +143,8 @@ public class RangeQueriesTest extends BaseQueriesTest {
         {buildSelectionQuery(DICTIONARIZED_INT_COL, 250, 500, false), 250, 500, false},
         {buildSelectionQuery(RAW_INT_COL, 250, 500, false), 250, 500, false},
         {buildSelectionQuery(RAW_LONG_COL, 250, 500, false), 250, 500, false},
-        {buildSelectionQuery(RAW_FLOAT_COL, 250, 500, false), 250, 500, true},
-        {buildSelectionQuery(RAW_DOUBLE_COL, 250, 500, false), 250, 500, true},
+        {buildSelectionQuery(RAW_FLOAT_COL, 250, 500, false), 250, 500, false},
+        {buildSelectionQuery(RAW_DOUBLE_COL, 250, 500, false), 250, 500, false},
     };
   }
 
@@ -169,8 +169,8 @@ public class RangeQueriesTest extends BaseQueriesTest {
         {buildCountQuery(DICTIONARIZED_INT_COL, 250, 500, false), 2},
         {buildCountQuery(RAW_INT_COL, 250, 500, false), 2},
         {buildCountQuery(RAW_LONG_COL, 250, 500, false), 2},
-        {buildCountQuery(RAW_FLOAT_COL, 250, 500, false), 3},
-        {buildCountQuery(RAW_DOUBLE_COL, 250, 500, false), 3},
+        {buildCountQuery(RAW_FLOAT_COL, 250, 500, false), 2},
+        {buildCountQuery(RAW_DOUBLE_COL, 250, 500, false), 2},
     };
   }
 


### PR DESCRIPTION
Borrow the same idea as in #8703, we can reflect the inclusiveness of the value bound through the comparison value to avoid extra per value if check. Also, if the lower bound comparison already fails, we may short-circuit the comparison for the upper bound.

Here are the benchmark result, each operation applies 30K values:
Before the change:
```
Benchmark                              Mode  Cnt    Score     Error  Units
BenchmarkRangeApplySV.doubleEvaluator  avgt    5   96.914 ±   5.245  us/op
BenchmarkRangeApplySV.floatEvaluator   avgt    5   98.179 ±   7.607  us/op
BenchmarkRangeApplySV.intEvaluator     avgt    5  111.091 ±   1.061  us/op
BenchmarkRangeApplySV.longEvaluator    avgt    5   95.441 ±   2.418  us/op
BenchmarkRangeApplySV.stringEvaluator  avgt    5  467.129 ±  89.302  us/op
```
After the change:
```
Benchmark                              Mode  Cnt    Score     Error  Units
BenchmarkRangeApplySV.doubleEvaluator  avgt    5   68.947 ±   1.562  us/op
BenchmarkRangeApplySV.floatEvaluator   avgt    5   78.496 ±   5.309  us/op
BenchmarkRangeApplySV.intEvaluator     avgt    5   66.792 ±   5.647  us/op
BenchmarkRangeApplySV.longEvaluator    avgt    5   67.519 ±   6.929  us/op
BenchmarkRangeApplySV.stringEvaluator  avgt    5  423.882 ± 135.095  us/op
```
Benchmark class:
```
@BenchmarkMode(Mode.AverageTime)
@OutputTimeUnit(TimeUnit.MICROSECONDS)
@Fork(1)
@Warmup(iterations = 3, time = 10)
@Measurement(iterations = 5, time = 10)
@State(Scope.Benchmark)
public class BenchmarkRangeApplySV {
  BaseRawValueBasedPredicateEvaluator _intEvaluator;
  BaseRawValueBasedPredicateEvaluator _longEvaluator;
  BaseRawValueBasedPredicateEvaluator _floatEvaluator;
  BaseRawValueBasedPredicateEvaluator _doubleEvaluator;
  BaseRawValueBasedPredicateEvaluator _stringEvaluator;

  @Setup
  public void setUp()
      throws Exception {
    RangePredicate rangePredicate = new RangePredicate(null, true, "10000", false, "20000");
    _intEvaluator = RangePredicateEvaluatorFactory.newRawValueBasedEvaluator(rangePredicate, FieldSpec.DataType.INT);
    _longEvaluator = RangePredicateEvaluatorFactory.newRawValueBasedEvaluator(rangePredicate, FieldSpec.DataType.LONG);
    _floatEvaluator =
        RangePredicateEvaluatorFactory.newRawValueBasedEvaluator(rangePredicate, FieldSpec.DataType.FLOAT);
    _doubleEvaluator =
        RangePredicateEvaluatorFactory.newRawValueBasedEvaluator(rangePredicate, FieldSpec.DataType.DOUBLE);
    _stringEvaluator =
        RangePredicateEvaluatorFactory.newRawValueBasedEvaluator(rangePredicate, FieldSpec.DataType.STRING);
  }

  @Benchmark
  public void intEvaluator(Blackhole bh) {
    for (int i = 0; i < 30000; i++) {
      bh.consume(_intEvaluator.applySV(i));
    }
  }

  @Benchmark
  public void longEvaluator(Blackhole bh) {
    for (int i = 0; i < 30000; i++) {
      bh.consume(_longEvaluator.applySV((long) i));
    }
  }

  @Benchmark
  public void floatEvaluator(Blackhole bh) {
    for (int i = 0; i < 30000; i++) {
      bh.consume(_floatEvaluator.applySV((float) i));
    }
  }

  @Benchmark
  public void doubleEvaluator(Blackhole bh) {
    for (int i = 0; i < 30000; i++) {
      bh.consume(_doubleEvaluator.applySV((double) i));
    }
  }

  @Benchmark
  public void stringEvaluator(Blackhole bh) {
    for (int i = 0; i < 30000; i++) {
      bh.consume(_stringEvaluator.applySV(Integer.toString(i)));
    }
  }
}
```