### PR TITLE
query option to use parser.jj extension instead of regex

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -154,7 +154,7 @@ public class PinotClientRequest {
     } catch (Exception e) {
       return new BrokerResponseNative(QueryException.getException(QueryException.SQL_PARSING_ERROR, e));
     }
-    PinotSqlType sqlType = CalciteSqlParser.extractSqlType(sqlNodeAndOptions.getSqlNode());
+    PinotSqlType sqlType = sqlNodeAndOptions.getSqlType();
     if (onlyDql && sqlType != PinotSqlType.DQL) {
       return new BrokerResponseNative(QueryException.getException(QueryException.SQL_PARSING_ERROR,
           new UnsupportedOperationException("Unsupported SQL type - " + sqlType + ", GET API only supports DQL.")));

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BrokerRequestOptionsTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BrokerRequestOptionsTest.java
@@ -104,7 +104,7 @@ public class BrokerRequestOptionsTest {
     Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption1"), "foo");
 
     // Has queryOptions in query
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from testTable option(queryOption1=foo)");
+    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from testTable; option(queryOption1='foo')");
     BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
     Assert.assertNull(pinotQuery.getDebugOptions());
     Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1);
@@ -120,7 +120,7 @@ public class BrokerRequestOptionsTest {
 
     // Has query options in both json payload and pinotQuery, pinotQuery takes priority
     jsonRequest.put(Request.QUERY_OPTIONS, "queryOption1=bar;queryOption2=moo");
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from testTable option(queryOption1=foo)");
+    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from testTable; option(queryOption1='foo')");
     BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
     Assert.assertNull(pinotQuery.getDebugOptions());
     Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 2);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
@@ -115,8 +115,8 @@ public class QueryValidationTest {
 
   @Test
   public void testReplicaGroupToQueryInvalidQuery() {
-    PinotQuery pinotQuery =
-        CalciteSqlParser.compileToPinotQuery("SELECT COUNT(*) FROM MY_TABLE OPTION(numReplicaGroupsToQuery=illegal)");
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+        "SELECT COUNT(*) FROM MY_TABLE; OPTION(numReplicaGroupsToQuery='illegal')");
     Assert.assertThrows(IllegalStateException.class, () -> BaseBrokerRequestHandler.validateRequest(pinotQuery, 10));
   }
 

--- a/pinot-common/src/main/codegen/config.fmpp
+++ b/pinot-common/src/main/codegen/config.fmpp
@@ -526,6 +526,7 @@ data: {
     # List of extended statement syntax to add
     statementParserMethods: [
       "SqlInsertFromFile()"
+      "SqlOptions()"
     ]
 
     # List of files in @includes directory that have parser method

--- a/pinot-common/src/main/codegen/includes/parserImpls.ftl
+++ b/pinot-common/src/main/codegen/includes/parserImpls.ftl
@@ -73,7 +73,74 @@ SqlInsertFromFile SqlInsertFromFile() :
     }
 }
 
