### PR TITLE
fixing REGEX OPTION parser

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -82,9 +82,8 @@ public class CalciteSqlParser {
   //
   // Multiple OPTIONs is also supported by:
   // `OPTION (<k1> = <v1>, <k2> = <v2>, <k3> = <v3>)`
-  @Deprecated
   private static final Pattern OPTIONS_REGEX_PATTEN =
-      Pattern.compile("option\\s*\\(([^\\)]+)\\)\\Z", Pattern.CASE_INSENSITIVE);
+      Pattern.compile("\\s*option\\s*\\(([^\\)]+)\\)\\s*\\Z", Pattern.CASE_INSENSITIVE);
 
   /**
    * Checks for the presence of semicolon in the sql query and modifies the query accordingly

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -81,13 +81,10 @@ public class CalciteSqlParser {
   // PQL syntax is: `OPTION (<key> = <value>)`
   //
   // Multiple OPTIONs is also supported by:
-  // either
-  //   `OPTION (<k1> = <v1>, <k2> = <v2>, <k3> = <v3>)`
-  // or
-  //   `OPTION (<k1> = <v1>) OPTION (<k2> = <v2>) OPTION (<k3> = <v3>)`
-  // TODO: move to use parser syntax extension: `OPTION` `(` `<key>` = `<value>` [, `<key>` = `<value>`]* `)`
+  // `OPTION (<k1> = <v1>, <k2> = <v2>, <k3> = <v3>)`
+  @Deprecated
   private static final Pattern OPTIONS_REGEX_PATTEN =
-      Pattern.compile("option\\s*\\(([^\\)]+)\\)", Pattern.CASE_INSENSITIVE);
+      Pattern.compile("option\\s*\\(([^\\)]+)\\)\\Z", Pattern.CASE_INSENSITIVE);
 
   /**
    * Checks for the presence of semicolon in the sql query and modifies the query accordingly

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/dml/InsertIntoFileTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/dml/InsertIntoFileTest.java
@@ -32,11 +32,11 @@ public class InsertIntoFileTest {
       throws Exception {
     String insertIntoSql = "INSERT INTO \"baseballStats\"\n"
         + "FROM FILE 's3://my-bucket/path/to/data/'\n"
-        + "OPTION(taskName=myTask-1)\n"
-        + "OPTION(input.fs.className=org.apache.pinot.plugin.filesystem.S3PinotFS)\n"
-        + "OPTION(input.fs.prop.accessKey=my-access-key)\n"
-        + "OPTION(input.fs.prop.secretKey=my-secret-key)\n"
-        + "OPTION(input.fs.prop.region=us-west-2)";
+        + "OPTION(taskName=myTask-1,"
+        + "input.fs.className=org.apache.pinot.plugin.filesystem.S3PinotFS,"
+        + "input.fs.prop.accessKey=my-access-key,"
+        + "input.fs.prop.secretKey=my-secret-key,"
+        + "input.fs.prop.region=us-west-2)";
     InsertIntoFile insertIntoFile = InsertIntoFile.parse(CalciteSqlParser.compileToSqlNodeAndOptions(insertIntoSql));
     Assert.assertEquals(insertIntoFile.getTable(), "baseballStats");
     Assert.assertEquals(insertIntoFile.getExecutionType(), DataManipulationStatement.ExecutionType.MINION);


### PR DESCRIPTION
Background
===
Fixes REGEX OPTION can be parsed anywhere in the SQL including within a STRING literal. 
See: #8906 for more details.

Details
===
1. only allow single OPTION keyword
2. only allow OPTION at end of file

Release Note
===
This PR introduces a backward incompatible change to `OPTION` keyword parsing. Multiple `OPTION` keyword is no longer supported.
For SQL such as `SELECT * FROM tbl OPTION(k1=v1) OPTION(k2=v2)` please use
`SELECT * FROM tbl OPTION(k1=v1,k2=v2)`