### PR TITLE
Allow moveToFinalLocation in METADATA push based on config

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -73,6 +73,8 @@ public class FileUploadDownloadClient implements AutoCloseable {
     public static final String UPLOAD_TYPE = "UPLOAD_TYPE";
     public static final String REFRESH_ONLY = "REFRESH_ONLY";
     public static final String DOWNLOAD_URI = "DOWNLOAD_URI";
+
+    public static final String MOVE_SEGMENT_TO_DEEP_STORE = "MOVE_SEGMENT_TO_DEEP_STORE";
     public static final String SEGMENT_ZK_METADATA_CUSTOM_MAP_MODIFIER = "Pinot-SegmentZKMetadataCustomMapModifier";
     public static final String CRYPTER = "CRYPTER";
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -256,7 +256,15 @@ public class PinotSegmentUploadDownloadRestletResource {
             throw new ControllerApplicationException(LOGGER, "Download URI is required for METADATA upload mode",
                 Response.Status.BAD_REQUEST);
           }
-          moveSegmentToFinalLocation = false;
+          // override moveSegmentToFinalLocation if override provided in headers:moveSegmentToDeepStore
+          // else set to false for backward compatibility
+          String moveSegmentToDeepStore =
+              extractHttpHeader(headers, FileUploadDownloadClient.CustomHeaders.MOVE_SEGMENT_TO_DEEP_STORE);
+          if (moveSegmentToDeepStore != null) {
+            moveSegmentToFinalLocation = Boolean.parseBoolean(moveSegmentToDeepStore);
+          } else {
+            moveSegmentToFinalLocation = false;
+          }
           createSegmentFileFromMultipart(multiPart, destFile);
           try {
             URI segmentURI = new URI(downloadURI);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
@@ -264,6 +264,10 @@ public class SegmentPushUtils implements Serializable {
               headers.add(new BasicHeader(FileUploadDownloadClient.CustomHeaders.DOWNLOAD_URI, segmentUriPath));
               headers.add(new BasicHeader(FileUploadDownloadClient.CustomHeaders.UPLOAD_TYPE,
                   FileUploadDownloadClient.FileUploadType.METADATA.toString()));
+              if (spec.getPushJobSpec() != null) {
+                headers.add(new BasicHeader(FileUploadDownloadClient.CustomHeaders.MOVE_SEGMENT_TO_DEEP_STORE,
+                    String.valueOf(spec.getPushJobSpec().getMoveToDeepStoreForMetadataPush())));
+              }
               headers.addAll(AuthProviderUtils.toRequestHeaders(authProvider));
 
               SimpleHttpResponse response = FILE_UPLOAD_DOWNLOAD_CLIENT

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/PushJobSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/PushJobSpec.java
@@ -42,6 +42,11 @@ public class PushJobSpec implements Serializable {
   private long _pushRetryIntervalMillis = 1000;
 
   /**
+   * Applicable for URI and METADATA push types.
+   * If true, and if segment was not already in the deep store, move it to deep store.
+   */
+  private boolean _moveToDeepStoreForMetadataPush;
+  /**
    * Used in SegmentUriPushJobRunner, which is used to composite the segment uri to send to pinot controller.
    * The URI sends to controller is in the format ${segmentUriPrefix}${segmentPath}${segmentUriSuffix}
    */
@@ -120,5 +125,13 @@ public class PushJobSpec implements Serializable {
 
   public void setPushParallelism(int pushParallelism) {
     _pushParallelism = pushParallelism;
+  }
+
+  public boolean getMoveToDeepStoreForMetadataPush() {
+    return _moveToDeepStoreForMetadataPush;
+  }
+
+  public void setMoveToDeepStoreForMetadataPush(boolean moveToDeepStoreForMetadataPush) {
+    _moveToDeepStoreForMetadataPush = moveToDeepStoreForMetadataPush;
   }
 }


### PR DESCRIPTION
`METADATA` push didn't allow the option of `moveSegmentToFinalLocation`. This meant that if someone had generated segments in a location that was not the deep store, there was absolutely no way to move those segments into deep store without manual scripting.
Chatting with @xiangfu0 ,  I understood that this was done on purpose, in order to keep METADATA push very light weight and not involve copying from outputDir to dataDir in the push. But this is a very valid scenario where users would want to generate segments in a location other than deep store, and still want to use METADATA push (reasons could be multiple, as listed in https://github.com/apache/pinot/issues/7328).

While there have been more elaborate solutions proposed in the issue above (like periodic background tasks), this PR simply enables one to allow METADATA push to so `moveToFinalLocation`. And while this would increase the data push time, it is a better solution than asking users to switch to SegmentTarPush or SegmentUriPush if the issue was disparate permissions between outputDir ad dataDir (one of the reasons mentioned in the issue).

Backward compatible behavior or this being false by default is maintained.