-/* define the rest of the sql into SqlStmtList
+
+/**
+ * Support option key value:
+ *   key = 'value'
+ */
+private void OptionKeyValueDef(List<SqlNode> list) :
+{
+    final SqlNode key;
+    final SqlNode value;
+}
+{
+    (
+        key = SimpleIdentifier()
+    |
+        key = StringLiteral()
+    )
+    <EQ>
+    value = StringLiteral() {
+        list.add(key);
+        list.add(value);
+    }
+}
+
+
+/**
+ * Support option key value parenthesized list.
+ *   (key = 'value' [, key = 'value'])
+ */
+SqlNodeList ParenthesizedOptionKeyValueCommaList() :
+{
+    final Span s;
+    final List<SqlNode> list = new ArrayList<SqlNode>();
+}
+{
+    { s = span(); }
+    <LPAREN>
+    KeyValueOption(list)
+    (
+        <COMMA>
+        KeyValueOption(list)
+    )*
+    <RPAREN>
+    {
+        return new SqlNodeList(list, s.end(this));
+    }
+}
+
+/**
+ * OPTION(key = 'value' [, key = 'value'])
+ */
+SqlOptions SqlOptions() :
+{
+    SqlParserPos pos;
+    SqlNodeList optionList = null;
+}
+{
+    <OPTION> { pos = getPos(); }
+    [
+        optionList = ParenthesizedKeyValueOptionCommaList()
+    ]
+    {
+        return new SqlOptions(pos, optionList);
+    }
+}
+
+
+/**
+ * define the rest of the sql into SqlStmtList
  */
 private void SqlStatementList(SqlNodeList list) :
 {

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.sql.parsers;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -127,7 +128,9 @@ public class CalciteSqlParser {
       } else if (sqlNode instanceof SqlOptions) {
         // extract options, these are non-execution statements
         List<SqlNode> operandList = ((SqlOptions) sqlNode).getOperandList();
-        for (int i = 0; i < operandList.size(); i += 2) {
+        int operandSize = operandList.size();
+        Preconditions.checkArgument((operandSize & 1) == 0, "option operands length must be a multiple of 2");
+        for (int i = 0; i < operandSize; i += 2) {
           SqlIdentifier key = (SqlIdentifier) operandList.get(i);
           SqlLiteral value = (SqlLiteral) operandList.get(i + 1);
           options.put(key.getSimple(), value.toValue());

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/SqlNodeAndOptions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/SqlNodeAndOptions.java
@@ -40,4 +40,8 @@ public class SqlNodeAndOptions {
   public Map<String, String> getOptions() {
     return _options;
   }
+
+  public PinotSqlType getSqlType() {
+    return _sqlType;
+  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/SqlNodeAndOptions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/SqlNodeAndOptions.java
@@ -18,16 +18,18 @@
  */
 package org.apache.pinot.sql.parsers;
 
-import java.util.List;
+import java.util.Map;
 import org.apache.calcite.sql.SqlNode;
 
 
 public class SqlNodeAndOptions {
   private final SqlNode _sqlNode;
-  private final List<String> _options;
+  private final PinotSqlType _sqlType;
+  private final Map<String, String> _options;
 
-  public SqlNodeAndOptions(SqlNode sqlNode, List<String> options) {
+  public SqlNodeAndOptions(SqlNode sqlNode, PinotSqlType sqlType, Map<String, String> options) {
     _sqlNode = sqlNode;
+    _sqlType = sqlType;
     _options = options;
   }
 
@@ -35,7 +37,7 @@ public class SqlNodeAndOptions {
     return _sqlNode;
   }
 
-  public List<String> getOptions() {
+  public Map<String, String> getOptions() {
     return _options;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/dml/InsertIntoFile.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/dml/InsertIntoFile.java
@@ -26,7 +26,6 @@ import org.apache.calcite.sql.SqlNodeList;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.spi.config.task.AdhocTaskConfig;
-import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
 import org.apache.pinot.sql.parsers.parser.SqlInsertFromFile;
 
@@ -69,7 +68,7 @@ public class InsertIntoFile implements DataManipulationStatement {
     String tableName = operandList.get(0) != null ? StringUtils.joinWith(",", operandList.get(0), operandList.get(1))
         : operandList.get(1).toString();
     // Set Options
-    Map<String, String> optionsMap = CalciteSqlParser.extractOptionsMap(sqlNodeAndOptions.getOptions());
+    Map<String, String> optionsMap = sqlNodeAndOptions.getOptions();
     List<String> inputDirList = new ArrayList<>();
     ((SqlNodeList) operandList.get(2)).getList()
         .forEach(sqlNode1 -> inputDirList.add(sqlNode1.toString().replace("'", "")));

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/parser/SqlOptions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/parser/SqlOptions.java
@@ -30,9 +30,9 @@ import org.apache.calcite.sql.parser.SqlParserPos;
 
 
 /**
- * Calcite extension for creating an INSERT sql node from a File object.
+ * Calcite extension for creating Pinot SQL options.
  *
- * <p>Syntax: INSERT INTO [db_name.]table_name FROM [ FILE | ARCHIVE ] 'file_uri' [, [ FILE | ARCHIVE ] 'file_uri' ]
+ * <p>Syntax: OPTION ( Identifier = StringLiteral [, Identifier = StringLiteral]* )
  */
 public class SqlOptions extends SqlCall {
   private static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("OPTION", SqlKind.OTHER_DDL);

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/parser/SqlOptions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/parser/SqlOptions.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.parser;
+
+import java.util.List;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+
+/**
+ * Calcite extension for creating an INSERT sql node from a File object.
+ *
+ * <p>Syntax: INSERT INTO [db_name.]table_name FROM [ FILE | ARCHIVE ] 'file_uri' [, [ FILE | ARCHIVE ] 'file_uri' ]
+ */
+public class SqlOptions extends SqlCall {
+  private static final SqlSpecialOperator OPERATOR = new SqlSpecialOperator("OPTION", SqlKind.OTHER_DDL);
+  private SqlNodeList _optionList;
+
+  public SqlOptions(SqlParserPos pos, SqlNodeList optionList) {
+    super(pos);
+    _optionList = optionList;
+  }
+
+  @Override
+  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    UnparseUtils u = new UnparseUtils(writer, leftPrec, rightPrec);
+    u.keyword("OPTION");
+    if (_optionList != null) {
+      u.nodeList(_optionList);
+    }
+  }
+
+  @Override
+  public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override
+  public List<SqlNode> getOperandList() {
+    return _optionList;
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -726,6 +726,23 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(pinotQuery.getQueryOptions().get("delicious"), "yes");
     Assert.assertEquals(pinotQuery.getQueryOptions().get("foo"), "1234");
     Assert.assertEquals(pinotQuery.getQueryOptions().get("bar"), "'potato'");
+
+    // test invalid options
+    try {
+      CalciteSqlParser.compileToPinotQuery("select * from vegetables OPTION (delicious='yes', foo='1234') "
+          + "where name <> 'Brussels sprouts'");
+      Assert.fail("SQL should not be compiled");
+    } catch (SqlCompilationException sce) {
+      // expected.
+    }
+
+    try {
+      CalciteSqlParser.compileToPinotQuery("select * from vegetables where name <> 'Brussels sprouts'; "
+          + "OPTION (delicious='yes', foo=1234)");
+      Assert.fail("SQL should not be compiled");
+    } catch (SqlCompilationException sce) {
+      // expected.
+    }
   }
 
   @Test

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/dml/InsertIntoFileTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/dml/InsertIntoFileTest.java
@@ -31,12 +31,12 @@ public class InsertIntoFileTest {
   public void testInsertIntoStatementParser()
       throws Exception {
     String insertIntoSql = "INSERT INTO \"baseballStats\"\n"
-        + "FROM FILE 's3://my-bucket/path/to/data/'\n"
-        + "OPTION(taskName=myTask-1)\n"
-        + "OPTION(input.fs.className=org.apache.pinot.plugin.filesystem.S3PinotFS)\n"
-        + "OPTION(input.fs.prop.accessKey=my-access-key)\n"
-        + "OPTION(input.fs.prop.secretKey=my-secret-key)\n"
-        + "OPTION(input.fs.prop.region=us-west-2)";
+        + "FROM FILE 's3://my-bucket/path/to/data/';\n"
+        + "OPTION(taskName='myTask-1');\n"
+        + "OPTION(\"input.fs.className\"='org.apache.pinot.plugin.filesystem.S3PinotFS');\n"
+        + "OPTION(\"input.fs.prop.accessKey\"='my-access-key');\n"
+        + "OPTION(\"input.fs.prop.secretKey\"='my-secret-key');\n"
+        + "OPTION(\"input.fs.prop.region\"='us-west-2');";
     InsertIntoFile insertIntoFile = InsertIntoFile.parse(CalciteSqlParser.compileToSqlNodeAndOptions(insertIntoSql));
     Assert.assertEquals(insertIntoFile.getTable(), "baseballStats");
     Assert.assertEquals(insertIntoFile.getExecutionType(), DataManipulationStatement.ExecutionType.MINION);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -108,7 +108,7 @@ public class PinotQueryResource {
       String queryOptions)
       throws Exception {
     SqlNodeAndOptions sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sqlQuery);
-    PinotSqlType sqlType = CalciteSqlParser.extractSqlType(sqlNodeAndOptions.getSqlNode());
+    PinotSqlType sqlType = sqlNodeAndOptions.getSqlType();
     switch (sqlType) {
       case DQL:
         return getQueryResponse(sqlQuery, sqlNodeAndOptions.getSqlNode(), traceEnabled, queryOptions, httpHeaders);
@@ -130,7 +130,7 @@ public class PinotQueryResource {
     try {
       LOGGER.debug("Trace: {}, Running query: {}", traceEnabled, sqlQuery);
       SqlNodeAndOptions sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sqlQuery);
-      PinotSqlType sqlType = CalciteSqlParser.extractSqlType(sqlNodeAndOptions.getSqlNode());
+      PinotSqlType sqlType = sqlNodeAndOptions.getSqlType();
       if (sqlType == PinotSqlType.DQL) {
         return getQueryResponse(sqlQuery, sqlNodeAndOptions.getSqlNode(), traceEnabled, queryOptions, httpHeaders);
       }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
@@ -408,7 +408,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
   public void testSelectVerbose() {
     // All segment plans for these queries generate a plan using the MatchAllFilterOperator as these queries select
     // columns without filtering
-    String query1 = "EXPLAIN PLAN FOR SELECT * FROM testTable OPTION(explainPlanVerbose=true)";
+    String query1 = "EXPLAIN PLAN FOR SELECT * FROM testTable; OPTION(explainPlanVerbose='true')";
     List<Object[]> result1 = new ArrayList<>();
     result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result1.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -428,7 +428,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
 
-    String query2 = "EXPLAIN PLAN FOR SELECT 'mickey' FROM testTable OPTION(explainPlanVerbose=true)";
+    String query2 = "EXPLAIN PLAN FOR SELECT 'mickey' FROM testTable; OPTION(explainPlanVerbose='true')";
     List<Object[]> result2 = new ArrayList<>();
     result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result2.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -441,8 +441,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result2.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
     check(query2, new ResultTable(DATA_SCHEMA, result2));
 
-    String query3 = "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1 FROM testTable LIMIT 100 "
-        + "OPTION(explainPlanVerbose=true)";
+    String query3 = "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1 FROM testTable LIMIT 100; "
+        + "OPTION(explainPlanVerbose='true')";
     List<Object[]> result3 = new ArrayList<>();
     result3.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result3.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -455,8 +455,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result3.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
     check(query3, new ResultTable(DATA_SCHEMA, result3));
 
-    String query4 = "EXPLAIN PLAN FOR SELECT DISTINCT invertedIndexCol1, noIndexCol1 FROM testTable LIMIT 100 "
-        + "OPTION(explainPlanVerbose=true)";
+    String query4 = "EXPLAIN PLAN FOR SELECT DISTINCT invertedIndexCol1, noIndexCol1 FROM testTable LIMIT 100; "
+        + "OPTION(explainPlanVerbose='true')";
     List<Object[]> result4 = new ArrayList<>();
     result4.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result4.add(new Object[]{"COMBINE_DISTINCT", 2, 1});
@@ -505,8 +505,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
   public void testSelectTransformFunctionVerbose() {
     // All segment plans for these queries generate a plan using the MatchAllFilterOperator as these queries select
     // columns without filtering and apply transforms
-    String query1 = "EXPLAIN PLAN FOR SELECT CASE WHEN noIndexCol1 < 10 THEN 'less' ELSE 'more' END  FROM testTable "
-        + "OPTION(explainPlanVerbose=true)";
+    String query1 = "EXPLAIN PLAN FOR SELECT CASE WHEN noIndexCol1 < 10 THEN 'less' ELSE 'more' END  FROM testTable; "
+        + "OPTION(explainPlanVerbose='true')";
     List<Object[]> result1 = new ArrayList<>();
     result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result1.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -519,8 +519,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
 
-    String query2 = "EXPLAIN PLAN FOR SELECT CONCAT(textIndexCol1, textIndexCol1, ':') FROM testTable "
-        + "OPTION(explainPlanVerbose=true)";
+    String query2 = "EXPLAIN PLAN FOR SELECT CONCAT(textIndexCol1, textIndexCol1, ':') FROM testTable; "
+        + "OPTION(explainPlanVerbose='true')";
     List<Object[]> result2 = new ArrayList<>();
     result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result2.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -572,7 +572,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // All segment plans for these queries generate a plan using the MatchAllFilterOperator as these queries select
     // columns without filtering and apply transforms along with order by
     String query1 = "EXPLAIN PLAN FOR SELECT CASE WHEN noIndexCol1 < 10 THEN 'less' ELSE 'more' END  FROM testTable "
-        + "ORDER BY 1 OPTION(explainPlanVerbose=true)";
+        + "ORDER BY 1; OPTION(explainPlanVerbose='true')";
     List<Object[]> result1 = new ArrayList<>();
     result1
         .add(new Object[]{"BROKER_REDUCE(sort:[case(less_than(noIndexCol1,'10'),'less','more') ASC],limit:10)", 1, 0});
@@ -586,8 +586,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
 
-    String query2 = "EXPLAIN PLAN FOR SELECT CONCAT(textIndexCol1, textIndexCol1, ':') FROM testTable ORDER BY 1 DESC "
-        + "OPTION(explainPlanVerbose=true)";
+    String query2 = "EXPLAIN PLAN FOR SELECT CONCAT(textIndexCol1, textIndexCol1, ':') FROM testTable ORDER BY 1 DESC; "
+        + "OPTION(explainPlanVerbose='true')";
     List<Object[]> result2 = new ArrayList<>();
     result2.add(new Object[]{"BROKER_REDUCE(sort:[concat(textIndexCol1,textIndexCol1,':') DESC],limit:10)", 1, 0});
     result2.add(new Object[]{"COMBINE_SELECT_ORDERBY", 2, 1});
@@ -729,7 +729,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // not true and removed from the query plan.
     String query1 =
         "EXPLAIN PLAN FOR SELECT noIndexCol1, noIndexCol2, sortedIndexCol1 FROM testTable WHERE sortedIndexCol1 = 1.5"
-            + " OR sortedIndexCol1 != 5 OR sortedIndexCol1 IN (10, 20, 30) LIMIT 100 OPTION(explainPlanVerbose=true)";
+            + " OR sortedIndexCol1 != 5 OR sortedIndexCol1 IN (10, 20, 30) LIMIT 100;"
+            + " OPTION(explainPlanVerbose='true')";
     List<Object[]> result1 = new ArrayList<>();
     result1.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result1.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -745,7 +746,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // The FILTER_AND is part of the query plan for all segments as both predicates are expressions
     String query2 =
         "EXPLAIN PLAN FOR SELECT noIndexCol1, noIndexCol2 FROM testTable WHERE DIV(noIndexCol1, noIndexCol2) BETWEEN "
-            + "10 AND 20 AND invertedIndexCol1 * 5 < 1000 OPTION(explainPlanVerbose=true)";
+            + "10 AND 20 AND invertedIndexCol1 * 5 < 1000; OPTION(explainPlanVerbose='true')";
     List<Object[]> result2 = new ArrayList<>();
     result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result2.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -769,7 +770,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // a MatchAllFilterOperator plan is returned. For the other segment, the actual FILTER_OR query plan is returned.
     String query3 =
         "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1 FROM testTable WHERE noIndexCol1 > 1 OR noIndexCol2"
-            + " BETWEEN 2 AND 101 LIMIT 100 OPTION(explainPlanVerbose=true)";
+            + " BETWEEN 2 AND 101 LIMIT 100; OPTION(explainPlanVerbose='true')";
     List<Object[]> result3 = new ArrayList<>();
     result3.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result3.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -796,7 +797,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // one of the rows for noIndexCol1. Due to this the three segments for which noIndexCol1 > 1 is true for all rows,
     // a MatchAllFilterOperator plan is returned. For the other segment, the actual FILTER_OR query plan is returned.
     String query4 = "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1 FROM testTable WHERE noIndexCol1 > 1 OR "
-        + "contains(textIndexCol1, 'daff') OR noIndexCol2 BETWEEN 2 AND 101 LIMIT 100 OPTION(explainPlanVerbose=true)";
+        + "contains(textIndexCol1, 'daff') OR noIndexCol2 BETWEEN 2 AND 101 LIMIT 100; "
+        + "OPTION(explainPlanVerbose='true')";
     List<Object[]> result4 = new ArrayList<>();
     result4.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result4.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -820,8 +822,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     check(query4, new ResultTable(DATA_SCHEMA, result4));
 
     // All segments match since noIndexCol4 has at least one row value set to 'true' across all segments
-    String query5 = "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1 FROM testTable WHERE noIndexCol4 LIMIT 100 "
-        + "OPTION(explainPlanVerbose=true)";
+    String query5 = "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1 FROM testTable WHERE noIndexCol4 LIMIT 100;"
+        + " OPTION(explainPlanVerbose='true')";
     List<Object[]> result5 = new ArrayList<>();
     result5.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result5.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -837,7 +839,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // The FILTER_AND is part of the query plan for all segments as the first predicate is an expression and the second
     // has at least one matching row in each segment
     String query6 = "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1 FROM testTable WHERE startsWith "
-        + "(textIndexCol1, 'daff') AND noIndexCol4 OPTION(explainPlanVerbose=true)";
+        + "(textIndexCol1, 'daff') AND noIndexCol4; OPTION(explainPlanVerbose='true')";
     List<Object[]> result6 = new ArrayList<>();
     result6.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result6.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -937,7 +939,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // Segment 3 results in an EmptyFilterOperator as the invertedIndexCol1 doesn't have the value 1.1 in it
     // and this is an AND predicate, but the values are within range
     String query1 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, sortedIndexCol1 FROM testTable WHERE "
-        + "invertedIndexCol1 = 1.1 AND sortedIndexCol1 = 100.1 LIMIT 100 OPTION(explainPlanVerbose=true)";
+        + "invertedIndexCol1 = 1.1 AND sortedIndexCol1 = 100.1 LIMIT 100; OPTION(explainPlanVerbose='true')";
     List<Object[]> result1 = new ArrayList<>();
     result1.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result1.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -966,7 +968,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // of its rows.
     String query2 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, sortedIndexCol1  FROM testTable WHERE "
         + "(invertedIndexCol1 = 1.1 OR sortedIndexCol1 = 100.2) OR (invertedIndexCol1 BETWEEN 0.2 AND 5 OR "
-        + "rangeIndexCol1 > 20) OPTION(explainPlanVerbose=true)";
+        + "rangeIndexCol1 > 20); OPTION(explainPlanVerbose='true')";
     List<Object[]> result2 = new ArrayList<>();
     result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result2.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -1006,8 +1008,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // Segment 1 does contain 'mickey' and two predicates of the OR are part of the query plan.
     String query3 =
         "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1 FROM testTable WHERE invertedIndexCol1 = 1.5 OR "
-            + "invertedIndexCol2 IN (1, 2, 30) OR invertedIndexCol3 NOT IN ('foo', 'mickey') LIMIT 100 "
-            + "OPTION(explainPlanVerbose=true)";
+            + "invertedIndexCol2 IN (1, 2, 30) OR invertedIndexCol3 NOT IN ('foo', 'mickey') LIMIT 100; "
+            + "OPTION(explainPlanVerbose='true')";
     List<Object[]> result3 = new ArrayList<>();
     result3.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result3.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -1067,8 +1069,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // checks using RANGE (>, >=, <, <=, BETWEEN ..) on a column with range index should use RANGE_INDEX_SCAN
     String query1 =
         "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1, rangeIndexCol1 FROM testTable WHERE rangeIndexCol1 >"
-            + " 10.1 AND rangeIndexCol2 >= 15 OR rangeIndexCol3 BETWEEN 21 AND 45 LIMIT 100 "
-            + "OPTION(explainPlanVerbose=true)";
+            + " 10.1 AND rangeIndexCol2 >= 15 OR rangeIndexCol3 BETWEEN 21 AND 45 LIMIT 100; "
+            + "OPTION(explainPlanVerbose='true')";
     List<Object[]> result1 = new ArrayList<>();
     result1.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result1.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -1135,7 +1137,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // All segments match the same plan for these queries
     String query1 =
         "EXPLAIN PLAN FOR SELECT noIndexCol1, noIndexCol2, max(noIndexCol2), min(noIndexCol3) FROM testTable WHERE "
-            + "TEXT_MATCH(textIndexCol1, 'foo') GROUP BY noIndexCol1, noIndexCol2 OPTION(explainPlanVerbose=true)";
+            + "TEXT_MATCH(textIndexCol1, 'foo') GROUP BY noIndexCol1, noIndexCol2; OPTION(explainPlanVerbose='true')";
     List<Object[]> result1 = new ArrayList<>();
     result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result1.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 2, 1});
@@ -1154,7 +1156,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     String query2 =
         "EXPLAIN PLAN FOR SELECT noIndexCol1, max(noIndexCol2) AS mymax, min(noIndexCol3) AS mymin FROM testTable "
             + "WHERE TEXT_MATCH (textIndexCol1, 'foo') GROUP BY noIndexCol1, noIndexCol2 ORDER BY noIndexCol1, max"
-            + "(noIndexCol2) OPTION(explainPlanVerbose=true)";
+            + "(noIndexCol2); OPTION(explainPlanVerbose='true')";
     List<Object[]> result2 = new ArrayList<>();
     result2.add(new Object[]{"BROKER_REDUCE(sort:[noIndexCol1 ASC, max(noIndexCol2) ASC],limit:10)", 1, 0});
     result2.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 2, 1});
@@ -1205,8 +1207,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     String query =
         "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1 FROM testTable WHERE (invertedIndexCol1 IN (10, 20, "
             + "30) AND sortedIndexCol1 != 100) OR (noIndexCol1 NOT IN (1, 20, 30) AND rangeIndexCol1 != 20 AND "
-            + "JSON_MATCH(jsonIndexCol1, 'key=1') AND TEXT_MATCH(textIndexCol1, 'foo')) "
-            + "OPTION(explainPlanVerbose=true)";
+            + "JSON_MATCH(jsonIndexCol1, 'key=1') AND TEXT_MATCH(textIndexCol1, 'foo')); "
+            + "OPTION(explainPlanVerbose='true')";
     List<Object[]> result = new ArrayList<>();
     result.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -1323,7 +1325,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // Segment 3 matches a row for '1.5' even though 'pluto' doesn't exist
     // Segment 1, 4 don't contain either '1.5' or 'pluto' but are within range so they return an EmptyFilter
     String query1 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, invertedIndexCol3 FROM testTable WHERE "
-        + "invertedIndexCol1 = 1.5 OR invertedIndexCol3 = 'pluto' LIMIT 100 OPTION(explainPlanVerbose=true)";
+        + "invertedIndexCol1 = 1.5 OR invertedIndexCol3 = 'pluto' LIMIT 100; OPTION(explainPlanVerbose='true')";
     List<Object[]> result1 = new ArrayList<>();
     result1.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result1.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -1355,7 +1357,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // Segment 3 doesn't contain 'mickey' or '1.1' and returns an EmptyFilter as '1.1' is within range
     // Segment 2, 4 do contain 1.1 but don't contain 'mickey' so part of the OR predicate is removed
     String query2 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, invertedIndexCol3 FROM testTable WHERE "
-        + "invertedIndexCol1 = 1.1 OR invertedIndexCol3 = 'mickey' LIMIT 100 OPTION(explainPlanVerbose=true)";
+        + "invertedIndexCol1 = 1.1 OR invertedIndexCol3 = 'mickey' LIMIT 100; OPTION(explainPlanVerbose='true')";
     List<Object[]> result2 = new ArrayList<>();
     result2.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result2.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -1389,7 +1391,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
 
     // An OR query that matches all predicates on all segments
     String query3 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, invertedIndexCol2 FROM testTable WHERE "
-        + "invertedIndexCol1 = 0.1 OR invertedIndexCol2 = 2 LIMIT 100 OPTION(explainPlanVerbose=true)";
+        + "invertedIndexCol1 = 0.1 OR invertedIndexCol2 = 2 LIMIT 100; OPTION(explainPlanVerbose='true')";
     List<Object[]> result3 = new ArrayList<>();
     result3.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result3.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -1410,7 +1412,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // Segments 1, 3 get pruned as '8' and 'pluto' are out of range
     // Segment 4 returns EmptyFilterOperator as though '8' is out of range, 'pluto' is within range but not present
     String query4 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol3 FROM testTable WHERE "
-        + "invertedIndexCol3 = 'pluto' OR noIndexCol1 = 8 LIMIT 100 OPTION(explainPlanVerbose=true)";
+        + "invertedIndexCol3 = 'pluto' OR noIndexCol1 = 8 LIMIT 100; OPTION(explainPlanVerbose='true')";
     List<Object[]> result4 = new ArrayList<>();
     result4.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result4.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -1518,7 +1520,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // Segment 2 has 'pluto' but doesn't have '1.5' so it returns EmptyFilterOperator
     // Segment 3 has '1.5' but doesn't have pluto so it also returns EmptyFilterOperator
     String query1 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, invertedIndexCol3 FROM testTable WHERE "
-        + "invertedIndexCol1 = 1.5 AND invertedIndexCol3 = 'pluto' LIMIT 100 OPTION(explainPlanVerbose=true)";
+        + "invertedIndexCol1 = 1.5 AND invertedIndexCol3 = 'pluto' LIMIT 100; OPTION(explainPlanVerbose='true')";
     List<Object[]> result1 = new ArrayList<>();
     result1.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result1.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -1535,7 +1537,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // Segment 2 is pruned as 'mickey' isn't in range (all values are 'pluto')
     // Segment 3, 4 return an EmptyFilterOperator plan as they contain '1.1' but don't contain 'mickey'
     String query2 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, invertedIndexCol3 FROM testTable WHERE "
-        + "invertedIndexCol1 = 1.1 AND invertedIndexCol3 = 'mickey' LIMIT 100 OPTION(explainPlanVerbose=true)";
+        + "invertedIndexCol1 = 1.1 AND invertedIndexCol3 = 'mickey' LIMIT 100; OPTION(explainPlanVerbose='true')";
     List<Object[]> result2 = new ArrayList<>();
     result2.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result2.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -1561,7 +1563,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
 
     // An AND query that matches all predicates on all segments
     String query3 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol1, invertedIndexCol2 FROM testTable WHERE "
-        + "invertedIndexCol1 = 0.1 AND invertedIndexCol2 = 1 LIMIT 100 OPTION(explainPlanVerbose=true)";
+        + "invertedIndexCol1 = 0.1 AND invertedIndexCol2 = 1 LIMIT 100; OPTION(explainPlanVerbose='true')";
     List<Object[]> result3 = new ArrayList<>();
     result3.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result3.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -1582,7 +1584,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // second predicate on one row.
     // Segments 1, 3, 4 are all pruned as '8' is out of range for all and 'pluto' doesn't match either
     String query4 = "EXPLAIN PLAN FOR SELECT noIndexCol1, invertedIndexCol3 FROM testTable WHERE "
-        + "invertedIndexCol3 = 'pluto' AND noIndexCol1 = 8 LIMIT 100 OPTION(explainPlanVerbose=true)";
+        + "invertedIndexCol3 = 'pluto' AND noIndexCol1 = 8 LIMIT 100; OPTION(explainPlanVerbose='true')";
     List<Object[]> result4 = new ArrayList<>();
     result4.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result4.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -1664,7 +1666,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
   public void testSelectAggregateVerbose() {
     // All segment plans for this queries generate a plan using the MatchAllFilterOperator as it selects and aggregates
     // columns without filtering
-    String query1 = "EXPLAIN PLAN FOR SELECT count(*) FROM testTable OPTION(explainPlanVerbose=true)";
+    String query1 = "EXPLAIN PLAN FOR SELECT count(*) FROM testTable; OPTION(explainPlanVerbose='true')";
     List<Object[]> result1 = new ArrayList<>();
     result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result1.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
@@ -1675,7 +1677,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     check(query1, new ResultTable(DATA_SCHEMA, result1));
 
     // No scan required as metadata is sufficient to answer teh query for all segments
-    String query2 = "EXPLAIN PLAN FOR SELECT min(invertedIndexCol1) FROM testTable OPTION(explainPlanVerbose=true)";
+    String query2 = "EXPLAIN PLAN FOR SELECT min(invertedIndexCol1) FROM testTable; OPTION(explainPlanVerbose='true')";
     List<Object[]> result2 = new ArrayList<>();
     result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result2.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
@@ -1687,8 +1689,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // All segment plans for this queries generate a plan using the MatchAllFilterOperator as it selects and aggregates
     // columns without filtering
     String query3 =
-        "EXPLAIN PLAN FOR SELECT count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol2) FROM testTable "
-            + "OPTION(explainPlanVerbose=true)";
+        "EXPLAIN PLAN FOR SELECT count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol2) FROM testTable; "
+            + "OPTION(explainPlanVerbose='true')";
     List<Object[]> result3 = new ArrayList<>();
     result3.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result3.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
@@ -1705,7 +1707,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // All segment plans for this queries generate a plan using the MatchAllFilterOperator as it selects and aggregates
     // columns without filtering
     String query4 = "EXPLAIN PLAN FOR SELECT sum(add(noIndexCol1, noIndexCol2)), MIN(ADD(DIV(noIndexCol1,noIndexCol2),"
-        + "noIndexCol3)) FROM testTable OPTION(explainPlanVerbose=true)";
+        + "noIndexCol3)) FROM testTable; OPTION(explainPlanVerbose='true')";
     List<Object[]> result4 = new ArrayList<>();
     result4.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result4.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
@@ -1749,7 +1751,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // Segment 1 has values which are < '3' so a FILTER_FULL_SCAN is returned
     String query1 =
         "EXPLAIN PLAN FOR SELECT noIndexCol2, sum(add(noIndexCol1, noIndexCol2)), min(noIndexCol3) FROM testTable "
-            + "WHERE noIndexCol1 < 3 GROUP BY noIndexCol2 OPTION(explainPlanVerbose=true)";
+            + "WHERE noIndexCol1 < 3 GROUP BY noIndexCol2; OPTION(explainPlanVerbose='true')";
     List<Object[]> result1 = new ArrayList<>();
     result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result1.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 2, 1});
@@ -1941,8 +1943,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // Segment 2 is pruned because 'mickey' is not within range (and all values in that segment are 'pluto')
     // Segments 3 and 4 don't contain 'mickey' but 'mickey' is within range so they return EmptyFilterOperator
     // Segment 1 contains 'mickey' so the FILTER_SORTED_INDEX plan is returned for it
-    String query1 = "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol3 = 'mickey' "
-        + "OPTION(explainPlanVerbose=true)";
+    String query1 = "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol3 = 'mickey'; "
+        + "OPTION(explainPlanVerbose='true')";
     List<Object[]> result1 = new ArrayList<>();
     result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result1.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
@@ -1960,8 +1962,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // Segment 2 is pruned because 'mickey' is not within range (and all values in that segment are 'pluto')
     // Segments 3 and 4 don't contain 'mickey' but 'mickey' is within range so they return EmptyFilterOperator
     // Segment 1 contains 'mickey' so the FILTER_SORTED_INDEX plan is returned for it
-    String query2 = "EXPLAIN PLAN FOR SELECT sum(noIndexCol2) FROM testTable WHERE invertedIndexCol3 = 'mickey' "
-        + "OPTION(explainPlanVerbose=true)";
+    String query2 = "EXPLAIN PLAN FOR SELECT sum(noIndexCol2) FROM testTable WHERE invertedIndexCol3 = 'mickey'; "
+        + "OPTION(explainPlanVerbose='true')";
     List<Object[]> result2 = new ArrayList<>();
     result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result2.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
@@ -1987,7 +1989,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // Segment 3 doesn't have the value '1.1' for the invertedIndexCol1 due to which one plan shows EmptyFilterOperator
     String query3 =
         "EXPLAIN PLAN FOR SELECT count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol3) FROM testTable WHERE "
-            + "invertedIndexCol1 = 1.1 OR noIndexCol1 = 20 OPTION(explainPlanVerbose=true)";
+            + "invertedIndexCol1 = 1.1 OR noIndexCol1 = 20; OPTION(explainPlanVerbose='true')";
     List<Object[]> result3 = new ArrayList<>();
     result3.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result3.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
@@ -2015,7 +2017,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // Segment 3 doesn't have the value '1.1' for the invertedIndexCol1 due to which one plan doesn't show the
     // FILTER_OR as that predicate is removed.
     String query4 = "EXPLAIN PLAN FOR SELECT invertedIndexCol3 FROM testTable WHERE concat (invertedIndexCol3, 'test',"
-        + "'-') = 'mickey-test' OR invertedIndexCol1 = 1.1 OPTION(explainPlanVerbose=true)";
+        + "'-') = 'mickey-test' OR invertedIndexCol1 = 1.1; OPTION(explainPlanVerbose='true')";
     List<Object[]> result4 = new ArrayList<>();
     result4.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result4.add(new Object[]{"COMBINE_SELECT", 2, 1});
@@ -2044,8 +2046,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // doesn't exist as a value in any row
     // Segment 3 contains a row with the value as '1.5' so a FILTERED_INVERTED_INDEX is returned for 1 segment
     String query5 =
-        "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol1 = 1.5 LIMIT 100 "
-            + "OPTION(explainPlanVerbose=true)";
+        "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol1 = 1.5 LIMIT 100; "
+            + "OPTION(explainPlanVerbose='true')";
     List<Object[]> result5 = new ArrayList<>();
     result5.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result5.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
@@ -2063,8 +2065,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // All segments have a EmptyFilterOperator plan for this query as '1.7' is within the min-max range but doesn't
     // exist as a value in any row
     String query6 =
-        "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol1 = 1.7 LIMIT 100 "
-            + "OPTION(explainPlanVerbose=true)";
+        "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol1 = 1.7 LIMIT 100; "
+            + "OPTION(explainPlanVerbose='true')";
     List<Object[]> result6 = new ArrayList<>();
     result6.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result6.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
@@ -2078,8 +2080,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // Segment 2 has a MatchAllFilterOperator plan as all rows match 'pluto'
     // Segment 4 has an EmptyFilterOperator plan as 'pluto' doesn't exist but is within the value ranges
     String query7 =
-        "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol3 = 'pluto' LIMIT 100 "
-            + "OPTION(explainPlanVerbose=true)";
+        "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol3 = 'pluto' LIMIT 100; "
+            + "OPTION(explainPlanVerbose='true')";
     List<Object[]> result7 = new ArrayList<>();
     result7.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result7.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
@@ -2096,8 +2098,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // Segment 1 has an EmptyFilterOperator plan for this query as '2' is within the segment range but not present
     // The other segments are pruned as '2' is less than the min for these segments
     String query8 =
-        "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE noIndexCol1 = 2 LIMIT 100 "
-            + "OPTION(explainPlanVerbose=true)";
+        "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE noIndexCol1 = 2 LIMIT 100; "
+            + "OPTION(explainPlanVerbose='true')";
     List<Object[]> result8 = new ArrayList<>();
     result8.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result8.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
@@ -2116,7 +2118,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // Segment 4 has an EmptyFilterOperator plan as neither 'minnie' nor 'pluto' exists but are within the value ranges
     String query9 =
         "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol3 = 'pluto' OR "
-            + "invertedIndexCol3 = 'minnie' LIMIT 100 OPTION(explainPlanVerbose=true)";
+            + "invertedIndexCol3 = 'minnie' LIMIT 100; OPTION(explainPlanVerbose='true')";
     List<Object[]> result9 = new ArrayList<>();
     result9.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result9.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
@@ -2138,7 +2140,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
 
     // All segments are pruned
     String query10 = "EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE invertedIndexCol3 = 'roadrunner' AND "
-        + "noIndexCol1 = 100 LIMIT 100 OPTION(explainPlanVerbose=true)";
+        + "noIndexCol1 = 100 LIMIT 100; OPTION(explainPlanVerbose='true')";
     List<Object[]> result10 = new ArrayList<>();
     result10.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result10.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
@@ -2173,7 +2175,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
   public void testSelectAggregateUsingFilterIndexGroupByVerbose() {
     // All segments match this query as '1' is present in all segments
     String query1 = "EXPLAIN PLAN FOR SELECT noIndexCol1, max(noIndexCol2), min(noIndexCol3) FROM testTable WHERE "
-        + "invertedIndexCol2 = 1 GROUP BY noIndexCol1 OPTION(explainPlanVerbose=true)";
+        + "invertedIndexCol2 = 1 GROUP BY noIndexCol1; OPTION(explainPlanVerbose='true')";
     List<Object[]> result1 = new ArrayList<>();
     result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result1.add(new Object[]{"COMBINE_GROUPBY_ORDERBY", 2, 1});
@@ -2221,7 +2223,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     String query1 =
         "EXPLAIN PLAN FOR SELECT noIndexCol1, concat(invertedIndexCol3, 'test', '-'), count(*) FROM testTable WHERE "
             + "invertedIndexCol2 != 1 GROUP BY noIndexCol1, concat(invertedIndexCol3, 'test', '-') ORDER BY "
-            + "noIndexCol1, concat(invertedIndexCol3, 'test', '-') OPTION(explainPlanVerbose=true)";
+            + "noIndexCol1, concat(invertedIndexCol3, 'test', '-'); OPTION(explainPlanVerbose='true')";
     List<Object[]> result1 = new ArrayList<>();
     result1.add(
         new Object[]{"BROKER_REDUCE(sort:[noIndexCol1 ASC, concat(invertedIndexCol3,'test','-') ASC],limit:10)", 1, 0});
@@ -2266,8 +2268,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
   public void testSelectAggregateUsingFilterIndexGroupByHavingVerbose() {
     // All segments match this query as '1' is present in all segments
     String query = "EXPLAIN PLAN FOR SELECT max(noIndexCol1), min(noIndexCol2), noIndexCol3 FROM testTable WHERE "
-        + "invertedIndexCol2 = 1 GROUP BY noIndexCol3 HAVING max(noIndexCol1) > 2 ORDER BY max(noIndexCol1) DESC "
-        + "OPTION(explainPlanVerbose=true)";
+        + "invertedIndexCol2 = 1 GROUP BY noIndexCol3 HAVING max(noIndexCol1) > 2 ORDER BY max(noIndexCol1) DESC; "
+        + "OPTION(explainPlanVerbose='true')";
     List<Object[]> result = new ArrayList<>();
     result.add(
         new Object[]{"BROKER_REDUCE(havingFilter:max(noIndexCol1) > '2',sort:[max(noIndexCol1) DESC],limit:10)", 1, 0});

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineGRPCServerIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineGRPCServerIntegrationTest.java
@@ -86,7 +86,7 @@ public class OfflineGRPCServerIntegrationTest extends BaseClusterIntegrationTest
   public void testGrpcQueryServer()
       throws Exception {
     GrpcQueryClient queryClient = getGrpcQueryClient();
-    String sql = "SELECT * FROM mytable_OFFLINE LIMIT 1000000 OPTION(timeoutMs=30000)";
+    String sql = "SELECT * FROM mytable_OFFLINE LIMIT 1000000; OPTION(timeoutMs=30000);";
     BrokerRequest brokerRequest = CalciteSqlCompiler.compileToBrokerRequest(sql);
     List<String> segments = _helixResourceManager.getSegmentsFor("mytable_OFFLINE", false);
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineGRPCServerIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineGRPCServerIntegrationTest.java
@@ -86,7 +86,7 @@ public class OfflineGRPCServerIntegrationTest extends BaseClusterIntegrationTest
   public void testGrpcQueryServer()
       throws Exception {
     GrpcQueryClient queryClient = getGrpcQueryClient();
-    String sql = "SELECT * FROM mytable_OFFLINE LIMIT 1000000; OPTION(timeoutMs=30000);";
+    String sql = "SELECT * FROM mytable_OFFLINE LIMIT 1000000; OPTION(timeoutMs='30000');";
     BrokerRequest brokerRequest = CalciteSqlCompiler.compileToBrokerRequest(sql);
     List<String> segments = _helixResourceManager.getSegmentsFor("mytable_OFFLINE", false);
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentGenerationMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentGenerationMinionClusterIntegrationTest.java
@@ -129,7 +129,7 @@ public class SegmentGenerationMinionClusterIntegrationTest extends BaseClusterIn
     assertEquals(rowCnt, 70);
 
     String insertFileStatement =
-        String.format("INSERT INTO %s FROM FILE '%s' OPTION(taskName=%s)", tableName, inputDir.getAbsolutePath(),
+        String.format("INSERT INTO %s FROM FILE '%s'; OPTION(taskName='%s')", tableName, inputDir.getAbsolutePath(),
             taskName);
     TestUtils.waitForCondition(aVoid -> {
       try {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentUploadIntegrationTest.java
@@ -141,7 +141,7 @@ public class UpsertTableSegmentUploadIntegrationTest extends BaseClusterIntegrat
   }
 
   private long getCurrentCountStarResultWithoutUpsert() {
-    return getPinotConnection().execute("SELECT COUNT(*) FROM " + getTableName() + " OPTION(skipUpsert=true)")
+    return getPinotConnection().execute("SELECT COUNT(*) FROM " + getTableName() + "; OPTION(skipUpsert='true')")
         .getResultSet(0).getLong(0);
   }
 


### PR DESCRIPTION
Background
===
Currently Query Options are parsed via regex match and replaced with empty string. This causes SQLi issue. 

Solution
===
- using parser.jj extension.
- backward-incompatible change, OPTIONS now can only be supported outside of a SQL statement (e.g. beginning or end of SQL string)

Release Note:
===
This is a backward incompatible change for utilizing `OPTION` keyword. 
- no longer allowed `OPTION(key=value)` ANYWHERE in the SQL query string; with this change only allow at the beginning or the end of the SQL string payload.
- new syntax also requires identifier to literal syntax, for example:
`OPTION(foo=bar, alice=123, bob='potato', complex.key=valueLiteral)`
is now:
`OPTION(foo='bar', alice='123', bob='''potato''', "complex.key"='valueLiteral');`
- Note that standard SQL syntax statement separateor `;` must be added between statements. both among multiple OPTION definitions; and between OPTION definitions and SQL DQL/DML statement. 

Additional Remark
===
This new syntax can theoretically support other literal types for example: 
- `OPTION(foo='bar', alice=123)` --> `Map<String, Object>.of("foo", (String) bar", "alice", (Integer) 123)`;
- `OPTION(foo=true)` --> `Map<String, Object>.of("foo", (boolean) true)`;

However since currently all k-v options support by Pinot is a string/string mapping, we will defer this to a new feature if necessary

Appendix
===
Full SQL syntax algebra

```
statementList:
      [ OPTION '(' option [, option ]* ')'; ]
      statement;
      [ OPTION '(' option [, option ]* ')'; ]

option:
      identifier
      '='
      literal

identifier:
      key | "complex.key"

literal
      QuotedLiteralString
```