### PR TITLE
Log Request header for Broker

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -667,7 +667,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
     boolean enableClientIpLogging = _config.getProperty(Broker.CONFIG_OF_BROKER_REQUEST_CLIENT_IP_LOGGING,
         Broker.DEFAULT_BROKER_REQUEST_CLIENT_IP_LOGGING);
-    String clientIp = "";
+    String clientIp = "unknown";
     // If reverse proxy is used X-Forwarded-For will be populated
     // If X-Forwarded-For is not present, check if x-real-ip is present
     // Since X-Forwarded-For can contain comma separated list of values, we convert it to ";" delimiter to avoid

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -673,15 +673,17 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     // Since X-Forwarded-For can contain comma separated list of values, we convert it to ";" delimiter to avoid
     // downstream parsing errors for other fields where "," is being used
     if (enableClientIpLogging && requesterIdentity != null) {
-      for (Map.Entry<String, String> entries : ((HttpRequesterIdentity) requesterIdentity).getHttpHeaders().entries()) {
-        if (entries.getKey().equalsIgnoreCase("x-forwarded-for")) {
-          if (entries.getValue().contains(",")) {
-            clientIp = String.join(";", entries.getValue().split(","));
+      for (Map.Entry<String, String> entry : ((HttpRequesterIdentity) requesterIdentity).getHttpHeaders().entries()) {
+        String key = entry.getKey();
+        String value = entry.getValue();
+        if (key.equalsIgnoreCase("x-forwarded-for")) {
+          if (value.contains(",")) {
+            clientIp = String.join(";", value.split(","));
           } else {
-            clientIp = entries.getValue();
+            clientIp = value;
           }
-        } else if (entries.getKey().equalsIgnoreCase("x-real-ip")) {
-          clientIp = entries.getValue();
+        } else if (key.equalsIgnoreCase("x-real-ip")) {
+          clientIp = value;
         }
       }
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -455,8 +455,13 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
       // Send empty response since we don't need to evaluate either offline or realtime request.
       BrokerResponseNative brokerResponse = BrokerResponseNative.empty();
+      // Extract source info from incoming request
+      Collection<String> remoteIps = null;
+      if (requesterIdentity != null) {
+        remoteIps = ((HttpRequesterIdentity) requesterIdentity).getHttpHeaders().get("X-Forwarded-For");
+      }
       logBrokerResponse(requestId, query, requestContext, tableName, 0, new ServerStats(), brokerResponse,
-          System.nanoTime(), null);
+          System.nanoTime(), remoteIps);
       return brokerResponse;
     }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -254,6 +254,10 @@ public class CommonConstants {
 
     public static final String CONTROLLER_URL = "pinot.broker.controller.url";
 
+    public static final String CONFIG_OF_BROKER_REQUEST_CLIENT_IP_LOGGING =
+        "pinot.broker.request.client.ip.logging";
+    public static final boolean DEFAULT_BROKER_REQUEST_CLIENT_IP_LOGGING = true;
+
     public static class Request {
       public static final String SQL = "sql";
       public static final String TRACE = "trace";


### PR DESCRIPTION
### Background

Add request header to broker logs
See #8869 for more details.

### Release Note
This PR introduces passing a new parameter ** remoteIps** to broker logs, so we can track the source info of queries being sent to the broker
