### PR TITLE
Allow to track storage tier in SegmentMetadata object as server loads segment

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentMetadata.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentMetadata.java
@@ -119,4 +119,8 @@ public interface SegmentMetadata {
    * @return json representation of segment metadata.
    */
   JsonNode toJson(@Nullable Set<String> columnFilter);
+
+  String getTier();
+
+  void setTier(String tier);
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/SegmentMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/SegmentMetadataImpl.java
@@ -97,6 +97,9 @@ public class SegmentMetadataImpl implements SegmentMetadata {
   @Deprecated
   private String _rawTableName;
 
+  // This is a runtime info set by server when loading the segment.
+  private String _tier;
+
   /**
    * For segments that can only provide the inputstream to the metadata
    */
@@ -461,6 +464,16 @@ public class SegmentMetadataImpl implements SegmentMetadata {
     }
 
     return segmentMetadata;
+  }
+
+  @Override
+  public String getTier() {
+    return _tier;
+  }
+
+  @Override
+  public void setTier(String tier) {
+    _tier = tier;
   }
 
   @Override


### PR DESCRIPTION
Extending SegmentMetadata interface a bit to track segment's storage tier, following up on https://github.com/apache/pinot/issues/8844. Using SegmentMetadata to carry it, as all kinds of segments (implementing IndexSegment) is supposed to have its SegmentMetadata object. 