### PR TITLE
Improve the Explain Plan accuracy

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -445,7 +445,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     }
 
     if (offlineBrokerRequest == null && realtimeBrokerRequest == null) {
-      if (serverPinotQuery.isExplain()) {
+      if (pinotQuery.isExplain()) {
         // EXPLAIN PLAN results to show that query is evaluated exclusively by Broker.
         return BrokerResponseNative.BROKER_ONLY_EXPLAIN_PLAN_OUTPUT;
       }
@@ -555,7 +555,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     //       - Compile time function invocation
     //       - Literal only queries
     //       - Any rewrites
-    if (serverPinotQuery.isExplain()) {
+    if (pinotQuery.isExplain()) {
       // Update routing tables to only send request to offline servers for OFFLINE and HYBRID tables.
       // TODO: Assess if the Explain Plan Query should also be routed to REALTIME servers for HYBRID tables
       if (offlineRoutingTable != null) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -26,7 +26,6 @@ import com.google.common.util.concurrent.RateLimiter;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -446,7 +445,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     }
 
     if (offlineBrokerRequest == null && realtimeBrokerRequest == null) {
-      if (pinotQuery.isExplain()) {
+      if (serverPinotQuery.isExplain()) {
         // EXPLAIN PLAN results to show that query is evaluated exclusively by Broker.
         return BrokerResponseNative.BROKER_ONLY_EXPLAIN_PLAN_OUTPUT;
       }
@@ -473,6 +472,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     Map<ServerInstance, List<String>> offlineRoutingTable = null;
     Map<ServerInstance, List<String>> realtimeRoutingTable = null;
     List<String> unavailableSegments = new ArrayList<>();
+    int numPrunedSegmentsTotal = 0;
     if (offlineBrokerRequest != null) {
       // NOTE: Routing table might be null if table is just removed
       RoutingTable routingTable = _routingManager.getRoutingTable(offlineBrokerRequest);
@@ -484,6 +484,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         } else {
           offlineBrokerRequest = null;
         }
+        numPrunedSegmentsTotal += routingTable.getNumPrunedSegments();
       } else {
         offlineBrokerRequest = null;
       }
@@ -499,6 +500,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         } else {
           realtimeBrokerRequest = null;
         }
+        numPrunedSegmentsTotal += routingTable.getNumPrunedSegments();
       } else {
         realtimeBrokerRequest = null;
       }
@@ -548,15 +550,18 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
     // Execute the query
     ServerStats serverStats = new ServerStats();
+    // TODO: Handle broker specific operations for explain plan queries such as:
+    //       - Alias handling
+    //       - Compile time function invocation
+    //       - Literal only queries
+    //       - Any rewrites
     if (serverPinotQuery.isExplain()) {
-      // Update routing tables to only send request to 1 server (& generate the plan for 1 segment).
+      // Update routing tables to only send request to offline servers for OFFLINE and HYBRID tables.
+      // TODO: Assess if the Explain Plan Query should also be routed to REALTIME servers for HYBRID tables
       if (offlineRoutingTable != null) {
-        setRoutingToOneSegment(offlineRoutingTable);
         // For OFFLINE and HYBRID tables, don't send EXPLAIN query to realtime servers.
         realtimeBrokerRequest = null;
         realtimeRoutingTable = null;
-      } else {
-        setRoutingToOneSegment(realtimeRoutingTable);
       }
     }
     // TODO: Modify processBrokerRequest() to directly take PinotQuery
@@ -564,6 +569,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         processBrokerRequest(requestId, brokerRequest, serverBrokerRequest, offlineBrokerRequest, offlineRoutingTable,
             realtimeBrokerRequest, realtimeRoutingTable, remainingTimeMs, serverStats, requestContext);
     brokerResponse.setExceptions(exceptions);
+    brokerResponse.setNumSegmentsPrunedByBroker(numPrunedSegmentsTotal);
     long executionEndTimeNs = System.nanoTime();
     _brokerMetrics.addPhaseTiming(rawTableName, BrokerQueryPhase.QUERY_EXECUTION,
         executionEndTimeNs - routingEndTimeNs);
@@ -638,15 +644,6 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     }
     function.getOperands()
         .forEach(operand -> setTimestampIndexExpressionOverrideHints(operand, timestampIndexColumns, pinotQuery));
-  }
-
-  /** Set EXPLAIN PLAN query to route to only one segment on one server. */
-  private void setRoutingToOneSegment(Map<ServerInstance, List<String>> routingTable) {
-    Set<Map.Entry<ServerInstance, List<String>>> servers = routingTable.entrySet();
-    // only send request to 1 server
-    Map.Entry<ServerInstance, List<String>> server = servers.iterator().next();
-    routingTable.clear();
-    routingTable.put(server.getKey(), Collections.singletonList(server.getValue().get(0)));
   }
 
   /** Given a {@link PinotQuery}, check if the WHERE clause will always evaluate to false. */

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
@@ -61,10 +61,17 @@ public interface InstanceSelector {
   class SelectionResult {
     private final Map<String, String> _segmentToInstanceMap;
     private final List<String> _unavailableSegments;
+    private int _numPrunedSegments;
 
     public SelectionResult(Map<String, String> segmentToInstanceMap, List<String> unavailableSegments) {
+      this(segmentToInstanceMap, unavailableSegments, 0);
+    }
+
+    public SelectionResult(Map<String, String> segmentToInstanceMap, List<String> unavailableSegments,
+        int numPrunedSegments) {
       _segmentToInstanceMap = segmentToInstanceMap;
       _unavailableSegments = unavailableSegments;
+      _numPrunedSegments = numPrunedSegments;
     }
 
     /**
@@ -79,6 +86,20 @@ public interface InstanceSelector {
      */
     public List<String> getUnavailableSegments() {
       return _unavailableSegments;
+    }
+
+    /**
+     * Returns the number of segments pruned by the broker
+     */
+    public int getNumPrunedSegments() {
+      return _numPrunedSegments;
+    }
+
+    /**
+     * Sets the number of segments pruned by the broker
+     */
+    public void setNumPrunedSegments(int numPrunedSegments) {
+      _numPrunedSegments = numPrunedSegments;
     }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
@@ -220,4 +220,44 @@ public interface BrokerResponse {
    * against realtime table in request handling, into the broker response.
    */
   void setRealtimeTotalCpuTimeNs(long realtimeTotalCpuTimeNs);
+
+  /**
+   * Get the total number of segments pruned on the Broker side
+   */
+  long getNumSegmentsPrunedByBroker();
+
+  /**
+   * Set the total number of segments pruned on the Broker side
+   */
+  void setNumSegmentsPrunedByBroker(long numSegmentsPrunedByBroker);
+
+  /**
+   * Get the total number of segments pruned on the Server side
+   */
+  long getNumSegmentsPrunedByServer();
+
+  /**
+   * Set the total number of segments pruned on the Server side
+   */
+  void setNumSegmentsPrunedByServer(long numSegmentsPrunedByServer);
+
+  /**
+   * Get the total number of segments with an EmptyFilterOperator when Explain Plan is called
+   */
+  long getExplainPlanNumEmptyFilterSegments();
+
+  /**
+   * Set the total number of segments with an EmptyFilterOperator when Explain Plan is called
+   */
+  void setExplainPlanNumEmptyFilterSegments(long explainPlanNumEmptyFilterSegments);
+
+  /**
+   * Get the total number of segments with a MatchAllFilterOperator when Explain Plan is called
+   */
+  long getExplainPlanNumMatchAllFilterSegments();
+
+  /**
+   * Set the total number of segments with a MatchAllFilterOperator when Explain Plan is called
+   */
+  void setExplainPlanNumMatchAllFilterSegments(long explainPlanNumMatchAllFilterSegments);
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
@@ -81,6 +81,10 @@ public class BrokerResponseNative implements BrokerResponse {
   private long _realtimeResponseSerializationCpuTimeNs = 0L;
   private long _offlineTotalCpuTimeNs = 0L;
   private long _realtimeTotalCpuTimeNs = 0L;
+  private long _numSegmentsPrunedByBroker = 0L;
+  private long _numSegmentsPrunedByServer = 0L;
+  private long _explainPlanNumEmptyFilterSegments = 0L;
+  private long _explainPlanNumMatchAllFilterSegments = 0L;
   private int _numRowsResultSet = 0;
   private ResultTable _resultTable;
   private Map<String, String> _traceInfo = new HashMap<>();
@@ -215,6 +219,54 @@ public class BrokerResponseNative implements BrokerResponse {
   @Override
   public void setRealtimeTotalCpuTimeNs(long realtimeTotalCpuTimeNs) {
     _realtimeTotalCpuTimeNs = realtimeTotalCpuTimeNs;
+  }
+
+  @JsonProperty("numSegmentsPrunedByBroker")
+  @Override
+  public long getNumSegmentsPrunedByBroker() {
+    return _numSegmentsPrunedByBroker;
+  }
+
+  @JsonProperty("numSegmentsPrunedByBroker")
+  @Override
+  public void setNumSegmentsPrunedByBroker(long numSegmentsPrunedByBroker) {
+    _numSegmentsPrunedByBroker = numSegmentsPrunedByBroker;
+  }
+
+  @JsonProperty("numSegmentsPrunedByServer")
+  @Override
+  public long getNumSegmentsPrunedByServer() {
+    return _numSegmentsPrunedByServer;
+  }
+
+  @JsonProperty("numSegmentsPrunedByServer")
+  @Override
+  public void setNumSegmentsPrunedByServer(long numSegmentsPrunedByServer) {
+    _numSegmentsPrunedByServer = numSegmentsPrunedByServer;
+  }
+
+  @JsonProperty("explainPlanNumEmptyFilterSegments")
+  @Override
+  public long getExplainPlanNumEmptyFilterSegments() {
+    return _explainPlanNumEmptyFilterSegments;
+  }
+
+  @JsonProperty("explainPlanNumEmptyFilterSegments")
+  @Override
+  public void setExplainPlanNumEmptyFilterSegments(long explainPlanNumEmptyFilterSegments) {
+    _explainPlanNumEmptyFilterSegments = explainPlanNumEmptyFilterSegments;
+  }
+
+  @JsonProperty("explainPlanNumMatchAllFilterSegments")
+  @Override
+  public long getExplainPlanNumMatchAllFilterSegments() {
+    return _explainPlanNumMatchAllFilterSegments;
+  }
+
+  @JsonProperty("explainPlanNumMatchAllFilterSegments")
+  @Override
+  public void setExplainPlanNumMatchAllFilterSegments(long explainPlanNumMatchAllFilterSegments) {
+    _explainPlanNumMatchAllFilterSegments = explainPlanNumMatchAllFilterSegments;
   }
 
   @JsonProperty("resultTable")

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataTable.java
@@ -111,7 +111,10 @@ public interface DataTable {
     RESIZE_TIME_MS("resizeTimeMs", MetadataValueType.LONG),
     THREAD_CPU_TIME_NS("threadCpuTimeNs", MetadataValueType.LONG),
     SYSTEM_ACTIVITIES_CPU_TIME_NS("systemActivitiesCpuTimeNs", MetadataValueType.LONG),
-    RESPONSE_SER_CPU_TIME_NS("responseSerializationCpuTimeNs", MetadataValueType.LONG);
+    RESPONSE_SER_CPU_TIME_NS("responseSerializationCpuTimeNs", MetadataValueType.LONG),
+    NUM_SEGMENTS_PRUNED_BY_SERVER("numSegmentsPrunedByServer", MetadataValueType.INT),
+    EXPLAIN_PLAN_NUM_EMPTY_FILTER_SEGMENTS("explainPlanNumEmptyFilterSegments", MetadataValueType.INT),
+    EXPLAIN_PLAN_NUM_MATCH_ALL_FILTER_SEGMENTS("explainPlanNumMatchAllFilterSegments", MetadataValueType.INT);
 
     private static final MetadataKey[] VALUES;
     private static final Map<String, MetadataKey> NAME_TO_ENUM_KEY_MAP = new HashMap<>();

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/ExplainPlanRowData.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/ExplainPlanRowData.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.common;
+
+import java.util.Objects;
+
+/**
+ * Class to hold the data for a single Explain plan row
+ */
+public class ExplainPlanRowData {
+  private final String _explainPlanString;
+  private final int _operatorId;
+  private final int _parentId;
+
+  public ExplainPlanRowData(String explainPlanString, int operatorId, int parentId) {
+    _explainPlanString = explainPlanString;
+    _operatorId = operatorId;
+    _parentId = parentId;
+  }
+
+  public String getExplainPlanString() {
+    return _explainPlanString;
+  }
+
+  public int getOperatorId() {
+    return _operatorId;
+  }
+
+  public int getParentId() {
+    return _parentId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ExplainPlanRowData that = (ExplainPlanRowData) o;
+    return _operatorId == that._operatorId && _parentId == that._parentId
+        && _explainPlanString.equals(that._explainPlanString);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_explainPlanString, _operatorId, _parentId);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/ExplainPlanRows.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/ExplainPlanRows.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.common;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Class to hold all the rows for a given Explain Plan
+ */
+public class ExplainPlanRows implements Comparable<ExplainPlanRows> {
+  public static final String ALL_SEGMENTS_PRUNED_ON_SERVER = "ALL_SEGMENTS_PRUNED_ON_SERVER";
+  public static final String PLAN_START = "PLAN_START(numSegmentsForThisPlan:";
+  public static final String PLAN_START_FORMAT = PLAN_START + "%d" + ")";
+  public static final int PLAN_START_IDS = -1;
+
+  private final List<ExplainPlanRowData> _explainPlanRowData;
+  private boolean _hasEmptyFilter;
+  private boolean _hasMatchAllFilter;
+  private boolean _hasNoMatchingSegment;
+  private int _numSegmentsMatchingThisPlan;
+
+  public ExplainPlanRows() {
+    _explainPlanRowData = new ArrayList<>();
+    _hasEmptyFilter = false;
+    _hasMatchAllFilter = false;
+    _hasNoMatchingSegment = false;
+    _numSegmentsMatchingThisPlan = 0;
+  }
+
+  public List<ExplainPlanRowData> getExplainPlanRowData() {
+    return _explainPlanRowData;
+  }
+
+  public void appendExplainPlanRowData(ExplainPlanRowData explainPlanRowData) {
+    _explainPlanRowData.add(explainPlanRowData);
+  }
+
+  public boolean isHasEmptyFilter() {
+    return _hasEmptyFilter;
+  }
+
+  public void setHasEmptyFilter(boolean hasEmptyFilter) {
+    _hasEmptyFilter = hasEmptyFilter;
+  }
+
+  public boolean isHasMatchAllFilter() {
+    return _hasMatchAllFilter;
+  }
+
+  public void setHasMatchAllFilter(boolean hasMatchAllFilter) {
+    _hasMatchAllFilter = hasMatchAllFilter;
+  }
+
+  public boolean isHasNoMatchingSegment() {
+    return _hasNoMatchingSegment;
+  }
+
+  public void setHasNoMatchingSegment(boolean hasNoMatchingSegment) {
+    _hasNoMatchingSegment = hasNoMatchingSegment;
+  }
+
+  public int getNumSegmentsMatchingThisPlan() {
+    return _numSegmentsMatchingThisPlan;
+  }
+
+  public void incrementNumSegmentsMatchingThisPlan() {
+    _numSegmentsMatchingThisPlan++;
+  }
+
+  public void setNumSegmentsMatchingThisPlan(int numSegmentsMatchingThisPlan) {
+    _numSegmentsMatchingThisPlan = numSegmentsMatchingThisPlan;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    ExplainPlanRows that = (ExplainPlanRows) o;
+    return _hasEmptyFilter == that._hasEmptyFilter && _hasMatchAllFilter == that._hasMatchAllFilter
+        && _hasNoMatchingSegment == that._hasNoMatchingSegment
+        && Objects.equals(_explainPlanRowData, that._explainPlanRowData);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_explainPlanRowData, _hasEmptyFilter, _hasMatchAllFilter, _hasNoMatchingSegment);
+  }
+
+  @Override
+  public int compareTo(ExplainPlanRows o) {
+    int thisHashCode = this.hashCode();
+    int otherHashCode = o.hashCode();
+    return Integer.compare(thisHashCode, otherHashCode);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/EmptyFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/EmptyFilterOperator.java
@@ -33,7 +33,7 @@ public final class EmptyFilterOperator extends BaseFilterOperator {
   }
 
 
-  private static final String EXPLAIN_NAME = "FILTER_EMPTY";
+  public static final String EXPLAIN_NAME = "FILTER_EMPTY";
 
   private static final EmptyFilterOperator INSTANCE = new EmptyFilterOperator();
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MatchAllFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MatchAllFilterOperator.java
@@ -26,7 +26,7 @@ import org.apache.pinot.core.operator.docidsets.MatchAllDocIdSet;
 
 
 public class MatchAllFilterOperator extends BaseFilterOperator {
-  private static final String EXPLAIN_NAME = "FILTER_MATCH_ENTIRE_SEGMENT";
+  public static final String EXPLAIN_NAME = "FILTER_MATCH_ENTIRE_SEGMENT";
   private final int _numDocs;
 
   public MatchAllFilterOperator(int numDocs) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseReduceService.java
@@ -142,6 +142,9 @@ public abstract class BaseReduceService {
     private long _realtimeResponseSerializationCpuTimeNs = 0L;
     private long _offlineTotalCpuTimeNs = 0L;
     private long _realtimeTotalCpuTimeNs = 0L;
+    private long _numSegmentsPrunedByServer = 0L;
+    private long _explainPlanNumEmptyFilterSegments = 0L;
+    private long _explainPlanNumMatchAllFilterSegments = 0L;
     private boolean _numGroupsLimitReached = false;
 
     protected ExecutionStatsAggregator(boolean enableTrace) {
@@ -230,6 +233,23 @@ public abstract class BaseReduceService {
       _realtimeTotalCpuTimeNs =
           _realtimeThreadCpuTimeNs + _realtimeSystemActivitiesCpuTimeNs + _realtimeResponseSerializationCpuTimeNs;
 
+      String numSegmentsPrunedByServer = metadata.get(MetadataKey.NUM_SEGMENTS_PRUNED_BY_SERVER.getName());
+      if (numSegmentsPrunedByServer != null) {
+        _numSegmentsPrunedByServer += Long.parseLong(numSegmentsPrunedByServer);
+      }
+
+      String explainPlanNumEmptyFilterSegments =
+          metadata.get(MetadataKey.EXPLAIN_PLAN_NUM_EMPTY_FILTER_SEGMENTS.getName());
+      if (explainPlanNumEmptyFilterSegments != null) {
+        _explainPlanNumEmptyFilterSegments += Long.parseLong(explainPlanNumEmptyFilterSegments);
+      }
+
+      String explainPlanNumMatchAllFilterSegments =
+          metadata.get(MetadataKey.EXPLAIN_PLAN_NUM_MATCH_ALL_FILTER_SEGMENTS.getName());
+      if (explainPlanNumMatchAllFilterSegments != null) {
+        _explainPlanNumMatchAllFilterSegments += Long.parseLong(explainPlanNumMatchAllFilterSegments);
+      }
+
       String numTotalDocsString = metadata.get(MetadataKey.TOTAL_DOCS.getName());
       if (numTotalDocsString != null) {
         _numTotalDocs += Long.parseLong(numTotalDocsString);
@@ -265,6 +285,9 @@ public abstract class BaseReduceService {
       brokerResponseNative.setRealtimeResponseSerializationCpuTimeNs(_realtimeResponseSerializationCpuTimeNs);
       brokerResponseNative.setOfflineTotalCpuTimeNs(_offlineTotalCpuTimeNs);
       brokerResponseNative.setRealtimeTotalCpuTimeNs(_realtimeTotalCpuTimeNs);
+      brokerResponseNative.setNumSegmentsPrunedByServer(_numSegmentsPrunedByServer);
+      brokerResponseNative.setExplainPlanNumEmptyFilterSegments(_explainPlanNumEmptyFilterSegments);
+      brokerResponseNative.setExplainPlanNumMatchAllFilterSegments(_explainPlanNumMatchAllFilterSegments);
       if (_numConsumingSegmentsProcessed > 0) {
         brokerResponseNative.setNumConsumingSegmentsQueried(_numConsumingSegmentsProcessed);
         brokerResponseNative.setMinConsumingFreshnessTimeMs(_minConsumingFreshnessTimeMs);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -117,7 +117,9 @@ public class BrokerReduceService extends BaseReduceService {
       gapfillProcessor.process(brokerResponseNative);
     }
 
-    updateAlias(queryContext, brokerResponseNative);
+    if (!serverQueryContext.isExplain()) {
+      updateAlias(queryContext, brokerResponseNative);
+    }
     return brokerResponseNative;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExplainPlanDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExplainPlanDataTableReducer.java
@@ -19,25 +19,33 @@
 package org.apache.pinot.core.query.reduce;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataTable;
+import org.apache.pinot.core.common.ExplainPlanRowData;
+import org.apache.pinot.core.common.ExplainPlanRows;
+import org.apache.pinot.core.operator.filter.EmptyFilterOperator;
+import org.apache.pinot.core.operator.filter.MatchAllFilterOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextUtils;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
+import org.apache.pinot.core.util.QueryOptionsUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
 public class ExplainPlanDataTableReducer implements DataTableReducer {
   private static final Logger LOGGER = LoggerFactory.getLogger(ExplainPlanDataTableReducer.class);
+  private static final String COMBINE = "COMBINE";
 
   private final QueryContext _queryContext;
 
@@ -50,27 +58,216 @@ public class ExplainPlanDataTableReducer implements DataTableReducer {
       Map<ServerRoutingInstance, DataTable> dataTableMap, BrokerResponseNative brokerResponseNative,
       DataTableReducerContext reducerContext, BrokerMetrics brokerMetrics) {
 
-    Map.Entry<ServerRoutingInstance, DataTable> entry = dataTableMap.entrySet().iterator().next();
-    DataTable dataTable = entry.getValue();
     List<Object[]> reducedRows = new ArrayList<>();
 
     // Top node should be a BROKER_REDUCE node.
     addBrokerReduceOperation(reducedRows);
 
-    // Add rest of the rows received from the server.
-    int numRows = dataTable.getNumberOfRows();
-    for (int rowId = 0; rowId < numRows; rowId++) {
-      reducedRows.add(SelectionOperatorUtils.extractRowFromDataTable(dataTable, rowId));
+    // Construct the combine node
+    Object[] combinedRow = extractCombineNode(dataTableMap);
+    if (combinedRow != null) {
+      reducedRows.add(combinedRow);
+    }
+
+    // Extract the query option denoting whether to return verbose output or not
+    Map<String, String> queryOptions = _queryContext.getQueryOptions();
+    boolean explainPlanVerbose = queryOptions != null && QueryOptionsUtils.isExplainPlanVerbose(queryOptions);
+
+    // Add the rest of the rows for each unique Explain plan received from the servers
+    List<ExplainPlanRows> explainPlanRowsList = extractUniqueExplainPlansAcrossServers(dataTableMap);
+    if (!explainPlanVerbose && (explainPlanRowsList.size() > 1)) {
+      // Pick the most appropriate plan if verbose option is disabled
+      explainPlanRowsList = chooseBestExplainPlanToUse(explainPlanRowsList);
+    }
+
+    // Construct the explain plan output
+    for (ExplainPlanRows explainPlanRows : explainPlanRowsList) {
+      String numSegmentsExplainString = String.format(ExplainPlanRows.PLAN_START_FORMAT,
+          explainPlanRows.getNumSegmentsMatchingThisPlan());
+      Object[] numSegmentsRow = {numSegmentsExplainString, ExplainPlanRows.PLAN_START_IDS,
+          ExplainPlanRows.PLAN_START_IDS};
+      reducedRows.add(numSegmentsRow);
+
+      for (ExplainPlanRowData explainPlanRowData : explainPlanRows.getExplainPlanRowData()) {
+        Object[] row = {explainPlanRowData.getExplainPlanString(), explainPlanRowData.getOperatorId(),
+            explainPlanRowData.getParentId()};
+        reducedRows.add(row);
+      }
     }
 
     ResultTable resultTable = new ResultTable(dataSchema, reducedRows);
     brokerResponseNative.setResultTable(resultTable);
   }
 
+  /**
+   * Extract the combine node to use as the global combine step if present. If no combine node is found, return null.
+   * A combine node may not be found if all segments were pruned across all servers.
+   */
+  private Object[] extractCombineNode(Map<ServerRoutingInstance, DataTable> dataTableMap) {
+    if (dataTableMap.isEmpty()) {
+      return null;
+    }
+
+    Object[] combineRow = null;
+    for (Map.Entry<ServerRoutingInstance, DataTable> entry : dataTableMap.entrySet()) {
+      DataTable dataTable = entry.getValue();
+      int numRows = dataTable.getNumberOfRows();
+      if (numRows > 0) {
+        // First row should be the combine row data, unless all segments were pruned from the Server side
+        Object[] row = SelectionOperatorUtils.extractRowFromDataTable(dataTable, 0);
+        String rowName = row[0].toString();
+        if (rowName.contains(COMBINE)) {
+          combineRow = row;
+          break;
+        }
+      }
+    }
+    return combineRow;
+  }
+
+  /**
+   * Extract a list of all the unique explain plans across all servers
+   */
+  private List<ExplainPlanRows> extractUniqueExplainPlansAcrossServers(
+      Map<ServerRoutingInstance, DataTable> dataTableMap) {
+    List<ExplainPlanRows> explainPlanRowsList = new ArrayList<>();
+    HashSet<Integer> explainPlanHashCodeSet = new HashSet<>();
+
+    for (Map.Entry<ServerRoutingInstance, DataTable> entry : dataTableMap.entrySet()) {
+      DataTable dataTable = entry.getValue();
+      int numRows = dataTable.getNumberOfRows();
+
+      ExplainPlanRows explainPlanRows = null;
+      for (int rowId = 0; rowId < numRows; rowId++) {
+        Object[] row = SelectionOperatorUtils.extractRowFromDataTable(dataTable, rowId);
+        String rowName = row[0].toString();
+        if (rowName.contains(COMBINE)) {
+          // Skip the combine explain plan nodes as we construct a global one for all the plans returned
+          continue;
+        } else if (rowName.contains(ExplainPlanRows.PLAN_START)) {
+          // There may be an ongoing explain plan being constructed. NUM_MATCHING_SEGMENTS is a delimiter for the
+          // various explain plans returned by each server. Thus complete the explain plan for the previous plan and
+          // start a new one.
+          updateExplainPlanRowsList(explainPlanRowsList, explainPlanHashCodeSet, explainPlanRows);
+          explainPlanRows = new ExplainPlanRows();
+          String numSegmentsString =
+              StringUtils.substringBefore(StringUtils.substringAfter(rowName, ExplainPlanRows.PLAN_START), ")");
+          explainPlanRows.setNumSegmentsMatchingThisPlan(Integer.parseInt(numSegmentsString));
+          continue;
+        }
+
+        if (explainPlanRows == null) {
+          explainPlanRows = new ExplainPlanRows();
+        }
+
+        if (rowName.contains(EmptyFilterOperator.EXPLAIN_NAME)) {
+          explainPlanRows.setHasEmptyFilter(true);
+        } else if (rowName.contains(MatchAllFilterOperator.EXPLAIN_NAME)) {
+          explainPlanRows.setHasMatchAllFilter(true);
+        } else if (rowName.contains(ExplainPlanRows.ALL_SEGMENTS_PRUNED_ON_SERVER)) {
+          explainPlanRows.setHasNoMatchingSegment(true);
+        }
+        explainPlanRows.getExplainPlanRowData().add(new ExplainPlanRowData(rowName, (int) row[1], (int) row[2]));
+      }
+      // The last plan needs to be completed so that it isn't lost. There is no end delimiter, just use end of rows
+      // as the end delimiter
+      updateExplainPlanRowsList(explainPlanRowsList, explainPlanHashCodeSet, explainPlanRows);
+    }
+
+    // Sorting the list of explain plans to ensure we get a deterministic ordering of the plans
+    Collections.sort(explainPlanRowsList);
+    return explainPlanRowsList;
+  }
+
+  /**
+   * Finalize and add a new explain plan to the explain plan list. Also dedupe duplicate explain plans
+   */
+  private void updateExplainPlanRowsList(List<ExplainPlanRows> explainPlanRowsList,
+      HashSet<Integer> explainPlanHashCodeSet, ExplainPlanRows explainPlanRows) {
+    if (explainPlanRows != null) {
+      int explainPlanRowsHashCode = explainPlanRows.hashCode();
+      if (!explainPlanHashCodeSet.contains(explainPlanRowsHashCode)) {
+        // Hashcode found is unique, add to the list of explain plan nodes
+        explainPlanRowsList.add(explainPlanRows);
+        explainPlanHashCodeSet.add(explainPlanRowsHashCode);
+      } else {
+        boolean explainPlanMatchFound = false;
+        for (ExplainPlanRows planRows : explainPlanRowsList) {
+          if ((planRows.hashCode() == explainPlanRowsHashCode) && (planRows.equals(explainPlanRows))) {
+            // If the hashcodes match and the plans are equal, update the number of segments matching this plan
+            int numSegments = planRows.getNumSegmentsMatchingThisPlan();
+            numSegments += explainPlanRows.getNumSegmentsMatchingThisPlan();
+            planRows.setNumSegmentsMatchingThisPlan(numSegments);
+            explainPlanMatchFound = true;
+            break;
+          }
+        }
+
+        // The hashcodes match but the plans aren't equal. HashCodes can cause collisions. Append this plan to the
+        // list of plans
+        if (!explainPlanMatchFound) {
+          explainPlanRowsList.add(explainPlanRows);
+        }
+      }
+    }
+  }
+
+  /**
+   * Choose the best explain plan to use when verbose mode is disabled. The precedence ordering is:
+   * - Other plan > match All plan > empty plan > no matching segment plan
+   * - Tree depth is used if more than 1 plan exists for the winning plan type from above
+   */
+  private List<ExplainPlanRows> chooseBestExplainPlanToUse(List<ExplainPlanRows> explainPlanRowsList) {
+    int maxOtherDepth = -1;
+    int maxEmptyFilterDepth = -1;
+    int maxMatchAllFilterDepth = -1;
+    int maxNoMatchingSegmentDepth = -1;
+    int maxOtherIdx = -1;
+    int maxEmptyFilterIdx = -1;
+    int maxMatchAllFilterIdx = -1;
+    int maxNoMatchingSegmentIdx = -1;
+
+    for (int i = 0; i < explainPlanRowsList.size(); i++) {
+      ExplainPlanRows explainPlanRows = explainPlanRowsList.get(i);
+      int explainPlanRowsSize = explainPlanRows.getExplainPlanRowData().size();
+      if (explainPlanRows.isHasNoMatchingSegment()) {
+        if (explainPlanRowsSize > maxNoMatchingSegmentDepth) {
+          maxNoMatchingSegmentDepth = explainPlanRowsSize;
+          maxNoMatchingSegmentIdx = i;
+        }
+      } else if (explainPlanRows.isHasEmptyFilter()) {
+        if (explainPlanRowsSize > maxEmptyFilterDepth) {
+          maxEmptyFilterDepth = explainPlanRowsSize;
+          maxEmptyFilterIdx = i;
+        }
+      } else if (explainPlanRows.isHasMatchAllFilter()) {
+        if (explainPlanRowsSize > maxMatchAllFilterDepth) {
+          maxMatchAllFilterDepth = explainPlanRowsSize;
+          maxMatchAllFilterIdx = i;
+        }
+      } else {
+        if (explainPlanRowsSize > maxOtherDepth) {
+          maxOtherDepth = explainPlanRowsSize;
+          maxOtherIdx = i;
+        }
+      }
+    }
+
+    // Precedence: Other > MatchAllFilter > EmptyFilter > NoMatchingSegment
+    if (maxOtherIdx > -1) {
+      return Collections.singletonList(explainPlanRowsList.get(maxOtherIdx));
+    } else if (maxMatchAllFilterIdx > -1) {
+      return Collections.singletonList(explainPlanRowsList.get(maxMatchAllFilterIdx));
+    } else if (maxEmptyFilterIdx > -1) {
+      return Collections.singletonList(explainPlanRowsList.get(maxEmptyFilterIdx));
+    }
+
+    return Collections.singletonList(explainPlanRowsList.get(maxNoMatchingSegmentIdx));
+  }
+
   private void addBrokerReduceOperation(List<Object[]> resultRows) {
 
     Set<String> postAggregations = new HashSet<>();
-    Set<String> regularTransforms = new HashSet<>();
     QueryContextUtils.collectPostAggregations(_queryContext, postAggregations);
     StringBuilder stringBuilder = new StringBuilder("BROKER_REDUCE").append('(');
 
@@ -97,7 +294,7 @@ public class ExplainPlanDataTableReducer implements DataTableReducer {
     }
 
     String brokerReduceNode = stringBuilder.append(')').toString();
-    Object[] brokerReduceRow = new Object[]{brokerReduceNode, 0, -1};
+    Object[] brokerReduceRow = new Object[]{brokerReduceNode, 1, 0};
 
     resultRows.add(brokerReduceRow);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/routing/RoutingTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/routing/RoutingTable.java
@@ -26,10 +26,13 @@ import org.apache.pinot.core.transport.ServerInstance;
 public class RoutingTable {
   private final Map<ServerInstance, List<String>> _serverInstanceToSegmentsMap;
   private final List<String> _unavailableSegments;
+  private final int _numPrunedSegments;
 
-  public RoutingTable(Map<ServerInstance, List<String>> serverInstanceToSegmentsMap, List<String> unavailableSegments) {
+  public RoutingTable(Map<ServerInstance, List<String>> serverInstanceToSegmentsMap, List<String> unavailableSegments,
+      int numPrunedSegments) {
     _serverInstanceToSegmentsMap = serverInstanceToSegmentsMap;
     _unavailableSegments = unavailableSegments;
+    _numPrunedSegments = numPrunedSegments;
   }
 
   public Map<ServerInstance, List<String>> getServerInstanceToSegmentsMap() {
@@ -38,5 +41,9 @@ public class RoutingTable {
 
   public List<String> getUnavailableSegments() {
     return _unavailableSegments;
+  }
+
+  public int getNumPrunedSegments() {
+    return _numPrunedSegments;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
@@ -52,6 +52,10 @@ public class QueryOptionsUtils {
     return numReplicaGroupsToQuery != null ? Integer.parseInt(numReplicaGroupsToQuery) : null;
   }
 
+  public static boolean isExplainPlanVerbose(Map<String, String> queryOptions) {
+    return Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.EXPLAIN_PLAN_VERBOSE));
+  }
+
   @Nullable
   public static Integer getMaxExecutionThreads(Map<String, String> queryOptions) {
     String maxExecutionThreadsString = queryOptions.get(Request.QueryOptionKey.MAX_EXECUTION_THREADS);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
@@ -19,14 +19,39 @@
 package org.apache.pinot.queries;
 
 import java.io.File;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
+import org.apache.helix.HelixManager;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.common.metrics.PinotMetricUtils;
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.InstanceRequest;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataTable;
+import org.apache.pinot.core.common.ExplainPlanRows;
+import org.apache.pinot.core.common.datatable.DataTableFactory;
+import org.apache.pinot.core.data.manager.InstanceDataManager;
+import org.apache.pinot.core.data.manager.offline.TableDataManagerProvider;
+import org.apache.pinot.core.query.executor.QueryExecutor;
+import org.apache.pinot.core.query.executor.ServerQueryExecutorV1Impl;
+import org.apache.pinot.core.query.reduce.BrokerReduceService;
+import org.apache.pinot.core.query.request.ServerQueryRequest;
+import org.apache.pinot.core.transport.ServerRoutingInstance;
+import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.segment.local.data.manager.TableDataManagerConfig;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
@@ -40,16 +65,29 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class ExplainPlanQueriesTest extends BaseQueriesTest {
   private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "ExplainPlanQueriesTest");
+  private static final String QUERY_EXECUTOR_CONFIG_PATH = "conf/query-executor.properties";
+  private static final ExecutorService QUERY_RUNNERS = Executors.newFixedThreadPool(20);
+
   private static final String RAW_TABLE_NAME = "testTable";
-  private static final String SEGMENT_NAME = "testSegment";
+  private static final String SEGMENT_NAME_1 = "testSegment1";
+  private static final String SEGMENT_NAME_2 = "testSegment2";
+  private static final String SEGMENT_NAME_3 = "testSegment3";
+  private static final String SEGMENT_NAME_4 = "testSegment4";
   private static final int NUM_RECORDS = 10;
 
   private final static String COL1_NO_INDEX = "noIndexCol1";
@@ -90,6 +128,11 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
 
   private IndexSegment _indexSegment;
   private List<IndexSegment> _indexSegments;
+  private List<String> _segmentNames;
+
+  private ServerMetrics _serverMetrics;
+  private QueryExecutor _queryExecutor;
+  private BrokerReduceService _brokerReduceService;
 
   @Override
   protected String getFilter() {
@@ -133,19 +176,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     return record;
   }
 
-  @BeforeClass
-  public void setUp()
+  ImmutableSegment createImmutableSegment(List<GenericRow> records, String segmentName)
       throws Exception {
-    FileUtils.deleteDirectory(INDEX_DIR);
-
-    List<GenericRow> records = new ArrayList<>(NUM_RECORDS);
-    records.add(createMockRecord(1, 2, 3, true, 1.1, 2, "daffy", 10.1, 20, 30, 100.1,
-        "{\"first\": \"daffy\", \"last\": " + "\"duck\"}", "daffy"));
-    records.add(createMockRecord(0, 1, 2, false, 0.1, 1, "mickey", 0.1, 10, 20, 100.2,
-        "{\"first\": \"mickey\", \"last\": " + "\"mouse\"}", "mickey"));
-    records.add(createMockRecord(3, 4, 5, true, 2.1, 3, "mickey", 20.1, 30, 40, 100.3,
-        "{\"first\": \"mickey\", \"last\": " + "\"mouse\"}", "mickey"));
-
     IndexingConfig indexingConfig = TABLE_CONFIG.getIndexingConfig();
 
     List<String> invertedIndexColumns = Arrays.asList(COL1_INVERTED_INDEX, COL2_INVERTED_INDEX, COL3_INVERTED_INDEX);
@@ -162,7 +194,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
 
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE_CONFIG, SCHEMA);
     segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
-    segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
+    segmentGeneratorConfig.setSegmentName(segmentName);
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getPath());
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
@@ -176,269 +208,827 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     indexLoadingConfig.setJsonIndexColumns(new HashSet<String>(jsonIndexColumns));
     indexLoadingConfig.setReadMode(ReadMode.mmap);
 
-    ImmutableSegment immutableSegment =
-        ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), indexLoadingConfig);
-    _indexSegment = immutableSegment;
-    _indexSegments = Arrays.asList(immutableSegment);
+    _segmentNames.add(segmentName);
+
+    return ImmutableSegmentLoader.load(new File(INDEX_DIR, segmentName), indexLoadingConfig);
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteDirectory(INDEX_DIR);
+    _segmentNames = new ArrayList<>();
+
+    List<GenericRow> records = new ArrayList<>(NUM_RECORDS);
+    records.add(createMockRecord(1, 2, 3, true, 1.1, 2, "daffy", 10.1, 20, 30, 100.1,
+        "{\"first\": \"daffy\", \"last\": " + "\"duck\"}", "daffy"));
+    records.add(createMockRecord(0, 1, 2, false, 0.1, 1, "mickey", 0.1, 10, 20, 100.2,
+        "{\"first\": \"mickey\", \"last\": " + "\"mouse\"}", "mickey"));
+    records.add(createMockRecord(3, 4, 5, true, 2.1, 3, "mickey", 20.1, 30, 40, 100.3,
+        "{\"first\": \"mickey\", \"last\": " + "\"mouse\"}", "mickey"));
+    ImmutableSegment immutableSegment1 = createImmutableSegment(records, SEGMENT_NAME_1);
+
+    List<GenericRow> records2 = new ArrayList<>(NUM_RECORDS);
+    records2.add(createMockRecord(5, 2, 3, true, 1.1, 2, "pluto", 10.1, 20, 30, 100.1,
+        "{\"first\": \"pluto\", \"last\": " + "\"dog\"}", "pluto"));
+    records2.add(createMockRecord(6, 1, 2, false, 0.1, 1, "pluto", 0.1, 10, 20, 100.2,
+        "{\"first\": \"pluto\", \"last\": " + "\"dog\"}", "pluto"));
+    records2.add(createMockRecord(8, 4, 5, true, 2.1, 3, "pluto", 20.1, 30, 40, 100.3,
+        "{\"first\": \"pluto\", \"last\": " + "\"dog\"}", "pluto"));
+    ImmutableSegment immutableSegment2 = createImmutableSegment(records2, SEGMENT_NAME_2);
+
+    List<GenericRow> records3 = new ArrayList<>(NUM_RECORDS);
+    records3.add(createMockRecord(5, 2, 3, true, 1.5, 2, "donald", 10.1, 20, 30, 100.1,
+        "{\"first\": \"donald\", \"last\": " + "\"duck\"}", "donald"));
+    records3.add(createMockRecord(6, 1, 2, false, 0.1, 1, "goofy", 0.1, 10, 20, 100.2,
+        "{\"first\": \"goofy\", \"last\": " + "\"dog\"}", "goofy"));
+    records3.add(createMockRecord(7, 4, 5, true, 2.1, 3, "minnie", 20.1, 30, 40, 100.3,
+        "{\"first\": \"minnie\", \"last\": " + "\"mouse\"}", "minnie"));
+    ImmutableSegment immutableSegment3 = createImmutableSegment(records3, SEGMENT_NAME_3);
+
+    List<GenericRow> records4 = new ArrayList<>(NUM_RECORDS);
+    records4.add(createMockRecord(5, 2, 3, true, 1.1, 2, "tweety", 10.1, 20, 30, 100.1,
+        "{\"first\": \"tweety\", \"last\": " + "\"bird\"}", "tweety"));
+    records4.add(createMockRecord(6, 1, 2, false, 0.1, 1, "bugs", 0.1, 10, 20, 100.2,
+        "{\"first\": \"bugs\", \"last\": " + "\"bunny\"}", "bugs"));
+    records4.add(createMockRecord(7, 4, 5, true, 2.1, 3, "sylvester", 20.1, 30, 40, 100.3,
+        "{\"first\": \"sylvester\", \"last\": " + "\"cat\"}", "sylvester"));
+    ImmutableSegment immutableSegment4 = createImmutableSegment(records4, SEGMENT_NAME_4);
+
+    _indexSegment = immutableSegment1;
+    _indexSegments = Arrays.asList(immutableSegment1, immutableSegment2, immutableSegment3, immutableSegment4);
+
+    // Mock the instance data manager
+    _serverMetrics = new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+    TableDataManagerConfig tableDataManagerConfig = mock(TableDataManagerConfig.class);
+    when(tableDataManagerConfig.getTableDataManagerType()).thenReturn("OFFLINE");
+    when(tableDataManagerConfig.getTableName()).thenReturn(RAW_TABLE_NAME);
+    when(tableDataManagerConfig.getDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
+    @SuppressWarnings("unchecked")
+    TableDataManager tableDataManager =
+        TableDataManagerProvider.getTableDataManager(tableDataManagerConfig, "testInstance",
+            mock(ZkHelixPropertyStore.class), mock(ServerMetrics.class), mock(HelixManager.class), null);
+    tableDataManager.start();
+    for (IndexSegment indexSegment : _indexSegments) {
+      tableDataManager.addSegment((ImmutableSegment) indexSegment);
+    }
+    InstanceDataManager instanceDataManager = mock(InstanceDataManager.class);
+    when(instanceDataManager.getTableDataManager(RAW_TABLE_NAME)).thenReturn(tableDataManager);
+
+    // Set up the query executor
+    URL resourceUrl = getClass().getClassLoader().getResource(QUERY_EXECUTOR_CONFIG_PATH);
+    Assert.assertNotNull(resourceUrl);
+    PropertiesConfiguration queryExecutorConfig = new PropertiesConfiguration();
+    queryExecutorConfig.setDelimiterParsingDisabled(false);
+    queryExecutorConfig.load(new File(resourceUrl.getFile()));
+    _queryExecutor = new ServerQueryExecutorV1Impl();
+    _queryExecutor.init(new PinotConfiguration(queryExecutorConfig), instanceDataManager, _serverMetrics);
+
+    // Create the BrokerReduceService
+    _brokerReduceService = new BrokerReduceService(new PinotConfiguration(
+        Collections.singletonMap(CommonConstants.Broker.CONFIG_OF_MAX_REDUCE_THREADS_PER_QUERY, 2)));
   }
 
   /** Checks the correctness of EXPLAIN PLAN output. */
   private void check(String query, ResultTable expected) {
-    QueriesTestUtils.testInterSegmentsResult(getBrokerResponse(query), expected);
+    BrokerRequest brokerRequest = CalciteSqlCompiler.compileToBrokerRequest(query);
+
+    int segmentsForServer1 = _segmentNames.size() / 2;
+    List<String> indexSegmentsForServer1 = new ArrayList<>();
+    List<String> indexSegmentsForServer2 = new ArrayList<>();
+    for (int i = 0; i < getIndexSegments().size(); i++) {
+      if (i < segmentsForServer1) {
+        indexSegmentsForServer1.add(_segmentNames.get(i));
+      } else {
+        indexSegmentsForServer2.add(_segmentNames.get(i));
+      }
+    }
+
+    InstanceRequest instanceRequest1 = new InstanceRequest(0L, brokerRequest);
+    instanceRequest1.setSearchSegments(indexSegmentsForServer1);
+    DataTable instanceResponse1 = _queryExecutor.processQuery(getQueryRequest(instanceRequest1), QUERY_RUNNERS);
+
+    InstanceRequest instanceRequest2 = new InstanceRequest(0L, brokerRequest);
+    instanceRequest2.setSearchSegments(indexSegmentsForServer2);
+    DataTable instanceResponse2 = _queryExecutor.processQuery(getQueryRequest(instanceRequest2), QUERY_RUNNERS);
+
+    // Broker side
+    // Use 2 Threads for 2 data-tables
+    // Different segments are assigned to each set of DataTables. This is necessary to simulate scenarios where
+    // certain segments may completely be pruned on one server but not the other.
+    Map<ServerRoutingInstance, DataTable> dataTableMap = new HashMap<>();
+    try {
+      // For multi-threaded BrokerReduceService, we cannot reuse the same data-table
+      byte[] serializedResponse1 = instanceResponse1.toBytes();
+      dataTableMap.put(new ServerRoutingInstance("localhost", 1234, TableType.OFFLINE),
+          DataTableFactory.getDataTable(serializedResponse1));
+      byte[] serializedResponse2 = instanceResponse2.toBytes();
+      dataTableMap.put(new ServerRoutingInstance("localhost", 1234, TableType.REALTIME),
+          DataTableFactory.getDataTable(serializedResponse2));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    BrokerResponseNative brokerResponse =
+        _brokerReduceService.reduceOnDataTable(brokerRequest, brokerRequest, dataTableMap,
+            CommonConstants.Broker.DEFAULT_BROKER_TIMEOUT_MS, null);
+
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, expected);
+  }
+
+  private ServerQueryRequest getQueryRequest(InstanceRequest instanceRequest) {
+    return new ServerQueryRequest(instanceRequest, _serverMetrics, System.currentTimeMillis());
   }
 
   @Test
   public void testSelect() {
+    // All segment plans for these queries generate a plan using the MatchAllFilterOperator as these queries select
+    // columns without filtering
     String query1 = "EXPLAIN PLAN FOR SELECT * FROM testTable";
     List<Object[]> result1 = new ArrayList<>();
-    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 0, -1});
-    result1.add(new Object[]{"COMBINE_SELECT", 1, 0});
+    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result1.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
     result1.add(new Object[]{
         "SELECT(selectList:invertedIndexCol1, invertedIndexCol2, invertedIndexCol3, jsonIndexCol1, "
             + "noIndexCol1, noIndexCol2, noIndexCol3, noIndexCol4, rangeIndexCol1, rangeIndexCol2, rangeIndexCol3, "
-            + "sortedIndexCol1, textIndexCol1)", 2, 1});
+            + "sortedIndexCol1, textIndexCol1)", 3, 2});
     result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, invertedIndexCol2, invertedIndexCol3, "
         + "jsonIndexCol1, noIndexCol1, noIndexCol2, noIndexCol3, noIndexCol4, rangeIndexCol1, rangeIndexCol2, "
-        + "rangeIndexCol3, sortedIndexCol1, textIndexCol1)", 3, 2});
+        + "rangeIndexCol3, sortedIndexCol1, textIndexCol1)", 4, 3});
     result1.add(new Object[]{"PROJECT(noIndexCol4, sortedIndexCol1, noIndexCol3, rangeIndexCol1, rangeIndexCol2, "
         + "invertedIndexCol1, noIndexCol2, invertedIndexCol2, noIndexCol1, rangeIndexCol3, textIndexCol1, "
-        + "jsonIndexCol1, invertedIndexCol3)", 4, 3});
-    result1.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
+        + "jsonIndexCol1, invertedIndexCol3)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
 
     String query2 = "EXPLAIN PLAN FOR SELECT 'mickey' FROM testTable";
     List<Object[]> result2 = new ArrayList<>();
-    result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 0, -1});
-    result2.add(new Object[]{"COMBINE_SELECT", 1, 0});
-    result2.add(new Object[]{"SELECT(selectList:'mickey')", 2, 1});
-    result2.add(new Object[]{"TRANSFORM('mickey')", 3, 2});
-    result2.add(new Object[]{"PROJECT()", 4, 3});
-    result2.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result2.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
+    result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result2.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"SELECT(selectList:'mickey')", 3, 2});
+    result2.add(new Object[]{"TRANSFORM('mickey')", 4, 3});
+    result2.add(new Object[]{"PROJECT()", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result2.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
     check(query2, new ResultTable(DATA_SCHEMA, result2));
 
     String query3 = "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1 FROM testTable LIMIT 100";
     List<Object[]> result3 = new ArrayList<>();
-    result3.add(new Object[]{"BROKER_REDUCE(limit:100)", 0, -1});
-    result3.add(new Object[]{"COMBINE_SELECT", 1, 0});
-    result3.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1)", 2, 1});
-    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 3, 2});
-    result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 4, 3});
-    result3.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result3.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
+    result3.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result3.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result3.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result3.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1)", 3, 2});
+    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
+    result3.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result3.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
     check(query3, new ResultTable(DATA_SCHEMA, result3));
 
     String query4 = "EXPLAIN PLAN FOR SELECT DISTINCT invertedIndexCol1, noIndexCol1 FROM testTable LIMIT 100";
     List<Object[]> result4 = new ArrayList<>();
-    result4.add(new Object[]{"BROKER_REDUCE(limit:100)", 0, -1});
-    result4.add(new Object[]{"COMBINE_DISTINCT", 1, 0});
-    result4.add(new Object[]{"DISTINCT(keyColumns:invertedIndexCol1, noIndexCol1)", 2, 1});
-    result4.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 3, 2});
-    result4.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 4, 3});
-    result4.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result4.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
+    result4.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result4.add(new Object[]{"COMBINE_DISTINCT", 2, 1});
+    result4.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result4.add(new Object[]{"DISTINCT(keyColumns:invertedIndexCol1, noIndexCol1)", 3, 2});
+    result4.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result4.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
+    result4.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result4.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
+    check(query4, new ResultTable(DATA_SCHEMA, result4));
+  }
+
+  @Test
+  public void testSelectVerbose() {
+    // All segment plans for these queries generate a plan using the MatchAllFilterOperator as these queries select
+    // columns without filtering
+    String query1 = "EXPLAIN PLAN FOR SELECT * FROM testTable OPTION(explainPlanVerbose=true)";
+    List<Object[]> result1 = new ArrayList<>();
+    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result1.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{
+        "SELECT(selectList:invertedIndexCol1, invertedIndexCol2, invertedIndexCol3, jsonIndexCol1, "
+            + "noIndexCol1, noIndexCol2, noIndexCol3, noIndexCol4, rangeIndexCol1, rangeIndexCol2, rangeIndexCol3, "
+            + "sortedIndexCol1, textIndexCol1)", 3, 2});
+    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, invertedIndexCol2, invertedIndexCol3, "
+        + "jsonIndexCol1, noIndexCol1, noIndexCol2, noIndexCol3, noIndexCol4, rangeIndexCol1, rangeIndexCol2, "
+        + "rangeIndexCol3, sortedIndexCol1, textIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(noIndexCol4, sortedIndexCol1, noIndexCol3, rangeIndexCol1, rangeIndexCol2, "
+        + "invertedIndexCol1, noIndexCol2, invertedIndexCol2, noIndexCol1, rangeIndexCol3, textIndexCol1, "
+        + "jsonIndexCol1, invertedIndexCol3)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
+    check(query1, new ResultTable(DATA_SCHEMA, result1));
+
+    String query2 = "EXPLAIN PLAN FOR SELECT 'mickey' FROM testTable OPTION(explainPlanVerbose=true)";
+    List<Object[]> result2 = new ArrayList<>();
+    result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result2.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"SELECT(selectList:'mickey')", 3, 2});
+    result2.add(new Object[]{"TRANSFORM('mickey')", 4, 3});
+    result2.add(new Object[]{"PROJECT()", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result2.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
+    check(query2, new ResultTable(DATA_SCHEMA, result2));
+
+    String query3 = "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1 FROM testTable LIMIT 100 "
+        + "OPTION(explainPlanVerbose=true)";
+    List<Object[]> result3 = new ArrayList<>();
+    result3.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result3.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result3.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result3.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1)", 3, 2});
+    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
+    result3.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result3.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
+    check(query3, new ResultTable(DATA_SCHEMA, result3));
+
+    String query4 = "EXPLAIN PLAN FOR SELECT DISTINCT invertedIndexCol1, noIndexCol1 FROM testTable LIMIT 100 "
+        + "OPTION(explainPlanVerbose=true)";
+    List<Object[]> result4 = new ArrayList<>();
+    result4.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result4.add(new Object[]{"COMBINE_DISTINCT", 2, 1});
+    result4.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result4.add(new Object[]{"DISTINCT(keyColumns:invertedIndexCol1, noIndexCol1)", 3, 2});
+    result4.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result4.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
+    result4.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result4.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
     check(query4, new ResultTable(DATA_SCHEMA, result4));
   }
 
   @Test
   public void testSelectTransformFunction() {
+    // All segment plans for these queries generate a plan using the MatchAllFilterOperator as these queries select
+    // columns without filtering and apply transforms
     String query1 = "EXPLAIN PLAN FOR SELECT CASE WHEN noIndexCol1 < 10 THEN 'less' ELSE 'more' END  FROM testTable";
     List<Object[]> result1 = new ArrayList<>();
-    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 0, -1});
-    result1.add(new Object[]{"COMBINE_SELECT", 1, 0});
-    result1.add(new Object[]{"SELECT(selectList:case(less_than(noIndexCol1,'10'),'less','more'))", 2, 1});
-    result1.add(new Object[]{"TRANSFORM(case(less_than(noIndexCol1,'10'),'less','more'))", 3, 2});
-    result1.add(new Object[]{"PROJECT(noIndexCol1)", 4, 3});
-    result1.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
+    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result1.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"SELECT(selectList:case(less_than(noIndexCol1,'10'),'less','more'))", 3, 2});
+    result1.add(new Object[]{"TRANSFORM(case(less_than(noIndexCol1,'10'),'less','more'))", 4, 3});
+    result1.add(new Object[]{"PROJECT(noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
 
     String query2 = "EXPLAIN PLAN FOR SELECT CONCAT(textIndexCol1, textIndexCol1, ':') FROM testTable";
     List<Object[]> result2 = new ArrayList<>();
-    result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 0, -1});
-    result2.add(new Object[]{"COMBINE_SELECT", 1, 0});
-    result2.add(new Object[]{"SELECT(selectList:concat(textIndexCol1,textIndexCol1,':'))", 2, 1});
-    result2.add(new Object[]{"TRANSFORM(concat(textIndexCol1,textIndexCol1,':'))", 3, 2});
-    result2.add(new Object[]{"PROJECT(textIndexCol1)", 4, 3});
-    result2.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result2.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
+    result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result2.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"SELECT(selectList:concat(textIndexCol1,textIndexCol1,':'))", 3, 2});
+    result2.add(new Object[]{"TRANSFORM(concat(textIndexCol1,textIndexCol1,':'))", 4, 3});
+    result2.add(new Object[]{"PROJECT(textIndexCol1)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result2.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
+    check(query2, new ResultTable(DATA_SCHEMA, result2));
+  }
+
+  @Test
+  public void testSelectTransformFunctionVerbose() {
+    // All segment plans for these queries generate a plan using the MatchAllFilterOperator as these queries select
+    // columns without filtering and apply transforms
+    String query1 = "EXPLAIN PLAN FOR SELECT CASE WHEN noIndexCol1 < 10 THEN 'less' ELSE 'more' END  FROM testTable "
+        + "OPTION(explainPlanVerbose=true)";
+    List<Object[]> result1 = new ArrayList<>();
+    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result1.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"SELECT(selectList:case(less_than(noIndexCol1,'10'),'less','more'))", 3, 2});
+    result1.add(new Object[]{"TRANSFORM(case(less_than(noIndexCol1,'10'),'less','more'))", 4, 3});
+    result1.add(new Object[]{"PROJECT(noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
+    check(query1, new ResultTable(DATA_SCHEMA, result1));
+
+    String query2 = "EXPLAIN PLAN FOR SELECT CONCAT(textIndexCol1, textIndexCol1, ':') FROM testTable "
+        + "OPTION(explainPlanVerbose=true)";
+    List<Object[]> result2 = new ArrayList<>();
+    result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result2.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"SELECT(selectList:concat(textIndexCol1,textIndexCol1,':'))", 3, 2});
+    result2.add(new Object[]{"TRANSFORM(concat(textIndexCol1,textIndexCol1,':'))", 4, 3});
+    result2.add(new Object[]{"PROJECT(textIndexCol1)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result2.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
     check(query2, new ResultTable(DATA_SCHEMA, result2));
   }
 
   @Test
   public void testSelectOrderBy() {
+    // All segment plans for these queries generate a plan using the MatchAllFilterOperator as these queries select
+    // columns without filtering and apply transforms along with order by
     String query1 = "EXPLAIN PLAN FOR SELECT CASE WHEN noIndexCol1 < 10 THEN 'less' ELSE 'more' END  FROM testTable "
         + "ORDER BY 1";
     List<Object[]> result1 = new ArrayList<>();
     result1
-        .add(new Object[]{"BROKER_REDUCE(sort:[case(less_than(noIndexCol1,'10'),'less','more') ASC],limit:10)", 0, -1});
-    result1.add(new Object[]{"COMBINE_SELECT_ORDERBY", 1, 0});
-    result1.add(new Object[]{"SELECT_ORDERBY(selectList:case(less_than(noIndexCol1,'10'),'less','more'))", 2, 1});
-    result1.add(new Object[]{"TRANSFORM(case(less_than(noIndexCol1,'10'),'less','more'))", 3, 2});
-    result1.add(new Object[]{"PROJECT(noIndexCol1)", 4, 3});
-    result1.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
+        .add(new Object[]{"BROKER_REDUCE(sort:[case(less_than(noIndexCol1,'10'),'less','more') ASC],limit:10)", 1, 0});
+    result1.add(new Object[]{"COMBINE_SELECT_ORDERBY", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"SELECT_ORDERBY(selectList:case(less_than(noIndexCol1,'10'),'less','more'))", 3, 2});
+    result1.add(new Object[]{"TRANSFORM(case(less_than(noIndexCol1,'10'),'less','more'))", 4, 3});
+    result1.add(new Object[]{"PROJECT(noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
 
     String query2 = "EXPLAIN PLAN FOR SELECT CONCAT(textIndexCol1, textIndexCol1, ':') FROM testTable ORDER BY 1 DESC";
     List<Object[]> result2 = new ArrayList<>();
-    result2.add(new Object[]{"BROKER_REDUCE(sort:[concat(textIndexCol1,textIndexCol1,':') DESC],limit:10)", 0, -1});
-    result2.add(new Object[]{"COMBINE_SELECT_ORDERBY", 1, 0});
-    result2.add(new Object[]{"SELECT_ORDERBY(selectList:concat(textIndexCol1,textIndexCol1,':'))", 2, 1});
-    result2.add(new Object[]{"TRANSFORM(concat(textIndexCol1,textIndexCol1,':'))", 3, 2});
-    result2.add(new Object[]{"PROJECT(textIndexCol1)", 4, 3});
-    result2.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result2.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
+    result2.add(new Object[]{"BROKER_REDUCE(sort:[concat(textIndexCol1,textIndexCol1,':') DESC],limit:10)", 1, 0});
+    result2.add(new Object[]{"COMBINE_SELECT_ORDERBY", 2, 1});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"SELECT_ORDERBY(selectList:concat(textIndexCol1,textIndexCol1,':'))", 3, 2});
+    result2.add(new Object[]{"TRANSFORM(concat(textIndexCol1,textIndexCol1,':'))", 4, 3});
+    result2.add(new Object[]{"PROJECT(textIndexCol1)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result2.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
+    check(query2, new ResultTable(DATA_SCHEMA, result2));
+  }
+
+  @Test
+  public void testSelectOrderByVerbose() {
+    // All segment plans for these queries generate a plan using the MatchAllFilterOperator as these queries select
+    // columns without filtering and apply transforms along with order by
+    String query1 = "EXPLAIN PLAN FOR SELECT CASE WHEN noIndexCol1 < 10 THEN 'less' ELSE 'more' END  FROM testTable "
+        + "ORDER BY 1 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result1 = new ArrayList<>();
+    result1
+        .add(new Object[]{"BROKER_REDUCE(sort:[case(less_than(noIndexCol1,'10'),'less','more') ASC],limit:10)", 1, 0});
+    result1.add(new Object[]{"COMBINE_SELECT_ORDERBY", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"SELECT_ORDERBY(selectList:case(less_than(noIndexCol1,'10'),'less','more'))", 3, 2});
+    result1.add(new Object[]{"TRANSFORM(case(less_than(noIndexCol1,'10'),'less','more'))", 4, 3});
+    result1.add(new Object[]{"PROJECT(noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
+    check(query1, new ResultTable(DATA_SCHEMA, result1));
+
+    String query2 = "EXPLAIN PLAN FOR SELECT CONCAT(textIndexCol1, textIndexCol1, ':') FROM testTable ORDER BY 1 DESC "
+        + "OPTION(explainPlanVerbose=true)";
+    List<Object[]> result2 = new ArrayList<>();
+    result2.add(new Object[]{"BROKER_REDUCE(sort:[concat(textIndexCol1,textIndexCol1,':') DESC],limit:10)", 1, 0});
+    result2.add(new Object[]{"COMBINE_SELECT_ORDERBY", 2, 1});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"SELECT_ORDERBY(selectList:concat(textIndexCol1,textIndexCol1,':'))", 3, 2});
+    result2.add(new Object[]{"TRANSFORM(concat(textIndexCol1,textIndexCol1,':'))", 4, 3});
+    result2.add(new Object[]{"PROJECT(textIndexCol1)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result2.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
     check(query2, new ResultTable(DATA_SCHEMA, result2));
   }
 
   /** Test case for SQL statements with filter that doesn't involve index access. */
   @Test
   public void testSelectColumnsUsingFilter() {
+    // MatchAllFilterOperator is returned for all segments because the predicate `sortedIndexCol1 != 5` is true for all
+    // values across all segments. The FILTER_OR doesn't show up in the plan because the other two OR predicates are
+    // not true and removed from the query plan.
     String query1 =
         "EXPLAIN PLAN FOR SELECT noIndexCol1, noIndexCol2, sortedIndexCol1 FROM testTable WHERE sortedIndexCol1 = 1.5"
             + " OR sortedIndexCol1 != 5 OR sortedIndexCol1 IN (10, 20, 30) LIMIT 100";
     List<Object[]> result1 = new ArrayList<>();
-    result1.add(new Object[]{"BROKER_REDUCE(limit:100)", 0, -1});
-    result1.add(new Object[]{"COMBINE_SELECT", 1, 0});
-    result1.add(new Object[]{"SELECT(selectList:noIndexCol1, noIndexCol2, sortedIndexCol1)", 2, 1});
-    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, sortedIndexCol1)", 3, 2});
-    result1.add(new Object[]{"PROJECT(sortedIndexCol1, noIndexCol2, noIndexCol1)", 4, 3});
-    result1.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
+    result1.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result1.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"SELECT(selectList:noIndexCol1, noIndexCol2, sortedIndexCol1)", 3, 2});
+    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, sortedIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(sortedIndexCol1, noIndexCol2, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
 
+    // The FILTER_AND is part of the query plan for all segments as both predicates are expressions
     String query2 =
         "EXPLAIN PLAN FOR SELECT noIndexCol1, noIndexCol2 FROM testTable WHERE DIV(noIndexCol1, noIndexCol2) BETWEEN "
             + "10 AND 20 AND invertedIndexCol1 * 5 < 1000";
     List<Object[]> result2 = new ArrayList<>();
-    result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 0, -1});
-    result2.add(new Object[]{"COMBINE_SELECT", 1, 0});
-    result2.add(new Object[]{"SELECT(selectList:noIndexCol1, noIndexCol2)", 2, 1});
-    result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2)", 3, 2});
-    result2.add(new Object[]{"PROJECT(noIndexCol2, noIndexCol1)", 4, 3});
-    result2.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result2.add(new Object[]{"FILTER_AND", 6, 5});
+    result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result2.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"SELECT(selectList:noIndexCol1, noIndexCol2)", 3, 2});
+    result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2)", 4, 3});
+    result2.add(new Object[]{"PROJECT(noIndexCol2, noIndexCol1)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result2.add(new Object[]{"FILTER_AND", 7, 6});
     result2.add(
         new Object[]{"FILTER_EXPRESSION(operator:RANGE,predicate:div(noIndexCol1,noIndexCol2) BETWEEN '10' AND '20')",
-            7, 6});
+            8, 7});
     result2
