### PR TITLE
Allow to track the storage tier where the segment directory is kept by server

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/EmptyIndexSegment.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/EmptyIndexSegment.java
@@ -113,4 +113,10 @@ public class EmptyIndexSegment implements ImmutableSegment {
   public long getSegmentSizeBytes() {
     return 0;
   }
+
+  @Nullable
+  @Override
+  public String getTier() {
+    return null;
+  }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -118,6 +118,11 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
   }
 
   @Override
+  public String getTier() {
+    return _segmentDirectory.getTier();
+  }
+
+  @Override
   public String getSegmentName() {
     return _segmentMetadata.getName();
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -117,6 +117,7 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
     return _segmentDirectory.getDiskSizeBytes();
   }
 
+  @Nullable
   @Override
   public String getTier() {
     return _segmentDirectory.getTier();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
@@ -27,6 +27,7 @@ import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nullable;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
@@ -118,13 +119,14 @@ public class SegmentLocalFSDirectory extends SegmentDirectory {
     }
   }
 
+  @Nullable
   @Override
   public String getTier() {
     return _tier;
   }
 
   @Override
-  public void setTier(String tier) {
+  public void setTier(@Nullable String tier) {
     _tier = tier;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
@@ -59,10 +59,10 @@ public class SegmentLocalFSDirectory extends SegmentDirectory {
   private final File _indexDir;
   private final File _segmentDirectory;
   private final SegmentLock _segmentLock;
-  private SegmentMetadataImpl _segmentMetadata;
   private final ReadMode _readMode;
-
+  private SegmentMetadataImpl _segmentMetadata;
   private ColumnIndexDirectory _columnIndexDirectory;
+  private String _tier;
 
   // Create an empty SegmentLocalFSDirectory object mainly used to
   // prepare env for subsequent processing on the segment.
@@ -116,6 +116,16 @@ public class SegmentLocalFSDirectory extends SegmentDirectory {
     if (src.exists() && !src.equals(dest)) {
       FileUtils.copyDirectory(src, dest);
     }
+  }
+
+  @Override
+  public String getTier() {
+    return _tier;
+  }
+
+  @Override
+  public void setTier(String tier) {
+    _tier = tier;
   }
 
   @Override

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/ImmutableSegment.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/ImmutableSegment.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.spi;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
@@ -61,7 +62,6 @@ public interface ImmutableSegment extends IndexSegment {
    *
    * @return storage tier, null by default.
    */
-  default String getTier() {
-    return null;
-  }
+  @Nullable
+  String getTier();
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/ImmutableSegment.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/ImmutableSegment.java
@@ -55,4 +55,13 @@ public interface ImmutableSegment extends IndexSegment {
    * @return Size of the segment in bytes
    */
   long getSegmentSizeBytes();
+
+  /**
+   * Get the storage tier of the immutable segment.
+   *
+   * @return storage tier, null by default.
+   */
+  default String getTier() {
+    return null;
+  }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/SegmentDirectory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/SegmentDirectory.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.pinot.segment.spi.FetchContext;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
@@ -154,12 +155,13 @@ public abstract class SegmentDirectory implements Closeable {
    *
    * @return storage tier, null by default.
    */
+  @Nullable
   public abstract String getTier();
 
   /**
    * Set the storage tier where the segment directory is placed by server.
    */
-  public abstract void setTier(String tier);
+  public abstract void setTier(@Nullable String tier);
 
   /**
    * Reader for columnar index buffers from segment directory

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/SegmentDirectory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/SegmentDirectory.java
@@ -150,6 +150,18 @@ public abstract class SegmentDirectory implements Closeable {
   }
 
   /**
+   * Get the storage tier where the segment directory is placed by server.
+   *
+   * @return storage tier, null by default.
+   */
+  public abstract String getTier();
+
+  /**
+   * Set the storage tier where the segment directory is placed by server.
+   */
+  public abstract void setTier(String tier);
+
+  /**
    * Reader for columnar index buffers from segment directory
    */
   public abstract class Reader implements Closeable {


### PR DESCRIPTION
Allow to set the storage tier of a segment as it's loaded by server, following up on https://github.com/apache/pinot/issues/8844. The tier is carried by the SegmentDirectory object as it abstracts where the segment data is stored. 
