### PR TITLE
Fix getConfigOverrides in MinionQuickstart

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
@@ -41,7 +41,7 @@ public class AuthQuickstart extends Quickstart {
 
   @Override
   public Map<String, Object> getConfigOverrides() {
-    Map<String, Object> properties = new HashMap<>();
+    Map<String, Object> properties = new HashMap<>(super.getConfigOverrides());
 
     // controller
     properties.put("pinot.controller.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/HybridQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/HybridQuickstart.java
@@ -67,7 +67,7 @@ public class HybridQuickstart extends QuickStartBase {
   }
 
   public Map<String, Object> getConfigOverrides() {
-    Map<String, Object> overrides = new HashMap<>();
+    Map<String, Object> overrides = new HashMap<>(super.getConfigOverrides());
     overrides.put("pinot.server.grpc.enable", "true");
     overrides.put("pinot.server.grpc.port", "8090");
     return overrides;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStartWithMinion.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStartWithMinion.java
@@ -64,7 +64,7 @@ public class RealtimeQuickStartWithMinion extends QuickStartBase {
   }
 
   public Map<String, Object> getConfigOverrides() {
-    Map<String, Object> properties = new HashMap<>();
+    Map<String, Object> properties = new HashMap<>(super.getConfigOverrides());
     properties.putIfAbsent("controller.task.scheduler.enabled", true);
     return properties;
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStartWithMinion.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStartWithMinion.java
@@ -25,6 +25,7 @@ import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -63,7 +64,7 @@ public class RealtimeQuickStartWithMinion extends QuickStartBase {
   }
 
   public Map<String, Object> getConfigOverrides() {
-    Map<String, Object> properties = super.getConfigOverrides();
+    Map<String, Object> properties = new HashMap<>();
     properties.putIfAbsent("controller.task.scheduler.enabled", true);
     return properties;
   }


### PR DESCRIPTION
Current quickstart fails because `super.getConfigOverrides();` is an Immutable Map. Anyway the overrides should be provided in a separate map.