### PR TITLE
[Draft] extract sort fields into a temp file for better data locality for sorting

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -93,6 +93,9 @@ public class MinionConstants {
     public static final String ROUND_BUCKET_TIME_PERIOD_KEY = "roundBucketTimePeriod";
     public static final String PARTITION_BUCKET_TIME_PERIOD_KEY = "partitionBucketTimePeriod";
 
+    // Sort config
+    public static final String USE_EXTRACTED_SORT_FIELDS_KEY = "useExtractedSortFields";
+
     // Merge config
     public static final String MERGE_TYPE_KEY = "mergeType";
     public static final String AGGREGATION_TYPE_KEY_SUFFIX = ".aggregationType";

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorConfig.java
@@ -43,10 +43,12 @@ public class SegmentProcessorConfig {
   private final MergeType _mergeType;
   private final Map<String, AggregationFunctionType> _aggregationTypes;
   private final SegmentConfig _segmentConfig;
+  private boolean _useExtractedSortFields;
 
   private SegmentProcessorConfig(TableConfig tableConfig, Schema schema, TimeHandlerConfig timeHandlerConfig,
       List<PartitionerConfig> partitionerConfigs, MergeType mergeType,
-      Map<String, AggregationFunctionType> aggregationTypes, SegmentConfig segmentConfig) {
+      Map<String, AggregationFunctionType> aggregationTypes, SegmentConfig segmentConfig,
+      boolean useExtractedSortFields) {
     _tableConfig = tableConfig;
     _schema = schema;
     _timeHandlerConfig = timeHandlerConfig;
@@ -54,6 +56,7 @@ public class SegmentProcessorConfig {
     _mergeType = mergeType;
     _aggregationTypes = aggregationTypes;
     _segmentConfig = segmentConfig;
+    _useExtractedSortFields = useExtractedSortFields;
   }
 
   /**
@@ -109,7 +112,12 @@ public class SegmentProcessorConfig {
   public String toString() {
     return "SegmentProcessorConfig{" + "_tableConfig=" + _tableConfig + ", _schema=" + _schema + ", _timeHandlerConfig="
         + _timeHandlerConfig + ", _partitionerConfigs=" + _partitionerConfigs + ", _mergeType=" + _mergeType
-        + ", _aggregationTypes=" + _aggregationTypes + ", _segmentConfig=" + _segmentConfig + '}';
+        + ", _aggregationTypes=" + _aggregationTypes + ", _segmentConfig=" + _segmentConfig
+        + ", _useExtractedSortFields=" + _useExtractedSortFields + '}';
+  }
+
+  public boolean useExtractedSortFields() {
+    return _useExtractedSortFields;
   }
 
   /**
@@ -123,6 +131,7 @@ public class SegmentProcessorConfig {
     private MergeType _mergeType;
     private Map<String, AggregationFunctionType> _aggregationTypes;
     private SegmentConfig _segmentConfig;
+    private boolean _useExtractedSortFields;
 
     public Builder setTableConfig(TableConfig tableConfig) {
       _tableConfig = tableConfig;
@@ -159,6 +168,11 @@ public class SegmentProcessorConfig {
       return this;
     }
 
+    public Builder setUseExtractedSortFields(boolean useExtractedSortFields) {
+      _useExtractedSortFields = useExtractedSortFields;
+      return this;
+    }
+
     public SegmentProcessorConfig build() {
       Preconditions.checkState(_tableConfig != null, "Must provide table config in SegmentProcessorConfig");
       Preconditions.checkState(_schema != null, "Must provide schema in SegmentProcessorConfig");
@@ -179,7 +193,7 @@ public class SegmentProcessorConfig {
         _segmentConfig = new SegmentConfig.Builder().build();
       }
       return new SegmentProcessorConfig(_tableConfig, _schema, _timeHandlerConfig, _partitionerConfigs, _mergeType,
-          _aggregationTypes, _segmentConfig);
+          _aggregationTypes, _segmentConfig, _useExtractedSortFields);
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowFileManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowFileManager.java
@@ -38,17 +38,24 @@ public class GenericRowFileManager {
   private final List<FieldSpec> _fieldSpecs;
   private final boolean _includeNullFields;
   private final int _numSortFields;
+  private final boolean _useExtractedSortFields;
 
   private GenericRowFileWriter _fileWriter;
   private GenericRowFileReader _fileReader;
 
   public GenericRowFileManager(File outputDir, List<FieldSpec> fieldSpecs, boolean includeNullFields,
       int numSortFields) {
+    this(outputDir, fieldSpecs, includeNullFields, numSortFields, false);
+  }
+
+  public GenericRowFileManager(File outputDir, List<FieldSpec> fieldSpecs, boolean includeNullFields, int numSortFields,
+      boolean useExtractedSortFields) {
     _offsetFile = new File(outputDir, OFFSET_FILE_NAME);
     _dataFile = new File(outputDir, DATA_FILE_NAME);
     _fieldSpecs = fieldSpecs;
     _includeNullFields = includeNullFields;
     _numSortFields = numSortFields;
+    _useExtractedSortFields = useExtractedSortFields;
   }
 
   /**
@@ -104,7 +111,8 @@ public class GenericRowFileManager {
     if (_fileReader == null) {
       Preconditions.checkState(_offsetFile.exists(), "Record offset file: %s does not exist", _offsetFile);
       Preconditions.checkState(_dataFile.exists(), "Record data file: %s does not exist", _dataFile);
-      _fileReader = new GenericRowFileReader(_offsetFile, _dataFile, _fieldSpecs, _includeNullFields, _numSortFields);
+      _fileReader = new GenericRowFileReader(_offsetFile, _dataFile, _fieldSpecs, _includeNullFields, _numSortFields,
+          _useExtractedSortFields);
     }
     return _fileReader;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowSerializer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowSerializer.java
@@ -193,6 +193,9 @@ public class GenericRowSerializer {
           break;
         case STRING:
           byte[] stringBytes = (byte[]) _stringBytes[fieldIndex];
+          if (stringBytes == null) {
+            stringBytes = ((String) value).getBytes(UTF_8);
+          }
           byteBuffer.putInt(stringBytes.length);
           byteBuffer.put(stringBytes);
           break;
@@ -231,9 +234,17 @@ public class GenericRowSerializer {
           break;
         case STRING:
           byte[][] stringBytesArray = (byte[][]) _stringBytes[fieldIndex];
-          for (byte[] stringBytes : stringBytesArray) {
-            byteBuffer.putInt(stringBytes.length);
-            byteBuffer.put(stringBytes);
+          if (stringBytesArray == null) {
+            for (Object element : multiValue) {
+              byte[] stringBytes = ((String) element).getBytes(UTF_8);
+              byteBuffer.putInt(stringBytes.length);
+              byteBuffer.put(stringBytes);
+            }
+          } else {
+            for (byte[] stringBytes : stringBytesArray) {
+              byteBuffer.putInt(stringBytes.length);
+              byteBuffer.put(stringBytes);
+            }
           }
           break;
         default:

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowSerializer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowSerializer.java
@@ -160,71 +160,7 @@ public class GenericRowSerializer {
 
     // Second pass: serialize the values
     for (int i = 0; i < _numFields; i++) {
-      Object value = row.getValue(_fieldNames[i]);
-
-      if (_isSingleValueFields[i]) {
-        switch (_storedTypes[i]) {
-          case INT:
-            byteBuffer.putInt((int) value);
-            break;
-          case LONG:
-            byteBuffer.putLong((long) value);
-            break;
-          case FLOAT:
-            byteBuffer.putFloat((float) value);
-            break;
-          case DOUBLE:
-            byteBuffer.putDouble((double) value);
-            break;
-          case STRING:
-            byte[] stringBytes = (byte[]) _stringBytes[i];
-            byteBuffer.putInt(stringBytes.length);
-            byteBuffer.put(stringBytes);
-            break;
-          case BYTES:
-            byte[] bytes = (byte[]) value;
-            byteBuffer.putInt(bytes.length);
-            byteBuffer.put(bytes);
-            break;
-          default:
-            throw new IllegalStateException("Unsupported SV stored type: " + _storedTypes[i]);
-        }
-      } else {
-        Object[] multiValue = (Object[]) value;
-        byteBuffer.putInt(multiValue.length);
-
-        switch (_storedTypes[i]) {
-          case INT:
-            for (Object element : multiValue) {
-              byteBuffer.putInt((int) element);
-            }
-            break;
-          case LONG:
-            for (Object element : multiValue) {
-              byteBuffer.putLong((long) element);
-            }
-            break;
-          case FLOAT:
-            for (Object element : multiValue) {
-              byteBuffer.putFloat((float) element);
-            }
-            break;
-          case DOUBLE:
-            for (Object element : multiValue) {
-              byteBuffer.putDouble((double) element);
-            }
-            break;
-          case STRING:
-            byte[][] stringBytesArray = (byte[][]) _stringBytes[i];
-            for (byte[] stringBytes : stringBytesArray) {
-              byteBuffer.putInt(stringBytes.length);
-              byteBuffer.put(stringBytes);
-            }
-            break;
-          default:
-            throw new IllegalStateException("Unsupported MV stored type: " + _storedTypes[i]);
-        }
-      }
+      serializeField(row, byteBuffer, i);
     }
 
     // Serialize null fields if enabled
@@ -236,5 +172,73 @@ public class GenericRowSerializer {
     }
 
     return serializedBytes;
+  }
+
+  public void serializeField(GenericRow row, ByteBuffer byteBuffer, int fieldIndex) {
+    Object value = row.getValue(_fieldNames[fieldIndex]);
+
+    if (_isSingleValueFields[fieldIndex]) {
+      switch (_storedTypes[fieldIndex]) {
+        case INT:
+          byteBuffer.putInt((int) value);
+          break;
+        case LONG:
+          byteBuffer.putLong((long) value);
+          break;
+        case FLOAT:
+          byteBuffer.putFloat((float) value);
+          break;
+        case DOUBLE:
+          byteBuffer.putDouble((double) value);
+          break;
+        case STRING:
+          byte[] stringBytes = (byte[]) _stringBytes[fieldIndex];
+          byteBuffer.putInt(stringBytes.length);
+          byteBuffer.put(stringBytes);
+          break;
+        case BYTES:
+          byte[] bytes = (byte[]) value;
+          byteBuffer.putInt(bytes.length);
+          byteBuffer.put(bytes);
+          break;
+        default:
+          throw new IllegalStateException("Unsupported SV stored type: " + _storedTypes[fieldIndex]);
+      }
+    } else {
+      Object[] multiValue = (Object[]) value;
+      byteBuffer.putInt(multiValue.length);
+
+      switch (_storedTypes[fieldIndex]) {
+        case INT:
+          for (Object element : multiValue) {
+            byteBuffer.putInt((int) element);
+          }
+          break;
+        case LONG:
+          for (Object element : multiValue) {
+            byteBuffer.putLong((long) element);
+          }
+          break;
+        case FLOAT:
+          for (Object element : multiValue) {
+            byteBuffer.putFloat((float) element);
+          }
+          break;
+        case DOUBLE:
+          for (Object element : multiValue) {
+            byteBuffer.putDouble((double) element);
+          }
+          break;
+        case STRING:
+          byte[][] stringBytesArray = (byte[][]) _stringBytes[fieldIndex];
+          for (byte[] stringBytes : stringBytesArray) {
+            byteBuffer.putInt(stringBytes.length);
+            byteBuffer.put(stringBytes);
+          }
+          break;
+        default:
+          throw new IllegalStateException("Unsupported MV stored type: " + _storedTypes[fieldIndex]);
+      }
+    }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
@@ -65,6 +65,7 @@ public class SegmentMapper {
   private final List<FieldSpec> _fieldSpecs;
   private final boolean _includeNullFields;
   private final int _numSortFields;
+  private final boolean _useExtractedSortFields;
 
   private final CompositeTransformer _recordTransformer;
   private final TimeHandler _timeHandler;
@@ -83,6 +84,7 @@ public class SegmentMapper {
         .getFieldSpecs(schema, processorConfig.getMergeType(), tableConfig.getIndexingConfig().getSortedColumn());
     _fieldSpecs = pair.getLeft();
     _numSortFields = pair.getRight();
+    _useExtractedSortFields = processorConfig.useExtractedSortFields();
     _includeNullFields = tableConfig.getIndexingConfig().isNullHandlingEnabled();
     _recordTransformer = CompositeTransformer.getDefaultTransformer(tableConfig, schema);
     _timeHandler = TimeHandlerFactory.getTimeHandler(processorConfig);
@@ -159,7 +161,8 @@ public class SegmentMapper {
     if (fileManager == null) {
       File partitionOutputDir = new File(_mapperOutputDir, partition);
       FileUtils.forceMkdir(partitionOutputDir);
-      fileManager = new GenericRowFileManager(partitionOutputDir, _fieldSpecs, _includeNullFields, _numSortFields);
+      fileManager = new GenericRowFileManager(partitionOutputDir, _fieldSpecs, _includeNullFields, _numSortFields,
+          _useExtractedSortFields);
       _partitionToFileManagerMap.put(partition, fileManager);
     }
 


### PR DESCRIPTION
This PR tries to optimize the SegmentProcessorFramework that's used when to generate segments. Today, quicksort is conducted over the data file that's memory mapped. If the data file is huge, random reads lead to page faults that slow down sorting. This PR tries an idea to extract the sort fields into a temp file for better data locality for sorting, mainly for use cases where the input files are full of very wide rows but just sort on a single column. 