### PR TITLE
Optimize ColumnValueSegmentPruner by caching value hashes

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
@@ -118,8 +118,8 @@ public class ColumnValueSegmentPruner implements SegmentPruner {
         // Prefetch bloom filter for columns within the EQ/IN predicate if exists
         for (int i = 0; i < numSegments; i++) {
           IndexSegment segment = segments.get(i);
-          Map<String, DataSource> dataSourceCache = new HashMap<>(eqInColumns.size());
-          Map<String, List<ColumnIndexType>> columnToIndexList = new HashMap<>(eqInColumns.size());
+          Map<String, DataSource> dataSourceCache = new HashMap<>();
+          Map<String, List<ColumnIndexType>> columnToIndexList = new HashMap<>();
           for (String column : eqInColumns) {
             DataSource dataSource = segment.getDataSource(column);
             dataSourceCache.put(column, dataSource);
@@ -165,7 +165,7 @@ public class ColumnValueSegmentPruner implements SegmentPruner {
         }
       }
     } else {
-      Map<String, DataSource> dataSourceCache = new HashMap<>(eqInColumns.size() + rangeColumns.size());
+      Map<String, DataSource> dataSourceCache = new HashMap<>();
       for (IndexSegment segment : segments) {
         dataSourceCache.clear();
         if (!pruneSegment(segment, filter, dataSourceCache, cachedValues)) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
@@ -499,7 +499,7 @@ public class ColumnValueSegmentPruner implements SegmentPruner {
     }
 
     private Comparable getComparableValue(DataType dt) {
-      if (_dt == null || _comparableValue == null) {
+      if (!dt.equals(_dt)) {
         _dt = dt;
         _comparableValue = convertValue(_strValue, dt);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
@@ -19,11 +19,6 @@
 package org.apache.pinot.core.query.pruner;
 
 import com.google.common.primitives.Longs;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.lang.invoke.VarHandle;
-import java.nio.ByteOrder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
@@ -38,6 +38,7 @@ import org.apache.pinot.common.request.context.predicate.RangePredicate;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.local.segment.index.readers.bloom.GuavaBloomFilterReaderUtils;
 import org.apache.pinot.segment.spi.FetchContext;
+import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
@@ -292,7 +293,9 @@ public class ColumnValueSegmentPruner implements SegmentPruner {
   private boolean pruneEqPredicate(IndexSegment segment, EqPredicate eqPredicate,
       Map<String, DataSource> dataSourceCache, Map<Predicate, Object> valueCache) {
     String column = eqPredicate.getLhs().getIdentifier();
-    DataSource dataSource = dataSourceCache.computeIfAbsent(column, segment::getDataSource);
+    DataSource dataSource = segment instanceof ImmutableSegment
+        ? segment.getDataSource(column)
+        : dataSourceCache.computeIfAbsent(column, segment::getDataSource);
     // NOTE: Column must exist after DataSchemaSegmentPruner
     assert dataSource != null;
     DataSourceMetadata dataSourceMetadata = dataSource.getDataSourceMetadata();
@@ -336,7 +339,9 @@ public class ColumnValueSegmentPruner implements SegmentPruner {
   private boolean pruneInPredicate(IndexSegment segment, InPredicate inPredicate,
       Map<String, DataSource> dataSourceCache, Map<Predicate, Object> valueCache) {
     String column = inPredicate.getLhs().getIdentifier();
-    DataSource dataSource = dataSourceCache.computeIfAbsent(column, segment::getDataSource);
+    DataSource dataSource = segment instanceof ImmutableSegment
+        ? segment.getDataSource(column)
+        : dataSourceCache.computeIfAbsent(column, segment::getDataSource);
     // NOTE: Column must exist after DataSchemaSegmentPruner
     assert dataSource != null;
     DataSourceMetadata dataSourceMetadata = dataSource.getDataSourceMetadata();
@@ -402,7 +407,9 @@ public class ColumnValueSegmentPruner implements SegmentPruner {
   private boolean pruneRangePredicate(IndexSegment segment, RangePredicate rangePredicate,
       Map<String, DataSource> dataSourceCache) {
     String column = rangePredicate.getLhs().getIdentifier();
-    DataSource dataSource = dataSourceCache.computeIfAbsent(column, segment::getDataSource);
+    DataSource dataSource = segment instanceof ImmutableSegment
+        ? segment.getDataSource(column)
+        : dataSourceCache.computeIfAbsent(column, segment::getDataSource);
     // NOTE: Column must exist after DataSchemaSegmentPruner
     assert dataSource != null;
     DataSourceMetadata dataSourceMetadata = dataSource.getDataSourceMetadata();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.query.pruner;
 
-import com.google.common.primitives.Longs;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -531,9 +530,10 @@ public class ColumnValueSegmentPruner implements SegmentPruner {
 
       private boolean mightBeContained(BloomFilterReader bloomFilter) {
         if (!_hashed) {
-          byte[] hash = GuavaBloomFilterReaderUtils.hash(_comparableValue.toString());
-          _hash1 = Longs.fromBytes(hash[7], hash[6], hash[5], hash[4], hash[3], hash[2], hash[1], hash[0]);
-          _hash2 = Longs.fromBytes(hash[15], hash[14], hash[13], hash[12], hash[11], hash[10], hash[9], hash[8]);
+          GuavaBloomFilterReaderUtils.Hash128AsLongs hash128AsLongs =
+              GuavaBloomFilterReaderUtils.hashAsLongs(_comparableValue.toString());
+          _hash1 = hash128AsLongs.getHash1();
+          _hash2 = hash128AsLongs.getHash2();
           _hashed = true;
         }
         return bloomFilter.mightContain(_hash1, _hash2);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
@@ -520,7 +520,7 @@ public class ColumnValueSegmentPruner implements SegmentPruner {
       }
 
       private void ensureDataType(DataType dt) {
-        if (!dt.equals(_dt)) {
+        if (dt != _dt) {
           String strValue = _value.toString();
           _dt = dt;
           _comparableValue = convertValue(strValue, dt);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
@@ -212,11 +212,10 @@ public class ColumnValueSegmentPruner implements SegmentPruner {
           }
           case IN: {
             InPredicate inPredicate = (InPredicate) predicate;
-            if (inPredicate.getValues().size() > _inPredicateThreshold) {
-              break;
+            if (inPredicate.getValues().size() <= _inPredicateThreshold) {
+              eqInColumns.add(column);
+              valueCache.add(inPredicate);
             }
-            eqInColumns.add(column);
-            valueCache.add(inPredicate);
             break;
           }
           case RANGE: {

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPrunerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPrunerTest.java
@@ -147,7 +147,7 @@ public class ColumnValueSegmentPrunerTest {
   }
 
   @Test
-  public void testBloomFilterInPredicatePruning()
+  public void testBloomFilterPredicatePruning()
       throws IOException {
     Map<String, Object> properties = new HashMap<>();
     // override default value
@@ -161,52 +161,52 @@ public class ColumnValueSegmentPrunerTest {
     // Add support for bloom filter
     DataSourceMetadata dataSourceMetadata = mock(DataSourceMetadata.class);
     BloomFilterReader bloomFilterReader = new BloomFilterReaderBuilder()
-        .put("1")
-        .put("2")
-        .put("3")
-        .put("5")
-        .put("7")
-        .put("21")
+        .put("1.0")
+        .put("2.0")
+        .put("3.0")
+        .put("5.0")
+        .put("7.0")
+        .put("21.0")
         .build();
 
-    when(dataSourceMetadata.getDataType()).thenReturn(DataType.INT);
+    when(dataSourceMetadata.getDataType()).thenReturn(DataType.DOUBLE);
     when(dataSource.getDataSourceMetadata()).thenReturn(dataSourceMetadata);
     when(dataSource.getBloomFilter()).thenReturn(bloomFilterReader);
-    when(dataSourceMetadata.getMinValue()).thenReturn(5);
-    when(dataSourceMetadata.getMaxValue()).thenReturn(10);
+    when(dataSourceMetadata.getMinValue()).thenReturn(5.0);
+    when(dataSourceMetadata.getMaxValue()).thenReturn(10.0);
 
     // all out the bloom filter and out of range
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (0)"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 0"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (0, 3, 4)"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (0.0)"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 0.0"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (0.0, 3.0, 4.0)"));
 
     // some in the bloom filter but all out of range
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 1"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (1)"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 21"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (21)"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (21, 30)"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 21 AND column = 30"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 21 OR column = 30"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 1.0"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (1.0)"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 21.0"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (21.0)"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (21.0, 30.0)"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 21.0 AND column = 30.0"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 21.0 OR column = 30.0"));
 
     // all out the bloom filter but some in range
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 6"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (6)"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 0 OR column = 6"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 6.0"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (6.0)"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 0.0 OR column = 6.0"));
 
     // all in the bloom filter and in range
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 5"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (5)"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 5 OR column = 7"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (5, 7)"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 5 AND column = 7"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 5.0"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (5.0)"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 5.0 OR column = 7.0"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (5.0, 7.0)"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 5.0 AND column = 7.0"));
 
     // some in the bloom filter and in range
     assertFalse(
-        runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)"));
-    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 5 OR column = 0"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 5 AND column = 0"));
-    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (8, 10)"));
+        runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (0.0, 5.0)"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 5.0 OR column = 0.0"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 5.0 AND column = 0.0"));
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column IN (8.0, 10.0)"));
   }
 
   private IndexSegment mockIndexSegment() {

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkBloomFilter.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkBloomFilter.java
@@ -1,0 +1,154 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import com.google.common.base.Preconditions;
+import com.google.common.hash.BloomFilter;
+import com.google.common.hash.Funnels;
+import com.google.common.primitives.Longs;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.pinot.segment.local.segment.index.readers.bloom.BaseGuavaBloomFilterReader;
+import org.apache.pinot.segment.local.segment.index.readers.bloom.GuavaBloomFilterReaderUtils;
+import org.apache.pinot.segment.local.segment.index.readers.bloom.OffHeapGuavaBloomFilterReader;
+import org.apache.pinot.segment.local.segment.index.readers.bloom.OnHeapGuavaBloomFilterReader;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.JavaFlightRecorderProfiler;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(1)
+@Warmup(iterations = 500, time = 10, timeUnit = TimeUnit.MICROSECONDS)
+@Measurement(iterations = 5, time = 1)
+@State(Scope.Benchmark)
+public class BenchmarkBloomFilter {
+
+  @Param(value = {OFF_HEAP})
+  private String _reader;
+
+  @Param(value = {"10000"})
+  private int _cardinality;
+  @Param(value = {"100", "1000"})
+  private int _maxSizeInBytes;
+
+  public static void main(String[] args)
+      throws Exception {
+    ChainedOptionsBuilder opt = new OptionsBuilder().include(BenchmarkBloomFilter.class.getSimpleName())
+        .addProfiler(JavaFlightRecorderProfiler.class);
+    new Runner(opt.build()).run();
+  }
+
+  private BaseGuavaBloomFilterReader _actualReader;
+  private Supplier<String> _valueSupplier;
+  private String _value;
+  private long _valueLong1;
+  private long _valueLong2;
+
+  public static final String ON_HEAP = "onHeap";
+  public static final String OFF_HEAP = "offHeap";
+
+  private BaseGuavaBloomFilterReader loadReader(BloomFilter<CharSequence> bloomFilter)
+      throws IOException {
+
+    File file = Files.createTempFile("test", ".bloom").toFile();
+    file.deleteOnExit();
+    try (FileOutputStream fos = new FileOutputStream(file)) {
+      bloomFilter.writeTo(fos);
+    }
+
+    PinotDataBuffer pinotDataBuffer = PinotDataBuffer.loadBigEndianFile(file);
+
+    switch (_reader) {
+      case ON_HEAP:
+        return new OnHeapGuavaBloomFilterReader(pinotDataBuffer);
+      case OFF_HEAP:
+        return new OffHeapGuavaBloomFilterReader(pinotDataBuffer);
+      default:
+        throw new IllegalArgumentException("Value " + _reader + " not recognized");
+    }
+  }
+
+  @Setup
+  public void setUp()
+      throws IOException {
+    long seed = 0;
+    Random r = new Random(seed);
+    List<String> words =
+        IntStream.generate(r::nextInt).limit(_cardinality).mapToObj(Integer::toString).collect(Collectors.toList());
+
+    double fpp = Math.max(0.01d, GuavaBloomFilterReaderUtils.computeFPP(_maxSizeInBytes, _cardinality));
+    BloomFilter<CharSequence> bloomFilter = BloomFilter.create(
+        Funnels.stringFunnel(StandardCharsets.UTF_8), _cardinality, fpp);
+    words.forEach(bloomFilter::put);
+
+    _actualReader = loadReader(bloomFilter);
+
+    _valueSupplier = () -> words.get(r.nextInt(_cardinality));
+  }
+
+  @Setup(Level.Iteration)
+  public void updateIndex() {
+    _value = _valueSupplier.get();
+
+    byte[] hash = GuavaBloomFilterReaderUtils.hash(_value);
+    _valueLong1 = Longs.fromBytes(hash[7], hash[6], hash[5], hash[4], hash[3], hash[2], hash[1], hash[0]);
+    _valueLong2 = Longs.fromBytes(hash[15], hash[14], hash[13], hash[12], hash[11], hash[10], hash[9], hash[8]);
+  }
+
+  @Benchmark
+  public boolean mightContainString() {
+    boolean result = _actualReader.mightContain(_value);
+    Preconditions.checkArgument(result);
+
+    return result;
+  }
+
+  @Benchmark
+  public boolean mightContainLongs() {
+    boolean result = _actualReader.mightContain(_valueLong1, _valueLong2);
+    Preconditions.checkArgument(result);
+
+    return result;
+  }
+}

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkColumnValueSegmentPruner.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkColumnValueSegmentPruner.java
@@ -77,9 +77,9 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @Warmup(iterations = 5, time = 2)
 @Measurement(iterations = 5, time = 2)
 @State(Scope.Benchmark)
-public class BenchmarkServerSegmentPruner {
+public class BenchmarkColumnValueSegmentPruner {
 
-  public static final String QUERY_1 = "SELECT * FROM MyTable WHERE SORTED_COL IN ('1', '2', '3', '4')";
+  public static final String QUERY_1 = "SELECT * FROM MyTable WHERE SORTED_COL IN (1, 2, 3, 4)";
 
   @Param({"10"})
   private int _numRows;
@@ -95,7 +95,7 @@ public class BenchmarkServerSegmentPruner {
 
   public static void main(String[] args)
       throws Exception {
-    ChainedOptionsBuilder opt = new OptionsBuilder().include(BenchmarkServerSegmentPruner.class.getSimpleName());
+    ChainedOptionsBuilder opt = new OptionsBuilder().include(BenchmarkColumnValueSegmentPruner.class.getSimpleName());
     new Runner(opt.build()).run();
   }
 

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkColumnValueSegmentPruner.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkColumnValueSegmentPruner.java
@@ -66,6 +66,7 @@ import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.profile.JavaFlightRecorderProfiler;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
@@ -96,6 +97,10 @@ public class BenchmarkColumnValueSegmentPruner {
   public static void main(String[] args)
       throws Exception {
     ChainedOptionsBuilder opt = new OptionsBuilder().include(BenchmarkColumnValueSegmentPruner.class.getSimpleName());
+    if (args.length > 0 && args[0].equals("jfr")) {
+      opt = opt.addProfiler(JavaFlightRecorderProfiler.class)
+          .jvmArgsAppend("-XX:+UnlockDiagnosticVMOptions", "-XX:+DebugNonSafepoints");
+    }
     new Runner(opt.build()).run();
   }
 

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkServerSegmentPruner.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkServerSegmentPruner.java
@@ -1,0 +1,215 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.function.LongSupplier;
+import java.util.stream.IntStream;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.core.query.pruner.ColumnValueSegmentPruner;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair;
+import org.apache.pinot.spi.config.table.BloomFilterConfig;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.ChainedOptionsBuilder;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(1)
+@Warmup(iterations = 5, time = 2)
+@Measurement(iterations = 5, time = 2)
+@State(Scope.Benchmark)
+public class BenchmarkServerSegmentPruner {
+
+  public static final String QUERY_1 = "SELECT * FROM MyTable WHERE SORTED_COL IN ('1', '2', '3', '4')";
+
+  @Param({"10"})
+  private int _numRows;
+  @Param({"10", "100", "1000"})
+  private int _numSegments;
+
+  private String _query = QUERY_1;
+  String _scenario = "EXP(0.5)";
+  private List<IndexSegment> _indexSegments;
+  private LongSupplier _supplier;
+  private ColumnValueSegmentPruner _pruner;
+  private QueryContext _queryContext;
+
+  public static void main(String[] args)
+      throws Exception {
+    ChainedOptionsBuilder opt = new OptionsBuilder().include(BenchmarkServerSegmentPruner.class.getSimpleName());
+    new Runner(opt.build()).run();
+  }
+
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "BenchmarkServerSegmentPruner");
+  private static final String TABLE_NAME = "MyTable";
+  private static final String INT_COL_NAME = "INT_COL";
+  private static final String SORTED_COL_NAME = "SORTED_COL";
+  private static final String RAW_INT_COL_NAME = "RAW_INT_COL";
+  private static final String RAW_STRING_COL_NAME = "RAW_STRING_COL";
+  private static final String NO_INDEX_INT_COL_NAME = "NO_INDEX_INT_COL";
+  private static final String NO_INDEX_STRING_COL = "NO_INDEX_STRING_COL";
+  private static final String LOW_CARDINALITY_STRING_COL = "LOW_CARDINALITY_STRING_COL";
+
+
+  @Setup
+  public void setUp()
+      throws Exception {
+    _supplier = Distribution.createLongSupplier(42, _scenario);
+    FileUtils.deleteQuietly(INDEX_DIR);
+
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
+
+    Set<String> invertedIndexCols = new HashSet<>();
+    invertedIndexCols.add(INT_COL_NAME);
+    invertedIndexCols.add(LOW_CARDINALITY_STRING_COL);
+
+    Map<String, BloomFilterConfig> bloomFilterConfigMap = new HashMap<>();
+    bloomFilterConfigMap.put(SORTED_COL_NAME, new BloomFilterConfig(BloomFilterConfig.DEFAULT_FPP, 10000, false));
+
+    indexLoadingConfig.setRangeIndexColumns(invertedIndexCols);
+    indexLoadingConfig.setInvertedIndexColumns(invertedIndexCols);
+    indexLoadingConfig.setBloomFilterConfigs(bloomFilterConfigMap);
+
+    _indexSegments = new ArrayList<>();
+    for (int i = 0; i < _numSegments; i++) {
+      String name = "segment_" + i;
+      buildSegment(name);
+      _indexSegments.add(ImmutableSegmentLoader.load(new File(INDEX_DIR, name), indexLoadingConfig));
+    }
+
+    _pruner = new ColumnValueSegmentPruner();
+    _pruner.init(new PinotConfiguration());
+    _queryContext = QueryContextConverterUtils.getQueryContext(_query);
+  }
+
+  @TearDown
+  public void tearDown() {
+    for (IndexSegment indexSegment : _indexSegments) {
+      indexSegment.destroy();
+    }
+
+    FileUtils.deleteQuietly(INDEX_DIR);
+  }
+
+  private List<GenericRow> createTestData(int numRows) {
+    Map<Integer, String> strings = new HashMap<>();
+    List<GenericRow> rows = new ArrayList<>();
+    String[] lowCardinalityValues = IntStream.range(0, 10).mapToObj(i -> "value" + i)
+        .toArray(String[]::new);
+    for (int i = 0; i < numRows; i++) {
+      GenericRow row = new GenericRow();
+      row.putValue(SORTED_COL_NAME, numRows - i);
+      row.putValue(INT_COL_NAME, (int) _supplier.getAsLong());
+      row.putValue(NO_INDEX_INT_COL_NAME, (int) _supplier.getAsLong());
+      row.putValue(RAW_INT_COL_NAME, (int) _supplier.getAsLong());
+      row.putValue(RAW_STRING_COL_NAME,
+          strings.computeIfAbsent((int) _supplier.getAsLong(), k -> UUID.randomUUID().toString()));
+      row.putValue(NO_INDEX_STRING_COL, row.getValue(RAW_STRING_COL_NAME));
+      row.putValue(LOW_CARDINALITY_STRING_COL, lowCardinalityValues[i % lowCardinalityValues.length]);
+      rows.add(row);
+    }
+    return rows;
+  }
+
+  private void buildSegment(String segmentName)
+      throws Exception {
+    List<GenericRow> rows = createTestData(_numRows);
+    List<FieldConfig> fieldConfigs = new ArrayList<>();
+
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setInvertedIndexColumns(Collections.singletonList(INT_COL_NAME))
+        .setFieldConfigList(fieldConfigs)
+        .setNoDictionaryColumns(Arrays.asList(RAW_INT_COL_NAME, RAW_STRING_COL_NAME))
+        .setSortedColumn(SORTED_COL_NAME)
+        .setVarLengthDictionaryColumns(Collections.singletonList(SORTED_COL_NAME))
+        .setBloomFilterColumns(Collections.singletonList(SORTED_COL_NAME))
+        .setStarTreeIndexConfigs(Collections.singletonList(new StarTreeIndexConfig(
+            Arrays.asList(SORTED_COL_NAME, INT_COL_NAME), null, Collections.singletonList(
+                new AggregationFunctionColumnPair(AggregationFunctionType.SUM, RAW_INT_COL_NAME).toColumnName()),
+            Integer.MAX_VALUE)))
+        .build();
+    Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .addSingleValueDimension(SORTED_COL_NAME, FieldSpec.DataType.INT)
+        .addSingleValueDimension(NO_INDEX_INT_COL_NAME, FieldSpec.DataType.INT)
+        .addSingleValueDimension(RAW_INT_COL_NAME, FieldSpec.DataType.INT)
+        .addSingleValueDimension(INT_COL_NAME, FieldSpec.DataType.INT)
+        .addSingleValueDimension(RAW_STRING_COL_NAME, FieldSpec.DataType.STRING)
+        .addSingleValueDimension(NO_INDEX_STRING_COL, FieldSpec.DataType.STRING)
+        .addSingleValueDimension(LOW_CARDINALITY_STRING_COL, FieldSpec.DataType.STRING)
+        .build();
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setOutDir(INDEX_DIR.getPath());
+    config.setTableName(TABLE_NAME);
+    config.setSegmentName(segmentName);
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    try (RecordReader recordReader = new GenericRowRecordReader(rows)) {
+      driver.init(config, recordReader);
+      driver.build();
+    }
+  }
+
+  @Benchmark
+  public List<IndexSegment> query() {
+    return _pruner.prune(_indexSegments, _queryContext);
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -115,12 +115,16 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
 
   @Override
   public DataSource getDataSource(String column) {
-    return _lazyDataSource.computeIfAbsent(column, c -> {
-      ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(c);
+    DataSource result = _lazyDataSource.get(column);
+    if (result == null) {
+      ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(column);
       Preconditions.checkNotNull(columnMetadata,
-          "ColumnMetadata for %s should not be null. Potentially invalid column name specified.", c);
-      return new ImmutableDataSource(columnMetadata, _indexContainerMap.get(c));
-    });
+          "ColumnMetadata for %s should not be null. Potentially invalid column name specified.",
+          column);
+      result = new ImmutableDataSource(columnMetadata, _indexContainerMap.get(column));
+      _lazyDataSource.put(column, result);
+    }
+    return result;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -70,12 +70,9 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
     _starTreeIndexContainer = starTreeIndexContainer;
     _dataSources = new HashMap<>(HashUtil.getHashMapCapacity(segmentMetadata.getColumnMetadataMap().size()));
 
-    for (String colName : segmentMetadata.getColumnMetadataMap().keySet()) {
-      ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(colName);
-      Preconditions.checkNotNull(columnMetadata,
-          "ColumnMetadata for %s should not be null. Potentially invalid column name specified.",
-          colName);
-      _dataSources.put(colName, new ImmutableDataSource(columnMetadata, _indexContainerMap.get(colName)));
+    for (Map.Entry<String, ColumnMetadata> entry : segmentMetadata.getColumnMetadataMap().entrySet()) {
+      String colName = entry.getKey();
+      _dataSources.put(colName, new ImmutableDataSource(entry.getValue(), _indexContainerMap.get(colName)));
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/bloom/GuavaBloomFilterReaderUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/bloom/GuavaBloomFilterReaderUtils.java
@@ -20,6 +20,7 @@ package org.apache.pinot.segment.local.segment.index.readers.bloom;
 
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
+import com.google.common.primitives.Longs;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -37,6 +38,15 @@ public class GuavaBloomFilterReaderUtils {
    */
   public static byte[] hash(String value) {
     return HASH_FUNCTION.hashBytes(value.getBytes(UTF_8)).asBytes();
+  }
+
+  /**
+   *  Like {@link #hash(String)} but returns the hash as a {@link Hash128AsLongs}.
+   */
+  public static Hash128AsLongs hashAsLongs(String value) {
+    byte[] hash = hash(value);
+    return new Hash128AsLongs(Longs.fromBytes(hash[7], hash[6], hash[5], hash[4], hash[3], hash[2], hash[1], hash[0]),
+        Longs.fromBytes(hash[15], hash[14], hash[13], hash[12], hash[11], hash[10], hash[9], hash[8]));
   }
 
   /* Cheat sheet:
@@ -62,5 +72,23 @@ public class GuavaBloomFilterReaderUtils {
     double b = (double) sizeInBytes * Byte.SIZE / numInsertions;
     double k = b * Math.log(2);
     return Math.pow(2, -k);
+  }
+
+  public static class Hash128AsLongs {
+    private final long _hash1;
+    private final long _hash2;
+
+    private Hash128AsLongs(long hash1, long hash2) {
+      _hash1 = hash1;
+      _hash2 = hash2;
+    }
+
+    public long getHash1() {
+      return _hash1;
+    }
+
+    public long getHash2() {
+      return _hash2;
+    }
   }
 }


### PR DESCRIPTION
ColumnValueSegmentPruner was calculating the hash of each value once per segment. This PR introduces a hash cache that is populated the first time one of each element is hashed. 

The cost of this map is that it may have more entries than a normal map, but they are always going to be limited by the number of literal expressions in the where expression.

The PR includes a two JMH microbenchmarks:
- `BenchmarkBloomFilter` is a benchmark that shows the performance difference between calling several times `mightContain(String)` and `mightContain(long, long)`.
- `BenchmarkServerSegmentPruner` is a benchmark that tests `ColumnValueSegmentPruner`. It initially create several IndexSegments and given a query, analyses how much time is spent in pruning it

`BenchmarkServerSegmentPruner` has been executed with the previous `ColumnValueSegmentPruner` version and with the optimized one. The results on my laptop are the following:

```
Without optimization
Benchmark                           (_numRows)  (_numSegments)  Mode  Cnt   Score   Error  Units
BenchmarkServerSegmentPruner.query          10              10  avgt    5   1.426 ± 0.003  us/op
BenchmarkServerSegmentPruner.query          10             100  avgt    5  14.719 ± 1.342  us/op
BenchmarkServerSegmentPruner.query          10            1000  avgt    5  174.879 ± 5.115  us/op
BenchmarkServerSegmentPruner.query         100              10  avgt    5   1.459 ± 0.009  us/op
BenchmarkServerSegmentPruner.query         100             100  avgt    5  13.966 ± 0.520  us/op
BenchmarkServerSegmentPruner.query        1000              10  avgt    5   1.445 ± 0.004  us/op
BenchmarkServerSegmentPruner.query        1000             100  avgt    5  15.349 ± 0.071  us/op

With optimization
Benchmark                           (_numRows)  (_numSegments)  Mode  Cnt   Score   Error  Units
BenchmarkServerSegmentPruner.query          10              10  avgt    5   0.972 ± 0.003  us/op
BenchmarkServerSegmentPruner.query          10             100  avgt    5  10.149 ± 0.046  us/op
BenchmarkServerSegmentPruner.query          10            1000  avgt    5  135.063 ± 14.670  us/op
BenchmarkServerSegmentPruner.query         100              10  avgt    5   0.960 ± 0.006  us/op
BenchmarkServerSegmentPruner.query         100             100  avgt    5  10.512 ± 0.054  us/op
BenchmarkServerSegmentPruner.query        1000              10  avgt    5   0.796 ± 0.003  us/op
BenchmarkServerSegmentPruner.query        1000             100  avgt    5  10.636 ± 0.021  us/op
```

As expected, the cost seems to be linear on the number of segments and it doesn't seem that the number of rows affects the results in a significant way. Given that the tests with 1000 segments takes a while to build, I've decided to do not test it with different number of rows. In this benchmark the time spent pruning has been reduced 23% and 30%.