-        .add(new Object[]{"FILTER_EXPRESSION(operator:RANGE,predicate:times(invertedIndexCol1,'5') < '1000')", 8, 6});
+        .add(new Object[]{"FILTER_EXPRESSION(operator:RANGE,predicate:times(invertedIndexCol1,'5') < '1000')", 9, 7});
     check(query2, new ResultTable(DATA_SCHEMA, result2));
 
+    // All segments have a match for noIndexCol2 'between 2 and 101'
+    // Segments 2, 3, 4 don't have a single value of noIndexCol1 as less than 1, whereas segment 1 has a 0 as
+    // one of the rows for noIndexCol1. Due to this the three segments for which noIndexCol1 > 1 is true for all rows,
+    // a MatchAllFilterOperator plan is returned. For the other segment, the actual FILTER_OR query plan is returned.
+    // Since verbose mode is turned off, the deepest plan is returned which is the FILTER_OR query plan in this case.
     String query3 =
         "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1 FROM testTable WHERE noIndexCol1 > 1 OR noIndexCol2"
             + " BETWEEN 2 AND 101 LIMIT 100";
     List<Object[]> result3 = new ArrayList<>();
-    result3.add(new Object[]{"BROKER_REDUCE(limit:100)", 0, -1});
-    result3.add(new Object[]{"COMBINE_SELECT", 1, 0});
-    result3.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1)", 2, 1});
-    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 3, 2});
-    result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 4, 3});
-    result3.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result3.add(new Object[]{"FILTER_OR", 6, 5});
-    result3.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol1 > '1')", 7, 6});
-    result3.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol2 BETWEEN '2' AND '101')", 8, 6});
+    result3.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result3.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result3.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result3.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1)", 3, 2});
+    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
+    result3.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result3.add(new Object[]{"FILTER_OR", 7, 6});
+    result3.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol1 > '1')", 8, 7});
+    result3.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol2 BETWEEN '2' AND '101')", 9, 7});
     check(query3, new ResultTable(DATA_SCHEMA, result3));
 
