### PR TITLE
Revert Hadoop Shading

### DIFF
--- a/pinot-distribution/pom.xml
+++ b/pinot-distribution/pom.xml
@@ -196,10 +196,6 @@
                   <shadedPattern>${shade.prefix}.org.apache.parquet</shadedPattern>
                 </relocation>
                 <relocation>
-                  <pattern>org.apache.hadoop</pattern>
-                  <shadedPattern>${shade.prefix}.org.apache.hadoop</shadedPattern>
-                </relocation>
-                <relocation>
                   <pattern>org.apache.commons</pattern>
                   <shadedPattern>shaded.org.apache.commons</shadedPattern>
                 </relocation>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -126,10 +126,6 @@
                       <shadedPattern>${shade.prefix}.org.apache.parquet</shadedPattern>
                     </relocation>
                     <relocation>
-                      <pattern>org.apache.hadoop</pattern>
-                      <shadedPattern>${shade.prefix}.org.apache.hadoop</shadedPattern>
-                    </relocation>
-                    <relocation>
                       <pattern>org.apache.kafka</pattern>
                       <shadedPattern>${shade.prefix}.org.apache.kafka</shadedPattern>
                     </relocation>


### PR DESCRIPTION
Hadoop shading was done so as to allow pinot to use the packaged hadoop classes and not conflict with the environment hadoop classes.

However, there are certain places in the hadoop code where reflections are used to fetch the classes. This breaks the code at runtime since the package names are not modified to shaded ones in reflection class strings in xml files.
