### PR TITLE
allow to set https as the default scheme

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -92,8 +92,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     beanConfig.setContact("https://github.com/apache/pinot");
     beanConfig.setVersion("1.0");
     if (_useHttps) {
-      // Still leave http there as a second choice in case of need for quick tests with http.
-      beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL, CommonConstants.HTTP_PROTOCOL});
+      beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL});
     } else {
       beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -45,6 +45,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
   private static final String RESOURCE_PACKAGE = "org.apache.pinot.broker.api.resources";
   public static final String PINOT_CONFIGURATION = "pinotConfiguration";
   public static final String BROKER_INSTANCE_ID = "brokerInstanceId";
+  private final String _swaggerDefaultProtocol;
 
   private HttpServer _httpServer;
 
@@ -52,6 +53,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
       BrokerMetrics brokerMetrics, PinotConfiguration brokerConf, SqlQueryExecutor sqlQueryExecutor) {
     packages(RESOURCE_PACKAGE);
     property(PINOT_CONFIGURATION, brokerConf);
+    _swaggerDefaultProtocol = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_SWAGGER_SERVER_DEFAULT_PROTOCOL);
     if (brokerConf.getProperty(CommonConstants.Broker.BROKER_SERVICE_AUTO_DISCOVERY, false)) {
       register(ServiceAutoDiscoveryFeature.class);
     }
@@ -89,7 +91,11 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     beanConfig.setDescription("APIs for accessing Pinot broker information");
     beanConfig.setContact("https://github.com/apache/pinot");
     beanConfig.setVersion("1.0");
-    beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
+    if (CommonConstants.HTTPS_PROTOCOL.equalsIgnoreCase(_swaggerDefaultProtocol)) {
+      beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL, CommonConstants.HTTP_PROTOCOL});
+    } else {
+      beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
+    }
     beanConfig.setBasePath("/");
     beanConfig.setResourcePackage(RESOURCE_PACKAGE);
     beanConfig.setScan(true);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -45,7 +45,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
   private static final String RESOURCE_PACKAGE = "org.apache.pinot.broker.api.resources";
   public static final String PINOT_CONFIGURATION = "pinotConfiguration";
   public static final String BROKER_INSTANCE_ID = "brokerInstanceId";
-  private final String _swaggerDefaultProtocol;
+  private final boolean _useHttps;
 
   private HttpServer _httpServer;
 
@@ -53,7 +53,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
       BrokerMetrics brokerMetrics, PinotConfiguration brokerConf, SqlQueryExecutor sqlQueryExecutor) {
     packages(RESOURCE_PACKAGE);
     property(PINOT_CONFIGURATION, brokerConf);
-    _swaggerDefaultProtocol = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_SWAGGER_SERVER_DEFAULT_PROTOCOL);
+    _useHttps = Boolean.parseBoolean(brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_SWAGGER_USE_HTTPS));
     if (brokerConf.getProperty(CommonConstants.Broker.BROKER_SERVICE_AUTO_DISCOVERY, false)) {
       register(ServiceAutoDiscoveryFeature.class);
     }
@@ -91,7 +91,8 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     beanConfig.setDescription("APIs for accessing Pinot broker information");
     beanConfig.setContact("https://github.com/apache/pinot");
     beanConfig.setVersion("1.0");
