### PR TITLE
make data dir accessible from ClusterInfoAccessor

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
@@ -160,7 +160,7 @@ public class ClusterInfoAccessor {
   }
 
   /**
-   * Gets the data dir.
+   * Get the data dir.
    *
    * @return the data dir.
    */

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
@@ -160,6 +160,15 @@ public class ClusterInfoAccessor {
   }
 
   /**
+   * Gets the data dir.
+   *
+   * @return the data dir.
+   */
+  public String getDataDir() {
+    return _controllerConf.getDataDir();
+  }
+
+  /**
    * Get the cluster config for a given config name, return null if not found.
    *
    * @return cluster config


### PR DESCRIPTION
Make data dir accessible from ClusterInfoAccessor so that minion can put data into the same data dir when pushing segments using SegmentPushType.metadata
