### PR TITLE
Allow moveToFinalLocation in METADATA push based on config

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -73,6 +73,8 @@ public class FileUploadDownloadClient implements AutoCloseable {
     public static final String UPLOAD_TYPE = "UPLOAD_TYPE";
     public static final String REFRESH_ONLY = "REFRESH_ONLY";
     public static final String DOWNLOAD_URI = "DOWNLOAD_URI";
+
+    public static final String MOVE_SEGMENT_TO_DEEP_STORE = "MOVE_SEGMENT_TO_DEEP_STORE";
     public static final String SEGMENT_ZK_METADATA_CUSTOM_MAP_MODIFIER = "Pinot-SegmentZKMetadataCustomMapModifier";
     public static final String CRYPTER = "CRYPTER";
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -74,7 +74,11 @@ public class FileUploadDownloadClient implements AutoCloseable {
     public static final String REFRESH_ONLY = "REFRESH_ONLY";
     public static final String DOWNLOAD_URI = "DOWNLOAD_URI";
 
-    public static final String MOVE_SEGMENT_TO_DEEP_STORE = "MOVE_SEGMENT_TO_DEEP_STORE";
+    /**
+     * This header is only used for METADATA push, to allow controller to copy segment to deep store,
+     * if segment was not placed in the deep store to begin with
+     */
+    public static final String COPY_SEGMENT_TO_DEEP_STORE = "COPY_SEGMENT_TO_DEEP_STORE";
     public static final String SEGMENT_ZK_METADATA_CUSTOM_MAP_MODIFIER = "Pinot-SegmentZKMetadataCustomMapModifier";
     public static final String CRYPTER = "CRYPTER";
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -273,11 +273,7 @@ public class PinotSegmentUploadDownloadRestletResource {
           // else set to false for backward compatibility
           String copySegmentToDeepStore =
               extractHttpHeader(headers, FileUploadDownloadClient.CustomHeaders.COPY_SEGMENT_TO_DEEP_STORE);
-          if (copySegmentToDeepStore != null) {
-            copySegmentToFinalLocation = Boolean.parseBoolean(copySegmentToDeepStore);
-          } else {
-            copySegmentToFinalLocation = false;
-          }
+          copySegmentToFinalLocation = Boolean.parseBoolean(copySegmentToDeepStore);
           createSegmentFileFromMultipart(multiPart, destFile);
           try {
             URI segmentURI = new URI(sourceDownloadURIStr);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/upload/ZKOperatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/upload/ZKOperatorTest.java
@@ -18,30 +18,39 @@
  */
 package org.apache.pinot.controller.api.upload;
 
+import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.net.URI;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
+import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerMetrics;
-import org.apache.pinot.common.utils.FileUploadDownloadClient;
+import org.apache.pinot.common.utils.FileUploadDownloadClient.FileUploadType;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.Realtime.Status;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -52,6 +61,9 @@ import static org.testng.Assert.*;
 
 
 public class ZKOperatorTest {
+  private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "ZKOperatorTest");
+  private static final File SEGMENT_DIR = new File(TEMP_DIR, "segmentDir");
+  private static final File DATA_DIR = new File(TEMP_DIR, "dataDir");
   private static final String RAW_TABLE_NAME = "testTable";
   private static final String OFFLINE_TABLE_NAME = TableNameBuilder.OFFLINE.tableNameWithType(RAW_TABLE_NAME);
   private static final String REALTIME_TABLE_NAME = TableNameBuilder.REALTIME.tableNameWithType(RAW_TABLE_NAME);
@@ -67,6 +79,7 @@ public class ZKOperatorTest {
   @BeforeClass
   public void setUp()
       throws Exception {
+    FileUtils.deleteQuietly(TEMP_DIR);
     TEST_INSTANCE.setupSharedStateAndValidate();
     _resourceManager = TEST_INSTANCE.getHelixResourceManager();
 
@@ -94,6 +107,86 @@ public class ZKOperatorTest {
     return streamConfigs;
   }
 
+  private File generateSegment()
+      throws Exception {
+    Schema schema =
+        new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME).addSingleValueDimension("colA", DataType.INT).build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    File outputDir = new File(SEGMENT_DIR, "segment");
+    config.setOutDir(outputDir.getAbsolutePath());
+    config.setSegmentName(SEGMENT_NAME);
+    GenericRow row = new GenericRow();
+    row.putValue("colA", "100");
+    List<GenericRow> rows = ImmutableList.of(row);
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(config, new GenericRowRecordReader(rows));
+    driver.build();
+    File segmentTar = new File(SEGMENT_DIR, SEGMENT_NAME + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
+    TarGzCompressionUtils.createTarGzFile(new File(outputDir, SEGMENT_NAME),
+        new File(SEGMENT_DIR, SEGMENT_NAME + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION));
+    FileUtils.deleteQuietly(outputDir);
+    return segmentTar;
+  }
+
+  private void checkSegmentZkMetadata() {
+    SegmentZKMetadata segmentZKMetadata = _resourceManager.getSegmentZKMetadata(OFFLINE_TABLE_NAME, SEGMENT_NAME);
+    assertNotNull(segmentZKMetadata);
+    assertEquals(segmentZKMetadata.getCrc(), 12345L);
+    assertEquals(segmentZKMetadata.getCreationTime(), 123L);
+    long pushTime = segmentZKMetadata.getPushTime();
+    assertTrue(pushTime > 0);
+    assertEquals(segmentZKMetadata.getRefreshTime(), Long.MIN_VALUE);
+    assertEquals(segmentZKMetadata.getDownloadUrl(), "downloadUrl");
+    assertEquals(segmentZKMetadata.getCrypterName(), "crypter");
+    assertEquals(segmentZKMetadata.getSegmentUploadStartTime(), -1);
+    assertEquals(segmentZKMetadata.getSizeInBytes(), 10);
+  }
+
+  @Test
+  public void testMetadataUploadType()
+      throws Exception {
+    FileUtils.deleteQuietly(TEMP_DIR);
+    ZKOperator zkOperator = new ZKOperator(_resourceManager, mock(ControllerConf.class), mock(ControllerMetrics.class));
+
+    SegmentMetadata segmentMetadata = mock(SegmentMetadata.class);
+    when(segmentMetadata.getName()).thenReturn(SEGMENT_NAME);
+    when(segmentMetadata.getCrc()).thenReturn("12345");
+    when(segmentMetadata.getIndexCreationTime()).thenReturn(123L);
+    HttpHeaders httpHeaders = mock(HttpHeaders.class);
+
+    File segmentTar = generateSegment();
+    String sourceDownloadURIStr = segmentTar.toURI().toString();
+    File segmentFile = new File("metadataOnly");
+
+    // with finalSegmentLocation not null
+    File finalSegmentLocation = new File(DATA_DIR, SEGMENT_NAME);
+    Assert.assertFalse(finalSegmentLocation.exists());
+    zkOperator.completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, FileUploadType.METADATA,
+        finalSegmentLocation.toURI(), segmentFile, sourceDownloadURIStr, "downloadUrl", "crypter", 10, true, true,
+        httpHeaders);
+    Assert.assertTrue(finalSegmentLocation.exists());
+    Assert.assertTrue(segmentTar.exists());
+    checkSegmentZkMetadata();
+
+    _resourceManager.deleteSegment(OFFLINE_TABLE_NAME, SEGMENT_NAME);
+    // Wait for the segment Zk entry to be deleted.
+    TestUtils.waitForCondition(aVoid -> {
+      SegmentZKMetadata segmentZKMetadata = _resourceManager.getSegmentZKMetadata(OFFLINE_TABLE_NAME, SEGMENT_NAME);
+      return segmentZKMetadata == null;
+    }, 30_000L, "Failed to delete segmentZkMetadata.");
+
+    FileUtils.deleteQuietly(DATA_DIR);
+    // with finalSegmentLocation null
+    zkOperator.completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, FileUploadType.METADATA, null,
+        segmentFile, sourceDownloadURIStr, "downloadUrl", "crypter", 10, true, true, httpHeaders);
+    Assert.assertFalse(finalSegmentLocation.exists());
+    Assert.assertTrue(segmentTar.exists());
+    checkSegmentZkMetadata();
+  }
+
   @Test
   public void testCompleteSegmentOperations()
       throws Exception {
@@ -111,9 +204,8 @@ public class ZKOperatorTest {
       URI finalSegmentLocationURI =
           URIUtils.getUri("mockPath", OFFLINE_TABLE_NAME, URIUtils.encode(segmentMetadata.getName()));
       File segmentFile = new File(new File("foo/bar"), "mockChild");
-
-      zkOperator.completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, FileUploadDownloadClient.FileUploadType.SEGMENT, finalSegmentLocationURI, segmentFile,
-          "downloadUrl", "downloadUrl", "crypter", 10, true, true, httpHeaders);
+      zkOperator.completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, FileUploadType.SEGMENT,
+          finalSegmentLocationURI, segmentFile, "downloadUrl", "downloadUrl", "crypter", 10, true, true, httpHeaders);
       fail();
     } catch (Exception e) {
       // Expected
@@ -125,8 +217,8 @@ public class ZKOperatorTest {
       return segmentZKMetadata == null;
     }, 30_000L, "Failed to delete segmentZkMetadata.");
 
-    zkOperator.completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, FileUploadDownloadClient.FileUploadType.SEGMENT, null, null, "downloadUrl","downloadUrl", "crypter", 10,
-        true, true, httpHeaders);
+    zkOperator.completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, FileUploadType.SEGMENT, null, null,
+        "downloadUrl", "downloadUrl", "crypter", 10, true, true, httpHeaders);
 
     SegmentZKMetadata segmentZKMetadata = _resourceManager.getSegmentZKMetadata(OFFLINE_TABLE_NAME, SEGMENT_NAME);
     assertNotNull(segmentZKMetadata);
@@ -142,8 +234,8 @@ public class ZKOperatorTest {
 
     // Upload the same segment with allowRefresh = false. Validate that an exception is thrown.
     try {
-      zkOperator.completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, FileUploadDownloadClient.FileUploadType.SEGMENT, null, null, "otherDownloadUrl","otherDownloadUrl",
-          "otherCrypter", 10, true, false, httpHeaders);
+      zkOperator.completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, FileUploadType.SEGMENT, null, null,
+          "otherDownloadUrl", "otherDownloadUrl", "otherCrypter", 10, true, false, httpHeaders);
       fail();
     } catch (Exception e) {
       // Expected
@@ -152,8 +244,8 @@ public class ZKOperatorTest {
     // Refresh the segment with unmatched IF_MATCH field
     when(httpHeaders.getHeaderString(HttpHeaders.IF_MATCH)).thenReturn("123");
     try {
-      zkOperator.completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, FileUploadDownloadClient.FileUploadType.SEGMENT, null, null, "otherDownloadUrl","otherDownloadUrl",
-          "otherCrypter", 10, true, true, httpHeaders);
+      zkOperator.completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, FileUploadType.SEGMENT, null, null,
+          "otherDownloadUrl", "otherDownloadUrl", "otherCrypter", 10, true, true, httpHeaders);
       fail();
     } catch (Exception e) {
       // Expected
@@ -163,8 +255,8 @@ public class ZKOperatorTest {
     // downloadURL and crypter
     when(httpHeaders.getHeaderString(HttpHeaders.IF_MATCH)).thenReturn("12345");
     when(segmentMetadata.getIndexCreationTime()).thenReturn(456L);
-    zkOperator.completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, FileUploadDownloadClient.FileUploadType.SEGMENT, null, null, "otherDownloadUrl","otherDownloadUrl",
-        "otherCrypter", 10, true, true, httpHeaders);
+    zkOperator.completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, FileUploadType.SEGMENT, null, null,
+        "otherDownloadUrl", "otherDownloadUrl", "otherCrypter", 10, true, true, httpHeaders);
 
     segmentZKMetadata = _resourceManager.getSegmentZKMetadata(OFFLINE_TABLE_NAME, SEGMENT_NAME);
     assertNotNull(segmentZKMetadata);