+    // All segments have a match for noIndexCol2 'between 2 and 101'
+    // Segments 2, 3, 4 don't have a single value of noIndexCol1 as less than 1, whereas segment 1 has a 0 as
+    // one of the rows for noIndexCol1. Due to this the three segments for which noIndexCol1 > 1 is true for all rows,
+    // a MatchAllFilterOperator plan is returned. For the other segment, the actual FILTER_OR query plan is returned.
+    // Since verbose mode is turned off, the deepest plan is returned which is the FILTER_OR query plan in this case.
     String query4 = "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1 FROM testTable WHERE noIndexCol1 > 1 OR "
         + "contains(textIndexCol1, 'daff') OR noIndexCol2 BETWEEN 2 AND 101 LIMIT 100";
     List<Object[]> result4 = new ArrayList<>();
-    result4.add(new Object[]{"BROKER_REDUCE(limit:100)", 0, -1});
-    result4.add(new Object[]{"COMBINE_SELECT", 1, 0});
-    result4.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1)", 2, 1});
-    result4.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 3, 2});
-    result4.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 4, 3});
-    result4.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result4.add(new Object[]{"FILTER_OR", 6, 5});
-    result4.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol1 > '1')", 7, 6});
-    result4.add(new Object[]{"FILTER_EXPRESSION(operator:EQ,predicate:contains(textIndexCol1,'daff') = 'true')", 8, 6});
-    result4.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol2 BETWEEN '2' AND '101')", 9, 6});
+    result4.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result4.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result4.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result4.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1)", 3, 2});
+    result4.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result4.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
+    result4.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result4.add(new Object[]{"FILTER_OR", 7, 6});
+    result4.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol1 > '1')", 8, 7});
+    result4.add(new Object[]{"FILTER_EXPRESSION(operator:EQ,predicate:contains(textIndexCol1,'daff') = 'true')", 9, 7});
+    result4.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol2 BETWEEN '2' AND '101')", 10, 7});
     check(query4, new ResultTable(DATA_SCHEMA, result4));
 
