### PR TITLE
Adding acl support for helm chart

### DIFF
--- a/kubernetes/helm/pinot/templates/broker/configmap.yaml
+++ b/kubernetes/helm/pinot/templates/broker/configmap.yaml
@@ -26,3 +26,9 @@ data:
     pinot.broker.client.queryPort={{ .Values.broker.service.port }}
     pinot.broker.routing.table.builder.class={{ .Values.broker.routingTable.builderClass }}
 {{ .Values.broker.extra.configs | indent 4 }}
+{{- if .Values.pinotAuth.enabled}}
+    pinot.broker.access.control.class={{ .Values.pinotAuth.brokerFactoryClass }}
+{{- range $config := .Values.pinotAuth.configs}}
+{{ printf "pinot.broker.%s" $config | indent 4 -}}
+{{- end }}
+{{- end }}

--- a/kubernetes/helm/pinot/templates/controller/configmap.yaml
+++ b/kubernetes/helm/pinot/templates/controller/configmap.yaml
@@ -32,3 +32,9 @@ data:
     controller.data.dir={{ .Values.controller.data.dir }}
     controller.zk.str={{ include "zookeeper.url" . }}
 {{ .Values.controller.extra.configs | indent 4 }}
+{{- if .Values.pinotAuth.enabled}}
+    controller.admin.access.control.factory.class={{ .Values.pinotAuth.controllerFactoryClass }}
+{{- range $config := .Values.pinotAuth.configs}}
+{{ printf "controller.admin.%s" $config | indent 4 -}}
+{{- end }}
+{{- end }}

--- a/kubernetes/helm/pinot/values.yaml
+++ b/kubernetes/helm/pinot/values.yaml
@@ -54,6 +54,18 @@ serviceAccount:
 
 additionalMatchLabels: {}
 
+
+pinotAuth:
+  enabled: false
+  controllerFactoryClass: org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory
+  brokerFactoryClass: org.apache.pinot.broker.broker.BasicAuthAccessControlFactory
+  configs:
+  #  - access.control.principals=admin,user
+  #  - access.control.principals.admin.password=verysecret
+  #  - access.control.principals.user.password=secret
+  #  - access.control.principals.user.tables=baseballStats,otherstuff
+  #  - access.control.principals.user.permissions=READ
+
 # ------------------------------------------------------------------------------
 # Pinot Controller:
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
Adding ACL support in helmChart.

Ref docs: https://docs.pinot.apache.org/operators/tutorials/authentication-authorization-and-acls#controller-authentication-and-authorization

helmChart values.yaml section:
```
pinotAuth:
  enabled: true
  controllerFactoryClass: org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory
  brokerFactoryClass: org.apache.pinot.broker.broker.BasicAuthAccessControlFactory
  configs:
    - access.control.principals=admin,user
    - access.control.principals.admin.password=verysecret
    - access.control.principals.user.password=secret
    - access.control.principals.user.tables=baseballStats,otherstuff
    - access.control.principals.user.permissions=READ
```

Generated controller configs:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: pinot-controller-config
data:
  pinot-controller.conf: |-
    controller.helix.cluster.name=pinot-quickstart
    controller.port=9000
    controller.data.dir=/var/pinot/controller/data
    controller.zk.str=pinot-zookeeper:2181
    pinot.set.instance.id.to.hostname=true
    controller.task.scheduler.enabled=true
    controller.admin.access.control.factory.class=org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory
    controller.admin.access.control.principals=admin,user
    controller.admin.access.control.principals.admin.password=verysecret
    controller.admin.access.control.principals.user.password=secret
    controller.admin.access.control.principals.user.tables=baseballStats,otherstuff
    controller.admin.access.control.principals.user.permissions=READ
```
Generated broker configs:
```
apiVersion: v1
kind: ConfigMap
metadata:
  name: pinot-broker-config
data:
  pinot-broker.conf: |-
    pinot.broker.client.queryPort=8099
    pinot.broker.routing.table.builder.class=random
    pinot.set.instance.id.to.hostname=true
    pinot.broker.access.control.class=org.apache.pinot.broker.broker.BasicAuthAccessControlFactory
    pinot.broker.access.control.principals=admin,user
    pinot.broker.access.control.principals.admin.password=verysecret
    pinot.broker.access.control.principals.user.password=secret
    pinot.broker.access.control.principals.user.tables=baseballStats,otherstuff
    pinot.broker.access.control.principals.user.permissions=READ
```

