### PR TITLE
Optimize the immutable STRING/BYTES dictionary lookup

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/FixedByteValueReaderWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/FixedByteValueReaderWriter.java
@@ -111,6 +111,42 @@ public final class FixedByteValueReaderWriter implements ValueReader {
     return value;
   }
 
+  @Override
+  public int compare(int index, int numBytesPerValue, byte[] value, int paddingByte) {
+    long startOffset = (long) index * numBytesPerValue;
+    int compareLength = Math.min(numBytesPerValue, value.length);
+    for (int i = 0; i < compareLength; i++) {
+      int i1 = Byte.toUnsignedInt(_dataBuffer.getByte(startOffset + i));
+      int i2 = Byte.toUnsignedInt(value[i]);
+      if (i1 != i2) {
+        return i1 - i2;
+      }
+    }
+    if (numBytesPerValue == value.length) {
+      return 0;
+    } else if (numBytesPerValue < value.length) {
+      return -1;
+    } else {
+      // If the given value length is smaller than numBytesPerValue, check if the remaining bytes in the buffer are
+      // paddings
+      return _dataBuffer.getByte(startOffset + compareLength) == paddingByte ? 0 : 1;
+    }
+  }
+
+  @Override
+  public int compare(int index, int numBytesPerValue, byte[] value) {
+    long startOffset = (long) index * numBytesPerValue;
+    int compareLength = Math.min(numBytesPerValue, value.length);
+    for (int i = 0; i < compareLength; i++) {
+      int i1 = Byte.toUnsignedInt(_dataBuffer.getByte(startOffset + i));
+      int i2 = Byte.toUnsignedInt(value[i]);
+      if (i1 != i2) {
+        return i1 - i2;
+      }
+    }
+    return Integer.compare(numBytesPerValue, value.length);
+  }
+
   public void writeInt(int index, int value) {
     _dataBuffer.putInt((long) index * Integer.BYTES, value);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/ValueReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/ValueReader.java
@@ -54,4 +54,14 @@ public interface ValueReader extends Closeable {
    * NOTE: Do not reuse buffer for BYTES because the return value can have variable length.
    */
   byte[] getBytes(int index, int numBytesPerValue);
+
+  /**
+   * Returns the comparison result of the value at the given index and the given UTF-8 encoded string value.
+   */
+  int compare(int index, int numBytesPerValue, byte[] value, int paddingByte);
+
+  /**
+   * Returns the comparison result of the value at the given index and the given bytes value.
+   */
+  int compare(int index, int numBytesPerValue, byte[] value);
 }


### PR DESCRIPTION
We use binary search to look up a string/byte[] from an immutable dictionary. Currently we read the whole value before comparing it with the look up value, which is not needed because we can early terminate after finding the first different byte. For string dictionary, because UTF-8 bytes preserve the same order as the code points, we don't need to decode the string before the comparison.
This PR optimizes it by comparing values byte by byte and early terminate. For a dictionary with 200K values, we get up to 3x performance:

Before:
```
Benchmark                                       (_maxValueLength)  Mode  Cnt     Score     Error  Units
BenchmarkStringDictionary.stringDictionaryRead                  8  avgt    5   792.757 ±  33.316  ms/op
BenchmarkStringDictionary.stringDictionaryRead                 16  avgt    5   898.899 ±  27.318  ms/op
BenchmarkStringDictionary.stringDictionaryRead                 32  avgt    5  1096.918 ± 139.193  ms/op
BenchmarkStringDictionary.stringDictionaryRead                 64  avgt    5  1250.916 ±  44.909  ms/op
BenchmarkStringDictionary.stringDictionaryRead                128  avgt    5  1694.212 ±  39.061  ms/op
BenchmarkStringDictionary.stringDictionaryRead                256  avgt    5  2264.023 ±  81.728  ms/op
BenchmarkStringDictionary.stringDictionaryRead                512  avgt    5  3544.365 ±  63.660  ms/op
BenchmarkStringDictionary.stringDictionaryRead               1024  avgt    5  5568.589 ± 112.454  ms/op
```

After:
```
Benchmark                                       (_maxValueLength)  Mode  Cnt     Score    Error  Units
BenchmarkStringDictionary.stringDictionaryRead                  8  avgt    5   307.097 ± 24.020  ms/op
BenchmarkStringDictionary.stringDictionaryRead                 16  avgt    5   344.153 ± 62.155  ms/op
BenchmarkStringDictionary.stringDictionaryRead                 32  avgt    5   434.944 ± 10.180  ms/op
BenchmarkStringDictionary.stringDictionaryRead                 64  avgt    5   532.598 ± 19.969  ms/op
BenchmarkStringDictionary.stringDictionaryRead                128  avgt    5   623.685 ±  7.924  ms/op
BenchmarkStringDictionary.stringDictionaryRead                256  avgt    5   891.540 ± 33.219  ms/op
BenchmarkStringDictionary.stringDictionaryRead                512  avgt    5  1297.558 ± 16.707  ms/op
BenchmarkStringDictionary.stringDictionaryRead               1024  avgt    5  1938.732 ± 14.882  ms/op
```