### PR TITLE
Make max consecutive idle count before recreating stream configurable

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -375,15 +375,72 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     }
   }
 
+  /**
+   * Inner class to track the idling of the consumer
+   */
+  private static class IdleContext {
+    final long idlePipeSleepTimeMillis = 100;
+    long idleStartTimeMillis;
+    long idleTimeoutMillis;
+    long consecutiveIdleCount;
+    long maxConsecutiveIdleCount;
+    String thresholdExceededReason;
+
+    public IdleContext(PartitionLevelStreamConfig partitionLevelStreamConfig) {
+      idleTimeoutMillis = partitionLevelStreamConfig.getIdleTimeoutMillis();
+      if (idleTimeoutMillis <=0) {
+        // backward compatible default behavior
+        maxConsecutiveIdleCount = (3 * 60 * 1000) / (idlePipeSleepTimeMillis + partitionLevelStreamConfig
+            .getFetchTimeoutMillis());  // 3 minute count
+      } else {
+        maxConsecutiveIdleCount = -1;
+      }
+      reset();
+    }
+
+    void reset() {
+      idleStartTimeMillis = -1;
+      consecutiveIdleCount = 0;
+      thresholdExceededReason = null;
+    }
+
+    void update() {
+      if (consecutiveIdleCount == 0) {
+        idleStartTimeMillis = System.currentTimeMillis();
+      }
+      consecutiveIdleCount++;
+    }
+
+    /**
+     * idleTimeoutMillis takes precedence over idleCount. If idleTimeoutMillis is configured, idleCount ignored
+     * @return true if any of the thresholds exceeded
+     */
+    boolean idleThresholdExceeded() {
+      if (idleTimeoutMillis > 0) {
+        long totalIdleTimeMillis = System.currentTimeMillis() - idleStartTimeMillis;
+        if (totalIdleTimeMillis > idleTimeoutMillis) {
+          thresholdExceededReason = String.format("Total idle time: %d ms exceeded idle timeout: %d ms", totalIdleTimeMillis,
+              idleTimeoutMillis);
+          return true;
+        }
+      } else {
+        if (consecutiveIdleCount > maxConsecutiveIdleCount) {
+          thresholdExceededReason = String.format("Consecutive idle count: %d exceeded max: %d", consecutiveIdleCount,
+              maxConsecutiveIdleCount);
+          return true;
+        }
+      }
+      return false;
+    }
+  }
+
   protected boolean consumeLoop()
       throws Exception {
     _numRowsErrored = 0;
-    final long idlePipeSleepTimeMillis = 100;
-    final long maxIdleCountBeforeStatUpdate = (3 * 60 * 1000) / (idlePipeSleepTimeMillis + _partitionLevelStreamConfig
-        .getFetchTimeoutMillis());  // 3 minute count
+    IdleContext idleContext = new IdleContext(_partitionLevelStreamConfig);
+
     StreamPartitionMsgOffset lastUpdatedOffset = _streamPartitionMsgOffsetFactory
         .create(_currentOffset);  // so that we always update the metric when we enter this method.
-    long consecutiveIdleCount = 0;
     // At this point, we know that we can potentially move the offset, so the old saved segment file is not valid
     // anymore. Remove the file if it exists.
     removeSegmentFile();
@@ -415,10 +472,10 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
         continue;
       }
 
-      processStreamEvents(messageBatch, idlePipeSleepTimeMillis);
+      processStreamEvents(messageBatch, idleContext);
 
       if (_currentOffset.compareTo(lastUpdatedOffset) != 0) {
-        consecutiveIdleCount = 0;
+        idleContext.reset();
         // We consumed something. Update the highest stream offset as well as partition-consuming metric.
         // TODO Issue 5359 Need to find a way to bump metrics without getting actual offset value.
         if (_currentOffset instanceof LongMsgOffset) {
@@ -438,14 +495,14 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
         _currentOffset = nextOffset;
         lastUpdatedOffset = _streamPartitionMsgOffsetFactory.create(nextOffset);
       } else {
-        // We did not consume any rows. Update the partition-consuming metric only if we have been idling for a long
-        // time.
-        // Create a new stream consumer wrapper, in case we are stuck on something.
-        consecutiveIdleCount++;
-        if (consecutiveIdleCount > maxIdleCountBeforeStatUpdate) {
+        idleContext.update();
+        if (idleContext.idleThresholdExceeded()) {
+          // We did not consume any rows.
+          // Update the partition-consuming metric only if we have been idling beyond idle thresholds.
+          // Create a new stream consumer wrapper, in case we are stuck on something.
           _serverMetrics.setValueOfTableGauge(_metricKeyName, ServerGauge.LLC_PARTITION_CONSUMING, 1);
-          consecutiveIdleCount = 0;
-          recreateStreamConsumer("Idle for too long");
+          recreateStreamConsumer(idleContext.thresholdExceededReason);
+          idleContext.reset();
         }
       }
     }
@@ -457,7 +514,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     return true;
   }
 