+    // All segments match for a full scan since noIndexCol4 has at least one row value set to 'true' across all segments
     String query5 = "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1 FROM testTable WHERE noIndexCol4 LIMIT 100";
     List<Object[]> result5 = new ArrayList<>();
-    result5.add(new Object[]{"BROKER_REDUCE(limit:100)", 0, -1});
-    result5.add(new Object[]{"COMBINE_SELECT", 1, 0});
-    result5.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1)", 2, 1});
-    result5.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 3, 2});
-    result5.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 4, 3});
-    result5.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result5.add(new Object[]{"FILTER_FULL_SCAN(operator:EQ,predicate:noIndexCol4 = 'true')", 6, 5});
+    result5.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result5.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result5.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result5.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1)", 3, 2});
+    result5.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result5.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
+    result5.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result5.add(new Object[]{"FILTER_FULL_SCAN(operator:EQ,predicate:noIndexCol4 = 'true')", 7, 6});
     check(query5, new ResultTable(DATA_SCHEMA, result5));
 
+    // The FILTER_AND is part of the query plan for all segments as the first predicate is an expression and the second
+    // has at least one matching row in each segment
     String query6 = "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1 FROM testTable WHERE startsWith "
         + "(textIndexCol1, 'daff') AND noIndexCol4";
     List<Object[]> result6 = new ArrayList<>();
-    result6.add(new Object[]{"BROKER_REDUCE(limit:10)", 0, -1});
-    result6.add(new Object[]{"COMBINE_SELECT", 1, 0});
-    result6.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1)", 2, 1});
-    result6.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 3, 2});
-    result6.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 4, 3});
-    result6.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result6.add(new Object[]{"FILTER_AND", 6, 5});
-    result6.add(new Object[]{"FILTER_FULL_SCAN(operator:EQ,predicate:noIndexCol4 = 'true')", 7, 6});
-    result6.add(new Object[]{"FILTER_EXPRESSION(operator:EQ,predicate:startswith(textIndexCol1,'daff') = 'true')", 8,
-        6});
+    result6.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result6.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result6.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result6.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1)", 3, 2});
+    result6.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result6.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
+    result6.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result6.add(new Object[]{"FILTER_AND", 7, 6});
+    result6.add(new Object[]{"FILTER_FULL_SCAN(operator:EQ,predicate:noIndexCol4 = 'true')", 8, 7});
+    result6.add(new Object[]{"FILTER_EXPRESSION(operator:EQ,predicate:startswith(textIndexCol1,'daff') = 'true')", 9,
+        7});
+    check(query6, new ResultTable(DATA_SCHEMA, result6));
+  }
+
+  /** Test case for SQL statements with filter that doesn't involve index access. */
+  @Test
+  public void testSelectColumnsUsingFilterVerbose() {
+    // MatchAllFilterOperator is returned for all segments because the predicate `sortedIndexCol1 != 5` is true for all
+    // values across all segments. The FILTER_OR doesn't show up in the plan because the other two OR predicates are
+    // not true and removed from the query plan.
+    String query1 =
+        "EXPLAIN PLAN FOR SELECT noIndexCol1, noIndexCol2, sortedIndexCol1 FROM testTable WHERE sortedIndexCol1 = 1.5"
+            + " OR sortedIndexCol1 != 5 OR sortedIndexCol1 IN (10, 20, 30) LIMIT 100 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result1 = new ArrayList<>();
+    result1.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result1.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"SELECT(selectList:noIndexCol1, noIndexCol2, sortedIndexCol1)", 3, 2});
+    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, sortedIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(sortedIndexCol1, noIndexCol2, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
+    check(query1, new ResultTable(DATA_SCHEMA, result1));
+
+    // The FILTER_AND is part of the query plan for all segments as both predicates are expressions
+    String query2 =
+        "EXPLAIN PLAN FOR SELECT noIndexCol1, noIndexCol2 FROM testTable WHERE DIV(noIndexCol1, noIndexCol2) BETWEEN "
+            + "10 AND 20 AND invertedIndexCol1 * 5 < 1000 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result2 = new ArrayList<>();
+    result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result2.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"SELECT(selectList:noIndexCol1, noIndexCol2)", 3, 2});
+    result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2)", 4, 3});
+    result2.add(new Object[]{"PROJECT(noIndexCol2, noIndexCol1)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result2.add(new Object[]{"FILTER_AND", 7, 6});
+    result2.add(
+        new Object[]{"FILTER_EXPRESSION(operator:RANGE,predicate:div(noIndexCol1,noIndexCol2) BETWEEN '10' AND '20')",
+            8, 7});
+    result2
+        .add(new Object[]{"FILTER_EXPRESSION(operator:RANGE,predicate:times(invertedIndexCol1,'5') < '1000')", 9, 7});
+    check(query2, new ResultTable(DATA_SCHEMA, result2));
+
+    // All segments have a match for noIndexCol2 'between 2 and 101'
+    // Segments 2, 3, 4 don't have a single value of noIndexCol1 as less than 1, whereas segment 1 has a 0 as
+    // one of the rows for noIndexCol1. Due to this the three segments for which noIndexCol1 > 1 is true for all rows,
+    // a MatchAllFilterOperator plan is returned. For the other segment, the actual FILTER_OR query plan is returned.
+    String query3 =
+        "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1 FROM testTable WHERE noIndexCol1 > 1 OR noIndexCol2"
+            + " BETWEEN 2 AND 101 LIMIT 100 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result3 = new ArrayList<>();
+    result3.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result3.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result3.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result3.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1)", 3, 2});
+    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
+    result3.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result3.add(new Object[]{"FILTER_OR", 7, 6});
+    result3.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol1 > '1')", 8, 7});
+    result3.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol2 BETWEEN '2' AND '101')", 9, 7});
+    result3.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:3)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result3.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1)", 3, 2});
+    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
+    result3.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result3.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
+    check(query3, new ResultTable(DATA_SCHEMA, result3));
+
+    // All segments have a match for noIndexCol2 'between 2 and 101'
+    // Segments 2, 3, 4 don't have a single value of noIndexCol1 as less than 1, whereas segment 1 has a 0 as
+    // one of the rows for noIndexCol1. Due to this the three segments for which noIndexCol1 > 1 is true for all rows,
+    // a MatchAllFilterOperator plan is returned. For the other segment, the actual FILTER_OR query plan is returned.
+    String query4 = "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1 FROM testTable WHERE noIndexCol1 > 1 OR "
+        + "contains(textIndexCol1, 'daff') OR noIndexCol2 BETWEEN 2 AND 101 LIMIT 100 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result4 = new ArrayList<>();
+    result4.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result4.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result4.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result4.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1)", 3, 2});
+    result4.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result4.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
+    result4.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result4.add(new Object[]{"FILTER_OR", 7, 6});
+    result4.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol1 > '1')", 8, 7});
+    result4.add(new Object[]{"FILTER_EXPRESSION(operator:EQ,predicate:contains(textIndexCol1,'daff') = 'true')", 9, 7});
+    result4.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol2 BETWEEN '2' AND '101')", 10, 7});
+    result4.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:3)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result4.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1)", 3, 2});
+    result4.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result4.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
+    result4.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result4.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
+    check(query4, new ResultTable(DATA_SCHEMA, result4));
+
+    // All segments match since noIndexCol4 has at least one row value set to 'true' across all segments
+    String query5 = "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1 FROM testTable WHERE noIndexCol4 LIMIT 100 "
+        + "OPTION(explainPlanVerbose=true)";
+    List<Object[]> result5 = new ArrayList<>();
+    result5.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result5.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result5.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result5.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1)", 3, 2});
+    result5.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result5.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
+    result5.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result5.add(new Object[]{"FILTER_FULL_SCAN(operator:EQ,predicate:noIndexCol4 = 'true')", 7, 6});
+    check(query5, new ResultTable(DATA_SCHEMA, result5));
+
+    // The FILTER_AND is part of the query plan for all segments as the first predicate is an expression and the second
+    // has at least one matching row in each segment
+    String query6 = "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1 FROM testTable WHERE startsWith "
+        + "(textIndexCol1, 'daff') AND noIndexCol4 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result6 = new ArrayList<>();
+    result6.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result6.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result6.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result6.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1)", 3, 2});
+    result6.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result6.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
+    result6.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result6.add(new Object[]{"FILTER_AND", 7, 6});
+    result6.add(new Object[]{"FILTER_FULL_SCAN(operator:EQ,predicate:noIndexCol4 = 'true')", 8, 7});
+    result6.add(new Object[]{"FILTER_EXPRESSION(operator:EQ,predicate:startswith(textIndexCol1,'daff') = 'true')", 9,
+        7});
     check(query6, new ResultTable(DATA_SCHEMA, result6));
   }
 
   /** Test case for SQL statements with filter that involves inverted or sorted index access. */
   @Test
   public void testSelectColumnsUsingFilterOnInvertedIndexColumn() {
+    // Segments 1, 2, 4 result in both the AND predicates getting evaluated as all three have some rows that match.
+    // Segment 3 results in an EmptyFilterOperator as the invertedIndexCol1 doesn't have the value 1.1 in it
+    // and this is an AND predicate, but the values are within range
+    // Since verbose mode is disabled, the non-EmptyFilterOperator plan is returned.
     String query1 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, sortedIndexCol1 FROM testTable WHERE "
         + "invertedIndexCol1 = 1.1 AND sortedIndexCol1 = 100.1 LIMIT 100";
     List<Object[]> result1 = new ArrayList<>();
-    result1.add(new Object[]{"BROKER_REDUCE(limit:100)", 0, -1});
-    result1.add(new Object[]{"COMBINE_SELECT", 1, 0});
-    result1.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, sortedIndexCol1)", 2, 1});
-    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1, sortedIndexCol1)", 3, 2});
-    result1.add(new Object[]{"PROJECT(sortedIndexCol1, invertedIndexCol1, noIndexCol1)", 4, 3});
-    result1.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result1.add(new Object[]{"FILTER_AND", 6, 5});
+    result1.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result1.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:3)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, sortedIndexCol1)", 3, 2});
+    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1, sortedIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(sortedIndexCol1, invertedIndexCol1, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_AND", 7, 6});
     result1.add(new Object[]{
-        "FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:sortedIndexCol1 = " + "'100.1')", 7, 6});
+        "FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:sortedIndexCol1 = " + "'100.1')", 8, 7});
     result1.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,"
