### PR TITLE
Fix Configuration Obfuscation test.

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
@@ -451,7 +451,7 @@ public class PinotConfiguration {
 
   @Override
   public String toString() {
-    return new Obfuscator().toJsonString(this);
+    return new Obfuscator().toJsonString(toMap());
   }
 
   public boolean isEmpty() {

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/ConfigUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/ConfigUtilsTest.java
@@ -132,11 +132,13 @@ public class ConfigUtilsTest {
     map.put("my.authToken", "secrettoken");
 
     Map<String, Object> nestedMap = new HashMap<>();
-    map.put("credentials", map);
+    nestedMap.put("credentials", map);
 
     PinotConfiguration config = new PinotConfiguration(nestedMap);
 
-    Assert.assertFalse(config.toString().contains("verysecret"));
-    Assert.assertFalse(config.toString().contains("secrettoken"));
+    String configString = config.toString();
+    Assert.assertTrue(configString.contains("credentials"));
+    Assert.assertFalse(configString.contains("verysecret"));
+    Assert.assertFalse(configString.contains("secrettoken"));
   }
 }


### PR DESCRIPTION
The test `ConfigUtilsTest.testDefaultObfuscation` had a bug where the configuration was not created
correctly and hence did not have any credentials. And the test asserted that it wouldn't find any
credentials when serialized to String.

- Fixed the test to create the configuration correctly. Enhanced the test to ensure it gets the
  `credentials` key, but not the credentials themselves.
- Had to modify the toString() method for `PinotConfiguration`, as it does not really serialize the
  the configurations, it has to be first converted `toMap()` before serialization.
