### PR TITLE
Add option to skip statree index evaluation during query

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByOrderByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByOrderByPlanNode.java
@@ -64,7 +64,7 @@ public class AggregationGroupByOrderByPlanNode implements PlanNode {
 
     // Use star-tree to solve the query if possible
     List<StarTreeV2> starTrees = _indexSegment.getStarTrees();
-    if (starTrees != null && !StarTreeUtils.isStarTreeDisabled(_queryContext)) {
+    if (starTrees != null && !_queryContext.isSkipStarTree()) {
       AggregationFunctionColumnPair[] aggregationFunctionColumnPairs =
           StarTreeUtils.extractAggregationFunctionPairs(aggregationFunctions);
       if (aggregationFunctionColumnPairs != null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -198,7 +198,7 @@ public class AggregationPlanNode implements PlanNode {
 
     // Use star-tree to solve the query if possible
     List<StarTreeV2> starTrees = _indexSegment.getStarTrees();
-    if (starTrees != null && !StarTreeUtils.isStarTreeDisabled(_queryContext)) {
+    if (starTrees != null && !_queryContext.isSkipStarTree()) {
       AggregationFunctionColumnPair[] aggregationFunctionColumnPairs =
           StarTreeUtils.extractAggregationFunctionPairs(aggregationFunctions);
       if (aggregationFunctionColumnPairs != null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -190,6 +190,9 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     // Set skipUpsert
     queryContext.setSkipUpsert(QueryOptionsUtils.isSkipUpsert(queryOptions));
 
+    // Set skipStartree
+    queryContext.setSkipStartree(QueryOptionsUtils.isSkipStartree(queryOptions));
+
     // Set maxExecutionThreads
     int maxExecutionThreads;
     Integer maxExecutionThreadsFromQuery = QueryOptionsUtils.getMaxExecutionThreads(queryOptions);

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -186,12 +186,13 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
 
   private void applyQueryOptions(QueryContext queryContext) {
     Map<String, String> queryOptions = queryContext.getQueryOptions();
+    Map<String, String> debugOptions = queryContext.getDebugOptions();
 
     // Set skipUpsert
     queryContext.setSkipUpsert(QueryOptionsUtils.isSkipUpsert(queryOptions));
 
     // Set skipStartree
-    queryContext.setSkipStartree(QueryOptionsUtils.isSkipStartree(queryOptions));
+    queryContext.setSkipStartree(QueryOptionsUtils.isSkipStartree(queryOptions, debugOptions));
 
     // Set maxExecutionThreads
     int maxExecutionThreads;

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -191,7 +191,7 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     // Set skipUpsert
     queryContext.setSkipUpsert(QueryOptionsUtils.isSkipUpsert(queryOptions));
 
-    // Set skipStartree
+    // Set skipStarTree
     queryContext.setSkipStarTree(QueryOptionsUtils.isSkipStarTree(queryOptions, debugOptions));
 
     // Set maxExecutionThreads

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -192,7 +192,7 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     queryContext.setSkipUpsert(QueryOptionsUtils.isSkipUpsert(queryOptions));
 
     // Set skipStartree
-    queryContext.setSkipStartree(QueryOptionsUtils.isSkipStartree(queryOptions, debugOptions));
+    queryContext.setSkipStarTree(QueryOptionsUtils.isSkipStarTree(queryOptions, debugOptions));
 
     // Set maxExecutionThreads
     int maxExecutionThreads;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -102,7 +102,7 @@ public class QueryContext {
   // Whether to skip upsert for the query
   private boolean _skipUpsert;
   // Whether to skip upsert for the query
-  private boolean _skipStartree;
+  private boolean _skipStarTree;
   // Maximum number of threads used to execute the query
   private int _maxExecutionThreads = InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS;
   // The following properties apply to group-by queries
@@ -316,12 +316,12 @@ public class QueryContext {
     _skipUpsert = skipUpsert;
   }
 
-  public boolean isSkipStartree() {
-    return _skipStartree;
+  public boolean isSkipStarTree() {
+    return _skipStarTree;
   }
 
-  public void setSkipStartree(boolean skipStartree) {
-    _skipStartree = skipStartree;
+  public void setSkipStarTree(boolean skipStarTree) {
+    _skipStarTree = skipStarTree;
   }
 
   public int getMaxExecutionThreads() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -101,7 +101,7 @@ public class QueryContext {
   private boolean _enablePrefetch;
   // Whether to skip upsert for the query
   private boolean _skipUpsert;
-  // Whether to skip upsert for the query
+  // Whether to skip star-tree index for the query
   private boolean _skipStarTree;
   // Maximum number of threads used to execute the query
   private int _maxExecutionThreads = InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -101,6 +101,8 @@ public class QueryContext {
   private boolean _enablePrefetch;
   // Whether to skip upsert for the query
   private boolean _skipUpsert;
+  // Whether to skip upsert for the query
+  private boolean _skipStartree;
   // Maximum number of threads used to execute the query
   private int _maxExecutionThreads = InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS;
   // The following properties apply to group-by queries
@@ -312,6 +314,14 @@ public class QueryContext {
 
   public void setSkipUpsert(boolean skipUpsert) {
     _skipUpsert = skipUpsert;
+  }
+
+  public boolean isSkipStartree() {
+    return _skipStartree;
+  }
+
+  public void setSkipStartree(boolean skipStartree) {
+    _skipStartree = skipStartree;
   }
 
   public int getMaxExecutionThreads() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
@@ -35,7 +35,6 @@ import org.apache.pinot.common.request.context.predicate.Predicate;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
-import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
@@ -46,13 +45,6 @@ import org.apache.pinot.segment.spi.index.startree.StarTreeV2Metadata;
 @SuppressWarnings("rawtypes")
 public class StarTreeUtils {
   private StarTreeUtils() {
-  }
-
-  /**
-   * Returns whether star-tree is disabled for the query.
-   */
-  public static boolean isStarTreeDisabled(QueryContext queryContext) {
-    return queryContext.isSkipStarTree();
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
@@ -48,14 +48,11 @@ public class StarTreeUtils {
   private StarTreeUtils() {
   }
 
-  public static final String USE_STAR_TREE_KEY = "useStarTree";
-
   /**
    * Returns whether star-tree is disabled for the query.
    */
   public static boolean isStarTreeDisabled(QueryContext queryContext) {
-    Map<String, String> debugOptions = queryContext.getDebugOptions();
-    return debugOptions != null && "false".equalsIgnoreCase(debugOptions.get(USE_STAR_TREE_KEY));
+    return queryContext.isSkipStartree();
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
@@ -52,7 +52,7 @@ public class StarTreeUtils {
    * Returns whether star-tree is disabled for the query.
    */
   public static boolean isStarTreeDisabled(QueryContext queryContext) {
-    return queryContext.isSkipStartree();
+    return queryContext.isSkipStarTree();
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
@@ -47,8 +47,11 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.SKIP_UPSERT));
   }
 
-  public static boolean isSkipStartree(Map<String, String> queryOptions) {
-    return Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.SKIP_STARTREE));
+  // TODO: Debug options has been kept for backward compatibility should be deprecated in future releases
+  public static boolean isSkipStartree(Map<String, String> queryOptions, Map<String, String> debugOptions) {
+    boolean disabledWithQueryOption = Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.SKIP_STARTREE));
+    return disabledWithQueryOption || (debugOptions != null
+        && !Boolean.parseBoolean(debugOptions.get(Request.DebugOptionsKey.USE_STAR_TREE_KEY)));
   }
 
   public static Integer getNumReplicaGroupsToQuery(Map<String, String> queryOptions) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
@@ -48,10 +48,11 @@ public class QueryOptionsUtils {
   }
 
   // TODO: Debug options has been kept for backward compatibility should be deprecated in future releases
-  public static boolean isSkipStartree(Map<String, String> queryOptions, Map<String, String> debugOptions) {
-    boolean disabledWithQueryOption = Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.SKIP_STARTREE));
+  public static boolean isSkipStarTree(Map<String, String> queryOptions, Map<String, String> debugOptions) {
+    boolean disabledWithQueryOption = !Boolean.parseBoolean(
+        queryOptions.getOrDefault(Request.QueryOptionKey.USE_STAR_TREE_KEY, "true"));
     return disabledWithQueryOption || (debugOptions != null
-        && !Boolean.parseBoolean(debugOptions.get(Request.DebugOptionsKey.USE_STAR_TREE_KEY)));
+        && !Boolean.parseBoolean(debugOptions.getOrDefault(Request.QueryOptionKey.USE_STAR_TREE_KEY, "true")));
   }
 
   public static Integer getNumReplicaGroupsToQuery(Map<String, String> queryOptions) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
@@ -47,6 +47,10 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.SKIP_UPSERT));
   }
 
+  public static boolean isSkipStartree(Map<String, String> queryOptions) {
+    return Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.SKIP_STARTREE));
+  }
+
   public static Integer getNumReplicaGroupsToQuery(Map<String, String> queryOptions) {
     String numReplicaGroupsToQuery = queryOptions.get(Request.QueryOptionKey.NUM_REPLICA_GROUPS_TO_QUERY);
     return numReplicaGroupsToQuery != null ? Integer.parseInt(numReplicaGroupsToQuery) : null;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -248,7 +248,7 @@ public class CommonConstants {
       public static class QueryOptionKey {
         public static final String TIMEOUT_MS = "timeoutMs";
         public static final String SKIP_UPSERT = "skipUpsert";
-        public static final String SKIP_STARTREE = "skipStarTree";
+        public static final String USE_STAR_TREE_KEY = "useStarTree";
         public static final String MAX_EXECUTION_THREADS = "maxExecutionThreads";
         public static final String MIN_SEGMENT_GROUP_TRIM_SIZE = "minSegmentGroupTrimSize";
         public static final String MIN_SERVER_GROUP_TRIM_SIZE = "minServerGroupTrimSize";
@@ -261,10 +261,6 @@ public class CommonConstants {
         public static final String RESPONSE_FORMAT = "responseFormat";
         @Deprecated
         public static final String GROUP_BY_MODE = "groupByMode";
-      }
-
-      public static class DebugOptionsKey {
-        public static final String USE_STAR_TREE_KEY = "useStarTree";
       }
     }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -248,6 +248,7 @@ public class CommonConstants {
       public static class QueryOptionKey {
         public static final String TIMEOUT_MS = "timeoutMs";
         public static final String SKIP_UPSERT = "skipUpsert";
+        public static final String SKIP_STARTREE = "skipStartree";
         public static final String MAX_EXECUTION_THREADS = "maxExecutionThreads";
         public static final String MIN_SEGMENT_GROUP_TRIM_SIZE = "minSegmentGroupTrimSize";
         public static final String MIN_SERVER_GROUP_TRIM_SIZE = "minServerGroupTrimSize";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -248,7 +248,7 @@ public class CommonConstants {
       public static class QueryOptionKey {
         public static final String TIMEOUT_MS = "timeoutMs";
         public static final String SKIP_UPSERT = "skipUpsert";
-        public static final String SKIP_STARTREE = "skipStartree";
+        public static final String SKIP_STARTREE = "skipStarTree";
         public static final String MAX_EXECUTION_THREADS = "maxExecutionThreads";
         public static final String MIN_SEGMENT_GROUP_TRIM_SIZE = "minSegmentGroupTrimSize";
         public static final String MIN_SERVER_GROUP_TRIM_SIZE = "minServerGroupTrimSize";
@@ -261,6 +261,10 @@ public class CommonConstants {
         public static final String RESPONSE_FORMAT = "responseFormat";
         @Deprecated
         public static final String GROUP_BY_MODE = "groupByMode";
+      }
+
+      public static class DebugOptionsKey {
+        public static final String USE_STAR_TREE_KEY = "useStarTree";
       }
     }
 


### PR DESCRIPTION
Currently, there are some cases where Startree index might not work properly (such as using aggregation with OR filters). For such cases, we can have the option in query itself to skip startree index.

You can set `option(useStarTree=false)` to skip starTree index.