-        + "predicate:invertedIndexCol1 = '1.1')", 8, 6});
+        + "predicate:invertedIndexCol1 = '1.1')", 9, 7});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
 
+    // Segments 1, 2, 4 result in a FILTER_OR plan which matches all the segments and all four predicates.
+    // Segment 3 removes the OR clause for 'invertedIndexCol1 = 1.1' since that segment doesn't have this value for any
+    // of its rows.
+    // The deepest plan is returned which matches the former which matches three segments and has four OR predicates
     String query2 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, sortedIndexCol1  FROM testTable WHERE "
         + "(invertedIndexCol1 = 1.1 OR sortedIndexCol1 = 100.2) OR (invertedIndexCol1 BETWEEN 0.2 AND 5 OR "
         + "rangeIndexCol1 > 20)";
     List<Object[]> result2 = new ArrayList<>();
-    result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 0, -1});
-    result2.add(new Object[]{"COMBINE_SELECT", 1, 0});
-    result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, sortedIndexCol1)", 2, 1});
-    result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1, sortedIndexCol1)", 3, 2});
-    result2.add(new Object[]{"PROJECT(sortedIndexCol1, invertedIndexCol1, noIndexCol1)", 4, 3});
-    result2.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result2.add(new Object[]{"FILTER_OR", 6, 5});
+    result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result2.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:3)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, sortedIndexCol1)", 3, 2});
+    result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1, sortedIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(sortedIndexCol1, invertedIndexCol1, noIndexCol1)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result2.add(new Object[]{"FILTER_OR", 7, 6});
     result2.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,"
-        + "predicate:invertedIndexCol1 = '1.1')", 7, 6});
+        + "predicate:invertedIndexCol1 = '1.1')", 8, 7});
     result2.add(new Object[]{
-        "FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:sortedIndexCol1 = " + "'100.2')", 8, 6});
+        "FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:sortedIndexCol1 = " + "'100.2')", 9, 7});
     result2
-        .add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:invertedIndexCol1 BETWEEN '0.2' AND '5')", 9, 6});
+        .add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:invertedIndexCol1 BETWEEN '0.2' AND '5')", 10, 7});
     result2.add(new Object[]{
-        "FILTER_RANGE_INDEX(indexLookUp:range_index,operator:RANGE,predicate:rangeIndexCol1 > " + "'20')", 10, 6});
+        "FILTER_RANGE_INDEX(indexLookUp:range_index,operator:RANGE,predicate:rangeIndexCol1 > " + "'20')", 11, 7});
     check(query2, new ResultTable(DATA_SCHEMA, result2));
 
+    // Segments 2, 3, 4 result in a MatchAllOperator because 'invertedIndexCol3 NOT IN ('foo', 'mickey')' matches all
+    // the rows in these segments.
+    // Segment 1 does contain 'mickey' and two predicates of the OR are part of the query plan.
+    // Since verbose mode is disabled The FILTER_OR plan is returned as it's the deepest.
     String query3 =
         "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1 FROM testTable WHERE invertedIndexCol1 = 1.5 OR "
             + "invertedIndexCol2 IN (1, 2, 30) OR invertedIndexCol3 NOT IN ('foo', 'mickey') LIMIT 100";
     List<Object[]> result3 = new ArrayList<>();
-    result3.add(new Object[]{"BROKER_REDUCE(limit:100)", 0, -1});
-    result3.add(new Object[]{"COMBINE_SELECT", 1, 0});
-    result3.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1)", 2, 1});
-    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 3, 2});
-    result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 4, 3});
-    result3.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result3.add(new Object[]{"FILTER_OR", 6, 5});
+    result3.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result3.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result3.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result3.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1)", 3, 2});
+    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
+    result3.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result3.add(new Object[]{"FILTER_OR", 7, 6});
     result3.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:IN,"
-        + "predicate:invertedIndexCol2 IN ('1','2','30'))", 7, 6});
+        + "predicate:invertedIndexCol2 IN ('1','2','30'))", 8, 7});
     result3.add(new Object[]{"FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:NOT_IN,"
-        + "predicate:invertedIndexCol3 NOT IN ('foo','mickey'))", 8, 6});
+        + "predicate:invertedIndexCol3 NOT IN ('foo','mickey'))", 9, 7});
+    check(query3, new ResultTable(DATA_SCHEMA, result3));
+  }
+
+  /** Test case for SQL statements with filter that involves inverted or sorted index access. */
+  @Test
+  public void testSelectColumnsUsingFilterOnInvertedIndexColumnVerbose() {
+    // Segments 1, 2, 4 result in both the AND predicates getting evaluated as all three have some rows that match.
+    // Segment 3 results in an EmptyFilterOperator as the invertedIndexCol1 doesn't have the value 1.1 in it
+    // and this is an AND predicate, but the values are within range
+    String query1 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, sortedIndexCol1 FROM testTable WHERE "
+        + "invertedIndexCol1 = 1.1 AND sortedIndexCol1 = 100.1 LIMIT 100 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result1 = new ArrayList<>();
+    result1.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result1.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:3)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, sortedIndexCol1)", 3, 2});
+    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1, sortedIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(sortedIndexCol1, invertedIndexCol1, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_AND", 7, 6});
+    result1.add(new Object[]{
+        "FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:sortedIndexCol1 = " + "'100.1')", 8, 7});
+    result1.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,"
+        + "predicate:invertedIndexCol1 = '1.1')", 9, 7});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, sortedIndexCol1)", 3, 2});
+    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1, sortedIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(sortedIndexCol1, invertedIndexCol1, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_EMPTY", 7, 6});
+    check(query1, new ResultTable(DATA_SCHEMA, result1));
+
+    // Segments 1, 2, 4 result in a FILTER_OR plan which matches all the segments and all four predicates.
+    // Segment 3 removes the OR clause for 'invertedIndexCol1 = 1.1' since that segment doesn't have this value for any
+    // of its rows.
+    String query2 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, sortedIndexCol1  FROM testTable WHERE "
+        + "(invertedIndexCol1 = 1.1 OR sortedIndexCol1 = 100.2) OR (invertedIndexCol1 BETWEEN 0.2 AND 5 OR "
+        + "rangeIndexCol1 > 20) OPTION(explainPlanVerbose=true)";
+    List<Object[]> result2 = new ArrayList<>();
+    result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result2.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:3)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, sortedIndexCol1)", 3, 2});
+    result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1, sortedIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(sortedIndexCol1, invertedIndexCol1, noIndexCol1)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result2.add(new Object[]{"FILTER_OR", 7, 6});
+    result2.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,"
+        + "predicate:invertedIndexCol1 = '1.1')", 8, 7});
+    result2.add(new Object[]{
+        "FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:sortedIndexCol1 = " + "'100.2')", 9, 7});
+    result2
+        .add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:invertedIndexCol1 BETWEEN '0.2' AND '5')", 10, 7});
+    result2.add(new Object[]{
+        "FILTER_RANGE_INDEX(indexLookUp:range_index,operator:RANGE,predicate:rangeIndexCol1 > " + "'20')", 11, 7});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, sortedIndexCol1)", 3, 2});
+    result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1, sortedIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(sortedIndexCol1, invertedIndexCol1, noIndexCol1)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result2.add(new Object[]{"FILTER_OR", 7, 6});
+    result2.add(new Object[]{"FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:sortedIndexCol1 "
+        + "= '100.2')", 8, 7});
+    result2.add(new Object[]{
+        "FILTER_FULL_SCAN(operator:RANGE,predicate:invertedIndexCol1 BETWEEN '0.2' AND '5')", 9, 7});
+    result2
+        .add(new Object[]{"FILTER_RANGE_INDEX(indexLookUp:range_index,operator:RANGE,predicate:rangeIndexCol1 > "
+            + "'20')", 10, 7});
+    check(query2, new ResultTable(DATA_SCHEMA, result2));
+
+    // Segments 2, 3, 4 result in a MatchAllOperator because 'invertedIndexCol3 NOT IN ('foo', 'mickey')' matches all
+    // the rows in these segments.
+    // Segment 1 does contain 'mickey' and two predicates of the OR are part of the query plan.
+    String query3 =
+        "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1 FROM testTable WHERE invertedIndexCol1 = 1.5 OR "
+            + "invertedIndexCol2 IN (1, 2, 30) OR invertedIndexCol3 NOT IN ('foo', 'mickey') LIMIT 100 "
+            + "OPTION(explainPlanVerbose=true)";
+    List<Object[]> result3 = new ArrayList<>();
+    result3.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result3.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result3.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result3.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1)", 3, 2});
+    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
+    result3.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result3.add(new Object[]{"FILTER_OR", 7, 6});
+    result3.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:IN,"
+        + "predicate:invertedIndexCol2 IN ('1','2','30'))", 8, 7});
+    result3.add(new Object[]{"FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:NOT_IN,"
+        + "predicate:invertedIndexCol3 NOT IN ('foo','mickey'))", 9, 7});
+    result3.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:3)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result3.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1)", 3, 2});
+    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
+    result3.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result3.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
     check(query3, new ResultTable(DATA_SCHEMA, result3));
   }
 
@@ -451,39 +1041,73 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1, rangeIndexCol1 FROM testTable WHERE rangeIndexCol1 >"
             + " 10.1 AND rangeIndexCol2 >= 15 OR rangeIndexCol3 BETWEEN 21 AND 45 LIMIT 100";
     List<Object[]> result1 = new ArrayList<>();
-    result1.add(new Object[]{"BROKER_REDUCE(limit:100)", 0, -1});
-    result1.add(new Object[]{"COMBINE_SELECT", 1, 0});
-    result1.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1, rangeIndexCol1)", 2, 1});
-    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1, rangeIndexCol1)", 3, 2});
-    result1.add(new Object[]{"PROJECT(rangeIndexCol1, invertedIndexCol1, noIndexCol1)", 4, 3});
-    result1.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result1.add(new Object[]{"FILTER_OR", 6, 5});
-    result1.add(new Object[]{"FILTER_AND", 7, 6});
+    result1.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result1.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1, rangeIndexCol1)", 3, 2});
+    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1, rangeIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(rangeIndexCol1, invertedIndexCol1, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_OR", 7, 6});
+    result1.add(new Object[]{"FILTER_AND", 8, 7});
     result1.add(new Object[]{
-        "FILTER_RANGE_INDEX(indexLookUp:range_index,operator:RANGE,predicate:rangeIndexCol1 > '10" + ".1')", 8, 7});
+        "FILTER_RANGE_INDEX(indexLookUp:range_index,operator:RANGE,predicate:rangeIndexCol1 > '10" + ".1')", 9, 8});
     result1.add(new Object[]{
-        "FILTER_RANGE_INDEX(indexLookUp:range_index,operator:RANGE,predicate:rangeIndexCol2 >= " + "'15')", 9, 7});
+        "FILTER_RANGE_INDEX(indexLookUp:range_index,operator:RANGE,predicate:rangeIndexCol2 >= " + "'15')", 10, 8});
     result1.add(new Object[]{"FILTER_RANGE_INDEX(indexLookUp:range_index,operator:RANGE,predicate:rangeIndexCol3 "
-        + "BETWEEN '21' AND '45')", 10, 6});
+        + "BETWEEN '21' AND '45')", 11, 7});
+    check(query1, new ResultTable(DATA_SCHEMA, result1));
+  }
+
+  /** Test case for SQL statements with filter that involves range index access. */
+  @Test
+  public void testSelectColumnUsingFilterOnRangeIndexColumnVerbose() {
+    // select * query triggering range index
+    // checks using RANGE (>, >=, <, <=, BETWEEN ..) on a column with range index should use RANGE_INDEX_SCAN
+    String query1 =
+        "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1, rangeIndexCol1 FROM testTable WHERE rangeIndexCol1 >"
+            + " 10.1 AND rangeIndexCol2 >= 15 OR rangeIndexCol3 BETWEEN 21 AND 45 LIMIT 100 "
+            + "OPTION(explainPlanVerbose=true)";
+    List<Object[]> result1 = new ArrayList<>();
+    result1.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result1.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"SELECT(selectList:invertedIndexCol1, noIndexCol1, rangeIndexCol1)", 3, 2});
+    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1, rangeIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(rangeIndexCol1, invertedIndexCol1, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_OR", 7, 6});
+    result1.add(new Object[]{"FILTER_AND", 8, 7});
+    result1.add(new Object[]{
+        "FILTER_RANGE_INDEX(indexLookUp:range_index,operator:RANGE,predicate:rangeIndexCol1 > '10" + ".1')", 9, 8});
+    result1.add(new Object[]{
+        "FILTER_RANGE_INDEX(indexLookUp:range_index,operator:RANGE,predicate:rangeIndexCol2 >= " + "'15')", 10, 8});
+    result1.add(new Object[]{"FILTER_RANGE_INDEX(indexLookUp:range_index,operator:RANGE,predicate:rangeIndexCol3 "
+        + "BETWEEN '21' AND '45')", 11, 7});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
   }
 
   @Test
   public void testSelectAggregateUsingFilterOnTextIndexColumn() {
+    // All segments match the same plan for these queries
     String query1 =
         "EXPLAIN PLAN FOR SELECT noIndexCol1, noIndexCol2, max(noIndexCol2), min(noIndexCol3) FROM testTable WHERE "
             + "TEXT_MATCH(textIndexCol1, 'foo') GROUP BY noIndexCol1, noIndexCol2";
     List<Object[]> result1 = new ArrayList<>();
-    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 0, -1});
-    result1.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 1, 0});
+    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result1.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
     result1.add(new Object[]{
         "AGGREGATE_GROUPBY_ORDERBY(groupKeys:noIndexCol1, noIndexCol2, aggregations:max(noIndexCol2), min"
-            + "(noIndexCol3))", 2, 1});
-    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, noIndexCol3)", 3, 2});
-    result1.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
-    result1.add(new Object[]{"DOC_ID_SET", 5, 4});
+            + "(noIndexCol3))", 3, 2});
+    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
+    result1.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
     result1.add(new Object[]{"FILTER_TEXT_INDEX(indexLookUp:text_index,operator:TEXT_MATCH,predicate:text_match"
-        + "(textIndexCol1,'foo'))", 6, 5});
+        + "(textIndexCol1,'foo'))", 7, 6});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
 
     String query2 =
@@ -491,218 +1115,1184 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
             + "WHERE TEXT_MATCH (textIndexCol1, 'foo') GROUP BY noIndexCol1, noIndexCol2 ORDER BY noIndexCol1, max"
             + "(noIndexCol2)";
     List<Object[]> result2 = new ArrayList<>();
-    result2.add(new Object[]{"BROKER_REDUCE(sort:[noIndexCol1 ASC, max(noIndexCol2) ASC],limit:10)", 0, -1});
-    result2.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 1, 0});
+    result2.add(new Object[]{"BROKER_REDUCE(sort:[noIndexCol1 ASC, max(noIndexCol2) ASC],limit:10)", 1, 0});
+    result2.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 2, 1});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
     result2.add(new Object[]{
-        "AGGREGATE_GROUPBY_ORDERBY(groupKeys:noIndexCol1,noIndexCol2,aggregations:max(noIndexCol2), min"
-            + "(noIndexCol3))", 2, 1});
-    result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, invertedIndexCol1)", 3, 2});
-    result2.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
-    result2.add(new Object[]{"DOC_ID_SET", 5, 4});
+        "AGGREGATE_GROUPBY_ORDERBY(groupKeys:noIndexCol1, noIndexCol2, aggregations:max(noIndexCol2), min"
+            + "(noIndexCol3))", 3, 2});
+    result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
+    result2.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
     result2.add(new Object[]{"FILTER_TEXT_INDEX(indexLookUp:text_index,operator:TEXT_MATCH,predicate:text_match"
-        + "(textIndexCol1,'foo'))", 6, 5});
+        + "(textIndexCol1,'foo'))", 7, 6});
+    check(query2, new ResultTable(DATA_SCHEMA, result2));
+  }
+
+  @Test
+  public void testSelectAggregateUsingFilterOnTextIndexColumnVerbose() {
+    // All segments match the same plan for these queries
+    String query1 =
+        "EXPLAIN PLAN FOR SELECT noIndexCol1, noIndexCol2, max(noIndexCol2), min(noIndexCol3) FROM testTable WHERE "
+            + "TEXT_MATCH(textIndexCol1, 'foo') GROUP BY noIndexCol1, noIndexCol2 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result1 = new ArrayList<>();
+    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result1.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{
+        "AGGREGATE_GROUPBY_ORDERBY(groupKeys:noIndexCol1, noIndexCol2, aggregations:max(noIndexCol2), min"
+            + "(noIndexCol3))", 3, 2});
+    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
+    result1.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_TEXT_INDEX(indexLookUp:text_index,operator:TEXT_MATCH,predicate:text_match"
+        + "(textIndexCol1,'foo'))", 7, 6});
+    check(query1, new ResultTable(DATA_SCHEMA, result1));
+
+    String query2 =
+        "EXPLAIN PLAN FOR SELECT noIndexCol1, max(noIndexCol2) AS mymax, min(noIndexCol3) AS mymin FROM testTable "
+            + "WHERE TEXT_MATCH (textIndexCol1, 'foo') GROUP BY noIndexCol1, noIndexCol2 ORDER BY noIndexCol1, max"
+            + "(noIndexCol2) OPTION(explainPlanVerbose=true)";
+    List<Object[]> result2 = new ArrayList<>();
+    result2.add(new Object[]{"BROKER_REDUCE(sort:[noIndexCol1 ASC, max(noIndexCol2) ASC],limit:10)", 1, 0});
+    result2.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 2, 1});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{
+        "AGGREGATE_GROUPBY_ORDERBY(groupKeys:noIndexCol1, noIndexCol2, aggregations:max(noIndexCol2), min"
+            + "(noIndexCol3))", 3, 2});
+    result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
+    result2.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result2.add(new Object[]{"FILTER_TEXT_INDEX(indexLookUp:text_index,operator:TEXT_MATCH,predicate:text_match"
+        + "(textIndexCol1,'foo'))", 7, 6});
+    check(query2, new ResultTable(DATA_SCHEMA, result2));
   }
 
   @Test
   public void testSelectColumnUsingFilterOnJsonIndexColumn() {
+    // Segment 2, 3, 4 don't match 'noIndexCol1 NOT IN (1, 20, 30)' so they return a plan without this OR predicate
+    // Segments 1 matches all three predicates so returns a plan with all three
+    // The plan with the deepest tree is returned which matches segment 1 as verbose mode is disabled
     String query =
         "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1 FROM testTable WHERE (invertedIndexCol1 IN (10, 20, "
             + "30) AND sortedIndexCol1 != 100) OR (noIndexCol1 NOT IN (1, 20, 30) AND rangeIndexCol1 != 20 AND "
             + "JSON_MATCH(jsonIndexCol1, 'key=1') AND TEXT_MATCH(textIndexCol1, 'foo'))";
     List<Object[]> result = new ArrayList<>();
-    result.add(new Object[]{"BROKER_REDUCE(limit:10)", 0, -1});
-    result.add(new Object[]{"COMBINE_SELECT", 1, 0});
-    result.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1)", 2, 1});
-    result.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 3, 2});
-    result.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 4, 3});
-    result.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result.add(new Object[]{"FILTER_AND", 6, 5});
+    result.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1)", 3, 2});
+    result.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
+    result.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result.add(new Object[]{"FILTER_AND", 7, 6});
     result.add(new Object[]{"FILTER_JSON_INDEX(indexLookUp:json_index,operator:JSON_MATCH,predicate:json_match"
-        + "(jsonIndexCol1,'key=1'))", 7, 6});
+        + "(jsonIndexCol1,'key=1'))", 8, 7});
     result.add(new Object[]{"FILTER_TEXT_INDEX(indexLookUp:text_index,operator:TEXT_MATCH,predicate:text_match"
-        + "(textIndexCol1,'foo'))", 8, 6});
-    result.add(new Object[]{"FILTER_FULL_SCAN(operator:NOT_IN,predicate:noIndexCol1 NOT IN ('1','20','30'))", 9, 6});
+        + "(textIndexCol1,'foo'))", 9, 7});
+    result.add(new Object[]{"FILTER_FULL_SCAN(operator:NOT_IN,predicate:noIndexCol1 NOT IN ('1','20','30'))", 10, 7});
     check(query, new ResultTable(DATA_SCHEMA, result));
   }
 
   @Test
