### PR TITLE
Adding support for broker routing queries to other tenants

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -243,6 +243,11 @@ public class CommonConstants {
 
     public static final String CONTROLLER_URL = "pinot.broker.controller.url";
 
+    // Turn on this config to allow any Pinot broker route queries to the correct tenant broker.
+    public static final String CONFIG_OF_ROUTE_REQUESTS_TO_OTHER_TENANTS =
+        "pinot.broker.route.requests.to.other.tenants";
+    public static final boolean DEFAULT_ROUTE_REQUESTS_TO_OTHER_TENANTS = false;
+
     public static class Request {
       public static final String SQL = "sql";
       public static final String TRACE = "trace";

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/MultiTenantQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/MultiTenantQuickstart.java
@@ -1,0 +1,258 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Preconditions;
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.auth.AuthProvider;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.tools.admin.PinotAdministrator;
+import org.apache.pinot.tools.admin.command.QuickstartRunner;
+
+
+public class MultiTenantQuickstart extends QuickStartBase {
+  @Override
+  public List<String> types() {
+    return Arrays.asList("MULTI-TENANT");
+  }
+
+  private static final String TAB = "\t\t";
+  private static final String NEW_LINE = "\n";
+  private static final String[] DEFAULT_BOOTSTRAP_DIRECTORY =
+      new String[]{"examples/multi-tenant/batch/baseballStats", "examples/multi-tenant/batch/airlineStats"};
+
+  public AuthProvider getAuthProvider() {
+    return null;
+  }
+
+  public static String prettyPrintResponse(JsonNode response) {
+    StringBuilder responseBuilder = new StringBuilder();
+
+    // Sql Results
+    if (response.has("resultTable")) {
+      JsonNode columns = response.get("resultTable").get("dataSchema").get("columnNames");
+      int numColumns = columns.size();
+      for (int i = 0; i < numColumns; i++) {
+        responseBuilder.append(columns.get(i).asText()).append(TAB);
+      }
+      responseBuilder.append(NEW_LINE);
+      JsonNode rows = response.get("resultTable").get("rows");
+      for (int i = 0; i < rows.size(); i++) {
+        JsonNode row = rows.get(i);
+        for (int j = 0; j < numColumns; j++) {
+          responseBuilder.append(row.get(j).asText()).append(TAB);
+        }
+        responseBuilder.append(NEW_LINE);
+      }
+    }
+    return responseBuilder.toString();
+  }
+
+  public void execute()
+      throws Exception {
+    List<QuickstartTableRequest> tableRequests = new ArrayList<>();
+    File quickstartTmpDir = new File(_dataDir, String.valueOf(System.currentTimeMillis()));
+    for (String bootstrapDirectory : DEFAULT_BOOTSTRAP_DIRECTORY) {
+      String tableName = getTableName(bootstrapDirectory);
+      File baseDir = new File(quickstartTmpDir, tableName);
+
+      if (useDefaultBootstrapTableDir()) {
+        copyResourceTableToTmpDirectory(getBootstrapDataDir(bootstrapDirectory), tableName, baseDir);
+      } else {
+        copyFilesystemTableToTmpDirectory(getBootstrapDataDir(bootstrapDirectory), tableName, baseDir);
+      }
+      tableRequests.add(new QuickstartTableRequest(baseDir.getAbsolutePath()));
+    }
+    File pinotDeploymentDir = new File(quickstartTmpDir, "pinotDeployment");
+    pinotDeploymentDir.mkdirs();
+    QuickstartRunner runner =
+        new QuickstartRunner(tableRequests, 1, 2, 2, 2, pinotDeploymentDir, false,
+            getAuthProvider(), getConfigOverrides(), null, true);
+
+    printStatus(Quickstart.Color.CYAN, "***** Starting Zookeeper, controller, broker and server *****");
+    runner.startAll();
+    waitForBootstrapToComplete(runner);
+
+    runner.createBrokerTenantWith(1, "brokerOne");
+    runner.createBrokerTenantWith(1, "brokerTwo");
+    runner.createServerTenantWith(1, 0, "serverOne");
+    runner.createServerTenantWith(1, 0, "serverTwo");
+    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+      try {
+        printStatus(Quickstart.Color.GREEN, "***** Shutting down offline quick start *****");
+        runner.stop();
+        FileUtils.deleteDirectory(quickstartTmpDir);
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
+    }));
+    printStatus(Quickstart.Color.CYAN, "***** Bootstrap tables *****");
+    runner.bootstrapTable();
+
+    waitForBootstrapToComplete(runner);
+
+    printStatus(Quickstart.Color.YELLOW, "***** Offline quickstart setup complete *****");
+
+    if (useDefaultBootstrapTableDir()) {
+      // Quickstart is using the default baseballStats sample table, so run sample queries.
+      runSampleQueries(runner);
+    }
+
+    printStatus(Quickstart.Color.GREEN,
+        "You can always go to http://localhost:9000 to play around in the query console");
+  }
+
+  private static void copyResourceTableToTmpDirectory(String sourcePath, String tableName, File baseDir)
+      throws IOException {
+
+    File schemaFile = new File(baseDir, tableName + "_schema.json");
+    File tableConfigFile = new File(baseDir, tableName + "_offline_table_config.json");
+
+    ClassLoader classLoader = MultiTenantQuickstart.class.getClassLoader();
+    URL resource = classLoader.getResource(sourcePath + File.separator + tableName + "_schema.json");
+    Preconditions.checkNotNull(resource);
+    FileUtils.copyURLToFile(resource, schemaFile);
+    resource = classLoader.getResource(sourcePath + File.separator + tableName + "_offline_table_config.json");
+    Preconditions.checkNotNull(resource);
+    FileUtils.copyURLToFile(resource, tableConfigFile);
+  }
+
+  private static void copyFilesystemTableToTmpDirectory(String sourcePath, String tableName, File baseDir)
+      throws IOException {
+    File fileDb = new File(sourcePath);
+
+    if (!fileDb.exists() || !fileDb.isDirectory()) {
+      throw new RuntimeException("Directory " + fileDb.getAbsolutePath() + " not found.");
+    }
+
+    File schemaFile = new File(fileDb, tableName + "_schema.json");
+    if (!schemaFile.exists()) {
+      throw new RuntimeException("Schema file " + schemaFile.getAbsolutePath() + " not found.");
+    }
+
+    File tableFile = new File(fileDb, tableName + "_offline_table_config.json");
+    if (!tableFile.exists()) {
+      throw new RuntimeException("Table table " + tableFile.getAbsolutePath() + " not found.");
+    }
+
+    File data = new File(fileDb, "rawdata" + File.separator + tableName + "_data.csv");
+    if (!data.exists()) {
+      throw new RuntimeException(("Data file " + data.getAbsolutePath() + " not found. "));
+    }
+
+    FileUtils.copyDirectory(fileDb, baseDir);
+  }
+
+  private static void runSampleQueries(QuickstartRunner runner)
+      throws Exception {
+    String q1 = "select count(*) from baseballStats limit 1";
+    printStatus(Quickstart.Color.YELLOW, "Total number of documents in the table");
+    printStatus(Quickstart.Color.CYAN, "Query : " + q1);
+    printStatus(Quickstart.Color.YELLOW, prettyPrintResponse(runner.runQuery(q1)));
+    printStatus(Quickstart.Color.GREEN, "***************************************************");
+
+    String q2 = "select playerName, sum(runs) from baseballStats group by playerName order by sum(runs) desc limit 5";
+    printStatus(Quickstart.Color.YELLOW, "Top 5 run scorers of all time ");
+    printStatus(Quickstart.Color.CYAN, "Query : " + q2);
+    printStatus(Quickstart.Color.YELLOW, prettyPrintResponse(runner.runQuery(q2)));
+    printStatus(Quickstart.Color.GREEN, "***************************************************");
+
+    String q3 =
+        "select playerName, sum(runs) from baseballStats where yearID=2000 group by playerName order by sum(runs) "
+            + "desc limit 5";
+    printStatus(Quickstart.Color.YELLOW, "Top 5 run scorers of the year 2000");
+    printStatus(Quickstart.Color.CYAN, "Query : " + q3);
+    printStatus(Quickstart.Color.YELLOW, prettyPrintResponse(runner.runQuery(q3)));
+    printStatus(Quickstart.Color.GREEN, "***************************************************");
+
+    String q4 =
+        "select playerName, sum(runs) from baseballStats where yearID>=2000 group by playerName order by sum(runs) "
+            + "desc limit 10";
+    printStatus(Quickstart.Color.YELLOW, "Top 10 run scorers after 2000");
+    printStatus(Quickstart.Color.CYAN, "Query : " + q4);
+    printStatus(Quickstart.Color.YELLOW, prettyPrintResponse(runner.runQuery(q4)));
+    printStatus(Quickstart.Color.GREEN, "***************************************************");
+
+    String q5 = "select playerName, runs, homeRuns from baseballStats order by yearID limit 10";
+    printStatus(Quickstart.Color.YELLOW,
+        "Print playerName,runs,homeRuns for 10 records from the table and order them by yearID");
+    printStatus(Quickstart.Color.CYAN, "Query : " + q5);
+    printStatus(Quickstart.Color.YELLOW, prettyPrintResponse(runner.runQuery(q5)));
+    printStatus(Quickstart.Color.GREEN, "***************************************************");
+
+    String q6 = "select count(*) from airlineStats limit 1";
+    printStatus(Quickstart.Color.YELLOW, "Total number of documents in the table");
+    printStatus(Quickstart.Color.CYAN, "Query : " + q6);
+    printStatus(Quickstart.Color.YELLOW, prettyPrintResponse(runner.runQuery(q6)));
+    printStatus(Quickstart.Color.GREEN, "***************************************************");
+
+    String q7 =
+        "select AirlineID, sum(Cancelled) from airlineStats group by AirlineID order by sum(Cancelled) desc limit 5";
+    printStatus(Quickstart.Color.YELLOW, "Top 5 airlines in cancellation ");
+    printStatus(Quickstart.Color.CYAN, "Query : " + q7);
+    printStatus(Quickstart.Color.YELLOW, prettyPrintResponse(runner.runQuery(q7)));
+    printStatus(Quickstart.Color.GREEN, "***************************************************");
+
+    String q8 =
+        "select AirlineID, Year, sum(Flights) from airlineStats where Year > 2010 group by AirlineID, Year order by "
+            + "sum(Flights) desc limit 5";
+    printStatus(Quickstart.Color.YELLOW, "Top 5 airlines in number of flights after 2010");
+    printStatus(Quickstart.Color.CYAN, "Query : " + q8);
+    printStatus(Quickstart.Color.YELLOW, prettyPrintResponse(runner.runQuery(q8)));
+    printStatus(Quickstart.Color.GREEN, "***************************************************");
+
+    String q9 =
+        "select OriginCityName, max(Flights) from airlineStats group by OriginCityName order by max(Flights) desc "
+            + "limit 5";
+    printStatus(Quickstart.Color.YELLOW, "Top 5 cities for number of flights");
+    printStatus(Quickstart.Color.CYAN, "Query : " + q9);
+    printStatus(Quickstart.Color.YELLOW, prettyPrintResponse(runner.runQuery(q9)));
+    printStatus(Quickstart.Color.GREEN, "***************************************************");
+
+    String q10 = "select AirlineID, OriginCityName, DestCityName, Year from airlineStats order by Year limit 5";
+    printStatus(Quickstart.Color.YELLOW,
+        "Print AirlineID, OriginCityName, DestCityName, Year for 5 records ordered by Year");
+    printStatus(Quickstart.Color.CYAN, "Query : " + q10);
+    printStatus(Quickstart.Color.YELLOW, prettyPrintResponse(runner.runQuery(q10)));
+    printStatus(Quickstart.Color.GREEN, "***************************************************");
+  }
+
+  protected Map<String, Object> getConfigOverrides() {
+    Map<String, Object> configOverrides = new HashMap<>(super.getConfigOverrides());
+    configOverrides.put(CommonConstants.Broker.CONFIG_OF_ROUTE_REQUESTS_TO_OTHER_TENANTS, true);
+    return configOverrides;
+  }
+
+  public static void main(String[] args)
+      throws Exception {
+    List<String> arguments = new ArrayList<>();
+    arguments.addAll(Arrays.asList("QuickStart", "-type", "MULTI-TENANT"));
+    arguments.addAll(Arrays.asList(args));
+    PinotAdministrator.main(arguments.toArray(new String[arguments.size()]));
+  }
+}

