### PR TITLE
add freshness lag when there are no consuming segments

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseReduceService.java
@@ -340,7 +340,7 @@ public abstract class BaseReduceService {
         brokerMetrics.addTimedTableValue(rawTableName, BrokerTimer.REALTIME_TOTAL_CPU_TIME_NS, _realtimeTotalCpuTimeNs,
             TimeUnit.NANOSECONDS);
 
-        if (_numConsumingSegmentsQueried > 0 && _minConsumingFreshnessTimeMs > 0) {
+        if (_minConsumingFreshnessTimeMs != Long.MAX_VALUE) {
           brokerMetrics.addTimedTableValue(rawTableName, BrokerTimer.FRESHNESS_LAG_MS,
               System.currentTimeMillis() - _minConsumingFreshnessTimeMs, TimeUnit.MILLISECONDS);
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseReduceService.java
@@ -310,6 +310,8 @@ public abstract class BaseReduceService {
       brokerResponseNative.setExplainPlanNumMatchAllFilterSegments(_explainPlanNumMatchAllFilterSegments);
       if (_numConsumingSegmentsQueried > 0) {
         brokerResponseNative.setNumConsumingSegmentsQueried(_numConsumingSegmentsQueried);
+      }
+      if (_minConsumingFreshnessTimeMs != Long.MAX_VALUE) {
         brokerResponseNative.setMinConsumingFreshnessTimeMs(_minConsumingFreshnessTimeMs);
       }
       brokerResponseNative.setNumConsumingSegmentsProcessed(_numConsumingSegmentsProcessed);


### PR DESCRIPTION
The current freshness lag metric doesn't emit a metric, when there are no
consuming segments. This won't emit lag when there are errors while consuming or
a consuming segment is not created, so calculate the lag from the endtime using
the last segment that was online as freshness.