@@ -186,8 +278,8 @@ public class ZKOperatorTest {
     when(segmentMetadata.getIndexCreationTime()).thenReturn(789L);
     // Add a tiny sleep to guarantee that refresh time is different from the previous round
     Thread.sleep(10);
-    zkOperator.completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, FileUploadDownloadClient.FileUploadType.SEGMENT, null, null, "otherDownloadUrl","otherDownloadUrl",
-        "otherCrypter", 100, true, true, httpHeaders);
+    zkOperator.completeSegmentOperations(OFFLINE_TABLE_NAME, segmentMetadata, FileUploadType.SEGMENT, null, null,
+        "otherDownloadUrl", "otherDownloadUrl", "otherCrypter", 100, true, true, httpHeaders);
 
     segmentZKMetadata = _resourceManager.getSegmentZKMetadata(OFFLINE_TABLE_NAME, SEGMENT_NAME);
     assertNotNull(segmentZKMetadata);
@@ -210,8 +302,8 @@ public class ZKOperatorTest {
     SegmentMetadata segmentMetadata = mock(SegmentMetadata.class);
     when(segmentMetadata.getName()).thenReturn(SEGMENT_NAME);
     when(segmentMetadata.getCrc()).thenReturn("12345");
-    zkOperator.completeSegmentOperations(REALTIME_TABLE_NAME, segmentMetadata, FileUploadDownloadClient.FileUploadType.SEGMENT, null, null, "downloadUrl","downloadUrl", null, 10,
-        true, true, mock(HttpHeaders.class));
+    zkOperator.completeSegmentOperations(REALTIME_TABLE_NAME, segmentMetadata, FileUploadType.SEGMENT, null, null,
+        "downloadUrl", "downloadUrl", null, 10, true, true, mock(HttpHeaders.class));
 
     SegmentZKMetadata segmentZKMetadata = _resourceManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, SEGMENT_NAME);
     assertNotNull(segmentZKMetadata);