--- a/pinot-tools/src/main/resources/examples/multi-tenant/batch/airlineStats/airlineStats_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/multi-tenant/batch/airlineStats/airlineStats_offline_table_config.json
@@ -1,0 +1,65 @@
+{
+  "tableName": "airlineStats",
+  "tableType": "OFFLINE",
+  "segmentsConfig": {
+    "timeColumnName": "DaysSinceEpoch",
+    "timeType": "DAYS",
+    "segmentPushType": "APPEND",
+    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
+    "replication": "1"
+  },
+  "tenants": {
+    "broker": "brokerOne",
+    "server": "serverOne"
+  },
+  "fieldConfigList": [
+    {
+      "name": "ts",
+      "encodingType": "DICTIONARY",
+      "indexTypes": ["TIMESTAMP"],
+      "timestampConfig": {
+        "granularities": [
+          "DAY",
+          "WEEK",
+          "MONTH"
+        ]
+      }
+    }
+  ],
+  "tableIndexConfig": {
+    "loadMode": "MMAP"
+  },
+  "metadata": {
+    "customConfigs": {}
+  },
+  "ingestionConfig": {
+    "batchIngestionConfig": {
+      "segmentIngestionType": "APPEND",
+      "segmentIngestionFrequency": "DAILY",
+      "batchConfigMaps": [
+        {
+          "inputDirURI": "examples/batch/airlineStats/rawdata",
+          "inputFormat": "avro"
+        }
+      ],
+      "segmentNameSpec": {},
+      "pushSpec": {}
+    },
+    "transformConfigs": [
+      {
+        "columnName": "ts",
+        "transformFunction": "fromEpochDays(DaysSinceEpoch)"
+      },
+      {
+        "columnName": "tsRaw",
+        "transformFunction": "fromEpochDays(DaysSinceEpoch)"
+      }
+    ]
+  },
+  "task": {
+    "taskTypeConfigsMap": {
+      "SegmentGenerationAndPushTask": {
+      }
+    }
+  }
+}

