### PR TITLE
Groovy transform function should evaluate the script when arguments are null

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/GroovyFunctionEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/GroovyFunctionEvaluatorTest.java
@@ -111,6 +111,17 @@ public class GroovyFunctionEvaluatorTest {
     entries.add(new Object[]{"Groovy({ArrTimeV2 != null ? ArrTimeV2: ArrTime }, ArrTime, ArrTimeV2)",
         Lists.newArrayList("ArrTime", "ArrTimeV2"), genericRow9, 101});
 
+    GenericRow genericRow10 = new GenericRow();
+    String jello = "Jello";
+    genericRow10.putValue("jello", jello);
+    entries.add(new Object[]{"Groovy({jello != null ? jello.length() : \"Jello\" }, jello)",
+        Lists.newArrayList("jello"), genericRow10, 5});
+
+    //Invalid groovy script
+    GenericRow genericRow11 = new GenericRow();
+    genericRow11.putValue("nullValue", null);
+    entries.add(new Object[]{"Groovy({nullValue == null ? nullValue.length() : \"Jello\" }, nullValue)",
+        Lists.newArrayList("nullValue"), genericRow11, null});
     return entries.toArray(new Object[entries.size()][]);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/GroovyFunctionEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/GroovyFunctionEvaluatorTest.java
@@ -105,6 +105,12 @@ public class GroovyFunctionEvaluatorTest {
         genericRow8, "01a54629efb952287e554eb23ef69c52097a75aecc0e3a93ca0855ab6d7a31a0"
     });
 
+    GenericRow genericRow9 = new GenericRow();
+    genericRow9.putValue("ArrTime", 101);
+    genericRow9.putValue("ArrTimeV2", null);
+    entries.add(new Object[]{"Groovy({ArrTimeV2 != null ? ArrTimeV2: ArrTime }, ArrTime, ArrTimeV2)",
+        Lists.newArrayList("ArrTime", "ArrTimeV2"), genericRow9, 101});
+
     return entries.toArray(new Object[entries.size()][]);
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/GroovyFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/GroovyFunctionEvaluator.java
@@ -88,7 +88,11 @@ public class GroovyFunctionEvaluator implements FunctionEvaluator {
       Object value = genericRow.getValue(argument);
       _binding.setVariable(argument, value);
     }
-    return _script.run();
+    try {
+      return _script.run();
+    } catch (Exception e) {
+      return null;
+    }
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/GroovyFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/GroovyFunctionEvaluator.java
@@ -86,10 +86,6 @@ public class GroovyFunctionEvaluator implements FunctionEvaluator {
   public Object evaluate(GenericRow genericRow) {
     for (String argument : _arguments) {
       Object value = genericRow.getValue(argument);
-      if (value == null) {
-        // FIXME: if any param is null a) exit OR b) assume function handles it ?
-        return null;
-      }
       _binding.setVariable(argument, value);
     }
     return _script.run();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/GroovyFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/GroovyFunctionEvaluator.java
@@ -84,14 +84,22 @@ public class GroovyFunctionEvaluator implements FunctionEvaluator {
 
   @Override
   public Object evaluate(GenericRow genericRow) {
+    boolean hasNullArgument = false;
     for (String argument : _arguments) {
       Object value = genericRow.getValue(argument);
+      if (value == null) {
+        hasNullArgument = true;
+      }
       _binding.setVariable(argument, value);
     }
     try {
       return _script.run();
     } catch (Exception e) {
-      return null;
+      if (hasNullArgument) {
+        return null;
+      } else {
+        throw e;
+      }
     }
   }
 


### PR DESCRIPTION
### Description
When the arguments for groovy transform are null, the evaluate function returns null without running the script. This fix removes that null check in order for the function to evaluate.
Details in isuue #8730 

### Testing Done

- Tested the transformation works when reloading a segment and when creating a new segment using generic rows. 
- Modified unit test to evaluate the supported groovy function. 
- Added Integration tests for segment building flow