### PR TITLE
Implement Mutable FST Index

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -243,7 +243,6 @@ public class MutableSegmentImpl implements MutableSegment {
     Set<String> noDictionaryColumns = config.getNoDictionaryColumns();
     Set<String> invertedIndexColumns = config.getInvertedIndexColumns();
     Set<String> textIndexColumns = config.getTextIndexColumns();
-    // TODO: Add mutable FST and wire it up
     Set<String> fstIndexColumns = config.getFSTIndexColumns();
     Set<String> jsonIndexColumns = config.getJsonIndexColumns();
     Map<String, H3IndexConfig> h3IndexConfigs = config.getH3IndexConfigs();
@@ -308,15 +307,13 @@ public class MutableSegmentImpl implements MutableSegment {
           invertedIndexColumns.contains(column) ? indexProvider.newInvertedIndex(context.forInvertedIndex()) : null;
 
       MutableTextIndex fstIndex = null;
-      //FST Index
-      if (fstIndexColumns.contains(column)) {
-        if (_fieldConfigList != null) {
-          for (FieldConfig fieldConfig : _fieldConfigList) {
-            if (fieldConfig.getName().equals(column)) {
-              Map<String, String> properties = fieldConfig.getProperties();
-              if (TextIndexUtils.isFstTypeNative(properties)) {
-                fstIndex = new NativeMutableFSTIndex(column);
-              }
+      // FST Index
+      if (_fieldConfigList != null && fstIndexColumns.contains(column)) {
+        for (FieldConfig fieldConfig : _fieldConfigList) {
+          if (fieldConfig.getName().equals(column)) {
+            Map<String, String> properties = fieldConfig.getProperties();
+            if (TextIndexUtils.isFstTypeNative(properties)) {
+              fstIndex = new NativeMutableFSTIndex(column);
             }
           }
         }
@@ -1327,10 +1324,9 @@ public class MutableSegmentImpl implements MutableSegment {
         @Nullable Set<Integer> partitions, NumValuesInfo numValuesInfo, MutableForwardIndex forwardIndex,
         @Nullable MutableDictionary dictionary, @Nullable MutableInvertedIndex invertedIndex,
         @Nullable RangeIndexReader rangeIndex, @Nullable MutableTextIndex textIndex,
-        @Nullable MutableTextIndex fstIndex, @Nullable MutableJsonIndex jsonIndex,
-        @Nullable MutableH3Index h3Index, @Nullable BloomFilterReader bloomFilter,
-        @Nullable MutableNullValueVector nullValueVector, @Nullable String sourceColumn,
-        @Nullable ValueAggregator valueAggregator) {
+        @Nullable MutableTextIndex fstIndex, @Nullable MutableJsonIndex jsonIndex, @Nullable MutableH3Index h3Index,
+        @Nullable BloomFilterReader bloomFilter, @Nullable MutableNullValueVector nullValueVector,
+        @Nullable String sourceColumn, @Nullable ValueAggregator valueAggregator) {
       _fieldSpec = fieldSpec;
       _partitionFunction = partitionFunction;
       _partitions = partitions;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeMutableFSTIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeMutableFSTIndex.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.realtime.impl.invertedindex;
+
+import java.io.IOException;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.apache.pinot.segment.local.utils.nativefst.mutablefst.MutableFST;
+import org.apache.pinot.segment.local.utils.nativefst.mutablefst.MutableFSTImpl;
+import org.apache.pinot.segment.local.utils.nativefst.utils.RealTimeRegexpMatcher;
+import org.apache.pinot.segment.spi.index.mutable.MutableTextIndex;
+import org.roaringbitmap.RoaringBitmapWriter;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
+
+public class NativeMutableFSTIndex implements MutableTextIndex {
+  private final String _column;
+  private final MutableFST _fst;
+  private int _dictId;
+  private final ReentrantReadWriteLock.ReadLock _readLock;
+  private final ReentrantReadWriteLock.WriteLock _writeLock;
+
+  public NativeMutableFSTIndex(String column) {
+    _column = column;
+    _fst = new MutableFSTImpl();
+
+    ReentrantReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+    _readLock = readWriteLock.readLock();
+    _writeLock = readWriteLock.writeLock();
+  }
+
+  @Override
+  public void add(String document) {
+    _writeLock.lock();
+    try {
+      _fst.addPath(document, _dictId);
+      _dictId++;
+    } finally {
+      _writeLock.unlock();
+    }
+  }
+
+  @Override
+  public ImmutableRoaringBitmap getDictIds(String searchQuery) {
+    RoaringBitmapWriter<MutableRoaringBitmap> writer = RoaringBitmapWriter.bufferWriter().get();
+    _readLock.lock();
+    try {
+      RealTimeRegexpMatcher.regexMatch(searchQuery, _fst, writer::add);
+      return writer.get();
+    } finally {
+      _readLock.unlock();
+    }
+  }
+
+  @Override
+  public MutableRoaringBitmap getDocIds(String searchQuery) {
+    return null;
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeMutableFSTIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeMutableFSTIndex.java
@@ -32,9 +32,9 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
 public class NativeMutableFSTIndex implements MutableTextIndex {
   private final String _column;
   private final MutableFST _fst;
-  private int _dictId;
   private final ReentrantReadWriteLock.ReadLock _readLock;
   private final ReentrantReadWriteLock.WriteLock _writeLock;
+  private int _dictId;
 
   public NativeMutableFSTIndex(String column) {
     _column = column;
@@ -70,7 +70,7 @@ public class NativeMutableFSTIndex implements MutableTextIndex {
 
   @Override
   public MutableRoaringBitmap getDocIds(String searchQuery) {
-    return null;
+    throw new UnsupportedOperationException("getDocIds is not supported for NativeMutableFSTIndex");
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/IntermediateIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/IntermediateIndexContainer.java
@@ -63,7 +63,7 @@ public class IntermediateIndexContainer implements Closeable {
   public DataSource toDataSource(int numDocsIndexed) {
     return new MutableDataSource(_fieldSpec, numDocsIndexed, _numValuesInfo._numValues,
         _numValuesInfo._maxNumValuesPerMVEntry, _partitionFunction, _partitions, _minValue, _maxValue, _forwardIndex,
-        _dictionary, null, null, null, null, null, null, null);
+        _dictionary, null, null, null, null, null, null, null, null);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/MutableDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/MutableDataSource.java
@@ -44,10 +44,11 @@ public class MutableDataSource extends BaseDataSource {
       @Nullable PartitionFunction partitionFunction, @Nullable Set<Integer> partitions, @Nullable Comparable minValue,
       @Nullable Comparable maxValue, ForwardIndexReader forwardIndex, @Nullable Dictionary dictionary,
       @Nullable InvertedIndexReader invertedIndex, @Nullable RangeIndexReader rangeIndex,
-      @Nullable TextIndexReader textIndex, @Nullable JsonIndexReader jsonIndex, @Nullable H3IndexReader h3Index,
-      @Nullable BloomFilterReader bloomFilter, @Nullable NullValueVectorReader nullValueVector) {
+      @Nullable TextIndexReader textIndex, @Nullable TextIndexReader fstIndex, @Nullable JsonIndexReader jsonIndex,
+      @Nullable H3IndexReader h3Index, @Nullable BloomFilterReader bloomFilter,
+      @Nullable NullValueVectorReader nullValueVector) {
     super(new MutableDataSourceMetadata(fieldSpec, numDocs, numValues, maxNumValuesPerMVEntry, partitionFunction,
-            partitions, minValue, maxValue), forwardIndex, dictionary, invertedIndex, rangeIndex, textIndex, null,
+            partitions, minValue, maxValue), forwardIndex, dictionary, invertedIndex, rangeIndex, textIndex, fstIndex,
         jsonIndex, h3Index, bloomFilter, nullValueVector);
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeAndLuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeAndLuceneMutableTextIndexTest.java
@@ -99,9 +99,6 @@ public class NativeAndLuceneMutableTextIndexTest {
   }
 
   private void testSelectionResults(String nativeQuery, String luceneQuery) {
-    MutableRoaringBitmap resultset = _realtimeLuceneTextIndex.getDocIds(luceneQuery);
-    MutableRoaringBitmap resultset2 = _nativeMutableTextIndex.getDocIds(nativeQuery);
-
     assertEquals(_nativeMutableTextIndex.getDocIds(nativeQuery), _realtimeLuceneTextIndex.getDocIds(luceneQuery));
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeAndLuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeAndLuceneMutableTextIndexTest.java
@@ -23,7 +23,6 @@ import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.search.SearcherManager;
-import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeMutableFSTIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeMutableFSTIndexTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 
 public class NativeMutableFSTIndexTest {
@@ -64,6 +65,10 @@ public class NativeMutableFSTIndexTest {
     nativeQuery = ".*ed";
     resultList = Arrays.asList(6);
     testSelectionResults(nativeQuery, 1, resultList);
+
+    nativeQuery = ".*m.*";
+    resultList = Arrays.asList(6, 7, 8);
+    testSelectionResults(nativeQuery, 3, resultList);
   }
 
   private List<String> getTextData() {
@@ -76,7 +81,7 @@ public class NativeMutableFSTIndexTest {
 
     if (results != null) {
       for (int result : results) {
-        assertEquals(resultMap.contains(result), true);
+        assertTrue(resultMap.contains(result));
       }
     }
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeMutableFSTIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeMutableFSTIndexTest.java
@@ -1,0 +1,83 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.realtime.impl.invertedindex;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class NativeMutableFSTIndexTest {
+  private static final String TEXT_COLUMN_NAME = "testColumnName";
+  private NativeMutableFSTIndex _nativeMutableFSTIndex;
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    _nativeMutableFSTIndex = new NativeMutableFSTIndex(TEXT_COLUMN_NAME);
+    List<String> documents = getTextData();
+
+    for (String doc : documents) {
+      _nativeMutableFSTIndex.add(doc);
+    }
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    _nativeMutableFSTIndex.close();
+  }
+
+  @Test
+  public void testQueries() {
+    String nativeQuery = "P.*";
+    List<Integer> resultList = Arrays.asList(0, 9);
+    testSelectionResults(nativeQuery, 2, resultList);
+
+    nativeQuery = "a.*";
+    resultList = Arrays.asList(5, 6);
+    testSelectionResults(nativeQuery, 2, resultList);
+
+    nativeQuery = ".*ed";
+    resultList = Arrays.asList(6);
+    testSelectionResults(nativeQuery, 1, resultList);
+  }
+
+  private List<String> getTextData() {
+    return Arrays.asList("Prince", "Andrew", "kept", "looking", "with", "an", "amused", "smile", "from", "Pierre");
+  }
+
+  private void testSelectionResults(String nativeQuery, int resultCount, @Nullable List<Integer> results) {
+    ImmutableRoaringBitmap resultMap = _nativeMutableFSTIndex.getDictIds(nativeQuery);
+    assertEquals(resultMap.getCardinality(), resultCount);
+
+    if (results != null) {
+      for (int result : results) {
+        assertEquals(resultMap.contains(result), true);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR implements a real time FST index, allowing fields containing tokenized documents to be directly stored in the FST index and queried in real time, with no flush requirement.

This can be enabled by specifying the following property in the properties section of the FST index, being created on a real time table:
`
 "properties":[{"fstType":"native"}]`