-  public void testSelectAggregate() {
-    String query1 = "EXPLAIN PLAN FOR SELECT count(*) FROM testTable";
+  public void testSelectColumnUsingFilterOnJsonIndexColumnVerbose() {
+    // Segment 2, 3, 4 don't match 'noIndexCol1 NOT IN (1, 20, 30)' so they return a plan without this OR predicate
+    // Segments 1 matches all three predicates so returns a plan with all three
+    String query =
+        "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1 FROM testTable WHERE (invertedIndexCol1 IN (10, 20, "
+            + "30) AND sortedIndexCol1 != 100) OR (noIndexCol1 NOT IN (1, 20, 30) AND rangeIndexCol1 != 20 AND "
+            + "JSON_MATCH(jsonIndexCol1, 'key=1') AND TEXT_MATCH(textIndexCol1, 'foo')) "
+            + "OPTION(explainPlanVerbose=true)";
+    List<Object[]> result = new ArrayList<>();
+    result.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:3)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1)", 3, 2});
+    result.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
+    result.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result.add(new Object[]{"FILTER_AND", 7, 6});
+    result.add(new Object[]{"FILTER_JSON_INDEX(indexLookUp:json_index,operator:JSON_MATCH,predicate:json_match"
+        + "(jsonIndexCol1,'key=1'))", 8, 7});
+    result.add(new Object[]{"FILTER_TEXT_INDEX(indexLookUp:text_index,operator:TEXT_MATCH,predicate:text_match"
+        + "(textIndexCol1,'foo'))", 9, 7});
+    result.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1)", 3, 2});
+    result.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)", 4, 3});
+    result.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
+    result.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result.add(new Object[]{"FILTER_AND", 7, 6});
+    result.add(new Object[]{"FILTER_JSON_INDEX(indexLookUp:json_index,operator:JSON_MATCH,predicate:json_match"
+        + "(jsonIndexCol1,'key=1'))", 8, 7});
+    result.add(new Object[]{"FILTER_TEXT_INDEX(indexLookUp:text_index,operator:TEXT_MATCH,predicate:text_match"
+        + "(textIndexCol1,'foo'))", 9, 7});
+    result.add(new Object[]{"FILTER_FULL_SCAN(operator:NOT_IN,predicate:noIndexCol1 NOT IN ('1','20','30'))", 10, 7});
+    check(query, new ResultTable(DATA_SCHEMA, result));
+  }
+
+  @Test
+  public void testSelectColumnsVariationsOfOrOperators() {
+    // Segment 2 returns match all as 'pluto' matches all rows even though '1.5' isn't present
+    // Segment 3 matches a row for '1.5' even though 'pluto' doesn't exist
+    // Segment 1, 4 don't contain either '1.5' or 'pluto' but are within range so they return an EmptyFilter
+    // The plan for segment 3 is returned as it has precedence and verbose mode is disabled
+    String query1 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, invertedIndexCol3 FROM testTable WHERE "
+        + "invertedIndexCol1 = 1.5 OR invertedIndexCol3 = 'pluto' LIMIT 100";
     List<Object[]> result1 = new ArrayList<>();
-    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 0, -1});
-    result1.add(new Object[]{"COMBINE_AGGREGATE", 1, 0});
-    result1.add(new Object[]{"FAST_FILTERED_COUNT", 2, 1});
-    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 3, 2});
+    result1.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result1.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
+    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol1"
+        + " = '1.5')", 7, 6});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
 
-    String query2 = "EXPLAIN PLAN FOR SELECT min(invertedIndexCol1) FROM testTable";
+    // Segment 1 matches both OR predicates so returns a FILTER_OR tree
+    // Segment 3 doesn't contain 'mickey' or '1.1' and returns an EmptyFilter as '1.1' is within range
+    // Segment 2, 4 do contain 1.1 but don't contain 'mickey' so part of the OR predicate is removed
+    // The deepest tree with FILTER_OR is returned as it has precedence and verbose mode is disabled
+    String query2 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, invertedIndexCol3 FROM testTable WHERE "
+        + "invertedIndexCol1 = 1.1 OR invertedIndexCol3 = 'mickey' LIMIT 100";
     List<Object[]> result2 = new ArrayList<>();
-    result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 0, -1});
-    result2.add(new Object[]{"COMBINE_AGGREGATE", 1, 0});
-    result2.add(new Object[]{"AGGREGATE_NO_SCAN", 2, 1});
+    result2.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result2.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
+    result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result2.add(new Object[]{"FILTER_OR", 7, 6});
+    result2.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol1"
+        + " = '1.1')", 8, 7});
+    result2.add(new Object[]{"FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:invertedIndexCol3"
+        + " = 'mickey')", 9, 7});
     check(query2, new ResultTable(DATA_SCHEMA, result2));
 
+    // An OR query that matches all predicates on all segments
+    String query3 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, invertedIndexCol2 FROM testTable WHERE "
+        + "invertedIndexCol1 = 0.1 OR invertedIndexCol2 = 2 LIMIT 100";
+    List<Object[]> result3 = new ArrayList<>();
+    result3.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result3.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result3.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result3.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol2)", 3, 2});
+    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, invertedIndexCol2, noIndexCol1)", 4, 3});
+    result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1, invertedIndexCol2)", 5, 4});
+    result3.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result3.add(new Object[]{"FILTER_OR", 7, 6});
+    result3.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol1"
+        + " = '0.1')", 8, 7});
+    result3.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol2"
+        + " = '2')", 9, 7});
+    check(query3, new ResultTable(DATA_SCHEMA, result3));
+
+    // Segment 2 matches all on the 'pluto' predicate
+    // Segments 1, 3 get pruned as '8' and 'pluto' are out of range
+    // Segment 4 returns EmptyFilterOperator as though '8' is out of range, 'pluto' is within range but not present
+    // The MatchAll plan is returned as it has precedence and verbose mode is disabled
+    String query4 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol3 FROM testTable WHERE "
+        + "invertedIndexCol3 = 'pluto' OR noIndexCol1 = 8 LIMIT 100";
+    List<Object[]> result4 = new ArrayList<>();
+    result4.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result4.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result4.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result4.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol3)", 3, 2});
+    result4.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol3, noIndexCol1)", 4, 3});
+    result4.add(new Object[]{"PROJECT(invertedIndexCol3, noIndexCol1)", 5, 4});
+    result4.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result4.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
+    check(query4, new ResultTable(DATA_SCHEMA, result4));
+  }
+
+  @Test
+  public void testSelectColumnsVariationsOfOrOperatorsVerbose() {
+    // Segment 2 returns match all as 'pluto' matches all rows even though '1.5' isn't present
+    // Segment 3 matches a row for '1.5' even though 'pluto' doesn't exist
+    // Segment 1, 4 don't contain either '1.5' or 'pluto' but are within range so they return an EmptyFilter
+    String query1 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, invertedIndexCol3 FROM testTable WHERE "
+        + "invertedIndexCol1 = 1.5 OR invertedIndexCol3 = 'pluto' LIMIT 100 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result1 = new ArrayList<>();
+    result1.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result1.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
+    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol1"
+        + " = '1.5')", 7, 6});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
+    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
+    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_EMPTY", 7, 6});
+    check(query1, new ResultTable(DATA_SCHEMA, result1));
+
+    // Segment 1 matches both OR predicates so returns a FILTER_OR tree
+    // Segment 3 doesn't contain 'mickey' or '1.1' and returns an EmptyFilter as '1.1' is within range
+    // Segment 2, 4 do contain 1.1 but don't contain 'mickey' so part of the OR predicate is removed
+    String query2 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, invertedIndexCol3 FROM testTable WHERE "
+        + "invertedIndexCol1 = 1.1 OR invertedIndexCol3 = 'mickey' LIMIT 100 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result2 = new ArrayList<>();
+    result2.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result2.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
+    result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result2.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol1"
+        + " = '1.1')", 7, 6});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
+    result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result2.add(new Object[]{"FILTER_OR", 7, 6});
+    result2.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol1"
+        + " = '1.1')", 8, 7});
+    result2.add(new Object[]{"FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:invertedIndexCol3"
+        + " = 'mickey')", 9, 7});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
+    result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result2.add(new Object[]{"FILTER_EMPTY", 7, 6});
+    check(query2, new ResultTable(DATA_SCHEMA, result2));
+
+    // An OR query that matches all predicates on all segments
+    String query3 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, invertedIndexCol2 FROM testTable WHERE "
+        + "invertedIndexCol1 = 0.1 OR invertedIndexCol2 = 2 LIMIT 100 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result3 = new ArrayList<>();
+    result3.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result3.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result3.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result3.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol2)", 3, 2});
+    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, invertedIndexCol2, noIndexCol1)", 4, 3});
+    result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1, invertedIndexCol2)", 5, 4});
+    result3.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result3.add(new Object[]{"FILTER_OR", 7, 6});
+    result3.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol1"
+        + " = '0.1')", 8, 7});
+    result3.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol2"
+        + " = '2')", 9, 7});
+    check(query3, new ResultTable(DATA_SCHEMA, result3));
+
+    // Segment 2 matches all on the 'pluto' predicate
+    // Segments 1, 3 get pruned as '8' and 'pluto' are out of range
+    // Segment 4 returns EmptyFilterOperator as though '8' is out of range, 'pluto' is within range but not present
+    String query4 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol3 FROM testTable WHERE "
+        + "invertedIndexCol3 = 'pluto' OR noIndexCol1 = 8 LIMIT 100 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result4 = new ArrayList<>();
+    result4.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result4.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result4.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result4.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol3)", 3, 2});
+    result4.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol3, noIndexCol1)", 4, 3});
+    result4.add(new Object[]{"PROJECT(invertedIndexCol3, noIndexCol1)", 5, 4});
+    result4.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result4.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
+    result4.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result4.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol3)", 3, 2});
+    result4.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol3, noIndexCol1)", 4, 3});
+    result4.add(new Object[]{"PROJECT(invertedIndexCol3, noIndexCol1)", 5, 4});
+    result4.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result4.add(new Object[]{"FILTER_EMPTY", 7, 6});
+    check(query4, new ResultTable(DATA_SCHEMA, result4));
+  }
+
+  @Test
+  public void testSelectColumnsVariationsOfAndOperators() {
+    // Segments 1 and 4 are pruned as 'pluto' isn't in range and nor is '1.5'
+    // Segment 2 has 'pluto' but doesn't have '1.5' so it returns EmptyFilterOperator
+    // Segment 3 has '1.5' but doesn't have pluto so it also returns EmptyFilterOperator
+    // Return the EmptyFilterOperator plan
+    String query1 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, invertedIndexCol3 FROM testTable WHERE "
+        + "invertedIndexCol1 = 1.5 AND invertedIndexCol3 = 'pluto' LIMIT 100";
+    List<Object[]> result1 = new ArrayList<>();
+    result1.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result1.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
+    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_EMPTY", 7, 6});
+    check(query1, new ResultTable(DATA_SCHEMA, result1));
+
+    // Segment 1 has a match for both predicates so it return a FILTER_AND plan
+    // Segment 2 is pruned as 'mickey' isn't in range (all values are 'pluto')
+    // Segment 3, 4 return an EmptyFilterOperator plan as they contain '1.1' but don't contain 'mickey'
+    // Return the FILTER_AND plan as it has precedence and verbose mode is disabled
+    String query2 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, invertedIndexCol3 FROM testTable WHERE "
+        + "invertedIndexCol1 = 1.1 AND invertedIndexCol3 = 'mickey' LIMIT 100";
+    List<Object[]> result2 = new ArrayList<>();
+    result2.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result2.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
+    result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result2.add(new Object[]{"FILTER_AND", 7, 6});
+    result2.add(new Object[]{"FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:invertedIndexCol3"
+        + " = 'mickey')", 8, 7});
+    result2.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol1"
+        + " = '1.1')", 9, 7});
+    check(query2, new ResultTable(DATA_SCHEMA, result2));
+
+    // An AND query that matches all predicates on all segments
+    String query3 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, invertedIndexCol2 FROM testTable WHERE "
+        + "invertedIndexCol1 = 0.1 AND invertedIndexCol2 = 1 LIMIT 100";
+    List<Object[]> result3 = new ArrayList<>();
+    result3.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result3.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result3.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result3.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol2)", 3, 2});
+    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, invertedIndexCol2, noIndexCol1)", 4, 3});
+    result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1, invertedIndexCol2)", 5, 4});
+    result3.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result3.add(new Object[]{"FILTER_AND", 7, 6});
+    result3.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol1"
+        + " = '0.1')", 8, 7});
+    result3.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol2"
+        + " = '1')", 9, 7});
+    check(query3, new ResultTable(DATA_SCHEMA, result3));
+
+    // Segment 2 matches all on the first predicate 'pluto' which is removed from the AND, and matches '8' for the
+    // second predicate on one row.
+    // Segments 1, 3, 4 are all pruned as '8' is out of range for all and 'pluto' doesn't match either
+    // The plan for segment 2 is returned as it has precedence over the others and verbose mode is disabled
+    String query4 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol3 FROM testTable WHERE "
+        + "invertedIndexCol3 = 'pluto' AND noIndexCol1 = 8 LIMIT 100";
+    List<Object[]> result4 = new ArrayList<>();
+    result4.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result4.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result4.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result4.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol3)", 3, 2});
+    result4.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol3, noIndexCol1)", 4, 3});
+    result4.add(new Object[]{"PROJECT(invertedIndexCol3, noIndexCol1)", 5, 4});
+    result4.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result4.add(new Object[]{"FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:noIndexCol1 = '8')",
+        7, 6});
+    check(query4, new ResultTable(DATA_SCHEMA, result4));
+  }
+
+  @Test
+  public void testSelectColumnsVariationsOfAndOperatorsVerbose() {
+    // Segments 1 and 4 are pruned as 'pluto' isn't in range and nor is '1.5'
+    // Segment 2 has 'pluto' but doesn't have '1.5' so it returns EmptyFilterOperator
+    // Segment 3 has '1.5' but doesn't have pluto so it also returns EmptyFilterOperator
+    String query1 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, invertedIndexCol3 FROM testTable WHERE "
+        + "invertedIndexCol1 = 1.5 AND invertedIndexCol3 = 'pluto' LIMIT 100 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result1 = new ArrayList<>();
+    result1.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result1.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
+    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_EMPTY", 7, 6});
+    check(query1, new ResultTable(DATA_SCHEMA, result1));
+
+    // Segment 1 has a match for both predicates so it return a FILTER_AND plan
+    // Segment 2 is pruned as 'mickey' isn't in range (all values are 'pluto')
+    // Segment 3, 4 return an EmptyFilterOperator plan as they contain '1.1' but don't contain 'mickey'
+    String query2 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, invertedIndexCol3 FROM testTable WHERE "
+        + "invertedIndexCol1 = 1.1 AND invertedIndexCol3 = 'mickey' LIMIT 100 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result2 = new ArrayList<>();
+    result2.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result2.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
+    result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result2.add(new Object[]{"FILTER_AND", 7, 6});
+    result2.add(new Object[]{"FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:invertedIndexCol3"
+        + " = 'mickey')", 8, 7});
+    result2.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol1"
+        + " = '1.1')", 9, 7});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol3)", 3, 2});
+    result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, invertedIndexCol3, noIndexCol1)", 4, 3});
+    result2.add(new Object[]{"PROJECT(invertedIndexCol3, invertedIndexCol1, noIndexCol1)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result2.add(new Object[]{"FILTER_EMPTY", 7, 6});
+    check(query2, new ResultTable(DATA_SCHEMA, result2));
+
+    // An AND query that matches all predicates on all segments
+    String query3 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, invertedIndexCol2 FROM testTable WHERE "
+        + "invertedIndexCol1 = 0.1 AND invertedIndexCol2 = 1 LIMIT 100 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result3 = new ArrayList<>();
+    result3.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result3.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result3.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result3.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol1, invertedIndexCol2)", 3, 2});
+    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol1, invertedIndexCol2, noIndexCol1)", 4, 3});
+    result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1, invertedIndexCol2)", 5, 4});
+    result3.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result3.add(new Object[]{"FILTER_AND", 7, 6});
+    result3.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol1"
+        + " = '0.1')", 8, 7});
+    result3.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol2"
+        + " = '1')", 9, 7});
+    check(query3, new ResultTable(DATA_SCHEMA, result3));
+
+    // Segment 2 matches all on the first predicate 'pluto' which is removed from the AND, and matches '8' for the
+    // second predicate on one row.
+    // Segments 1, 3, 4 are all pruned as '8' is out of range for all and 'pluto' doesn't match either
+    String query4 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol3 FROM testTable WHERE "
+        + "invertedIndexCol3 = 'pluto' AND noIndexCol1 = 8 LIMIT 100 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result4 = new ArrayList<>();
+    result4.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result4.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result4.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result4.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol3)", 3, 2});
+    result4.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol3, noIndexCol1)", 4, 3});
+    result4.add(new Object[]{"PROJECT(invertedIndexCol3, noIndexCol1)", 5, 4});
+    result4.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result4.add(new Object[]{"FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:noIndexCol1 = '8')",
+        7, 6});
+    result4.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result4.add(new Object[]{"ALL_SEGMENTS_PRUNED_ON_SERVER", 2, 1});
+    check(query4, new ResultTable(DATA_SCHEMA, result4));
+  }
+
+  @Test
+  public void testSelectAggregate() {
+    // All segment plans for this queries generate a plan using the MatchAllFilterOperator as it selects and aggregates
+    // columns without filtering
+    String query1 = "EXPLAIN PLAN FOR SELECT count(*) FROM testTable";
+    List<Object[]> result1 = new ArrayList<>();
+    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result1.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 4, 3});
+    check(query1, new ResultTable(DATA_SCHEMA, result1));
+
+    // No scan required as metadata is sufficient to answer teh query for all segments
+    String query2 = "EXPLAIN PLAN FOR SELECT min(invertedIndexCol1) FROM testTable";
+    List<Object[]> result2 = new ArrayList<>();
+    result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result2.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"AGGREGATE_NO_SCAN", 3, 2});
+    check(query2, new ResultTable(DATA_SCHEMA, result2));
+
+    // All segment plans for this queries generate a plan using the MatchAllFilterOperator as it selects and aggregates
+    // columns without filtering
     String query3 =
         "EXPLAIN PLAN FOR SELECT count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol2) FROM testTable";
     List<Object[]> result3 = new ArrayList<>();
-    result3.add(new Object[]{"BROKER_REDUCE(limit:10)", 0, -1});
-    result3.add(new Object[]{"COMBINE_AGGREGATE", 1, 0});
+    result3.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result3.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result3.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
     result3.add(
-        new Object[]{"AGGREGATE(aggregations:count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol2))", 2, 1});
-    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2)", 3, 2});
-    result3.add(new Object[]{"PROJECT(noIndexCol2, noIndexCol1)", 4, 3});
-    result3.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result3.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
+        new Object[]{"AGGREGATE(aggregations:count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol2))", 3, 2});
+    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2)", 4, 3});
+    result3.add(new Object[]{"PROJECT(noIndexCol2, noIndexCol1)", 5, 4});
+    result3.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result3.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
     check(query3, new ResultTable(DATA_SCHEMA, result3));
 
+    // All segment plans for this queries generate a plan using the MatchAllFilterOperator as it selects and aggregates
+    // columns without filtering
     String query4 = "EXPLAIN PLAN FOR SELECT sum(add(noIndexCol1, noIndexCol2)), MIN(ADD(DIV(noIndexCol1,noIndexCol2),"
         + "noIndexCol3)) FROM testTable";
     List<Object[]> result4 = new ArrayList<>();