-    if (CommonConstants.HTTPS_PROTOCOL.equalsIgnoreCase(_swaggerDefaultProtocol)) {
+    if (_useHttps) {
+      // Still leave http there as a second choice in case of need for quick tests with http.
       beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL, CommonConstants.HTTP_PROTOCOL});
     } else {
       beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -63,6 +63,7 @@ public class ControllerConf extends PinotConfiguration {
   public static final String HELIX_CLUSTER_NAME = "controller.helix.cluster.name";
   public static final String CLUSTER_TENANT_ISOLATION_ENABLE = "cluster.tenant.isolation.enable";
   public static final String CONSOLE_WEBAPP_ROOT_PATH = "controller.query.console";
+  public static final String CONSOLE_WEBAPP_DEFAULT_PROTOCOL = "controller.query.console.default.protocol";
   public static final String CONTROLLER_MODE = "controller.mode";
   public static final String LEAD_CONTROLLER_RESOURCE_REBALANCE_STRATEGY = "controller.resource.rebalance.strategy";
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -63,7 +63,7 @@ public class ControllerConf extends PinotConfiguration {
   public static final String HELIX_CLUSTER_NAME = "controller.helix.cluster.name";
   public static final String CLUSTER_TENANT_ISOLATION_ENABLE = "cluster.tenant.isolation.enable";
   public static final String CONSOLE_WEBAPP_ROOT_PATH = "controller.query.console";
-  public static final String CONSOLE_WEBAPP_DEFAULT_PROTOCOL = "controller.query.console.default.protocol";
+  public static final String CONSOLE_SWAGGER_USE_HTTPS = "controller.swagger.use.https";
   public static final String CONTROLLER_MODE = "controller.mode";
   public static final String LEAD_CONTROLLER_RESOURCE_REBALANCE_STRATEGY = "controller.resource.rebalance.strategy";
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
@@ -49,7 +49,7 @@ public class ControllerAdminApiApplication extends ResourceConfig {
   public static final String PINOT_CONFIGURATION = "pinotConfiguration";
 
   private final String _controllerResourcePackages;
-  private final String _swaggerDefaultProtocol;
+  private final boolean _useHttps;
   private HttpServer _httpServer;
 
   public ControllerAdminApiApplication(ControllerConf conf) {
@@ -60,7 +60,7 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     packages(_controllerResourcePackages);
     // TODO See ControllerResponseFilter
     // register(new LoggingFeature());
-    _swaggerDefaultProtocol = conf.getProperty(ControllerConf.CONSOLE_WEBAPP_DEFAULT_PROTOCOL);
+    _useHttps = Boolean.parseBoolean(conf.getProperty(ControllerConf.CONSOLE_SWAGGER_USE_HTTPS));
     if (conf.getProperty(CommonConstants.Controller.CONTROLLER_SERVICE_AUTO_DISCOVERY, false)) {
       register(ServiceAutoDiscoveryFeature.class);
     }
@@ -111,7 +111,8 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     beanConfig.setDescription("APIs for accessing Pinot Controller information");
     beanConfig.setContact("https://github.com/apache/pinot");
     beanConfig.setVersion("1.0");
-    if (CommonConstants.HTTPS_PROTOCOL.equalsIgnoreCase(_swaggerDefaultProtocol)) {
+    if (_useHttps) {
+      // Still leave http there as a second choice in case of need for quick tests with http.
       beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL, CommonConstants.HTTP_PROTOCOL});
     } else {
       beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
@@ -49,6 +49,7 @@ public class ControllerAdminApiApplication extends ResourceConfig {
   public static final String PINOT_CONFIGURATION = "pinotConfiguration";
 
   private final String _controllerResourcePackages;
+  private final String _swaggerDefaultProtocol;
   private HttpServer _httpServer;
 
   public ControllerAdminApiApplication(ControllerConf conf) {
@@ -58,7 +59,8 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     _controllerResourcePackages = conf.getControllerResourcePackages();
     packages(_controllerResourcePackages);
     // TODO See ControllerResponseFilter
-//    register(new LoggingFeature());
+    // register(new LoggingFeature());
+    _swaggerDefaultProtocol = conf.getProperty(ControllerConf.CONSOLE_WEBAPP_DEFAULT_PROTOCOL);
     if (conf.getProperty(CommonConstants.Controller.CONTROLLER_SERVICE_AUTO_DISCOVERY, false)) {
       register(ServiceAutoDiscoveryFeature.class);
     }
@@ -109,7 +111,11 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     beanConfig.setDescription("APIs for accessing Pinot Controller information");
     beanConfig.setContact("https://github.com/apache/pinot");
     beanConfig.setVersion("1.0");
-    beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
+    if (CommonConstants.HTTPS_PROTOCOL.equalsIgnoreCase(_swaggerDefaultProtocol)) {
+      beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL, CommonConstants.HTTP_PROTOCOL});
+    } else {
+      beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
+    }
     beanConfig.setBasePath("/");
     beanConfig.setResourcePackage(_controllerResourcePackages);
     beanConfig.setScan(true);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
@@ -112,8 +112,7 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     beanConfig.setContact("https://github.com/apache/pinot");
     beanConfig.setVersion("1.0");
     if (_useHttps) {
-      // Still leave http there as a second choice in case of need for quick tests with http.
-      beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL, CommonConstants.HTTP_PROTOCOL});
+      beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL});
     } else {
       beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
     }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
@@ -48,11 +48,12 @@ public class MinionAdminApiApplication extends ResourceConfig {
   public static final String MINION_INSTANCE_ID = "minionInstanceId";
 
   private HttpServer _httpServer;
+  private final String _swaggerDefaultProtocol;
 
   public MinionAdminApiApplication(String instanceId, PinotConfiguration minionConf) {
     packages(RESOURCE_PACKAGE);
     property(PINOT_CONFIGURATION, minionConf);
-
+    _swaggerDefaultProtocol = minionConf.getProperty(CommonConstants.Minion.CONFIG_OF_SWAGGER_SERVER_DEFAULT_PROTOCOL);
     register(new AbstractBinder() {
       @Override
       protected void configure() {
@@ -84,7 +85,11 @@ public class MinionAdminApiApplication extends ResourceConfig {
     beanConfig.setDescription("APIs for accessing Pinot Minion information");
     beanConfig.setContact("https://github.com/apache/pinot");
     beanConfig.setVersion("1.0");
-    beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
+    if (CommonConstants.HTTPS_PROTOCOL.equalsIgnoreCase(_swaggerDefaultProtocol)) {
+      beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL, CommonConstants.HTTP_PROTOCOL});
+    } else {
+      beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
+    }
     beanConfig.setBasePath("/");
     beanConfig.setResourcePackage(RESOURCE_PACKAGE);
     beanConfig.setScan(true);

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
@@ -86,8 +86,7 @@ public class MinionAdminApiApplication extends ResourceConfig {
     beanConfig.setContact("https://github.com/apache/pinot");
     beanConfig.setVersion("1.0");
     if (_useHttps) {
-      // Still leave http there as a second choice in case of need for quick tests with http.
-      beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL, CommonConstants.HTTP_PROTOCOL});
+      beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL});
     } else {
       beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
     }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
@@ -48,12 +48,12 @@ public class MinionAdminApiApplication extends ResourceConfig {
   public static final String MINION_INSTANCE_ID = "minionInstanceId";
 
   private HttpServer _httpServer;
-  private final String _swaggerDefaultProtocol;
+  private final boolean _useHttps;
 
   public MinionAdminApiApplication(String instanceId, PinotConfiguration minionConf) {
     packages(RESOURCE_PACKAGE);
     property(PINOT_CONFIGURATION, minionConf);
-    _swaggerDefaultProtocol = minionConf.getProperty(CommonConstants.Minion.CONFIG_OF_SWAGGER_SERVER_DEFAULT_PROTOCOL);
+    _useHttps = Boolean.parseBoolean(minionConf.getProperty(CommonConstants.Minion.CONFIG_OF_SWAGGER_USE_HTTPS));
     register(new AbstractBinder() {
       @Override
       protected void configure() {
@@ -85,7 +85,8 @@ public class MinionAdminApiApplication extends ResourceConfig {
     beanConfig.setDescription("APIs for accessing Pinot Minion information");
     beanConfig.setContact("https://github.com/apache/pinot");
     beanConfig.setVersion("1.0");
-    if (CommonConstants.HTTPS_PROTOCOL.equalsIgnoreCase(_swaggerDefaultProtocol)) {
+    if (_useHttps) {
+      // Still leave http there as a second choice in case of need for quick tests with http.
       beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL, CommonConstants.HTTP_PROTOCOL});
     } else {
       beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/AdminApiApplication.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/AdminApiApplication.java
@@ -115,8 +115,8 @@ public class AdminApiApplication extends ResourceConfig {
     beanConfig.setDescription("APIs for accessing Pinot server information");
     beanConfig.setContact("https://github.com/apache/pinot");
     beanConfig.setVersion("1.0");
-    if (CommonConstants.HTTPS_PROTOCOL.equalsIgnoreCase(
-        pinotConfiguration.getProperty(CommonConstants.Server.CONFIG_OF_SWAGGER_SERVER_DEFAULT_PROTOCOL))) {
+    if (Boolean.parseBoolean(pinotConfiguration.getProperty(CommonConstants.Server.CONFIG_OF_SWAGGER_USE_HTTPS))) {
+      // Still leave http there as a second choice in case of need for quick tests with http.
       beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL, CommonConstants.HTTP_PROTOCOL});
     } else {
       beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/AdminApiApplication.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/AdminApiApplication.java
@@ -116,8 +116,7 @@ public class AdminApiApplication extends ResourceConfig {
     beanConfig.setContact("https://github.com/apache/pinot");
     beanConfig.setVersion("1.0");
     if (Boolean.parseBoolean(pinotConfiguration.getProperty(CommonConstants.Server.CONFIG_OF_SWAGGER_USE_HTTPS))) {
-      // Still leave http there as a second choice in case of need for quick tests with http.
-      beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL, CommonConstants.HTTP_PROTOCOL});
+      beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL});
     } else {
       beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -200,7 +200,7 @@ public class CommonConstants {
     public static final long DEFAULT_BROKER_TIMEOUT_MS = 10_000L;
     public static final String CONFIG_OF_BROKER_ID = "pinot.broker.id";
     public static final String CONFIG_OF_BROKER_HOSTNAME = "pinot.broker.hostname";
-    public static final String CONFIG_OF_SWAGGER_SERVER_DEFAULT_PROTOCOL = "pinot.broker.swagger.default.protocol";
+    public static final String CONFIG_OF_SWAGGER_USE_HTTPS = "pinot.broker.swagger.use.https";
     // Configuration to consider the broker ServiceStatus as being STARTED if the percent of resources (tables) that
     // are ONLINE for this this broker has crossed the threshold percentage of the total number of tables
     // that it is expected to serve.
@@ -318,7 +318,7 @@ public class CommonConstants {
     public static final boolean DEFAULT_NETTYTLS_SERVER_ENABLED = false;
     public static final String CONFIG_OF_SWAGGER_SERVER_ENABLED = "pinot.server.swagger.enabled";
     public static final boolean DEFAULT_SWAGGER_SERVER_ENABLED = true;
-    public static final String CONFIG_OF_SWAGGER_SERVER_DEFAULT_PROTOCOL = "pinot.server.swagger.default.protocol";
+    public static final String CONFIG_OF_SWAGGER_USE_HTTPS = "pinot.server.swagger.use.https";
     public static final String CONFIG_OF_ADMIN_API_PORT = "pinot.server.adminapi.port";
     public static final int DEFAULT_ADMIN_API_PORT = 8097;
 
@@ -497,7 +497,7 @@ public class CommonConstants {
     public static final String METADATA_EVENT_OBSERVER_PREFIX = "metadata.event.notifier";
 
     // Config keys
-    public static final String CONFIG_OF_SWAGGER_SERVER_DEFAULT_PROTOCOL = "pinot.minion.swagger.default.protocol";
+    public static final String CONFIG_OF_SWAGGER_USE_HTTPS = "pinot.minion.swagger.use.https";
     public static final String CONFIG_OF_METRICS_PREFIX_KEY = "pinot.minion.metrics.prefix";
     @Deprecated
     public static final String DEPRECATED_CONFIG_OF_METRICS_PREFIX_KEY = "metricsPrefix";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -200,6 +200,7 @@ public class CommonConstants {
     public static final long DEFAULT_BROKER_TIMEOUT_MS = 10_000L;
     public static final String CONFIG_OF_BROKER_ID = "pinot.broker.id";
     public static final String CONFIG_OF_BROKER_HOSTNAME = "pinot.broker.hostname";
+    public static final String CONFIG_OF_SWAGGER_SERVER_DEFAULT_PROTOCOL = "pinot.broker.swagger.default.protocol";
     // Configuration to consider the broker ServiceStatus as being STARTED if the percent of resources (tables) that
     // are ONLINE for this this broker has crossed the threshold percentage of the total number of tables
     // that it is expected to serve.
@@ -317,6 +318,7 @@ public class CommonConstants {
     public static final boolean DEFAULT_NETTYTLS_SERVER_ENABLED = false;
     public static final String CONFIG_OF_SWAGGER_SERVER_ENABLED = "pinot.server.swagger.enabled";
     public static final boolean DEFAULT_SWAGGER_SERVER_ENABLED = true;
+    public static final String CONFIG_OF_SWAGGER_SERVER_DEFAULT_PROTOCOL = "pinot.server.swagger.default.protocol";
     public static final String CONFIG_OF_ADMIN_API_PORT = "pinot.server.adminapi.port";
     public static final int DEFAULT_ADMIN_API_PORT = 8097;
 
@@ -495,6 +497,7 @@ public class CommonConstants {
     public static final String METADATA_EVENT_OBSERVER_PREFIX = "metadata.event.notifier";
 
     // Config keys
+    public static final String CONFIG_OF_SWAGGER_SERVER_DEFAULT_PROTOCOL = "pinot.minion.swagger.default.protocol";
     public static final String CONFIG_OF_METRICS_PREFIX_KEY = "pinot.minion.metrics.prefix";
     @Deprecated
     public static final String DEPRECATED_CONFIG_OF_METRICS_PREFIX_KEY = "metricsPrefix";


### PR DESCRIPTION
This PR adds a switch to set 'https' as the default scheme for Swagger UI, so that in TLS enabled env, requests issued from Swagger UI will use https automatically. 

## Release notes
New configs are added for each Pinot component and followed the existing naming convention. By default, `http` is used as before.
- controller.swagger.use.https
- pinot.broker.swagger.use.https
- pinot.server.swagger.use.https
- pinot.minion.swagger.use.https