### PR TITLE
Add noServerFoundExceptions metric to broker.yaml

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/broker.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/broker.yml
@@ -103,6 +103,11 @@ rules:
   cache: true
   labels:
     table: "$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.(\\w+)\\.noServerFoundExceptions\"><>(\\w+)"
+  name: "pinot_broker_noServerFoundExceptions_$2"
+  cache: true
+  labels:
+    table: "$1"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.(\\w+)\\.brokerResponsesWithProcessingExceptions\"><>(\\w+)"
   name: "pinot_broker_brokerResponsesWithProcessingExceptions_$2"
   cache: true


### PR DESCRIPTION
Adding this metric so we can find it in prometheus and use it for alerting.

Verified can see this metric in prometheus server using quickstart