### PR TITLE
[BugFix] Avoid reporting negative values for server latency.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerResponse.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerResponse.java
@@ -62,11 +62,17 @@ public class ServerResponse {
   }
 
   public int getResponseDelayMs() {
-    if (_receiveDataTableTimeMs != 0) {
-      return (int) (_receiveDataTableTimeMs - _submitRequestTimeMs);
-    } else {
+    if (_receiveDataTableTimeMs == 0) {
       return -1;
     }
+    if (_receiveDataTableTimeMs < _submitRequestTimeMs) {
+      // We currently mark a request as submitted after sending the request to the server. In highQPS-lowLatency
+      // usecases, there can be a race condition where the DataTable/response is received before the request is
+      // marked as submitted. Return 0 to avoid reporting negative values.
+      return 0;
+    }
+
+    return (int) (_receiveDataTableTimeMs - _submitRequestTimeMs);
   }
 
   public int getResponseSize() {


### PR DESCRIPTION
While working on testing changes in #8808, noticed that we report negative
values for ResponseDelayMs in high QPS/low latency usecases. This can happen if the 
response from the server is received before the query is marked as submitted. 


Logs:

> serverStats=(Server=SubmitDelayMs,ResponseDelayMs,ResponseSize,DeserializationTimeMs,RequestSentDelayMs); lor1-app17752_O=0,177,1506,0,12; lor1-app14439_O=279,-102,902,167,279, offlineThreadCpuTimeNs(total/thread/sysActivity/resSer):1774825/1385527/365294/24004        ,realtimeThreadCpuTimeNs(total/thread/sysActivity/resSer):0/0/0/0,query=select item, action, sum(count) from feedItemPopularityTest_OFFLINE where feedType = 'main_feed' and messageTimeDays >= 19141 and item in ('a        YBx67PXHAAA=', 'aYCbMwvqG4AA=', 'aXgdhUTGA0AA=', 'aYDx8jwOHQAA=', 'aX+NVxrWHUAA=', 'aYD301xXGkAE=', 'aXvl/T2eAsAE=', 'aYECXEsWHsAE=', 'aYEFqR4BHUAA=', 'aYDvsN5DHUAA=', 'aYEF2QZ3HgAA=', 'aYCNqKV7GsAA=', 'aYAEkA