### PR TITLE
(BUGFIX) Fix auth provider for minion

### DIFF
--- a/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
@@ -33,6 +33,7 @@ import org.apache.helix.manager.zk.ZKHelixManager;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.task.TaskStateModelFactory;
 import org.apache.pinot.common.Utils;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.metrics.MinionMeter;
 import org.apache.pinot.common.metrics.MinionMetrics;
@@ -188,7 +189,8 @@ public abstract class BaseMinionStarter implements ServiceStartable {
     }
 
     // initialize authentication
-    minionContext.setTaskAuthToken(_config.getProperty(CommonConstants.Minion.CONFIG_OF_TASK_AUTH_TOKEN));
+    minionContext.setTaskAuthProvider(
+        AuthProviderUtils.extractAuthProvider(_config, CommonConstants.Minion.CONFIG_TASK_AUTH_NAMESPACE));
 
     // Start all components
     LOGGER.info("Initializing PinotFSFactory");

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionContext.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionContext.java
@@ -24,6 +24,7 @@ import org.apache.helix.ZNRecord;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metrics.MinionMetrics;
 import org.apache.pinot.core.minion.SegmentPurger;
+import org.apache.pinot.spi.auth.AuthProvider;
 
 
 /**
@@ -45,7 +46,7 @@ public class MinionContext {
 
   // For segment upload
   private SSLContext _sslContext;
-  private String _taskAuthToken;
+  private AuthProvider _taskAuthProvider;
 
   // For PurgeTask
   private SegmentPurger.RecordPurgerFactory _recordPurgerFactory;
@@ -99,11 +100,11 @@ public class MinionContext {
     _recordModifierFactory = recordModifierFactory;
   }
 
-  public String getTaskAuthToken() {
-    return _taskAuthToken;
+  public AuthProvider getTaskAuthProvider() {
+    return _taskAuthProvider;
   }
 
-  public void setTaskAuthToken(String taskAuthToken) {
-    _taskAuthToken = taskAuthToken;
+  public void setTaskAuthProvider(AuthProvider taskAuthProvider) {
+    _taskAuthProvider = taskAuthProvider;
   }
 }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
@@ -29,6 +29,7 @@ import org.apache.helix.task.TaskConfig;
 import org.apache.helix.task.TaskDriver;
 import org.apache.helix.task.TaskFactory;
 import org.apache.helix.task.TaskResult;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.metrics.MinionGauge;
 import org.apache.pinot.common.metrics.MinionMeter;
 import org.apache.pinot.common.metrics.MinionMetrics;
@@ -99,7 +100,8 @@ public class TaskFactoryRegistry {
               PinotTaskConfig pinotTaskConfig = PinotTaskConfig.fromHelixTaskConfig(_taskConfig);
               if (StringUtils.isBlank(pinotTaskConfig.getConfigs().get(MinionConstants.AUTH_TOKEN))) {
                 pinotTaskConfig.getConfigs()
-                    .put(MinionConstants.AUTH_TOKEN, MinionContext.getInstance().getTaskAuthToken());
+                    .put(MinionConstants.AUTH_TOKEN,
+                        AuthProviderUtils.toStaticToken(MinionContext.getInstance().getTaskAuthProvider()));
               }
 
               _eventObserver.notifyTaskStart(pinotTaskConfig);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -538,7 +538,7 @@ public class CommonConstants {
      * Service token for accessing protected controller APIs.
      * E.g. null (auth disabled), "Basic abcdef..." (basic auth), "Bearer 123def..." (oauth2)
      */
-    public static final String CONFIG_OF_TASK_AUTH_TOKEN = "task.auth.token";
+    public static final String CONFIG_TASK_AUTH_NAMESPACE = "task.auth";
     public static final String MINION_TLS_PREFIX = "pinot.minion.tls";
     public static final String CONFIG_OF_MINION_QUERY_REWRITER_CLASS_NAMES = "pinot.minion.query.rewriter.class.names";
   }


### PR DESCRIPTION
Bug fix for auth in minion tasks.

**Problem**
The auth token was not being generated in the minion starter. As a result, any request made to the controller was failing with a 403.

**Fix**
Token is now generated using the auth provider. Tested with a local snapshot and verified http calls in minion tasks are now working.