-    result4.add(new Object[]{"BROKER_REDUCE(limit:10)", 0, -1});
-    result4.add(new Object[]{"COMBINE_AGGREGATE", 1, 0});
+    result4.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result4.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result4.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
     result4.add(new Object[]{"AGGREGATE(aggregations:sum(add(noIndexCol1,noIndexCol2)), min(add(div(noIndexCol1,"
-        + "noIndexCol2),noIndexCol3)))", 2, 1});
+        + "noIndexCol2),noIndexCol3)))", 3, 2});
     result4.add(
-        new Object[]{"TRANSFORM(add(div(noIndexCol1,noIndexCol2),noIndexCol3), add(noIndexCol1,noIndexCol2))", 3, 2});
-    result4.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
-    result4.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result4.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
+        new Object[]{"TRANSFORM(add(div(noIndexCol1,noIndexCol2),noIndexCol3), add(noIndexCol1,noIndexCol2))", 4, 3});
+    result4.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 5, 4});
+    result4.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result4.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
+    check(query4, new ResultTable(DATA_SCHEMA, result4));
+  }
+
+  @Test
+  public void testSelectAggregateVerbose() {
+    // All segment plans for this queries generate a plan using the MatchAllFilterOperator as it selects and aggregates
+    // columns without filtering
+    String query1 = "EXPLAIN PLAN FOR SELECT count(*) FROM testTable OPTION(explainPlanVerbose=true)";
+    List<Object[]> result1 = new ArrayList<>();
+    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result1.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 4, 3});
+    check(query1, new ResultTable(DATA_SCHEMA, result1));
+
+    // No scan required as metadata is sufficient to answer teh query for all segments
+    String query2 = "EXPLAIN PLAN FOR SELECT min(invertedIndexCol1) FROM testTable OPTION(explainPlanVerbose=true)";
+    List<Object[]> result2 = new ArrayList<>();
+    result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result2.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"AGGREGATE_NO_SCAN", 3, 2});
+    check(query2, new ResultTable(DATA_SCHEMA, result2));
+
+    // All segment plans for this queries generate a plan using the MatchAllFilterOperator as it selects and aggregates
+    // columns without filtering
+    String query3 =
+        "EXPLAIN PLAN FOR SELECT count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol2) FROM testTable "
+            + "OPTION(explainPlanVerbose=true)";
+    List<Object[]> result3 = new ArrayList<>();
+    result3.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result3.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result3.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result3.add(
+        new Object[]{"AGGREGATE(aggregations:count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol2))", 3, 2});
+    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2)", 4, 3});
+    result3.add(new Object[]{"PROJECT(noIndexCol2, noIndexCol1)", 5, 4});
+    result3.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result3.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
+    check(query3, new ResultTable(DATA_SCHEMA, result3));
+
+    // All segment plans for this queries generate a plan using the MatchAllFilterOperator as it selects and aggregates
+    // columns without filtering
+    String query4 = "EXPLAIN PLAN FOR SELECT sum(add(noIndexCol1, noIndexCol2)), MIN(ADD(DIV(noIndexCol1,noIndexCol2),"
+        + "noIndexCol3)) FROM testTable OPTION(explainPlanVerbose=true)";
+    List<Object[]> result4 = new ArrayList<>();
+    result4.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result4.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result4.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result4.add(new Object[]{"AGGREGATE(aggregations:sum(add(noIndexCol1,noIndexCol2)), min(add(div(noIndexCol1,"
+        + "noIndexCol2),noIndexCol3)))", 3, 2});
+    result4.add(
+        new Object[]{"TRANSFORM(add(div(noIndexCol1,noIndexCol2),noIndexCol3), add(noIndexCol1,noIndexCol2))", 4, 3});
+    result4.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 5, 4});
+    result4.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result4.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
     check(query4, new ResultTable(DATA_SCHEMA, result4));
   }
 
   @Test
   public void testSelectAggregateUsingFilterGroupBy() {
+    // Segments 2, 3, 4 are pruned as noIndexCol1's values are all > '3'
+    // Segment 1 has values which are < '3' so a FILTER_FULL_SCAN is returned
+    // The plan for FILTER_FULL_SCAN is returned as it has precedence over NoMatch and verbose mode is disabled
     String query1 =
         "EXPLAIN PLAN FOR SELECT noIndexCol2, sum(add(noIndexCol1, noIndexCol2)), min(noIndexCol3) FROM testTable "
             + "WHERE noIndexCol1 < 3 GROUP BY noIndexCol2";
     List<Object[]> result1 = new ArrayList<>();
-    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 0, -1});
-    result1.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 1, 0});
+    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result1.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
     result1.add(new Object[]{"AGGREGATE_GROUPBY_ORDERBY(groupKeys:noIndexCol2, aggregations:sum(add(noIndexCol1,"
-        + "noIndexCol2)), min(noIndexCol3))", 2, 1});
-    result1.add(new Object[]{"TRANSFORM(add(noIndexCol1,noIndexCol2), noIndexCol2, noIndexCol3)", 3, 2});
-    result1.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
-    result1.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result1.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol1 < '3')", 6, 5});
+        + "noIndexCol2)), min(noIndexCol3))", 3, 2});
+    result1.add(new Object[]{"TRANSFORM(add(noIndexCol1,noIndexCol2), noIndexCol2, noIndexCol3)", 4, 3});
+    result1.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol1 < '3')", 7, 6});
+    check(query1, new ResultTable(DATA_SCHEMA, result1));
+  }
+
+  @Test
+  public void testSelectAggregateUsingFilterGroupByVerbose() {
+    // Segments 2, 3, 4 are pruned as noIndexCol1's values are all > '3'
+    // Segment 1 has values which are < '3' so a FILTER_FULL_SCAN is returned
+    String query1 =
+        "EXPLAIN PLAN FOR SELECT noIndexCol2, sum(add(noIndexCol1, noIndexCol2)), min(noIndexCol3) FROM testTable "
+            + "WHERE noIndexCol1 < 3 GROUP BY noIndexCol2 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result1 = new ArrayList<>();
+    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result1.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"ALL_SEGMENTS_PRUNED_ON_SERVER", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"AGGREGATE_GROUPBY_ORDERBY(groupKeys:noIndexCol2, aggregations:sum(add(noIndexCol1,"
+        + "noIndexCol2)), min(noIndexCol3))", 3, 2});
+    result1.add(new Object[]{"TRANSFORM(add(noIndexCol1,noIndexCol2), noIndexCol2, noIndexCol3)", 4, 3});
+    result1.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol1 < '3')", 7, 6});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
   }
 
   @Test
   public void testSelectAggregateUsingFilterIndex() {
+    // Segment 2 is pruned because 'mickey' is not within range (and all values in that segment are 'pluto')
+    // Segments 3 and 4 don't contain 'mickey' but 'mickey' is within range so they return EmptyFilterOperator
+    // Segment 1 contains 'mickey' so the FILTER_SORTED_INDEX plan is returned for it
+    // The non-EmptyFilterOperator plan is returned as it has precedence and verbose mode is disabled
     String query1 = "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol3 = 'mickey'";
     List<Object[]> result1 = new ArrayList<>();
-    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 0, -1});
-    result1.add(new Object[]{"COMBINE_AGGREGATE", 1, 0});
-    result1.add(new Object[]{"FAST_FILTERED_COUNT", 2, 1});
+    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result1.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
     result1.add(new Object[]{"FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:invertedIndexCol3 "
-        + "= 'mickey')", 3, 2});
+        + "= 'mickey')", 4, 3});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
 
+    // Segment 2 is pruned because 'mickey' is not within range (and all values in that segment are 'pluto')
+    // Segments 3 and 4 don't contain 'mickey' but 'mickey' is within range so they return EmptyFilterOperator
+    // Segment 1 contains 'mickey' so the FILTER_SORTED_INDEX plan is returned for it
+    // The non-EmptyFilterOperator plan is returned as it has precedence and verbose mode is disabled
     String query2 = "EXPLAIN PLAN FOR SELECT sum(noIndexCol2) FROM testTable WHERE invertedIndexCol3 = 'mickey'";
     List<Object[]> result2 = new ArrayList<>();
-    result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 0, -1});
-    result2.add(new Object[]{"COMBINE_AGGREGATE", 1, 0});
-    result2.add(new Object[]{"AGGREGATE(aggregations:sum(noIndexCol2))", 2, 1});
-    result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol2)", 3, 2});
-    result2.add(new Object[]{"PROJECT(noIndexCol2)", 4, 3});
-    result2.add(new Object[]{"DOC_ID_SET", 5, 4});
+    result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result2.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"AGGREGATE(aggregations:sum(noIndexCol2))", 3, 2});
+    result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol2)", 4, 3});
+    result2.add(new Object[]{"PROJECT(noIndexCol2)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
     result2.add(new Object[]{
-        "FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:invertedIndexCol3 = " + "'mickey')", 6, 5});
+        "FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:invertedIndexCol3 = " + "'mickey')", 7, 6});
     check(query2, new ResultTable(DATA_SCHEMA, result2));
 
+    // None of the segments have a value of '20' for the noIndexCol1 so this part of the OR predicate is removed for
+    // all segments.
+    // Segment 3 doesn't have the value '1.1' for the invertedIndexCol1 due to which one plan shows EmptyFilterOperator
+    // The non-EmptyFilterOperator plan is returned as it has precedence and verbose mode is disabled
     String query3 =
         "EXPLAIN PLAN FOR SELECT count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol3) FROM testTable WHERE "
             + "invertedIndexCol1 = 1.1 OR noIndexCol1 = 20";
     List<Object[]> result3 = new ArrayList<>();
-    result3.add(new Object[]{"BROKER_REDUCE(limit:10)", 0, -1});
-    result3.add(new Object[]{"COMBINE_AGGREGATE", 1, 0});
+    result3.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result3.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result3.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:3)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
     result3.add(
-        new Object[]{"AGGREGATE(aggregations:count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol3))", 2, 1});
-    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, noIndexCol3)", 3, 2});
-    result3.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
-    result3.add(new Object[]{"DOC_ID_SET", 5, 4});
+        new Object[]{"AGGREGATE(aggregations:count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol3))", 3, 2});
+    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
+    result3.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 5, 4});
+    result3.add(new Object[]{"DOC_ID_SET", 6, 5});
     result3.add(new Object[]{
         "FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol1 = '1"
-            + ".1')", 6, 5});
+            + ".1')", 7, 6});
     check(query3, new ResultTable(DATA_SCHEMA, result3));
 
     // Use a Transform function in filter on an indexed column.
+    // Segment 3 doesn't have the value '1.1' for the invertedIndexCol1 due to which one plan doesn't show the
+    // FILTER_OR as that predicate is removed.
+    // The deepest tree plan is returned which happens to be the plan with FILTER_OR
     String query4 = "EXPLAIN PLAN FOR SELECT invertedIndexCol3 FROM testTable WHERE concat (invertedIndexCol3, 'test',"
         + "'-') = 'mickey-test' OR invertedIndexCol1 = 1.1";
     List<Object[]> result4 = new ArrayList<>();
-    result4.add(new Object[]{"BROKER_REDUCE(limit:10)", 0, -1});
-    result4.add(new Object[]{"COMBINE_SELECT", 1, 0});
-    result4.add(new Object[]{"SELECT(selectList:invertedIndexCol3)", 2, 1});
-    result4.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol3)", 3, 2});
-    result4.add(new Object[]{"PROJECT(invertedIndexCol3)", 4, 3});
-    result4.add(new Object[]{"DOC_ID_SET", 5, 4});
-    result4.add(new Object[]{"FILTER_OR", 6, 5});
+    result4.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result4.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result4.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:3)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result4.add(new Object[]{"SELECT(selectList:invertedIndexCol3)", 3, 2});
+    result4.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol3)", 4, 3});
+    result4.add(new Object[]{"PROJECT(invertedIndexCol3)", 5, 4});
+    result4.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result4.add(new Object[]{"FILTER_OR", 7, 6});
+    result4.add(new Object[]{
+        "FILTER_EXPRESSION(operator:EQ,predicate:concat(invertedIndexCol3,'test','-') = " + "'mickey-test')", 8, 7});
+    result4.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,"
+        + "predicate:invertedIndexCol1 = '1.1')", 9, 7});
+    check(query4, new ResultTable(DATA_SCHEMA, result4));
+
+    // Segments 1, 2, 4 have an EmptyFilterOperator plan for this query as '1.5' is within the min-max range but
+    // doesn't exist as a value in any row
+    // Segment 3 contains a row with the value as '1.5' so a FILTERED_INVERTED_INDEX is returned for 1 segment
+    String query5 =
+        "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol1 = 1.5 LIMIT 100";
+    List<Object[]> result5 = new ArrayList<>();
+    result5.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result5.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result5.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result5.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result5.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:"
+        + "invertedIndexCol1 = '1.5')", 4, 3});
+    check(query5, new ResultTable(DATA_SCHEMA, result5));
+
+    // All segments have a EmptyFilterOperator plan for this query as '1.7' is within the min-max range but doesn't
+    // exist as a value in any row
+    String query6 =
+        "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol1 = 1.7 LIMIT 100";
+    List<Object[]> result6 = new ArrayList<>();
+    result6.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result6.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result6.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result6.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result6.add(new Object[]{"FILTER_EMPTY", 4, 3});
+    check(query6, new ResultTable(DATA_SCHEMA, result6));
+
+    // Ssegments 1 and 3 are pruned because 'pluto' is outside the range of min-max values of these segments
+    // Segment 2 has a MatchAllFilterOperator plan as all rows match 'pluto'
+    // Segment 4 has an EmptyFilterOperator plan as 'pluto' doesn't exist but is within the value ranges
+    // Only the MatchAllOperator plan is returned as it has higher precedence than no matching segment and verbose is
+    // disabled
+    String query7 =
+        "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol3 = 'pluto' LIMIT 100";
+    List<Object[]> result7 = new ArrayList<>();
+    result7.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result7.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result7.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result7.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result7.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 4, 3});
+    check(query7, new ResultTable(DATA_SCHEMA, result7));
+
+    // Segment 1 has an EmptyFilterOperator plan for this query as '2' is within the segment range but not present
+    // The other segments are pruned as '2' is less than the min for these segments
+    // Only the EmptyFilterOperator plan is returned as it has higher precedence than no matching segment and verbose
+    // is disabled
+    String query8 =
+        "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE noIndexCol1 = 2 LIMIT 100";
+    List<Object[]> result8 = new ArrayList<>();
+    result8.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result8.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result8.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result8.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result8.add(new Object[]{"FILTER_EMPTY", 4, 3});
+    check(query8, new ResultTable(DATA_SCHEMA, result8));
+
+    // Segment 1 is pruned because 'minnie' and 'pluto' are outside the range of min-max values of the segment
+    // Segment 2 has a MatchAllFilterOperator plan as all rows match 'pluto'
+    // Segment 3 has a FILTERED_SORTED_COUNT plan as it contains 'minnie'
+    // Segment 4 has an EmptyFilterOperator plan as neither 'minnie' nor 'pluto' exists but are within the value ranges
+    // Only the FILTERED_SORTED_COUNT plan is returned as it has higher precedence than the others and verbose is
+    // disabled
+    String query9 =
+        "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol3 = 'pluto' OR "
+            + "invertedIndexCol3 = 'minnie' LIMIT 100";
+    List<Object[]> result9 = new ArrayList<>();
+    result9.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result9.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result9.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result9.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result9.add(
+        new Object[]{"FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:invertedIndexCol3 = 'minnie')",
+            4, 3});
+    check(query9, new ResultTable(DATA_SCHEMA, result9));
+
+    // All segments are pruned
+    String query10 = "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol3 = 'roadrunner' AND "
+        + "noIndexCol1 = 100 LIMIT 100";
+    List<Object[]> result10 = new ArrayList<>();
+    result10.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result10.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result10.add(new Object[]{"ALL_SEGMENTS_PRUNED_ON_SERVER", 2, 1});
+    check(query10, new ResultTable(DATA_SCHEMA, result10));
+  }
+
+  @Test
+  public void testSelectAggregateUsingFilterIndexVerbose() {
+    // Segment 2 is pruned because 'mickey' is not within range (and all values in that segment are 'pluto')
+    // Segments 3 and 4 don't contain 'mickey' but 'mickey' is within range so they return EmptyFilterOperator
+    // Segment 1 contains 'mickey' so the FILTER_SORTED_INDEX plan is returned for it
+    String query1 = "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol3 = 'mickey' "
+        + "OPTION(explainPlanVerbose=true)";
+    List<Object[]> result1 = new ArrayList<>();
+    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result1.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result1.add(new Object[]{"FILTER_EMPTY", 4, 3});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result1.add(new Object[]{"FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:invertedIndexCol3 "
+        + "= 'mickey')", 4, 3});
+    check(query1, new ResultTable(DATA_SCHEMA, result1));
+
+    // Segment 2 is pruned because 'mickey' is not within range (and all values in that segment are 'pluto')
+    // Segments 3 and 4 don't contain 'mickey' but 'mickey' is within range so they return EmptyFilterOperator
+    // Segment 1 contains 'mickey' so the FILTER_SORTED_INDEX plan is returned for it
+    String query2 = "EXPLAIN PLAN FOR SELECT sum(noIndexCol2) FROM testTable WHERE invertedIndexCol3 = 'mickey' "
+        + "OPTION(explainPlanVerbose=true)";
+    List<Object[]> result2 = new ArrayList<>();
+    result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result2.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"AGGREGATE(aggregations:sum(noIndexCol2))", 3, 2});
+    result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol2)", 4, 3});
+    result2.add(new Object[]{"PROJECT(noIndexCol2)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result2.add(new Object[]{
+        "FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:invertedIndexCol3 = " + "'mickey')", 7, 6});
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result2.add(new Object[]{"AGGREGATE(aggregations:sum(noIndexCol2))", 3, 2});
+    result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol2)", 4, 3});
+    result2.add(new Object[]{"PROJECT(noIndexCol2)", 5, 4});
+    result2.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result2.add(new Object[]{"FILTER_EMPTY", 7, 6});
+    check(query2, new ResultTable(DATA_SCHEMA, result2));
+
+    // None of the segments have a value of '20' for the noIndexCol1 so this part of the OR predicate is removed for
+    // all segments.
+    // Segment 3 doesn't have the value '1.1' for the invertedIndexCol1 due to which one plan shows EmptyFilterOperator
+    String query3 =
+        "EXPLAIN PLAN FOR SELECT count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol3) FROM testTable WHERE "
+            + "invertedIndexCol1 = 1.1 OR noIndexCol1 = 20 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result3 = new ArrayList<>();
+    result3.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result3.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result3.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result3.add(
+        new Object[]{"AGGREGATE(aggregations:count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol3))", 3, 2});
+    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
+    result3.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 5, 4});
+    result3.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result3.add(new Object[]{"FILTER_EMPTY", 7, 6});
+    result3.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:3)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result3.add(
+        new Object[]{"AGGREGATE(aggregations:count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol3))", 3, 2});
+    result3.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
+    result3.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 5, 4});
+    result3.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result3.add(new Object[]{
+        "FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol1 = '1"
+            + ".1')", 7, 6});
+    check(query3, new ResultTable(DATA_SCHEMA, result3));
+
+    // Use a Transform function in filter on an indexed column.
+    // Segment 3 doesn't have the value '1.1' for the invertedIndexCol1 due to which one plan doesn't show the
+    // FILTER_OR as that predicate is removed.
+    String query4 = "EXPLAIN PLAN FOR SELECT invertedIndexCol3 FROM testTable WHERE concat (invertedIndexCol3, 'test',"
+        + "'-') = 'mickey-test' OR invertedIndexCol1 = 1.1 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result4 = new ArrayList<>();
+    result4.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result4.add(new Object[]{"COMBINE_SELECT", 2, 1});
+    result4.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result4.add(new Object[]{"SELECT(selectList:invertedIndexCol3)", 3, 2});
+    result4.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol3)", 4, 3});
+    result4.add(new Object[]{"PROJECT(invertedIndexCol3)", 5, 4});
+    result4.add(new Object[]{"DOC_ID_SET", 6, 5});
     result4.add(new Object[]{
         "FILTER_EXPRESSION(operator:EQ,predicate:concat(invertedIndexCol3,'test','-') = " + "'mickey-test')", 7, 6});
