### PR TITLE
Indexes on segment page

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -30,6 +30,7 @@ import io.swagger.annotations.ApiResponses;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -286,9 +287,11 @@ public class PinotSegmentRestletResource {
   @Path("segments/{tableName}/{segmentName}/metadata")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Get the metadata for a segment", notes = "Get the metadata for a segment")
-  public Map<String, String> getSegmentMetadata(
+  public Map<String, Object> getSegmentMetadata(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
-      @ApiParam(value = "Name of the segment", required = true) @PathParam("segmentName") @Encoded String segmentName) {
+      @ApiParam(value = "Name of the segment", required = true) @PathParam("segmentName") @Encoded String segmentName,
+      @ApiParam(value = "Columns name", allowMultiple = true) @QueryParam("columns") @DefaultValue("")
+          List<String> columns) {
     segmentName = URIUtils.decode(segmentName);
     Map<String, String> segmentMetadata = null;
     if (TableNameBuilder.getTableTypeFromTableName(tableName) != null) {
@@ -302,7 +305,24 @@ public class PinotSegmentRestletResource {
     }
 
     if (segmentMetadata != null) {
-      return segmentMetadata;
+      Map<String, Object> result = new HashMap<>(segmentMetadata);
+      try {
+        JsonNode segmentsMetadataJson = getSegmentMetadataFromServer(tableName, segmentName, columns);
+        if (segmentsMetadataJson.has("indexes")) {
+          result.put("indexes", segmentsMetadataJson.get("indexes"));
+        }
+        if (segmentsMetadataJson.has("columns")) {
+          result.put("columns", segmentsMetadataJson.get("columns"));
+        }
+
+      } catch (InvalidConfigException e) {
+        throw new ControllerApplicationException(LOGGER, e.getMessage(), Status.BAD_REQUEST);
+      } catch (IOException ioe) {
+        throw new ControllerApplicationException(LOGGER, "Error parsing Pinot server response: " + ioe.getMessage(),
+            Status.INTERNAL_SERVER_ERROR, ioe);
+      }
+
+      return result;
     } else {
       throw new ControllerApplicationException(LOGGER,
           "Failed to find segment: " + segmentName + " in table: " + tableName, Status.NOT_FOUND);
@@ -336,7 +356,7 @@ public class PinotSegmentRestletResource {
         ResourceUtils.getExistingTableNamesWithType(_pinotHelixResourceManager, tableName, tableType, LOGGER);
     List<List<Map<String, Object>>> resultList = new ArrayList<>(tableNamesWithType.size());
     for (String tableNameWithType : tableNamesWithType) {
-      Map<String, String> segmentMetadata = getSegmentMetadata(tableNameWithType, segmentName);
+      Map<String, Object> segmentMetadata = getSegmentMetadata(tableNameWithType, segmentName, Collections.emptyList());
       if (segmentMetadata != null) {
         // NOTE: DO NOT change the format for backward-compatibility
         Map<String, Object> resultForTable = new LinkedHashMap<>();
@@ -734,6 +754,14 @@ public class PinotSegmentRestletResource {
         new TableMetadataReader(_executor, _connectionManager, _pinotHelixResourceManager);
     return tableMetadataReader
         .getSegmentsMetadata(tableNameWithType, columns, _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
+  }
+
+  private JsonNode getSegmentMetadataFromServer(String tableNameWithType, String segmentName, List<String> columns)
+      throws InvalidConfigException, IOException {
+    TableMetadataReader tableMetadataReader =
+        new TableMetadataReader(_executor, _connectionManager, _pinotHelixResourceManager);
+    return tableMetadataReader.getSegmentMetadata(tableNameWithType, segmentName, columns,
+        _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
   }
 
   // TODO: Move this API into PinotTableRestletResource

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -314,7 +314,6 @@ public class PinotSegmentRestletResource {
         if (segmentsMetadataJson.has("columns")) {
           result.put("columns", segmentsMetadataJson.get("columns"));
         }
-
       } catch (InvalidConfigException e) {
         throw new ControllerApplicationException(LOGGER, e.getMessage(), Status.BAD_REQUEST);
       } catch (IOException ioe) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2505,6 +2505,21 @@ public class PinotHelixResourceManager {
   }
 
   /**
+   * Returns a set of server instances for a given table and segment
+   */
+  public Set<String> getServers(String tableNameWithType, String segmentName) {
+    IdealState idealState = _helixAdmin.getResourceIdealState(_helixClusterName, tableNameWithType);
+    if (idealState == null) {
+      throw new IllegalStateException("Ideal state does not exist for table: " + tableNameWithType);
+    }
+
+    return idealState.getPartitionSet().stream()
+        .filter(segmentName::equals)
+        .flatMap(s -> idealState.getInstanceStateMap(s).keySet().stream())
+        .collect(Collectors.toSet());
+  }
+
+  /**
    * Returns a set of CONSUMING segments for the given realtime table.
    */
   public Set<String> getConsumingSegments(String tableNameWithType) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
@@ -102,7 +102,7 @@ public class TableMetadataReader {
       JsonNode responseJson = JsonUtils.stringToJsonNode(segmentMetadata);
       String segmentNameJson = responseJson.get("segmentName").asText();
 
-      if(segmentNameJson.equals(segmentName)) {
+      if (segmentNameJson.equals(segmentName)) {
         return responseJson;
       }
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
@@ -21,10 +21,13 @@ package org.apache.pinot.controller.util;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.BiMap;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executor;
+import java.util.stream.Collectors;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.restlet.resources.TableMetadataInfo;
@@ -76,12 +79,19 @@ public class TableMetadataReader {
     return JsonUtils.objectToJsonNode(response);
   }
 
+  /**
+   * This method retrieves the full segment metadata for a given table and segment
+   * @return segment metadata
+   */
   public JsonNode getSegmentMetadata(String tableNameWithType, String segmentName, List<String> columns, int timeoutMs)
       throws InvalidConfigException, IOException {
-    final Map<String, List<String>> serverToSegments =
-        _pinotHelixResourceManager.getServerToSegmentsMap(tableNameWithType);
+    Set<String> servers = _pinotHelixResourceManager.getServers(tableNameWithType, segmentName);
+
+    Map<String, List<String>> serverToSegments = servers.stream()
+        .collect(Collectors.toMap(s -> s, s -> Collections.singletonList(segmentName)));
+
     BiMap<String, String> endpoints =
-        _pinotHelixResourceManager.getDataInstanceAdminEndpoints(serverToSegments.keySet());
+        _pinotHelixResourceManager.getDataInstanceAdminEndpoints(servers);
     ServerSegmentMetadataReader serverSegmentMetadataReader =
         new ServerSegmentMetadataReader(_executor, _connectionManager);
 

--- a/pinot-controller/src/main/resources/app/pages/SegmentDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/SegmentDetails.tsx
@@ -114,10 +114,16 @@ const SegmentDetails = ({ match }: RouteComponentProps<Props>) => {
     records: []
   });
 
+  const [indexes, setIndexes] = useState({
+      columns: [],
+      records: []
+  });
   const [value, setValue] = useState('');
   const fetchData = async () => {
     const result = await PinotMethodUtils.getSegmentDetails(tableName, segmentName);
+    console.log("result", result)
     setSegmentSummary(result.summary);
+    setIndexes(result.indexes);
     setReplica(result.replicaSet);
     setValue(JSON.stringify(result.JSON, null, 2));
     setFetching(false);
@@ -250,7 +256,19 @@ const SegmentDetails = ({ match }: RouteComponentProps<Props>) => {
             </SimpleAccordion>
           </div>
         </Grid>
+
       </Grid>
+
+              <Grid item xs={12}>
+                <CustomizedTables
+                  title="Indexes"
+                  data={indexes}
+                  isPagination={true}
+                  showSearchBox={true}
+                  inAccordionFormat={true}
+                />
+              </Grid>
+
       {confirmDialog && dialogDetails && <Confirm
         openDialog={confirmDialog}
         dialogTitle={dialogDetails.title}

--- a/pinot-controller/src/main/resources/app/requests/index.ts
+++ b/pinot-controller/src/main/resources/app/requests/index.ts
@@ -55,7 +55,7 @@ export const putSchema = (name: string, params: string): Promise<AxiosResponse<O
   baseApi.put(`/schemas/${name}`, params, { headers });
 
 export const getSegmentMetadata = (tableName: string, segmentName: string): Promise<AxiosResponse<IdealState>> =>
-  baseApi.get(`/segments/${tableName}/${segmentName}/metadata`);
+  baseApi.get(`/segments/${tableName}/${segmentName}/metadata?columns=*`);
 
 export const getTableSize = (name: string): Promise<AxiosResponse<TableSize>> =>
   baseApi.get(`/tables/${name}/size`);

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -571,6 +571,10 @@ const getSegmentDetails = (tableName, segmentName) => {
       }
     }
 
+    const segmentMetaDataJson = { ...segmentMetaData }
+    delete segmentMetaDataJson.indexes
+    delete segmentMetaDataJson.columns
+
     return {
       replicaSet: {
         columns: ['Server Name', 'Status'],
@@ -597,7 +601,7 @@ const getSegmentDetails = (tableName, segmentName) => {
           'MMMM Do YYYY, h:mm:ss'
         ),
       },
-      JSON: segmentMetaData
+      JSON: segmentMetaDataJson
     };
   });
 };

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -576,6 +576,20 @@ const getSegmentDetails = (tableName, segmentName) => {
         columns: ['Server Name', 'Status'],
         records: [...result],
       },
+      indexes: {
+        columns: ['Field Name', 'Bloom Filter', 'Dictionary', 'Forward Index', 'Sorted', 'Inverted Index', 'JSON Index', 'Null Value Vector Reader', 'Range Index'],
+        records: Object.keys(segmentMetaData.indexes).map(fieldName => [
+          fieldName,
+          segmentMetaData.indexes[fieldName]["bloom-filter"] === "YES",
+          segmentMetaData.indexes[fieldName]["dictionary"] === "YES",
+          segmentMetaData.indexes[fieldName]["forward-index"] === "YES",
+          ((segmentMetaData.columns || []).filter(row => row.columnName === fieldName)[0] || {sorted: false}).sorted,
+          segmentMetaData.indexes[fieldName]["inverted-index"] === "YES",
+          segmentMetaData.indexes[fieldName]["json-index"] === "YES",
+          segmentMetaData.indexes[fieldName]["null-value-vector-reader"] === "YES",
+          segmentMetaData.indexes[fieldName]["range-index"] === "YES",
+        ])
+      },
       summary: {
         segmentName,
         totalDocs: segmentMetaData['segment.total.docs'],


### PR DESCRIPTION
When Karin and I were demoing Pinot at a conference last week, we were talking about Pinot's indexes, but then couldn't easily show the attendees which indexes had been defined on a column. 

This PR adds those indexes to the segment page in the Pinot UI. It consists of the following changes:

* `segments/{tableName}/{segmentName}/metadata` on the controller takes a `columns` query parameter
* Added an extra method to `PinotHelixResourceManager` that gets back the servers for a given table + segment
* Added an extra method to `TableMetadataReader` that returns the metadata for a single segment 
* `segments/{tableName}/{segmentName}/metadata` on the controller extracts `indexes` and `columns` from the metadata retrieved via `TableMetadataReader` and returns those fields as part of its response
* Updates to the segments front end code to render the indexes in a table

Screenshot included below:

![image](https://user-images.githubusercontent.com/13220/169502913-891ddde5-f48e-4e40-a009-451b560526e2.png)
