### PR TITLE
Streamed segment download & untar with rate limiter to control disk usage

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -64,6 +64,8 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   RELOAD_FAILURES("segments", false),
   REFRESH_FAILURES("segments", false),
   UNTAR_FAILURES("segments", false),
+  SEGMENT_STREAMED_DOWNLOAD_UNTAR_FAILURES("segments", false),
+  SEGMENT_DIR_MOVEMENT_FAILURES("segments", false),
   SEGMENT_DOWNLOAD_FAILURES("segments", false),
   NUM_RESIZES("numResizes", false),
   NO_TABLE_ACCESS("tables", true),

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -1011,17 +1011,17 @@ public class FileUploadDownloadClient implements AutoCloseable {
    * @param dest File destination
    * @param authProvider auth token
    * @param httpHeaders http headers
-   * @param rateLimit limit the rate to write download-untar stream to disk, in bytes
+   * @param maxDownloadRateInByte limit the rate to write download-untar stream to disk, in bytes
    *                  -1 for no disk write limit, 0 for limit the writing to min(untar, download) rate
    * @return Response status code
    * @throws IOException
    * @throws HttpErrorStatusException
    */
   public File downloadUntarFileStreamed(URI uri, File dest, AuthProvider authProvider, List<Header> httpHeaders,
-      long rateLimit)
+      long maxDownloadRateInByte)
       throws IOException, HttpErrorStatusException {
     return _httpClient.downloadUntarFileStreamed(uri, HttpClient.DEFAULT_SOCKET_TIMEOUT_MS, dest, authProvider,
-        httpHeaders, rateLimit);
+        httpHeaders, maxDownloadRateInByte);
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -1005,13 +1005,14 @@ public class FileUploadDownloadClient implements AutoCloseable {
   }
 
   /**
-   * Download and untar a file.
+   * Download and untar a file in a streamed way with rate limit
    *
    * @param uri URI
    * @param dest File destination
    * @param authProvider auth token
    * @param httpHeaders http headers
-   * @param rateLimit
+   * @param rateLimit limit the rate to write download-untar stream to disk, in bytes
+   *                  -1 for no disk write limit, 0 for limit the writing to min(untar, download) rate
    * @return Response status code
    * @throws IOException
    * @throws HttpErrorStatusException

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -1005,6 +1005,25 @@ public class FileUploadDownloadClient implements AutoCloseable {
   }
 
   /**
+   * Download and untar a file.
+   *
+   * @param uri URI
+   * @param dest File destination
+   * @param authProvider auth token
+   * @param httpHeaders http headers
+   * @param rateLimit
+   * @return Response status code
+   * @throws IOException
+   * @throws HttpErrorStatusException
+   */
+  public File downloadUntarFileStreamed(URI uri, File dest, AuthProvider authProvider, List<Header> httpHeaders,
+      long rateLimit)
+      throws IOException, HttpErrorStatusException {
+    return _httpClient.downloadUntarFileStreamed(uri, HttpClient.DEFAULT_SOCKET_TIMEOUT_MS, dest, authProvider,
+        httpHeaders, rateLimit);
+  }
+
+  /**
    * Generate a param list with a table name attribute.
    *
    * @param tableName table name

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -1011,17 +1011,17 @@ public class FileUploadDownloadClient implements AutoCloseable {
    * @param dest File destination
    * @param authProvider auth token
    * @param httpHeaders http headers
-   * @param maxDownloadRateInByte limit the rate to write download-untar stream to disk, in bytes
+   * @param maxStreamRateInByte limit the rate to write download-untar stream to disk, in bytes
    *                  -1 for no disk write limit, 0 for limit the writing to min(untar, download) rate
    * @return Response status code
    * @throws IOException
    * @throws HttpErrorStatusException
    */
   public File downloadUntarFileStreamed(URI uri, File dest, AuthProvider authProvider, List<Header> httpHeaders,
-      long maxDownloadRateInByte)
+      long maxStreamRateInByte)
       throws IOException, HttpErrorStatusException {
     return _httpClient.downloadUntarFileStreamed(uri, HttpClient.DEFAULT_SOCKET_TIMEOUT_MS, dest, authProvider,
-        httpHeaders, maxDownloadRateInByte);
+        httpHeaders, maxStreamRateInByte);
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/BaseSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/BaseSegmentFetcher.java
@@ -102,6 +102,11 @@ public abstract class BaseSegmentFetcher implements SegmentFetcher {
     });
   }
 