--- a/pinot-tools/src/main/resources/examples/multi-tenant/batch/airlineStats/airlineStats_schema.json
+++ b/pinot-tools/src/main/resources/examples/multi-tenant/batch/airlineStats/airlineStats_schema.json
@@ -1,0 +1,348 @@
+{
+  "metricFieldSpecs": [
+  ],
+  "dimensionFieldSpecs": [
+    {
+      "dataType": "INT",
+      "name": "ActualElapsedTime"
+    },
+    {
+      "dataType": "INT",
+      "name": "AirTime"
+    },
+    {
+      "dataType": "INT",
+      "name": "AirlineID"
+    },
+    {
+      "dataType": "INT",
+      "name": "ArrDel15"
+    },
+    {
+      "dataType": "INT",
+      "name": "ArrDelay"
+    },
+    {
+      "dataType": "INT",
+      "name": "ArrDelayMinutes"
+    },
+    {
+      "dataType": "INT",
+      "name": "ArrTime"
+    },
+    {
+      "dataType": "STRING",
+      "name": "ArrTimeBlk"
+    },
+    {
+      "dataType": "INT",
+      "name": "ArrivalDelayGroups"
+    },
+    {
+      "dataType": "INT",
+      "name": "CRSArrTime"
+    },
+    {
+      "dataType": "INT",
+      "name": "CRSDepTime"
+    },
+    {
+      "dataType": "INT",
+      "name": "CRSElapsedTime"
+    },
+    {
+      "dataType": "STRING",
+      "name": "CancellationCode"
+    },
+    {
+      "dataType": "INT",
+      "name": "Cancelled"
+    },
+    {
+      "dataType": "STRING",
+      "name": "Carrier"
+    },
+    {
+      "dataType": "INT",
+      "name": "CarrierDelay"
+    },
+    {
+      "dataType": "INT",
+      "name": "DayOfWeek"
+    },
+    {
+      "dataType": "INT",
+      "name": "DayofMonth"
+    },
+    {
+      "dataType": "INT",
+      "name": "DepDel15"
+    },
+    {
+      "dataType": "INT",
+      "name": "DepDelay"
+    },
+    {
+      "dataType": "INT",
+      "name": "DepDelayMinutes"
+    },
+    {
+      "dataType": "INT",
+      "name": "DepTime"
+    },
+    {
+      "dataType": "STRING",
+      "name": "DepTimeBlk"
+    },
+    {
+      "dataType": "INT",
+      "name": "DepartureDelayGroups"
+    },
+    {
+      "dataType": "STRING",
+      "name": "Dest"
+    },
+    {
+      "dataType": "INT",
+      "name": "DestAirportID"
+    },
+    {
+      "dataType": "INT",
+      "name": "DestAirportSeqID"
+    },
+    {
+      "dataType": "INT",
+      "name": "DestCityMarketID"
+    },
+    {
+      "dataType": "STRING",
+      "name": "DestCityName"
+    },
+    {
+      "dataType": "STRING",
+      "name": "DestState"
+    },
+    {
+      "dataType": "INT",
+      "name": "DestStateFips"
+    },
+    {
+      "dataType": "STRING",
+      "name": "DestStateName"
+    },
+    {
+      "dataType": "INT",
+      "name": "DestWac"
+    },
+    {
+      "dataType": "INT",
+      "name": "Distance"
+    },
+    {
+      "dataType": "INT",
+      "name": "DistanceGroup"
+    },
+    {
+      "dataType": "INT",
+      "name": "DivActualElapsedTime"
+    },
+    {
+      "dataType": "INT",
+      "name": "DivAirportIDs",
+      "singleValueField": false
+    },
+    {
+      "dataType": "INT",
+      "name": "DivAirportLandings"
+    },
+    {
+      "dataType": "INT",
+      "name": "DivAirportSeqIDs",
+      "singleValueField": false
+    },
+    {
+      "dataType": "STRING",
+      "name": "DivAirports",
+      "singleValueField": false
+    },
+    {
+      "dataType": "INT",
+      "name": "DivArrDelay"
+    },
+    {
+      "dataType": "INT",
+      "name": "DivDistance"
+    },
+    {
+      "dataType": "INT",
+      "name": "DivLongestGTimes",
+      "singleValueField": false
+    },
+    {
+      "dataType": "INT",
+      "name": "DivReachedDest"
+    },
+    {
+      "dataType": "STRING",
+      "name": "DivTailNums",
+      "singleValueField": false
+    },
+    {
+      "dataType": "INT",
+      "name": "DivTotalGTimes",
+      "singleValueField": false
+    },
+    {
+      "dataType": "INT",
+      "name": "DivWheelsOffs",
+      "singleValueField": false
+    },
+    {
+      "dataType": "INT",
+      "name": "DivWheelsOns",
+      "singleValueField": false
+    },
+    {
+      "dataType": "INT",
+      "name": "Diverted"
+    },
+    {
+      "dataType": "INT",
+      "name": "FirstDepTime"
+    },
+    {
+      "dataType": "STRING",
+      "name": "FlightDate"
+    },
+    {
+      "dataType": "INT",
+      "name": "FlightNum"
+    },
+    {
+      "dataType": "INT",
+      "name": "Flights"
+    },
+    {
+      "dataType": "INT",
+      "name": "LateAircraftDelay"
+    },
+    {
+      "dataType": "INT",
+      "name": "LongestAddGTime"
+    },
+    {
+      "dataType": "INT",
+      "name": "Month"
+    },
+    {
+      "dataType": "INT",
+      "name": "NASDelay"
+    },
+    {
+      "dataType": "STRING",
+      "name": "Origin"
+    },
+    {
+      "dataType": "INT",
+      "name": "OriginAirportID"
+    },
+    {
+      "dataType": "INT",
+      "name": "OriginAirportSeqID"
+    },
+    {
+      "dataType": "INT",
+      "name": "OriginCityMarketID"
+    },
+    {
+      "dataType": "STRING",
+      "name": "OriginCityName"
+    },
+    {
+      "dataType": "STRING",
+      "name": "OriginState"
+    },
+    {
+      "dataType": "INT",
+      "name": "OriginStateFips"
+    },
+    {
+      "dataType": "STRING",
+      "name": "OriginStateName"
+    },
+    {
+      "dataType": "INT",
+      "name": "OriginWac"
+    },
+    {
+      "dataType": "INT",
+      "name": "Quarter"
+    },
+    {
+      "dataType": "STRING",
+      "name": "RandomAirports",
+      "singleValueField": false
+    },
+    {
+      "dataType": "INT",
+      "name": "SecurityDelay"
+    },
+    {
+      "dataType": "STRING",
+      "name": "TailNum"
+    },
+    {
+      "dataType": "INT",
+      "name": "TaxiIn"
+    },
+    {
+      "dataType": "INT",
+      "name": "TaxiOut"
+    },
+    {
+      "dataType": "INT",
+      "name": "Year"
+    },
+    {
+      "dataType": "INT",
+      "name": "WheelsOn"
+    },
+    {
+      "dataType": "INT",
+      "name": "WheelsOff"
+    },
+    {
+      "dataType": "INT",
+      "name": "WeatherDelay"
+    },
+    {
+      "dataType": "STRING",
+      "name": "UniqueCarrier"
+    },
+    {
+      "dataType": "INT",
+      "name": "TotalAddGTime"
+    }
+  ],
+  "dateTimeFieldSpecs": [
+    {
+      "name": "DaysSinceEpoch",
+      "dataType": "INT",
+      "format": "1:DAYS:EPOCH",
+      "granularity": "1:DAYS"
+    },
+    {
+      "name": "ts",
+      "dataType": "TIMESTAMP",
+      "format": "1:MILLISECONDS:TIMESTAMP",
+      "granularity": "1:SECONDS"
+    },
+    {
+      "name": "tsRaw",
+      "dataType": "TIMESTAMP",
+      "format": "1:MILLISECONDS:TIMESTAMP",
+      "granularity": "1:SECONDS"
+    }
+  ],
+  "schemaName": "airlineStats"
+}

