### PR TITLE
Honor "retry.count" config instead of use number of IP addresses when fetch segment

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
@@ -48,7 +48,10 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
     // Create a RoundRobinURIProvider to round robin IP addresses when retry uploading. Otherwise may always try to
     // download from a same broken host as: 1) DNS may not RR the IP addresses 2) OS cache the DNS resolution result.
     RoundRobinURIProvider uriProvider = new RoundRobinURIProvider(downloadURI);
-    int retryCount = Math.max(_retryCount, uriProvider.numAddresses());
+
+    // Use the minimal value of configured retry count and number of IP addresses.
+    int retryCount = Math.min(_retryCount, uriProvider.numAddresses());
+
     _logger.info("Retry downloading for {} times. retryCount from pinot server config: {}, number of IP addresses for "
         + "download URI: {}", retryCount, _retryCount, uriProvider.numAddresses());
     RetryPolicies.exponentialBackoffRetryPolicy(retryCount, _retryWaitMs, _retryDelayScaleFactor).attempt(() -> {


### PR DESCRIPTION
When downloadURI is backed by a large number of instances, say 9 instances, the backoff logic may take up to 2 days:
```
retry delay time for attempt 0: 0 sec
retry delay time for attempt 1: 2 sec
retry delay time for attempt 2: 10 sec
retry delay time for attempt 3: 28 sec
retry delay time for attempt 4: 88 sec
retry delay time for attempt 5: 723 sec
retry delay time for attempt 6: 5389 sec
retry delay time for attempt 7: 36734 sec
retry delay time for attempt 8: 171520 sec
``` 

This change use the number of IP Addresses as default retry count when "retry.count" is not configured, otherwise, use the configured value.

cc @snleee @jtao15 