### PR TITLE
BUGFIX: Adding util for getting URL from InstanceConfig

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/helix/ExtraInstanceConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/helix/ExtraInstanceConfig.java
@@ -64,7 +64,7 @@ public class ExtraInstanceConfig {
           protocol = CommonConstants.HTTP_PROTOCOL;
           port = _proxy.getPort();
         }
-      } catch (Exception e2) {
+      } catch (Exception ignored) {
       }
     }
     if (port != null) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/helix/ExtraInstanceConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/helix/ExtraInstanceConfig.java
@@ -47,8 +47,9 @@ public class ExtraInstanceConfig {
   }
 
   /**
-   * Returns an instance URL from the InstanceConfig. Will set the appropriate protocol and port. Returns null
-   * if the URL cannot be constructed.
+   * Returns an instance URL from the InstanceConfig. Will set the appropriate protocol and port. Note that the helix
+   * participant port will be returned. For the Pinot server this will not correspond to the admin port.
+   * Returns null if the URL cannot be constructed.
    */
   public String getComponentUrl() {
     String protocol = null;

--- a/pinot-common/src/main/java/org/apache/pinot/common/helix/ExtraInstanceConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/helix/ExtraInstanceConfig.java
@@ -47,21 +47,10 @@ public class ExtraInstanceConfig {
   }
 
   /**
-   * Returns an instance URL from the InstanceConfig. Will set the appropriate protocol and port.
+   * Returns an instance URL from the InstanceConfig. Will set the appropriate protocol and port. Returns null
+   * if the URL cannot be constructed.
    */
   public String getComponentUrl() {
-    String hostName = _proxy.getHostName();
-    // Backward-compatible with legacy hostname of format 'Controller_<hostname>'
-    if (hostName.startsWith(CommonConstants.Helix.PREFIX_OF_CONTROLLER_INSTANCE)) {
-      hostName = hostName.substring(CommonConstants.Helix.CONTROLLER_INSTANCE_PREFIX_LENGTH);
-    } else if (hostName.startsWith(CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE)) {
-      hostName = hostName.substring(CommonConstants.Helix.SERVER_INSTANCE_PREFIX_LENGTH);
-    } else if (hostName.startsWith(CommonConstants.Helix.PREFIX_OF_BROKER_INSTANCE)) {
-      hostName = hostName.substring(CommonConstants.Helix.BROKER_INSTANCE_PREFIX_LENGTH);
-    } else if (hostName.startsWith(CommonConstants.Helix.PREFIX_OF_MINION_INSTANCE)) {
-      hostName = hostName.substring(CommonConstants.Helix.MINION_INSTANCE_PREFIX_LENGTH);
-    }
-
     String protocol = null;
     String port = null;
     try {
@@ -79,7 +68,7 @@ public class ExtraInstanceConfig {
       }
     }
     if (port != null) {
-      return String.format("%s://%s:%s", protocol, hostName, port);
+      return String.format("%s://%s:%s", protocol, _proxy.getHostName(), port);
     }
     return null;
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/NoOpTableTableConfigTuner.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/NoOpTableTableConfigTuner.java
@@ -32,4 +32,10 @@ public class NoOpTableTableConfigTuner implements TableConfigTuner {
       TableConfig initialConfig, Schema schema, Map<String, String> extraProperties) {
     return initialConfig;
   }
+
+  @Override
+  public TableConfig apply(PinotHelixResourceManager pinotHelixResourceManager,
+      TableConfig initialConfig, Schema schema, Map<String, String> extraProperties, Map<String, String> httpHeaders) {
+    return initialConfig;
+  }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/RealTimeAutoIndexTuner.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/RealTimeAutoIndexTuner.java
@@ -42,4 +42,10 @@ public class RealTimeAutoIndexTuner implements TableConfigTuner {
     initialIndexingConfig.setNoDictionaryColumns(schema.getMetricNames());
     return tableConfig;
   }
+
+  @Override
+  public TableConfig apply(PinotHelixResourceManager pinotHelixResourceManager,
+      TableConfig tableConfig, Schema schema, Map<String, String> extraProperties, Map<String, String> httpHeaders) {
+    return apply(pinotHelixResourceManager, tableConfig, schema, extraProperties);
+  }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/TableConfigTuner.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/tuner/TableConfigTuner.java
@@ -42,4 +42,16 @@ public interface TableConfigTuner {
    */
   TableConfig apply(@Nullable PinotHelixResourceManager pinotHelixResourceManager,
       TableConfig tableConfig, Schema schema, Map<String, String> extraProperties);
+
+  /**
+   * Apply tuner to a {@link TableConfig}.
+   *
+   * @param pinotHelixResourceManager Pinot Helix Resource Manager to access Helix resources
+   * @param tableConfig tableConfig that needs to be tuned.
+   * @param schema Table schema
+   * @param extraProperties extraProperties for the tuner implementation.
+   * @param httpHeaders Http headers required for any remote calls
+   */
+  TableConfig apply(@Nullable PinotHelixResourceManager pinotHelixResourceManager,
+      TableConfig tableConfig, Schema schema, Map<String, String> extraProperties, Map<String, String> httpHeaders);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/sql/SqlQueryExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/sql/SqlQueryExecutor.java
@@ -77,7 +77,11 @@ public class SqlQueryExecutor {
     PropertyKey.Builder keyBuilder = helixDataAccessor.keyBuilder();
     ExtraInstanceConfig extraInstanceConfig = new ExtraInstanceConfig(helixDataAccessor.getProperty(
         keyBuilder.instanceConfig(CommonConstants.Helix.PREFIX_OF_CONTROLLER_INSTANCE + instanceId)));
-    return extraInstanceConfig.getComponentUrl();
+    String controllerBaseUrl = extraInstanceConfig.getComponentUrl();
+    if (controllerBaseUrl == null) {
+      throw new RuntimeException("Unable to extract the base url from the leader pinot controller");
+    }
+    return controllerBaseUrl;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/sql/SqlQueryExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/sql/SqlQueryExecutor.java
@@ -24,14 +24,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
+import org.apache.helix.PropertyKey;
 import org.apache.pinot.common.exception.QueryException;
+import org.apache.pinot.common.helix.ExtraInstanceConfig;
 import org.apache.pinot.common.minion.MinionClient;
 import org.apache.pinot.common.response.BrokerResponse;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.helix.LeadControllerUtils;
 import org.apache.pinot.spi.config.task.AdhocTaskConfig;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
 import org.apache.pinot.sql.parsers.dml.DataManipulationStatement;
 import org.apache.pinot.sql.parsers.dml.DataManipulationStatementParser;
@@ -64,17 +68,16 @@ public class SqlQueryExecutor {
   }
 
   private static String getControllerBaseUrl(HelixManager helixManager) {
-    String instanceHostPort = LeadControllerUtils.getHelixClusterLeader(helixManager);
-    if (instanceHostPort == null) {
+    String instanceId = LeadControllerUtils.getHelixClusterLeader(helixManager);
+    if (instanceId == null) {
       throw new RuntimeException("Unable to locate the leader pinot controller, please retry later...");
     }
-    int index = instanceHostPort.lastIndexOf('_');
-    if (index < 0) {
-      throw new RuntimeException("Unable to parse pinot controller instance name for " + instanceHostPort);
-    }
-    String leaderHost = instanceHostPort.substring(0, index);
-    String leaderPort = instanceHostPort.substring(index + 1);
-    return "http://" + leaderHost + ":" + leaderPort;
+
+    HelixDataAccessor helixDataAccessor = helixManager.getHelixDataAccessor();
+    PropertyKey.Builder keyBuilder = helixDataAccessor.keyBuilder();
+    ExtraInstanceConfig extraInstanceConfig = new ExtraInstanceConfig(helixDataAccessor.getProperty(
+        keyBuilder.instanceConfig(CommonConstants.Helix.PREFIX_OF_CONTROLLER_INSTANCE + instanceId)));
+    return extraInstanceConfig.getComponentUrl();
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
@@ -30,6 +30,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.stream.Collectors;
 import org.apache.commons.configuration.ConfigurationException;
@@ -525,6 +526,16 @@ public class TlsIntegrationTest extends BaseClusterIntegrationTest {
     } catch (Exception e) {
       // this should fail
     }
+  }
+
+  @Test
+  public void testComponentUrlWithTlsPort() {
+    List<InstanceConfig> instanceConfigs = HelixHelper.getInstanceConfigs(_helixManager);
+    List<String> httpsComponentUrls = instanceConfigs.stream().map(ExtraInstanceConfig::new)
+        .filter(pinotInstanceConfig -> pinotInstanceConfig.getTlsPort() != null)
+        .map(ExtraInstanceConfig::getComponentUrl).filter(Objects::nonNull).collect(Collectors.toList());
+
+    Assert.assertFalse(httpsComponentUrls.isEmpty());
   }
 
   private java.sql.Connection getValidJDBCConnection(int controllerPort) throws Exception {


### PR DESCRIPTION
Adding a util for getting URL from an InstanceConfig. This is required to fix some places where http is hardcoded which will fail if TLS is enabld.

Also modifying the auto-tune interface to accept request headers for TLS enabled environments.