### PR TITLE
Emit metrics if there's no consuming segment for a partition

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -103,8 +103,11 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   // Number of online minion instances
   ONLINE_MINION_INSTANCES("onlineMinionInstances", true),
 
-  // Number of missing consuming segments in ideal state
-  MISSING_CONSUMING_SEGMENT_COUNT("missingConsumingSegmentCount", false),
+  // Number of partitions with missing consuming segments in ideal state
+  MISSING_CONSUMING_SEGMENT_TOTAL_COUNT("missingConsumingSegmentTotalCount", false),
+
+  // Number of new partitions with missing consuming segments in ideal state
+  MISSING_CONSUMING_SEGMENT_NEW_PARTITION_COUNT("missingConsumingSegmentNewPartitionCount", false),
 
   // Maximum duration of a missing consuming segment in ideal state (in minutes)
   MISSING_CONSUMING_SEGMENT_MAX_DURATION_MINUTES("missingSegmentsMaxDurationInMinutes", false);

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -101,7 +101,13 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   DROPPED_MINION_INSTANCES("droppedMinionInstances", true),
 
   // Number of online minion instances
-  ONLINE_MINION_INSTANCES("onlineMinionInstances", true);
+  ONLINE_MINION_INSTANCES("onlineMinionInstances", true),
+
+  // Number of missing consuming segments in ideal state
+  MISSING_CONSUMING_SEGMENT_COUNT("missingConsumingSegmentCount", false),
+
+  // Maximum duration of a missing consuming segment in ideal state (in minutes)
+  MISSING_CONSUMING_SEGMENT_MAX_DURATION_MINUTES("missingSegmentsMaxDurationInMinutes", false);
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -27,9 +27,11 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
+import org.apache.helix.ZNRecord;
 import org.apache.helix.manager.zk.ZNRecordSerializer;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.lineage.SegmentLineage;
 import org.apache.pinot.common.lineage.SegmentLineageAccessHelper;