--- a/pinot-tools/src/main/resources/examples/multi-tenant/batch/baseballStats/baseballStats_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/multi-tenant/batch/baseballStats/baseballStats_offline_table_config.json
@@ -1,0 +1,45 @@
+{
+  "tableName": "baseballStats",
+  "tableType": "OFFLINE",
+  "segmentsConfig": {
+    "segmentPushType": "APPEND",
+    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
+    "schemaName": "baseball",
+    "replication": "1"
+  },
+  "tenants": {
+    "broker": "brokerTwo",
+    "server": "serverTwo"
+  },
+  "tableIndexConfig": {
+    "loadMode": "HEAP",
+    "invertedIndexColumns": [
+      "playerID",
+      "teamID"
+    ]
+  },
+  "metadata": {
+    "customConfigs": {
+    }
+  },
+  "ingestionConfig": {
+    "batchIngestionConfig": {
+      "segmentIngestionType": "APPEND",
+      "segmentIngestionFrequency": "DAILY",
+      "batchConfigMaps": [
+        {
+          "inputDirURI": "examples/minions/batch/baseballStats/rawdata",
+          "inputFormat": "csv"
+        }
+      ],
+      "segmentNameSpec": {},
+      "pushSpec": {}
+    }
+  },
+  "task": {
+    "taskTypeConfigsMap": {
+      "SegmentGenerationAndPushTask": {
+      }
+    }
+  }
+}

