### PR TITLE
Default turn on grpc server endpoint

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineGRPCServerIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineGRPCServerIntegrationTest.java
@@ -32,7 +32,6 @@ import org.apache.pinot.common.utils.grpc.GrpcRequestBuilder;
 import org.apache.pinot.core.common.datatable.DataTableFactory;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
 import org.apache.pinot.util.TestUtils;
@@ -44,11 +43,6 @@ import static org.testng.Assert.*;
 
 
 public class OfflineGRPCServerIntegrationTest extends BaseClusterIntegrationTest {
-
-  @Override
-  protected void overrideServerConf(PinotConfiguration serverConf) {
-    serverConf.setProperty(CommonConstants.Server.CONFIG_OF_ENABLE_GRPC_SERVER, true);
-  }
 
   @BeforeClass
   public void setUp()

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineSecureGRPCServerIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineSecureGRPCServerIntegrationTest.java
@@ -34,7 +34,6 @@ public class OfflineSecureGRPCServerIntegrationTest extends OfflineGRPCServerInt
 
   @Override
   protected void overrideServerConf(PinotConfiguration serverConf) {
-    serverConf.setProperty(Server.CONFIG_OF_ENABLE_GRPC_SERVER, true);
     serverConf.setProperty(Server.CONFIG_OF_GRPCTLS_SERVER_ENABLED, true);
     serverConf.setProperty("pinot.server.grpctls.client.auth.enabled", true);
     serverConf.setProperty("pinot.server.grpctls.keystore.type", JKS);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -311,7 +311,7 @@ public class CommonConstants {
     public static final boolean DEFAULT_NETTY_SERVER_ENABLED = true;
     public static final String CONFIG_OF_NETTY_PORT = "pinot.server.netty.port";
     public static final String CONFIG_OF_ENABLE_GRPC_SERVER = "pinot.server.grpc.enable";
-    public static final boolean DEFAULT_ENABLE_GRPC_SERVER = false;
+    public static final boolean DEFAULT_ENABLE_GRPC_SERVER = true;
     public static final String CONFIG_OF_GRPC_PORT = "pinot.server.grpc.port";
     public static final int DEFAULT_GRPC_PORT = 8090;
     public static final String CONFIG_OF_GRPCTLS_SERVER_ENABLED = "pinot.server.grpctls.enabled";


### PR DESCRIPTION
With more people using pinot with prestodb/trino, the default netty server endpoint doesn't handle old broker requests anymore(They all on 0.8.0 or 0.10.0, which doesn't set PinotQuery in PinotScatterGatherQueryClient).

So by default, Pinot has to enable grpc endpoint for prestodb and trino to connect.