### PR TITLE
Make row metadata available in Kafka 2.0 record ingestion

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMessageBatch.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMessageBatch.java
@@ -19,15 +19,15 @@
 package org.apache.pinot.plugin.stream.kafka20;
 
 import java.util.List;
-import org.apache.pinot.plugin.stream.kafka.MessageAndOffset;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.MessageBatch;
+import org.apache.pinot.spi.stream.RowMetadata;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 
 
 public class KafkaMessageBatch implements MessageBatch<byte[]> {
 
-  private final List<MessageAndOffset> _messageList;
+  private final List<MessageAndOffsetAndMetadata> _messageList;
   private final int _unfilteredMessageCount;
   private final long _lastOffset;
 
@@ -36,7 +36,7 @@ public class KafkaMessageBatch implements MessageBatch<byte[]> {
    * @param lastOffset the offset of the last message in the batch
    * @param batch the messages, which may be smaller than {@see unfilteredMessageCount}
    */
-  public KafkaMessageBatch(int unfilteredMessageCount, long lastOffset, List<MessageAndOffset> batch) {
+  public KafkaMessageBatch(int unfilteredMessageCount, long lastOffset, List<MessageAndOffsetAndMetadata> batch) {
     _messageList = batch;
     _lastOffset = lastOffset;
     _unfilteredMessageCount = unfilteredMessageCount;
@@ -80,5 +80,10 @@ public class KafkaMessageBatch implements MessageBatch<byte[]> {
   @Override
   public StreamPartitionMsgOffset getOffsetOfNextBatch() {
     return new LongMsgOffset(_lastOffset + 1);
+  }
+
+  @Override
+  public RowMetadata getMetadataAtIndex(int index) {
+    return _messageList.get(index).getRowMetadata();
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConnectionHandler.java
@@ -45,6 +45,7 @@ public abstract class KafkaPartitionLevelConnectionHandler {
   protected final String _topic;
   protected final Consumer<String, Bytes> _consumer;
   protected final TopicPartition _topicPartition;
+  protected final RowMetadataExtractor _rowMetadataExtractor;
 
   public KafkaPartitionLevelConnectionHandler(String clientId, StreamConfig streamConfig, int partition) {
     _config = new KafkaPartitionLevelStreamConfig(streamConfig);
@@ -62,6 +63,7 @@ public abstract class KafkaPartitionLevelConnectionHandler {
     _consumer = new KafkaConsumer<>(consumerProp);
     _topicPartition = new TopicPartition(_topic, _partition);
     _consumer.assign(Collections.singletonList(_topicPartition));
+    _rowMetadataExtractor = RowMetadataExtractor.build(_config.isPopulateMetadata());
   }
 
   public void close()

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/MessageAndOffsetAndMetadata.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/MessageAndOffsetAndMetadata.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.kafka20;
+
+import java.nio.ByteBuffer;
+import org.apache.pinot.plugin.stream.kafka.MessageAndOffset;
+import org.apache.pinot.spi.stream.RowMetadata;
+
+
+public class MessageAndOffsetAndMetadata extends MessageAndOffset {
+  private final RowMetadata _rowMetadata;
+
+  public MessageAndOffsetAndMetadata(byte[] message, long offset, RowMetadata rowMetadata) {
+    super(message, offset);
+    _rowMetadata = rowMetadata;
+  }
+
+  public MessageAndOffsetAndMetadata(ByteBuffer message, long offset, RowMetadata rowMetadata) {
+    super(message, offset);
+    _rowMetadata = rowMetadata;
+  }
+
+  public RowMetadata getRowMetadata() {
+    return _rowMetadata;
+  }
+}

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/RowMetadataExtractor.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/RowMetadataExtractor.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.kafka20;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.pinot.spi.stream.RowMetadata;
+import org.apache.pinot.spi.stream.StreamMessageMetadata;
+
+
+@FunctionalInterface
+public interface RowMetadataExtractor {
+  static RowMetadataExtractor build(boolean populateMetadata) {
+    return populateMetadata ? record -> new StreamMessageMetadata(record.timestamp()) : record -> null;
+  }
+
+  RowMetadata extract(ConsumerRecord<?, ?> consumerRecord);
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
@@ -49,6 +49,7 @@ public class StreamConfigProperties {
   public static final String GROUP_ID = "hlc.group.id";
   public static final String PARTITION_MSG_OFFSET_FACTORY_CLASS = "partition.offset.factory.class.name";
   public static final String TOPIC_CONSUMPTION_RATE_LIMIT = "topic.consumption.rate.limit";
+  public static final String METADATA_POPULATE = "metadata.populate";
 
   /**
    * Time threshold that will keep the realtime segment open for before we complete the segment


### PR DESCRIPTION
This is a "new feature" of Kafka 2.0 stream ingestion plugin

Fixes #8773 