-  private void processStreamEvents(MessageBatch messagesAndOffsets, long idlePipeSleepTimeMillis) {
+  private void processStreamEvents(MessageBatch messagesAndOffsets, IdleContext idleContext) {
 
     int messageCount = messagesAndOffsets.getMessageCount();
     _rateLimiter.throttle(messageCount);
@@ -560,10 +617,10 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       }
     } else if (messagesAndOffsets.getUnfilteredMessageCount() == 0) {
       if (_segmentLogger.isDebugEnabled()) {
-        _segmentLogger.debug("empty batch received - sleeping for {}ms", idlePipeSleepTimeMillis);
+        _segmentLogger.debug("empty batch received - sleeping for {}ms", idleContext.idlePipeSleepTimeMillis);
       }
       // If there were no messages to be fetched from stream, wait for a little bit as to avoid hammering the stream
-      Uninterruptibles.sleepUninterruptibly(idlePipeSleepTimeMillis, TimeUnit.MILLISECONDS);
+      Uninterruptibles.sleepUninterruptibly(idleContext.idlePipeSleepTimeMillis, TimeUnit.MILLISECONDS);
     }
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -56,7 +56,7 @@ public class StreamConfig {
 
   public static final long DEFAULT_STREAM_CONNECTION_TIMEOUT_MILLIS = 30_000;
   public static final int DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS = 5_000;
-  public static final int DEFAULT_IDLE_TIMEOUT_MILLIS = -1; // disabled, will use default idle count mechanism
+  public static final int DEFAULT_IDLE_TIMEOUT_MILLIS = 3 * 60 * 1000;
 
   private static final String SIMPLE_CONSUMER_TYPE_STRING = "simple";
 
@@ -182,8 +182,8 @@ public class StreamConfig {
       try {
         idleTimeoutMillis = Integer.parseInt(idleTimeoutMillisValue);
       } catch (Exception e) {
-        LOGGER.warn("Invalid config {}: {}, defaulting to: {} (i.e. no idle timeout, use only max idle count)",
-            idleTimeoutMillisKey, idleTimeoutMillisValue, DEFAULT_IDLE_TIMEOUT_MILLIS);
+        LOGGER.warn("Invalid config {}: {}, defaulting to: {}", idleTimeoutMillisKey, idleTimeoutMillisValue,
+            DEFAULT_IDLE_TIMEOUT_MILLIS);
       }
     }
     _idleTimeoutMillis = idleTimeoutMillis;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -56,6 +56,7 @@ public class StreamConfig {
 
   public static final long DEFAULT_STREAM_CONNECTION_TIMEOUT_MILLIS = 30_000;
   public static final int DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS = 5_000;
+  public static final int DEFAULT_IDLE_TIMEOUT_MILLIS = -1; // disabled, will use default idle count mechanism
 
   private static final String SIMPLE_CONSUMER_TYPE_STRING = "simple";
 
@@ -71,6 +72,8 @@ public class StreamConfig {
 
   private final long _connectionTimeoutMillis;
   private final int _fetchTimeoutMillis;
+
+  private final long _idleTimeoutMillis;
 
   private final int _flushThresholdRows;
   private final long _flushThresholdTimeMillis;
@@ -170,6 +173,20 @@ public class StreamConfig {
       }
     }
     _fetchTimeoutMillis = fetchTimeoutMillis;
+
+    int idleTimeoutMillis = DEFAULT_IDLE_TIMEOUT_MILLIS;
+    String idleTimeoutMillisKey =
+        StreamConfigProperties.constructStreamProperty(_type, StreamConfigProperties.STREAM_IDLE_TIMEOUT_MILLIS);
+    String idleTimeoutMillisValue = streamConfigMap.get(idleTimeoutMillisKey);
+    if (idleTimeoutMillisValue != null) {
+      try {
+        idleTimeoutMillis = Integer.parseInt(idleTimeoutMillisValue);
+      } catch (Exception e) {
+        LOGGER.warn("Invalid config {}: {}, defaulting to: {} (i.e. no idle timeout, use only max idle count)",
+            idleTimeoutMillisKey, idleTimeoutMillisValue, DEFAULT_IDLE_TIMEOUT_MILLIS);
+      }
+    }
+    _idleTimeoutMillis = idleTimeoutMillis;
 
     _flushThresholdRows = extractFlushThresholdRows(streamConfigMap);
     _flushThresholdTimeMillis = extractFlushThresholdTimeMillis(streamConfigMap);
@@ -312,6 +329,10 @@ public class StreamConfig {
 
   public int getFetchTimeoutMillis() {
     return _fetchTimeoutMillis;
+  }
+
+  public long getIdleTimeoutMillis() {
+    return _idleTimeoutMillis;
   }
 
   public int getFlushThresholdRows() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -373,11 +373,12 @@ public class StreamConfig {
     return "StreamConfig{" + "_type='" + _type + '\'' + ", _topicName='" + _topicName + '\'' + ", _consumerTypes="
         + _consumerTypes + ", _consumerFactoryClassName='" + _consumerFactoryClassName + '\'' + ", _offsetCriteria='"
         + _offsetCriteria + '\'' + ", _connectionTimeoutMillis=" + _connectionTimeoutMillis + ", _fetchTimeoutMillis="
-        + _fetchTimeoutMillis + ", _flushThresholdRows=" + _flushThresholdRows + ", _flushThresholdTimeMillis="
-        + _flushThresholdTimeMillis + ", _flushSegmentDesiredSizeBytes=" + _flushThresholdSegmentSizeBytes
-        + ", _flushAutotuneInitialRows=" + _flushAutotuneInitialRows + ", _decoderClass='" + _decoderClass + '\''
-        + ", _decoderProperties=" + _decoderProperties + ", _groupId='" + _groupId + "', _topicConsumptionRateLimit="
-        + _topicConsumptionRateLimit + ", _tableNameWithType='" + _tableNameWithType + '}';
+        + _fetchTimeoutMillis + ", _idleTimeoutMillis=" + _idleTimeoutMillis + ", _flushThresholdRows="
+        + _flushThresholdRows + ", _flushThresholdTimeMillis=" + _flushThresholdTimeMillis
+        + ", _flushSegmentDesiredSizeBytes=" + _flushThresholdSegmentSizeBytes + ", _flushAutotuneInitialRows="
+        + _flushAutotuneInitialRows + ", _decoderClass='" + _decoderClass + '\'' + ", _decoderProperties="
+        + _decoderProperties + ", _groupId='" + _groupId + "', _topicConsumptionRateLimit=" + _topicConsumptionRateLimit
+        + ", _tableNameWithType='" + _tableNameWithType + '}';
   }
 
   @Override
@@ -392,19 +393,18 @@ public class StreamConfig {
 
     StreamConfig that = (StreamConfig) o;
 
-    return EqualityUtils.isEqual(_connectionTimeoutMillis, that._connectionTimeoutMillis) && EqualityUtils
-        .isEqual(_fetchTimeoutMillis, that._fetchTimeoutMillis) && EqualityUtils
-        .isEqual(_flushThresholdRows, that._flushThresholdRows) && EqualityUtils
-        .isEqual(_flushThresholdTimeMillis, that._flushThresholdTimeMillis) && EqualityUtils
-        .isEqual(_flushThresholdSegmentSizeBytes, that._flushThresholdSegmentSizeBytes) && EqualityUtils
-        .isEqual(_flushAutotuneInitialRows, that._flushAutotuneInitialRows) && EqualityUtils.isEqual(_type, that._type)
-        && EqualityUtils.isEqual(_topicName, that._topicName) && EqualityUtils
-        .isEqual(_consumerTypes, that._consumerTypes) && EqualityUtils
-        .isEqual(_consumerFactoryClassName, that._consumerFactoryClassName) && EqualityUtils
-        .isEqual(_offsetCriteria, that._offsetCriteria) && EqualityUtils.isEqual(_decoderClass, that._decoderClass)
-        && EqualityUtils.isEqual(_decoderProperties, that._decoderProperties) && EqualityUtils
-        .isEqual(_groupId, that._groupId) && EqualityUtils.isEqual(_tableNameWithType, that._tableNameWithType)
-        && EqualityUtils.isEqual(_topicConsumptionRateLimit, that._topicConsumptionRateLimit)
+    return EqualityUtils.isEqual(_connectionTimeoutMillis, that._connectionTimeoutMillis) && EqualityUtils.isEqual(
+        _fetchTimeoutMillis, that._fetchTimeoutMillis) && EqualityUtils.isEqual(_idleTimeoutMillis,
+        that._idleTimeoutMillis) && EqualityUtils.isEqual(_flushThresholdRows, that._flushThresholdRows)
+        && EqualityUtils.isEqual(_flushThresholdTimeMillis, that._flushThresholdTimeMillis) && EqualityUtils.isEqual(
+        _flushThresholdSegmentSizeBytes, that._flushThresholdSegmentSizeBytes) && EqualityUtils.isEqual(
+        _flushAutotuneInitialRows, that._flushAutotuneInitialRows) && EqualityUtils.isEqual(_type, that._type)
+        && EqualityUtils.isEqual(_topicName, that._topicName) && EqualityUtils.isEqual(_consumerTypes,
+        that._consumerTypes) && EqualityUtils.isEqual(_consumerFactoryClassName, that._consumerFactoryClassName)
+        && EqualityUtils.isEqual(_offsetCriteria, that._offsetCriteria) && EqualityUtils.isEqual(_decoderClass,
+        that._decoderClass) && EqualityUtils.isEqual(_decoderProperties, that._decoderProperties)
+        && EqualityUtils.isEqual(_groupId, that._groupId) && EqualityUtils.isEqual(_tableNameWithType,
+        that._tableNameWithType) && EqualityUtils.isEqual(_topicConsumptionRateLimit, that._topicConsumptionRateLimit)
         && EqualityUtils.isEqual(_streamConfigMap, that._streamConfigMap);
   }
 
@@ -417,6 +417,7 @@ public class StreamConfig {
     result = EqualityUtils.hashCodeOf(result, _offsetCriteria);
     result = EqualityUtils.hashCodeOf(result, _connectionTimeoutMillis);
     result = EqualityUtils.hashCodeOf(result, _fetchTimeoutMillis);
+    result = EqualityUtils.hashCodeOf(result, _idleTimeoutMillis);
     result = EqualityUtils.hashCodeOf(result, _flushThresholdRows);
     result = EqualityUtils.hashCodeOf(result, _flushThresholdTimeMillis);
     result = EqualityUtils.hashCodeOf(result, _flushThresholdSegmentSizeBytes);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
@@ -43,6 +43,7 @@ public class StreamConfigProperties {
   public static final String STREAM_CONSUMER_OFFSET_CRITERIA = "consumer.prop.auto.offset.reset";
   public static final String STREAM_FETCH_TIMEOUT_MILLIS = "fetch.timeout.millis";
   public static final String STREAM_CONNECTION_TIMEOUT_MILLIS = "connection.timeout.millis";
+  public static final String STREAM_IDLE_TIMEOUT_MILLIS = "idle.timeout.millis";
   public static final String STREAM_DECODER_CLASS = "decoder.class.name";
   public static final String DECODER_PROPS_PREFIX = "decoder.prop";
   public static final String GROUP_ID = "hlc.group.id";


### PR DESCRIPTION
Making max consecutive idle count configurable. 
For some cases, idle is expected. We want to avoid overhead of recreating the stream (which happens if this idle count is exceeded). Making this configurable so we can tune this based on usecase.