### PR TITLE
Fix bug in IngestionUtils creating segment uri to tar map

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
@@ -240,7 +240,7 @@ public final class IngestionUtils {
           }
           PinotFS outputFileFS = getOutputPinotFS(batchConfig, outputSegmentDirURI);
           Map<String, String> segmentUriToTarPathMap = SegmentPushUtils.getSegmentUriToTarPathMap(outputSegmentDirURI,
-              segmentUploadSpec.getPushJobSpec(), new String[] { segmentTarURIs.toString() });
+              segmentUploadSpec.getPushJobSpec(), segmentTarURIs.stream().map(URI::toString).toArray(String[]::new));
           SegmentPushUtils.sendSegmentUriAndMetadata(segmentUploadSpec, outputFileFS, segmentUriToTarPathMap);
         } catch (RetriableOperationException | AttemptsExceededException e) {
           throw new RuntimeException(String


### PR DESCRIPTION
Fix bug in IngestionUtils where a list of segment URIs is converted to its string list representation, when it should have been converting each URI to its string representation.

Previously this code path would fail with

```
Caused by: java.net.URISyntaxException: Illegal character in path at index 0:
at java.base/java.net.URI$Parser.fail(URI.java:2913)
	at java.base/java.net.URI$Parser.checkChars(URI.java:3084)
	at java.base/java.net.URI$Parser.parseHierarchical(URI.java:3166)
	at java.base/java.net.URI$Parser.parse(URI.java:3125)
	at java.base/java.net.URI.<init>(URI.java:600)
	at java.base/java.net.URI.create(URI.java:881)
	... 19 more
```

At line 309 in SegmentPushUtils:
```
  URI uri = URI.create(file);
      if (uri.getPath().endsWith(Constants.TAR_GZ_FILE_EXT)) {
        URI updatedURI = SegmentPushUtils.generateSegmentTarURI(outputDirURI, uri, pushSpec.getSegmentUriPrefix(),
            pushSpec.getSegmentUriSuffix());
        segmentUriToTarPathMap.put(updatedURI.toString(), file);
      }
    }
    return segmentUriToTarPathMap;
```