### PR TITLE
[Work in progress] Distinct count HLL pre-agg

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountHLLValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountHLLValueAggregator.java
@@ -20,6 +20,11 @@ package org.apache.pinot.segment.local.aggregator;
 
 import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.segment.local.utils.CustomSerDeUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -28,7 +33,27 @@ import org.apache.pinot.spi.utils.CommonConstants;
 
 public class DistinctCountHLLValueAggregator implements ValueAggregator<Object, HyperLogLog> {
   public static final DataType AGGREGATED_VALUE_TYPE = DataType.BYTES;
-  private static final int DEFAULT_LOG2M_BYTE_SIZE = 180;
+  private int _log2m = CommonConstants.Helix.DEFAULT_HYPERLOGLOG_LOG2M;
+  private int _log2m_byte_size = 180;
+
+  public DistinctCountHLLValueAggregator() {}
+  
+  public DistinctCountHLLValueAggregator(List<ExpressionContext> arguments) {
+    // length 1 means we use the default _log2m of 8
+    if (arguments.size() <= 1) {
+      return;
+    }
+
+    String log2mLiteral = arguments.get(1).getLiteral();
+    Preconditions.checkState(StringUtils.isNumeric(log2mLiteral), "log2m argument must be a numeric literal");
+
+    _log2m = Integer.parseInt(log2mLiteral);
+    try {
+      _log2m_byte_size = (new HyperLogLog(_log2m)).getBytes().length;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
   // Byte size won't change once we get the initial aggregated value
   private int _maxByteSize;
@@ -51,10 +76,9 @@ public class DistinctCountHLLValueAggregator implements ValueAggregator<Object, 
       initialValue = deserializeAggregatedValue(bytes);
       _maxByteSize = Math.max(_maxByteSize, bytes.length);
     } else {
-      // TODO: Handle configurable log2m for StarTreeBuilder
-      initialValue = new HyperLogLog(CommonConstants.Helix.DEFAULT_HYPERLOGLOG_LOG2M);
+      initialValue = new HyperLogLog(_log2m);
       initialValue.offer(rawValue);
-      _maxByteSize = Math.max(_maxByteSize, DEFAULT_LOG2M_BYTE_SIZE);
+      _maxByteSize = Math.max(_maxByteSize, _log2m_byte_size);
     }
     return initialValue;
   }
@@ -100,6 +124,9 @@ public class DistinctCountHLLValueAggregator implements ValueAggregator<Object, 
 
   @Override
   public HyperLogLog deserializeAggregatedValue(byte[] bytes) {
+    if (bytes == null || bytes.length == 0) {
+      return new HyperLogLog(_log2m);
+    }
     return CustomSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(bytes);
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/ValueAggregatorFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/ValueAggregatorFactory.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.segment.local.aggregator;
 
+import java.util.List;
+import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
@@ -36,7 +38,7 @@ public class ValueAggregatorFactory {
    * @param aggregationType Aggregation type
    * @return Value aggregator
    */
-  public static ValueAggregator getValueAggregator(AggregationFunctionType aggregationType) {
+  public static ValueAggregator getValueAggregator(AggregationFunctionType aggregationType, List<ExpressionContext> arguments) {
     switch (aggregationType) {
       case COUNT:
         return new CountValueAggregator();
@@ -56,7 +58,7 @@ public class ValueAggregatorFactory {
         return new DistinctCountBitmapValueAggregator();
       case DISTINCTCOUNTHLL:
       case DISTINCTCOUNTRAWHLL:
-        return new DistinctCountHLLValueAggregator();
+        return new DistinctCountHLLValueAggregator(arguments);
       case PERCENTILEEST:
       case PERCENTILERAWEST:
         return new PercentileEstValueAggregator();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/DefaultMutableIndexProvider.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/DefaultMutableIndexProvider.java
@@ -34,6 +34,7 @@ import org.apache.pinot.segment.spi.index.mutable.provider.MutableIndexContext;
 import org.apache.pinot.segment.spi.index.mutable.provider.MutableIndexProvider;
 import org.apache.pinot.spi.data.FieldSpec;
 
+import static org.apache.pinot.spi.data.FieldSpec.DataType.BYTES;
 import static org.apache.pinot.spi.data.FieldSpec.DataType.INT;
 
 
@@ -49,6 +50,7 @@ public class DefaultMutableIndexProvider implements MutableIndexProvider {
     String column = context.getFieldSpec().getName();
     String segmentName = context.getSegmentName();
     FieldSpec.DataType storedType = context.getFieldSpec().getDataType().getStoredType();
+    int maxLength = context.getFieldSpec().getMaxLength();
     boolean isSingleValue = context.getFieldSpec().isSingleValueField();
     if (!context.hasDictionary()) {
       // No dictionary column must be single-valued
@@ -56,8 +58,10 @@ public class DefaultMutableIndexProvider implements MutableIndexProvider {
       String allocationContext =
           buildAllocationContext(context.getSegmentName(), context.getFieldSpec().getName(),
               V1Constants.Indexes.RAW_SV_FORWARD_INDEX_FILE_EXTENSION);
-      if (storedType.isFixedWidth()) {
-        return new FixedByteSVMutableForwardIndex(false, storedType, context.getCapacity(), context.getMemoryManager(),
+      // We consider BYTES with a specific maxLength as being also fixed width maxLength's purpose doubles as the fixed width
+      // when used on a BYTES field.
+      if (storedType.isFixedWidth() || (storedType.getStoredType() == BYTES && maxLength > 0)) {
+        return new FixedByteSVMutableForwardIndex(false, storedType, maxLength, context.getCapacity(), context.getMemoryManager(),
             allocationContext);
       } else {
         // RealtimeSegmentStatsHistory does not have the stats for no-dictionary columns from previous consuming

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -573,6 +573,7 @@ public class MutableSegmentImpl implements MutableSegment {
     for (Map.Entry<String, IndexContainer> entry : _indexContainerMap.entrySet()) {
       IndexContainer indexContainer = entry.getValue();
       MutableDictionary dictionary = indexContainer._dictionary;
+
       if (dictionary == null) {
         continue;
       }
@@ -623,6 +624,9 @@ public class MutableSegmentImpl implements MutableSegment {
             break;
           case DOUBLE:
             forwardIndex.setDouble(docId, ((Number) value).doubleValue());
+            break;
+          case BYTES:
+            forwardIndex.setBytes(docId, indexContainer._valueAggregator.serializeAggregatedValue(value));
             break;
           default:
             throw new UnsupportedOperationException(
@@ -871,6 +875,11 @@ public class MutableSegmentImpl implements MutableSegment {
               throw new UnsupportedOperationException(String.format("Aggregation type %s of %s not supported for %s",
                   valueAggregator.getAggregatedValueType(), valueAggregator.getAggregationType(), dataType));
           }
+          break;
+        case BYTES:
+          Object currentValue = valueAggregator.deserializeAggregatedValue(forwardIndex.getBytes(docId));
+          Object newVal = valueAggregator.applyRawValue(currentValue, value);
+          forwardIndex.setBytes(docId, valueAggregator.serializeAggregatedValue(newVal));
           break;
         default:
           throw new UnsupportedOperationException(
@@ -1262,7 +1271,7 @@ public class MutableSegmentImpl implements MutableSegment {
     Map<String, Pair<String, ValueAggregator>> columnNameToAggregator = new HashMap<>();
     for (String metricName : segmentConfig.getSchema().getMetricNames()) {
       columnNameToAggregator.put(metricName,
-          Pair.of(metricName, ValueAggregatorFactory.getValueAggregator(AggregationFunctionType.SUM)));
+          Pair.of(metricName, ValueAggregatorFactory.getValueAggregator(AggregationFunctionType.SUM, Collections.EMPTY_LIST)));
     }
     return columnNameToAggregator;
   }
@@ -1279,8 +1288,18 @@ public class MutableSegmentImpl implements MutableSegment {
           "aggregation function must be a function: %s", config);
       FunctionContext functionContext = expressionContext.getFunction();
       TableConfigUtils.validateIngestionAggregation(functionContext.getFunctionName());
-      Preconditions.checkState(functionContext.getArguments().size() == 1,
-          "aggregation function can only have one argument: %s", config);
+
+
+      switch (functionContext.getFunctionName().toLowerCase()) {
+        case "distinctcounthll":
+          Preconditions.checkState(functionContext.getArguments().size() >= 1 && functionContext.getArguments().size() <= 2,
+              "distinctcounthll function can have max two arguments: %s", config);
+          break;
+        default:
+          Preconditions.checkState(functionContext.getArguments().size() == 1,
+              "aggregation function can only have one argument: %s", config);
+      }
+
       ExpressionContext argument = functionContext.getArguments().get(0);
       Preconditions.checkState(argument.getType() == ExpressionContext.Type.IDENTIFIER,
           "aggregator function argument must be a identifier: %s", config);
@@ -1289,7 +1308,7 @@ public class MutableSegmentImpl implements MutableSegment {
           AggregationFunctionType.getAggregationFunctionType(functionContext.getFunctionName());
 
       columnNameToAggregator.put(config.getColumnName(),
-          Pair.of(argument.getLiteral(), ValueAggregatorFactory.getValueAggregator(functionType)));
+          Pair.of(argument.getLiteral(), ValueAggregatorFactory.getValueAggregator(functionType, functionContext.getArguments())));
     }
 
     return columnNameToAggregator;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
@@ -63,20 +63,30 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
 
   /**
    * @param valueType Data type of the values
+   * @param fixedLength Fixed length of values if known: only used for BYTES field and specifically Hyperloglog values for now.
    * @param numRowsPerChunk Number of rows to pack in one chunk before a new chunk is created.
    * @param memoryManager Memory manager to be used for allocating memory.
    * @param allocationContext Allocation allocationContext.
    */
-  public FixedByteSVMutableForwardIndex(boolean dictionaryEncoded, DataType valueType, int numRowsPerChunk,
+  public FixedByteSVMutableForwardIndex(boolean dictionaryEncoded, DataType valueType, int fixedLength, int numRowsPerChunk,
       PinotDataBufferMemoryManager memoryManager, String allocationContext) {
     _dictionaryEncoded = dictionaryEncoded;
     _valueType = valueType;
-    _valueSizeInBytes = valueType.size();
+    if (valueType == DataType.BYTES) {
+      _valueSizeInBytes = fixedLength;
+    } else {
+      _valueSizeInBytes = valueType.size();
+    }
     _numRowsPerChunk = numRowsPerChunk;
     _chunkSizeInBytes = numRowsPerChunk * _valueSizeInBytes;
     _memoryManager = memoryManager;
     _allocationContext = allocationContext;
     addBuffer();
+  }
+
+  public FixedByteSVMutableForwardIndex(boolean dictionaryEncoded, DataType valueType, int numRowsPerChunk,
+                                        PinotDataBufferMemoryManager memoryManager, String allocationContext) {
+    this(dictionaryEncoded, valueType, -1, numRowsPerChunk, memoryManager, allocationContext);
   }
 
   @Override
@@ -195,6 +205,22 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
     getWriterForRow(docId).setDouble(docId, value);
   }
 
+  @Override
+  public byte[] getBytes(int docId) {
+    int bufferId = getBufferId(docId);
+    return _readers.get(bufferId).getBytes(docId);
+  }
+
+  @Override
+  public void setBytes(int docId, byte[] value) {
+    if (value.length != _valueSizeInBytes) {
+      throw new IllegalArgumentException("Expected value size to be " + _valueSizeInBytes + " but was " + value.length);
+    }
+
+    addBufferIfNeeded(docId);
+    getWriterForRow(docId).setBytes(docId, value);
+  }
+
   private WriterWithOffset getWriterForRow(int row) {
     return _writers.get(getBufferId(row));
   }
@@ -267,6 +293,10 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
     public void setDouble(int row, double value) {
       _writer.setDouble(row - _startRowId, 0, value);
     }
+
+    public void setBytes(int row, byte[] value) {
+      _writer.setBytes(row - _startRowId, 0, value);
+    }
   }
 
   /**
@@ -305,6 +335,10 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
 
     public BigDecimal getBigDecimal(int row) {
       return BigDecimalUtils.deserialize(_reader.getBytes(row - _startRowId, 0));
+    }
+
+    public byte[] getBytes(int row) {
+      return _reader.getBytes(row - _startRowId, 0);
     }
 
     public FixedByteSingleValueMultiColReader getReader() {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/BaseSingleTreeBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/BaseSingleTreeBuilder.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -142,7 +143,7 @@ abstract class BaseSingleTreeBuilder implements SingleTreeBuilder {
     for (AggregationFunctionColumnPair functionColumnPair : functionColumnPairs) {
       _metrics[index] = functionColumnPair.toColumnName();
       _functionColumnPairs[index] = functionColumnPair;
-      _valueAggregators[index] = ValueAggregatorFactory.getValueAggregator(functionColumnPair.getFunctionType());
+      _valueAggregators[index] = ValueAggregatorFactory.getValueAggregator(functionColumnPair.getFunctionType(), Collections.EMPTY_LIST);
 
       // Ignore the column for COUNT aggregation function
       if (_valueAggregators[index].getAggregationType() != AggregationFunctionType.COUNT) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplIngestionAggregationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplIngestionAggregationTest.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplIngestionAggregationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplIngestionAggregationTest.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.segment.local.indexsegment.mutable;
 
+import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
+import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.segment.local.aggregator.DistinctCountHLLValueAggregator;
 import org.apache.pinot.spi.config.table.ingestion.AggregationConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
@@ -81,10 +85,10 @@ public class MutableSegmentImplIngestionAggregationTest {
     for (List<Metric> metrics : addRows(1, mutableSegmentImpl)) {
       expectedMin.put(metrics.get(0).getKey(),
           Math.min(expectedMin.getOrDefault(metrics.get(0).getKey(), Double.POSITIVE_INFINITY),
-              metrics.get(0).getValue()));
+              (Integer) metrics.get(0).getValue()));
       expectedMax.put(metrics.get(0).getKey(),
           Math.max(expectedMax.getOrDefault(metrics.get(0).getKey(), Double.NEGATIVE_INFINITY),
-              metrics.get(0).getValue()));
+              (Integer) metrics.get(0).getValue()));
     }
 
     GenericRow reuse = new GenericRow();
@@ -115,9 +119,9 @@ public class MutableSegmentImplIngestionAggregationTest {
     Map<String, Long> expectedSum2 = new HashMap<>();
     for (List<Metric> metrics : addRows(2, mutableSegmentImpl)) {
       expectedSum1.put(metrics.get(0).getKey(),
-          expectedSum1.getOrDefault(metrics.get(0).getKey(), 0) + metrics.get(0).getValue());
+          expectedSum1.getOrDefault(metrics.get(0).getKey(), 0) + (Integer) (metrics.get(0).getValue()));
       expectedSum2.put(metrics.get(1).getKey(),
-          expectedSum2.getOrDefault(metrics.get(1).getKey(), 0L) + metrics.get(1).getValue().longValue());
+          expectedSum2.getOrDefault(metrics.get(1).getKey(), 0L) + ((Integer) metrics.get(1).getValue()).longValue());
     }
 
     GenericRow reuse = new GenericRow();
@@ -128,6 +132,64 @@ public class MutableSegmentImplIngestionAggregationTest {
       Assert.assertEquals(row.getValue(m2), expectedSum2.get(key), key);
     }
 
+    mutableSegmentImpl.destroy();
+  }
+
+  @Test
+  public void testDISTINCTCOUNTHLL() throws Exception {
+    String m1 = "metric_DISTINCTCOUNTHLL";
+    Schema schema = getSchemaBuilder().addMetric(m1, FieldSpec.DataType.BYTES).build();
+    // Size of hll object for when log2m is 12
+    schema.getFieldSpecFor(m1).setMaxLength(2740);
+
+    MutableSegmentImpl mutableSegmentImpl =
+        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m1)),
+            VAR_LENGTH_SET, INVERTED_INDEX_SET,
+            Arrays.asList(new AggregationConfig(m1, "DISTINCTCOUNTHLL(metric, 12)")));
+
+    Map<String, HLLTestData> expected = new HashMap<>();
+    List<Metric> metrics = addRowsDistinctCountHLL(998, mutableSegmentImpl);
+    for (Metric metric : metrics) {
+      expected.put(metric.getKey(), (HLLTestData) metric.getValue());
+    }
+
+    List<ExpressionContext> arguments = List.of(ExpressionContext.forIdentifier("distinctcounthll"), ExpressionContext.forLiteral("12"));
+    DistinctCountHLLValueAggregator valueAggregator = new DistinctCountHLLValueAggregator(arguments);
+
+    Set<Integer> integers = new HashSet<>();
+
+    /*
+    Assert that the distinct count is within an error margin. We assert on the cardinality of the HLL in the docID and the
+    HLL we made, but also on the cardinality of the HLL in the docID and the actual cardinality from the set of integers.
+     */
+    GenericRow reuse = new GenericRow();
+    for (int docId = 0; docId < expected.size(); docId++) {
+      GenericRow row = mutableSegmentImpl.getRecord(docId, reuse);
+      String key = buildKey(row);
+
+      integers.addAll(expected.get(key).integers);
+
+      HyperLogLog expectedHLL = expected.get(key).hll;
+      HyperLogLog actualHLL = valueAggregator.deserializeAggregatedValue((byte[]) row.getValue(m1));
+
+      Assert.assertEquals(actualHLL.cardinality(), expectedHLL.cardinality(), (int) (expectedHLL.cardinality() * 0.04), "The HLL cardinality from the index is within a tolerable error margin (4%) of the cardinality of the expected HLL.");
+      Assert.assertEquals(actualHLL.cardinality(), expected.get(key).integers.size(), (int) (expected.get(key).integers.size()) * 0.04, "The HLL cardinality from the index is within a tolerable error margin (4%) of the actual cardinality of the integers.");
+    }
+
+    /*
+    Assert that the aggregated HyperLogLog is also within the error margin
+     */
+    HyperLogLog togetherHLL = new HyperLogLog(12);
+    expected.forEach((key, value) -> {
+      try {
+        togetherHLL.addAll(value.hll);
+      } catch (CardinalityMergeException e) {
+        e.printStackTrace();
+        throw new RuntimeException(e);
+      }
+    });
+
+    Assert.assertEquals(togetherHLL.cardinality(), integers.size(), (int) (integers.size() * 0.04), "The aggregated HLL cardinality is within a tolerable error margin (4%) of the actual cardinality of the integers.");
     mutableSegmentImpl.destroy();
   }
 
@@ -166,22 +228,40 @@ public class MutableSegmentImplIngestionAggregationTest {
         TIME_COLUMN1) + KEY_SEPARATOR + row.getValue(TIME_COLUMN2);
   }
 
-  private GenericRow getRow(Random random) {
+  private GenericRow getRow(Random random, Integer multiplicationFactor) {
     GenericRow row = new GenericRow();
 
-    row.putValue(DIMENSION_1, random.nextInt(10));
+    row.putValue(DIMENSION_1, random.nextInt(2 * multiplicationFactor));
     row.putValue(DIMENSION_2, STRING_VALUES.get(random.nextInt(STRING_VALUES.size())));
-    row.putValue(TIME_COLUMN1, random.nextInt(10));
-    row.putValue(TIME_COLUMN2, random.nextInt(5));
+    row.putValue(TIME_COLUMN1, random.nextInt(2 * multiplicationFactor));
+    row.putValue(TIME_COLUMN2, random.nextInt(2 * multiplicationFactor));
 
     return row;
   }
 
+  private class HLLTestData {
+    private HyperLogLog hll;
+    private Set<Integer> integers;
+
+    public HLLTestData(HyperLogLog hll, Set<Integer> integers) {
+      this.hll = hll;
+      this.integers = integers;
+    }
+
+    public HyperLogLog getHll() {
+      return hll;
+    }
+
+    public Set<Integer> getIntegers() {
+      return integers;
+    }
+  }
+
   private class Metric {
     private final String _key;
-    private final Integer _value;
+    private final Object _value;
 
-    Metric(String key, Integer value) {
+    Metric(String key, Object value) {
       _key = key;
       _value = value;
     }
@@ -190,9 +270,52 @@ public class MutableSegmentImplIngestionAggregationTest {
       return _key;
     }
 
-    public Integer getValue() {
+    public Object getValue() {
       return _value;
     }
+  }
+
+  private List<Metric> addRowsDistinctCountHLL(long seed, MutableSegmentImpl mutableSegmentImpl)
+      throws Exception {
+    List<Metric> metrics = new ArrayList<>();
+
+    Random random = new Random(seed);
+    StreamMessageMetadata defaultMetadata = new StreamMessageMetadata(System.currentTimeMillis());
+
+    HashMap<String, HyperLogLog> hllMap = new HashMap<>();
+    HashMap<String, Set<Integer>> distinctMap = new HashMap<>();
+
+    Integer rows = 500000;
+
+    for (int i = 0; i < (rows); i++) {
+      GenericRow row = getRow(random, 1);
+      String key = buildKey(row);
+
+      int metricValue = random.nextInt(5000000);
+      row.putValue(METRIC, metricValue);
+
+      if (hllMap.containsKey(key)) {
+        hllMap.get(key).offer(row.getValue(METRIC));
+        distinctMap.get(key).add(metricValue);
+      } else {
+        HyperLogLog hll = new HyperLogLog(12);
+        hll.offer(row.getValue(METRIC));
+        hllMap.put(key, hll);
+        distinctMap.put(key, new HashSet<>(metricValue));
+      }
+
+      mutableSegmentImpl.index(row, defaultMetadata);
+    }
+
+    distinctMap.forEach((key, value) -> metrics.add(new Metric(key, new HLLTestData(hllMap.get(key), distinctMap.get(key)))));
+
+    int numDocsIndexed = mutableSegmentImpl.getNumDocsIndexed();
+    Assert.assertEquals(numDocsIndexed, hllMap.keySet().size());
+
+    // Assert that aggregation happened.
+    Assert.assertTrue(numDocsIndexed < NUM_ROWS);
+
+    return metrics;
   }
 
   private List<List<Metric>> addRows(long seed, MutableSegmentImpl mutableSegmentImpl)
@@ -205,8 +328,8 @@ public class MutableSegmentImplIngestionAggregationTest {
     StreamMessageMetadata defaultMetadata = new StreamMessageMetadata(System.currentTimeMillis());
 
     for (int i = 0; i < NUM_ROWS; i++) {
-      GenericRow row = getRow(random);
-      // This needs to be relatively low since it will tend to overflow with the Int-to-Double conversion.
+      // Generate random int to prevent overflow
+      GenericRow row = getRow(random, 1);
       Integer metricValue = random.nextInt(10000);
       Integer metric2Value = random.nextInt();
       row.putValue(METRIC, metricValue);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/mutable/FixedByteSVMutableForwardIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/mutable/FixedByteSVMutableForwardIndexTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.segment.index.forward.mutable;
 
+import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
@@ -109,6 +110,74 @@ public class FixedByteSVMutableForwardIndexTest {
     start = rows * 2;
     for (int i = 0; i < 2 * rows; i++) {
       Assert.assertEquals(readerWriter.getDictId(start + i), 0);
+    }
+    readerWriter.close();
+  }
+
+  @Test
+  public void testBytes() throws IOException {
+    int rows = 10;
+    Random r = new Random();
+    final long seed = r.nextLong();
+    r = new Random(seed);
+    for (int div = 1; div <= rows / 2; div++) {
+      testBytes(r, rows, div);
+    }
+  }
+
+  private void testBytes(final Random random, final int rows, final int div) throws IOException {
+    int HLL_log2m_12_size = 2740;
+    int log2m = 12;
+
+    FixedByteSVMutableForwardIndex readerWriter;
+    readerWriter = new FixedByteSVMutableForwardIndex(false, DataType.BYTES, HLL_log2m_12_size, rows / div, _memoryManager, "Long");
+    byte[][] data = new byte[rows][];
+
+    for (int i = 0; i < rows; i++) {
+      HyperLogLog hll = new HyperLogLog(log2m);
+      hll.offer(random.nextLong());
+      data[i] = hll.getBytes();
+      Assert.assertEquals(data[i].length, HLL_log2m_12_size);
+      readerWriter.setBytes(i, data[i]);
+      Assert.assertEquals(readerWriter.getBytes(i).length, data[i].length);
+      Assert.assertEquals(readerWriter.getBytes(i), data[i]);
+    }
+    for (int i = 0; i < rows; i++) {
+      Assert.assertEquals(readerWriter.getBytes(i), data[i]);
+    }
+
+    // Test mutability by overwriting randomly selected rows.
+    for (int i = 0; i < rows; i++) {
+      if (random.nextFloat() >= 0.5) {
+        HyperLogLog hll = new HyperLogLog(log2m);
+        hll.offer(random.nextLong());
+        data[i] = hll.getBytes();
+        readerWriter.setBytes(i, data[i]);
+      }
+    }
+    for (int i = 0; i < rows; i++) {
+      Assert.assertEquals(readerWriter.getBytes(i), data[i]);
+    }
+
+    // Write to a large enough row index to ensure multiple chunks are correctly allocated.
+    int start = rows * 4;
+    for (int i = 0; i < rows; i++) {
+      HyperLogLog hll = new HyperLogLog(log2m);
+      hll.offer(random.nextLong());
+      data[i] = hll.getBytes();
+      readerWriter.setBytes(start + i, data[i]);
+    }
+
+    for (int i = 0; i < rows; i++) {
+      Assert.assertEquals(readerWriter.getBytes(start + i), data[i]);
+    }
+
+    // Ensure that rows not written default to an empty byte array.
+    byte[] emptyBytes = new byte[HLL_log2m_12_size];
+    start = rows * 2;
+    for (int i = 0; i < 2 * rows; i++) {
+      byte[] bytes = readerWriter.getBytes(start + i);
+      Assert.assertEquals(bytes, emptyBytes);
     }
     readerWriter.close();
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -466,8 +466,17 @@ public class TableConfigUtilsTest {
       // expected
     }
 
-    ingestionConfig.setAggregationConfigs(
-        Collections.singletonList(new AggregationConfig("m1", "DISTINCTCOUNTHLL(s1)")));
+    schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addMetric("d1", FieldSpec.DataType.BYTES).build();
+    schema.getFieldSpecFor("d1").setMaxLength(180);
+
+    // distinctcounthllmv is not supported, we expect this to not validate
+    List<AggregationConfig> aggregationConfigs = Arrays.asList(new AggregationConfig("d1", "DISTINCTCOUNTHLLMV(s1)"));
+    ingestionConfig =
+        new IngestionConfig(null, null, null, null, null, aggregationConfigs);
+    tableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName("myTable_REALTIME").setTimeColumnName("timeColumn")
+            .setIngestionConfig(ingestionConfig).build();
+
     try {
       TableConfigUtils.validateIngestionConfig(tableConfig, schema);
       Assert.fail("Should fail due to not supported aggregation function");
@@ -475,7 +484,53 @@ public class TableConfigUtilsTest {
       // expected
     }
 
-    ingestionConfig.setAggregationConfigs(Collections.singletonList(new AggregationConfig("m1", "s1 + s2")));
+    // test the distinctcounthll validation for various log2m sizes
+    HashMap<Integer, Integer> log2mToExpectedSize = new HashMap<>();
+    log2mToExpectedSize.put(8, 180);
+    log2mToExpectedSize.put(12, 2740);
+
+    for (Map.Entry<Integer, Integer> entry : log2mToExpectedSize.entrySet()) {
+      // set the max length to the HLL expected bytes size
+      schema.getFieldSpecFor("d1").setMaxLength(entry.getValue());
+
+      aggregationConfigs = Arrays.asList(new AggregationConfig("d1", "DISTINCTCOUNTHLL(s1, " + entry.getKey() + ")"));
+      ingestionConfig =
+          new IngestionConfig(null, null, null,
+              null, null, aggregationConfigs);
+      tableConfig =
+          new TableConfigBuilder(TableType.REALTIME).setTableName("myTable_REALTIME").setTimeColumnName("timeColumn")
+              .setIngestionConfig(ingestionConfig).build();
+
+      try {
+        TableConfigUtils.validateIngestionConfig(tableConfig, schema);
+      } catch (IllegalStateException e) {
+        Assert.fail("The HLL object size based on the log2m doesn't match the destination BYTES field's maxLength property");
+      }
+    }
+
+    // distinctcounthll, expect not specified log2m argument to default to 8
+    schema.getFieldSpecFor("d1").setMaxLength(180);
+    aggregationConfigs = Arrays.asList(new AggregationConfig("d1", "DISTINCTCOUNTHLL(s1)"));
+    ingestionConfig =
+        new IngestionConfig(null, null, null,
+            null, null, aggregationConfigs);
+    tableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName("myTable_REALTIME").setTimeColumnName("timeColumn")
+            .setIngestionConfig(ingestionConfig).build();
+
+    try {
+      TableConfigUtils.validateIngestionConfig(tableConfig, schema);
+    } catch (IllegalStateException e) {
+      Assert.fail("Log2m defaulted to 8 but BYTES schema maxLength is not the expected size of 180");
+    }
+
+    aggregationConfigs = Arrays.asList(new AggregationConfig("d1", "s1 + s2"));
+    ingestionConfig =
+        new IngestionConfig(null, null, null, null, null, aggregationConfigs);
+    tableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName("myTable_REALTIME").setTimeColumnName("timeColumn")
+            .setIngestionConfig(ingestionConfig).build();
+
     try {
       TableConfigUtils.validateIngestionConfig(tableConfig, schema);
       Assert.fail("Should fail due to multiple arguments");

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -68,7 +68,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
   protected DataType _dataType;
   protected boolean _isSingleValueField = true;
 
-  // NOTE: for STRING column, this is the max number of characters; for BYTES column, this is the max number of bytes
+  // NOTE: for STRING column, this is the max number of characters; for BYTES column, this is the fixed number of bytes
   private int _maxLength = DEFAULT_MAX_LENGTH;
 
   protected Object _defaultNullValue;


### PR DESCRIPTION
**TODO**: still need to format this into the format expected for pull requests.
----

This adds support for distinct count hll pre-aggregation. It introduces a new property on the fieldSpec, `fixedLength` in bytes so that BYTES data type can be treated as fixed length and we can utilize the FixedByteSVMutableForwardIndex.
When used for Hyperloglog data values, the `fixedLength` should represent in bytes the size of the Hyperloglog object when serialized.

Hyperloglog w/ log2m of `8` has a size of 180 bytes, with a log2m of `12` has a size of 2740 bytes. I unit tested using log2m of 12 because that's the size one of our use cases require

- unit tests for the fixedByte mutable forward indexes' getBytes() and setBytes() new implementation
- unit tests for aggregating rows and asserting on their Hyperloglog objects

Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
