### PR TITLE
Deprecate debug options and always use query options

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1480,6 +1480,16 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   @VisibleForTesting
   static void setOptions(PinotQuery pinotQuery, long requestId, String query, JsonNode jsonRequest) {
     Map<String, String> queryOptions = new HashMap<>();
+    if (jsonRequest.has(Broker.Request.DEBUG_OPTIONS)) {
+      Map<String, String> debugOptions = getOptionsFromJson(jsonRequest, Broker.Request.DEBUG_OPTIONS);
+      if (!debugOptions.isEmpty()) {
+        LOGGER.debug("Debug options are set to: {} for request {}: {}", debugOptions, requestId, query);
+        pinotQuery.setDebugOptions(debugOptions);
+
+        // NOTE: Debug options are deprecated. Put all debug options into query options for backward compatibility.
+        queryOptions.putAll(debugOptions);
+      }
+    }
     if (jsonRequest.has(Broker.Request.QUERY_OPTIONS)) {
       Map<String, String> queryOptionsFromJson = getOptionsFromJson(jsonRequest, Broker.Request.QUERY_OPTIONS);
       queryOptions.putAll(queryOptionsFromJson);
@@ -1496,14 +1506,6 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     pinotQuery.setQueryOptions(queryOptions);
     if (!queryOptions.isEmpty()) {
       LOGGER.debug("Query options are set to: {} for request {}: {}", queryOptions, requestId, query);
-    }
-
-    if (jsonRequest.has(Broker.Request.DEBUG_OPTIONS)) {
-      Map<String, String> debugOptions = getOptionsFromJson(jsonRequest, Broker.Request.DEBUG_OPTIONS);
-      if (!debugOptions.isEmpty()) {
-        LOGGER.debug("Debug options are set to: {} for request {}: {}", debugOptions, requestId, query);
-        pinotQuery.setDebugOptions(debugOptions);
-      }
     }
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1483,6 +1483,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     if (jsonRequest.has(Broker.Request.DEBUG_OPTIONS)) {
       Map<String, String> debugOptions = getOptionsFromJson(jsonRequest, Broker.Request.DEBUG_OPTIONS);
       if (!debugOptions.isEmpty()) {
+        // TODO: Do not set debug options after releasing 0.11.0. Currently we kept it for backward compatibility.
         LOGGER.debug("Debug options are set to: {} for request {}: {}", debugOptions, requestId, query);
         pinotQuery.setDebugOptions(debugOptions);
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/RealtimeSegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/RealtimeSegmentSelector.java
@@ -33,6 +33,7 @@ import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.utils.HLCSegmentName;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.SegmentName;
+import org.apache.pinot.core.util.QueryOptionsUtils;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 
 
@@ -49,9 +50,6 @@ import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateM
  * </ul>
  */
 public class RealtimeSegmentSelector implements SegmentSelector {
-  public static final String ROUTING_OPTIONS_KEY = "routingOptions";
-  public static final String FORCE_HLC = "FORCE_HLC";
-
   private final AtomicLong _requestId = new AtomicLong();
   private volatile List<Set<String>> _hlcSegments;
   private volatile Set<String> _llcSegments;
@@ -95,8 +93,8 @@ public class RealtimeSegmentSelector implements SegmentSelector {
         if (instanceStateMap.containsValue(SegmentStateModel.CONSUMING)) {
           // Keep the first CONSUMING segment for each partition
           LLCSegmentName llcSegmentName = new LLCSegmentName(segment);
-          partitionIdToFirstConsumingLLCSegmentMap
-              .compute(llcSegmentName.getPartitionGroupId(), (k, consumingSegment) -> {
+          partitionIdToFirstConsumingLLCSegmentMap.compute(llcSegmentName.getPartitionGroupId(),
+              (k, consumingSegment) -> {
                 if (consumingSegment == null) {
                   return llcSegmentName;
                 } else {
@@ -150,14 +148,8 @@ public class RealtimeSegmentSelector implements SegmentSelector {
     }
 
     // Handle HLC and LLC coexisting scenario, select HLC segments only if it is forced in the routing options
-    Map<String, String> debugOptions = brokerRequest.getPinotQuery().getDebugOptions();
-    if (debugOptions != null) {
-      String routingOptions = debugOptions.get(ROUTING_OPTIONS_KEY);
-      if (routingOptions != null && routingOptions.toUpperCase().contains(FORCE_HLC)) {
-        return selectHLCSegments();
-      }
-    }
-    return selectLLCSegments();
+    return QueryOptionsUtils.isRoutingForceHLC(brokerRequest.getPinotQuery().getQueryOptions()) ? selectHLCSegments()
+        : selectLLCSegments();
   }
 
   private Set<String> selectHLCSegments() {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/RealtimeSegmentSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentselector/RealtimeSegmentSelector.java
@@ -93,8 +93,8 @@ public class RealtimeSegmentSelector implements SegmentSelector {
         if (instanceStateMap.containsValue(SegmentStateModel.CONSUMING)) {
           // Keep the first CONSUMING segment for each partition
           LLCSegmentName llcSegmentName = new LLCSegmentName(segment);
-          partitionIdToFirstConsumingLLCSegmentMap.compute(llcSegmentName.getPartitionGroupId(),
-              (k, consumingSegment) -> {
+          partitionIdToFirstConsumingLLCSegmentMap
+              .compute(llcSegmentName.getPartitionGroupId(), (k, consumingSegment) -> {
                 if (consumingSegment == null) {
                   return llcSegmentName;
                 } else {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BrokerRequestOptionsTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BrokerRequestOptionsTest.java
@@ -62,7 +62,7 @@ public class BrokerRequestOptionsTest {
     Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1);
     Assert.assertEquals(pinotQuery.getQueryOptions().get(Request.TRACE), "true");
 
-    // DEBUG_OPTIONS
+    // DEBUG_OPTIONS (debug options will also be included as query options)
     // Has debugOptions
     jsonRequest = JsonUtils.newObjectNode();
     jsonRequest.put(Request.DEBUG_OPTIONS, "debugOption1=foo");
@@ -70,7 +70,7 @@ public class BrokerRequestOptionsTest {
     BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
     Assert.assertEquals(pinotQuery.getDebugOptionsSize(), 1);
     Assert.assertEquals(pinotQuery.getDebugOptions().get("debugOption1"), "foo");
-    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 0);
+    Assert.assertEquals(pinotQuery.getQueryOptions(), pinotQuery.getDebugOptions());
 
     // Has multiple debugOptions
     jsonRequest.put(Request.DEBUG_OPTIONS, "debugOption1=foo;debugOption2=bar");
@@ -79,7 +79,7 @@ public class BrokerRequestOptionsTest {
     Assert.assertEquals(pinotQuery.getDebugOptionsSize(), 2);
     Assert.assertEquals(pinotQuery.getDebugOptions().get("debugOption1"), "foo");
     Assert.assertEquals(pinotQuery.getDebugOptions().get("debugOption2"), "bar");
-    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 0);
+    Assert.assertEquals(pinotQuery.getQueryOptions(), pinotQuery.getDebugOptions());
 
     // Invalid debug options
     jsonRequest.put(Request.DEBUG_OPTIONS, "debugOption1");
@@ -136,9 +136,10 @@ public class BrokerRequestOptionsTest {
     BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
     Assert.assertEquals(pinotQuery.getDebugOptionsSize(), 1);
     Assert.assertEquals(pinotQuery.getDebugOptions().get("debugOption1"), "foo");
-    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 3);
+    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 4);
     Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption1"), "bar");
     Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption2"), "moo");
     Assert.assertEquals(pinotQuery.getQueryOptions().get(Request.TRACE), "true");
+    Assert.assertEquals(pinotQuery.getDebugOptions().get("debugOption1"), "foo");
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentselector/SegmentSelectorTest.java
@@ -30,10 +30,9 @@ import org.apache.pinot.common.utils.HLCSegmentName;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.CommonConstants.Broker.Request;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.broker.routing.segmentselector.RealtimeSegmentSelector.FORCE_HLC;
-import static org.apache.pinot.broker.routing.segmentselector.RealtimeSegmentSelector.ROUTING_OPTIONS_KEY;
 import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING;
 import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE;
 import static org.mockito.Mockito.mock;
@@ -119,7 +118,8 @@ public class SegmentSelectorTest {
     assertEqualsNoOrder(segmentSelector.select(brokerRequest).toArray(), expectedSelectedLLCSegments);
 
     // When HLC is forced, should select the HLC segments from the second group
-    when(pinotQuery.getDebugOptions()).thenReturn(Collections.singletonMap(ROUTING_OPTIONS_KEY, FORCE_HLC));
+    when(pinotQuery.getQueryOptions()).thenReturn(
+        Collections.singletonMap(Request.QueryOptionKey.ROUTING_OPTIONS, Request.QueryOptionValue.ROUTING_FORCE_HLC));
     assertEqualsNoOrder(segmentSelector.select(brokerRequest).toArray(), hlcSegments[1]);
 
     // Remove all the HLC segments from ideal state, should select the LLC segments even when HLC is forced

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByOrderByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationGroupByOrderByPlanNode.java
@@ -76,8 +76,8 @@ public class AggregationGroupByOrderByPlanNode implements PlanNode {
             if (StarTreeUtils.isFitForStarTree(starTreeV2.getMetadata(), aggregationFunctionColumnPairs,
                 groupByExpressions, predicateEvaluatorsMap.keySet())) {
               TransformOperator transformOperator =
-                  new StarTreeTransformPlanNode(starTreeV2, aggregationFunctionColumnPairs, groupByExpressions,
-                      predicateEvaluatorsMap, _queryContext.getDebugOptions()).run();
+                  new StarTreeTransformPlanNode(_queryContext, starTreeV2, aggregationFunctionColumnPairs,
+                      groupByExpressions, predicateEvaluatorsMap).run();
               return new AggregationGroupByOrderByOperator(aggregationFunctions, groupByExpressions, transformOperator,
                   numTotalDocs, _queryContext, true);
             }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -59,9 +59,9 @@ import static org.apache.pinot.segment.spi.AggregationFunctionType.*;
 @SuppressWarnings("rawtypes")
 public class AggregationPlanNode implements PlanNode {
   private static final EnumSet<AggregationFunctionType> DICTIONARY_BASED_FUNCTIONS =
-      EnumSet.of(MIN, MINMV, MAX, MAXMV, MINMAXRANGE, MINMAXRANGEMV, DISTINCTCOUNT, DISTINCTCOUNTMV,
-          DISTINCTCOUNTHLL, DISTINCTCOUNTHLLMV, DISTINCTCOUNTRAWHLL, DISTINCTCOUNTRAWHLLMV,
-          SEGMENTPARTITIONEDDISTINCTCOUNT, DISTINCTCOUNTSMARTHLL);
+      EnumSet.of(MIN, MINMV, MAX, MAXMV, MINMAXRANGE, MINMAXRANGEMV, DISTINCTCOUNT, DISTINCTCOUNTMV, DISTINCTCOUNTHLL,
+          DISTINCTCOUNTHLLMV, DISTINCTCOUNTRAWHLL, DISTINCTCOUNTRAWHLLMV, SEGMENTPARTITIONEDDISTINCTCOUNT,
+          DISTINCTCOUNTSMARTHLL);
 
   // DISTINCTCOUNT excluded because consuming segment metadata contains unknown cardinality when there is no dictionary
   private static final EnumSet<AggregationFunctionType> METADATA_BASED_FUNCTIONS =
@@ -210,8 +210,8 @@ public class AggregationPlanNode implements PlanNode {
             if (StarTreeUtils.isFitForStarTree(starTreeV2.getMetadata(), aggregationFunctionColumnPairs, null,
                 predicateEvaluatorsMap.keySet())) {
               TransformOperator transformOperator =
-                  new StarTreeTransformPlanNode(starTreeV2, aggregationFunctionColumnPairs, null,
-                      predicateEvaluatorsMap, _queryContext.getDebugOptions()).run();
+                  new StarTreeTransformPlanNode(_queryContext, starTreeV2, aggregationFunctionColumnPairs, null,
+                      predicateEvaluatorsMap).run();
               return new AggregationOperator(aggregationFunctions, transformOperator, numTotalDocs, true);
             }
           }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -92,8 +92,8 @@ public class FilterPlanNode implements PlanNode {
       BaseFilterOperator filterOperator = constructPhysicalOperator(filter, numDocs);
       if (validDocIdsSnapshot != null) {
         BaseFilterOperator validDocFilter = new BitmapBasedFilterOperator(validDocIdsSnapshot, false, numDocs);
-        return FilterOperatorUtils.getAndFilterOperator(Arrays.asList(filterOperator, validDocFilter), numDocs,
-            _queryContext.getDebugOptions());
+        return FilterOperatorUtils.getAndFilterOperator(_queryContext, Arrays.asList(filterOperator, validDocFilter),
+            numDocs);
       } else {
         return filterOperator;
       }
@@ -203,7 +203,7 @@ public class FilterPlanNode implements PlanNode {
             childFilterOperators.add(childFilterOperator);
           }
         }
-        return FilterOperatorUtils.getAndFilterOperator(childFilterOperators, numDocs, _queryContext.getDebugOptions());
+        return FilterOperatorUtils.getAndFilterOperator(_queryContext, childFilterOperators, numDocs);
       case OR:
         childFilters = filter.getChildren();
         childFilterOperators = new ArrayList<>(childFilters.size());
@@ -217,12 +217,12 @@ public class FilterPlanNode implements PlanNode {
             childFilterOperators.add(childFilterOperator);
           }
         }
-        return FilterOperatorUtils.getOrFilterOperator(childFilterOperators, numDocs, _queryContext.getDebugOptions());
+        return FilterOperatorUtils.getOrFilterOperator(_queryContext, childFilterOperators, numDocs);
       case NOT:
         childFilters = filter.getChildren();
         assert childFilters.size() == 1;
         BaseFilterOperator childFilterOperator = constructPhysicalOperator(childFilters.get(0), numDocs);
-        return FilterOperatorUtils.getNotFilterOperator(childFilterOperator, numDocs, null);
+        return FilterOperatorUtils.getNotFilterOperator(_queryContext, childFilterOperator, numDocs);
       case PREDICATE:
         Predicate predicate = filter.getPredicate();
         ExpressionContext lhs = predicate.getLhs();

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -186,13 +186,15 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
 
   private void applyQueryOptions(QueryContext queryContext) {
     Map<String, String> queryOptions = queryContext.getQueryOptions();
-    Map<String, String> debugOptions = queryContext.getDebugOptions();
 
     // Set skipUpsert
     queryContext.setSkipUpsert(QueryOptionsUtils.isSkipUpsert(queryOptions));
 
     // Set skipStarTree
-    queryContext.setSkipStarTree(QueryOptionsUtils.isSkipStarTree(queryOptions, debugOptions));
+    queryContext.setSkipStarTree(QueryOptionsUtils.isSkipStarTree(queryOptions));
+
+    // Set skipScanFilterReorder
+    queryContext.setSkipScanFilterReorder(QueryOptionsUtils.isSkipScanFilterReorder(queryOptions));
 
     // Set maxExecutionThreads
     int maxExecutionThreads;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -80,7 +80,6 @@ public class QueryContext {
   private final int _limit;
   private final int _offset;
   private final Map<String, String> _queryOptions;
-  private final Map<String, String> _debugOptions;
   private final Map<ExpressionContext, ExpressionContext> _expressionOverrideHints;
   private final boolean _explain;
 
@@ -103,6 +102,8 @@ public class QueryContext {
   private boolean _skipUpsert;
   // Whether to skip star-tree index for the query
   private boolean _skipStarTree;
+  // Whether to skip reordering scan filters for the query
+  private boolean _skipScanFilterReorder;
   // Maximum number of threads used to execute the query
   private int _maxExecutionThreads = InstancePlanMakerImplV2.DEFAULT_MAX_EXECUTION_THREADS;
   // The following properties apply to group-by queries
@@ -121,8 +122,8 @@ public class QueryContext {
       List<ExpressionContext> selectExpressions, List<String> aliasList, @Nullable FilterContext filter,
       @Nullable List<ExpressionContext> groupByExpressions, @Nullable FilterContext havingFilter,
       @Nullable List<OrderByExpressionContext> orderByExpressions, int limit, int offset,
-      Map<String, String> queryOptions, @Nullable Map<String, String> debugOptions,
-      @Nullable Map<ExpressionContext, ExpressionContext> expressionOverrideHints, boolean explain) {
+      Map<String, String> queryOptions, @Nullable Map<ExpressionContext, ExpressionContext> expressionOverrideHints,
+      boolean explain) {
     _tableName = tableName;
     _subquery = subquery;
     _selectExpressions = selectExpressions;
@@ -134,7 +135,6 @@ public class QueryContext {
     _limit = limit;
     _offset = offset;
     _queryOptions = queryOptions;
-    _debugOptions = debugOptions;
     _expressionOverrideHints = expressionOverrideHints;
     _explain = explain;
   }
@@ -230,14 +230,6 @@ public class QueryContext {
   }
 
   /**
-   * Returns the debug options of the query, or {@code null} if not exist.
-   */
-  @Nullable
-  public Map<String, String> getDebugOptions() {
-    return _debugOptions;
-  }
-
-  /**
    * Returns {@code true} if the query is an EXPLAIN query, {@code false} otherwise.
    */
   public boolean isExplain() {
@@ -324,6 +316,14 @@ public class QueryContext {
     _skipStarTree = skipStarTree;
   }
 
+  public boolean isSkipScanFilterReorder() {
+    return _skipScanFilterReorder;
+  }
+
+  public void setSkipScanFilterReorder(boolean skipScanFilterReorder) {
+    _skipScanFilterReorder = skipScanFilterReorder;
+  }
+
   public int getMaxExecutionThreads() {
     return _maxExecutionThreads;
   }
@@ -394,8 +394,8 @@ public class QueryContext {
     return "QueryContext{" + "_tableName='" + _tableName + '\'' + ", _subquery=" + _subquery + ", _selectExpressions="
         + _selectExpressions + ", _aliasList=" + _aliasList + ", _filter=" + _filter + ", _groupByExpressions="
         + _groupByExpressions + ", _havingFilter=" + _havingFilter + ", _orderByExpressions=" + _orderByExpressions
-        + ", _limit=" + _limit + ", _offset=" + _offset + ", _queryOptions=" + _queryOptions + ", _debugOptions="
-        + _debugOptions + ", _expressionOverrideHints=" + _expressionOverrideHints + ", _explain=" + _explain + '}';
+        + ", _limit=" + _limit + ", _offset=" + _offset + ", _queryOptions=" + _queryOptions
+        + ", _expressionOverrideHints=" + _expressionOverrideHints + ", _explain=" + _explain + '}';
   }
 
   public static class Builder {
@@ -469,11 +469,6 @@ public class QueryContext {
       return this;
     }
 
-    public Builder setDebugOptions(Map<String, String> debugOptions) {
-      _debugOptions = debugOptions;
-      return this;
-    }
-
     public Builder setExpressionOverrideHints(Map<ExpressionContext, ExpressionContext> expressionOverrideHints) {
       _expressionOverrideHints = expressionOverrideHints;
       return this;
@@ -492,8 +487,7 @@ public class QueryContext {
       }
       QueryContext queryContext =
           new QueryContext(_tableName, _subquery, _selectExpressions, _aliasList, _filter, _groupByExpressions,
-              _havingFilter, _orderByExpressions, _limit, _offset, _queryOptions, _debugOptions,
-              _expressionOverrideHints, _explain);
+              _havingFilter, _orderByExpressions, _limit, _offset, _queryOptions, _expressionOverrideHints, _explain);
 
       // Pre-calculate the aggregation functions and columns for the query
       generateAggregationFunctions(queryContext);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextConverterUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextConverterUtils.java
@@ -159,7 +159,7 @@ public class QueryContextConverterUtils {
         .setSelectExpressions(selectExpressions).setAliasList(aliasList).setFilter(filter)
         .setGroupByExpressions(groupByExpressions).setOrderByExpressions(orderByExpressions)
         .setHavingFilter(havingFilter).setLimit(pinotQuery.getLimit()).setOffset(pinotQuery.getOffset())
-        .setQueryOptions(pinotQuery.getQueryOptions()).setDebugOptions(pinotQuery.getDebugOptions())
-        .setExpressionOverrideHints(expressionContextOverrideHints).setExplain(pinotQuery.isExplain()).build();
+        .setQueryOptions(pinotQuery.getQueryOptions()).setExpressionOverrideHints(expressionContextOverrideHints)
+        .setExplain(pinotQuery.isExplain()).build();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/operator/StarTreeFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/operator/StarTreeFilterOperator.java
@@ -197,14 +197,14 @@ public class StarTreeFilterOperator extends BaseFilterOperator {
         int numPredicateEvaluators = predicateEvaluators.size();
         if (numPredicateEvaluators == 1) {
           // Single predicate evaluator
-          childFilterOperators.add(
-              FilterOperatorUtils.getLeafFilterOperator(predicateEvaluators.get(0), dataSource, numDocs));
+          childFilterOperators
+              .add(FilterOperatorUtils.getLeafFilterOperator(predicateEvaluators.get(0), dataSource, numDocs));
         } else {
           // Predicate evaluators conjoined with OR
           List<BaseFilterOperator> orChildFilterOperators = new ArrayList<>(numPredicateEvaluators);
           for (PredicateEvaluator childPredicateEvaluator : predicateEvaluators) {
-            orChildFilterOperators.add(
-                FilterOperatorUtils.getLeafFilterOperator(childPredicateEvaluator, dataSource, numDocs));
+            orChildFilterOperators
+                .add(FilterOperatorUtils.getLeafFilterOperator(childPredicateEvaluator, dataSource, numDocs));
           }
           childFilterOperators.add(
               FilterOperatorUtils.getOrFilterOperator(_queryContext, orChildFilterOperators, numDocs));

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/operator/StarTreeFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/operator/StarTreeFilterOperator.java
@@ -41,6 +41,7 @@ import org.apache.pinot.core.operator.filter.BitmapBasedFilterOperator;
 import org.apache.pinot.core.operator.filter.EmptyFilterOperator;
 import org.apache.pinot.core.operator.filter.FilterOperatorUtils;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.startree.CompositePredicateEvaluator;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.startree.StarTree;
@@ -114,27 +115,23 @@ public class StarTreeFilterOperator extends BaseFilterOperator {
       _remainingPredicateColumns = remainingPredicateColumns;
     }
   }
+
   // If (number of matching dictionary ids * threshold) > (number of child nodes), use scan to traverse nodes instead of
   // binary search on each dictionary id
   private static final int USE_SCAN_TO_TRAVERSE_NODES_THRESHOLD = 10;
 
-  // Star-tree
+  private final QueryContext _queryContext;
   private final StarTreeV2 _starTreeV2;
-  // Map from column to predicate evaluators
   private final Map<String, List<CompositePredicateEvaluator>> _predicateEvaluatorsMap;
-  // Set of group-by columns
   private final Set<String> _groupByColumns;
-
-  private final Map<String, String> _debugOptions;
 
   boolean _resultEmpty = false;
 
-  public StarTreeFilterOperator(StarTreeV2 starTreeV2,
-      Map<String, List<CompositePredicateEvaluator>> predicateEvaluatorsMap, Set<String> groupByColumns,
-      @Nullable Map<String, String> debugOptions) {
+  public StarTreeFilterOperator(QueryContext queryContext, StarTreeV2 starTreeV2,
+      Map<String, List<CompositePredicateEvaluator>> predicateEvaluatorsMap, @Nullable Set<String> groupByColumns) {
+    _queryContext = queryContext;
     _starTreeV2 = starTreeV2;
     _predicateEvaluatorsMap = predicateEvaluatorsMap;
-    _debugOptions = debugOptions;
 
     if (groupByColumns != null) {
       _groupByColumns = new HashSet<>(groupByColumns);
@@ -157,7 +154,6 @@ public class StarTreeFilterOperator extends BaseFilterOperator {
   public boolean isResultEmpty() {
     return _resultEmpty;
   }
-
 
   @Override
   public String toExplainString() {
@@ -201,22 +197,22 @@ public class StarTreeFilterOperator extends BaseFilterOperator {
         int numPredicateEvaluators = predicateEvaluators.size();
         if (numPredicateEvaluators == 1) {
           // Single predicate evaluator
-          childFilterOperators
-              .add(FilterOperatorUtils.getLeafFilterOperator(predicateEvaluators.get(0), dataSource, numDocs));
+          childFilterOperators.add(
+              FilterOperatorUtils.getLeafFilterOperator(predicateEvaluators.get(0), dataSource, numDocs));
         } else {
           // Predicate evaluators conjoined with OR
           List<BaseFilterOperator> orChildFilterOperators = new ArrayList<>(numPredicateEvaluators);
           for (PredicateEvaluator childPredicateEvaluator : predicateEvaluators) {
-            orChildFilterOperators
-                .add(FilterOperatorUtils.getLeafFilterOperator(childPredicateEvaluator, dataSource, numDocs));
+            orChildFilterOperators.add(
+                FilterOperatorUtils.getLeafFilterOperator(childPredicateEvaluator, dataSource, numDocs));
           }
-          childFilterOperators
-              .add(FilterOperatorUtils.getOrFilterOperator(orChildFilterOperators, numDocs, _debugOptions));
+          childFilterOperators.add(
+              FilterOperatorUtils.getOrFilterOperator(_queryContext, orChildFilterOperators, numDocs));
         }
       }
     }
 
-    return FilterOperatorUtils.getAndFilterOperator(childFilterOperators, numDocs, _debugOptions);
+    return FilterOperatorUtils.getAndFilterOperator(_queryContext, childFilterOperators, numDocs);
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeDocIdSetPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeDocIdSetPlanNode.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 import org.apache.pinot.core.operator.DocIdSetOperator;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.core.plan.PlanNode;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.startree.CompositePredicateEvaluator;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 
@@ -32,11 +33,10 @@ import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 public class StarTreeDocIdSetPlanNode implements PlanNode {
   private final StarTreeFilterPlanNode _starTreeFilterPlanNode;
 
-  public StarTreeDocIdSetPlanNode(StarTreeV2 starTreeV2,
-      Map<String, List<CompositePredicateEvaluator>> predicateEvaluatorsMap, @Nullable Set<String> groupByColumns,
-      @Nullable Map<String, String> debugOptions) {
+  public StarTreeDocIdSetPlanNode(QueryContext queryContext, StarTreeV2 starTreeV2,
+      Map<String, List<CompositePredicateEvaluator>> predicateEvaluatorsMap, @Nullable Set<String> groupByColumns) {
     _starTreeFilterPlanNode =
-        new StarTreeFilterPlanNode(starTreeV2, predicateEvaluatorsMap, groupByColumns, debugOptions);
+        new StarTreeFilterPlanNode(queryContext, starTreeV2, predicateEvaluatorsMap, groupByColumns);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeFilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeFilterPlanNode.java
@@ -23,28 +23,28 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.plan.PlanNode;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.startree.CompositePredicateEvaluator;
 import org.apache.pinot.core.startree.operator.StarTreeFilterOperator;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 
 
 public class StarTreeFilterPlanNode implements PlanNode {
+  private final QueryContext _queryContext;
   private final StarTreeV2 _starTreeV2;
   private final Map<String, List<CompositePredicateEvaluator>> _predicateEvaluatorsMap;
   private final Set<String> _groupByColumns;
-  private final Map<String, String> _debugOptions;
 
-  public StarTreeFilterPlanNode(StarTreeV2 starTreeV2,
-      Map<String, List<CompositePredicateEvaluator>> predicateEvaluatorsMap, @Nullable Set<String> groupByColumns,
-      @Nullable Map<String, String> debugOptions) {
+  public StarTreeFilterPlanNode(QueryContext queryContext, StarTreeV2 starTreeV2,
+      Map<String, List<CompositePredicateEvaluator>> predicateEvaluatorsMap, @Nullable Set<String> groupByColumns) {
+    _queryContext = queryContext;
     _starTreeV2 = starTreeV2;
     _predicateEvaluatorsMap = predicateEvaluatorsMap;
     _groupByColumns = groupByColumns;
-    _debugOptions = debugOptions;
   }
 
   @Override
   public StarTreeFilterOperator run() {
-    return new StarTreeFilterOperator(_starTreeV2, _predicateEvaluatorsMap, _groupByColumns, _debugOptions);
+    return new StarTreeFilterOperator(_queryContext, _starTreeV2, _predicateEvaluatorsMap, _groupByColumns);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeProjectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeProjectionPlanNode.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.operator.ProjectionOperator;
 import org.apache.pinot.core.plan.PlanNode;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.startree.CompositePredicateEvaluator;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
@@ -34,15 +35,14 @@ public class StarTreeProjectionPlanNode implements PlanNode {
   private final Map<String, DataSource> _dataSourceMap;
   private final StarTreeDocIdSetPlanNode _starTreeDocIdSetPlanNode;
 
-  public StarTreeProjectionPlanNode(StarTreeV2 starTreeV2, Set<String> projectionColumns,
-      Map<String, List<CompositePredicateEvaluator>> predicateEvaluatorsMap, @Nullable Set<String> groupByColumns,
-      @Nullable Map<String, String> debugOptions) {
+  public StarTreeProjectionPlanNode(QueryContext queryContext, StarTreeV2 starTreeV2, Set<String> projectionColumns,
+      Map<String, List<CompositePredicateEvaluator>> predicateEvaluatorsMap, @Nullable Set<String> groupByColumns) {
     _dataSourceMap = new HashMap<>();
     for (String projectionColumn : projectionColumns) {
       _dataSourceMap.put(projectionColumn, starTreeV2.getDataSource(projectionColumn));
     }
     _starTreeDocIdSetPlanNode =
-        new StarTreeDocIdSetPlanNode(starTreeV2, predicateEvaluatorsMap, groupByColumns, debugOptions);
+        new StarTreeDocIdSetPlanNode(queryContext, starTreeV2, predicateEvaluatorsMap, groupByColumns);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeTransformPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeTransformPlanNode.java
@@ -28,6 +28,7 @@ import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.plan.PlanNode;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.startree.CompositePredicateEvaluator;
 import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
@@ -37,10 +38,9 @@ public class StarTreeTransformPlanNode implements PlanNode {
   private final List<ExpressionContext> _groupByExpressions;
   private final StarTreeProjectionPlanNode _starTreeProjectionPlanNode;
 
-  public StarTreeTransformPlanNode(StarTreeV2 starTreeV2,
+  public StarTreeTransformPlanNode(QueryContext queryContext, StarTreeV2 starTreeV2,
       AggregationFunctionColumnPair[] aggregationFunctionColumnPairs, @Nullable ExpressionContext[] groupByExpressions,
-      Map<String, List<CompositePredicateEvaluator>> predicateEvaluatorsMap,
-      @Nullable Map<String, String> debugOptions) {
+      Map<String, List<CompositePredicateEvaluator>> predicateEvaluatorsMap) {
     Set<String> projectionColumns = new HashSet<>();
     for (AggregationFunctionColumnPair aggregationFunctionColumnPair : aggregationFunctionColumnPairs) {
       projectionColumns.add(aggregationFunctionColumnPair.toColumnName());
@@ -58,8 +58,8 @@ public class StarTreeTransformPlanNode implements PlanNode {
       groupByColumns = null;
     }
     _starTreeProjectionPlanNode =
-        new StarTreeProjectionPlanNode(starTreeV2, projectionColumns, predicateEvaluatorsMap, groupByColumns,
-            debugOptions);
+        new StarTreeProjectionPlanNode(queryContext, starTreeV2, projectionColumns, predicateEvaluatorsMap,
+            groupByColumns);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
@@ -47,14 +47,20 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.SKIP_UPSERT));
   }
 
-  // TODO: Debug options has been kept for backward compatibility should be deprecated in future releases
-  public static boolean isSkipStarTree(Map<String, String> queryOptions, Map<String, String> debugOptions) {
-    boolean disabledWithQueryOption = !Boolean.parseBoolean(
-        queryOptions.getOrDefault(Request.QueryOptionKey.USE_STAR_TREE_KEY, "true"));
-    return disabledWithQueryOption || (debugOptions != null
-        && !Boolean.parseBoolean(debugOptions.getOrDefault(Request.QueryOptionKey.USE_STAR_TREE_KEY, "true")));
+  public static boolean isSkipStarTree(Map<String, String> queryOptions) {
+    return "false".equalsIgnoreCase(queryOptions.get(Request.QueryOptionKey.USE_STAR_TREE));
   }
 
+  public static boolean isRoutingForceHLC(Map<String, String> queryOptions) {
+    String routingOptions = queryOptions.get(Request.QueryOptionKey.ROUTING_OPTIONS);
+    return routingOptions != null && routingOptions.toUpperCase().contains(Request.QueryOptionValue.ROUTING_FORCE_HLC);
+  }
+
+  public static boolean isSkipScanFilterReorder(Map<String, String> queryOptions) {
+    return "false".equalsIgnoreCase(queryOptions.get(Request.QueryOptionKey.USE_SCAN_REORDER_OPTIMIZATION));
+  }
+
+  @Nullable
   public static Integer getNumReplicaGroupsToQuery(Map<String, String> queryOptions) {
     String numReplicaGroupsToQuery = queryOptions.get(Request.QueryOptionKey.NUM_REPLICA_GROUPS_TO_QUERY);
     return numReplicaGroupsToQuery != null ? Integer.parseInt(numReplicaGroupsToQuery) : null;

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/FilterOperatorUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/FilterOperatorUtilsTest.java
@@ -20,12 +20,15 @@ package org.apache.pinot.core.operator.filter;
 
 import java.util.Arrays;
 import java.util.Collections;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.testng.annotations.Test;
 
+import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertTrue;
 
 
 public class FilterOperatorUtilsTest {
+  private static final QueryContext QUERY_CONTEXT = mock(QueryContext.class);
   private static final int NUM_DOCS = 10;
   private static final BaseFilterOperator EMPTY_FILTER_OPERATOR = EmptyFilterOperator.getInstance();
   private static final BaseFilterOperator MATCH_ALL_FILTER_OPERATOR = new MatchAllFilterOperator(NUM_DOCS);
@@ -34,62 +37,68 @@ public class FilterOperatorUtilsTest {
   @Test
   public void testGetAndFilterOperator() {
     BaseFilterOperator filterOperator =
-        FilterOperatorUtils.getAndFilterOperator(Collections.emptyList(), NUM_DOCS, null);
+        FilterOperatorUtils.getAndFilterOperator(QUERY_CONTEXT, Collections.emptyList(), NUM_DOCS);
     assertTrue(filterOperator instanceof MatchAllFilterOperator);
 
     filterOperator =
-        FilterOperatorUtils.getAndFilterOperator(Collections.singletonList(EMPTY_FILTER_OPERATOR), NUM_DOCS, null);
+        FilterOperatorUtils.getAndFilterOperator(QUERY_CONTEXT, Collections.singletonList(EMPTY_FILTER_OPERATOR),
+            NUM_DOCS);
     assertTrue(filterOperator instanceof EmptyFilterOperator);
 
     filterOperator =
-        FilterOperatorUtils.getAndFilterOperator(Collections.singletonList(MATCH_ALL_FILTER_OPERATOR), NUM_DOCS, null);
+        FilterOperatorUtils.getAndFilterOperator(QUERY_CONTEXT, Collections.singletonList(MATCH_ALL_FILTER_OPERATOR),
+            NUM_DOCS);
     assertTrue(filterOperator instanceof MatchAllFilterOperator);
 
     filterOperator =
-        FilterOperatorUtils.getAndFilterOperator(Collections.singletonList(REGULAR_FILTER_OPERATOR), NUM_DOCS, null);
+        FilterOperatorUtils.getAndFilterOperator(QUERY_CONTEXT, Collections.singletonList(REGULAR_FILTER_OPERATOR),
+            NUM_DOCS);
     assertTrue(filterOperator instanceof TestFilterOperator);
 
-    filterOperator = FilterOperatorUtils
-        .getAndFilterOperator(Arrays.asList(EMPTY_FILTER_OPERATOR, MATCH_ALL_FILTER_OPERATOR), NUM_DOCS, null);
+    filterOperator = FilterOperatorUtils.getAndFilterOperator(QUERY_CONTEXT,
+        Arrays.asList(EMPTY_FILTER_OPERATOR, MATCH_ALL_FILTER_OPERATOR), NUM_DOCS);
     assertTrue(filterOperator instanceof EmptyFilterOperator);
 
-    filterOperator = FilterOperatorUtils
-        .getAndFilterOperator(Arrays.asList(EMPTY_FILTER_OPERATOR, REGULAR_FILTER_OPERATOR), NUM_DOCS, null);
+    filterOperator = FilterOperatorUtils.getAndFilterOperator(QUERY_CONTEXT,
+        Arrays.asList(EMPTY_FILTER_OPERATOR, REGULAR_FILTER_OPERATOR), NUM_DOCS);
     assertTrue(filterOperator instanceof EmptyFilterOperator);
 
-    filterOperator = FilterOperatorUtils
-        .getAndFilterOperator(Arrays.asList(MATCH_ALL_FILTER_OPERATOR, REGULAR_FILTER_OPERATOR), NUM_DOCS, null);
+    filterOperator = FilterOperatorUtils.getAndFilterOperator(QUERY_CONTEXT,
+        Arrays.asList(MATCH_ALL_FILTER_OPERATOR, REGULAR_FILTER_OPERATOR), NUM_DOCS);
     assertTrue(filterOperator instanceof TestFilterOperator);
   }
 
   @Test
   public void testGetOrFilterOperator() {
     BaseFilterOperator filterOperator =
-        FilterOperatorUtils.getOrFilterOperator(Collections.emptyList(), NUM_DOCS, null);
+        FilterOperatorUtils.getOrFilterOperator(QUERY_CONTEXT, Collections.emptyList(), NUM_DOCS);
     assertTrue(filterOperator instanceof EmptyFilterOperator);
 
     filterOperator =
-        FilterOperatorUtils.getOrFilterOperator(Collections.singletonList(EMPTY_FILTER_OPERATOR), NUM_DOCS, null);
+        FilterOperatorUtils.getOrFilterOperator(QUERY_CONTEXT, Collections.singletonList(EMPTY_FILTER_OPERATOR),
+            NUM_DOCS);
     assertTrue(filterOperator instanceof EmptyFilterOperator);
 
     filterOperator =
-        FilterOperatorUtils.getOrFilterOperator(Collections.singletonList(MATCH_ALL_FILTER_OPERATOR), NUM_DOCS, null);
+        FilterOperatorUtils.getOrFilterOperator(QUERY_CONTEXT, Collections.singletonList(MATCH_ALL_FILTER_OPERATOR),
+            NUM_DOCS);
     assertTrue(filterOperator instanceof MatchAllFilterOperator);
 
     filterOperator =
-        FilterOperatorUtils.getOrFilterOperator(Collections.singletonList(REGULAR_FILTER_OPERATOR), NUM_DOCS, null);
+        FilterOperatorUtils.getOrFilterOperator(QUERY_CONTEXT, Collections.singletonList(REGULAR_FILTER_OPERATOR),
+            NUM_DOCS);
     assertTrue(filterOperator instanceof TestFilterOperator);
 
-    filterOperator = FilterOperatorUtils
-        .getOrFilterOperator(Arrays.asList(EMPTY_FILTER_OPERATOR, MATCH_ALL_FILTER_OPERATOR), NUM_DOCS, null);
+    filterOperator = FilterOperatorUtils.getOrFilterOperator(QUERY_CONTEXT,
+        Arrays.asList(EMPTY_FILTER_OPERATOR, MATCH_ALL_FILTER_OPERATOR), NUM_DOCS);
     assertTrue(filterOperator instanceof MatchAllFilterOperator);
 
-    filterOperator = FilterOperatorUtils
-        .getOrFilterOperator(Arrays.asList(EMPTY_FILTER_OPERATOR, REGULAR_FILTER_OPERATOR), NUM_DOCS, null);
+    filterOperator = FilterOperatorUtils.getOrFilterOperator(QUERY_CONTEXT,
+        Arrays.asList(EMPTY_FILTER_OPERATOR, REGULAR_FILTER_OPERATOR), NUM_DOCS);
     assertTrue(filterOperator instanceof TestFilterOperator);
 
-    filterOperator = FilterOperatorUtils
-        .getOrFilterOperator(Arrays.asList(MATCH_ALL_FILTER_OPERATOR, REGULAR_FILTER_OPERATOR), NUM_DOCS, null);
+    filterOperator = FilterOperatorUtils.getOrFilterOperator(QUERY_CONTEXT,
+        Arrays.asList(MATCH_ALL_FILTER_OPERATOR, REGULAR_FILTER_OPERATOR), NUM_DOCS);
     assertTrue(filterOperator instanceof MatchAllFilterOperator);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
@@ -257,7 +257,7 @@ abstract class BaseStarTreeV2Test<R, A> {
 
     // Extract values with star-tree
     PlanNode starTreeFilterPlanNode =
-        new StarTreeFilterPlanNode(_starTreeV2, predicateEvaluatorsMap, groupByColumnSet, null);
+        new StarTreeFilterPlanNode(queryContext, _starTreeV2, predicateEvaluatorsMap, groupByColumnSet);
     List<ForwardIndexReader> starTreeAggregationColumnReaders = new ArrayList<>(numAggregations);
     for (AggregationFunctionColumnPair aggregationFunctionColumnPair : aggregationFunctionColumnPairs) {
       starTreeAggregationColumnReaders.add(

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -249,7 +249,9 @@ public class CommonConstants {
       public static class QueryOptionKey {
         public static final String TIMEOUT_MS = "timeoutMs";
         public static final String SKIP_UPSERT = "skipUpsert";
-        public static final String USE_STAR_TREE_KEY = "useStarTree";
+        public static final String USE_STAR_TREE = "useStarTree";
+        public static final String ROUTING_OPTIONS = "routingOptions";
+        public static final String USE_SCAN_REORDER_OPTIMIZATION = "useScanReorderOpt";
         public static final String MAX_EXECUTION_THREADS = "maxExecutionThreads";
         public static final String MIN_SEGMENT_GROUP_TRIM_SIZE = "minSegmentGroupTrimSize";
         public static final String MIN_SERVER_GROUP_TRIM_SIZE = "minServerGroupTrimSize";
@@ -263,6 +265,10 @@ public class CommonConstants {
         public static final String RESPONSE_FORMAT = "responseFormat";
         @Deprecated
         public static final String GROUP_BY_MODE = "groupByMode";
+      }
+
+      public static class QueryOptionValue {
+        public static final String ROUTING_FORCE_HLC = "FORCE_HLC";
       }
     }
 


### PR DESCRIPTION
Currently there are 2 ways to provide extra options when running a query: query options and debug options. Most of the options are provided through the query options, and user can embed query options into the query which makes it very easy to use. On the other hand, debug options can only be provided through the query parameter of the broker GET request, which is hard to use, and sometimes impossible when querying the controller. Managing 2 sets of query options also adds confusion and extra management overhead.
This PR simplifies the query options by also including the debug options into the query options, and only look at query options when executing the query.

## Release-Note
The following debug options can also be accepted as query options:
- routingOptions
- useScanReorderOpt