### PR TITLE
Fix a typo in ServerInstance.startQueryServer()

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
@@ -183,7 +183,7 @@ public class ServerInstance {
       _grpcQueryServer.start();
     }
 
-    _dataManagerStarted = true;
+    _queryServerStarted = true;
     LOGGER.info("Finish starting query server");
   }
 


### PR DESCRIPTION
Fix a typo introduced in #8785 