### PR TITLE
Skip creating null value vector when there is no null value

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFrameworkTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFrameworkTest.java
@@ -18,10 +18,10 @@
  */
 package org.apache.pinot.core.segment.processing.framework;
 
-import com.google.common.collect.Lists;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.IntStream;
 import org.apache.commons.io.FileUtils;
@@ -74,15 +74,15 @@ public class SegmentProcessorFrameworkTest {
   private Schema _schema;
   private Schema _schemaMV;
 
-  private final List<Object[]> _rawData = Lists
-      .newArrayList(new Object[]{"abc", 1000, 1597719600000L}, new Object[]{null, 2000, 1597773600000L},
+  private final List<Object[]> _rawData =
+      Arrays.asList(new Object[]{"abc", 1000, 1597719600000L}, new Object[]{null, 2000, 1597773600000L},
           new Object[]{"abc", null, 1597777200000L}, new Object[]{"abc", 4000, 1597795200000L},
           new Object[]{"abc", 3000, 1597802400000L}, new Object[]{null, null, 1597838400000L},
           new Object[]{"xyz", 4000, 1597856400000L}, new Object[]{null, 1000, 1597878000000L},
           new Object[]{"abc", 7000, 1597881600000L}, new Object[]{"xyz", 6000, 1597892400000L});
 
-  private final List<Object[]> _rawDataMultiValue = Lists
-      .newArrayList(new Object[]{new String[]{"a", "b"}, 1000, 1597795200000L},
+  private final List<Object[]> _rawDataMultiValue =
+      Arrays.asList(new Object[]{new String[]{"a", "b"}, 1000, 1597795200000L},
           new Object[]{null, null, 1597795200000L}, new Object[]{null, 1000, 1597795200000L},
           new Object[]{new String[]{"a", "b"}, null, 1597795200000L});
 
@@ -243,9 +243,7 @@ public class SegmentProcessorFrameworkTest {
     assertNotNull(clicksNullValueVector);
     assertEquals(clicksNullValueVector.getNullBitmap().toArray(), new int[]{2, 5});
     timeDataSource = segment.getDataSource("time");
-    NullValueVectorReader timeNullValueVector = timeDataSource.getNullValueVector();
-    assertNotNull(timeNullValueVector);
-    assertTrue(timeNullValueVector.getNullBitmap().isEmpty());
+    assertNull(timeDataSource.getNullValueVector());
     assertEquals(segmentMetadata.getName(), "myTable_1597719600000_1597892400000_0");
     segment.destroy();
     FileUtils.cleanDirectory(workingDir);
@@ -266,7 +264,7 @@ public class SegmentProcessorFrameworkTest {
 
     // Time filter
     config = new SegmentProcessorConfig.Builder().setTableConfig(_tableConfig).setSchema(_schema).setTimeHandlerConfig(
-        new TimeHandlerConfig.Builder(TimeHandler.Type.EPOCH).setTimeRange(1597795200000L, 1597881600000L).build())
+            new TimeHandlerConfig.Builder(TimeHandler.Type.EPOCH).setTimeRange(1597795200000L, 1597881600000L).build())
         .build();
     framework = new SegmentProcessorFramework(_singleSegment, config, workingDir);
     outputSegments = framework.process();
@@ -300,7 +298,7 @@ public class SegmentProcessorFrameworkTest {
 
     // Time filter - filtered everything
     config = new SegmentProcessorConfig.Builder().setTableConfig(_tableConfig).setSchema(_schema).setTimeHandlerConfig(
-        new TimeHandlerConfig.Builder(TimeHandler.Type.EPOCH).setTimeRange(1597968000000L, 1598054400000L).build())
+            new TimeHandlerConfig.Builder(TimeHandler.Type.EPOCH).setTimeRange(1597968000000L, 1598054400000L).build())
         .build();
     framework = new SegmentProcessorFramework(_singleSegment, config, workingDir);
     outputSegments = framework.process();
@@ -390,13 +388,9 @@ public class SegmentProcessorFrameworkTest {
     assertNotNull(campaignNullValueVector);
     assertEquals(campaignNullValueVector.getNullBitmap().toArray(), new int[]{0});
     clicksDataSource = segment.getDataSource("clicks");
-    clicksNullValueVector = clicksDataSource.getNullValueVector();
-    assertNotNull(clicksNullValueVector);
-    assertTrue(clicksNullValueVector.getNullBitmap().isEmpty());
+    assertNull(clicksDataSource.getNullValueVector());
     timeDataSource = segment.getDataSource("time");
-    timeNullValueVector = timeDataSource.getNullValueVector();
-    assertNotNull(timeNullValueVector);
-    assertTrue(timeNullValueVector.getNullBitmap().isEmpty());
+    assertNull(timeDataSource.getNullValueVector());
     assertEquals(segmentMetadata.getName(), "myTable_1597708800000_1597708800000_0");
     segment.destroy();
     // segment 1
@@ -420,13 +414,9 @@ public class SegmentProcessorFrameworkTest {
     assertNotNull(campaignNullValueVector);
     assertEquals(campaignNullValueVector.getNullBitmap().toArray(), new int[]{0});
     clicksDataSource = segment.getDataSource("clicks");
-    clicksNullValueVector = clicksDataSource.getNullValueVector();
-    assertNotNull(clicksNullValueVector);
-    assertTrue(clicksNullValueVector.getNullBitmap().isEmpty());
+    assertNull(clicksDataSource.getNullValueVector());
     timeDataSource = segment.getDataSource("time");
-    timeNullValueVector = timeDataSource.getNullValueVector();
-    assertNotNull(timeNullValueVector);
-    assertTrue(timeNullValueVector.getNullBitmap().isEmpty());
+    assertNull(timeDataSource.getNullValueVector());
     assertEquals(segmentMetadata.getName(), "myTable_1597795200000_1597795200000_1");
     segment.destroy();
     FileUtils.cleanDirectory(workingDir);
@@ -558,13 +548,9 @@ public class SegmentProcessorFrameworkTest {
     assertNotNull(campaignNullValueVector);
     assertEquals(campaignNullValueVector.getNullBitmap().toArray(), new int[]{0});
     DataSource clicksDataSource = segment.getDataSource("clicks");
-    NullValueVectorReader clicksNullValueVector = clicksDataSource.getNullValueVector();
-    assertNotNull(clicksNullValueVector);
-    assertTrue(clicksNullValueVector.getNullBitmap().isEmpty());
+    assertNull(clicksDataSource.getNullValueVector());
     DataSource timeDataSource = segment.getDataSource("time");
-    NullValueVectorReader timeNullValueVector = timeDataSource.getNullValueVector();
-    assertNotNull(timeNullValueVector);
-    assertTrue(timeNullValueVector.getNullBitmap().isEmpty());
+    assertNull(timeDataSource.getNullValueVector());
     assertEquals(segmentMetadata.getName(), "myTable_1597795200000_1597795200000_0");
     segment.destroy();
     FileUtils.cleanDirectory(workingDir);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableColumnStatistics.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableColumnStatistics.java
@@ -164,11 +164,6 @@ public class MutableColumnStatistics implements ColumnStatistics {
   }
 
   @Override
-  public boolean hasNull() {
-    return false;
-  }
-
-  @Override
   public PartitionFunction getPartitionFunction() {
     return _dataSource.getDataSourceMetadata().getPartitionFunction();
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableNoDictionaryColStatistics.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableNoDictionaryColStatistics.java
@@ -84,11 +84,6 @@ public class MutableNoDictionaryColStatistics implements ColumnStatistics {
   }
 
   @Override
-  public boolean hasNull() {
-    return false;
-  }
-
-  @Override
   public PartitionFunction getPartitionFunction() {
     return _dataSourceMetadata.getPartitionFunction();
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/BigDecimalColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/BigDecimalColumnPreIndexStatsCollector.java
@@ -112,11 +112,6 @@ public class BigDecimalColumnPreIndexStatsCollector extends AbstractColumnStatis
   }
 
   @Override
-  public boolean hasNull() {
-    return false;
-  }
-
-  @Override
   public void seal() {
     _sortedValues = _values.toArray(new BigDecimal[0]);
     Arrays.sort(_sortedValues);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/BytesColumnPredIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/BytesColumnPredIndexStatsCollector.java
@@ -122,11 +122,6 @@ public class BytesColumnPredIndexStatsCollector extends AbstractColumnStatistics
   }
 
   @Override
-  public boolean hasNull() {
-    return false;
-  }
-
-  @Override
   public void seal() {
     _sortedValues = _values.toArray(new ByteArray[0]);
     Arrays.sort(_sortedValues);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/DoubleColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/DoubleColumnPreIndexStatsCollector.java
@@ -99,11 +99,6 @@ public class DoubleColumnPreIndexStatsCollector extends AbstractColumnStatistics
   }
 
   @Override
-  public boolean hasNull() {
-    return false;
-  }
-
-  @Override
   public void seal() {
     _sortedValues = _values.toDoubleArray();
     Arrays.sort(_sortedValues);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/FloatColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/FloatColumnPreIndexStatsCollector.java
@@ -99,11 +99,6 @@ public class FloatColumnPreIndexStatsCollector extends AbstractColumnStatisticsC
   }
 
   @Override
-  public boolean hasNull() {
-    return false;
-  }
-
-  @Override
   public void seal() {
     _sortedValues = _values.toFloatArray();
     Arrays.sort(_sortedValues);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/IntColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/IntColumnPreIndexStatsCollector.java
@@ -99,11 +99,6 @@ public class IntColumnPreIndexStatsCollector extends AbstractColumnStatisticsCol
   }
 
   @Override
-  public boolean hasNull() {
-    return false;
-  }
-
-  @Override
   public void seal() {
     _sortedValues = _values.toIntArray();
     Arrays.sort(_sortedValues);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/LongColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/LongColumnPreIndexStatsCollector.java
@@ -99,11 +99,6 @@ public class LongColumnPreIndexStatsCollector extends AbstractColumnStatisticsCo
   }
 
   @Override
-  public boolean hasNull() {
-    return false;
-  }
-
-  @Override
   public void seal() {
     _sortedValues = _values.toLongArray();
     Arrays.sort(_sortedValues);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/StringColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/StringColumnPreIndexStatsCollector.java
@@ -117,11 +117,6 @@ public class StringColumnPreIndexStatsCollector extends AbstractColumnStatistics
   }
 
   @Override
-  public boolean hasNull() {
-    return false;
-  }
-
-  @Override
   public void seal() {
     _sortedValues = _values.toArray(new String[0]);
     Arrays.sort(_sortedValues);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/DefaultColumnStatistics.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/DefaultColumnStatistics.java
@@ -35,7 +35,6 @@ public class DefaultColumnStatistics implements ColumnStatistics {
   private final boolean _isSorted;
   private final int _totalNumberOfEntries;
   private final int _maxNumberOfMultiValues;
-  private final boolean _hasNull = false;
 
   public DefaultColumnStatistics(Object minValue, Object maxValue, Object uniqueValuesSet, boolean isSorted,
       int totalNumberOfEntries, int maxNumberOfMultiValues) {
@@ -90,11 +89,6 @@ public class DefaultColumnStatistics implements ColumnStatistics {
   @Override
   public int getMaxNumberOfMultiValues() {
     return _maxNumberOfMultiValues;
-  }
-
-  @Override
-  public boolean hasNull() {
-    return _hasNull;
   }
 
   @Override

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/ColumnIndexCreationInfo.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/ColumnIndexCreationInfo.java
@@ -75,10 +75,6 @@ public class ColumnIndexCreationInfo implements Serializable {
     return _columnStatistics.isSorted();
   }
 
-  public boolean hasNulls() {
-    return _columnStatistics.hasNull();
-  }
-
   public int getTotalNumberOfEntries() {
     return _columnStatistics.getTotalNumberOfEntries();
   }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/ColumnStatistics.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/ColumnStatistics.java
@@ -90,11 +90,6 @@ public interface ColumnStatistics extends Serializable {
     return -1;
   }
 
-  /**
-   * @return Returns if any of the values have nulls in the segments.
-   */
-  boolean hasNull();
-
   PartitionFunction getPartitionFunction();
 
   int getNumPartitions();


### PR DESCRIPTION
Also clean up the unused `hasNull()` in the stats collection. A column contains null values when the null value vector exists and not empty.