+    result4.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:3)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result4.add(new Object[]{"SELECT(selectList:invertedIndexCol3)", 3, 2});
+    result4.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol3)", 4, 3});
+    result4.add(new Object[]{"PROJECT(invertedIndexCol3)", 5, 4});
+    result4.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result4.add(new Object[]{"FILTER_OR", 7, 6});
+    result4.add(new Object[]{
+        "FILTER_EXPRESSION(operator:EQ,predicate:concat(invertedIndexCol3,'test','-') = " + "'mickey-test')", 8, 7});
     result4.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,"
-        + "predicate:invertedIndexCol1 = '1.1')", 8, 6});
+        + "predicate:invertedIndexCol1 = '1.1')", 9, 7});
     check(query4, new ResultTable(DATA_SCHEMA, result4));
+
+    // Segments 1, 2, 4 have an EmptyFilterOperator plan for this query as '1.5' is within the min-max range but
+    // doesn't exist as a value in any row
+    // Segment 3 contains a row with the value as '1.5' so a FILTERED_INVERTED_INDEX is returned for 1 segment
+    String query5 =
+        "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol1 = 1.5 LIMIT 100 "
+            + "OPTION(explainPlanVerbose=true)";
+    List<Object[]> result5 = new ArrayList<>();
+    result5.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result5.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result5.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:3)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result5.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result5.add(new Object[]{"FILTER_EMPTY", 4, 3});
+    result5.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result5.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result5.add(new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:"
+        + "invertedIndexCol1 = '1.5')", 4, 3});
+    check(query5, new ResultTable(DATA_SCHEMA, result5));
+
+    // All segments have a EmptyFilterOperator plan for this query as '1.7' is within the min-max range but doesn't
+    // exist as a value in any row
+    String query6 =
+        "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol1 = 1.7 LIMIT 100 "
+            + "OPTION(explainPlanVerbose=true)";
+    List<Object[]> result6 = new ArrayList<>();
+    result6.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result6.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result6.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result6.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result6.add(new Object[]{"FILTER_EMPTY", 4, 3});
+    check(query6, new ResultTable(DATA_SCHEMA, result6));
+
+    // Ssegments 1 and 3 are pruned because 'pluto' is outside the range of min-max values of these segments
+    // Segment 2 has a MatchAllFilterOperator plan as all rows match 'pluto'
+    // Segment 4 has an EmptyFilterOperator plan as 'pluto' doesn't exist but is within the value ranges
+    String query7 =
+        "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol3 = 'pluto' LIMIT 100 "
+            + "OPTION(explainPlanVerbose=true)";
+    List<Object[]> result7 = new ArrayList<>();
+    result7.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result7.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result7.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result7.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result7.add(new Object[]{"FILTER_EMPTY", 4, 3});
+    result7.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result7.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result7.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 4, 3});
+    check(query7, new ResultTable(DATA_SCHEMA, result7));
+
+    // Segment 1 has an EmptyFilterOperator plan for this query as '2' is within the segment range but not present
+    // The other segments are pruned as '2' is less than the min for these segments
+    String query8 =
+        "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE noIndexCol1 = 2 LIMIT 100 "
+            + "OPTION(explainPlanVerbose=true)";
+    List<Object[]> result8 = new ArrayList<>();
+    result8.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result8.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result8.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result8.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result8.add(new Object[]{"FILTER_EMPTY", 4, 3});
+    result8.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result8.add(new Object[]{"ALL_SEGMENTS_PRUNED_ON_SERVER", 2, 1});
+    check(query8, new ResultTable(DATA_SCHEMA, result8));
+
+    // Segment 1 is pruned because 'minnie' and 'pluto' are outside the range of min-max values of the segment
+    // Segment 2 has a MatchAllFilterOperator plan as all rows match 'pluto'
+    // Segment 3 has a FILTERED_SORTED_COUNT plan as it contains 'minnie'
+    // Segment 4 has an EmptyFilterOperator plan as neither 'minnie' nor 'pluto' exists but are within the value ranges
+    String query9 =
+        "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol3 = 'pluto' OR "
+            + "invertedIndexCol3 = 'minnie' LIMIT 100 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result9 = new ArrayList<>();
+    result9.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result9.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result9.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result9.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result9.add(
+        new Object[]{"FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:invertedIndexCol3 = 'minnie')",
+            4, 3});
+    result9.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result9.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result9.add(new Object[]{"FILTER_EMPTY", 4, 3});
+    result9.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result9.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result9.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 4, 3});
+    check(query9, new ResultTable(DATA_SCHEMA, result9));
+
+    // All segments are pruned
+    String query10 = "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol3 = 'roadrunner' AND "
+        + "noIndexCol1 = 100 LIMIT 100 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result10 = new ArrayList<>();
+    result10.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
+    result10.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result10.add(new Object[]{"ALL_SEGMENTS_PRUNED_ON_SERVER", 2, 1});
+    check(query10, new ResultTable(DATA_SCHEMA, result10));
   }
 
   @Test
   public void testSelectAggregateUsingFilterIndexGroupBy() {
+    // All segments match this query as '1' is present in all segments
     String query1 = "EXPLAIN PLAN FOR SELECT noIndexCol1, max(noIndexCol2), min(noIndexCol3) FROM testTable WHERE "
         + "invertedIndexCol2 = 1 GROUP BY noIndexCol1";
     List<Object[]> result1 = new ArrayList<>();
-    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 0, -1});
-    result1.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 1, 0});
+    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result1.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
     result1.add(new Object[]{
         "AGGREGATE_GROUPBY_ORDERBY(groupKeys:noIndexCol1, aggregations:max(noIndexCol2), min(noIndexCol3)"
-            + ")", 2, 1});
-    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, noIndexCol3)", 3, 2});
-    result1.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
-    result1.add(new Object[]{"DOC_ID_SET", 5, 4});
+            + ")", 3, 2});
+    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
+    result1.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
     result1.add(
         new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol2 = '1')",
-            6, 5});
+            7, 6});
+    check(query1, new ResultTable(DATA_SCHEMA, result1));
+  }
+
+  @Test
+  public void testSelectAggregateUsingFilterIndexGroupByVerbose() {
+    // All segments match this query as '1' is present in all segments
+    String query1 = "EXPLAIN PLAN FOR SELECT noIndexCol1, max(noIndexCol2), min(noIndexCol3) FROM testTable WHERE "
+        + "invertedIndexCol2 = 1 GROUP BY noIndexCol1 OPTION(explainPlanVerbose=true)";
+    List<Object[]> result1 = new ArrayList<>();
+    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result1.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{
+        "AGGREGATE_GROUPBY_ORDERBY(groupKeys:noIndexCol1, aggregations:max(noIndexCol2), min(noIndexCol3)"
+            + ")", 3, 2});
+    result1.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
+    result1.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(
+        new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol2 = '1')",
+            7, 6});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
   }
 
   @Test
   public void testSelectAggregateUsingFilterIndexGroupByOrderBy() {
+    // All segments match this query as '1' is present in all segments but not for all rows
     String query1 =
         "EXPLAIN PLAN FOR SELECT noIndexCol1, concat(invertedIndexCol3, 'test', '-'), count(*) FROM testTable WHERE "
             + "invertedIndexCol2 != 1 GROUP BY noIndexCol1, concat(invertedIndexCol3, 'test', '-') ORDER BY "
             + "noIndexCol1, concat(invertedIndexCol3, 'test', '-')";
     List<Object[]> result1 = new ArrayList<>();
     result1.add(
-        new Object[]{"BROKER_REDUCE(sort:[noIndexCol1 ASC, concat(invertedIndexCol3,'test','-') ASC],limit:10)", 0,
-            -1});
-    result1.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 1, 0});
+        new Object[]{"BROKER_REDUCE(sort:[noIndexCol1 ASC, concat(invertedIndexCol3,'test','-') ASC],limit:10)", 1, 0});
+    result1.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
     result1.add(new Object[]{"AGGREGATE_GROUPBY_ORDERBY(groupKeys:noIndexCol1, concat(invertedIndexCol3,'test','-'), "
-        + "aggregations:count(*))", 2, 1});
-    result1.add(new Object[]{"TRANSFORM(concat(invertedIndexCol3,'test','-'), noIndexCol1)", 3, 2});
-    result1.add(new Object[]{"PROJECT(invertedIndexCol3, noIndexCol1)", 4, 3});
-    result1.add(new Object[]{"DOC_ID_SET", 5, 4});
+        + "aggregations:count(*))", 3, 2});
+    result1.add(new Object[]{"TRANSFORM(concat(invertedIndexCol3,'test','-'), noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(invertedIndexCol3, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
     result1.add(new Object[]{
         "FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:NOT_EQ,predicate:invertedIndexCol2 !="
-            + " '1')", 6, 5});
+            + " '1')", 7, 6});
+    check(query1, new ResultTable(DATA_SCHEMA, result1));
+  }
+
+  @Test
+  public void testSelectAggregateUsingFilterIndexGroupByOrderByVerbose() {
+    // All segments match this query as '1' is present in all segments but not for all rows
+    String query1 =
+        "EXPLAIN PLAN FOR SELECT noIndexCol1, concat(invertedIndexCol3, 'test', '-'), count(*) FROM testTable WHERE "
+            + "invertedIndexCol2 != 1 GROUP BY noIndexCol1, concat(invertedIndexCol3, 'test', '-') ORDER BY "
+            + "noIndexCol1, concat(invertedIndexCol3, 'test', '-') OPTION(explainPlanVerbose=true)";
+    List<Object[]> result1 = new ArrayList<>();
+    result1.add(
+        new Object[]{"BROKER_REDUCE(sort:[noIndexCol1 ASC, concat(invertedIndexCol3,'test','-') ASC],limit:10)", 1, 0});
+    result1.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"AGGREGATE_GROUPBY_ORDERBY(groupKeys:noIndexCol1, concat(invertedIndexCol3,'test','-'), "
+        + "aggregations:count(*))", 3, 2});
+    result1.add(new Object[]{"TRANSFORM(concat(invertedIndexCol3,'test','-'), noIndexCol1)", 4, 3});
+    result1.add(new Object[]{"PROJECT(invertedIndexCol3, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{
+        "FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:NOT_EQ,predicate:invertedIndexCol2 !="
+            + " '1')", 7, 6});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
   }
 
   @Test
   public void testSelectAggregateUsingFilterIndexGroupByHaving() {
+    // All segments match this query as '1' is present in all segments
     String query = "EXPLAIN PLAN FOR SELECT max(noIndexCol1), min(noIndexCol2), noIndexCol3 FROM testTable WHERE "
         + "invertedIndexCol2 = 1 GROUP BY noIndexCol3 HAVING max(noIndexCol1) > 2 ORDER BY max(noIndexCol1) DESC";
     List<Object[]> result = new ArrayList<>();
     result.add(
-        new Object[]{"BROKER_REDUCE(havingFilter:max(noIndexCol1) > '2',sort:[max(noIndexCol1) DESC],limit:10)", 0,
-            -1});
-    result.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 1, 0});
+        new Object[]{"BROKER_REDUCE(havingFilter:max(noIndexCol1) > '2',sort:[max(noIndexCol1) DESC],limit:10)", 1, 0});
+    result.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 2, 1});
+    result.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
     result.add(new Object[]{
         "AGGREGATE_GROUPBY_ORDERBY(groupKeys:noIndexCol3, aggregations:max(noIndexCol1), min(noIndexCol2)"
-            + ")", 2, 1});
-    result.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, noIndexCol3)", 3, 2});
-    result.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 4, 3});
-    result.add(new Object[]{"DOC_ID_SET", 5, 4});
+            + ")", 3, 2});
+    result.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
+    result.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 5, 4});
+    result.add(new Object[]{"DOC_ID_SET", 6, 5});
     result.add(
         new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol2 = '1')",
-            6, 5});
+            7, 6});
     check(query, new ResultTable(DATA_SCHEMA, result));
+  }
+
+  @Test
+  public void testSelectAggregateUsingFilterIndexGroupByHavingVerbose() {
+    // All segments match this query as '1' is present in all segments
+    String query = "EXPLAIN PLAN FOR SELECT max(noIndexCol1), min(noIndexCol2), noIndexCol3 FROM testTable WHERE "
+        + "invertedIndexCol2 = 1 GROUP BY noIndexCol3 HAVING max(noIndexCol1) > 2 ORDER BY max(noIndexCol1) DESC "
+        + "OPTION(explainPlanVerbose=true)";
+    List<Object[]> result = new ArrayList<>();
+    result.add(
+        new Object[]{"BROKER_REDUCE(havingFilter:max(noIndexCol1) > '2',sort:[max(noIndexCol1) DESC],limit:10)", 1, 0});
+    result.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 2, 1});
+    result.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result.add(new Object[]{
+        "AGGREGATE_GROUPBY_ORDERBY(groupKeys:noIndexCol3, aggregations:max(noIndexCol1), min(noIndexCol2)"
+            + ")", 3, 2});
+    result.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol1, noIndexCol2, noIndexCol3)", 4, 3});
+    result.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 5, 4});
+    result.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result.add(
+        new Object[]{"FILTER_INVERTED_INDEX(indexLookUp:inverted_index,operator:EQ,predicate:invertedIndexCol2 = '1')",
+            7, 6});
+    check(query, new ResultTable(DATA_SCHEMA, result));
+  }
+
+  @AfterClass
+  public void tearDown() {
+    _brokerReduceService.shutDown();
+    _queryExecutor.shutDown();
+    for (IndexSegment segment : _indexSegments) {
+      segment.destroy();
+    }
+    FileUtils.deleteQuietly(INDEX_DIR);
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -2000,9 +2000,10 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
     assertEquals(response1, "{\"dataSchema\":{\"columnNames\":[\"Operator\",\"Operator_Id\",\"Parent_Id\"],"
         + "\"columnDataTypes\":[\"STRING\",\"INT\",\"INT\"]},\"rows\":[[\"BROKER_REDUCE(sort:[count(*) ASC],limit:10)"
-        + "\",0,-1],[\"COMBINE_GROUPBY_ORDERBY\",1,0],[\"AGGREGATE_GROUPBY_ORDERBY(groupKeys:Carrier, "
-        + "aggregations:count(*))\",2,1],[\"TRANSFORM_PASSTHROUGH(Carrier)\",3,2],[\"PROJECT(Carrier)\",4,3],"
-        + "[\"DOC_ID_SET\",5,4],[\"FILTER_MATCH_ENTIRE_SEGMENT(docs:*)\",6,5]]}");
+        + "\",1,0],[\"COMBINE_GROUPBY_ORDERBY\",2,1],[\"PLAN_START(numSegmentsForThisPlan:1)\",-1,-1],"
+        + "[\"AGGREGATE_GROUPBY_ORDERBY(groupKeys:Carrier, aggregations:count(*))\",3,2],"
+        + "[\"TRANSFORM_PASSTHROUGH(Carrier)\",4,3],[\"PROJECT(Carrier)\",5,4],"
+        + "[\"DOC_ID_SET\",6,5],[\"FILTER_MATCH_ENTIRE_SEGMENT(docs:*)\",7,6]]}");
 
     // In the query below, FlightNum column has an inverted index and there is no data satisfying the predicate
     // "FlightNum < 0". Hence, all segments are pruned out before query execution on the server side.
@@ -2010,8 +2011,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     String response2 = postQuery(query2, _brokerBaseApiUrl).get("resultTable").toString();
 
     assertEquals(response2, "{\"dataSchema\":{\"columnNames\":[\"Operator\",\"Operator_Id\",\"Parent_Id\"],"
-        + "\"columnDataTypes\":[\"STRING\",\"INT\",\"INT\"]},\"rows\":[[\"BROKER_REDUCE(limit:10)\",0,-1],"
-        + "[\"NO_MATCHING_SEGMENT\",1,0]]}");
+        + "\"columnDataTypes\":[\"STRING\",\"INT\",\"INT\"]},\"rows\":[[\"BROKER_REDUCE(limit:10)\",1,0],"
+        + "[\"PLAN_START(numSegmentsForThisPlan:12)\",-1,-1],[\"ALL_SEGMENTS_PRUNED_ON_SERVER\",2,1]]}");
   }
 
   /** Test to make sure we are properly handling string comparisons in predicates. */

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -252,6 +252,7 @@ public class CommonConstants {
         public static final String MIN_SEGMENT_GROUP_TRIM_SIZE = "minSegmentGroupTrimSize";
         public static final String MIN_SERVER_GROUP_TRIM_SIZE = "minServerGroupTrimSize";
         public static final String NUM_REPLICA_GROUPS_TO_QUERY = "numReplicaGroupsToQuery";
+        public static final String EXPLAIN_PLAN_VERBOSE = "explainPlanVerbose";
 
         // TODO: Remove these keys (only apply to PQL) after releasing 0.11.0
         @Deprecated


### PR DESCRIPTION
A vast majority of the code changes are in the tests.

The existing behavior for EXPLAIN PLAN has the following limitations:
- The plan query is sent to only one random server with a random segment. This can have the following issues:
    - The segment may get pruned on the server side
    - The segment may produce an Empty filter during the operator tree creation
    - The segment may produce a Match All filter during the operator tree creation
    - AND and OR operators may result in one or both predicate subtrees getting degenerated into an Empty or Match All filter. Due to this the AND or OR subtree may be converted into a leaf level predicate. This leads to confusion in the user's mind regarding the output of the explain plan.
- The overall approach is not a good representation of the distributed query planning for each segment

This PR address the above limitations by the following changes:
- Send the plan query to all segments on all servers (the ones chosen by the Broker after broker side pruning) 
    - Each server returns a set of deduplicated plans along with the count of number of segments matching each plan
    - Each server returns the following data as part of the metadata:
        - Number of segments pruned by the server side
        - Number of segments with an empty filter tree
        - Number of segments with a match all filter tree
    - On the Broker side the set of plans returned by each server is again deduplicated and the number of segments matching each plan is updated for each unique plan
    - Each broker returns the number of segments pruned by the broker side as part of the BrokerResponse
    - Adds a verbose explain plan option which returns all of the deduplicated plans.
    - If verbose is disabled (default option) then a single explain plan out of the deduplicated plan is returned with the deepest plan tree. This is a better approximation than the current explain plan functionality due to deduplication across servers and segments.

Example query (verbose enabled): 
```
EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1 FROM testTable WHERE startsWith (textIndexCol1, 'daff') AND noIndexCol4 OPTION(explainPlanVerbose=true)
```

Here's an example of the Explain Plan output with verbose mode enabled:
```
BROKER_REDUCE
    COMBINE_SELECT
        PLAN_START(numSegmentsForThisPlan:3)
            SELECT(selectList:invertedIndexCol1, noIndexCol1)
                TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)
                     PROJECT(invertedIndexCol1, noIndexCol1)
                         DOC_ID_SET
                             FILTER_AND
                                 FILTER_FULL_SCAN(operator:EQ,predicate:noIndexCol4 = 'true')"
                                 FILTER_EXPRESSION(operator:EQ,predicate:startswith(textIndexCol1,'daff') = 'true')
        PLAN_START(numSegmentsForThisPlan:1)
            SELECT(selectList:invertedIndexCol1, noIndexCol1)
                TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)
                     PROJECT(invertedIndexCol1, noIndexCol1)
                         DOC_ID_SET
                             FILTER_EXPRESSION(operator:EQ,predicate:startswith(textIndexCol1,'daff') = 'true')
```

Example query (verbose disabled): 
```
EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1 FROM testTable WHERE startsWith (textIndexCol1, 'daff') AND noIndexCol4
```

With verbose mode disabled, only the first plan will be selected as it has the deepest tree:
```
BROKER_REDUCE
    COMBINE_SELECT
        PLAN_START(numSegmentsForThisPlan:3)
            SELECT(selectList:invertedIndexCol1, noIndexCol1)
                TRANSFORM_PASSTHROUGH(invertedIndexCol1, noIndexCol1)
                     PROJECT(invertedIndexCol1, noIndexCol1)
                         DOC_ID_SET
                             FILTER_AND
                                 FILTER_FULL_SCAN(operator:EQ,predicate:noIndexCol4 = 'true')"
                                 FILTER_EXPRESSION(operator:EQ,predicate:startswith(textIndexCol1,'daff') = 'true')
```

cc @siddharthteotia 