### PR TITLE
Add histogram aggregation function `feature` 

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
@@ -466,6 +467,8 @@ public class DataSchema {
           doubleValues[i] = longValues[i];
         }
         return doubleValues;
+      } else if (value instanceof DoubleArrayList) {
+        return ((DoubleArrayList) value).elements();
       } else {
         float[] floatValues = (float[]) value;
         int length = floatValues.length;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -451,6 +451,8 @@ public class DataSchema {
     private static double[] toDoubleArray(Object value) {
       if (value instanceof double[]) {
         return (double[]) value;
+      } else if (value instanceof DoubleArrayList) {
+        return ((DoubleArrayList) value).elements();
       } else if (value instanceof int[]) {
         int[] intValues = (int[]) value;
         int length = intValues.length;
@@ -467,8 +469,6 @@ public class DataSchema {
           doubleValues[i] = longValues[i];
         }
         return doubleValues;
-      } else if (value instanceof DoubleArrayList) {
-        return ((DoubleArrayList) value).elements();
       } else {
         float[] floatValues = (float[]) value;
         int length = floatValues.length;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -273,7 +273,8 @@ public class AggregationFunctionFactory {
         }
       }
     } catch (Exception e) {
-      throw new BadQueryRequestException("Invalid aggregation function: " + function);
+      throw new BadQueryRequestException(
+          "Invalid aggregation function: " + function + ", Exception: " + e.getMessage());
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -274,7 +274,7 @@ public class AggregationFunctionFactory {
       }
     } catch (Exception e) {
       throw new BadQueryRequestException(
-          "Invalid aggregation function: " + function + ", Exception: " + e.getMessage());
+          "Invalid aggregation function: " + function + "; Reason: " + e.getMessage());
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -266,6 +266,8 @@ public class AggregationFunctionFactory {
                 queryContext.getLimit());
           case STUNION:
             return new StUnionAggregationFunction(firstArgument);
+          case HISTOGRAM:
+            return new HistogramAggregationFunction(arguments);
           default:
             throw new IllegalArgumentException();
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/HistogramAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/HistogramAggregationFunction.java
@@ -53,7 +53,7 @@ public class HistogramAggregationFunction extends BaseSingleInputAggregationFunc
     super(arguments.get(0));
     int numArguments = arguments.size();
     Preconditions.checkArgument(numArguments == 4 || numArguments == 2, "Histogram expects 2 or 4 arguments, got: %s;"
-        + "usage example: `Histogram(columnName, ARRAY[0,1,10,100])` to specify bins [0,1), [1,10), [10,1000] or "
+        + " usage example: `Histogram(columnName, ARRAY[0,1,10,100])` to specify bins [0,1), [1,10), [10,1000] or "
         + "`Histogram(columnName, 0, 1000, 10)` to specify 10 equal-length bins "
         + "[0,100), [100,200), ..., [900,1000]", numArguments);
     if (numArguments == 2) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/HistogramAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/HistogramAggregationFunction.java
@@ -1,0 +1,361 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.core.query.aggregation.utils.DoubleVectorOpUtils;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
+
+
+/**
+ * Histogram for single-value numerical columns
+ * usage example:
+ * `Histogram(columnName, ARRAY[0,1,10,100])` to specify bins [0,1), [1,10), [10,1000] or
+ * `Histogram(columnName, 0, 1000, 10)` to specify 10 equal-length bins [0,100), [100,200), ..., [900,1000]
+ */
+public class HistogramAggregationFunction extends BaseSingleInputAggregationFunction<DoubleArrayList, DoubleArrayList> {
+
+  private static final String ARRAY_CONSTRUCTOR = "arrayvalueconstructor";
+  private static final int INVALID_BIN = -1;
+  double[] _bucketEdges;
+  boolean _isEqualLength = false;
+  double _lower;
+  double _upper;
+  double _binLength;
+
+  public HistogramAggregationFunction(List<ExpressionContext> arguments) {
+    super(arguments.get(0));
+    int numArguments = arguments.size();
+    Preconditions.checkArgument(numArguments == 4 || numArguments == 2, "Histogram expects 2 or 4 arguments, got: %s;"
+        + "usage example: `Histogram(columnName, ARRAY[0,1,10,100])` to specify bins [0,1), [1,10), [10,1000] or "
+        + "`Histogram(columnName, 0, 1000, 10)` to specify 10 equal-length bins "
+        + "[0,100), [100,200), ..., [900,1000]", numArguments);
+    if (numArguments == 2) {
+      ExpressionContext arrayExpression = arguments.get(1);
+      Preconditions.checkArgument(
+          (arrayExpression.getType() == ExpressionContext.Type.FUNCTION) && (arrayExpression.getFunction()
+              .getFunctionName().equals(ARRAY_CONSTRUCTOR)),
+          "Please use the format of `Histogram(columnName, ARRAY[1,10,100])` to specify the bin edges");
+      _bucketEdges = parseVector(arrayExpression.getFunction().getArguments());
+      _lower = _bucketEdges[0];
+      _upper = _bucketEdges[_bucketEdges.length - 1];
+    } else {
+      _isEqualLength = true;
+      _lower = Double.parseDouble(arguments.get(1).getLiteral());
+      _upper = Double.parseDouble(arguments.get(2).getLiteral());
+      int numBins = Integer.parseInt(arguments.get(3).getLiteral());
+      Preconditions.checkArgument(_upper > _lower,
+          "The right most edge must be greater than left most edge, given %s and %s", _lower, _upper);
+      Preconditions.checkArgument(numBins > 0, "The number of bins must be greater than zero, given %s", numBins);
+      _bucketEdges = new double[numBins + 1];
+      _bucketEdges[0] = _lower;
+      _bucketEdges[numBins] = _upper;
+      _binLength = (_upper - _lower) / numBins;
+      for (int i = 1; i < numBins; i++) {
+        _bucketEdges[i] = i * _binLength + _lower;
+      }
+    }
+  }
+
+  int getNumBins() {
+    return _bucketEdges.length - 1;
+  }
+
+  int getNumEdges() {
+    return _bucketEdges.length;
+  }
+
+  private double[] parseVector(List<ExpressionContext> arrayStr) {
+    int len = arrayStr.size();
+    Preconditions.checkArgument(len > 1, "The number of bin edges must be greater than 1");
+    double[] ret = new double[len];
+    for (int i = 0; i < len; i++) {
+      ret[i] = Double.parseDouble(arrayStr.get(i).getLiteral());
+      if (i > 0) {
+        Preconditions.checkState(ret[i] > ret[i - 1], "The bin edges must be strictly increasing");
+      }
+    }
+    return ret;
+  }
+
+  /**
+   * Find the bin id for the input value. Use division for equal-length bins, and binary search otherwise.
+   * @param val input value
+   * @return bin id
+   */
+  private int getBinId(double val) {
+    if (val > _upper || val < _lower) {
+      return INVALID_BIN;
+    }
+    if (val == _upper) {
+      return getNumBins() - 1;
+    }
+    int id;
+    if (_isEqualLength) {
+      id = (int) Math.floor((val - _lower) / _binLength);
+    } else {
+      int i = 0;
+      int j = this.getNumEdges() - 1;
+      while (i < j) {
+        int mid = (i + j + 1) / 2;
+        if (_bucketEdges[mid] > val) {
+          j = mid - 1;
+        } else {
+          i = mid;
+        }
+      }
+     id = i;
+    }
+    return id;
+  }
+
+  @Override
+  public AggregationFunctionType getType() {
+    return AggregationFunctionType.HISTOGRAM;
+  }
+
+  @Override
+  public AggregationResultHolder createAggregationResultHolder() {
+    return new ObjectAggregationResultHolder();
+  }
+
+  @Override
+  public GroupByResultHolder createGroupByResultHolder(int initialCapacity, int maxCapacity) {
+    return new ObjectGroupByResultHolder(initialCapacity, maxCapacity);
+  }
+
+  @Override
+  public DoubleArrayList extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
+    DoubleArrayList aggregationResultHolderResult = aggregationResultHolder.getResult();
+    int count = aggregationResultHolderResult.size();
+    if (count < 1) {
+      throw new IllegalStateException("histogram result shouldn't be empty!");
+    } else {
+      return aggregationResultHolderResult;
+    }
+  }
+
+  @Override
+  public DoubleArrayList extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
+    return groupByResultHolder.getResult(groupKey);
+  }
+
+  @Override
+  public DoubleArrayList merge(DoubleArrayList intermediateResult1, DoubleArrayList intermediateResult2) {
+    DoubleVectorOpUtils.vectorAdd(intermediateResult1, intermediateResult2);
+    return intermediateResult1;
+  }
+
+  @Override
+  public ColumnDataType getIntermediateResultColumnType() {
+    return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.DOUBLE_ARRAY;
+  }
+
+  @Override
+  public DoubleArrayList extractFinalResult(DoubleArrayList doubleArrayList) {
+    int count = doubleArrayList.size();
+    if (count < 1L) {
+      throw new IllegalStateException("histogram result shouldn't be empty!");
+    } else {
+      return new DoubleArrayList(doubleArrayList.elements());
+    }
+  }
+
+  @Override
+  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    Preconditions.checkState(blockValSet.isSingleValue(), "Histogram currently only supports single-valued column");
+    switch (blockValSet.getValueType().getStoredType()) {
+      case INT: {
+        int[] values = blockValSet.getIntValuesSV();
+        for (int i = 0; i < length && i < values.length; i++) {
+          double value = values[i];
+          for (int groupKey : groupKeysArray[i]) {
+            setGroupByResult(groupKey, groupByResultHolder, value);
+          }
+        }
+        break;
+      }
+      case LONG: {
+        long[] values = blockValSet.getLongValuesSV();
+        for (int i = 0; i < length && i < values.length; i++) {
+          double value = values[i];
+          for (int groupKey : groupKeysArray[i]) {
+            setGroupByResult(groupKey, groupByResultHolder, value);
+          }
+        }
+        break;
+      }
+      case FLOAT: {
+        float[] values = blockValSet.getFloatValuesSV();
+        for (int i = 0; i < length && i < values.length; i++) {
+          double value = values[i];
+          for (int groupKey : groupKeysArray[i]) {
+            setGroupByResult(groupKey, groupByResultHolder, value);
+          }
+        }
+        break;
+      }
+      case DOUBLE: {
+        double[] values = blockValSet.getDoubleValuesSV();
+        for (int i = 0; i < length && i < values.length; i++) {
+          double value = values[i];
+          for (int groupKey : groupKeysArray[i]) {
+            setGroupByResult(groupKey, groupByResultHolder, value);
+          }
+        }
+        break;
+      }
+      default:
+        throw new IllegalStateException("Cannot compute histogram for non-numeric type: " + blockValSet.getValueType());
+    }
+  }
+
+  @Override
+  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    switch (blockValSet.getValueType().getStoredType()) {
+      case INT: {
+        int[] values = blockValSet.getIntValuesSV();
+        for (int i = 0; i < length && i < values.length; i++) {
+          setGroupByResult(groupKeyArray[i], groupByResultHolder, values[i]);
+        }
+        break;
+      }
+      case LONG: {
+        long[] values = blockValSet.getLongValuesSV();
+        for (int i = 0; i < length && i < values.length; i++) {
+          setGroupByResult(groupKeyArray[i], groupByResultHolder, values[i]);
+        }
+        break;
+      }
+      case FLOAT: {
+        float[] values = blockValSet.getFloatValuesSV();
+        for (int i = 0; i < length && i < values.length; i++) {
+          setGroupByResult(groupKeyArray[i], groupByResultHolder, values[i]);
+        }
+        break;
+      }
+      case DOUBLE: {
+        double[] values = blockValSet.getDoubleValuesSV();
+        for (int i = 0; i < length && i < values.length; i++) {
+          setGroupByResult(groupKeyArray[i], groupByResultHolder, values[i]);
+        }
+        break;
+      }
+      default:
+        throw new IllegalStateException("Cannot compute histogram for non-numeric type: " + blockValSet.getValueType());
+    }
+  }
+
+  protected void setGroupByResult(int groupKey, GroupByResultHolder groupByResultHolder, double val) {
+    int binID = getBinId(val);
+    DoubleArrayList byResultHolderResult = groupByResultHolder.getResult(groupKey);
+    if (byResultHolderResult == null) {
+      byResultHolderResult = DoubleVectorOpUtils.createAndInitialize(getNumBins());
+      groupByResultHolder.setValueForKey(groupKey, byResultHolderResult);
+    }
+    if (binID != INVALID_BIN) {
+      DoubleVectorOpUtils.incrementElementByOne(byResultHolderResult, binID);
+    }
+  }
+
+  @Override
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    //TODO: Add MV support for histogram
+    Preconditions.checkState(blockValSet.isSingleValue(), "Histogram currently only supports single-valued column");
+    double[] histogram = new double[this.getNumBins()];
+    switch (blockValSet.getValueType().getStoredType()) {
+      case INT: {
+        int[] values = blockValSet.getIntValuesSV();
+        for (int i = 0; i < length && i < values.length; i++) {
+          int binId = this.getBinId(values[i]);
+          if (binId != INVALID_BIN) {
+            histogram[binId] += 1;
+          }
+        }
+        setAggregationResult(aggregationResultHolder, histogram);
+        break;
+      }
+      case LONG: {
+        long[] values = blockValSet.getLongValuesSV();
+        for (int i = 0; i < length && i < values.length; i++) {
+          int binId = this.getBinId(values[i]);
+          if (binId != INVALID_BIN) {
+            histogram[binId] += 1;
+          }
+        }
+        setAggregationResult(aggregationResultHolder, histogram);
+        break;
+      }
+      case FLOAT: {
+        float[] values = blockValSet.getFloatValuesSV();
+        for (int i = 0; i < length && i < values.length; i++) {
+          int binId = this.getBinId(values[i]);
+          if (binId != INVALID_BIN) {
+            histogram[binId] += 1;
+          }
+        }
+        setAggregationResult(aggregationResultHolder, histogram);
+        break;
+      }
+      case DOUBLE: {
+        double[] values = blockValSet.getDoubleValuesSV();
+        for (int i = 0; i < length && i < values.length; i++) {
+          int binId = this.getBinId(values[i]);
+          if (binId != INVALID_BIN) {
+            histogram[binId] += 1;
+          }
+        }
+        setAggregationResult(aggregationResultHolder, histogram);
+        break;
+      }
+      default:
+        throw new IllegalStateException("Cannot compute histogram for non-numeric type: " + blockValSet.getValueType());
+    }
+  }
+
+  protected void setAggregationResult(AggregationResultHolder aggregationResultHolder, double[] histogram) {
+    DoubleArrayList aggregatedHistogram = aggregationResultHolder.getResult();
+    if (aggregatedHistogram == null) {
+      aggregationResultHolder.setValue(DoubleVectorOpUtils.createAndInitialize(histogram));
+    } else {
+      DoubleVectorOpUtils.vectorAdd(aggregatedHistogram, histogram);
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/DoubleVectorOpUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/utils/DoubleVectorOpUtils.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.utils;
+
+import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+
+
+public class DoubleVectorOpUtils {
+  private DoubleVectorOpUtils() {
+  }
+
+  public static DoubleArrayList vectorAdd(DoubleArrayList a, DoubleArrayList b) {
+    Preconditions.checkState(a.size() == b.size(), "The two operand arrays are not of the same size! provided %s, %s",
+        a.size(), b.size());
+    for (int i = 0; i < a.size(); i++) {
+      a.elements()[i] += b.elements()[i];
+    }
+    return a;
+  }
+
+  public static DoubleArrayList vectorAdd(DoubleArrayList a, double[] b) {
+    Preconditions.checkState(a.size() == b.length, "The two operand arrays are not of the same size! provided %s, %s",
+        a.size(), b.length);
+    ;
+    for (int i = 0; i < a.size(); i++) {
+      a.elements()[i] += b[i];
+    }
+    return a;
+  }
+
+  /**
+   * return a new DoubleArrayList initialized with a
+   * @param a array to initialize
+   * @return a new DoubleArrayList initialized with a
+   */
+  public static DoubleArrayList createAndInitialize(double[] a) {
+    return new DoubleArrayList(a);
+  }
+
+  /**
+   * return a new DoubleArrayList with all zeros
+   * @param len length of array
+   * @return a new DoubleArrayList with all zeros
+   */
+  public static DoubleArrayList createAndInitialize(int len) {
+    Preconditions.checkState(len > 0, "Asking for an array of length %s", len);
+    return new DoubleArrayList(new double[len]);
+  }
+
+  public static DoubleArrayList incrementElement(DoubleArrayList a, int offset, double val) {
+    Preconditions.checkState(a.size() > offset, "The offset %s exceeds the array size!", offset);
+    a.elements()[offset] += val;
+    return a;
+  }
+
+  public static DoubleArrayList incrementElementByOne(DoubleArrayList a, int offset) {
+    return incrementElement(a, offset, 1d);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/HistogramQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/HistogramQueriesTest.java
@@ -1,0 +1,251 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
+import org.apache.pinot.core.operator.query.AggregationGroupByOrderByOperator;
+import org.apache.pinot.core.operator.query.AggregationOperator;
+import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Queries test for histogram queries.
+ */
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class HistogramQueriesTest extends BaseQueriesTest {
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "HistogramQueriesTest");
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String SEGMENT_NAME = "testSegment";
+  private static final Random RANDOM = new Random();
+
+  private static final int NUM_RECORDS = 2000;
+  private static final int MAX_VALUE = 3000;
+
+  private static final String INT_COLUMN = "intColumn";
+  private static final String LONG_COLUMN = "longColumn";
+  private static final String FLOAT_COLUMN = "floatColumn";
+  private static final String DOUBLE_COLUMN = "doubleColumn";
+  private static final Schema SCHEMA = new Schema.SchemaBuilder().addSingleValueDimension(INT_COLUMN, DataType.INT)
+      .addSingleValueDimension(LONG_COLUMN, DataType.LONG).addSingleValueDimension(FLOAT_COLUMN, DataType.FLOAT)
+      .addSingleValueDimension(DOUBLE_COLUMN, DataType.DOUBLE).build();
+  private static final TableConfig TABLE_CONFIG =
+      new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+
+  private IndexSegment _indexSegment;
+  private List<IndexSegment> _indexSegments;
+
+  @Override
+  protected String getFilter() {
+    return " WHERE intColumn >=  500";
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteDirectory(INDEX_DIR);
+
+    List<GenericRow> records = new ArrayList<>(NUM_RECORDS);
+    for (int i = 0; i < NUM_RECORDS; i++) {
+      GenericRow record = new GenericRow();
+      record.putValue(INT_COLUMN, i);
+      record.putValue(LONG_COLUMN, (long) i - NUM_RECORDS / 2);
+      record.putValue(FLOAT_COLUMN, (float) i * 0.5);
+      record.putValue(DOUBLE_COLUMN, (double) i);
+      records.add(record);
+    }
+
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE_CONFIG, SCHEMA);
+    segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
+    segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
+    segmentGeneratorConfig.setOutDir(INDEX_DIR.getPath());
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records));
+    driver.build();
+
+    ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.mmap);
+    _indexSegment = immutableSegment;
+    _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
+  }
+
+  @Test
+  public void testAggregationOnlyVer1() {
+    String query = "SELECT HISTOGRAM(intColumn,ARRAY[0,1,10,100,1000,10000]) FROM testTable";
+
+    // Inner segment
+    Object operator = getOperator(query);
+    assertTrue(operator instanceof AggregationOperator);
+    IntermediateResultsBlock resultsBlock = ((AggregationOperator) operator).nextBlock();
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(((Operator) operator).getExecutionStatistics(), NUM_RECORDS, 0,
+        NUM_RECORDS, NUM_RECORDS);
+    List<Object> aggregationResult = resultsBlock.getAggregationResult();
+    assertNotNull(aggregationResult);
+    assertEquals(((DoubleArrayList) aggregationResult.get(0)).elements(), new double[]{1, 9, 90, 900, 1000});
+
+    query = "SELECT HISTOGRAM(intColumn,ARRAY[\"-Infinity\",1,10,100,1000,\"Infinity\"]) FROM testTable";
+
+    // Inner segment
+    operator = getOperator(query);
+    assertTrue(operator instanceof AggregationOperator);
+    resultsBlock = ((AggregationOperator) operator).nextBlock();
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(((Operator) operator).getExecutionStatistics(), NUM_RECORDS, 0,
+        NUM_RECORDS, NUM_RECORDS);
+    aggregationResult = resultsBlock.getAggregationResult();
+    assertNotNull(aggregationResult);
+    assertEquals(((DoubleArrayList) aggregationResult.get(0)).elements(), new double[]{1, 9, 90, 900, 1000});
+
+    operator = getOperatorWithFilter(query);
+    assertTrue(operator instanceof AggregationOperator);
+    resultsBlock = ((AggregationOperator) operator).nextBlock();
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(((Operator) operator).getExecutionStatistics(), 1500, 0, 1500,
+        NUM_RECORDS);
+    aggregationResult = resultsBlock.getAggregationResult();
+    assertNotNull(aggregationResult);
+    assertEquals(((DoubleArrayList) aggregationResult.get(0)).elements(), new double[]{0, 0, 0, 500, 1000});
+
+    // Inter segment
+    BrokerResponseNative brokerResponse = getBrokerResponse(query);
+    ResultTable resultTable = brokerResponse.getResultTable();
+    List<Object[]> rows = resultTable.getRows();
+    assertEquals(rows.get(0)[0], new double[]{4, 36, 360, 3600, 4000});
+  }
+
+  @Test
+  public void testAggregationOnlyVer2() {
+    String query = "SELECT HISTOGRAM(intColumn,0,1000,10) FROM testTable";
+
+    // Inner segment
+    Object operator = getOperator(query);
+    assertTrue(operator instanceof AggregationOperator);
+    IntermediateResultsBlock resultsBlock = ((AggregationOperator) operator).nextBlock();
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(((Operator) operator).getExecutionStatistics(), NUM_RECORDS, 0,
+        NUM_RECORDS, NUM_RECORDS);
+    List<Object> aggregationResult = resultsBlock.getAggregationResult();
+    assertNotNull(aggregationResult);
+    assertEquals(((DoubleArrayList) aggregationResult.get(0)).elements(),
+        new double[]{100, 100, 100, 100, 100, 100, 100, 100, 100, 101});
+
+    operator = getOperatorWithFilter(query);
+    assertTrue(operator instanceof AggregationOperator);
+    resultsBlock = ((AggregationOperator) operator).nextBlock();
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(((Operator) operator).getExecutionStatistics(), 1500, 0, 1500,
+        NUM_RECORDS);
+    aggregationResult = resultsBlock.getAggregationResult();
+    assertNotNull(aggregationResult);
+    assertEquals(((DoubleArrayList) aggregationResult.get(0)).elements(),
+        new double[]{0, 0, 0, 0, 0, 100, 100, 100, 100, 101});
+
+    // Inter segment
+    BrokerResponseNative brokerResponse = getBrokerResponse(query);
+    ResultTable resultTable = brokerResponse.getResultTable();
+    List<Object[]> rows = resultTable.getRows();
+    assertEquals(rows.get(0)[0], new double[]{400, 400, 400, 400, 400, 400, 400, 400, 400, 404});
+  }
+
+  @Test
+  public void testAggregationGroupBy() {
+    String query = "SELECT HISTOGRAM(doubleColumn,0,2000,20) FROM testTable GROUP BY CEIL(DIV(intColumn, 400)) "
+        + "ORDER BY CEIL(DIV(intColumn, 400))";
+
+    // Inner segment
+    Object operator = getOperator(query);
+    assertTrue(operator instanceof AggregationGroupByOrderByOperator);
+    IntermediateResultsBlock resultsBlock = ((AggregationGroupByOrderByOperator) operator).nextBlock();
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(((Operator) operator).getExecutionStatistics(), NUM_RECORDS, 0,
+        NUM_RECORDS * 2, NUM_RECORDS);
+    AggregationGroupByResult aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
+    assertNotNull(aggregationGroupByResult);
+    assertEquals(((DoubleArrayList) aggregationGroupByResult.getResultForGroupId(0, 0)).elements(),
+        new double[]{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}); // [0]
+    assertEquals(((DoubleArrayList) aggregationGroupByResult.getResultForGroupId(0, 1)).elements(),
+        new double[]{99, 100, 100, 100, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}); // [1-400]
+    assertEquals(((DoubleArrayList) aggregationGroupByResult.getResultForGroupId(0, 2)).elements(),
+        new double[]{0, 0, 0, 0, 99, 100, 100, 100, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}); // [401-800]
+    assertEquals(((DoubleArrayList) aggregationGroupByResult.getResultForGroupId(0, 3)).elements(),
+        new double[]{0, 0, 0, 0, 0, 0, 0, 0, 99, 100, 100, 100, 1, 0, 0, 0, 0, 0, 0, 0}); // [801-1200]
+    assertEquals(((DoubleArrayList) aggregationGroupByResult.getResultForGroupId(0, 4)).elements(),
+        new double[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 99, 100, 100, 100, 1, 0, 0, 0}); // [1201-1600]
+    assertEquals(((DoubleArrayList) aggregationGroupByResult.getResultForGroupId(0, 5)).elements(),
+        new double[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 99, 100, 100, 100}); // [1601-2000]
+
+    // Inter segment
+    BrokerResponseNative brokerResponse = getBrokerResponse(query);
+    ResultTable resultTable = brokerResponse.getResultTable();
+    List<Object[]> rows = resultTable.getRows();
+    assertEquals(rows.get(0)[0], new double[]{4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+    assertEquals(rows.get(1)[0],
+        new double[]{396, 400, 400, 400, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+    assertEquals(rows.get(2)[0],
+        new double[]{0, 0, 0, 0, 396, 400, 400, 400, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+    assertEquals(rows.get(3)[0],
+        new double[]{0, 0, 0, 0, 0, 0, 0, 0, 396, 400, 400, 400, 4, 0, 0, 0, 0, 0, 0, 0});
+    assertEquals(rows.get(4)[0],
+        new double[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 396, 400, 400, 400, 4, 0, 0, 0});
+    assertEquals(rows.get(5)[0],
+        new double[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 396, 400, 400, 400});
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    _indexSegment.destroy();
+    FileUtils.deleteDirectory(INDEX_DIR);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/HistogramQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/HistogramQueriesTest.java
@@ -268,9 +268,9 @@ public class HistogramQueriesTest extends BaseQueriesTest {
     BrokerResponseNative brokerResponse = getBrokerResponse(query);
     ResultTable resultTable = brokerResponse.getResultTable();
     List<Object[]> rows = resultTable.getRows();
-    assertEquals(rows.get(0)[0],
-        new double[]{200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200,
-            204});
+    assertEquals(rows.get(0)[0], new double[]{
+        200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 204
+    });
   }
 
   @Test
@@ -283,7 +283,9 @@ public class HistogramQueriesTest extends BaseQueriesTest {
       assertTrue(operator instanceof AggregationOperator);
       IntermediateResultsBlock resultsBlock = ((AggregationOperator) operator).nextBlock();
     } catch (Exception e) {
-      assertEquals(e.getMessage(), "Invalid aggregation function: histogram(intColumn,'1000','1000','10')");
+      assertEquals(e.getMessage(),
+          "Invalid aggregation function: histogram(intColumn,'1000','1000','10'), Exception: The right most edge must"
+              + " be greater than left most edge, given 1000.0 and 1000.0");
     }
 
     try {
@@ -292,7 +294,9 @@ public class HistogramQueriesTest extends BaseQueriesTest {
       assertTrue(operator instanceof AggregationOperator);
       IntermediateResultsBlock resultsBlock = ((AggregationOperator) operator).nextBlock();
     } catch (Exception e) {
-      assertEquals(e.getMessage(), "Invalid aggregation function: histogram(intColumn,'0','1000','-1')");
+      assertEquals(e.getMessage(),
+          "Invalid aggregation function: histogram(intColumn,'0','1000','-1'), Exception: The number of bins must be "
+              + "greater than zero, given -1");
     }
 
     try {
@@ -301,7 +305,9 @@ public class HistogramQueriesTest extends BaseQueriesTest {
       assertTrue(operator instanceof AggregationOperator);
       IntermediateResultsBlock resultsBlock = ((AggregationOperator) operator).nextBlock();
     } catch (Exception e) {
-      assertEquals(e.getMessage(), "Invalid aggregation function: histogram(intColumn,arrayvalueconstructor('0'))");
+      assertEquals(e.getMessage(),
+          "Invalid aggregation function: histogram(intColumn,arrayvalueconstructor('0')), Exception: The number of "
+              + "bin edges must be greater than 1");
     }
 
     try {
@@ -321,7 +327,8 @@ public class HistogramQueriesTest extends BaseQueriesTest {
       IntermediateResultsBlock resultsBlock = ((AggregationOperator) operator).nextBlock();
     } catch (Exception e) {
       assertEquals(e.getMessage(),
-          "Invalid aggregation function: histogram(intColumn,arrayvalueconstructor('0','0','1','2'))");
+          "Invalid aggregation function: histogram(intColumn,arrayvalueconstructor('0','0','1','2')), Exception: The "
+              + "bin edges must be strictly increasing");
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/HistogramQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/HistogramQueriesTest.java
@@ -231,16 +231,11 @@ public class HistogramQueriesTest extends BaseQueriesTest {
     ResultTable resultTable = brokerResponse.getResultTable();
     List<Object[]> rows = resultTable.getRows();
     assertEquals(rows.get(0)[0], new double[]{4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
-    assertEquals(rows.get(1)[0],
-        new double[]{396, 400, 400, 400, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
-    assertEquals(rows.get(2)[0],
-        new double[]{0, 0, 0, 0, 396, 400, 400, 400, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
-    assertEquals(rows.get(3)[0],
-        new double[]{0, 0, 0, 0, 0, 0, 0, 0, 396, 400, 400, 400, 4, 0, 0, 0, 0, 0, 0, 0});
-    assertEquals(rows.get(4)[0],
-        new double[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 396, 400, 400, 400, 4, 0, 0, 0});
-    assertEquals(rows.get(5)[0],
-        new double[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 396, 400, 400, 400});
+    assertEquals(rows.get(1)[0], new double[]{396, 400, 400, 400, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+    assertEquals(rows.get(2)[0], new double[]{0, 0, 0, 0, 396, 400, 400, 400, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0});
+    assertEquals(rows.get(3)[0], new double[]{0, 0, 0, 0, 0, 0, 0, 0, 396, 400, 400, 400, 4, 0, 0, 0, 0, 0, 0, 0});
+    assertEquals(rows.get(4)[0], new double[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 396, 400, 400, 400, 4, 0, 0, 0});
+    assertEquals(rows.get(5)[0], new double[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 396, 400, 400, 400});
   }
 
   @Test
@@ -252,7 +247,7 @@ public class HistogramQueriesTest extends BaseQueriesTest {
     assertTrue(operator instanceof AggregationOperator);
     IntermediateResultsBlock resultsBlock = ((AggregationOperator) operator).nextBlock();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(((Operator) operator).getExecutionStatistics(), NUM_RECORDS, 0,
-        2*NUM_RECORDS, NUM_RECORDS);
+        2 * NUM_RECORDS, NUM_RECORDS);
     List<Object> aggregationResult = resultsBlock.getAggregationResult();
     assertNotNull(aggregationResult);
     assertEquals(((DoubleArrayList) aggregationResult.get(0)).elements(),
@@ -274,7 +269,8 @@ public class HistogramQueriesTest extends BaseQueriesTest {
     ResultTable resultTable = brokerResponse.getResultTable();
     List<Object[]> rows = resultTable.getRows();
     assertEquals(rows.get(0)[0],
-        new double[]{200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 204});
+        new double[]{200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200, 200,
+            204});
   }
 
   @Test
@@ -286,9 +282,8 @@ public class HistogramQueriesTest extends BaseQueriesTest {
       Object operator = getOperator(query);
       assertTrue(operator instanceof AggregationOperator);
       IntermediateResultsBlock resultsBlock = ((AggregationOperator) operator).nextBlock();
-    } catch (Exception e){
-      assertEquals(e.getMessage(),
-          "Invalid aggregation function: histogram(intColumn,'1000','1000','10')");
+    } catch (Exception e) {
+      assertEquals(e.getMessage(), "Invalid aggregation function: histogram(intColumn,'1000','1000','10')");
     }
 
     try {
@@ -296,9 +291,8 @@ public class HistogramQueriesTest extends BaseQueriesTest {
       Object operator = getOperator(query);
       assertTrue(operator instanceof AggregationOperator);
       IntermediateResultsBlock resultsBlock = ((AggregationOperator) operator).nextBlock();
-    } catch (Exception e){
-      assertEquals(e.getMessage(),
-          "Invalid aggregation function: histogram(intColumn,'0','1000','-1')");
+    } catch (Exception e) {
+      assertEquals(e.getMessage(), "Invalid aggregation function: histogram(intColumn,'0','1000','-1')");
     }
 
     try {
@@ -306,9 +300,8 @@ public class HistogramQueriesTest extends BaseQueriesTest {
       Object operator = getOperator(query);
       assertTrue(operator instanceof AggregationOperator);
       IntermediateResultsBlock resultsBlock = ((AggregationOperator) operator).nextBlock();
-    } catch (Exception e){
-      assertEquals(e.getMessage(),
-          "Invalid aggregation function: histogram(intColumn,arrayvalueconstructor('0'))");
+    } catch (Exception e) {
+      assertEquals(e.getMessage(), "Invalid aggregation function: histogram(intColumn,arrayvalueconstructor('0'))");
     }
 
     try {
@@ -316,7 +309,7 @@ public class HistogramQueriesTest extends BaseQueriesTest {
       Object operator = getOperator(query);
       assertTrue(operator instanceof AggregationOperator);
       IntermediateResultsBlock resultsBlock = ((AggregationOperator) operator).nextBlock();
-    } catch (Exception e){
+    } catch (Exception e) {
       assertEquals(e.getMessage(),
           "Caught exception while parsing query: SELECT HISTOGRAM(intColumn,FUNCTION[0, 10, 20]) FROM testTable");
     }
@@ -326,7 +319,7 @@ public class HistogramQueriesTest extends BaseQueriesTest {
       Object operator = getOperator(query);
       assertTrue(operator instanceof AggregationOperator);
       IntermediateResultsBlock resultsBlock = ((AggregationOperator) operator).nextBlock();
-    } catch (Exception e){
+    } catch (Exception e) {
       assertEquals(e.getMessage(),
           "Invalid aggregation function: histogram(intColumn,arrayvalueconstructor('0','0','1','2'))");
     }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
@@ -56,6 +56,7 @@ public enum AggregationFunctionType {
   PERCENTILERAWTDIGEST("percentileRawTDigest"),
   PERCENTILESMARTTDIGEST("percentileSmartTDigest"),
   IDSET("idSet"),
+  HISTOGRAM("histogram"),
 
   // Geo aggregation functions
   STUNION("STUnion"),


### PR DESCRIPTION
This effort is part of the issue https://github.com/apache/pinot/issues/8493
The histogram aggregation function for single value numerical columns is implemented. 
usage example: 
`Histogram(columnName, ARRAY[0,1,10,100])` to specify bins [0,1), [1,10), [10,1000] 
`HISTOGRAM(intColumn,ARRAY["-Infinity",0,1,10,100,1000, "+Infinity"])`  to specify bins (-inf, 0), [0,1), [1,10), [10,1000), [1000, +inf)
`Histogram(columnName, 0, 1000, 10)` to specify 10 equal-length bins [0,100), [100,200), ..., [900,1000]
This is a proof of concept histogram function, the following are some TODOs that we want to address in a follow up pr:

1.  Add support for multi-value column
2. Add support for automatically collect min/max values when lower/upper bounds are not specified
3. Count for outlier values as an additional bin