+  public File fetchUntarSegmentToLocalStreamed(URI uri, File dest, long rateLimit)
+      throws Exception {
+    throw new UnsupportedOperationException();
+  }
+
   /**
    * Fetches a segment from URI location to local without retry. Sub-class should override this or
    * {@link #fetchSegmentToLocal(URI, File)}.

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.net.URI;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.http.Header;
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpStatus;
@@ -88,6 +89,54 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
         return false;
       }
     });
+  }
+
+  @Override
+  public File fetchUntarSegmentToLocalStreamed(URI downloadURI, File dest, long rateLimit)
+      throws Exception {
+    // Create a RoundRobinURIProvider to round robin IP addresses when retry uploading. Otherwise may always try to
+    // download from a same broken host as: 1) DNS may not RR the IP addresses 2) OS cache the DNS resolution result.
+    RoundRobinURIProvider uriProvider = new RoundRobinURIProvider(downloadURI);
+    int retryCount = Math.max(_retryCount, uriProvider.numAddresses());
+    AtomicReference<File> ret = new AtomicReference<>(); // return the untared segment directory
+    _logger.info("Retry downloading for {} times. retryCount from pinot server config: {}, number of IP addresses for "
+        + "download URI: {}", retryCount, _retryCount, uriProvider.numAddresses());
+    RetryPolicies.exponentialBackoffRetryPolicy(retryCount, _retryWaitMs, _retryDelayScaleFactor).attempt(() -> {
+      URI uri = uriProvider.next();
+      try {
+        String hostName = downloadURI.getHost();
+        int port = downloadURI.getPort();
+        // If the original download address is specified as host name, need add a "HOST" HTTP header to the HTTP
+        // request. Otherwise, if the download address is a LB address, when the LB be configured as "disallow direct
+        // access by IP address", downloading will fail.
+        List<Header> httpHeaders = new LinkedList<>();
+        if (!InetAddresses.isInetAddress(hostName)) {
+          httpHeaders.add(new BasicHeader(HttpHeaders.HOST, hostName + ":" + port));
+        }
+        ret.set(_httpClient.downloadUntarFileStreamed(uri, dest, _authProvider, httpHeaders, rateLimit));
+
+        return true;
+      } catch (HttpErrorStatusException e) {
+        int statusCode = e.getStatusCode();
+        if (statusCode == HttpStatus.SC_NOT_FOUND || statusCode >= 500) {
+          // Temporary exception
+          // 404 is treated as a temporary exception, as the downloadURI may be backed by multiple hosts,
+          // if singe host is down, can retry with another host.
+          _logger.warn("Got temporary error status code: {} while downloading segment from: {} to: {}", statusCode, uri,
+              dest, e);
+          return false;
+        } else {
+          // Permanent exception
+          _logger.error("Got permanent error status code: {} while downloading segment from: {} to: {}, won't retry",
+              statusCode, uri, dest, e);
+          throw e;
+        }
+      } catch (Exception e) {
+        _logger.warn("Caught exception while downloading segment from: {} to: {}", uri, dest, e);
+        return false;
+      }
+    });
+    return ret.get();
   }
 
   @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
@@ -93,7 +93,7 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
   }
 
   @Override
-  public File fetchUntarSegmentToLocalStreamed(URI downloadURI, File dest, long maxDownloadRateInByte)
+  public File fetchUntarSegmentToLocalStreamed(URI downloadURI, File dest, long maxStreamRateInByte)
       throws Exception {
     // Create a RoundRobinURIProvider to round robin IP addresses when retry uploading. Otherwise may always try to
     // download from a same broken host as: 1) DNS may not RR the IP addresses 2) OS cache the DNS resolution result.
@@ -114,7 +114,7 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
         if (!InetAddresses.isInetAddress(hostName)) {
           httpHeaders.add(new BasicHeader(HttpHeaders.HOST, hostName + ":" + port));
         }
-        ret.set(_httpClient.downloadUntarFileStreamed(uri, dest, _authProvider, httpHeaders, maxDownloadRateInByte));
+        ret.set(_httpClient.downloadUntarFileStreamed(uri, dest, _authProvider, httpHeaders, maxStreamRateInByte));
 
         return true;
       } catch (HttpErrorStatusException e) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
@@ -93,7 +93,7 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
   }
 
   @Override
-  public File fetchUntarSegmentToLocalStreamed(URI downloadURI, File dest, long rateLimit)
+  public File fetchUntarSegmentToLocalStreamed(URI downloadURI, File dest, long maxDownloadRateInByte)
       throws Exception {
     // Create a RoundRobinURIProvider to round robin IP addresses when retry uploading. Otherwise may always try to
     // download from a same broken host as: 1) DNS may not RR the IP addresses 2) OS cache the DNS resolution result.
@@ -114,7 +114,7 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
         if (!InetAddresses.isInetAddress(hostName)) {
           httpHeaders.add(new BasicHeader(HttpHeaders.HOST, hostName + ":" + port));
         }
-        ret.set(_httpClient.downloadUntarFileStreamed(uri, dest, _authProvider, httpHeaders, rateLimit));
+        ret.set(_httpClient.downloadUntarFileStreamed(uri, dest, _authProvider, httpHeaders, maxDownloadRateInByte));
 
         return true;
       } catch (HttpErrorStatusException e) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
@@ -20,6 +20,7 @@ package org.apache.pinot.common.utils.fetcher;
 
 import com.google.common.net.InetAddresses;
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.util.LinkedList;
 import java.util.List;
@@ -131,6 +132,10 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
               statusCode, uri, dest, e);
           throw e;
         }
+      } catch (IOException e) {
+        _logger.warn("Caught IOException while stream download-untarring segment from: {} to: {}, retrying",
+            uri, dest, e);
+        return false;
       } catch (Exception e) {
         _logger.warn("Caught exception while downloading segment from: {} to: {}", uri, dest, e);
         return false;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcher.java
@@ -38,6 +38,12 @@ public interface SegmentFetcher {
       throws Exception;
 
   /**
+   * Fetches a segment from URI location to local.
+   */
+  File fetchUntarSegmentToLocalStreamed(URI uri, File dest, long rateLimit)
+      throws Exception;
+
+  /**
    * Fetches a segment to local from any uri in the given list.
    */
   void fetchSegmentToLocal(List<URI> uri, File dest)

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcher.java
@@ -38,7 +38,7 @@ public interface SegmentFetcher {
       throws Exception;
 
   /**
-   * Fetches a segment from URI location to local.
+   * Fetches a segment from URI location and untar to local in a streamed manner
    */
   File fetchUntarSegmentToLocalStreamed(URI uri, File dest, long rateLimit)
       throws Exception;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
@@ -153,12 +153,21 @@ public class SegmentFetcherFactory {
     getSegmentFetcher(uri.getScheme()).fetchSegmentToLocal(uri, dest);
   }
 
-  public static File fetchUntarToLocalStreamed(String uri, File tempRootDir, long rateLimit)
+  /**
+   * Fetches a segment from URI location to local and untar it in a streamed manner.
+   * @param uri URI
+   * @param tempRootDir Tmp dir to download
+   * @param rateLimit limit the rate to write download-untar stream to disk, in bytes
+   *                  -1 for no disk write limit, 0 for limit the writing to min(untar, download) rate
+   * @return the untared directory
+   * @throws Exception
+   */
+  public static File fetchAndStreamUntarToLocal(String uri, File tempRootDir, long rateLimit)
       throws Exception {
-    return getInstance().fetchUntarSegmentToLocalStreamedInternal(new URI(uri), tempRootDir, rateLimit);
+    return getInstance().fetchAndStreamUntarToLocalInternal(new URI(uri), tempRootDir, rateLimit);
   }
 
-  private File fetchUntarSegmentToLocalStreamedInternal(URI uri, File tempRootDir, long rateLimit)
+  private File fetchAndStreamUntarToLocalInternal(URI uri, File tempRootDir, long rateLimit)
       throws Exception {
     return getSegmentFetcher(uri.getScheme()).fetchUntarSegmentToLocalStreamed(uri, tempRootDir, rateLimit);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
@@ -157,19 +157,19 @@ public class SegmentFetcherFactory {
    * Fetches a segment from URI location to local and untar it in a streamed manner.
    * @param uri URI
    * @param tempRootDir Tmp dir to download
-   * @param maxDownloadRateInByte limit the rate to write download-untar stream to disk, in bytes
+   * @param maxStreamRateInByte limit the rate to write download-untar stream to disk, in bytes
    *                  -1 for no disk write limit, 0 for limit the writing to min(untar, download) rate
    * @return the untared directory
    * @throws Exception
    */
-  public static File fetchAndStreamUntarToLocal(String uri, File tempRootDir, long maxDownloadRateInByte)
+  public static File fetchAndStreamUntarToLocal(String uri, File tempRootDir, long maxStreamRateInByte)
       throws Exception {
-    return getInstance().fetchAndStreamUntarToLocalInternal(new URI(uri), tempRootDir, maxDownloadRateInByte);
+    return getInstance().fetchAndStreamUntarToLocalInternal(new URI(uri), tempRootDir, maxStreamRateInByte);
   }
 
-  private File fetchAndStreamUntarToLocalInternal(URI uri, File tempRootDir, long maxDownloadRateInByte)
+  private File fetchAndStreamUntarToLocalInternal(URI uri, File tempRootDir, long maxStreamRateInByte)
       throws Exception {
-    return getSegmentFetcher(uri.getScheme()).fetchUntarSegmentToLocalStreamed(uri, tempRootDir, maxDownloadRateInByte);
+    return getSegmentFetcher(uri.getScheme()).fetchUntarSegmentToLocalStreamed(uri, tempRootDir, maxStreamRateInByte);
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
@@ -157,19 +157,19 @@ public class SegmentFetcherFactory {
    * Fetches a segment from URI location to local and untar it in a streamed manner.
    * @param uri URI
    * @param tempRootDir Tmp dir to download
-   * @param rateLimit limit the rate to write download-untar stream to disk, in bytes
+   * @param maxDownloadRateInByte limit the rate to write download-untar stream to disk, in bytes
    *                  -1 for no disk write limit, 0 for limit the writing to min(untar, download) rate
    * @return the untared directory
    * @throws Exception
    */
-  public static File fetchAndStreamUntarToLocal(String uri, File tempRootDir, long rateLimit)
+  public static File fetchAndStreamUntarToLocal(String uri, File tempRootDir, long maxDownloadRateInByte)
       throws Exception {
-    return getInstance().fetchAndStreamUntarToLocalInternal(new URI(uri), tempRootDir, rateLimit);
+    return getInstance().fetchAndStreamUntarToLocalInternal(new URI(uri), tempRootDir, maxDownloadRateInByte);
   }
 
-  private File fetchAndStreamUntarToLocalInternal(URI uri, File tempRootDir, long rateLimit)
+  private File fetchAndStreamUntarToLocalInternal(URI uri, File tempRootDir, long maxDownloadRateInByte)
       throws Exception {
-    return getSegmentFetcher(uri.getScheme()).fetchUntarSegmentToLocalStreamed(uri, tempRootDir, rateLimit);
+    return getSegmentFetcher(uri.getScheme()).fetchUntarSegmentToLocalStreamed(uri, tempRootDir, maxDownloadRateInByte);
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
@@ -153,6 +153,16 @@ public class SegmentFetcherFactory {
     getSegmentFetcher(uri.getScheme()).fetchSegmentToLocal(uri, dest);
   }
 
+  public static File fetchUntarToLocalStreamed(String uri, File tempRootDir, long rateLimit)
+      throws Exception {
+    return getInstance().fetchUntarSegmentToLocalStreamedInternal(new URI(uri), tempRootDir, rateLimit);
+  }
+
+  private File fetchUntarSegmentToLocalStreamedInternal(URI uri, File tempRootDir, long rateLimit)
+      throws Exception {
+    return getSegmentFetcher(uri.getScheme()).fetchUntarSegmentToLocalStreamed(uri, tempRootDir, rateLimit);
+  }
+
   /**
    * Fetches a segment from a URI location to a local file and decrypts it if needed
    * @param uri remote segment location

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
@@ -395,6 +395,20 @@ public class HttpClient implements AutoCloseable {
     }
   }
 
+  /**
+   * Download and untar in a streamed manner a file using default settings, with an optional auth token
+   *
+   * @param uri URI
+   * @param socketTimeoutMs Socket timeout in milliseconds
+   * @param dest File destination
+   * @param authProvider auth provider
+   * @param httpHeaders http headers
+   * @param rateLimit limit the rate to write download-untar stream to disk, in bytes
+   *                  -1 for no disk write limit, 0 for limit the writing to min(untar, download) rate
+   * @return The untarred directory
+   * @throws IOException
+   * @throws HttpErrorStatusException
+   */
   public File downloadUntarFileStreamed(URI uri, int socketTimeoutMs, File dest, AuthProvider authProvider,
       List<Header> httpHeaders, long rateLimit)
       throws IOException, HttpErrorStatusException {
@@ -408,10 +422,10 @@ public class HttpClient implements AutoCloseable {
       }
 
       try (InputStream inputStream = response.getEntity().getContent()) {
-        ret = TarGzCompressionUtils.untarRateLimit(inputStream, dest, rateLimit).get(0);
+        ret = TarGzCompressionUtils.untarWithRateLimiter(inputStream, dest, rateLimit).get(0);
       }
 
-      LOGGER.info("Downloaded from: {} to: {}; Response status code: {}", uri, dest,
+      LOGGER.info("Downloaded from: {} to: {} with rate limiter; Response status code: {}", uri, dest,
               statusCode);
 
       return ret;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
@@ -403,14 +403,14 @@ public class HttpClient implements AutoCloseable {
    * @param dest File destination
    * @param authProvider auth provider
    * @param httpHeaders http headers
-   * @param maxDownloadRateInByte limit the rate to write download-untar stream to disk, in bytes
+   * @param maxStreamRateInByte limit the rate to write download-untar stream to disk, in bytes
    *                  -1 for no disk write limit, 0 for limit the writing to min(untar, download) rate
    * @return The untarred directory
    * @throws IOException
    * @throws HttpErrorStatusException
    */
   public File downloadUntarFileStreamed(URI uri, int socketTimeoutMs, File dest, AuthProvider authProvider,
-      List<Header> httpHeaders, long maxDownloadRateInByte)
+      List<Header> httpHeaders, long maxStreamRateInByte)
       throws IOException, HttpErrorStatusException {
     HttpUriRequest request = getDownloadFileRequest(uri, socketTimeoutMs, authProvider, httpHeaders);
     File ret;
@@ -422,7 +422,7 @@ public class HttpClient implements AutoCloseable {
       }
 
       try (InputStream inputStream = response.getEntity().getContent()) {
-        ret = TarGzCompressionUtils.untarWithRateLimiter(inputStream, dest, maxDownloadRateInByte).get(0);
+        ret = TarGzCompressionUtils.untarWithRateLimiter(inputStream, dest, maxStreamRateInByte).get(0);
       }
 
       LOGGER.info("Downloaded from: {} to: {} with rate limiter; Response status code: {}", uri, dest,

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
@@ -403,14 +403,14 @@ public class HttpClient implements AutoCloseable {
    * @param dest File destination
    * @param authProvider auth provider
    * @param httpHeaders http headers
-   * @param rateLimit limit the rate to write download-untar stream to disk, in bytes
+   * @param maxDownloadRateInByte limit the rate to write download-untar stream to disk, in bytes
    *                  -1 for no disk write limit, 0 for limit the writing to min(untar, download) rate
    * @return The untarred directory
    * @throws IOException
    * @throws HttpErrorStatusException
    */
   public File downloadUntarFileStreamed(URI uri, int socketTimeoutMs, File dest, AuthProvider authProvider,
-      List<Header> httpHeaders, long rateLimit)
+      List<Header> httpHeaders, long maxDownloadRateInByte)
       throws IOException, HttpErrorStatusException {
     HttpUriRequest request = getDownloadFileRequest(uri, socketTimeoutMs, authProvider, httpHeaders);
     File ret;
@@ -422,7 +422,7 @@ public class HttpClient implements AutoCloseable {
       }
 
       try (InputStream inputStream = response.getEntity().getContent()) {
-        ret = TarGzCompressionUtils.untarWithRateLimiter(inputStream, dest, rateLimit).get(0);
+        ret = TarGzCompressionUtils.untarWithRateLimiter(inputStream, dest, maxDownloadRateInByte).get(0);
       }
 
       LOGGER.info("Downloaded from: {} to: {} with rate limiter; Response status code: {}", uri, dest,

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactoryTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactoryTest.java
@@ -115,6 +115,14 @@ public class SegmentFetcherFactoryTest {
     }
 
     @Override
+    public File fetchUntarSegmentToLocalStreamed(URI uri, File dest, long rateLimit)
+        throws Exception {
+      assertEquals(uri, new URI(TEST_URI));
+      _fetchFileToLocalCalled++;
+      return new File("fakeSegmentIndexFile");
+    }
+
+    @Override
     public void fetchSegmentToLocal(List<URI> uri, File dest)
         throws Exception {
       throw new UnsupportedOperationException();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -502,8 +502,8 @@ public abstract class BaseTableDataManager implements TableDataManager {
       LOGGER.info("Download and untarred segment: {} for table: {} from: {}", segmentName, _tableNameWithType, uri);
       return ret;
     } catch (AttemptsExceededException e) {
-      LOGGER.error("Attempts exceeded when downloading segment: {} for table: {} from: {} to: {}", segmentName,
-          _tableNameWithType, uri, tempRootDir);
+      LOGGER.error("Attempts exceeded when stream download-untarring segment: {} for table: {} from: {} to: {}",
+          segmentName, _tableNameWithType, uri, tempRootDir);
       _serverMetrics.addMeteredTableValue(_tableNameWithType, ServerMeter.SEGMENT_STREAMED_DOWNLOAD_UNTAR_FAILURES, 1L);
       throw e;
     } finally {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -94,7 +94,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
   protected Logger _logger;
   protected HelixManager _helixManager;
   protected AuthProvider _authProvider;
-  protected long _StreamSegmentDownloadUntarRateLimit;
+  protected long _streamSegmentDownloadUntarRateLimit;
   protected boolean _isStreamSegmentDownloadUntar;
 
   // Fixed size LRU cache with TableName - SegmentName pair as key, and segment related
@@ -134,12 +134,12 @@ public abstract class BaseTableDataManager implements TableDataManager {
           _resourceTmpDir);
     }
     _errorCache = errorCache;
-    _StreamSegmentDownloadUntarRateLimit = tableDataManagerParams.getStreamSegmentDownloadUntarRateLimit();
+    _streamSegmentDownloadUntarRateLimit = tableDataManagerParams.getStreamSegmentDownloadUntarRateLimit();
     _isStreamSegmentDownloadUntar = tableDataManagerParams.isStreamSegmentDownloadUntar();
     if (_isStreamSegmentDownloadUntar) {
       LOGGER.info("Using streamed download-untar for segment download!");
       LOGGER.info("The rate limit interval for streamed download-untar is {} ms",
-          _StreamSegmentDownloadUntarRateLimit);
+          _streamSegmentDownloadUntarRateLimit);
     }
     int maxParallelSegmentDownloads = tableDataManagerParams.getMaxParallelSegmentDownloads();
     if (maxParallelSegmentDownloads > 0) {
@@ -424,7 +424,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
     if (_isStreamSegmentDownloadUntar && zkMetadata.getCrypterName() == null) {
       try {
         File untaredSegDir = downloadAndStreamUntarRateLimit(segmentName, zkMetadata, tempRootDir,
-            _StreamSegmentDownloadUntarRateLimit);
+            _streamSegmentDownloadUntarRateLimit);
         return moveSegment(segmentName, untaredSegDir);
       } finally {
         FileUtils.deleteQuietly(tempRootDir);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -94,8 +94,8 @@ public abstract class BaseTableDataManager implements TableDataManager {
   protected Logger _logger;
   protected HelixManager _helixManager;
   protected AuthProvider _authProvider;
-  protected long _segmentDownloadUntarRateLimit;
-  protected boolean _isSegmentDownloadUntarStreamed;
+  protected long _StreamSegmentDownloadUntarRateLimit;
+  protected boolean _isStreamSegmentDownloadUntar;
 
   // Fixed size LRU cache with TableName - SegmentName pair as key, and segment related
   // errors as the value.
@@ -134,12 +134,12 @@ public abstract class BaseTableDataManager implements TableDataManager {
           _resourceTmpDir);
     }
     _errorCache = errorCache;
-    _segmentDownloadUntarRateLimit = tableDataManagerParams.getSegmentDownloadUntarRateLimit();
-    _isSegmentDownloadUntarStreamed = tableDataManagerParams.getSegmentDownloadUntarStreamed();
-    if (_isSegmentDownloadUntarStreamed) {
+    _StreamSegmentDownloadUntarRateLimit = tableDataManagerParams.getStreamSegmentDownloadUntarRateLimit();
+    _isStreamSegmentDownloadUntar = tableDataManagerParams.isStreamSegmentDownloadUntar();
+    if (_isStreamSegmentDownloadUntar) {
       LOGGER.info("Using streamed download-untar for segment download!");
       LOGGER.info("The rate limit interval for streamed download-untar is {} ms",
-          _segmentDownloadUntarRateLimit);
+          _StreamSegmentDownloadUntarRateLimit);
     }
     int maxParallelSegmentDownloads = tableDataManagerParams.getMaxParallelSegmentDownloads();
     if (maxParallelSegmentDownloads > 0) {
@@ -421,10 +421,10 @@ public abstract class BaseTableDataManager implements TableDataManager {
       throws Exception {
     File tempRootDir = getTmpSegmentDataDir("tmp-" + segmentName + "-" + UUID.randomUUID());
     FileUtils.forceMkdir(tempRootDir);
-    if (_isSegmentDownloadUntarStreamed && zkMetadata.getCrypterName() == null) {
+    if (_isStreamSegmentDownloadUntar && zkMetadata.getCrypterName() == null) {
       try {
         File untaredSegDir = downloadAndStreamUntarRateLimit(segmentName, zkMetadata, tempRootDir,
-            _segmentDownloadUntarRateLimit);
+            _StreamSegmentDownloadUntarRateLimit);
         return moveSegment(segmentName, untaredSegDir);
       } finally {
         FileUtils.deleteQuietly(tempRootDir);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -485,7 +485,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
   }
 
   private File downloadAndStreamUntarWithRateLimit(String segmentName, SegmentZKMetadata zkMetadata, File tempRootDir,
-      long maxDownloadRateInByte)
+      long maxStreamRateInByte)
       throws Exception {
     if (_segmentDownloadSemaphore != null) {
       long startTime = System.currentTimeMillis();
@@ -495,11 +495,11 @@ public abstract class BaseTableDataManager implements TableDataManager {
       LOGGER.info("Acquired segment download semaphore for: {} (lock-time={}ms, queue-length={}).", segmentName,
           System.currentTimeMillis() - startTime, _segmentDownloadSemaphore.getQueueLength());
     }
-    LOGGER.info("Trying to download segment {} using streamed download-untar with maxDownloadRateInByte {}",
-        segmentName, maxDownloadRateInByte);
+    LOGGER.info("Trying to download segment {} using streamed download-untar with maxStreamRateInByte {}",
+        segmentName, maxStreamRateInByte);
     String uri = zkMetadata.getDownloadUrl();
     try {
-      File ret = SegmentFetcherFactory.fetchAndStreamUntarToLocal(uri, tempRootDir, maxDownloadRateInByte);
+      File ret = SegmentFetcherFactory.fetchAndStreamUntarToLocal(uri, tempRootDir, maxStreamRateInByte);
       LOGGER.info("Download and untarred segment: {} for table: {} from: {}", segmentName, _tableNameWithType, uri);
       return ret;
     } catch (AttemptsExceededException e) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -423,7 +423,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
     FileUtils.forceMkdir(tempRootDir);
     if (_isSegmentDownloadUntarStreamed && zkMetadata.getCrypterName() == null) {
       try {
-        File untaredSegDir = streamedDownloadUntarRateLimit(segmentName, zkMetadata, tempRootDir,
+        File untaredSegDir = downloadAndStreamUntarRateLimit(segmentName, zkMetadata, tempRootDir,
             _segmentDownloadUntarRateLimit);
         return moveSegment(segmentName, untaredSegDir);
       } finally {
@@ -483,7 +483,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
     }
   }
 
-  private File streamedDownloadUntarRateLimit(String segmentName, SegmentZKMetadata zkMetadata, File tempRootDir,
+  private File downloadAndStreamUntarRateLimit(String segmentName, SegmentZKMetadata zkMetadata, File tempRootDir,
       long rateLimit)
       throws Exception {
     if (_segmentDownloadSemaphore != null) {
@@ -498,8 +498,8 @@ public abstract class BaseTableDataManager implements TableDataManager {
         rateLimit);
     String uri = zkMetadata.getDownloadUrl();
     try {
-      File ret = SegmentFetcherFactory.fetchUntarToLocalStreamed(uri, tempRootDir, rateLimit);
-      LOGGER.info("Downloaded tarred segment: {} for table: {} from: {}", segmentName, _tableNameWithType, uri);
+      File ret = SegmentFetcherFactory.fetchAndStreamUntarToLocal(uri, tempRootDir, rateLimit);
+      LOGGER.info("Download and untarred segment: {} for table: {} from: {}", segmentName, _tableNameWithType, uri);
       return ret;
     } catch (AttemptsExceededException e) {
       LOGGER.error("Attempts exceeded when downloading segment: {} for table: {} from: {} to: {}", segmentName,

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/TableDataManagerProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/TableDataManagerProvider.java
@@ -29,6 +29,7 @@ import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
 import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManagerConfig;
+import org.apache.pinot.segment.local.data.manager.TableDataManagerParams;
 import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.TableType;
 
@@ -38,7 +39,7 @@ import org.apache.pinot.spi.config.table.TableType;
  */
 public class TableDataManagerProvider {
   private static Semaphore _segmentBuildSemaphore;
-  private static int _maxParallelSegmentDownloads;
+  private static TableDataManagerParams _tableDataManagerParams;
 
   private TableDataManagerProvider() {
   }
@@ -48,7 +49,7 @@ public class TableDataManagerProvider {
     if (maxParallelBuilds > 0) {
       _segmentBuildSemaphore = new Semaphore(maxParallelBuilds, true);
     }
-    _maxParallelSegmentDownloads = instanceDataManagerConfig.getMaxParallelSegmentDownloads();
+    _tableDataManagerParams = new TableDataManagerParams(instanceDataManagerConfig);
   }
 
   public static TableDataManager getTableDataManager(TableDataManagerConfig tableDataManagerConfig, String instanceId,
@@ -70,7 +71,7 @@ public class TableDataManagerProvider {
         throw new IllegalStateException();
     }
     tableDataManager.init(tableDataManagerConfig, instanceId, propertyStore, serverMetrics, helixManager, errorCache,
-        _maxParallelSegmentDownloads);
+        _tableDataManagerParams);
     return tableDataManager;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerAcquireSegmentTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerAcquireSegmentTest.java
@@ -40,6 +40,7 @@ import org.apache.pinot.core.data.manager.offline.OfflineTableDataManager;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManagerConfig;
+import org.apache.pinot.segment.local.data.manager.TableDataManagerParams;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
@@ -122,7 +123,8 @@ public class BaseTableDataManagerAcquireSegmentTest {
       when(config.getAuthConfig()).thenReturn(new MapConfiguration(new HashMap<>()));
     }
     tableDataManager.init(config, "dummyInstance", mock(ZkHelixPropertyStore.class),
-        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class), null, 0);
+        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class), null,
+        new TableDataManagerParams(0, false, -1));
     tableDataManager.start();
     Field segsMapField = BaseTableDataManager.class.getDeclaredField("_segmentDataManagerMap");
     segsMapField.setAccessible(true);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -39,6 +39,7 @@ import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.core.data.manager.offline.OfflineTableDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManagerConfig;
+import org.apache.pinot.segment.local.data.manager.TableDataManagerParams;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
@@ -532,7 +533,8 @@ public class BaseTableDataManagerTest {
 
     OfflineTableDataManager tableDataManager = new OfflineTableDataManager();
     tableDataManager.init(config, "dummyInstance", mock(ZkHelixPropertyStore.class),
-        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class), null, 0);
+        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class), null,
+        new TableDataManagerParams(0, false, -1));
     tableDataManager.start();
     return tableDataManager;
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
@@ -32,6 +32,7 @@ import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.SchemaUtils;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManagerConfig;
+import org.apache.pinot.segment.local.data.manager.TableDataManagerParams;
 import org.apache.pinot.segment.local.segment.creator.SegmentTestUtils;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentCreationDriverFactory;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
@@ -118,7 +119,8 @@ public class DimensionTableDataManagerTest {
       when(config.getDataDir()).thenReturn(TEMP_DIR.getAbsolutePath());
     }
     tableDataManager.init(config, "dummyInstance", helixManager.getHelixPropertyStore(),
-        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), helixManager, null, 0);
+        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), helixManager, null,
+        new TableDataManagerParams(0, false, -1));
     tableDataManager.start();
     return tableDataManager;
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -723,6 +723,12 @@ public class LLRealtimeSegmentDataManagerTest {
     when(tableDataManagerConfig.getTableDataManagerType()).thenReturn("REALTIME");
     when(tableDataManagerConfig.getTableName()).thenReturn(tableConfig.getTableName());
     when(tableDataManagerConfig.getDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
+    InstanceDataManagerConfig instanceDataManagerConfig = mock(InstanceDataManagerConfig.class);
+    when(instanceDataManagerConfig.getMaxParallelSegmentBuilds()).thenReturn(4);
+    when(instanceDataManagerConfig.getSegmentDownloadUntarRateLimit()).thenReturn(-1L);
+    when(instanceDataManagerConfig.getMaxParallelSegmentDownloads()).thenReturn(-1);
+    when(instanceDataManagerConfig.isSegmentDownloadUntarStreamed()).thenReturn(false);
+    TableDataManagerProvider.init(instanceDataManagerConfig);
 
     TableDataManager tableDataManager =
         TableDataManagerProvider.getTableDataManager(tableDataManagerConfig, "testInstance", propertyStore,

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -725,9 +725,9 @@ public class LLRealtimeSegmentDataManagerTest {
     when(tableDataManagerConfig.getDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
     InstanceDataManagerConfig instanceDataManagerConfig = mock(InstanceDataManagerConfig.class);
     when(instanceDataManagerConfig.getMaxParallelSegmentBuilds()).thenReturn(4);
-    when(instanceDataManagerConfig.getSegmentDownloadUntarRateLimit()).thenReturn(-1L);
+    when(instanceDataManagerConfig.getStreamSegmentDownloadUntarRateLimit()).thenReturn(-1L);
     when(instanceDataManagerConfig.getMaxParallelSegmentDownloads()).thenReturn(-1);
-    when(instanceDataManagerConfig.isSegmentDownloadUntarStreamed()).thenReturn(false);
+    when(instanceDataManagerConfig.isStreamSegmentDownloadUntar()).thenReturn(false);
     TableDataManagerProvider.init(instanceDataManagerConfig);
 
     TableDataManager tableDataManager =

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorExceptionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorExceptionsTest.java
@@ -136,9 +136,9 @@ public class QueryExecutorExceptionsTest {
     when(tableDataManagerConfig.getDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
     InstanceDataManagerConfig instanceDataManagerConfig = mock(InstanceDataManagerConfig.class);
     when(instanceDataManagerConfig.getMaxParallelSegmentBuilds()).thenReturn(4);
-    when(instanceDataManagerConfig.getSegmentDownloadUntarRateLimit()).thenReturn(-1L);
+    when(instanceDataManagerConfig.getStreamSegmentDownloadUntarRateLimit()).thenReturn(-1L);
     when(instanceDataManagerConfig.getMaxParallelSegmentDownloads()).thenReturn(-1);
-    when(instanceDataManagerConfig.isSegmentDownloadUntarStreamed()).thenReturn(false);
+    when(instanceDataManagerConfig.isStreamSegmentDownloadUntar()).thenReturn(false);
     TableDataManagerProvider.init(instanceDataManagerConfig);
     @SuppressWarnings("unchecked")
     TableDataManager tableDataManager =

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorExceptionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorExceptionsTest.java
@@ -47,6 +47,7 @@ import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
+import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.IngestionSchemaValidator;
@@ -133,6 +134,12 @@ public class QueryExecutorExceptionsTest {
     when(tableDataManagerConfig.getTableDataManagerType()).thenReturn("OFFLINE");
     when(tableDataManagerConfig.getTableName()).thenReturn(TABLE_NAME);
     when(tableDataManagerConfig.getDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
+    InstanceDataManagerConfig instanceDataManagerConfig = mock(InstanceDataManagerConfig.class);
+    when(instanceDataManagerConfig.getMaxParallelSegmentBuilds()).thenReturn(4);
+    when(instanceDataManagerConfig.getSegmentDownloadUntarRateLimit()).thenReturn(-1L);
+    when(instanceDataManagerConfig.getMaxParallelSegmentDownloads()).thenReturn(-1);
+    when(instanceDataManagerConfig.isSegmentDownloadUntarStreamed()).thenReturn(false);
+    TableDataManagerProvider.init(instanceDataManagerConfig);
     @SuppressWarnings("unchecked")
     TableDataManager tableDataManager =
         TableDataManagerProvider.getTableDataManager(tableDataManagerConfig, "testInstance",

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorTest.java
@@ -43,6 +43,7 @@ import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
+import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.IngestionSchemaValidator;
@@ -127,6 +128,12 @@ public class QueryExecutorTest {
     when(tableDataManagerConfig.getTableDataManagerType()).thenReturn("OFFLINE");
     when(tableDataManagerConfig.getTableName()).thenReturn(TABLE_NAME);
     when(tableDataManagerConfig.getDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
+    InstanceDataManagerConfig instanceDataManagerConfig = mock(InstanceDataManagerConfig.class);
+    when(instanceDataManagerConfig.getMaxParallelSegmentBuilds()).thenReturn(4);
+    when(instanceDataManagerConfig.getSegmentDownloadUntarRateLimit()).thenReturn(-1L);
+    when(instanceDataManagerConfig.getMaxParallelSegmentDownloads()).thenReturn(-1);
+    when(instanceDataManagerConfig.isSegmentDownloadUntarStreamed()).thenReturn(false);
+    TableDataManagerProvider.init(instanceDataManagerConfig);
     @SuppressWarnings("unchecked")
     TableDataManager tableDataManager =
         TableDataManagerProvider.getTableDataManager(tableDataManagerConfig, "testInstance",

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorTest.java
@@ -130,9 +130,9 @@ public class QueryExecutorTest {
     when(tableDataManagerConfig.getDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
     InstanceDataManagerConfig instanceDataManagerConfig = mock(InstanceDataManagerConfig.class);
     when(instanceDataManagerConfig.getMaxParallelSegmentBuilds()).thenReturn(4);
-    when(instanceDataManagerConfig.getSegmentDownloadUntarRateLimit()).thenReturn(-1L);
+    when(instanceDataManagerConfig.getStreamSegmentDownloadUntarRateLimit()).thenReturn(-1L);
     when(instanceDataManagerConfig.getMaxParallelSegmentDownloads()).thenReturn(-1);
-    when(instanceDataManagerConfig.isSegmentDownloadUntarStreamed()).thenReturn(false);
+    when(instanceDataManagerConfig.isStreamSegmentDownloadUntar()).thenReturn(false);
     TableDataManagerProvider.init(instanceDataManagerConfig);
     @SuppressWarnings("unchecked")
     TableDataManager tableDataManager =

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
@@ -267,9 +267,9 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     when(tableDataManagerConfig.getDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
     InstanceDataManagerConfig instanceDataManagerConfig = mock(InstanceDataManagerConfig.class);
     when(instanceDataManagerConfig.getMaxParallelSegmentBuilds()).thenReturn(4);
-    when(instanceDataManagerConfig.getSegmentDownloadUntarRateLimit()).thenReturn(-1L);
+    when(instanceDataManagerConfig.getStreamSegmentDownloadUntarRateLimit()).thenReturn(-1L);
     when(instanceDataManagerConfig.getMaxParallelSegmentDownloads()).thenReturn(-1);
-    when(instanceDataManagerConfig.isSegmentDownloadUntarStreamed()).thenReturn(false);
+    when(instanceDataManagerConfig.isStreamSegmentDownloadUntar()).thenReturn(false);
     TableDataManagerProvider.init(instanceDataManagerConfig);
     @SuppressWarnings("unchecked")
     TableDataManager tableDataManager =

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
@@ -58,6 +58,7 @@ import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -264,6 +265,12 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     when(tableDataManagerConfig.getTableDataManagerType()).thenReturn("OFFLINE");
     when(tableDataManagerConfig.getTableName()).thenReturn(RAW_TABLE_NAME);
     when(tableDataManagerConfig.getDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
+    InstanceDataManagerConfig instanceDataManagerConfig = mock(InstanceDataManagerConfig.class);
+    when(instanceDataManagerConfig.getMaxParallelSegmentBuilds()).thenReturn(4);
+    when(instanceDataManagerConfig.getSegmentDownloadUntarRateLimit()).thenReturn(-1L);
+    when(instanceDataManagerConfig.getMaxParallelSegmentDownloads()).thenReturn(-1);
+    when(instanceDataManagerConfig.isSegmentDownloadUntarStreamed()).thenReturn(false);
+    TableDataManagerProvider.init(instanceDataManagerConfig);
     @SuppressWarnings("unchecked")
     TableDataManager tableDataManager =
         TableDataManagerProvider.getTableDataManager(tableDataManagerConfig, "testInstance",

--- a/pinot-core/src/test/java/org/apache/pinot/queries/SegmentWithNullValueVectorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/SegmentWithNullValueVectorTest.java
@@ -51,6 +51,7 @@ import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
@@ -71,6 +72,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.apache.pinot.segment.local.segment.index.creator.RawIndexCreatorTest.getRandomValue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 /**
@@ -141,6 +144,12 @@ public class SegmentWithNullValueVectorTest {
     Mockito.when(tableDataManagerConfig.getTableDataManagerType()).thenReturn("OFFLINE");
     Mockito.when(tableDataManagerConfig.getTableName()).thenReturn(TABLE_NAME);
     Mockito.when(tableDataManagerConfig.getDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
+    InstanceDataManagerConfig instanceDataManagerConfig = mock(InstanceDataManagerConfig.class);
+    when(instanceDataManagerConfig.getMaxParallelSegmentBuilds()).thenReturn(4);
+    when(instanceDataManagerConfig.getSegmentDownloadUntarRateLimit()).thenReturn(-1L);
+    when(instanceDataManagerConfig.getMaxParallelSegmentDownloads()).thenReturn(-1);
+    when(instanceDataManagerConfig.isSegmentDownloadUntarStreamed()).thenReturn(false);
+    TableDataManagerProvider.init(instanceDataManagerConfig);
     @SuppressWarnings("unchecked")
     TableDataManager tableDataManager =
         TableDataManagerProvider.getTableDataManager(tableDataManagerConfig, "testInstance",

--- a/pinot-core/src/test/java/org/apache/pinot/queries/SegmentWithNullValueVectorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/SegmentWithNullValueVectorTest.java
@@ -146,9 +146,9 @@ public class SegmentWithNullValueVectorTest {
     Mockito.when(tableDataManagerConfig.getDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
     InstanceDataManagerConfig instanceDataManagerConfig = mock(InstanceDataManagerConfig.class);
     when(instanceDataManagerConfig.getMaxParallelSegmentBuilds()).thenReturn(4);
-    when(instanceDataManagerConfig.getSegmentDownloadUntarRateLimit()).thenReturn(-1L);
+    when(instanceDataManagerConfig.getStreamSegmentDownloadUntarRateLimit()).thenReturn(-1L);
     when(instanceDataManagerConfig.getMaxParallelSegmentDownloads()).thenReturn(-1);
-    when(instanceDataManagerConfig.isSegmentDownloadUntarStreamed()).thenReturn(false);
+    when(instanceDataManagerConfig.isStreamSegmentDownloadUntar()).thenReturn(false);
     TableDataManagerProvider.init(instanceDataManagerConfig);
     @SuppressWarnings("unchecked")
     TableDataManager tableDataManager =

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -49,7 +49,7 @@ public interface TableDataManager {
    */
   void init(TableDataManagerConfig tableDataManagerConfig, String instanceId,
       ZkHelixPropertyStore<ZNRecord> propertyStore, ServerMetrics serverMetrics, HelixManager helixManager,
-      LoadingCache<Pair<String, String>, SegmentErrorInfo> errorCache, int maxParallelSegmentDownloads);
+      LoadingCache<Pair<String, String>, SegmentErrorInfo> errorCache, TableDataManagerParams tableDataManagerParams);
 
   /**
    * Starts the table data manager. Should be called only once after table data manager gets initialized but before

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManagerParams.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManagerParams.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.data.manager;
+
+import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
+
+
+public class TableDataManagerParams {
+  private boolean _isSegmentDownloadUntarStreamed;
+  private long _segmentDownloadUntarRateLimit;
+  private int _maxParallelSegmentDownloads;
+
+  public TableDataManagerParams(int maxParallelSegmentDownloads, boolean isSegmentDownloadUntarStreamed,
+      long segmentDownloadUntarRateLimit) {
+    _maxParallelSegmentDownloads = maxParallelSegmentDownloads;
+    _isSegmentDownloadUntarStreamed = isSegmentDownloadUntarStreamed;
+    _segmentDownloadUntarRateLimit = segmentDownloadUntarRateLimit;
+  }
+
+  public TableDataManagerParams(InstanceDataManagerConfig instanceDataManagerConfig) {
+    _maxParallelSegmentDownloads = instanceDataManagerConfig.getMaxParallelSegmentDownloads();
+    _isSegmentDownloadUntarStreamed = instanceDataManagerConfig.isSegmentDownloadUntarStreamed();
+    _segmentDownloadUntarRateLimit = instanceDataManagerConfig.getSegmentDownloadUntarRateLimit();
+  }
+
+  public boolean getSegmentDownloadUntarStreamed() {
+    return _isSegmentDownloadUntarStreamed;
+  }
+
+  public long getSegmentDownloadUntarRateLimit() {
+    return _segmentDownloadUntarRateLimit;
+  }
+
+  public void setSegmentDownloadUntarStreamed(boolean segmentDownloadUntarStreamed) {
+    _isSegmentDownloadUntarStreamed = segmentDownloadUntarStreamed;
+  }
+
+  public void setSegmentDownloadUntarRateLimit(long segmentDownloadUntarRateLimit) {
+    _segmentDownloadUntarRateLimit = segmentDownloadUntarRateLimit;
+  }
+
+  public int getMaxParallelSegmentDownloads() {
+    return _maxParallelSegmentDownloads;
+  }
+
+  public void setMaxParallelSegmentDownloads(int maxParallelSegmentDownloads) {
+    _maxParallelSegmentDownloads = maxParallelSegmentDownloads;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManagerParams.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManagerParams.java
@@ -23,20 +23,20 @@ import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 
 public class TableDataManagerParams {
   private boolean _isStreamSegmentDownloadUntar;
-  private long _StreamSegmentDownloadUntarRateLimit;
+  private long _streamSegmentDownloadUntarRateLimit;
   private int _maxParallelSegmentDownloads;
 
   public TableDataManagerParams(int maxParallelSegmentDownloads, boolean isStreamSegmentDownloadUntar,
       long streamSegmentDownloadUntarRateLimit) {
     _maxParallelSegmentDownloads = maxParallelSegmentDownloads;
     _isStreamSegmentDownloadUntar = isStreamSegmentDownloadUntar;
-    _StreamSegmentDownloadUntarRateLimit = streamSegmentDownloadUntarRateLimit;
+    _streamSegmentDownloadUntarRateLimit = streamSegmentDownloadUntarRateLimit;
   }
 
   public TableDataManagerParams(InstanceDataManagerConfig instanceDataManagerConfig) {
     _maxParallelSegmentDownloads = instanceDataManagerConfig.getMaxParallelSegmentDownloads();
     _isStreamSegmentDownloadUntar = instanceDataManagerConfig.isStreamSegmentDownloadUntar();
-    _StreamSegmentDownloadUntarRateLimit = instanceDataManagerConfig.getStreamSegmentDownloadUntarRateLimit();
+    _streamSegmentDownloadUntarRateLimit = instanceDataManagerConfig.getStreamSegmentDownloadUntarRateLimit();
   }
 
   public boolean isStreamSegmentDownloadUntar() {
@@ -44,7 +44,7 @@ public class TableDataManagerParams {
   }
 
   public long getStreamSegmentDownloadUntarRateLimit() {
-    return _StreamSegmentDownloadUntarRateLimit;
+    return _streamSegmentDownloadUntarRateLimit;
   }
 
   public void setStreamSegmentDownloadUntar(boolean streamSegmentDownloadUntar) {
@@ -52,7 +52,7 @@ public class TableDataManagerParams {
   }
 
   public void setStreamSegmentDownloadUntarRateLimit(long streamSegmentDownloadUntarRateLimit) {
-    _StreamSegmentDownloadUntarRateLimit = streamSegmentDownloadUntarRateLimit;
+    _streamSegmentDownloadUntarRateLimit = streamSegmentDownloadUntarRateLimit;
   }
 
   public int getMaxParallelSegmentDownloads() {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManagerParams.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManagerParams.java
@@ -22,37 +22,38 @@ import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 
 
 public class TableDataManagerParams {
-  private boolean _isStreamSegmentDownloadUntar;
-  private long _streamSegmentDownloadUntarRateLimit;
-  private int _maxParallelSegmentDownloads;
+  private boolean _isStreamSegmentDownloadUntar; // whether to turn on stream segment download-untar
+  private long _streamSegmentDownloadUntarRateLimitBytesPerSec; // the per segment rate limit for stream download-untar
+  private int _maxParallelSegmentDownloads; // max number of segment download in parallel per table
 
   public TableDataManagerParams(int maxParallelSegmentDownloads, boolean isStreamSegmentDownloadUntar,
-      long streamSegmentDownloadUntarRateLimit) {
+      long streamSegmentDownloadUntarRateLimitBytesPerSec) {
     _maxParallelSegmentDownloads = maxParallelSegmentDownloads;
     _isStreamSegmentDownloadUntar = isStreamSegmentDownloadUntar;
-    _streamSegmentDownloadUntarRateLimit = streamSegmentDownloadUntarRateLimit;
+    _streamSegmentDownloadUntarRateLimitBytesPerSec = streamSegmentDownloadUntarRateLimitBytesPerSec;
   }
 
   public TableDataManagerParams(InstanceDataManagerConfig instanceDataManagerConfig) {
     _maxParallelSegmentDownloads = instanceDataManagerConfig.getMaxParallelSegmentDownloads();
     _isStreamSegmentDownloadUntar = instanceDataManagerConfig.isStreamSegmentDownloadUntar();
-    _streamSegmentDownloadUntarRateLimit = instanceDataManagerConfig.getStreamSegmentDownloadUntarRateLimit();
+    _streamSegmentDownloadUntarRateLimitBytesPerSec =
+        instanceDataManagerConfig.getStreamSegmentDownloadUntarRateLimit();
   }
 
   public boolean isStreamSegmentDownloadUntar() {
     return _isStreamSegmentDownloadUntar;
   }
 
-  public long getStreamSegmentDownloadUntarRateLimit() {
-    return _streamSegmentDownloadUntarRateLimit;
+  public long getStreamSegmentDownloadUntarRateLimitBytesPerSec() {
+    return _streamSegmentDownloadUntarRateLimitBytesPerSec;
   }
 
   public void setStreamSegmentDownloadUntar(boolean streamSegmentDownloadUntar) {
     _isStreamSegmentDownloadUntar = streamSegmentDownloadUntar;
   }
 
-  public void setStreamSegmentDownloadUntarRateLimit(long streamSegmentDownloadUntarRateLimit) {
-    _streamSegmentDownloadUntarRateLimit = streamSegmentDownloadUntarRateLimit;
+  public void setStreamSegmentDownloadUntarRateLimitBytesPerSec(long streamSegmentDownloadUntarRateLimitBytesPerSec) {
+    _streamSegmentDownloadUntarRateLimitBytesPerSec = streamSegmentDownloadUntarRateLimitBytesPerSec;
   }
 
   public int getMaxParallelSegmentDownloads() {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManagerParams.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManagerParams.java
@@ -22,37 +22,37 @@ import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 
 
 public class TableDataManagerParams {
-  private boolean _isSegmentDownloadUntarStreamed;
-  private long _segmentDownloadUntarRateLimit;
+  private boolean _isStreamSegmentDownloadUntar;
+  private long _StreamSegmentDownloadUntarRateLimit;
   private int _maxParallelSegmentDownloads;
 
-  public TableDataManagerParams(int maxParallelSegmentDownloads, boolean isSegmentDownloadUntarStreamed,
-      long segmentDownloadUntarRateLimit) {
+  public TableDataManagerParams(int maxParallelSegmentDownloads, boolean isStreamSegmentDownloadUntar,
+      long streamSegmentDownloadUntarRateLimit) {
     _maxParallelSegmentDownloads = maxParallelSegmentDownloads;
-    _isSegmentDownloadUntarStreamed = isSegmentDownloadUntarStreamed;
-    _segmentDownloadUntarRateLimit = segmentDownloadUntarRateLimit;
+    _isStreamSegmentDownloadUntar = isStreamSegmentDownloadUntar;
+    _StreamSegmentDownloadUntarRateLimit = streamSegmentDownloadUntarRateLimit;
   }
 
   public TableDataManagerParams(InstanceDataManagerConfig instanceDataManagerConfig) {
     _maxParallelSegmentDownloads = instanceDataManagerConfig.getMaxParallelSegmentDownloads();
-    _isSegmentDownloadUntarStreamed = instanceDataManagerConfig.isSegmentDownloadUntarStreamed();
-    _segmentDownloadUntarRateLimit = instanceDataManagerConfig.getSegmentDownloadUntarRateLimit();
+    _isStreamSegmentDownloadUntar = instanceDataManagerConfig.isStreamSegmentDownloadUntar();
+    _StreamSegmentDownloadUntarRateLimit = instanceDataManagerConfig.getStreamSegmentDownloadUntarRateLimit();
   }
 
-  public boolean getSegmentDownloadUntarStreamed() {
-    return _isSegmentDownloadUntarStreamed;
+  public boolean isStreamSegmentDownloadUntar() {
+    return _isStreamSegmentDownloadUntar;
   }
 
-  public long getSegmentDownloadUntarRateLimit() {
-    return _segmentDownloadUntarRateLimit;
+  public long getStreamSegmentDownloadUntarRateLimit() {
+    return _StreamSegmentDownloadUntarRateLimit;
   }
 
-  public void setSegmentDownloadUntarStreamed(boolean segmentDownloadUntarStreamed) {
-    _isSegmentDownloadUntarStreamed = segmentDownloadUntarStreamed;
+  public void setStreamSegmentDownloadUntar(boolean streamSegmentDownloadUntar) {
+    _isStreamSegmentDownloadUntar = streamSegmentDownloadUntar;
   }
 
-  public void setSegmentDownloadUntarRateLimit(long segmentDownloadUntarRateLimit) {
-    _segmentDownloadUntarRateLimit = segmentDownloadUntarRateLimit;
+  public void setStreamSegmentDownloadUntarRateLimit(long streamSegmentDownloadUntarRateLimit) {
+    _StreamSegmentDownloadUntarRateLimit = streamSegmentDownloadUntarRateLimit;
   }
 
   public int getMaxParallelSegmentDownloads() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -83,13 +83,14 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   // Key of server segment download rate limit
   // limit the rate to write download-untar stream to disk, in bytes
   // -1 for no disk write limit, 0 for limit the writing to min(untar, download) rate
-  private static final String SEGMENT_DOWNLOAD_UNTAR_RATE_LIMIT
-      = "segment.download.untar.rate.limit.bytes.per.sec";
-  private static final long DEFAULT_SEGMENT_DOWNLOAD_UNTAR_RATE_LIMIT = TarGzCompressionUtils.NO_RATE_LIMIT;
+  private static final String STREAM_SEGMENT_DOWNLOAD_UNTAR_RATE_LIMIT
+      = "segment.stream.download.untar.rate.limit.bytes.per.sec";
+  private static final long DEFAULT_STREAM_SEGMENT_DOWNLOAD_UNTAR_RATE_LIMIT
+      = TarGzCompressionUtils.NO_DISK_WRITE_RATE_LIMIT;
 
   // Key of whether to use streamed server segment download-untar
-  private static final String IS_SEGMENT_DOWNLOAD_UNTAR_STREAMED = "segment.download.streamed.untar";
-  private static final boolean DEFAULT_IS_SEGMENT_DOWNLOAD_UNTAR_STREAMED = false;
+  private static final String ENABLE_STREAM_SEGMENT_DOWNLOAD_UNTAR = "segment.stream.download.untar";
+  private static final boolean DEFAULT_ENABLE_STREAM_SEGMENT_DOWNLOAD_UNTAR = false;
 
   // Key of whether to enable split commit
   private static final String ENABLE_SPLIT_COMMIT = "enable.split.commit";
@@ -245,15 +246,15 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   }
 
   @Override
-  public boolean isSegmentDownloadUntarStreamed() {
-    return _instanceDataManagerConfiguration.getProperty(IS_SEGMENT_DOWNLOAD_UNTAR_STREAMED,
-        DEFAULT_IS_SEGMENT_DOWNLOAD_UNTAR_STREAMED);
+  public boolean isStreamSegmentDownloadUntar() {
+    return _instanceDataManagerConfiguration.getProperty(ENABLE_STREAM_SEGMENT_DOWNLOAD_UNTAR,
+        DEFAULT_ENABLE_STREAM_SEGMENT_DOWNLOAD_UNTAR);
   }
 
   @Override
-  public long getSegmentDownloadUntarRateLimit() {
-    return _instanceDataManagerConfiguration.getProperty(SEGMENT_DOWNLOAD_UNTAR_RATE_LIMIT,
-        DEFAULT_SEGMENT_DOWNLOAD_UNTAR_RATE_LIMIT);
+  public long getStreamSegmentDownloadUntarRateLimit() {
+    return _instanceDataManagerConfiguration.getProperty(STREAM_SEGMENT_DOWNLOAD_UNTAR_RATE_LIMIT,
+        DEFAULT_STREAM_SEGMENT_DOWNLOAD_UNTAR_RATE_LIMIT);
   }
 
   @Override

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -81,11 +81,13 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   private static final int DEFAULT_MAX_PARALLEL_SEGMENT_DOWNLOADS = -1;
 
   // Key of server segment download rate limit
+  // limit the rate to write download-untar stream to disk, in bytes
+  // -1 for no disk write limit, 0 for limit the writing to min(untar, download) rate
   private static final String SEGMENT_DOWNLOAD_UNTAR_RATE_LIMIT
-      = "segment.download.untar.rate.limit";
+      = "segment.download.untar.rate.limit.bytes.per.sec";
   private static final long DEFAULT_SEGMENT_DOWNLOAD_UNTAR_RATE_LIMIT = TarGzCompressionUtils.NO_RATE_LIMIT;
 
-  // Key of streamed server segment download-untar
+  // Key of whether to use streamed server segment download-untar
   private static final String IS_SEGMENT_DOWNLOAD_UNTAR_STREAMED = "segment.download.streamed.untar";
   private static final boolean DEFAULT_IS_SEGMENT_DOWNLOAD_UNTAR_STREAMED = false;
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -20,6 +20,7 @@ package org.apache.pinot.server.starter.helix;
 
 import java.util.Optional;
 import org.apache.commons.configuration.ConfigurationException;
+import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderRegistry;
 import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -78,6 +79,15 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   // causing controllers unavailable for that period of time.
   private static final String MAX_PARALLEL_SEGMENT_DOWNLOADS = "table.level.max.parallel.segment.downloads";
   private static final int DEFAULT_MAX_PARALLEL_SEGMENT_DOWNLOADS = -1;
+
+  // Key of server segment download rate limit
+  private static final String SEGMENT_DOWNLOAD_UNTAR_RATE_LIMIT
+      = "segment.download.untar.rate.limit";
+  private static final long DEFAULT_SEGMENT_DOWNLOAD_UNTAR_RATE_LIMIT = TarGzCompressionUtils.NO_RATE_LIMIT;
+
+  // Key of streamed server segment download-untar
+  private static final String IS_SEGMENT_DOWNLOAD_UNTAR_STREAMED = "segment.download.streamed.untar";
+  private static final boolean DEFAULT_IS_SEGMENT_DOWNLOAD_UNTAR_STREAMED = false;
 
   // Key of whether to enable split commit
   private static final String ENABLE_SPLIT_COMMIT = "enable.split.commit";
@@ -230,6 +240,18 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   @Override
   public long getErrorCacheSize() {
     return _instanceDataManagerConfiguration.getProperty(ERROR_CACHE_SIZE, DEFAULT_ERROR_CACHE_SIZE);
+  }
+
+  @Override
+  public boolean isSegmentDownloadUntarStreamed() {
+    return _instanceDataManagerConfiguration.getProperty(IS_SEGMENT_DOWNLOAD_UNTAR_STREAMED,
+        DEFAULT_IS_SEGMENT_DOWNLOAD_UNTAR_STREAMED);
+  }
+
+  @Override
+  public long getSegmentDownloadUntarRateLimit() {
+    return _instanceDataManagerConfiguration.getProperty(SEGMENT_DOWNLOAD_UNTAR_RATE_LIMIT,
+        DEFAULT_SEGMENT_DOWNLOAD_UNTAR_RATE_LIMIT);
   }
 
   @Override

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
@@ -40,6 +40,7 @@ import org.apache.pinot.core.data.manager.realtime.SegmentUploader;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManagerConfig;
+import org.apache.pinot.segment.local.data.manager.TableDataManagerParams;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.SegmentTestUtils;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
@@ -193,7 +194,7 @@ public abstract class BaseResourceTest {
     TableDataManager tableDataManager = new OfflineTableDataManager();
     tableDataManager
         .init(tableDataManagerConfig, "testInstance", mock(ZkHelixPropertyStore.class), mock(ServerMetrics.class),
-            mock(HelixManager.class), null, 0);
+            mock(HelixManager.class), null, new TableDataManagerParams(0, false, -1));
     tableDataManager.start();
     _tableDataManagerMap.put(tableNameWithType, tableDataManager);
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
@@ -59,7 +59,7 @@ public interface InstanceDataManagerConfig {
 
   long getErrorCacheSize();
 
-  boolean isSegmentDownloadUntarStreamed();
+  boolean isStreamSegmentDownloadUntar();
 
-  long getSegmentDownloadUntarRateLimit();
+  long getStreamSegmentDownloadUntarRateLimit();
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
@@ -58,4 +58,8 @@ public interface InstanceDataManagerConfig {
   String getSegmentDirectoryLoader();
 
   long getErrorCacheSize();
+
+  boolean isSegmentDownloadUntarStreamed();
+
+  long getSegmentDownloadUntarRateLimit();
 }


### PR DESCRIPTION
We found that during the segment push of large and daily-refresh dataset the disk usage is pretty spiky. It will basically max out the disk throughput (to a few GB/s for SSD), during which the query latency can be impacted. However, the average disk throughput is just at a few hundred MB/s level in minute granularity, which means if we can make better use of the disk the contention on bandwidth may be mitigated. Meanwhile the current offline->online process for an offline segment is basically `download -> untar -> MMAP -> download -> untar -> …`. This can potentially be improved in the following ways:

1. If we can combine `download -> untar` and directly write the untarred segments to disk we can save some unnecessary r/w.

2. If we can cap the download speed on top of limiting the number of segments download in parallel (see https://github.com/apache/pinot/pull/8694). We may may improve the query performance during refresh.


**Test Table (2.7GB/segment, 114 segments):**
CPU profiling using Top/ODP given the same downloading time
<img width="566" alt="Screen Shot 2022-06-09 at 4 56 22 PM" src="https://user-images.githubusercontent.com/10736840/172963887-0540a094-8d46-492d-bb76-889b4e9dec32.png">

Disk profiling using PCP in 50ms granularity given the same downloading time:
<img width="700" alt="Screen Shot 2022-06-09 at 4 57 07 PM" src="https://user-images.githubusercontent.com/10736840/172963964-81a87fce-1700-4fb5-9ab4-ea20848904ab.png">

IO size captured with PCP w.r.t. different buffer size:
<img width="734" alt="Screen Shot 2022-06-09 at 4 59 35 PM" src="https://user-images.githubusercontent.com/10736840/172964201-95a0609f-440c-4290-b09c-f5b6509b5592.png">

**Findings & Conclusions:**
- Experiment shows with [Jack's change](https://github.com/apache/pinot/pull/8694) to control download parallelism we can make the disk write rate curve very constant even at 50ms granularity.
- The streamed download-untar feature bypasses writing tarball to the disk, as will reduce the disk IO to 2/3 in the tested case.
- ODP profiling shows the new download code has minimum CPU impact: RateLimiter: [0.583%] / FileDescriptor#sync: [0.583%], and top profiling also indicates similar/lower CPU utilization.
- The rate limiter can also effectively control the network rx rate.