### PR TITLE
Adding dependabot github config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Dependabot GitHub Configuration
+
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"
+
+  - package-ecosystem: "npm"
+    directory: "/pinot-controller/src/main/resources"
+    schedule:
+      interval: "daily"
+    # Disable version updates for npm dependencies
+    open-pull-requests-limit: 0
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,21 @@
+# 
+# Licensed to the Apache Software Foundation (ASF) under one     
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
 # Dependabot GitHub Configuration
 
 version: 2


### PR DESCRIPTION
Currently the Pinot OSS has dependabot enabled with default configuration. To have a better control, we can explicitly define the dependabot rules as shown in this PR.

Specifically for `NPM`, we want to hold off on the dependabot PRs for version updates as it sometimes recommends changing transitive dependendencies that could cause breaking changes. Although this should not disable security updates. For more info reference the dependabot docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#open-pull-requests-limit

`npm audit fix` should be the preferred way of identifying dependencies vulnerabilities without causing breaking changes.