### PR TITLE
Fix typo in AddTableCommand

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTableCommand.java
@@ -185,7 +185,7 @@ public class AddTableCommand extends AbstractBaseAdminCommand implements Command
         .sendRequest("POST", ControllerRequestURLBuilder.baseUrl(_controllerAddress).forTableCreate(), node.toString(),
             makeAuthHeaders(makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password)));
     LOGGER.info(res);
-    return res.contains("succesfully added");
+    return res.contains("successfully added");
   }
 
   @Override


### PR DESCRIPTION
Fix typo in sentence "Table {tablename} succesfully added" -> Table {tablename} successfully added"