### PR TITLE
move TracedThread and related classes to spi trace pkg to extend trace coverage

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -35,7 +35,7 @@ import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.ThreadTimer;
 import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
-import org.apache.pinot.core.util.trace.TraceRunnable;
+import org.apache.pinot.core.util.trace.ContextBasedTraceRunnable;
 import org.apache.pinot.spi.exception.EarlyTerminationException;
 import org.apache.pinot.spi.trace.Tracing;
 import org.slf4j.Logger;
@@ -85,7 +85,7 @@ public abstract class BaseCombineOperator extends BaseOperator<IntermediateResul
     Tracing.activeRecording().setNumTasks(_numTasks);
     for (int i = 0; i < _numTasks; i++) {
       int taskIndex = i;
-      _futures[i] = _executorService.submit(new TraceRunnable() {
+      _futures[i] = _executorService.submit(new ContextBasedTraceRunnable() {
         @Override
         public void runJob() {
           ThreadTimer executionThreadTimer = new ThreadTimer();

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
@@ -39,7 +39,7 @@ import org.apache.pinot.core.operator.combine.SelectionOrderByCombineOperator;
 import org.apache.pinot.core.operator.streaming.StreamingSelectionOnlyCombineOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextUtils;
-import org.apache.pinot.core.util.trace.TraceCallable;
+import org.apache.pinot.core.util.trace.ContextBasedTraceCallable;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.apache.pinot.spi.trace.InvocationRecording;
 import org.apache.pinot.spi.trace.InvocationScope;
@@ -117,7 +117,7 @@ public class CombinePlanNode implements PlanNode {
       Future[] futures = new Future[numTasks];
       for (int i = 0; i < numTasks; i++) {
         int index = i;
-        futures[i] = _executorService.submit(new TraceCallable<List<Operator>>() {
+        futures[i] = _executorService.submit(new ContextBasedTraceCallable<List<Operator>>() {
           @Override
           public List<Operator> callJob() {
             try {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -50,7 +50,7 @@ import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
 import org.apache.pinot.core.util.GroupByUtils;
-import org.apache.pinot.core.util.trace.TraceRunnable;
+import org.apache.pinot.core.util.trace.ContextBasedTraceRunnable;
 
 
 /**
@@ -241,7 +241,7 @@ public class GroupByDataTableReducer implements DataTableReducer {
     ColumnDataType[] storedColumnDataTypes = dataSchema.getStoredColumnDataTypes();
     for (int i = 0; i < numReduceThreadsToUse; i++) {
       List<DataTable> reduceGroup = reduceGroups.get(i);
-      futures[i] = reducerContext.getExecutorService().submit(new TraceRunnable() {
+      futures[i] = reducerContext.getExecutorService().submit(new ContextBasedTraceRunnable() {
         @Override
         public void runJob() {
           for (DataTable dataTable : reduceGroup) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/resources/ResourceManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/resources/ResourceManager.java
@@ -26,8 +26,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.scheduler.SchedulerGroupAccountant;
-import org.apache.pinot.core.util.trace.TracedThreadFactory;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.trace.TracedThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/trace/ContextBasedTraceCallable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/trace/ContextBasedTraceCallable.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.util.trace;
+
+import org.apache.pinot.spi.trace.TraceCallable;
+
+
+/**
+ * Extend {@link TraceCallable} to automatically register/un-register itself to/from a request.
+ */
+public abstract class ContextBasedTraceCallable<V> extends TraceCallable<V> {
+  private final TraceContext.TraceEntry _parentTraceEntry;
+
+  /**
+   * If trace is not enabled, parent trace entry will be null.
+   */
+  public ContextBasedTraceCallable() {
+    _parentTraceEntry = TraceContext.getTraceEntry();
+  }
+
+  @Override
+  public void preCall() {
+    if (_parentTraceEntry != null) {
+      TraceContext.registerThreadToRequest(_parentTraceEntry);
+    }
+  }
+
+  @Override
+  public void postCall() {
+    if (_parentTraceEntry != null) {
+      TraceContext.unregisterThreadFromRequest();
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/trace/TraceContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/trace/TraceContext.java
@@ -39,7 +39,7 @@ import org.apache.pinot.spi.utils.JsonUtils;
  * {@link #register(long requestId)}.
  * <p>
  * To trace the {@link Runnable} or {@link java.util.concurrent.Callable} jobs the request handler creates and will be
- * executed in other threads, use {@link TraceRunnable} or {@link TraceCallable} instead.
+ * executed in other threads, use {@link ContextBasedTraceRunnable} or {@link ContextBasedTraceCallable} instead.
  * <p>
  * At the end of tracing a request, the request handler thread should call {@link #unregister()} to un-register the
  * request from tracing to prevent resource leak.

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/trace/TraceContextTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/trace/TraceContextTest.java
@@ -90,7 +90,7 @@ public class TraceContextTest {
       final int childValue = RANDOM.nextInt();
       expectedTraces.add(getTraceString(chileKey, childValue));
 
-      futures[i] = executorService.submit(new TraceRunnable() {
+      futures[i] = executorService.submit(new ContextBasedTraceRunnable() {
         @Override
         public void runJob() {
           // Add (requestId + 1) logs

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIndexedTable.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkIndexedTable.java
@@ -39,7 +39,7 @@ import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.data.table.SimpleIndexedTable;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
-import org.apache.pinot.core.util.trace.TraceRunnable;
+import org.apache.pinot.core.util.trace.ContextBasedTraceRunnable;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Mode;
@@ -125,7 +125,7 @@ public class BenchmarkIndexedTable {
     CountDownLatch operatorLatch = new CountDownLatch(numSegments);
     Future[] futures = new Future[numSegments];
     for (int i = 0; i < numSegments; i++) {
-      futures[i] = _executorService.submit(new TraceRunnable() {
+      futures[i] = _executorService.submit(new ContextBasedTraceRunnable() {
         @SuppressWarnings("unchecked")
         @Override
         public void runJob() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/TraceCallable.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/TraceCallable.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.trace;
+
+import java.util.concurrent.Callable;
+
+
+/**
+ * Wrapper class for {@link Callable} to provide hooks for some preparation and cleanup around calling the job.
+ */
+public abstract class TraceCallable<V> implements Callable<V> {
+
+  @Override
+  public V call()
+      throws Exception {
+    preCall();
+    try {
+      return callJob();
+    } finally {
+      postCall();
+    }
+  }
+
+  protected void preCall() {
+  }
+
+  protected void postCall() {
+  }
+
+  public abstract V callJob()
+      throws Exception;
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/TraceRunnable.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/TraceRunnable.java
@@ -16,33 +16,26 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.core.util.trace;
+package org.apache.pinot.spi.trace;
 
 /**
- * Wrapper class for {@link Runnable} to automatically register/un-register itself to/from a request.
+ * Wrapper class for {@link Runnable} to provide hooks for some preparation and cleanup around running the job.
  */
 public abstract class TraceRunnable implements Runnable {
-  private final TraceContext.TraceEntry _parentTraceEntry;
-
-  /**
-   * If trace is not enabled, parent trace entry will be null.
-   */
-  public TraceRunnable() {
-    _parentTraceEntry = TraceContext.getTraceEntry();
-  }
-
   @Override
   public void run() {
-    if (_parentTraceEntry != null) {
-      TraceContext.registerThreadToRequest(_parentTraceEntry);
-    }
+    preRun();
     try {
       runJob();
     } finally {
-      if (_parentTraceEntry != null) {
-        TraceContext.unregisterThreadFromRequest();
-      }
+      postRun();
     }
+  }
+
+  protected void preRun() {
+  }
+
+  protected void postRun() {
   }
 
   public abstract void runJob();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/TracedThread.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/TracedThread.java
@@ -16,12 +16,10 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.core.util.trace;
+package org.apache.pinot.spi.trace;
 
 import java.util.ArrayDeque;
 import java.util.Deque;
-import org.apache.pinot.spi.trace.InvocationRecording;
-import org.apache.pinot.spi.trace.TraceState;
 
 
 final class TracedThread extends Thread implements TraceState {


### PR DESCRIPTION
move TracedThread and a few related util classes to spi trace pkg, so that trace context can be propagated to other thread pools, other than the two existing thread pools for query executions, i.e. queryRunners and queryWorkers. For example, a separate thread pool may be used to prefetch segments from remote storage to execute query. 