### PR TITLE
regexp_like fusing

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/QueryOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/QueryOptimizer.java
@@ -28,6 +28,7 @@ import org.apache.pinot.core.query.optimizer.filter.FilterOptimizer;
 import org.apache.pinot.core.query.optimizer.filter.FlattenAndOrFilterOptimizer;
 import org.apache.pinot.core.query.optimizer.filter.MergeEqInFilterOptimizer;
 import org.apache.pinot.core.query.optimizer.filter.MergeRangeFilterOptimizer;
+import org.apache.pinot.core.query.optimizer.filter.MergeRegexFilterOptimizer;
 import org.apache.pinot.core.query.optimizer.filter.NumericalFilterOptimizer;
 import org.apache.pinot.core.query.optimizer.filter.TimePredicateFilterOptimizer;
 import org.apache.pinot.core.query.optimizer.statement.StatementOptimizer;
@@ -44,7 +45,7 @@ public class QueryOptimizer {
   //   values to the proper format so that they can be properly parsed
   private static final List<FilterOptimizer> FILTER_OPTIMIZERS =
       Arrays.asList(new FlattenAndOrFilterOptimizer(), new MergeEqInFilterOptimizer(), new NumericalFilterOptimizer(),
-          new TimePredicateFilterOptimizer(), new MergeRangeFilterOptimizer());
+          new TimePredicateFilterOptimizer(), new MergeRangeFilterOptimizer(), new MergeRegexFilterOptimizer());
 
   private static final List<StatementOptimizer> STATEMENT_OPTIMIZERS =
       Collections.singletonList(new StringPredicateFilterOptimizer());
