### PR TITLE
Add metric for replication count from config

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
@@ -20,6 +20,12 @@ rules:
   labels:
     table: "$1"
     tableType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.replicationFromConfig.(\\w+)_(\\w+)\"><>(\\w+)"
+  name: "pinot_controller_replicationFromConfig_$3"
+  cache: true
+  labels:
+    table: "$1"
+    tableType: "$2"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.numberOfReplicas.(\\w+)_(\\w+)\"><>(\\w+)"
   name: "pinot_controller_numberOfReplicas_$3"
   cache: true

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -26,6 +26,7 @@ import org.apache.pinot.common.Utils;
  */
 public enum ControllerGauge implements AbstractMetrics.Gauge {
 
+  REPLICATION_FROM_CONFIG("replicas", false),
   // Number of complete replicas of table in external view containing all segments online in ideal state
   NUMBER_OF_REPLICAS("replicas", false),
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -41,6 +41,7 @@ import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.periodictask.ControllerPeriodicTask;
 import org.apache.pinot.controller.util.TableSizeReader;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
@@ -108,6 +109,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
   @Override
   protected void processTable(String tableNameWithType, Context context) {
     try {
+      updateTableConfigMetrics(tableNameWithType);
       updateSegmentMetrics(tableNameWithType, context);
       updateTableSizeMetrics(tableNameWithType);
     } catch (Exception e) {
@@ -122,6 +124,26 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
     _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.REALTIME_TABLE_COUNT, context._realTimeTableCount);
     _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.OFFLINE_TABLE_COUNT, context._offlineTableCount);
     _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.DISABLED_TABLE_COUNT, context._disabledTableCount);
+  }
+
+  /**
+   * Updates metrics related to the table config.
+   * If table config not found, resets the metrics
+   */
+  private void updateTableConfigMetrics(String tableNameWithType) {
+    TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+    if (tableConfig == null) {
+      LOGGER.warn("Found null table config for table: {}. Resetting table config metrics.", tableNameWithType);
+      _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.REPLICATION_FROM_CONFIG, 0);
+      return;
+    }
+    int replication;
+    if (tableConfig.getTableType() == TableType.REALTIME) {
+      replication = tableConfig.getValidationConfig().getReplicasPerPartitionNumber();
+    } else {
+      replication = tableConfig.getValidationConfig().getReplicationNumber();
+    }
+    _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.REPLICATION_FROM_CONFIG, replication);
   }
 
   private void updateTableSizeMetrics(String tableNameWithType)


### PR DESCRIPTION
Adding a metric REPLICATION_FROM_CONFIG which will be emitted by SegmentStatusChecker, the periodic task which emits replication and segment related metrics every 5 minutes by default.
The motivation for this is to know the true replication count and use it in conjunction with metrics which are per replica (e.g. LLC_PARTITION_CONSUMING) to have finer alerts set on such metrics.