### PR TITLE
Improve accuracy of aggregate group-by without order-by queries by adding a query rewriter to convert aggregate group-by only queries to add order-by

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/GroupByOnlyToOrderByRewriter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/GroupByOnlyToOrderByRewriter.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.rewriter;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.common.utils.request.RequestUtils;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+
+
+public class GroupByOnlyToOrderByRewriter implements QueryRewriter {
+  /**
+   * Rewrite aggregate group by only query to an order by query based on the group by expressions. Converting group by
+   * queries to order by queries can improve the accuracy and provide deterministic query results.
+   * Caveat: This can result in group by queries becoming more expensive due to ordering
+   *
+   * E.g.
+   * ```
+   *   SELECT col1, col2, max(col3) FROM foo GROUP BY col1, col2 => SELECT col1, col2, max(col3) FROM foo GROUP BY
+   *          col1, col2 ORDER BY col1, col2
+   *   SELECT col1, avg(col2) FROM foo GROUP BY col1 => SELECT col1, avg(col2) FROM foo GROUP BY col1 ORDER BY col1
+   * ```
+   * @param pinotQuery
+   */
+  @Override
+  public PinotQuery rewrite(PinotQuery pinotQuery) {
+    if (pinotQuery.getOrderByListSize() > 0) {
+      // No need to add order-by if it is already present
+      return pinotQuery;
+    }
+
+    boolean hasAggregation = false;
+    for (Expression select : pinotQuery.getSelectList()) {
+      if (CalciteSqlParser.isAggregateExpression(select)) {
+        hasAggregation = true;
+      }
+    }
+
+    if (hasAggregation && pinotQuery.getGroupByListSize() > 0) {
+      // Convert the group-by expressions into order-by expressions with ascending ordering. This is done to get
+      // better accuracy and deterministic results for group-by aggregate queries without order-by
+      List<Expression> orderByExpr = new ArrayList<>();
+      for (Expression expression : pinotQuery.getGroupByList()) {
+        Expression orderByExpression = RequestUtils.getFunctionExpression("asc");
+        orderByExpression.getFunctionCall().addToOperands(expression);
+        orderByExpr.add(orderByExpression);
+      }
+      pinotQuery.setOrderByList(orderByExpr);
+    }
+    return pinotQuery;
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/GroupByOnlyToOrderByRewriterTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/GroupByOnlyToOrderByRewriterTest.java
@@ -1,0 +1,246 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.rewriter;
+
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class GroupByOnlyToOrderByRewriterTest {
+
+  private static final QueryRewriter QUERY_REWRITER = new GroupByOnlyToOrderByRewriter();
+
+  @Test
+  public void testQuery1() {
+    // SELECT A, max(B) FROM myTable GROUP BY A
+    // -> SELECT A, max(B) FROM myTable GROUP BY A ORDER BY A
+    final PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT A, max(B) FROM myTable GROUP BY A");
+    QUERY_REWRITER.rewrite(pinotQuery);
+    Assert.assertNotNull(pinotQuery.getOrderByList());
+    Assert.assertEquals(pinotQuery.getOrderByListSize(), 1);
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperator(), "asc");
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "A");
+  }
+
+  @Test
+  public void testQuery2() {
+    // Negative test - ensure that non-aggregate queries aren't rewritten to add order by
+    final PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT A, B FROM myTable GROUP BY A, B");
+    QUERY_REWRITER.rewrite(pinotQuery);
+    Assert.assertNull(pinotQuery.getOrderByList());
+    Assert.assertEquals(pinotQuery.getOrderByListSize(), 0);
+  }
+
+  @Test
+  public void testQuery3() {
+    // SELECT A, max(B), C FROM myTable GROUP BY A, C
+    // -> SELECT A, max(B), C FROM myTable GROUP BY A, C ORDER BY A, C
+    final PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+        "SELECT A, max(B), C FROM myTable GROUP BY A, C");
+    QUERY_REWRITER.rewrite(pinotQuery);
+    Assert.assertNotNull(pinotQuery.getOrderByList());
+    Assert.assertEquals(pinotQuery.getOrderByListSize(), 2);
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperator(), "asc");
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "A");
+    Assert.assertEquals(pinotQuery.getOrderByList().get(1).getFunctionCall().getOperator(), "asc");
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "C");
+  }
+
+  @Test
+  public void testQuery4() {
+    // SELECT concat(A, 'test'), avg(B) FROM myTable GROUP BY concat(A, 'test')
+    // -> SELECT concat(A, 'test'), avg(B) FROM myTable GROUP BY concat(A, 'test') ORDER BY concat(A, 'test')
+    final PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+        "SELECT concat(A, 'test'), avg(B) FROM myTable GROUP BY concat(A, 'test')");
+    QUERY_REWRITER.rewrite(pinotQuery);
+    Assert.assertNotNull(pinotQuery.getOrderByList());
+    Assert.assertEquals(pinotQuery.getOrderByListSize(), 1);
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperator(), "asc");
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "concat");
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall()
+        .getOperands().size(), 2);
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall()
+        .getOperands().get(0).getIdentifier().getName(), "A");
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall()
+        .getOperands().get(1).getLiteral().getStringValue(), "test");
+  }
+
+  @Test
+  public void testQuery5() {
+    // SELECT A, concat(B, '-', 'test'), count(C) FROM myTable GROUP BY A, concat(B, '-', 'test')
+    // -> SELECT A, concat(B, '-', 'test'), count(C) FROM myTable GROUP BY A, concat(B, '-', 'test')
+    //    ORDER BY A, concat(B, '-', 'test')
+    final PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+        "SELECT A, concat(B, '-', 'test'), count(C) FROM myTable GROUP BY A, concat(B, '-', 'test')");
+    QUERY_REWRITER.rewrite(pinotQuery);
+    Assert.assertNotNull(pinotQuery.getOrderByList());
+    Assert.assertEquals(pinotQuery.getOrderByListSize(), 2);
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperator(), "asc");
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "A");
+    Assert.assertEquals(pinotQuery.getOrderByList().get(1).getFunctionCall().getOperator(), "asc");
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "concat");
+    Assert.assertEquals(pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall()
+            .getOperands().size(), 3);
+    Assert.assertEquals(pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall()
+        .getOperands().get(0).getIdentifier().getName(), "B");
+    Assert.assertEquals(pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall()
+        .getOperands().get(1).getLiteral().getStringValue(), "-");
+    Assert.assertEquals(pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall()
+        .getOperands().get(2).getLiteral().getStringValue(), "test");
+  }
+
+  @Test
+  public void testQuery6() {
+    // SELECT A, count(B) FROM myTable GROUP BY A ORDER BY A, count(C)
+    // Should not be modified
+    final PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+        "SELECT A, count(B) FROM myTable GROUP BY A ORDER BY A, count(C)");
+    QUERY_REWRITER.rewrite(pinotQuery);
+    Assert.assertNotNull(pinotQuery.getOrderByList());
+    Assert.assertEquals(pinotQuery.getOrderByListSize(), 2);
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperator(), "asc");
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "A");
+    Assert.assertEquals(pinotQuery.getOrderByList().get(1).getFunctionCall().getOperator(), "asc");
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "count");
+    Assert.assertEquals(pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall()
+        .getOperands().size(), 1);
+    Assert.assertEquals(pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall()
+        .getOperands().get(0).getIdentifier().getName(), "C");
+  }
+
+  @Test
+  public void testQuery7() {
+    // SELECT A, concat(B, '-', 'test'), count(C) FROM myTable GROUP BY A, concat(B, '-', 'test') ORDER BY count(C) DESC
+    // Should not be modified
+    final PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+        "SELECT A, concat(B, '-', 'test'), count(C) FROM myTable GROUP BY A, concat(B, '-', 'test') ORDER BY "
+            + "count(C) DESC");
+    QUERY_REWRITER.rewrite(pinotQuery);
+    Assert.assertNotNull(pinotQuery.getOrderByList());
+    Assert.assertEquals(pinotQuery.getOrderByListSize(), 1);
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperator(), "desc");
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "count");
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall()
+        .getOperands().size(), 1);
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall()
+        .getOperands().get(0).getIdentifier().getName(), "C");
+  }
+
+  @Test
+  public void testQuery8() {
+    // SELECT max(A), min(B), C FROM testTable WHERE D = 1 GROUP BY C HAVING max(A) > 2
+    // -> SELECT max(A), min(B), C FROM testTable WHERE D = 1 GROUP BY C HAVING max(A) > 2 ORDER BY C
+    final PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+        "SELECT max(A), min(B), C FROM testTable WHERE D = 1 GROUP BY C HAVING max(A) > 2");
+    QUERY_REWRITER.rewrite(pinotQuery);
+    Assert.assertNotNull(pinotQuery.getOrderByList());
+    Assert.assertEquals(pinotQuery.getOrderByListSize(), 1);
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperator(), "asc");
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "C");
+    Assert.assertNotNull(pinotQuery.getHavingExpression());
+    Assert.assertEquals(pinotQuery.getHavingExpression().getFunctionCall().getOperator(), "GREATER_THAN");
+    Assert.assertEquals(pinotQuery.getHavingExpression().getFunctionCall().getOperands().size(), 2);
+  }
+
+  @Test
+  public void testQuery9() {
+    // SELECT max(A), min(B), C FROM testTable WHERE D = 1 GROUP BY C HAVING max(A) > 2 ORDER BY max(A) DESC
+    // Should not be modified
+    final PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT max(A), min(B), C "
+        + "FROM testTable WHERE D = 1 GROUP BY C HAVING max(A) > 2 ORDER BY max(A) DESC");
+    QUERY_REWRITER.rewrite(pinotQuery);
+    Assert.assertNotNull(pinotQuery.getOrderByList());
+    Assert.assertEquals(pinotQuery.getOrderByListSize(), 1);
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperator(), "desc");
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "max");
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall()
+        .getOperands().size(), 1);
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall()
+        .getOperands().get(0).getIdentifier().getName(), "A");
+    Assert.assertNotNull(pinotQuery.getHavingExpression());
+    Assert.assertEquals(pinotQuery.getHavingExpression().getFunctionCall().getOperator(), "GREATER_THAN");
+    Assert.assertEquals(pinotQuery.getHavingExpression().getFunctionCall().getOperands().size(), 2);
+  }
+
+  @Test
+  public void testQuery10() {
+    // SELECT SUM('A'), MAX(B) FROM myTable GROUP BY 'A', B
+    // -> SELECT SUM('A'), MAX(B) FROM myTable GROUP BY 'A', B ORDER BY 'A', B
+    final PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+        "SELECT SUM('A'), MAX(B) FROM myTable GROUP BY 'A', B");
+    QUERY_REWRITER.rewrite(pinotQuery);
+    Assert.assertNotNull(pinotQuery.getOrderByList());
+    Assert.assertEquals(pinotQuery.getOrderByListSize(), 2);
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperator(), "asc");
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().size(), 1);
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getLiteral().getStringValue(), "A");
+    Assert.assertEquals(pinotQuery.getOrderByList().get(1).getFunctionCall().getOperator(), "asc");
+    Assert.assertEquals(pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().size(), 1);
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "B");
+  }
+
+  @Test
+  public void testQuery11() {
+    final PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+    "SELECT SUM(volume) FROM callistoInteractions WHERE \"time\" >= 26194020 AND \"time\" < 26326560 AND pageUrn "
+        + "IN (123) GROUP BY dateTimeConvert(\"time\",'1:MINUTES:EPOCH','1:MINUTES:EPOCH','1:MINUTES') LIMIT 100000");
+    QUERY_REWRITER.rewrite(pinotQuery);
+    Assert.assertNotNull(pinotQuery.getOrderByList());
+    Assert.assertEquals(pinotQuery.getOrderByListSize(), 1);
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperator(), "asc");
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().size(), 1);
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
+        "datetimeconvert");
+    Assert.assertEquals(pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall()
+        .getOperands().size(), 4);
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands()
+            .get(0).getIdentifier().getName(), "time");
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands()
+            .get(1).getLiteral().getStringValue(), "1:MINUTES:EPOCH");
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands()
+            .get(2).getLiteral().getStringValue(), "1:MINUTES:EPOCH");
+    Assert.assertEquals(
+        pinotQuery.getOrderByList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands()
+            .get(3).getLiteral().getStringValue(), "1:MINUTES");
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/QueryRewriterFactoryTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/QueryRewriterFactoryTest.java
@@ -42,11 +42,13 @@ public class QueryRewriterFactoryTest {
     // Check init with other configs
     QueryRewriterFactory.init("org.apache.pinot.sql.parsers.rewriter.PredicateComparisonRewriter,"
         + "org.apache.pinot.sql.parsers.rewriter.CompileTimeFunctionsInvoker,"
-        + "org.apache.pinot.sql.parsers.rewriter.SelectionsRewriter");
-    Assert.assertEquals(QUERY_REWRITERS.size(), 3);
+        + "org.apache.pinot.sql.parsers.rewriter.SelectionsRewriter,"
+        + "org.apache.pinot.sql.parsers.rewriter.GroupByOnlyToOrderByRewriter");
+    Assert.assertEquals(QUERY_REWRITERS.size(), 4);
     Assert.assertTrue(QUERY_REWRITERS.get(0) instanceof PredicateComparisonRewriter);
     Assert.assertTrue(QUERY_REWRITERS.get(1) instanceof CompileTimeFunctionsInvoker);
     Assert.assertTrue(QUERY_REWRITERS.get(2) instanceof SelectionsRewriter);
+    Assert.assertTrue(QUERY_REWRITERS.get(3) instanceof GroupByOnlyToOrderByRewriter);
 
     // Revert back to default behavior
     QueryRewriterFactory.init(null);


### PR DESCRIPTION
Today aggregate group-by without order-by queries can be inaccurate and non-deterministic. The results are truncated at multiple stages (segment level and server level) and depending on the order in which the rows are processed the aggregate group-by can return very different results limit on the number of results to be returned is smaller than the total number of rows matching the query.

Aggregate group-by with order-by on the other hand has to keep track of the top K results based on the ordering criteria due to which the results are more accurate and deterministic.

This PR adds a new query rewriter to rewrite aggregate group-by only queries to include order-by based on the group-by predicates. By default the query rewriter is not added to the list of default query rewriters but this can be overridden via the broker side config. i.e. by default the new group-by only to group-by order-by query rewriter is disabled.

Note: Treating aggregate group-by only queries to include order-by can lead to a performance hit as compared to the group-by only queries as the results need to be sorted and some processing is done under a lock to trim the data-structure for queries including order-by. The performance will be no worse than if the order-by clause was included as part of the original query.

cc @siddharthteotia 