--- a/pinot-tools/src/main/resources/examples/multi-tenant/batch/baseballStats/baseballStats_schema.json
+++ b/pinot-tools/src/main/resources/examples/multi-tenant/batch/baseballStats/baseballStats_schema.json
@@ -1,0 +1,107 @@
+{
+  "metricFieldSpecs": [
+    {
+      "dataType": "INT",
+      "name": "playerStint"
+    },
+    {
+      "dataType": "INT",
+      "name": "numberOfGames"
+    },
+    {
+      "dataType": "INT",
+      "name": "numberOfGamesAsBatter"
+    },
+    {
+      "dataType": "INT",
+      "name": "AtBatting"
+    },
+    {
+      "dataType": "INT",
+      "name": "runs"
+    },
+    {
+      "dataType": "INT",
+      "name": "hits"
+    },
+    {
+      "dataType": "INT",
+      "name": "doules"
+    },
+    {
+      "dataType": "INT",
+      "name": "tripples"
+    },
+    {
+      "dataType": "INT",
+      "name": "homeRuns"
+    },
+    {
+      "dataType": "INT",
+      "name": "runsBattedIn"
+    },
+    {
+      "dataType": "INT",
+      "name": "stolenBases"
+    },
+    {
+      "dataType": "INT",
+      "name": "caughtStealing"
+    },
+    {
+      "dataType": "INT",
+      "name": "baseOnBalls"
+    },
+    {
+      "dataType": "INT",
+      "name": "strikeouts"
+    },
+    {
+      "dataType": "INT",
+      "name": "intentionalWalks"
+    },
+    {
+      "dataType": "INT",
+      "name": "hitsByPitch"
+    },
+    {
+      "dataType": "INT",
+      "name": "sacrificeHits"
+    },
+    {
+      "dataType": "INT",
+      "name": "sacrificeFlies"
+    },
+    {
+      "dataType": "INT",
+      "name": "groundedIntoDoublePlays"
+    },
+    {
+      "dataType": "INT",
+      "name": "G_old"
+    }
+  ],
+  "dimensionFieldSpecs": [
+    {
+      "dataType": "STRING",
+      "name": "playerID"
+    },
+    {
+      "dataType": "INT",
+      "name": "yearID"
+    },
+    {
+      "dataType": "STRING",
+      "name": "teamID"
+    },
+    {
+      "dataType": "STRING",
+      "name": "league"
+    },
+    {
+      "dataType": "STRING",
+      "name": "playerName"
+    }
+  ],
+  "schemaName": "baseballStats"
+}


### PR DESCRIPTION
Allow pinot brokers re-route queries to the right broker tenant to serve the queries.
Adding a new broker config: `pinot.broker.route.requests.to.other.tenants` to turn on this feature.