@@ -41,6 +43,7 @@ import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.periodictask.ControllerPeriodicTask;
+import org.apache.pinot.controller.helix.core.realtime.MissingConsumingSegmentFinder;
 import org.apache.pinot.controller.util.TableSizeReader;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -157,7 +160,8 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
    * TODO: revisit the logic and reduce the ZK access
    */
   private void updateSegmentMetrics(String tableNameWithType, Context context) {
-    if (TableNameBuilder.getTableTypeFromTableName(tableNameWithType) == TableType.OFFLINE) {
+    TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
+    if (tableType == TableType.OFFLINE) {
       context._offlineTableCount++;
     } else {
       context._realTimeTableCount++;
@@ -197,8 +201,8 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
     // Get the segments excluding the replaced segments which are specified in the segment lineage entries and cannot
     // be queried from the table.
     Set<String> segmentsExcludeReplaced = new HashSet<>(idealState.getPartitionSet());
-    SegmentLineage segmentLineage =
-        SegmentLineageAccessHelper.getSegmentLineage(_pinotHelixResourceManager.getPropertyStore(), tableNameWithType);
+    ZkHelixPropertyStore<ZNRecord> propertyStore = _pinotHelixResourceManager.getPropertyStore();
+    SegmentLineage segmentLineage = SegmentLineageAccessHelper.getSegmentLineage(propertyStore, tableNameWithType);
     SegmentLineageUtils.filterSegmentsBasedOnLineageInPlace(segmentsExcludeReplaced, segmentLineage);
     _controllerMetrics
         .setValueOfTableGauge(tableNameWithType, ControllerGauge.IDEALSTATE_ZNODE_SIZE, idealState.toString().length());
@@ -298,6 +302,11 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
     if (nReplicasExternal < nReplicasIdealMax) {
       LOGGER.warn("Table {} has {} replicas, below replication threshold :{}", tableNameWithType, nReplicasExternal,
           nReplicasIdealMax);
+    }
+
+    if (tableType == TableType.REALTIME) {
+      new MissingConsumingSegmentFinder(tableNameWithType, propertyStore, _controllerMetrics)
+          .findAndEmitMetrics(idealState);
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -306,7 +306,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
           nReplicasIdealMax);
     }
 
-    if (tableType == TableType.REALTIME) {
+    if (tableType == TableType.REALTIME && tableConfig != null) {
       PartitionLevelStreamConfig streamConfig = new PartitionLevelStreamConfig(tableConfig.getTableName(),
           IngestionConfigUtils.getStreamConfigMap(tableConfig));
       new MissingConsumingSegmentFinder(tableNameWithType, propertyStore, _controllerMetrics, streamConfig)

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinder.java
@@ -35,6 +35,8 @@ import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.zookeeper.data.Stat;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -44,6 +46,7 @@ import org.apache.zookeeper.data.Stat;
  *   - Maximum duration (in minutes) that a partition hasn't had a consuming segment
  */
 public class MissingConsumingSegmentFinder {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MissingConsumingSegmentFinder.class);
 
   private String _realtimeTableName;
   private ControllerMetrics _controllerMetrics;
@@ -96,6 +99,7 @@ public class MissingConsumingSegmentFinder {
         if (duration > missingSegmentInfo._maxDurationInMinutes) {
           missingSegmentInfo._maxDurationInMinutes = duration;
         }
+        LOGGER.warn("Partition group id {} hasn't had a consuming segment for {} minutes!", partitionGroupId, duration);
       }
     });
     return missingSegmentInfo;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinder.java
@@ -1,0 +1,151 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.realtime;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.helix.AccessOption;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metrics.ControllerMeter;
+import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
+import org.apache.pinot.common.metrics.ControllerGauge;
+import org.apache.zookeeper.data.Stat;
+
+
+/**
+ * For a given table, this class finds out if there is any partition group for which there's no consuming segment in
+ * ideal state. If so, it emits two metrics:
+ *   - Number of missing consuming segments
+ *   - Maximum duration (in minutes) that a partition hasn't had a consuming segment
+ */
+public class MissingConsumingSegmentFinder {
+
+  private String _realtimeTableName;
+  private ControllerMetrics _controllerMetrics;
+  private SegmentMetadataFetcher _segmentMetadataFetcher;
+
+  public MissingConsumingSegmentFinder(String realtimeTableName, ZkHelixPropertyStore<ZNRecord> propertyStore,
+      ControllerMetrics controllerMetrics) {
+    _realtimeTableName = realtimeTableName;
+    _controllerMetrics = controllerMetrics;
+    _segmentMetadataFetcher = new SegmentMetadataFetcher(propertyStore, controllerMetrics);
+  }
+
+  @VisibleForTesting
+  MissingConsumingSegmentFinder(String realtimeTableName, SegmentMetadataFetcher segmentMetadataFetcher) {
+    _realtimeTableName = realtimeTableName;
+    _segmentMetadataFetcher = segmentMetadataFetcher;
+  }
+
+  public void findAndEmitMetrics(IdealState idealState) {
+    MissingSegmentInfo info = findMissingSegments(idealState.getRecord().getMapFields(), Instant.now());
+    _controllerMetrics.setValueOfTableGauge(_realtimeTableName, ControllerGauge.MISSING_CONSUMING_SEGMENT_COUNT,
+        info._count);
+    _controllerMetrics
+        .setValueOfTableGauge(_realtimeTableName, ControllerGauge.MISSING_CONSUMING_SEGMENT_MAX_DURATION_MINUTES,
+            info._maxDurationInMinutes);
+  }
+
+  @VisibleForTesting
+  MissingSegmentInfo findMissingSegments(Map<String, Map<String, String>> idealStateMap, Instant now) {
+    // create the maps
+    Map<Integer, LLCSegmentName> partitionGroupIdToLatestConsumingSegmentMap = new HashMap<>();
+    Map<Integer, LLCSegmentName> partitionGroupIdToLatestCompletedSegmentMap = new HashMap<>();
+    idealStateMap.forEach((segmentName, instanceToStatusMap) -> {
+      LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentName);
+      if (llcSegmentName != null) { // TODO add comments for uploaded segments
+        if (instanceToStatusMap.containsValue(SegmentStateModel.CONSUMING)) {
+          updateMap(partitionGroupIdToLatestConsumingSegmentMap, llcSegmentName);
+        } else if (instanceToStatusMap.containsValue(SegmentStateModel.ONLINE)) {
+          updateMap(partitionGroupIdToLatestCompletedSegmentMap, llcSegmentName);
+        }
+      }
+    });
+
+    MissingSegmentInfo missingSegmentInfo = new MissingSegmentInfo();
+    partitionGroupIdToLatestCompletedSegmentMap.forEach((partitionGroupId, latestCompletedSegment) -> {
+      if (!partitionGroupIdToLatestConsumingSegmentMap.containsKey(partitionGroupId)) {
+        missingSegmentInfo._count++;
+        long segmentCompletionTimeMillis = getSegmentCompletionTimeFromZk(latestCompletedSegment.getSegmentName());
+        long duration = Duration.between(Instant.ofEpochMilli(segmentCompletionTimeMillis), now).toMinutes();
+        if (duration > missingSegmentInfo._maxDurationInMinutes) {
+          missingSegmentInfo._maxDurationInMinutes = duration;
+        }
+      }
+    });
+    return missingSegmentInfo;
+  }
+
+  private void updateMap(Map<Integer, LLCSegmentName> partitionGroupIdToLatestSegmentMap,
+      LLCSegmentName llcSegmentName) {
+    int partitionGroupId = llcSegmentName.getPartitionGroupId();
+    partitionGroupIdToLatestSegmentMap.compute(partitionGroupId, (pid, existingSegment) -> {
+      if (existingSegment == null) {
+        return llcSegmentName;
+      } else {
+        return existingSegment.getSequenceNumber() > llcSegmentName.getSequenceNumber() ? existingSegment
+            : llcSegmentName;
+      }
+    });
+  }
+
+  private long getSegmentCompletionTimeFromZk(String segmentName) {
+    return _segmentMetadataFetcher.fetchZNodeModificationTime(_realtimeTableName, segmentName);
+  }
+
+  @VisibleForTesting
+  static class MissingSegmentInfo {
+    long _count;
+    long _maxDurationInMinutes;
+  }
+
+  static class SegmentMetadataFetcher {
+    private ZkHelixPropertyStore<ZNRecord> _propertyStore;
+    private ControllerMetrics _controllerMetrics;
+
+    public SegmentMetadataFetcher(ZkHelixPropertyStore<ZNRecord> propertyStore, ControllerMetrics controllerMetrics) {
+      _propertyStore = propertyStore;
+      _controllerMetrics = controllerMetrics;
+    }
+
+    public long fetchZNodeModificationTime(String tableName, String segmentName) {
+      try {
+        Stat stat = new Stat();
+        ZNRecord znRecord = _propertyStore
+            .get(ZKMetadataProvider.constructPropertyStorePathForSegment(tableName, segmentName), stat,
+                AccessOption.PERSISTENT);
+        Preconditions.checkState(znRecord != null, "Failed to find segment ZK metadata for segment: %s of table: %s",
+            segmentName, tableName);
+        return stat.getMtime();
+      } catch (Exception e) {
+        _controllerMetrics.addMeteredTableValue(tableName, ControllerMeter.LLC_ZOOKEEPER_FETCH_FAILURES, 1L);
+        throw e;
+      }
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinder.java
@@ -78,7 +78,7 @@ public class MissingConsumingSegmentFinder {
     Map<Integer, LLCSegmentName> partitionGroupIdToLatestCompletedSegmentMap = new HashMap<>();
     idealStateMap.forEach((segmentName, instanceToStatusMap) -> {
       LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentName);
-      if (llcSegmentName != null) { // TODO add comments for uploaded segments
+      if (llcSegmentName != null) { // Skip the uploaded realtime segments that don't conform to llc naming
         if (instanceToStatusMap.containsValue(SegmentStateModel.CONSUMING)) {
           updateMap(partitionGroupIdToLatestConsumingSegmentMap, llcSegmentName);
         } else if (instanceToStatusMap.containsValue(SegmentStateModel.ONLINE)) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinder.java
@@ -29,11 +29,11 @@ import org.apache.helix.ZNRecord;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
-import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.zookeeper.data.Stat;
 
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinder.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.helix.AccessOption;
@@ -29,46 +30,79 @@ import org.apache.helix.ZNRecord;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.controller.helix.core.PinotTableIdealStateBuilder;
+import org.apache.pinot.spi.stream.OffsetCriteria;
+import org.apache.pinot.spi.stream.PartitionLevelStreamConfig;
+import org.apache.pinot.spi.stream.StreamConsumerFactoryProvider;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffsetFactory;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
-import org.apache.zookeeper.data.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
 /**
  * For a given table, this class finds out if there is any partition group for which there's no consuming segment in
- * ideal state. If so, it emits two metrics:
- *   - Number of missing consuming segments
+ * ideal state. If so, it emits three metrics:
+ *   - Total number of partitions with missing consuming segments including
+ *   - Number of newly added partitions for which there's no consuming segment (there's no completed segment either)
  *   - Maximum duration (in minutes) that a partition hasn't had a consuming segment
  */
 public class MissingConsumingSegmentFinder {
   private static final Logger LOGGER = LoggerFactory.getLogger(MissingConsumingSegmentFinder.class);
 
-  private String _realtimeTableName;
+  private final String _realtimeTableName;
+  private final SegmentMetadataFetcher _segmentMetadataFetcher;
+  private final Map<Integer, StreamPartitionMsgOffset> _partitionGroupIdToLargestStreamOffsetMap;
+  private final StreamPartitionMsgOffsetFactory _streamPartitionMsgOffsetFactory;
+
   private ControllerMetrics _controllerMetrics;
-  private SegmentMetadataFetcher _segmentMetadataFetcher;
 
   public MissingConsumingSegmentFinder(String realtimeTableName, ZkHelixPropertyStore<ZNRecord> propertyStore,
-      ControllerMetrics controllerMetrics) {
+      ControllerMetrics controllerMetrics, PartitionLevelStreamConfig streamConfig) {
     _realtimeTableName = realtimeTableName;
     _controllerMetrics = controllerMetrics;
     _segmentMetadataFetcher = new SegmentMetadataFetcher(propertyStore, controllerMetrics);
+    _streamPartitionMsgOffsetFactory =
+        StreamConsumerFactoryProvider.create(streamConfig).createStreamMsgOffsetFactory();
+
+    // create partition group id to largest stream offset map
+    _partitionGroupIdToLargestStreamOffsetMap = new HashMap<>();
+    streamConfig.setOffsetCriteria(OffsetCriteria.LARGEST_OFFSET_CRITERIA);
+    try {
+      PinotTableIdealStateBuilder.getPartitionGroupMetadataList(streamConfig, Collections.emptyList())
+          .forEach(metadata -> {
+            _partitionGroupIdToLargestStreamOffsetMap.put(metadata.getPartitionGroupId(), metadata.getStartOffset());
+          });
+    } catch (Exception e) {
+      LOGGER.warn("Problem encountered in fetching stream metadata for topic: {} of table: {}. "
+              + "Continue finding missing consuming segment only with ideal state information.",
+          streamConfig.getTopicName(), streamConfig.getTableNameWithType());
+    }
   }
 
   @VisibleForTesting
-  MissingConsumingSegmentFinder(String realtimeTableName, SegmentMetadataFetcher segmentMetadataFetcher) {
+  MissingConsumingSegmentFinder(String realtimeTableName, SegmentMetadataFetcher segmentMetadataFetcher,
+      Map<Integer, StreamPartitionMsgOffset> partitionGroupIdToLargestStreamOffsetMap,
+      StreamPartitionMsgOffsetFactory streamPartitionMsgOffsetFactory) {
     _realtimeTableName = realtimeTableName;
     _segmentMetadataFetcher = segmentMetadataFetcher;
+    _partitionGroupIdToLargestStreamOffsetMap = partitionGroupIdToLargestStreamOffsetMap;
+    _streamPartitionMsgOffsetFactory = streamPartitionMsgOffsetFactory;
   }
 
   public void findAndEmitMetrics(IdealState idealState) {
     MissingSegmentInfo info = findMissingSegments(idealState.getRecord().getMapFields(), Instant.now());
-    _controllerMetrics.setValueOfTableGauge(_realtimeTableName, ControllerGauge.MISSING_CONSUMING_SEGMENT_COUNT,
-        info._count);
+    _controllerMetrics.setValueOfTableGauge(_realtimeTableName, ControllerGauge.MISSING_CONSUMING_SEGMENT_TOTAL_COUNT,
+        info._totalCount);
+    _controllerMetrics
+        .setValueOfTableGauge(_realtimeTableName, ControllerGauge.MISSING_CONSUMING_SEGMENT_NEW_PARTITION_COUNT,
+            info._newPartitionGroupCount);
     _controllerMetrics
         .setValueOfTableGauge(_realtimeTableName, ControllerGauge.MISSING_CONSUMING_SEGMENT_MAX_DURATION_MINUTES,
             info._maxDurationInMinutes);
@@ -91,18 +125,50 @@ public class MissingConsumingSegmentFinder {
     });
 
     MissingSegmentInfo missingSegmentInfo = new MissingSegmentInfo();
-    partitionGroupIdToLatestCompletedSegmentMap.forEach((partitionGroupId, latestCompletedSegment) -> {
-      if (!partitionGroupIdToLatestConsumingSegmentMap.containsKey(partitionGroupId)) {
-        missingSegmentInfo._count++;
-        long segmentCompletionTimeMillis = getSegmentCompletionTimeFromZk(latestCompletedSegment.getSegmentName());
-        long duration = Duration.between(Instant.ofEpochMilli(segmentCompletionTimeMillis), now).toMinutes();
-        if (duration > missingSegmentInfo._maxDurationInMinutes) {
-          missingSegmentInfo._maxDurationInMinutes = duration;
+    if (!_partitionGroupIdToLargestStreamOffsetMap.isEmpty()) {
+      _partitionGroupIdToLargestStreamOffsetMap.forEach((partitionGroupId, largestStreamOffset) -> {
+        if (!partitionGroupIdToLatestConsumingSegmentMap.containsKey(partitionGroupId)) {
+          LLCSegmentName latestCompletedSegment = partitionGroupIdToLatestCompletedSegmentMap.get(partitionGroupId);
+          if (latestCompletedSegment == null) {
+            // There's no consuming or completed segment for this partition group. Possibilities:
+            //   1) it's a new partition group that has not yet been detected
+            //   2) the first consuming segment has been deleted from ideal state manually
+            missingSegmentInfo._newPartitionGroupCount++;
+            missingSegmentInfo._totalCount++;
+          } else {
+            // completed segment is available, but there's no consuming segment
+            SegmentZKMetadata segmentZKMetadata = _segmentMetadataFetcher
+                .fetchSegmentZkMetadata(_realtimeTableName, latestCompletedSegment.getSegmentName());
+            StreamPartitionMsgOffset completedSegmentEndOffset =
+                _streamPartitionMsgOffsetFactory.create(segmentZKMetadata.getEndOffset());
+            if (completedSegmentEndOffset.compareTo(largestStreamOffset) < 0) {
+              // there are unconsumed messages available on the stream
+              missingSegmentInfo._totalCount++;
+              updateMaxDurationInfo(missingSegmentInfo, partitionGroupId, segmentZKMetadata.getCreationTime(), now);
+            }
+          }
         }
-        LOGGER.warn("Partition group id {} hasn't had a consuming segment for {} minutes!", partitionGroupId, duration);
-      }
-    });
+      });
+    } else {
+      partitionGroupIdToLatestCompletedSegmentMap.forEach((partitionGroupId, latestCompletedSegment) -> {
+        if (!partitionGroupIdToLatestConsumingSegmentMap.containsKey(partitionGroupId)) {
+          missingSegmentInfo._totalCount++;
+          long segmentCompletionTimeMillis = _segmentMetadataFetcher
+              .fetchSegmentCreationTime(_realtimeTableName, latestCompletedSegment.getSegmentName());
+          updateMaxDurationInfo(missingSegmentInfo, partitionGroupId, segmentCompletionTimeMillis, now);
+        }
+      });
+    }
     return missingSegmentInfo;
+  }
+
+  private void updateMaxDurationInfo(MissingSegmentInfo missingSegmentInfo, Integer partitionGroupId,
+      long segmentCompletionTimeMillis, Instant now) {
+    long duration = Duration.between(Instant.ofEpochMilli(segmentCompletionTimeMillis), now).toMinutes();
+    if (duration > missingSegmentInfo._maxDurationInMinutes) {
+      missingSegmentInfo._maxDurationInMinutes = duration;
+    }
+    LOGGER.warn("PartitionGroupId {} hasn't had a consuming segment for {} minutes!", partitionGroupId, duration);
   }
 
   private void updateMap(Map<Integer, LLCSegmentName> partitionGroupIdToLatestSegmentMap,
@@ -118,13 +184,10 @@ public class MissingConsumingSegmentFinder {
     });
   }
 
-  private long getSegmentCompletionTimeFromZk(String segmentName) {
-    return _segmentMetadataFetcher.fetchZNodeModificationTime(_realtimeTableName, segmentName);
-  }
-
   @VisibleForTesting
   static class MissingSegmentInfo {
-    long _count;
+    long _totalCount;
+    long _newPartitionGroupCount;
     long _maxDurationInMinutes;
   }
 
@@ -137,19 +200,22 @@ public class MissingConsumingSegmentFinder {
       _controllerMetrics = controllerMetrics;
     }
 
-    public long fetchZNodeModificationTime(String tableName, String segmentName) {
+    public SegmentZKMetadata fetchSegmentZkMetadata(String tableName, String segmentName) {
       try {
-        Stat stat = new Stat();
         ZNRecord znRecord = _propertyStore
-            .get(ZKMetadataProvider.constructPropertyStorePathForSegment(tableName, segmentName), stat,
+            .get(ZKMetadataProvider.constructPropertyStorePathForSegment(tableName, segmentName), null,
                 AccessOption.PERSISTENT);
         Preconditions.checkState(znRecord != null, "Failed to find segment ZK metadata for segment: %s of table: %s",
             segmentName, tableName);
-        return stat.getMtime();
+        return new SegmentZKMetadata(znRecord);
       } catch (Exception e) {
         _controllerMetrics.addMeteredTableValue(tableName, ControllerMeter.LLC_ZOOKEEPER_FETCH_FAILURES, 1L);
         throw e;
       }
+    }
+
+    public long fetchSegmentCreationTime(String tableName, String segmentName) {
+      return fetchSegmentZkMetadata(tableName, segmentName).getCreationTime();
     }
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -871,8 +871,6 @@ public class PinotLLCRealtimeSegmentManager {
     HelixHelper.updateIdealState(_helixManager, realtimeTableName, idealState -> {
       assert idealState != null;
       if (idealState.isEnabled()) {
-        new MissingConsumingSegmentFinder(realtimeTableName, _propertyStore, _controllerMetrics)
-            .findAndEmitMetrics(idealState);
         List<PartitionGroupConsumptionStatus> currentPartitionGroupConsumptionStatusList =
             getPartitionGroupConsumptionStatusList(idealState, streamConfig);
         // Read the smallest offset when a new partition is detected

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinderTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinderTest.java
@@ -22,6 +22,11 @@ import com.google.common.collect.ImmutableMap;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.spi.stream.LongMsgOffset;
+import org.apache.pinot.spi.stream.LongMsgOffsetFactory;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffsetFactory;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
@@ -31,17 +36,138 @@ import static org.testng.Assert.*;
 
 public class MissingConsumingSegmentFinderTest {
 
-  MissingConsumingSegmentFinder.SegmentMetadataFetcher _metadataFetcher =
-      mock(MissingConsumingSegmentFinder.SegmentMetadataFetcher.class);
+  private StreamPartitionMsgOffsetFactory _offsetFactory = new LongMsgOffsetFactory();
 
   @Test
-  public void testFindMissingSegments() {
+  public void noMissingConsumingSegmentsScenario1() {
+    // scenario 1: no missing segments, but connecting to stream throws exception
+    // only ideal state info is used
+
     Map<String, Map<String, String>> idealStateMap = new HashMap<>();
     // partition 0
     idealStateMap.put("tableA__0__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
     idealStateMap.put("tableA__0__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
     idealStateMap.put("tableA__0__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
-    // partition 1 (no consuming segment)
+    // partition 1
+    idealStateMap.put("tableA__1__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__1__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__1__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    // partition 2
+    idealStateMap.put("tableA__2__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__2__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__2__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    // partition 3
+    idealStateMap.put("tableA__3__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__3__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__3__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+
+    Instant now = Instant.parse("2022-06-01T18:00:00.00Z");
+    MissingConsumingSegmentFinder finder = new MissingConsumingSegmentFinder("tableA", null, new HashMap<>(), null);
+    MissingConsumingSegmentFinder.MissingSegmentInfo info = finder.findMissingSegments(idealStateMap, now);
+    assertEquals(info._totalCount, 0);
+    assertEquals(info._newPartitionGroupCount, 0);
+    assertEquals(info._maxDurationInMinutes, 0);
+  }
+
+  @Test
+  public void noMissingConsumingSegmentsScenario2() {
+    // scenario 2: no missing segments and there's no exception in connecting to stream
+
+    Map<String, Map<String, String>> idealStateMap = new HashMap<>();
+    // partition 0
+    idealStateMap.put("tableA__0__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__0__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__0__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    // partition 1
+    idealStateMap.put("tableA__1__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__1__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__1__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    // partition 2
+    idealStateMap.put("tableA__2__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__2__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__2__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    // partition 3
+    idealStateMap.put("tableA__3__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__3__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__3__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+
+    Map<Integer, StreamPartitionMsgOffset> partitionGroupIdToLargestStreamOffsetMap = ImmutableMap.of(
+        0, new LongMsgOffset(1000),
+        1, new LongMsgOffset(1001),
+        2, new LongMsgOffset(1002),
+        3, new LongMsgOffset(1003)
+    );
+
+    Instant now = Instant.parse("2022-06-01T18:00:00.00Z");
+    MissingConsumingSegmentFinder finder =
+        new MissingConsumingSegmentFinder("tableA", null, partitionGroupIdToLargestStreamOffsetMap, null);
+    MissingConsumingSegmentFinder.MissingSegmentInfo info = finder.findMissingSegments(idealStateMap, now);
+    assertEquals(info._totalCount, 0);
+    assertEquals(info._newPartitionGroupCount, 0);
+    assertEquals(info._maxDurationInMinutes, 0);
+  }
+
+  @Test
+  public void noMissingConsumingSegmentsScenario3() {
+    // scenario 3: no missing segments and there's no exception in connecting to stream
+    // two partitions have reached end of life
+
+    Map<String, Map<String, String>> idealStateMap = new HashMap<>();
+    // partition 0
+    idealStateMap.put("tableA__0__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__0__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__0__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    // partition 1 (has reached end of life)
+    idealStateMap.put("tableA__1__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__1__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    // partition 2
+    idealStateMap.put("tableA__2__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__2__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__2__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    // partition 3 (has reached end of life)
+    idealStateMap.put("tableA__3__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__3__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+
+    Map<Integer, StreamPartitionMsgOffset> partitionGroupIdToLargestStreamOffsetMap = ImmutableMap.of(
+        0, new LongMsgOffset(1000),
+        1, new LongMsgOffset(701),
+        2, new LongMsgOffset(1002),
+        3, new LongMsgOffset(703)
+    );
+
+    // setup segment metadata fetcher
+    SegmentZKMetadata m1 = mock(SegmentZKMetadata.class);
+    when(m1.getEndOffset()).thenReturn("701");
+    SegmentZKMetadata m3 = mock(SegmentZKMetadata.class);
+    when(m3.getEndOffset()).thenReturn("703");
+    MissingConsumingSegmentFinder.SegmentMetadataFetcher metadataFetcher =
+        mock(MissingConsumingSegmentFinder.SegmentMetadataFetcher.class);
+    when(metadataFetcher.fetchSegmentZkMetadata("tableA", "tableA__1__1__20220601T1200Z")).thenReturn(m1);
+    when(metadataFetcher.fetchSegmentZkMetadata("tableA", "tableA__3__1__20220601T1200Z")).thenReturn(m3);
+
+    Instant now = Instant.parse("2022-06-01T18:00:00.00Z");
+    MissingConsumingSegmentFinder finder =
+        new MissingConsumingSegmentFinder("tableA", metadataFetcher, partitionGroupIdToLargestStreamOffsetMap,
+            _offsetFactory);
+    MissingConsumingSegmentFinder.MissingSegmentInfo info = finder.findMissingSegments(idealStateMap, now);
+    assertEquals(info._totalCount, 0);
+    assertEquals(info._newPartitionGroupCount, 0);
+    assertEquals(info._maxDurationInMinutes, 0);
+  }
+
+  @Test
+  public void noMissingConsumingSegmentsScenario4() {
+    // scenario 4: no missing segments, but connecting to stream throws exception
+    // two partitions have reached end of life
+    // since there's no way to detect if the partitions have reached end of life,  those partitions are reported as
+    // missing consuming segments
+
+    Map<String, Map<String, String>> idealStateMap = new HashMap<>();
+    // partition 0
+    idealStateMap.put("tableA__0__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__0__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__0__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    // partition 1 (has reached end of life)
     idealStateMap.put("tableA__1__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
     idealStateMap.put("tableA__1__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
     // partition 2
@@ -52,49 +178,129 @@ public class MissingConsumingSegmentFinderTest {
     idealStateMap.put("tableA__3__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
     idealStateMap.put("tableA__3__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
     idealStateMap.put("tableA__3__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
-    // partition 4 (no consuming segment)
+    // partition 4 (has reached end of life)
     idealStateMap.put("tableA__4__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
     // partition 5
     idealStateMap.put("tableA__5__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
     idealStateMap.put("tableA__5__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
     idealStateMap.put("tableA__5__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
 
-    when(_metadataFetcher.fetchZNodeModificationTime("tableA", "tableA__1__1__20220601T1200Z"))
+    // setup segment metadata fetcher
+    MissingConsumingSegmentFinder.SegmentMetadataFetcher metadataFetcher =
+        mock(MissingConsumingSegmentFinder.SegmentMetadataFetcher.class);
+    when(metadataFetcher.fetchSegmentCreationTime("tableA", "tableA__1__1__20220601T1200Z"))
         .thenReturn(Instant.parse("2022-06-01T15:00:00.00Z").toEpochMilli());
-    when(_metadataFetcher.fetchZNodeModificationTime("tableA", "tableA__4__0__20220601T0900Z"))
+    when(metadataFetcher.fetchSegmentCreationTime("tableA", "tableA__4__0__20220601T0900Z"))
         .thenReturn(Instant.parse("2022-06-01T12:00:00.00Z").toEpochMilli());
 
     Instant now = Instant.parse("2022-06-01T18:00:00.00Z");
-    MissingConsumingSegmentFinder finder = new MissingConsumingSegmentFinder("tableA", _metadataFetcher);
+    MissingConsumingSegmentFinder finder =
+        new MissingConsumingSegmentFinder("tableA", metadataFetcher, new HashMap<>(), null);
     MissingConsumingSegmentFinder.MissingSegmentInfo info = finder.findMissingSegments(idealStateMap, now);
-    assertEquals(info._count, 2);
+    assertEquals(info._totalCount, 2);
+    assertEquals(info._newPartitionGroupCount, 0);
     assertEquals(info._maxDurationInMinutes, 6 * 60); // (18:00:00 - 12:00:00) in minutes
   }
 
   @Test
-  public void testFindMissingSegmentsWithNoMissingSegment() {
+  public void missingConsumingSegments() {
+
     Map<String, Map<String, String>> idealStateMap = new HashMap<>();
     // partition 0
-    idealStateMap.put("tableB__0__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
-    idealStateMap.put("tableB__0__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
-    idealStateMap.put("tableB__0__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
-    // partition 1
-    idealStateMap.put("tableB__1__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
-    idealStateMap.put("tableB__1__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
-    idealStateMap.put("tableB__1__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    idealStateMap.put("tableA__0__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__0__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__0__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    // partition 1 (missing consuming segment)
+    idealStateMap.put("tableA__1__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__1__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
     // partition 2
-    idealStateMap.put("tableB__2__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
-    idealStateMap.put("tableB__2__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
-    idealStateMap.put("tableB__2__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    idealStateMap.put("tableA__2__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__2__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__2__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
     // partition 3
-    idealStateMap.put("tableB__3__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
-    idealStateMap.put("tableB__3__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
-    idealStateMap.put("tableB__3__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    idealStateMap.put("tableA__3__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__3__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__3__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    // partition 4 (missing consuming segment)
+    idealStateMap.put("tableA__4__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    // partition 5
+    idealStateMap.put("tableA__5__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__5__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__5__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    // partition 6 is a new partition and there's no consuming segment in ideal states for it
+
+    Map<Integer, StreamPartitionMsgOffset> partitionGroupIdToLargestStreamOffsetMap = new HashMap<>();
+    partitionGroupIdToLargestStreamOffsetMap.put(0, new LongMsgOffset(1000));
+    partitionGroupIdToLargestStreamOffsetMap.put(1, new LongMsgOffset(1001));
+    partitionGroupIdToLargestStreamOffsetMap.put(2, new LongMsgOffset(1002));
+    partitionGroupIdToLargestStreamOffsetMap.put(3, new LongMsgOffset(1003));
+    partitionGroupIdToLargestStreamOffsetMap.put(4, new LongMsgOffset(1004));
+    partitionGroupIdToLargestStreamOffsetMap.put(5, new LongMsgOffset(1005));
+    partitionGroupIdToLargestStreamOffsetMap.put(6, new LongMsgOffset(16));
+
+    // setup segment metadata fetcher
+    SegmentZKMetadata m1 = mock(SegmentZKMetadata.class);
+    when(m1.getEndOffset()).thenReturn("701");
+    when(m1.getCreationTime()).thenReturn(Instant.parse("2022-06-01T15:00:00.00Z").toEpochMilli());
+    SegmentZKMetadata m4 = mock(SegmentZKMetadata.class);
+    when(m4.getEndOffset()).thenReturn("704");
+    when(m4.getCreationTime()).thenReturn(Instant.parse("2022-06-01T12:00:00.00Z").toEpochMilli());
+    MissingConsumingSegmentFinder.SegmentMetadataFetcher metadataFetcher =
+        mock(MissingConsumingSegmentFinder.SegmentMetadataFetcher.class);
+    when(metadataFetcher.fetchSegmentZkMetadata("tableA", "tableA__1__1__20220601T1200Z")).thenReturn(m1);
+    when(metadataFetcher.fetchSegmentZkMetadata("tableA", "tableA__4__0__20220601T0900Z")).thenReturn(m4);
 
     Instant now = Instant.parse("2022-06-01T18:00:00.00Z");
-    MissingConsumingSegmentFinder finder = new MissingConsumingSegmentFinder("tableB", _metadataFetcher);
+    MissingConsumingSegmentFinder finder =
+        new MissingConsumingSegmentFinder("tableA", metadataFetcher, partitionGroupIdToLargestStreamOffsetMap,
+            _offsetFactory);
     MissingConsumingSegmentFinder.MissingSegmentInfo info = finder.findMissingSegments(idealStateMap, now);
-    assertEquals(info._count, 0);
-    assertEquals(info._maxDurationInMinutes, 0);
+    assertEquals(info._totalCount, 3);
+    assertEquals(info._newPartitionGroupCount, 1);
+    assertEquals(info._maxDurationInMinutes, 6 * 60); // (18:00:00 - 12:00:00) in minutes
+  }
+
+  @Test
+  public void missingConsumingSegmentsWithStreamConnectionIssue() {
+
+    Map<String, Map<String, String>> idealStateMap = new HashMap<>();
+    // partition 0
+    idealStateMap.put("tableA__0__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__0__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__0__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    // partition 1 (missing consuming segment)
+    idealStateMap.put("tableA__1__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__1__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    // partition 2
+    idealStateMap.put("tableA__2__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__2__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__2__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    // partition 3
+    idealStateMap.put("tableA__3__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__3__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__3__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    // partition 4 (missing consuming segment)
+    idealStateMap.put("tableA__4__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    // partition 5
+    idealStateMap.put("tableA__5__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__5__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__5__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    // partition 6 is a new partition and there's no consuming segment in ideal states for it
+
+    // setup segment metadata fetcher
+    MissingConsumingSegmentFinder.SegmentMetadataFetcher metadataFetcher =
+        mock(MissingConsumingSegmentFinder.SegmentMetadataFetcher.class);
+    when(metadataFetcher.fetchSegmentCreationTime("tableA", "tableA__1__1__20220601T1200Z"))
+        .thenReturn(Instant.parse("2022-06-01T15:00:00.00Z").toEpochMilli());
+    when(metadataFetcher.fetchSegmentCreationTime("tableA", "tableA__4__0__20220601T0900Z"))
+        .thenReturn(Instant.parse("2022-06-01T12:00:00.00Z").toEpochMilli());
+
+    Instant now = Instant.parse("2022-06-01T18:00:00.00Z");
+    MissingConsumingSegmentFinder finder =
+        new MissingConsumingSegmentFinder("tableA", metadataFetcher, new HashMap<>(), _offsetFactory);
+    MissingConsumingSegmentFinder.MissingSegmentInfo info = finder.findMissingSegments(idealStateMap, now);
+    assertEquals(info._totalCount, 2);
+    assertEquals(info._newPartitionGroupCount, 0);
+    assertEquals(info._maxDurationInMinutes, 6 * 60); // (18:00:00 - 12:00:00) in minutes
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinderTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinderTest.java
@@ -159,7 +159,7 @@ public class MissingConsumingSegmentFinderTest {
   public void noMissingConsumingSegmentsScenario4() {
     // scenario 4: no missing segments, but connecting to stream throws exception
     // two partitions have reached end of life
-    // since there's no way to detect if the partitions have reached end of life,  those partitions are reported as
+    // since there's no way to detect if the partitions have reached end of life, those partitions are reported as
     // missing consuming segments
 
     Map<String, Map<String, String>> idealStateMap = new HashMap<>();
@@ -188,9 +188,9 @@ public class MissingConsumingSegmentFinderTest {
     // setup segment metadata fetcher
     MissingConsumingSegmentFinder.SegmentMetadataFetcher metadataFetcher =
         mock(MissingConsumingSegmentFinder.SegmentMetadataFetcher.class);
-    when(metadataFetcher.fetchSegmentCreationTime("tableA", "tableA__1__1__20220601T1200Z"))
+    when(metadataFetcher.fetchSegmentCompletionTime("tableA", "tableA__1__1__20220601T1200Z"))
         .thenReturn(Instant.parse("2022-06-01T15:00:00.00Z").toEpochMilli());
-    when(metadataFetcher.fetchSegmentCreationTime("tableA", "tableA__4__0__20220601T0900Z"))
+    when(metadataFetcher.fetchSegmentCompletionTime("tableA", "tableA__4__0__20220601T0900Z"))
         .thenReturn(Instant.parse("2022-06-01T12:00:00.00Z").toEpochMilli());
 
     Instant now = Instant.parse("2022-06-01T18:00:00.00Z");
@@ -290,9 +290,9 @@ public class MissingConsumingSegmentFinderTest {
     // setup segment metadata fetcher
     MissingConsumingSegmentFinder.SegmentMetadataFetcher metadataFetcher =
         mock(MissingConsumingSegmentFinder.SegmentMetadataFetcher.class);
-    when(metadataFetcher.fetchSegmentCreationTime("tableA", "tableA__1__1__20220601T1200Z"))
+    when(metadataFetcher.fetchSegmentCompletionTime("tableA", "tableA__1__1__20220601T1200Z"))
         .thenReturn(Instant.parse("2022-06-01T15:00:00.00Z").toEpochMilli());
-    when(metadataFetcher.fetchSegmentCreationTime("tableA", "tableA__4__0__20220601T0900Z"))
+    when(metadataFetcher.fetchSegmentCompletionTime("tableA", "tableA__4__0__20220601T0900Z"))
         .thenReturn(Instant.parse("2022-06-01T12:00:00.00Z").toEpochMilli());
 
     Instant now = Instant.parse("2022-06-01T18:00:00.00Z");

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinderTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinderTest.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.realtime;
+
+import com.google.common.collect.ImmutableMap;
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
+
+
+public class MissingConsumingSegmentFinderTest {
+
+  MissingConsumingSegmentFinder.SegmentMetadataFetcher _metadataFetcher =
+      mock(MissingConsumingSegmentFinder.SegmentMetadataFetcher.class);
+
+  @Test
+  public void testFindMissingSegments() {
+    Map<String, Map<String, String>> idealStateMap = new HashMap<>();
+    // partition 0
+    idealStateMap.put("tableA__0__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__0__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__0__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    // partition 1 (no consuming segment)
+    idealStateMap.put("tableA__1__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__1__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    // partition 2
+    idealStateMap.put("tableA__2__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__2__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__2__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    // partition 3
+    idealStateMap.put("tableA__3__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__3__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__3__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    // partition 4 (no consuming segment)
+    idealStateMap.put("tableA__4__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    // partition 5
+    idealStateMap.put("tableA__5__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__5__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableA__5__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+
+    when(_metadataFetcher.fetchZNodeModificationTime("tableA", "tableA__1__1__20220601T1200Z"))
+        .thenReturn(Instant.parse("2022-06-01T15:00:00.00Z").toEpochMilli());
+    when(_metadataFetcher.fetchZNodeModificationTime("tableA", "tableA__4__0__20220601T0900Z"))
+        .thenReturn(Instant.parse("2022-06-01T12:00:00.00Z").toEpochMilli());
+
+    Instant now = Instant.parse("2022-06-01T18:00:00.00Z");
+    MissingConsumingSegmentFinder finder = new MissingConsumingSegmentFinder("tableA", _metadataFetcher);
+    MissingConsumingSegmentFinder.MissingSegmentInfo info = finder.findMissingSegments(idealStateMap, now);
+    assertEquals(info._count, 2);
+    assertEquals(info._maxDurationInMinutes, 6 * 60); // (18:00:00 - 12:00:00) in minutes
+  }
+
+  @Test
+  public void testFindMissingSegmentsWithNoMissingSegment() {
+    Map<String, Map<String, String>> idealStateMap = new HashMap<>();
+    // partition 0
+    idealStateMap.put("tableB__0__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableB__0__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableB__0__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    // partition 1
+    idealStateMap.put("tableB__1__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableB__1__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableB__1__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    // partition 2
+    idealStateMap.put("tableB__2__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableB__2__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableB__2__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+    // partition 3
+    idealStateMap.put("tableB__3__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableB__3__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
+    idealStateMap.put("tableB__3__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
+
+    Instant now = Instant.parse("2022-06-01T18:00:00.00Z");
+    MissingConsumingSegmentFinder finder = new MissingConsumingSegmentFinder("tableB", _metadataFetcher);
+    MissingConsumingSegmentFinder.MissingSegmentInfo info = finder.findMissingSegments(idealStateMap, now);
+    assertEquals(info._count, 0);
+    assertEquals(info._maxDurationInMinutes, 0);
+  }
+}


### PR DESCRIPTION
## Description
Currently if there's no consuming segment for a partition, it remains undetected. 
With the changes in this PR, the following two metrics get emitted if for a partition group has no consuming segment.
- Total number of partitions with missing consuming segments including
- Number of newly added partitions for which there's no consuming segment (there's no completed segment either)
- Maximum duration (in minutes) that a partition hasn't had a consuming segment

The check happens at the beginning of the SegmentStatusChecker periodic task.

## Testing Done
- Unit tests
- Ran LLC cluster integration test. Then deleted a consuming segment in ideal state and after that ran the periodic task. Here are the MBeans for the emitted metrics:
![image](https://user-images.githubusercontent.com/8548220/175836500-2881d7ad-dcee-4880-96ab-3fd467ee7fe1.png)