@@ -63,7 +64,7 @@ public class QueryOptimizer {
     Expression filterExpression = pinotQuery.getFilterExpression();
     if (filterExpression != null) {
       for (FilterOptimizer filterOptimizer : FILTER_OPTIMIZERS) {
-        filterExpression = filterOptimizer.optimize(filterExpression, schema);
+        filterExpression = filterOptimizer.optimize(filterExpression, schema, pinotQuery.getQueryOptions());
       }
       pinotQuery.setFilterExpression(filterExpression);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/FilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/FilterOptimizer.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.core.query.optimizer.filter;
 
+import java.util.HashMap;
+import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.spi.data.Schema;
@@ -32,5 +34,9 @@ public interface FilterOptimizer {
   /**
    * Optimizes the given filter, returns the optimized filter.
    */
-  Expression optimize(Expression filterExpression, @Nullable Schema schema);
+  Expression optimize(Expression filterExpression, @Nullable Schema schema, @Nullable Map<String, String> queryOptions);
+
+  default Expression optimize(Expression filterExpression, @Nullable Schema schema) {
+    return optimize(filterExpression, schema, new HashMap<>());
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/FlattenAndOrFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/FlattenAndOrFilterOptimizer.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.optimizer.filter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.Function;
@@ -34,7 +35,8 @@ import org.apache.pinot.sql.FilterKind;
 public class FlattenAndOrFilterOptimizer implements FilterOptimizer {
 
   @Override
-  public Expression optimize(Expression filterExpression, @Nullable Schema schema) {
+  public Expression optimize(Expression filterExpression, @Nullable Schema schema,
+      @Nullable Map<String, String> queryOptions) {
     return optimize(filterExpression);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/MergeEqInFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/MergeEqInFilterOptimizer.java
@@ -50,7 +50,8 @@ import org.apache.pinot.sql.FilterKind;
 public class MergeEqInFilterOptimizer implements FilterOptimizer {
 
   @Override
-  public Expression optimize(Expression filterExpression, @Nullable Schema schema) {
+  public Expression optimize(Expression filterExpression, @Nullable Schema schema,
+      @Nullable Map<String, String> queryOptions) {
     return filterExpression.getType() == ExpressionType.FUNCTION ? optimize(filterExpression) : filterExpression;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/MergeRangeFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/MergeRangeFilterOptimizer.java
@@ -44,7 +44,8 @@ import org.apache.pinot.sql.FilterKind;
 public class MergeRangeFilterOptimizer implements FilterOptimizer {
 
   @Override
-  public Expression optimize(Expression filterExpression, @Nullable Schema schema) {
+  public Expression optimize(Expression filterExpression, @Nullable Schema schema,
+      @Nullable Map<String, String> queryOptions) {
     if (schema == null || filterExpression.getType() != ExpressionType.FUNCTION) {
       return filterExpression;
     }
@@ -62,7 +63,7 @@ public class MergeRangeFilterOptimizer implements FilterOptimizer {
         FilterKind filterKind = FilterKind.valueOf(childFunction.getOperator());
         assert filterKind != FilterKind.AND;
         if (filterKind == FilterKind.OR || filterKind == FilterKind.NOT) {
-          childFunction.getOperands().replaceAll(o -> optimize(o, schema));
+          childFunction.getOperands().replaceAll(o -> optimize(o, schema, queryOptions));
           newChildren.add(child);
         } else if (filterKind.isRange()) {
           List<Expression> operands = childFunction.getOperands();
@@ -112,7 +113,7 @@ public class MergeRangeFilterOptimizer implements FilterOptimizer {
         return filterExpression;
       }
     } else if (operator.equals(FilterKind.OR.name()) || operator.equals(FilterKind.NOT.name())) {
-      function.getOperands().replaceAll(c -> optimize(c, schema));
+      function.getOperands().replaceAll(c -> optimize(c, schema, queryOptions));
       return filterExpression;
     } else {
       return filterExpression;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/MergeRegexFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/MergeRegexFilterOptimizer.java
@@ -1,0 +1,232 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.optimizer.filter;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.ExpressionType;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.Literal;
+import org.apache.pinot.common.utils.request.RequestUtils;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.sql.FilterKind;
+
+
+/**
+ * Merges boolean algebra and regex into a single regex. Specifically:
+ * <ul>
+ *   <li>regexp_like(col1, "r1") or regexp_like(col1, "r2") is merged into regexp_like(col1, "(?:r1)|(?:r2)")</li>
+ *   <li>regexp_like(col1, "r1") and regexp_like(col1, "r2") is merged into regexp_like(col1, "(?=r1)(?=r2)")</li>
+ *   <li>not regexp_like(col1, "r1") is merged into regexp_like(col1, "(?!r1)")</li>
+ * </ul>
+ *
+ * This optimization breaks the semantic in some advanced regex. For example, when they use backreferences. Therefore,
+ * it can be enabled or disabled by changing the {@link CommonConstants.Query.Request.Optimization#FUSE_REGEX} query
+ * option.
+ *
+ * NOTE: This optimizer follows the {@link FlattenAndOrFilterOptimizer}, so all the AND/OR filters are already
+ *       flattened.
+ * @see <a href="https://www.regular-expressions.info/refadv.html">https://www.regular-expressions.info/refadv.html</a>
+ */
+public class MergeRegexFilterOptimizer implements FilterOptimizer {
+
+  private static final Pattern HAS_BACKREFERENCES_PATTERN =
+      Pattern.compile(".*(?:(?:\\\\[0-9]+)|(?:\\\\k\\<\\w+\\>)).*");
+
+  @Override
+  public Expression optimize(Expression filterExpression, @Nullable Schema schema,
+      @Nullable Map<String, String> queryOptions) {
+    boolean fuseRegex = queryOptions != null && Boolean.parseBoolean(
+        queryOptions.get(CommonConstants.Query.Request.Optimization.FUSE_REGEX));
+    if (schema == null || filterExpression.getType() != ExpressionType.FUNCTION || !fuseRegex) {
+      return filterExpression;
+    }
+    return optimize(filterExpression);
+  }
+
+  private Expression optimize(Expression filterExpression) {
+    if (filterExpression.getType() != ExpressionType.FUNCTION) {
+      return filterExpression;
+    }
+    Function function = filterExpression.getFunctionCall();
+    FilterKind operator;
+    try {
+      operator = FilterKind.valueOf(function.getOperator());
+    } catch (IllegalArgumentException ex) {
+      return filterExpression;
+    }
+
+    switch (operator) {
+      case AND: {
+        return optimizeAnd(filterExpression);
+      }
+      case OR: {
+        return optimizeOr(filterExpression);
+      }
+      case NOT: {
+        return optimizeNot(filterExpression);
+      }
+      default: {
+        return filterExpression;
+      }
+    }
+  }
+
+  private Expression optimizeOr(Expression filterExpression) {
+    return optimizeBinary(filterExpression, "(?:", ")", "|");
+  }
+
+  private Expression optimizeAnd(Expression filterExpression) {
+    return optimizeBinary(filterExpression, "(?=", ")", "");
+  }
+
+  private Expression optimizeNot(Expression filterExpression) {
+    Function function = filterExpression.getFunctionCall();
+    List<Expression> operands = function.getOperands();
+    if (operands.size() != 1) {
+      return filterExpression;
+    }
+    Expression operand = optimize(operands.get(0));
+    operands.set(0, operand);
+
+    FilterKind childFilterKind = FilterKind.valueOf(operand.getFunctionCall().getOperator());
+    if (childFilterKind != FilterKind.REGEXP_LIKE) {
+      operands.set(0, optimize(operand));
+      return filterExpression;
+    }
+
+    List<Expression> matchOperands = operand.getFunctionCall().getOperands();
+    Expression lhs = matchOperands.get(0);
+    Expression valueExpr = matchOperands.get(1);
+
+    if (!valueExpr.isSetLiteral() || !isOptimizable(valueExpr.getLiteral())) {
+      return filterExpression;
+    }
+
+    return createTextMatch(lhs, wrap("(?!", valueExpr, ")"));
+  }
+
+  private Expression optimizeBinary(Expression filterExpression, String prefix, String suffix, String separator) {
+
+    Function function = filterExpression.getFunctionCall();
+    List<Expression> operands = function.getOperands();
+
+    operands.replaceAll(this::optimize);
+
+    HashMap<String, List<Expression>> matchByCol = new HashMap<>();
+
+    for (Expression child : operands) {
+      Function functionCall = child.getFunctionCall();
+      if (!functionCall.getOperator().equals(FilterKind.REGEXP_LIKE.name())) {
+        continue;
+      }
+      List<Expression> matchChildren = functionCall.getOperands();
+      if (matchChildren.size() != 2) {
+        continue;
+      }
+      Expression lhs = matchChildren.get(0);
+      if (lhs.getType() != ExpressionType.IDENTIFIER) {
+        continue;
+      }
+      Expression predicate = matchChildren.get(1);
+      if (!predicate.isSetLiteral()) {
+        continue;
+      }
+      if (!isOptimizable(predicate.getLiteral())) {
+        continue;
+      }
+      matchByCol.merge(lhs.getIdentifier().getName(), Collections.singletonList(child), (old, current) -> {
+        ArrayList<Expression> result = new ArrayList<>(old.size() + current.size());
+        result.addAll(old);
+        result.addAll(current);
+        return result;
+      });
+    }
+
+    matchByCol.entrySet().removeIf(stringListEntry -> stringListEntry.getValue().size() <= 1);
+    operands.removeAll(matchByCol.values().stream().flatMap(Collection::stream).collect(Collectors.toList()));
+
+    for (Map.Entry<String, List<Expression>> entry : matchByCol.entrySet()) {
+      String colName = entry.getKey();
+      List<Expression> matches = entry.getValue();
+      if (matches.size() <= 1) {
+        continue;
+      }
+
+      String joinedStringPredicate = matches.stream()
+          .map(matchExpr -> matchExpr.getFunctionCall().getOperands().get(1).getLiteral())
+          .map(matchLiteral -> wrap(prefix, matchLiteral.getStringValue(), suffix))
+          .collect(Collectors.joining(separator));
+
+      Expression equivalentPredicate = RequestUtils.getLiteralExpression(joinedStringPredicate);
+
+      Expression equivalent = RequestUtils.getFunctionExpression(FilterKind.REGEXP_LIKE.name());
+      equivalent.getFunctionCall().setOperands(new ArrayList<>(2));
+      equivalent.getFunctionCall().getOperands().add(RequestUtils.getIdentifierExpression(colName));
+      equivalent.getFunctionCall().getOperands().add(equivalentPredicate);
+
+      operands.add(equivalent);
+    }
+    if (operands.size() == 1) {
+      return operands.get(0);
+    }
+
+    return filterExpression;
+  }
+
+  private static Expression createTextMatch(Expression lhs, Expression value) {
+    Expression result = RequestUtils.getFunctionExpression(FilterKind.REGEXP_LIKE.name());
+    List<Expression> operands = new ArrayList<>(2);
+    operands.add(lhs);
+    operands.add(value);
+    result.getFunctionCall().setOperands(operands);
+    return result;
+  }
+
+  private static String wrap(String prefix, String stringValue, String suffix) {
+    return prefix + stringValue + suffix;
+  }
+
+  private static Expression wrap(String prefix, Expression literalExpression, String suffix) {
+    Literal literal = literalExpression.getLiteral();
+    String stringValue = literal.getStringValue();
+
+    return RequestUtils.getLiteralExpression(prefix + stringValue + suffix);
+  }
+
+  /**
+   * This method tries to detect expressions that may not be optimizable, likes the ones that use backreferences.
+   *
+   * Given that we don't have a proper way to parse the regexp in a way that it is compatible with the regexp engine,
+   * this method may have false positives.
+   */
+  private static boolean isOptimizable(Literal literal) {
+    String strValue = literal.getStringValue();
+    return !HAS_BACKREFERENCES_PATTERN.matcher(strValue).matches();
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizer.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.optimizer.filter;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
@@ -66,7 +67,8 @@ public class NumericalFilterOptimizer implements FilterOptimizer {
   private static final Expression FALSE = RequestUtils.getLiteralExpression(false);
 
   @Override
-  public Expression optimize(Expression expression, @Nullable Schema schema) {
+  public Expression optimize(Expression expression, @Nullable Schema schema,
+      @Nullable Map<String, String> queryOptions) {
     ExpressionType type = expression.getType();
     if (type != ExpressionType.FUNCTION || schema == null) {
       // We have nothing to rewrite if expression is not a function or schema is null
@@ -81,7 +83,7 @@ public class NumericalFilterOptimizer implements FilterOptimizer {
       case OR:
       case NOT:
         // Recursively traverse the expression tree to find an operator node that can be rewritten.
-        operands.forEach(operand -> optimize(operand, schema));
+        operands.forEach(operand -> optimize(operand, schema, queryOptions));
 
         // We have rewritten the child operands, so rewrite the parent if needed.
         return optimizeCurrent(expression);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/TimePredicateFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/TimePredicateFilterOptimizer.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
@@ -60,7 +61,8 @@ public class TimePredicateFilterOptimizer implements FilterOptimizer {
   private static final Logger LOGGER = LoggerFactory.getLogger(TimePredicateFilterOptimizer.class);
 
   @Override
-  public Expression optimize(Expression filterExpression, @Nullable Schema schema) {
+  public Expression optimize(Expression filterExpression, @Nullable Schema schema,
+      @Nullable Map<String, String> queryOptions) {
     return filterExpression.getType() == ExpressionType.FUNCTION ? optimize(filterExpression) : filterExpression;
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/filter/MergeRegexFilterOptimizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/filter/MergeRegexFilterOptimizerTest.java
@@ -1,0 +1,253 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.optimizer.filter;
+
+import java.util.HashMap;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class MergeRegexFilterOptimizerTest {
+  private static final MergeRegexFilterOptimizer OPTIMIZER = new MergeRegexFilterOptimizer();
+  private static final Schema SCHEMA =
+      new Schema.SchemaBuilder().setSchemaName("t1")
+          .addSingleValueDimension("col1", FieldSpec.DataType.STRING)
+          .addSingleValueDimension("col2", FieldSpec.DataType.STRING)
+          .build();
+
+
+  @Test
+  public void notDoesNotOptimizeIndexedBackreferences() {
+    assertNotOptimized("not REGEXP_LIKE(col1, '(r1)\\1')");
+  }
+
+  @Test
+  public void notDoesNotOptimizeNamedBackreferences() {
+    assertNotOptimized("not REGEXP_LIKE(col1, '(?<x>r1)\\k<x>')");
+  }
+
+  @Test
+  public void notDoesOptimizeRegex() {
+    assertOptimizedTo("not REGEXP_LIKE(col1, 'r1')", "REGEXP_LIKE(col1, '(?!r1)')");
+  }
+
+  @Test
+  public void notWithNot() {
+    assertOptimizedTo("not not REGEXP_LIKE(col1, 'r1')", "REGEXP_LIKE(col1, '(?!(?!r1))')");
+  }
+
+  @Test
+  public void notWithAnd() {
+    assertOptimizedTo("not (REGEXP_LIKE(col1, 'r1') and REGEXP_LIKE(col1, 'r2'))",
+        "REGEXP_LIKE(col1, '(?!(?=r1)(?=r2))')");
+  }
+
+  @Test
+  public void notWithOr() {
+    assertOptimizedTo("not (REGEXP_LIKE(col1, 'r1') or REGEXP_LIKE(col1, 'r2'))",
+        "REGEXP_LIKE(col1, '(?!(?:r1)|(?:r2))')");
+  }
+
+  @Test
+  public void andDoesNotOptimizeIndexedBackreferences() {
+    assertNotOptimized("REGEXP_LIKE(col1, '(r1)\\1') and REGEXP_LIKE(col1, 'r2')");
+    assertNotOptimized("REGEXP_LIKE(col1, 'r1') and REGEXP_LIKE(col1, '(r2)\\1')");
+  }
+
+  @Test
+  public void andDoesNotOptimizeNamedBackreferences() {
+    assertNotOptimized("REGEXP_LIKE(col1, '(?<x>r1)\\k<x>') and REGEXP_LIKE(col1, 'r2')");
+    assertNotOptimized("REGEXP_LIKE(col1, 'r1') and REGEXP_LIKE(col1, '(?<x>r2)\\k<x>')");
+  }
+
+  @Test
+  public void andDoesNotOptimizedWhenSingleTextMatchPerColumn() {
+    // Same column, only one REGEXP_LIKE
+    assertNotOptimized("REGEXP_LIKE(col1, 'r1') and col1 is not null");
+    // two REGEXP_LIKE with different columns
+    assertNotOptimized("REGEXP_LIKE(col1, 'r1') and REGEXP_LIKE(col2, 'r1')");
+    // two REGEXP_LIKE with same columns, only one is optimizable regex
+    assertNotOptimized("REGEXP_LIKE(col1, 'r1') and REGEXP_LIKE(col2, '(r1)\\1')");
+  }
+
+  @Test
+  public void andDoesOptimizeRegex() {
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r1') and REGEXP_LIKE(col1, 'r2')", "REGEXP_LIKE(col1, '(?=r1)(?=r2)')");
+  }
+
+  @Test
+  void andConservesOtherPredicates() {
+    // CAUTION: order in the optimized version depends on the actual implementation
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r1') and REGEXP_LIKE(col1, 'r2') and col1 is not null",
+        "col1 is not null and REGEXP_LIKE(col1, '(?=r1)(?=r2)')");
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r1') and col1 is not null and REGEXP_LIKE(col1, 'r2')",
+        "col1 is not null and REGEXP_LIKE(col1, '(?=r1)(?=r2)')");
+    assertOptimizedTo("col1 is not null and REGEXP_LIKE(col1, 'r1') and REGEXP_LIKE(col1, 'r2')",
+        "col1 is not null and REGEXP_LIKE(col1, '(?=r1)(?=r2)')");
+
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r1') and REGEXP_LIKE(col1, 'r2') and col2 is not null",
+        "col2 is not null and REGEXP_LIKE(col1, '(?=r1)(?=r2)')");
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r1') and col2 is not null and REGEXP_LIKE(col1, 'r2')",
+        "col2 is not null and REGEXP_LIKE(col1, '(?=r1)(?=r2)')");
+    assertOptimizedTo("col2 is not null and REGEXP_LIKE(col1, 'r1') and REGEXP_LIKE(col1, 'r2')",
+        "col2 is not null and REGEXP_LIKE(col1, '(?=r1)(?=r2)')");
+  }
+
+  @Test
+  public void andMultipleColumns() {
+    // CAUTION: order in the optimized version depends on the actual implementation
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r1') and REGEXP_LIKE(col1, 'r2') "
+            + "and REGEXP_LIKE(col2, 'r1') and REGEXP_LIKE(col2, 'r2')",
+        "REGEXP_LIKE(col2, '(?=r1)(?=r2)') and REGEXP_LIKE(col1, '(?=r1)(?=r2)')");
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r1') and REGEXP_LIKE(col2, 'r1') "
+            + "and REGEXP_LIKE(col1, 'r2') and REGEXP_LIKE(col2, 'r2')",
+        "REGEXP_LIKE(col2, '(?=r1)(?=r2)') and REGEXP_LIKE(col1, '(?=r1)(?=r2)')");
+  }
+
+  @Test
+  public void andWithNot() {
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r1') and not REGEXP_LIKE(col1, 'r2')",
+        "REGEXP_LIKE(col1, '(?=r1)(?=(?!r2))')");
+    assertOptimizedTo("not REGEXP_LIKE(col1, 'r2') and REGEXP_LIKE(col1, 'r1')",
+        "REGEXP_LIKE(col1, '(?=(?!r2))(?=r1)')");
+  }
+
+  @Test
+  public void andWithAnd() {
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r1') and REGEXP_LIKE(col1, 'r2') and REGEXP_LIKE(col1, 'r3')",
+        "REGEXP_LIKE(col1, '(?=r1)(?=r2)(?=r3)')");
+  }
+
+  @Test
+  public void andWithOr() {
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r1') and (REGEXP_LIKE(col1, 'r2') or REGEXP_LIKE(col1, 'r3'))",
+        "REGEXP_LIKE(col1, '(?=r1)(?=(?:r2)|(?:r3))')");
+    assertOptimizedTo("(REGEXP_LIKE(col1, 'r2') or REGEXP_LIKE(col1, 'r3')) and REGEXP_LIKE(col1, 'r1')",
+        "REGEXP_LIKE(col1, '(?=(?:r2)|(?:r3))(?=r1)')");
+  }
+
+  @Test
+  public void orDoesNotOptimizeIndexedBackreferences() {
+    assertNotOptimized("REGEXP_LIKE(col1, '(r1)\\1') or REGEXP_LIKE(col1, 'r2')");
+    assertNotOptimized("REGEXP_LIKE(col1, 'r1') or REGEXP_LIKE(col1, '(r2)\\1')");
+  }
+
+  @Test
+  public void orDoesNotOptimizeNamedBackreferences() {
+    assertNotOptimized("REGEXP_LIKE(col1, '(?<x>r1)\\k<x>') or REGEXP_LIKE(col1, 'r2')");
+    assertNotOptimized("REGEXP_LIKE(col1, 'r1') or REGEXP_LIKE(col1, '(?<x>r2)\\k<x>')");
+  }
+
+  @Test
+  public void orDoesNotOptimizedWhenSingleTextMatchPerColumn() {
+    // Same column, only one REGEXP_LIKE
+    assertNotOptimized("REGEXP_LIKE(col1, 'r1') or col1 is not null");
+    // two REGEXP_LIKE with different columns
+    assertNotOptimized("REGEXP_LIKE(col1, 'r1') or REGEXP_LIKE(col2, 'r1')");
+    // two REGEXP_LIKE with same columns, only one is optimizable regex
+    assertNotOptimized("REGEXP_LIKE(col1, 'r1') or REGEXP_LIKE(col2, '(r1)\\1')");
+  }
+
+  @Test
+  public void orDoesOptimizeRegex() {
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r1') or REGEXP_LIKE(col1, 'r2')", "REGEXP_LIKE(col1, '(?:r1)|(?:r2)')");
+  }
+
+  @Test
+  void orConservesOtherPredicates() {
+    // CAUTION: order in the optimized version depends on the actual implementation
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r1') or REGEXP_LIKE(col1, 'r2') or col1 is not null",
+        "col1 is not null or REGEXP_LIKE(col1, '(?:r1)|(?:r2)')");
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r1') or col1 is not null or REGEXP_LIKE(col1, 'r2')",
+        "col1 is not null or REGEXP_LIKE(col1, '(?:r1)|(?:r2)')");
+    assertOptimizedTo("col1 is not null or REGEXP_LIKE(col1, 'r1') or REGEXP_LIKE(col1, 'r2')",
+        "col1 is not null or REGEXP_LIKE(col1, '(?:r1)|(?:r2)')");
+
+
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r1') or REGEXP_LIKE(col1, 'r2') or col2 is not null",
+        "col2 is not null or REGEXP_LIKE(col1, '(?:r1)|(?:r2)')");
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r1') or col2 is not null or REGEXP_LIKE(col1, 'r2')",
+        "col2 is not null or REGEXP_LIKE(col1, '(?:r1)|(?:r2)')");
+    assertOptimizedTo("col2 is not null or REGEXP_LIKE(col1, 'r1') or REGEXP_LIKE(col1, 'r2')",
+        "col2 is not null or REGEXP_LIKE(col1, '(?:r1)|(?:r2)')");
+  }
+
+  @Test
+  public void orMultipleColumns() {
+    // CAUTION: order in the optimized version depends on the actual implementation
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r1') or REGEXP_LIKE(col1, 'r2') "
+            + "or REGEXP_LIKE(col2, 'r1') or REGEXP_LIKE(col2, 'r2')",
+        "REGEXP_LIKE(col2, '(?:r1)|(?:r2)') or REGEXP_LIKE(col1, '(?:r1)|(?:r2)')");
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r1') or REGEXP_LIKE(col2, 'r1') "
+            + "or REGEXP_LIKE(col1, 'r2') or REGEXP_LIKE(col2, 'r2')",
+        "REGEXP_LIKE(col2, '(?:r1)|(?:r2)') or REGEXP_LIKE(col1, '(?:r1)|(?:r2)')");
+  }
+
+  @Test
+  public void orWithNot() {
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r1') or not REGEXP_LIKE(col1, 'r2')",
+        "REGEXP_LIKE(col1, '(?:r1)|(?:(?!r2))')");
+    assertOptimizedTo("not REGEXP_LIKE(col1, 'r2') or REGEXP_LIKE(col1, 'r1')",
+        "REGEXP_LIKE(col1, '(?:(?!r2))|(?:r1)')");
+  }
+
+  @Test
+  public void orWithAnd() {
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r1') or (REGEXP_LIKE(col1, 'r2') and REGEXP_LIKE(col1, 'r3'))",
+        "REGEXP_LIKE(col1, '(?:r1)|(?:(?=r2)(?=r3))')");
+    assertOptimizedTo("(REGEXP_LIKE(col1, 'r2') and REGEXP_LIKE(col1, 'r3') or REGEXP_LIKE(col1, 'r1'))",
+        "REGEXP_LIKE(col1, '(?:(?=r2)(?=r3))|(?:r1)')");
+  }
+
+  @Test
+  public void orWithOr() {
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r1') or REGEXP_LIKE(col1, 'r2') or REGEXP_LIKE(col1, 'r3')",
+        "REGEXP_LIKE(col1, '(?:r1)|(?:r2)|(?:r3)')");
+  }
+
+
+  private static void assertNotOptimized(String unoptimized) {
+    assertOptimizedTo(unoptimized, unoptimized);
+  }
+
+  private static void assertOptimizedTo(String unoptimized, String optimized) {
+    String prefix = "select * from t1 where ";
+
+    PinotQuery unoptimizedQuery = CalciteSqlParser.compileToPinotQuery(prefix + unoptimized);
+    Expression unoptimizedExpression = unoptimizedQuery.getFilterExpression();
+
+    HashMap<String, String> queryOptions = new HashMap<>();
+    queryOptions.put(CommonConstants.Query.Request.Optimization.FUSE_REGEX, "true");
+
+    Expression actualExpression = OPTIMIZER.optimize(unoptimizedExpression, SCHEMA, queryOptions);
+
+    PinotQuery expectedQuery = CalciteSqlParser.compileToPinotQuery(prefix + optimized);
+    Expression expectedExpression = expectedQuery.getFilterExpression();
+
+
+    assertEquals(actualExpression.toString(), expectedExpression.toString());
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/filter/MergeRegexFilterOptimizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/filter/MergeRegexFilterOptimizerTest.java
@@ -60,6 +60,11 @@ public class MergeRegexFilterOptimizerTest {
   }
 
   @Test
+  public void notWithLike() {
+    assertOptimizedTo("not col1 LIKE 'r1'", "REGEXP_LIKE(col1, '(?!^r1$)')");
+  }
+
+  @Test
   public void notWithAnd() {
     assertOptimizedTo("not (REGEXP_LIKE(col1, 'r1') and REGEXP_LIKE(col1, 'r2'))",
         "REGEXP_LIKE(col1, '(?!(?=r1)(?=r2))')");
@@ -133,6 +138,12 @@ public class MergeRegexFilterOptimizerTest {
         "REGEXP_LIKE(col1, '(?=r1)(?=(?!r2))')");
     assertOptimizedTo("not REGEXP_LIKE(col1, 'r2') and REGEXP_LIKE(col1, 'r1')",
         "REGEXP_LIKE(col1, '(?=(?!r2))(?=r1)')");
+  }
+
+  @Test
+  public void andWithLike() {
+    assertOptimizedTo("col1 LIKE 'r1' and REGEXP_LIKE(col1, 'r2')", "REGEXP_LIKE(col1, '(?=^r1$)(?=r2)')");
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r2') and col1 LIKE 'r1'", "REGEXP_LIKE(col1, '(?=r2)(?=^r1$)')");
   }
 
   @Test
@@ -215,6 +226,12 @@ public class MergeRegexFilterOptimizerTest {
   }
 
   @Test
+  public void orWithLike() {
+    assertOptimizedTo("col1 LIKE 'r1' or REGEXP_LIKE(col1, 'r2')", "REGEXP_LIKE(col1, '(?:^r1$)|(?:r2)')");
+    assertOptimizedTo("REGEXP_LIKE(col1, 'r2') or col1 LIKE 'r1'", "REGEXP_LIKE(col1, '(?:r2)|(?:^r1$)')");
+  }
+
+  @Test
   public void orWithAnd() {
     assertOptimizedTo("REGEXP_LIKE(col1, 'r1') or (REGEXP_LIKE(col1, 'r2') and REGEXP_LIKE(col1, 'r3'))",
         "REGEXP_LIKE(col1, '(?:r1)|(?:(?=r2)(?=r3))')");
@@ -227,7 +244,6 @@ public class MergeRegexFilterOptimizerTest {
     assertOptimizedTo("REGEXP_LIKE(col1, 'r1') or REGEXP_LIKE(col1, 'r2') or REGEXP_LIKE(col1, 'r3')",
         "REGEXP_LIKE(col1, '(?:r1)|(?:r2)|(?:r3)')");
   }
-
 
   private static void assertNotOptimized(String unoptimized) {
     assertOptimizedTo(unoptimized, unoptimized);

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkFuseRegexp.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkFuseRegexp.java
@@ -1,0 +1,343 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.queries.BaseQueriesTest;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.table.FSTType;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.CompilerControl;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(1)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@State(Scope.Benchmark)
+public class BenchmarkFuseRegexp extends BaseQueriesTest {
+
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "BenchmarkFuseRegexp");
+  private static final String TABLE_NAME = "MyTable";
+  private static final String SEGMENT_NAME = "testSegment";
+  private static final String DOMAIN_NAMES_COL = "DOMAIN_NAMES";
+  private static final String INT_COL_NAME = "INT_COL";
+  private static final String NO_INDEX_STRING_COL_NAME = "NO_INDEX_COL";
+
+  @Param({"LUCENE", "NATIVE", "null"})
+  private String _fstType;
+  //@Param({"DOMAIN_NAMES LIKE '%domain<i>%'"})
+  String _predicate = "DOMAIN_NAMES LIKE '%domain<i>%'";
+  //@Param({"and", "or"})
+  String _conjunction = "or";
+//  @Param("2500000")
+  int _numRows = 2500000;
+//  @Param("1000")
+  int _intBaseValue = 1000;
+//  @Param({"100"})
+  int _numBlocks = 100;
+
+  private IndexSegment _indexSegment;
+  private Schema _schema;
+  private TableConfig _tableConfig;
+
+  @Setup(Level.Trial)
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteQuietly(INDEX_DIR);
+    FSTType fstType = _fstType.equals("null") ? null : FSTType.valueOf(_fstType);
+    buildSegment(fstType);
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
+    if (fstType != null) {
+      Set<String> fstIndexCols = new HashSet<>();
+      fstIndexCols.add(DOMAIN_NAMES_COL);
+      indexLoadingConfig.setFSTIndexColumns(fstIndexCols);
+      indexLoadingConfig.setFSTIndexType(fstType);
+    }
+    _indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), indexLoadingConfig);
+
+    checkCorrectness();
+  }
+
+  @TearDown(Level.Trial)
+  public void tearDown() {
+    _indexSegment.destroy();
+    FileUtils.deleteQuietly(INDEX_DIR);
+    EXECUTOR_SERVICE.shutdownNow();
+  }
+
+  private List<GenericRow> createTestData(int numRows) {
+    List<GenericRow> rows = new ArrayList<>(numRows);
+    String[] domainNames = new String[]{
+        "www.domain1.com", "www.domain1.co.ab", "www.domain1.co.bc",
+        "www.domain1.co.cd", "www.sd.domain1.com", "www.sd.domain1.co.ab", "www.sd.domain1.co.bc",
+        "www.sd.domain1.co.cd", "www.domain2.com", "www.domain2.co.ab", "www.domain2.co.bc", "www.domain2.co.cd",
+        "www.sd.domain2.com", "www.sd.domain2.co.ab", "www.sd.domain2.co.bc", "www.sd.domain2.co.cd"
+    };
+    String[] noIndexData = new String[]{"test1", "test2", "test3", "test4", "test5"};
+    for (int i = 0; i < numRows; i++) {
+      String domain = domainNames[i % domainNames.length];
+      GenericRow row = new GenericRow();
+      row.putField(INT_COL_NAME, _intBaseValue + i);
+      row.putField(NO_INDEX_STRING_COL_NAME, noIndexData[i % noIndexData.length]);
+      row.putField(DOMAIN_NAMES_COL, domain);
+      rows.add(row);
+    }
+    return rows;
+  }
+
+  private void buildSegment(FSTType fstType)
+      throws Exception {
+    List<GenericRow> rows = createTestData(_numRows);
+    List<FieldConfig> fieldConfigs = new ArrayList<>();
+    fieldConfigs.add(
+        new FieldConfig(DOMAIN_NAMES_COL, FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null));
+    _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setInvertedIndexColumns(Collections.singletonList(DOMAIN_NAMES_COL)).setFieldConfigList(fieldConfigs).build();
+    _schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .addSingleValueDimension(DOMAIN_NAMES_COL, FieldSpec.DataType.STRING)
+        .addSingleValueDimension(NO_INDEX_STRING_COL_NAME, FieldSpec.DataType.STRING)
+        .addMetric(INT_COL_NAME, FieldSpec.DataType.INT).build();
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(_tableConfig, _schema);
+    config.setOutDir(INDEX_DIR.getPath());
+    config.setTableName(TABLE_NAME);
+    config.setSegmentName(SEGMENT_NAME);
+    if (fstType != null) {
+      config.setFSTIndexType(fstType);
+    }
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    try (RecordReader recordReader = new GenericRowRecordReader(rows)) {
+      driver.init(config, recordReader);
+      driver.build();
+    }
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public void optimal1Like(Blackhole bh) {
+    String query = "SELECT INT_COL FROM MyTable WHERE DOMAIN_NAMES LIKE '%domain0%'";
+    bh.consume(getBrokerResponse(query));
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public void optimal1Regex(Blackhole bh) {
+    String query = "SELECT INT_COL FROM MyTable WHERE regexp_like(DOMAIN_NAMES, 'domain0')";
+    bh.consume(getBrokerResponse(query));
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public void optimal10(Blackhole bh) {
+    String query = "SELECT INT_COL FROM MyTable WHERE regexp_like(DOMAIN_NAMES, 'domain\\d')";
+    bh.consume(getBrokerResponse(query));
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public void increasing10Like(Blackhole bh) {
+    String query = "SELECT INT_COL FROM MyTable WHERE "
+        + "DOMAIN_NAMES LIKE '%domain0%' or "
+        + "DOMAIN_NAMES LIKE '%domain1%' or "
+        + "DOMAIN_NAMES LIKE '%domain2%' or "
+        + "DOMAIN_NAMES LIKE '%domain3%' or "
+        + "DOMAIN_NAMES LIKE '%domain4%' or "
+        + "DOMAIN_NAMES LIKE '%domain5%' or "
+        + "DOMAIN_NAMES LIKE '%domain6%' or "
+        + "DOMAIN_NAMES LIKE '%domain7%' or "
+        + "DOMAIN_NAMES LIKE '%domain8%' or "
+        + "DOMAIN_NAMES LIKE '%domain9%'";
+    bh.consume(getBrokerResponse(query));
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public void increasing10Regex(Blackhole bh) {
+    String query = "SELECT INT_COL FROM MyTable WHERE "
+        + "regexp_like(DOMAIN_NAMES, '^.domain0.*$') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain1.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain2.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain3.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain4.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain5.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain6.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain7.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain8.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain9.*')";
+    bh.consume(getBrokerResponse(query));
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public void increasing10Fusing(Blackhole bh) {
+    String query = "SELECT INT_COL FROM MyTable WHERE "
+        + "regexp_like(DOMAIN_NAMES, '"
+        + "(?:^.*domain0.*$)|"
+        + "(?:^.*domain1.*$)|"
+        + "(?:^.*domain2.*$)|"
+        + "(?:^.*domain3.*$)|"
+        + "(?:^.*domain4.*$)|"
+        + "(?:^.*domain5.*$)|"
+        + "(?:^.*domain6.*$)|"
+        + "(?:^.*domain7.*$)|"
+        + "(?:^.*domain8.*$)|"
+        + "(?:^.*domain9.*$)')";
+
+    bh.consume(getBrokerResponse(query));
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public void decreasing9Like(Blackhole bh) {
+    String query = "SELECT INT_COL FROM MyTable WHERE "
+        + "DOMAIN_NAMES LIKE '%domain9%' or "
+        + "DOMAIN_NAMES LIKE '%domain8%' or "
+        + "DOMAIN_NAMES LIKE '%domain7%' or "
+        + "DOMAIN_NAMES LIKE '%domain6%' or "
+        + "DOMAIN_NAMES LIKE '%domain5%' or "
+        + "DOMAIN_NAMES LIKE '%domain4%' or "
+        + "DOMAIN_NAMES LIKE '%domain3%' or "
+        + "DOMAIN_NAMES LIKE '%domain2%' or "
+        + "DOMAIN_NAMES LIKE '%domain1%'";
+    bh.consume(getBrokerResponse(query));
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public void decreasing9Regex(Blackhole bh) {
+    String query = "SELECT INT_COL FROM MyTable WHERE "
+        + "regexp_like(DOMAIN_NAMES, '^.domain9.*$') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain8.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain7.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain6.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain5.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain4.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain3.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain2.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain2.*')";
+    bh.consume(getBrokerResponse(query));
+  }
+
+  @Benchmark
+  @CompilerControl(CompilerControl.Mode.DONT_INLINE)
+  public void decreasing9Fusing(Blackhole bh) {
+    String query = "SELECT INT_COL FROM MyTable WHERE "
+        + "regexp_like(DOMAIN_NAMES, '"
+        + "(?:^.*domain9.*$)|"
+        + "(?:^.*domain8.*$)|"
+        + "(?:^.*domain7.*$)|"
+        + "(?:^.*domain6.*$)|"
+        + "(?:^.*domain5.*$)|"
+        + "(?:^.*domain4.*$)|"
+        + "(?:^.*domain3.*$)|"
+        + "(?:^.*domain2.*$)|"
+        + "(?:^.*domain1.*$)')";
+
+    bh.consume(getBrokerResponse(query));
+  }
+
+  @Override
+  protected String getFilter() {
+    return null;
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
+  protected List<IndexSegment> getIndexSegments() {
+    return Collections.singletonList(_indexSegment);
+  }
+
+  public static void main(String[] args)
+      throws Exception {
+    new Runner(new OptionsBuilder().include(BenchmarkFuseRegexp.class.getSimpleName())
+//        .addProfiler(JavaFlightRecorderProfiler.class)
+        .build()).run();
+  }
+
+  private void checkCorrectness() {
+    String query1 = "SELECT INT_COL FROM MyTable WHERE "
+        + "regexp_like(DOMAIN_NAMES, '^.domain9.*$') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain8.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain7.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain6.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain5.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain4.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain3.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain2.*') or "
+        + "regexp_like(DOMAIN_NAMES, '^.domain2.*')";
+    String query2 = "SELECT INT_COL FROM MyTable WHERE "
+        + "regexp_like(DOMAIN_NAMES, '"
+        + "(?:^.*domain9.*$)|"
+        + "(?:^.*domain8.*$)|"
+        + "(?:^.*domain7.*$)|"
+        + "(?:^.*domain6.*$)|"
+        + "(?:^.*domain5.*$)|"
+        + "(?:^.*domain4.*$)|"
+        + "(?:^.*domain3.*$)|"
+        + "(?:^.*domain2.*$)|"
+        + "(?:^.*domain1.*$)')";
+
+    long total1 = getBrokerResponse(query1).getTotalDocs();
+    long total2 = getBrokerResponse(query2).getTotalDocs();
+
+    if (total1 != total2) {
+      throw new RuntimeException("Expressions are not equivalent: " + total1 + " vs " + total2);
+    }
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -644,6 +644,10 @@ public class CommonConstants {
         public static final String SQL = "sql";
         public static final String BROKER_REQUEST = "brokerRequest";
       }
+
+      public static class Optimization {
+        public static final String FUSE_REGEX = "fuseRegex";
+      }
     }
 
     public static class Response {


### PR DESCRIPTION
When executing queries like:
```sql
select col1, col2 from Table where regexp_like(col1, '/r1/') or regexp_like(col1, '/r2/')
```
Pinot has to scan the referred column twice. This PR creates an optimization that tries to fuse boolean algebra and `regexp_like` predicates. Specifically, as indicated in the Javadoc:
- Queries `where regexp_like(col1, 'r1') and regexp_like(col1, '/r2/')` will be translated to `where regexp_like(col1, '(?=r1)(?=r2)')`
- Queries `where regexp_like(col1, 'r1') or regexp_like(col1, '/r2/')` will be translated to `where regexp_like(col1, '(?:r1)|(?:r2)')`
- Queries `where not regexp_like(col1, 'r1')` will be translated to `where regexp_like(col1, '(?!r1)')`

There are some tests that apply the optimization to more advanced cases.

Regex can be quite complex. By doing some analysis I'm sure that this optimization will break some regex. For example, predicates that use backrefences may change the semantics when this optimization is applied. 

To know if the optimization can be applied or not, it would be necessary to analyze the regex, which would require to parse the regex into a AST. As far as I know Pinot doesn't have that, so this optimization is disabled by default and can be enabled by activating a new query option. There is an heuristic that applies a basic analysis to try to find incompatible expressions like backreferences. Even when the query option is enabled, the regexp that are detected as not optimizable by the heuristic will not be optimized.

Future improvements may include to translate some `text_match`, where this optimization may be useful.

PD: Originally this PR was focused on optimizing `text_match` instead of `regexp_like`. Some comments may still be referred to the original version