@@ -223,8 +315,8 @@ public class ZKOperatorTest {
     when(segmentMetadata.getName()).thenReturn(LLC_SEGMENT_NAME);
     when(segmentMetadata.getCrc()).thenReturn("23456");
     try {
-      zkOperator.completeSegmentOperations(REALTIME_TABLE_NAME, segmentMetadata, FileUploadDownloadClient.FileUploadType.SEGMENT, null, null, "downloadUrl","downloadUrl", null, 10,
-          true, true, mock(HttpHeaders.class));
+      zkOperator.completeSegmentOperations(REALTIME_TABLE_NAME, segmentMetadata, FileUploadType.SEGMENT, null, null,
+          "downloadUrl", "downloadUrl", null, 10, true, true, mock(HttpHeaders.class));
       fail();
     } catch (ControllerApplicationException e) {
       assertEquals(e.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
@@ -234,8 +326,8 @@ public class ZKOperatorTest {
     // Uploading a segment with LLC segment name and start/end offset should success
     when(segmentMetadata.getStartOffset()).thenReturn("0");
     when(segmentMetadata.getEndOffset()).thenReturn("1234");
-    zkOperator.completeSegmentOperations(REALTIME_TABLE_NAME, segmentMetadata, FileUploadDownloadClient.FileUploadType.SEGMENT, null, null, "downloadUrl","downloadUrl", null, 10,
-        true, true, mock(HttpHeaders.class));
+    zkOperator.completeSegmentOperations(REALTIME_TABLE_NAME, segmentMetadata, FileUploadType.SEGMENT, null, null,
+        "downloadUrl", "downloadUrl", null, 10, true, true, mock(HttpHeaders.class));
 
     segmentZKMetadata = _resourceManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, LLC_SEGMENT_NAME);
     assertNotNull(segmentZKMetadata);
@@ -247,8 +339,8 @@ public class ZKOperatorTest {
     when(segmentMetadata.getCrc()).thenReturn("34567");
     when(segmentMetadata.getStartOffset()).thenReturn(null);
     when(segmentMetadata.getEndOffset()).thenReturn(null);
-    zkOperator.completeSegmentOperations(REALTIME_TABLE_NAME, segmentMetadata, FileUploadDownloadClient.FileUploadType.SEGMENT, null, null, "downloadUrl","downloadUrl", null, 10,
-        true, true, mock(HttpHeaders.class));
+    zkOperator.completeSegmentOperations(REALTIME_TABLE_NAME, segmentMetadata, FileUploadType.SEGMENT, null, null,
+        "downloadUrl", "downloadUrl", null, 10, true, true, mock(HttpHeaders.class));
 
     segmentZKMetadata = _resourceManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, LLC_SEGMENT_NAME);
     assertNotNull(segmentZKMetadata);
@@ -260,8 +352,8 @@ public class ZKOperatorTest {
     when(segmentMetadata.getCrc()).thenReturn("45678");
     when(segmentMetadata.getStartOffset()).thenReturn("1234");
     when(segmentMetadata.getEndOffset()).thenReturn("2345");
-    zkOperator.completeSegmentOperations(REALTIME_TABLE_NAME, segmentMetadata, FileUploadDownloadClient.FileUploadType.SEGMENT, null, null, "downloadUrl","downloadUrl", null, 10,
-        true, true, mock(HttpHeaders.class));
+    zkOperator.completeSegmentOperations(REALTIME_TABLE_NAME, segmentMetadata, FileUploadType.SEGMENT, null, null,
+        "downloadUrl", "downloadUrl", null, 10, true, true, mock(HttpHeaders.class));
 
     segmentZKMetadata = _resourceManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, LLC_SEGMENT_NAME);
     assertNotNull(segmentZKMetadata);
@@ -272,6 +364,7 @@ public class ZKOperatorTest {
 
   @AfterClass
   public void tearDown() {
+    FileUtils.deleteQuietly(TEMP_DIR);
     TEST_INSTANCE.cleanup();
   }
 }

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
@@ -283,12 +283,28 @@ public class ClusterIntegrationTestUtils {
   public static void buildSegmentFromAvro(File avroFile, TableConfig tableConfig,
       org.apache.pinot.spi.data.Schema schema, int segmentIndex, File segmentDir, File tarDir)
       throws Exception {
+    // Test segment with space and special character in the file name
+    buildSegmentFromAvro(avroFile, tableConfig, schema, segmentIndex + " %", segmentDir, tarDir);
+  }
+
+  /**
+   * Builds one Pinot segment from the given Avro file.
+   *
+   * @param avroFile Avro file
+   * @param tableConfig Pinot table config
+   * @param schema Pinot schema
+   * @param segmentNamePostfix Segment name postfix
+   * @param segmentDir Output directory for the un-tarred segments
+   * @param tarDir Output directory for the tarred segments
+   */
+  public static void buildSegmentFromAvro(File avroFile, TableConfig tableConfig,
+      org.apache.pinot.spi.data.Schema schema, String segmentNamePostfix, File segmentDir, File tarDir)
+      throws Exception {
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     segmentGeneratorConfig.setInputFilePath(avroFile.getPath());
     segmentGeneratorConfig.setOutDir(segmentDir.getPath());
     segmentGeneratorConfig.setTableName(tableConfig.getTableName());
-    // Test segment with space and special character in the file name
-    segmentGeneratorConfig.setSegmentNamePostfix(segmentIndex + " %");
+    segmentGeneratorConfig.setSegmentNamePostfix(segmentNamePostfix);
 
     // Build the segment
     SegmentIndexCreationDriver driver = new SegmentIndexCreationDriverImpl();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentMetadataPushIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentMetadataPushIntegrationTest.java
@@ -1,0 +1,229 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.plugin.ingestion.batch.standalone.SegmentMetadataPushJobRunner;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.ingestion.batch.spec.PinotClusterSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.PushJobSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.TableSpec;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.util.TestUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Test for advanced push types.
+ * Currently only tests METADATA push type.
+ * todo: add test for URI push
+ */
+public class SegmentMetadataPushIntegrationTest extends BaseClusterIntegrationTest {
+
+  @Override
+  protected Map<String, String> getStreamConfigs() {
+    return null;
+  }
+
+  @Override
+  protected String getSortedColumn() {
+    return null;
+  }
+
+  @Override
+  protected List<String> getInvertedIndexColumns() {
+    return null;
+  }
+
+  @Override
+  protected List<String> getNoDictionaryColumns() {
+    return null;
+  }
+
+  @Override
+  protected List<String> getRangeIndexColumns() {
+    return null;
+  }
+
+  @Override
+  protected List<String> getBloomFilterColumns() {
+    return null;
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+    // Start Zk and Kafka
+    startZk();
+
+    // Start the Pinot cluster
+    startController();
+    startBroker();
+    startServer();
+  }
+
+  @Test
+  public void testUploadAndQuery()
+      throws Exception {
+    // Create and upload the schema and table config
+    Schema schema = createSchema();
+    addSchema(schema);
+    TableConfig offlineTableConfig = createOfflineTableConfig();
+    addTableConfig(offlineTableConfig);
+
+    List<File> avroFiles = getAllAvroFiles();
+
+    // Create 1 segment, for METADATA push WITH move to final location
+    ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFiles.get(0), offlineTableConfig, schema, "_with_move",
+        _segmentDir, _tarDir);
+
+    SegmentMetadataPushJobRunner runner = new SegmentMetadataPushJobRunner();
+    SegmentGenerationJobSpec jobSpec = new SegmentGenerationJobSpec();
+    PushJobSpec pushJobSpec = new PushJobSpec();
+    // set moveToDeepStoreForMetadataPush to true
+    pushJobSpec.setMoveToDeepStoreForMetadataPush(true);
+    jobSpec.setPushJobSpec(pushJobSpec);
+    PinotFSSpec fsSpec = new PinotFSSpec();
+    fsSpec.setScheme("file");
+    fsSpec.setClassName("org.apache.pinot.spi.filesystem.LocalPinotFS");
+    jobSpec.setPinotFSSpecs(Lists.newArrayList(fsSpec));
+    jobSpec.setOutputDirURI(_tarDir.getAbsolutePath());
+    TableSpec tableSpec = new TableSpec();
+    tableSpec.setTableName(DEFAULT_TABLE_NAME);
+    jobSpec.setTableSpec(tableSpec);
+    PinotClusterSpec clusterSpec = new PinotClusterSpec();
+    clusterSpec.setControllerURI(_controllerBaseApiUrl);
+    jobSpec.setPinotClusterSpecs(new PinotClusterSpec[]{clusterSpec});
+
+    File dataDir = new File(_controllerConfig.getDataDir());
+    File dataDirSegments = new File(dataDir, DEFAULT_TABLE_NAME);
+
+    // Not present in dataDir, only present in sourceDir
+    Assert.assertFalse(dataDirSegments.exists());
+    Assert.assertEquals(_tarDir.listFiles().length, 1);
+
+    runner.init(jobSpec);
+    runner.run();
+
+    // Segment should be seen in dataDir
+    Assert.assertTrue(dataDirSegments.exists());
+    Assert.assertEquals(dataDirSegments.listFiles().length, 1);
+    Assert.assertEquals(_tarDir.listFiles().length, 1);
+
+    // test segment loaded
+    JsonNode segmentsList = getSegmentsList();
+    Assert.assertEquals(segmentsList.size(), 1);
+    String segmentNameWithMove = segmentsList.get(0).asText();
+    Assert.assertTrue(segmentNameWithMove.endsWith("_with_move"));
+    long numDocs = getNumDocs(segmentNameWithMove);
+    testCountStar(numDocs);
+
+    // Clear segment and tar dir
+    for (File segment : _segmentDir.listFiles()) {
+      FileUtils.deleteQuietly(segment);
+    }
+    for (File tar : _tarDir.listFiles()) {
+      FileUtils.deleteQuietly(tar);
+    }
+
+    // Create 1 segment, for METADATA push WITHOUT move to final location
+    ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFiles.get(1), offlineTableConfig, schema, "_without_move",
+        _segmentDir, _tarDir);
+    jobSpec.setPushJobSpec(new PushJobSpec());
+    runner = new SegmentMetadataPushJobRunner();
+
+    Assert.assertEquals(dataDirSegments.listFiles().length, 1);
+    Assert.assertEquals(_tarDir.listFiles().length, 1);
+
+    runner.init(jobSpec);
+    runner.run();
+
+    // should not see new segments in dataDir
+    Assert.assertEquals(dataDirSegments.listFiles().length, 1);
+    Assert.assertEquals(_tarDir.listFiles().length, 1);
+
+    // test segment loaded
+    segmentsList = getSegmentsList();
+    Assert.assertEquals(segmentsList.size(), 2);
+    String segmentNameWithoutMove = null;
+    for (JsonNode segment : segmentsList) {
+      if (segment.asText().endsWith("_without_move")) {
+        segmentNameWithoutMove = segment.asText();
+      }
+    }
+    Assert.assertNotNull(segmentNameWithoutMove);
+    numDocs += getNumDocs(segmentNameWithoutMove);
+    testCountStar(numDocs);
+  }
+
+  private long getNumDocs(String segmentName)
+      throws IOException {
+    return JsonUtils.stringToJsonNode(
+            sendGetRequest(_controllerRequestURLBuilder.forSegmentMetadata(DEFAULT_TABLE_NAME, segmentName)))
+        .get("segment.total.docs").asLong();
+  }
+
+  private JsonNode getSegmentsList()
+      throws IOException {
+    return JsonUtils.stringToJsonNode(sendGetRequest(
+            _controllerRequestURLBuilder.forSegmentListAPIWithTableType(DEFAULT_TABLE_NAME,
+                TableType.OFFLINE.toString())))
+        .get(0).get("OFFLINE");
+  }
+
+  protected void testCountStar(final long countStarResult) {
+    TestUtils.waitForCondition(new Function<>() {
+      @Nullable
+      @Override
+      public Boolean apply(@Nullable Void aVoid) {
+        try {
+          return getCurrentCountStarResult() == countStarResult;
+        } catch (Exception e) {
+          return null;
+        }
+      }
+    }, 100L, 300_000, "Failed to load " + countStarResult + " documents", true);
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws Exception {
+    dropOfflineTable(getTableName());
+    stopServer();
+    stopBroker();
+    stopController();
+    stopZk();
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentMetadataPushIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentMetadataPushIntegrationTest.java
@@ -204,7 +204,7 @@ public class SegmentMetadataPushIntegrationTest extends BaseClusterIntegrationTe
   }
 
   protected void testCountStar(final long countStarResult) {
-    TestUtils.waitForCondition(new Function<>() {
+    TestUtils.waitForCondition(new Function<Void, Boolean>() {
       @Nullable
       @Override
       public Boolean apply(@Nullable Void aVoid) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
@@ -113,7 +113,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     SegmentGenerationJobSpec jobSpec = new SegmentGenerationJobSpec();
     PushJobSpec pushJobSpec = new PushJobSpec();
     // set moveToDeepStoreForMetadataPush to true
-    pushJobSpec.setMoveToDeepStoreForMetadataPush(true);
+    pushJobSpec.setCopyToDeepStoreForMetadataPush(true);
     jobSpec.setPushJobSpec(pushJobSpec);
     PinotFSSpec fsSpec = new PinotFSSpec();
     fsSpec.setScheme("file");

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
@@ -49,7 +49,7 @@ import org.testng.annotations.Test;
  * Currently only tests METADATA push type.
  * todo: add test for URI push
  */
-public class SegmentMetadataPushIntegrationTest extends BaseClusterIntegrationTest {
+public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
 
   @Override
   protected Map<String, String> getStreamConfigs() {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
@@ -264,6 +264,10 @@ public class SegmentPushUtils implements Serializable {
               headers.add(new BasicHeader(FileUploadDownloadClient.CustomHeaders.DOWNLOAD_URI, segmentUriPath));
               headers.add(new BasicHeader(FileUploadDownloadClient.CustomHeaders.UPLOAD_TYPE,
                   FileUploadDownloadClient.FileUploadType.METADATA.toString()));
+              if (spec.getPushJobSpec() != null) {
+                headers.add(new BasicHeader(FileUploadDownloadClient.CustomHeaders.MOVE_SEGMENT_TO_DEEP_STORE,
+                    String.valueOf(spec.getPushJobSpec().getMoveToDeepStoreForMetadataPush())));
+              }
               headers.addAll(AuthProviderUtils.toRequestHeaders(authProvider));
 
               SimpleHttpResponse response = FILE_UPLOAD_DOWNLOAD_CLIENT

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
@@ -265,7 +265,7 @@ public class SegmentPushUtils implements Serializable {
               headers.add(new BasicHeader(FileUploadDownloadClient.CustomHeaders.UPLOAD_TYPE,
                   FileUploadDownloadClient.FileUploadType.METADATA.toString()));
               if (spec.getPushJobSpec() != null) {
-                headers.add(new BasicHeader(FileUploadDownloadClient.CustomHeaders.MOVE_SEGMENT_TO_DEEP_STORE,
+                headers.add(new BasicHeader(FileUploadDownloadClient.CustomHeaders.COPY_SEGMENT_TO_DEEP_STORE,
                     String.valueOf(spec.getPushJobSpec().getMoveToDeepStoreForMetadataPush())));
               }
               headers.addAll(AuthProviderUtils.toRequestHeaders(authProvider));

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
@@ -266,7 +266,7 @@ public class SegmentPushUtils implements Serializable {
                   FileUploadDownloadClient.FileUploadType.METADATA.toString()));
               if (spec.getPushJobSpec() != null) {
                 headers.add(new BasicHeader(FileUploadDownloadClient.CustomHeaders.COPY_SEGMENT_TO_DEEP_STORE,
-                    String.valueOf(spec.getPushJobSpec().getMoveToDeepStoreForMetadataPush())));
+                    String.valueOf(spec.getPushJobSpec().getCopyToDeepStoreForMetadataPush())));
               }
               headers.addAll(AuthProviderUtils.toRequestHeaders(authProvider));
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/PushJobSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/PushJobSpec.java
@@ -42,6 +42,11 @@ public class PushJobSpec implements Serializable {
   private long _pushRetryIntervalMillis = 1000;
 
   /**
+   * Applicable for URI and METADATA push types.
+   * If true, and if segment was not already in the deep store, move it to deep store.
+   */
+  private boolean _moveToDeepStoreForMetadataPush;
+  /**
    * Used in SegmentUriPushJobRunner, which is used to composite the segment uri to send to pinot controller.
    * The URI sends to controller is in the format ${segmentUriPrefix}${segmentPath}${segmentUriSuffix}
    */
@@ -120,5 +125,13 @@ public class PushJobSpec implements Serializable {
 
   public void setPushParallelism(int pushParallelism) {
     _pushParallelism = pushParallelism;
+  }
+
+  public boolean getMoveToDeepStoreForMetadataPush() {
+    return _moveToDeepStoreForMetadataPush;
+  }
+
+  public void setMoveToDeepStoreForMetadataPush(boolean moveToDeepStoreForMetadataPush) {
+    _moveToDeepStoreForMetadataPush = moveToDeepStoreForMetadataPush;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/PushJobSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/PushJobSpec.java
@@ -45,7 +45,7 @@ public class PushJobSpec implements Serializable {
    * Applicable for URI and METADATA push types.
    * If true, and if segment was not already in the deep store, move it to deep store.
    */
-  private boolean _moveToDeepStoreForMetadataPush;
+  private boolean _copyToDeepStoreForMetadataPush;
   /**
    * Used in SegmentUriPushJobRunner, which is used to composite the segment uri to send to pinot controller.
    * The URI sends to controller is in the format ${segmentUriPrefix}${segmentPath}${segmentUriSuffix}
@@ -127,11 +127,11 @@ public class PushJobSpec implements Serializable {
     _pushParallelism = pushParallelism;
   }
 
-  public boolean getMoveToDeepStoreForMetadataPush() {
-    return _moveToDeepStoreForMetadataPush;
+  public boolean getCopyToDeepStoreForMetadataPush() {
+    return _copyToDeepStoreForMetadataPush;
   }
 
-  public void setMoveToDeepStoreForMetadataPush(boolean moveToDeepStoreForMetadataPush) {
-    _moveToDeepStoreForMetadataPush = moveToDeepStoreForMetadataPush;
+  public void setCopyToDeepStoreForMetadataPush(boolean copyToDeepStoreForMetadataPush) {
+    _copyToDeepStoreForMetadataPush = copyToDeepStoreForMetadataPush;
   }
 }


### PR DESCRIPTION
`METADATA` push didn't allow the option of `moveSegmentToFinalLocation`. This meant that if someone had generated segments in a location that was not the deep store, there was absolutely no way to move those segments into deep store without manual scripting.
Chatting with @xiangfu0 , I understood that this was done on purpose, in order to keep METADATA push very light weight and not involve copying from `outputDir` to `dataDir` in the push. But this is a very valid scenario where users would want to generate segments in a location other than deep store, and still want to use `METADATA` push (reasons could be multiple, as listed in https://github.com/apache/pinot/issues/7328).

While there have been more elaborate solutions proposed in the issue above (like periodic background tasks), this PR simply enables one to allow `METADATA` push to do `moveToFinalLocation`. And while this would increase the data push time, it is a better solution than asking users to switch to `SegmentTarPush` or `SegmentUriPush`, especially if the issue was disparate permissions between outputDir ad dataDir (one of the reasons mentioned in the issue).

Backward compatible behavior or this being `false` by default is maintained.

Added an integration test.