### PR TITLE
fix data table vs. block format issue

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableUtils.java
@@ -71,8 +71,7 @@ public class DataTableUtils {
         case LONG:
           rowSizeInBytes += 8;
           break;
-        // TODO: fix float size (should be 4).
-        // For backward compatible, DON'T CHANGE.
+        // TODO: fix float size (should be 4). For backward compatible, DON'T CHANGE for now.
         case FLOAT:
           rowSizeInBytes += 8;
           break;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.pinot.query.service.QueryConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.util.TestUtils;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTest {
+  private static final String SCHEMA_FILE_NAME =
+      "On_Time_On_Time_Performance_2014_100k_subset_nonulls_single_value_columns.schema";
+
+  @Override
+  protected String getSchemaFileName() {
+    return SCHEMA_FILE_NAME;
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+
+    // Start the Pinot cluster
+    startZk();
+    startController();
+    startBroker();
+    startServer();
+
+    // Create and upload the schema and table config
+    Schema schema = createSchema();
+    addSchema(schema);
+    TableConfig tableConfig = createOfflineTableConfig();
+    addTableConfig(tableConfig);
+
+    // Unpack the Avro files
+    List<File> avroFiles = unpackAvroData(_tempDir);
+
+    // Create and upload segments
+    ClusterIntegrationTestUtils.buildSegmentsFromAvro(avroFiles, tableConfig, schema, 0, _segmentDir, _tarDir);
+    uploadSegments(getTableName(), _tarDir);
+
+    // Set up the H2 connection
+    setUpH2Connection(avroFiles);
+
+    // Initialize the query generator
+    setUpQueryGenerator(avroFiles);
+
+    // Wait for all documents loaded
+    waitForAllDocsLoaded(600_000L);
+  }
+
+  @Override
+  protected void overrideBrokerConf(PinotConfiguration brokerConf) {
+    brokerConf.setProperty(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_ENABLED, true);
+    brokerConf.setProperty(QueryConfig.KEY_OF_QUERY_RUNNER_PORT, 8421);
+  }
+
+  @Override
+  protected void overrideServerConf(PinotConfiguration serverConf) {
+    serverConf.setProperty(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_ENABLED, true);
+    serverConf.setProperty(QueryConfig.KEY_OF_QUERY_SERVER_PORT, 8842);
+    serverConf.setProperty(QueryConfig.KEY_OF_QUERY_RUNNER_PORT, 8422);
+  }
+
+  @Test(dataProvider = "multiStageQueryEngineSqlTestSet")
+  public void testMultiStageQuery(String sql, int expectedNumOfRows, int expectedNumOfColumns)
+      throws IOException {
+    JsonNode multiStageResponse = JsonUtils.stringToJsonNode(
+        sendPostRequest(_brokerBaseApiUrl + "/query/sql", "{\"useMultistageEngine\": true, \"sql\":\"" + sql + "\"}"));
+    Assert.assertTrue(multiStageResponse.has("resultTable"));
+    ArrayNode jsonNode = (ArrayNode) multiStageResponse.get("resultTable").get("rows");
+    Assert.assertEquals(jsonNode.size(), expectedNumOfRows);
+    Assert.assertEquals(jsonNode.get(0).size(), expectedNumOfColumns);
+  }
+
+  @DataProvider
+  public Object[][] multiStageQueryEngineSqlTestSet() {
+    return new Object[][] {
+        new Object[]{"SELECT * FROM mytable_OFFLINE", 10, 73},
+        new Object[]{"SELECT CarrierDelay, ArrDelay FROM mytable_OFFLINE WHERE CarrierDelay=15 AND ArrDelay>20", 10, 2},
+        new Object[]{"SELECT * FROM mytable_OFFLINE AS a JOIN mytable_OFFLINE AS b ON a.AirlineID = b.AirlineID "
+            + " WHERE a.CarrierDelay=15 AND a.ArrDelay>20 AND b.ArrDelay<20", 10, 146}
+    };
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -101,7 +101,8 @@ public class QueryRunner {
       BaseDataBlock dataBlock;
       try {
         DataTable dataTable = _serverExecutor.processQuery(serverQueryRequest, executorService, null);
-        // this works because default DataTableImplV3 will have ordinal 0, which maps to ROW(0)
+        // this works because default DataTableImplV3 will have a version number at beginning,
+        // which maps to ROW type of version 3.
         dataBlock = DataBlockUtils.getDataBlock(ByteBuffer.wrap(dataTable.toBytes()));
       } catch (IOException e) {
         throw new RuntimeException("Unable to convert byte buffer", e);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/DataBlockBuilder.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/DataBlockBuilder.java
@@ -93,8 +93,10 @@ public class DataBlockBuilder {
           case LONG:
             byteBuffer.putLong(((Number) value).longValue());
             break;
+          // TODO: fix float size (should be 4). For backward compatible, DON'T CHANGE for now.
           case FLOAT:
             byteBuffer.putFloat(((Number) value).floatValue());
+            byteBuffer.position(byteBuffer.position() + 4);
             break;
           case DOUBLE:
             byteBuffer.putDouble(((Number) value).doubleValue());
@@ -190,9 +192,11 @@ public class DataBlockBuilder {
             byteBuffer.putLong(((Number) value).longValue());
           }
           break;
+        // TODO: fix float size (should be 4). For backward compatible, DON'T CHANGE for now.
         case FLOAT:
           for (Object value : column) {
             byteBuffer.putFloat(((Number) value).floatValue());
+            byteBuffer.position(byteBuffer.position() + 4);
           }
           break;
         case DOUBLE:

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/DataBlockUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/DataBlockUtils.java
@@ -34,6 +34,7 @@ public final class DataBlockUtils {
 
   private static final DataSchema EMPTY_SCHEMA = new DataSchema(new String[0], new DataSchema.ColumnDataType[0]);
   private static final MetadataBlock EOS_DATA_BLOCK = new MetadataBlock(EMPTY_SCHEMA);
+
   static {
     EOS_DATA_BLOCK._metadata.put(DataTable.MetadataKey.TABLE.getName(), "END_OF_STREAM");
   }
@@ -116,8 +117,9 @@ public final class DataBlockUtils {
         case LONG:
           rowSizeInBytes += 8;
           break;
+        // TODO: fix float size (should be 4). For backward compatible, DON'T CHANGE for now.
         case FLOAT:
-          rowSizeInBytes += 4;
+          rowSizeInBytes += 8;
           break;
         case DOUBLE:
           rowSizeInBytes += 8;
@@ -155,8 +157,9 @@ public final class DataBlockUtils {
         case LONG:
           columnSizes[i] = 8;
           break;
+        // TODO: fix float size (should be 4). For backward compatible, DON'T CHANGE for now.
         case FLOAT:
-          columnSizes[i] = 4;
+          columnSizes[i] = 8;
           break;
         case DOUBLE:
           columnSizes[i] = 8;


### PR DESCRIPTION
previously multi-stage engine assumes no backward compatibility issue with existing pinot query server. however we are still depending on pinot-server to return `DataTableImplV3` byte format to intermediate multi-stage engine. 

To avoid duplicate ser/de we decided to backward compatible support these old ser/de formats. namely, the old 8-bytes floating point.

also, this:
- doesn't work with `OBJECT`/`BYTES_ARRAY` type
- doesn't support `BYTES` type as old bytes are converted into hexString and encoded as STRING column.
