### PR TITLE
Pulsar throws NPE when closing consumer

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarPartitionLevelConnectionHandler.java
@@ -87,7 +87,12 @@ public class PulsarPartitionLevelConnectionHandler {
 
   public void close()
       throws IOException {
-    _reader.close();
-    _pulsarClient.close();
+    if (_reader != null) {
+      _reader.close();
+    }
+
+    if (_pulsarClient != null) {
+      _pulsarClient.close();
+    }
   }
 }


### PR DESCRIPTION
This happens when Pulsar is not able to create reader for some reason while fetching metadata and tries to close it. Adding a null check should prevent this error.