### PR TITLE
Close Pulsar consumer correctly when fetching offsets

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
@@ -82,13 +82,10 @@ public class PulsarStreamMetadataProvider extends PulsarPartitionLevelConnection
   @Override
   public StreamPartitionMsgOffset fetchStreamPartitionOffset(OffsetCriteria offsetCriteria, long timeoutMillis) {
     Preconditions.checkNotNull(offsetCriteria);
-    Consumer consumer = null;
-    try {
-      MessageId offset = null;
-      consumer =
-          _pulsarClient.newConsumer().topic(_topic)
-              .subscriptionInitialPosition(PulsarUtils.offsetCriteriaToSubscription(offsetCriteria))
-              .subscriptionName("Pinot_" + UUID.randomUUID()).subscribe();
+    MessageId offset = null;
+    try (Consumer<byte[]> consumer = _pulsarClient.newConsumer().topic(_topic)
+        .subscriptionInitialPosition(PulsarUtils.offsetCriteriaToSubscription(offsetCriteria))
+        .subscriptionName("Pinot_" + UUID.randomUUID()).subscribe()) {
 
       if (offsetCriteria.isLargest()) {
         offset = consumer.getLastMessageId();
@@ -102,8 +99,6 @@ public class PulsarStreamMetadataProvider extends PulsarPartitionLevelConnection
       LOGGER.error("Cannot fetch offsets for partition " + _partition + " and topic " + _topic + " and offsetCriteria "
           + offsetCriteria, e);
       return null;
-    } finally {
-      closeConsumer(consumer);
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -136,7 +136,8 @@ public class ComplexTypeTransformer implements RecordTransformer {
    */
   @Nullable
   public static ComplexTypeTransformer getComplexTypeTransformer(TableConfig tableConfig) {
-    if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getComplexTypeConfig() != null) {
+    if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getComplexTypeConfig() != null
+    && tableConfig.getIngestionConfig().getComplexTypeConfig().getFieldsToUnnest() != null) {
       return new ComplexTypeTransformer(tableConfig);
     }
     return null;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -136,8 +136,7 @@ public class ComplexTypeTransformer implements RecordTransformer {
    */
   @Nullable
   public static ComplexTypeTransformer getComplexTypeTransformer(TableConfig tableConfig) {
-    if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getComplexTypeConfig() != null
-    && tableConfig.getIngestionConfig().getComplexTypeConfig().getFieldsToUnnest() != null) {
+    if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getComplexTypeConfig() != null) {
       return new ComplexTypeTransformer(tableConfig);
     }
     return null;


### PR DESCRIPTION
Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
