### PR TITLE
Shade Hadoop Dependencies

### DIFF
--- a/pinot-distribution/pom.xml
+++ b/pinot-distribution/pom.xml
@@ -187,6 +187,10 @@
                   <pattern>org.apache.parquet</pattern>
                   <shadedPattern>shaded.org.apache.parquet</shadedPattern>
                 </relocation>
+                <relocation>
+                  <pattern>org.apache.hadoop</pattern>
+                  <shadedPattern>shaded.org.apache.hadoop</shadedPattern>
+                </relocation>
               </relocations>
             </configuration>
           </execution>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -126,6 +126,10 @@
                       <shadedPattern>shaded.org.apache.parquet</shadedPattern>
                     </relocation>
                     <relocation>
+                      <pattern>org.apache.hadoop</pattern>
+                      <shadedPattern>shaded.org.apache.hadoop</shadedPattern>
+                    </relocation>
+                    <relocation>
                       <pattern>org.apache.kafka</pattern>
                       <shadedPattern>shaded.org.apache.kafka</shadedPattern>
                     </relocation>

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -136,7 +136,8 @@ public class ComplexTypeTransformer implements RecordTransformer {
    */
   @Nullable
   public static ComplexTypeTransformer getComplexTypeTransformer(TableConfig tableConfig) {
-    if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getComplexTypeConfig() != null) {
+    if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getComplexTypeConfig() != null
+    && tableConfig.getIngestionConfig().getComplexTypeConfig().getFieldsToUnnest() != null) {
       return new ComplexTypeTransformer(tableConfig);
     }
     return null;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -136,8 +136,7 @@ public class ComplexTypeTransformer implements RecordTransformer {
    */
   @Nullable
   public static ComplexTypeTransformer getComplexTypeTransformer(TableConfig tableConfig) {
-    if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getComplexTypeConfig() != null
-    && tableConfig.getIngestionConfig().getComplexTypeConfig().getFieldsToUnnest() != null) {
+    if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getComplexTypeConfig() != null) {
       return new ComplexTypeTransformer(tableConfig);
     }
     return null;


### PR DESCRIPTION
When `pinot-parquet` plugin is used in a Spark YARN cluster, it can cause issues due to hadoop dependencies being bundled with the plugin. These deps can't be used in `provided` scope due to #6743. The solution is to shade these deps.