### PR TITLE
add api to check segment storage tier

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/TableTierInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/TableTierInfo.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.restlet.resources;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class TableTierInfo {
+  private final String _tableName;
+  private final Map<String, String> _segmentTiers;
+
+  @JsonCreator
+  public TableTierInfo(@JsonProperty("tableName") String tableName,
+      @JsonProperty("segmentTiers") Map<String, String> segmentTiers) {
+    _tableName = tableName;
+    _segmentTiers = segmentTiers;
+  }
+
+  public String getTableName() {
+    return _tableName;
+  }
+
+  public Map<String, String> getSegmentTiers() {
+    return _segmentTiers;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/TableTierInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/TableTierInfo.java
@@ -21,12 +21,16 @@ package org.apache.pinot.common.restlet.resources;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import java.util.Map;
 
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TableTierInfo {
+  @JsonPropertyDescription("Name of table to look for segment storage tiers")
   private final String _tableName;
+
+  @JsonPropertyDescription("Storage tiers of segments hosted on the server")
   private final Map<String, String> _segmentTiers;
 
   @JsonCreator

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/TableTierInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/TableTierInfo.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import java.util.Map;
+import java.util.Set;
 
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -33,11 +34,16 @@ public class TableTierInfo {
   @JsonPropertyDescription("Storage tiers of segments hosted on the server")
   private final Map<String, String> _segmentTiers;
 
+  @JsonPropertyDescription("Segments that's not immutable and has no storage tier")
+  private final Set<String> _mutableSegments;
+
   @JsonCreator
   public TableTierInfo(@JsonProperty("tableName") String tableName,
-      @JsonProperty("segmentTiers") Map<String, String> segmentTiers) {
+      @JsonProperty("segmentTiers") Map<String, String> segmentTiers,
+      @JsonProperty("mutableSegments") Set<String> mutableSegments) {
     _tableName = tableName;
     _segmentTiers = segmentTiers;
+    _mutableSegments = mutableSegments;
   }
 
   public String getTableName() {
@@ -46,5 +52,9 @@ public class TableTierInfo {
 
   public Map<String, String> getSegmentTiers() {
     return _segmentTiers;
+  }
+
+  public Set<String> getMutableSegments() {
+    return _mutableSegments;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -93,8 +93,8 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
  *       <li>"/segments/{tableName}/crc": get a map from segment to CRC of the segment (OFFLINE table only)</li>
  *       <li>"/segments/{tableName}/{segmentName}/metadata: get the metadata for a segment</li>
  *       <li>"/segments/{tableName}/metadata: get the metadata for all segments from the server</li>
- *       <li>"/segments/{tableName}/{segmentName}/tier": get storage tier for the segment in the table</li>
- *       <li>"/segments/{tableName}/tier": get storage tier for all segments in the table</li>
+ *       <li>"/segments/{tableName}/{segmentName}/tiers": get storage tier for the segment in the table</li>
+ *       <li>"/segments/{tableName}/tiers": get storage tier for all segments in the table</li>
  *     </ul>
  *   </li>
  *   <li>
@@ -721,33 +721,34 @@ public class PinotSegmentRestletResource {
   }
 
   @GET
-  @Path("segments/{tableName}/tier")
+  @Path("segments/{tableName}/tiers")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Get storage tier for all segments in the given table", notes = "Get storage tier for all "
       + "segments in the given table")
-  public TableTierReader.TableTierDetails getTableTier(
+  public TableTierReader.TableTierDetails getTableTiers(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
-      @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr) {
+      @ApiParam(value = "OFFLINE|REALTIME", required = true) @QueryParam("type") String tableTypeStr) {
     LOGGER.info("Received a request to get storage tier for all segments for table {}", tableName);
     return getTableTierInternal(tableName, null, tableTypeStr);
   }
 
   @GET
-  @Path("segments/{tableName}/{segmentName}/tier")
+  @Path("segments/{tableName}/{segmentName}/tiers")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Get storage tiers for the given segment", notes = "Get storage tiers for the given segment")
-  public TableTierReader.TableTierDetails getSegmentTier(
+  public TableTierReader.TableTierDetails getSegmentTiers(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "Name of the segment", required = true) @PathParam("segmentName") @Encoded String segmentName,
-      @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr) {
+      @ApiParam(value = "OFFLINE|REALTIME", required = true) @QueryParam("type") String tableTypeStr) {
     segmentName = URIUtils.decode(segmentName);
     LOGGER.info("Received a request to get storage tier for segment {} in table {}", segmentName, tableName);
     return getTableTierInternal(tableName, segmentName, tableTypeStr);
   }
 
   private TableTierReader.TableTierDetails getTableTierInternal(String tableName, @Nullable String segmentName,
-      String tableTypeStr) {
+      @Nullable String tableTypeStr) {
     TableType tableType = Constants.validateTableType(tableTypeStr);
+    Preconditions.checkNotNull(tableType, "Table type is required to get table tiers");
     String tableNameWithType =
         ResourceUtils.getExistingTableNamesWithType(_pinotHelixResourceManager, tableName, tableType, LOGGER).get(0);
     TableTierReader tableTierReader = new TableTierReader(_executor, _connectionManager, _pinotHelixResourceManager);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -725,6 +725,10 @@ public class PinotSegmentRestletResource {
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Get storage tier for all segments in the given table", notes = "Get storage tier for all "
       + "segments in the given table")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error"),
+      @ApiResponse(code = 404, message = "Table not found")
+  })
   public TableTierReader.TableTierDetails getTableTiers(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "OFFLINE|REALTIME", required = true) @QueryParam("type") String tableTypeStr) {
@@ -736,6 +740,10 @@ public class PinotSegmentRestletResource {
   @Path("segments/{tableName}/{segmentName}/tiers")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Get storage tiers for the given segment", notes = "Get storage tiers for the given segment")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error"),
+      @ApiResponse(code = 404, message = "Table or segment not found")
+  })
   public TableTierReader.TableTierDetails getSegmentTiers(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "Name of the segment", required = true) @PathParam("segmentName") @Encoded String segmentName,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -757,12 +757,13 @@ public class PinotSegmentRestletResource {
       tableTierDetails = tableTierReader.getTableTierDetails(tableNameWithType, segmentName,
           _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
     } catch (Throwable t) {
-      throw new ControllerApplicationException(LOGGER,
-          String.format("Failed to get tier info for segment: %s in table: %s", segmentName, tableName),
-          Response.Status.INTERNAL_SERVER_ERROR, t);
+      throw new ControllerApplicationException(LOGGER, String
+          .format("Failed to get tier info for segment: %s in table: %s of type: %s", segmentName, tableName,
+              tableTypeStr), Response.Status.INTERNAL_SERVER_ERROR, t);
     }
     if (segmentName != null && !tableTierDetails.getSegmentTiers().containsKey(segmentName)) {
-      throw new ControllerApplicationException(LOGGER, "Segment " + segmentName + " not found in table " + tableName,
+      throw new ControllerApplicationException(LOGGER,
+          String.format("Segment: %s is not found in table: %s of type: %s", segmentName, tableName, tableTypeStr),
           Response.Status.NOT_FOUND);
     }
     return tableTierDetails;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -756,11 +756,9 @@ public class PinotSegmentRestletResource {
       tableTierDetails = tableTierReader.getTableTierDetails(tableNameWithType, segmentName,
           _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
     } catch (Throwable t) {
-      throw new ControllerApplicationException(LOGGER, String.format("Failed to get table tier for %s", tableName),
+      throw new ControllerApplicationException(LOGGER,
+          String.format("Failed to get tier info for segment: %s in table: %s", segmentName, tableName),
           Response.Status.INTERNAL_SERVER_ERROR, t);
-    }
-    if (tableTierDetails == null) {
-      throw new ControllerApplicationException(LOGGER, "Table " + tableName + " not found", Response.Status.NOT_FOUND);
     }
     if (segmentName != null && !tableTierDetails.getSegmentTiers().containsKey(segmentName)) {
       throw new ControllerApplicationException(LOGGER, "Segment " + segmentName + " not found in table " + tableName,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerTableTierReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerTableTierReader.java
@@ -55,7 +55,7 @@ public class ServerTableTierReader {
     List<String> serverUrls = new ArrayList<>(numServers);
     BiMap<String, String> endpointsToServers = serverEndPoints.inverse();
     for (String endpoint : endpointsToServers.keySet()) {
-      String tableTierUri = endpoint + "/tables/" + tableNameWithType + "/tier";
+      String tableTierUri = endpoint + "/tables/" + tableNameWithType + "/tiers";
       serverUrls.add(tableTierUri);
     }
     CompletionServiceHelper completionServiceHelper =

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerTableTierReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerTableTierReader.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.util;
+
+import com.google.common.collect.BiMap;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import org.apache.commons.httpclient.HttpConnectionManager;
+import org.apache.pinot.common.restlet.resources.TableTierInfo;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Get the storage tier details from multi servers in parallel. Only servers returning success are returned by the
+ * method. For those returning errors (http error or otherwise), no entry is created in the return map.
+ */
+public class ServerTableTierReader {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ServerTableTierReader.class);
+
+  private final Executor _executor;
+  private final HttpConnectionManager _connectionManager;
+
+  public ServerTableTierReader(Executor executor, HttpConnectionManager connectionManager) {
+    _executor = executor;
+    _connectionManager = connectionManager;
+  }
+
+  public Map<String, TableTierInfo> getTableTierInfoFromServers(BiMap<String, String> serverEndPoints,
+      String tableNameWithType, int timeoutMs) {
+    int numServers = serverEndPoints.size();
+    LOGGER.info("Getting segment storage tiers from {} servers for table: {} with timeout: {}ms", numServers,
+        tableNameWithType, timeoutMs);
+    List<String> serverUrls = new ArrayList<>(numServers);
+    BiMap<String, String> endpointsToServers = serverEndPoints.inverse();
+    for (String endpoint : endpointsToServers.keySet()) {
+      String tableTierUri = endpoint + "/tables/" + tableNameWithType + "/tier";
+      serverUrls.add(tableTierUri);
+    }
+    CompletionServiceHelper completionServiceHelper =
+        new CompletionServiceHelper(_executor, _connectionManager, endpointsToServers);
+    CompletionServiceHelper.CompletionServiceResponse serviceResponse =
+        completionServiceHelper.doMultiGetRequest(serverUrls, tableNameWithType, false, timeoutMs);
+    Map<String, TableTierInfo> serverToTableTierInfoMap = new HashMap<>();
+    int failedParses = 0;
+    for (Map.Entry<String, String> streamResponse : serviceResponse._httpResponses.entrySet()) {
+      try {
+        TableTierInfo tableTierInfo = JsonUtils.stringToObject(streamResponse.getValue(), TableTierInfo.class);
+        serverToTableTierInfoMap.put(streamResponse.getKey(), tableTierInfo);
+      } catch (IOException e) {
+        failedParses++;
+        LOGGER.error("Failed to parse server {} response", streamResponse.getKey(), e);
+      }
+    }
+    if (failedParses != 0) {
+      LOGGER.warn("Failed to parse {} / {} TableTierInfo responses from servers.", failedParses, serverUrls.size());
+    }
+    return serverToTableTierInfoMap;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableTierReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableTierReader.java
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.util;
+
+import com.google.common.collect.BiMap;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import javax.annotation.Nullable;
+import org.apache.commons.httpclient.HttpConnectionManager;
+import org.apache.pinot.common.exception.InvalidConfigException;
+import org.apache.pinot.common.restlet.resources.TableTierInfo;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+
+
+/**
+ * Reads segment storage tiers from servers for the given table.
+ */
+public class TableTierReader {
+  private final Executor _executor;
+  private final HttpConnectionManager _connectionManager;
+  private final PinotHelixResourceManager _helixResourceManager;
+
+  public TableTierReader(Executor executor, HttpConnectionManager connectionManager,
+      PinotHelixResourceManager helixResourceManager) {
+    _executor = executor;
+    _connectionManager = connectionManager;
+    _helixResourceManager = helixResourceManager;
+  }
+
+  /**
+   * Get the segment storage tiers for the given table. The servers or segments not responding the request are
+   * recorded in the result to be checked by caller.
+   *
+   * @param tableNameWithType table name with type
+   * @param timeoutMs timeout for reading segment tiers from servers
+   * @return details of segment storage tiers for the given table
+   */
+  public TableTierDetails getTableTierDetails(String tableNameWithType, @Nullable String segmentName, int timeoutMs)
+      throws InvalidConfigException {
+    Map<String, List<String>> serverToSegmentsMap = new HashMap<>();
+    if (segmentName == null) {
+      serverToSegmentsMap.putAll(_helixResourceManager.getServerToSegmentsMap(tableNameWithType));
+    } else {
+      List<String> segmentInList = Collections.singletonList(segmentName);
+      for (String server : _helixResourceManager.getServers(tableNameWithType, segmentName)) {
+        serverToSegmentsMap.put(server, segmentInList);
+      }
+    }
+    BiMap<String, String> endpoints = _helixResourceManager.getDataInstanceAdminEndpoints(serverToSegmentsMap.keySet());
+    ServerTableTierReader serverTableTierReader = new ServerTableTierReader(_executor, _connectionManager);
+    Map<String, TableTierInfo> serverToTableTierInfoMap =
+        serverTableTierReader.getTableTierInfoFromServers(endpoints, tableNameWithType, timeoutMs);
+
+    TableTierDetails tableTierDetails = new TableTierDetails(tableNameWithType);
+    for (Map.Entry<String, List<String>> entry : serverToSegmentsMap.entrySet()) {
+      String server = entry.getKey();
+      TableTierInfo tableTierInfo = serverToTableTierInfoMap.get(server);
+      if (tableTierInfo == null) {
+        tableTierDetails._missingServers.add(server);
+        continue;
+      }
+      Map<String, String> segmentTiers = tableTierInfo.getSegmentTiers();
+      for (String expectedSegment : entry.getValue()) {
+        if (!segmentTiers.containsKey(expectedSegment)) {
+          tableTierDetails._missingSegments.computeIfAbsent(server, (k) -> new HashSet<>()).add(expectedSegment);
+        } else {
+          tableTierDetails._segmentTiers.computeIfAbsent(expectedSegment, (k) -> new HashMap<>())
+              .put(server, segmentTiers.get(expectedSegment));
+        }
+      }
+    }
+    return tableTierDetails;
+  }
+
+  // This class aggregates the TableTierInfo returned from multi servers.
+  public static class TableTierDetails {
+    private final String _tableName;
+    private final Set<String> _missingServers = new HashSet<>();
+    private final Map<String/*server*/, Set<String>/*segments*/> _missingSegments = new HashMap<>();
+    private final Map<String/*segment*/, Map<String/*server*/, String/*tier*/>> _segmentTiers = new HashMap<>();
+
+    TableTierDetails(String tableName) {
+      _tableName = tableName;
+    }
+
+    public String getTableName() {
+      return _tableName;
+    }
+
+    public Map<String, Map<String, String>> getSegmentTiers() {
+      return _segmentTiers;
+    }
+
+    public Map<String, Set<String>> getMissingSegments() {
+      return _missingSegments;
+    }
+
+    public Set<String> getMissingServers() {
+      return _missingServers;
+    }
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableTierReaderTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableTierReaderTest.java
@@ -1,0 +1,259 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.sun.net.httpserver.HttpHandler;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import org.apache.commons.httpclient.HttpConnectionManager;
+import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
+import org.apache.pinot.common.exception.InvalidConfigException;
+import org.apache.pinot.common.restlet.resources.TableTierInfo;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.util.TableTierReader;
+import org.apache.pinot.controller.utils.FakeHttpServer;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.mockito.ArgumentMatchers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class TableTierReaderTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TableTierReaderTest.class);
+  private static final String URI_PATH = "/tables/";
+  private static final int TIMEOUT_MSEC = 3000;
+  private static final int EXTENDED_TIMEOUT_FACTOR = 100;
+
+  private final Executor _executor = Executors.newFixedThreadPool(1);
+  private final HttpConnectionManager _connectionManager = new MultiThreadedHttpConnectionManager();
+  private final Map<String, FakeSizeServer> _serverMap = new HashMap<>();
+  private PinotHelixResourceManager _helix;
+
+  @BeforeClass
+  public void setUp()
+      throws IOException {
+    _helix = mock(PinotHelixResourceManager.class);
+
+    int counter = 0;
+    // server0 - all good
+    Map<String, String> segTierMap = new HashMap<>();
+    segTierMap.put("seg01", null);
+    segTierMap.put("seg02", "someTier");
+    FakeSizeServer s = new FakeSizeServer(segTierMap);
+    s.start(URI_PATH, createHandler(200, s._segTierMap, 0));
+    _serverMap.put(serverName(counter), s);
+    counter++;
+
+    // server1 - all good
+    s = new FakeSizeServer(Collections.singletonMap("seg01", null));
+    s.start(URI_PATH, createHandler(200, s._segTierMap, 0));
+    _serverMap.put(serverName(counter), s);
+    counter++;
+
+    // server2 - always 404
+    s = new FakeSizeServer(Collections.singletonMap("seg02", "someTier"));
+    s.start(URI_PATH, createHandler(404, s._segTierMap, 0));
+    _serverMap.put(serverName(counter), s);
+    counter++;
+
+    // server3 - empty server
+    s = new FakeSizeServer(Collections.emptyMap());
+    s.start(URI_PATH, createHandler(200, s._segTierMap, 0));
+    _serverMap.put(serverName(counter), s);
+    counter++;
+
+    // server4 - missing seg03
+    segTierMap = new HashMap<>();
+    segTierMap.put("seg02", "someTier");
+    segTierMap.put("seg03", "someTier");
+    s = new FakeSizeServer(segTierMap);
+    segTierMap = new HashMap<>(segTierMap);
+    segTierMap.remove("seg03");
+    s.start(URI_PATH, createHandler(200, segTierMap, 0));
+    _serverMap.put(serverName(counter), s);
+    counter++;
+
+    // server5 ... timing out server
+    s = new FakeSizeServer(Collections.singletonMap("seg05", "someTier"));
+    s.start(URI_PATH, createHandler(200, s._segTierMap, TIMEOUT_MSEC * EXTENDED_TIMEOUT_FACTOR));
+    _serverMap.put(serverName(counter), s);
+  }
+
+  @AfterClass
+  public void tearDown() {
+    for (Map.Entry<String, FakeSizeServer> fakeServerEntry : _serverMap.entrySet()) {
+      fakeServerEntry.getValue().stop();
+    }
+  }
+
+  private HttpHandler createHandler(int status, Map<String, String> segTierMap, int sleepTimeMs) {
+    return httpExchange -> {
+      if (sleepTimeMs > 0) {
+        try {
+          Thread.sleep(sleepTimeMs);
+        } catch (InterruptedException e) {
+          LOGGER.info("Handler interrupted during sleep");
+        }
+      }
+      TableTierInfo tableInfo = new TableTierInfo("myTable", segTierMap);
+      String json = JsonUtils.objectToString(tableInfo);
+      httpExchange.sendResponseHeaders(status, json.length());
+      OutputStream responseBody = httpExchange.getResponseBody();
+      responseBody.write(json.getBytes());
+      responseBody.close();
+    };
+  }
+
+  private String serverName(int index) {
+    return "server" + index;
+  }
+
+  private static class FakeSizeServer extends FakeHttpServer {
+    Map<String, String> _segTierMap;
+
+    FakeSizeServer(Map<String, String> segTierMap) {
+      _segTierMap = segTierMap;
+    }
+  }
+
+  private Map<String, List<String>> subsetOfServerSegments(String... servers) {
+    Map<String, List<String>> subset = new HashMap<>();
+    for (String server : servers) {
+      subset.put(server, new ArrayList<>(_serverMap.get(server)._segTierMap.keySet()));
+    }
+    return subset;
+  }
+
+  private BiMap<String, String> serverEndpoints(String... servers) {
+    BiMap<String, String> endpoints = HashBiMap.create(servers.length);
+    for (String server : servers) {
+      endpoints.put(server, _serverMap.get(server)._endpoint);
+    }
+    return endpoints;
+  }
+
+  private TableTierReader.TableTierDetails testRunner(final String[] servers, String tableName, String segmentName)
+      throws InvalidConfigException {
+    when(_helix.getServerToSegmentsMap(ArgumentMatchers.anyString()))
+        .thenAnswer(invocationOnMock -> subsetOfServerSegments(servers));
+    if (segmentName != null) {
+      when(_helix.getServers(ArgumentMatchers.anyString(), ArgumentMatchers.anyString()))
+          .thenAnswer(invocationOnMock -> new HashSet<>(Arrays.asList(servers)));
+    }
+    when(_helix.getDataInstanceAdminEndpoints(ArgumentMatchers.<String>anySet()))
+        .thenAnswer(invocationOnMock -> serverEndpoints(servers));
+    TableTierReader reader = new TableTierReader(_executor, _connectionManager, _helix);
+    return reader.getTableTierDetails(tableName, segmentName, TIMEOUT_MSEC);
+  }
+
+  @Test
+  public void testGetTableTierInfoAllSuccess()
+      throws InvalidConfigException {
+    final String[] servers = {"server0", "server1"};
+    TableTierReader.TableTierDetails tableTierDetails = testRunner(servers, "myTable_OFFLINE", null);
+    assertTrue(tableTierDetails.getMissingServers().isEmpty());
+    assertTrue(tableTierDetails.getMissingSegments().isEmpty());
+
+    assertEquals(tableTierDetails.getSegmentTiers().size(), 2);
+    Map<String, String> tiersByServer = tableTierDetails.getSegmentTiers().get("seg01");
+    assertEquals(tiersByServer.size(), 2);
+    assertNull(tiersByServer.get("server0"));
+    assertNull(tiersByServer.get("server1"));
+    tiersByServer = tableTierDetails.getSegmentTiers().get("seg02");
+    assertEquals(tiersByServer.size(), 1);
+    assertEquals(tiersByServer.get("server0"), "someTier");
+  }
+
+  @Test
+  public void testGetTableTierInfoAllErrors()
+      throws InvalidConfigException {
+    String[] servers = {"server2", "server5"};
+    TableTierReader.TableTierDetails tableTierDetails = testRunner(servers, "myTable_OFFLINE", null);
+    assertEquals(tableTierDetails.getMissingServers().size(), 2);
+    assertTrue(tableTierDetails.getMissingServers().contains("server2"));
+    assertTrue(tableTierDetails.getMissingServers().contains("server5"));
+    assertTrue(tableTierDetails.getSegmentTiers().isEmpty());
+    assertTrue(tableTierDetails.getMissingSegments().isEmpty());
+  }
+
+  @Test
+  public void testGetTableTierInfoFromAllServers()
+      throws InvalidConfigException {
+    final String[] servers = {"server0", "server1", "server2", "server3", "server4", "server5"};
+    TableTierReader.TableTierDetails tableTierDetails = testRunner(servers, "myTable_OFFLINE", null);
+
+    assertEquals(tableTierDetails.getMissingServers().size(), 2);
+    assertTrue(tableTierDetails.getMissingServers().contains("server2"));
+    assertTrue(tableTierDetails.getMissingServers().contains("server5"));
+
+    assertEquals(tableTierDetails.getMissingSegments().size(), 1);
+    assertTrue(tableTierDetails.getMissingSegments().get("server4").contains("seg03"));
+
+    assertEquals(tableTierDetails.getSegmentTiers().size(), 2);
+    Map<String, String> tiersByServer = tableTierDetails.getSegmentTiers().get("seg01");
+    assertEquals(tiersByServer.size(), 2);
+    assertNull(tiersByServer.get("server0"));
+    assertNull(tiersByServer.get("server1"));
+    tiersByServer = tableTierDetails.getSegmentTiers().get("seg02");
+    assertEquals(tiersByServer.size(), 2);
+    assertEquals(tiersByServer.get("server0"), "someTier");
+    assertEquals(tiersByServer.get("server4"), "someTier");
+  }
+
+  @Test
+  public void testGetSegmentTierInfoFromAllServers()
+      throws InvalidConfigException {
+    final String[] servers = {"server0", "server1", "server2", "server3", "server4", "server5"};
+    TableTierReader.TableTierDetails tableTierDetails = testRunner(servers, "myTable_OFFLINE", "seg01");
+
+    assertEquals(tableTierDetails.getMissingServers().size(), 2);
+    assertTrue(tableTierDetails.getMissingServers().contains("server2"));
+    assertTrue(tableTierDetails.getMissingServers().contains("server5"));
+
+    assertEquals(tableTierDetails.getMissingSegments().size(), 2);
+    assertTrue(tableTierDetails.getMissingSegments().get("server3").contains("seg01"));
+    assertTrue(tableTierDetails.getMissingSegments().get("server4").contains("seg01"));
+
+    assertEquals(tableTierDetails.getSegmentTiers().size(), 1);
+    Map<String, String> tiersByServer = tableTierDetails.getSegmentTiers().get("seg01");
+    assertEquals(tiersByServer.size(), 2);
+    assertNull(tiersByServer.get("server0"));
+    assertNull(tiersByServer.get("server1"));
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableTierReaderTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableTierReaderTest.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import org.apache.commons.httpclient.HttpConnectionManager;
@@ -55,7 +56,8 @@ import static org.testng.Assert.assertNull;
 
 public class TableTierReaderTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(TableTierReaderTest.class);
-  private static final String URI_PATH = "/tables/";
+  private static final String URI_PATH_TABLE_TIERS = "/tables/";
+  private static final String URI_PATH_SEGMENT_TIERS = "/segments/";
   private static final int TIMEOUT_MSEC = 3000;
   private static final int EXTENDED_TIMEOUT_FACTOR = 100;
 
@@ -70,30 +72,33 @@ public class TableTierReaderTest {
     _helix = mock(PinotHelixResourceManager.class);
 
     int counter = 0;
+
+    // following servers are configured to get table tiers
     // server0 - all good
     Map<String, String> segTierMap = new HashMap<>();
     segTierMap.put("seg01", null);
     segTierMap.put("seg02", "someTier");
-    FakeSizeServer s = new FakeSizeServer(segTierMap);
-    s.start(URI_PATH, createHandler(200, s._segTierMap, 0));
+    Set<String> muSegs = Collections.singleton("muSeg01");
+    FakeSizeServer s = new FakeSizeServer(segTierMap, muSegs);
+    s.start(URI_PATH_TABLE_TIERS, createHandler(200, s._segTierMap, muSegs, 0));
     _serverMap.put(serverName(counter), s);
     counter++;
 
     // server1 - all good
     s = new FakeSizeServer(Collections.singletonMap("seg01", null));
-    s.start(URI_PATH, createHandler(200, s._segTierMap, 0));
+    s.start(URI_PATH_TABLE_TIERS, createHandler(200, s._segTierMap, Collections.emptySet(), 0));
     _serverMap.put(serverName(counter), s);
     counter++;
 
     // server2 - always 404
     s = new FakeSizeServer(Collections.singletonMap("seg02", "someTier"));
-    s.start(URI_PATH, createHandler(404, s._segTierMap, 0));
+    s.start(URI_PATH_TABLE_TIERS, createHandler(404, s._segTierMap, Collections.emptySet(), 0));
     _serverMap.put(serverName(counter), s);
     counter++;
 
     // server3 - empty server
     s = new FakeSizeServer(Collections.emptyMap());
-    s.start(URI_PATH, createHandler(200, s._segTierMap, 0));
+    s.start(URI_PATH_TABLE_TIERS, createHandler(200, s._segTierMap, Collections.emptySet(), 0));
     _serverMap.put(serverName(counter), s);
     counter++;
 
@@ -104,14 +109,47 @@ public class TableTierReaderTest {
     s = new FakeSizeServer(segTierMap);
     segTierMap = new HashMap<>(segTierMap);
     segTierMap.remove("seg03");
-    s.start(URI_PATH, createHandler(200, segTierMap, 0));
+    s.start(URI_PATH_TABLE_TIERS, createHandler(200, segTierMap, Collections.emptySet(), 0));
     _serverMap.put(serverName(counter), s);
     counter++;
 
-    // server5 ... timing out server
+    // server5 - timing out server
     s = new FakeSizeServer(Collections.singletonMap("seg04", "someTier"));
-    s.start(URI_PATH, createHandler(200, s._segTierMap, TIMEOUT_MSEC * EXTENDED_TIMEOUT_FACTOR));
+    s.start(URI_PATH_TABLE_TIERS,
+        createHandler(200, s._segTierMap, Collections.emptySet(), TIMEOUT_MSEC * EXTENDED_TIMEOUT_FACTOR));
     _serverMap.put(serverName(counter), s);
+    counter++;
+
+    // following servers are configured to get segment tiers
+    // server6 - all good for segX
+    segTierMap = new HashMap<>();
+    segTierMap.put("segX", "someTier");
+    muSegs = Collections.singleton("segY");
+    s = new FakeSizeServer(segTierMap, muSegs);
+    s.start(URI_PATH_SEGMENT_TIERS, createHandler(200, s._segTierMap, muSegs, 0));
+    _serverMap.put(serverName(counter), s);
+    counter++;
+
+    // server7 - missing segX
+    s = new FakeSizeServer(segTierMap);
+    segTierMap = new HashMap<>(segTierMap);
+    segTierMap.remove("segX");
+    s.start(URI_PATH_SEGMENT_TIERS, createHandler(200, segTierMap, Collections.emptySet(), 0));
+    _serverMap.put(serverName(counter), s);
+    counter++;
+
+    // server8 - 404
+    s = new FakeSizeServer(Collections.singletonMap("segX", null));
+    s.start(URI_PATH_TABLE_TIERS, createHandler(404, s._segTierMap, Collections.emptySet(), 0));
+    _serverMap.put(serverName(counter), s);
+    counter++;
+
+    // server9 - timing out
+    s = new FakeSizeServer(Collections.singletonMap("segX", null));
+    s.start(URI_PATH_TABLE_TIERS,
+        createHandler(200, s._segTierMap, Collections.emptySet(), TIMEOUT_MSEC * EXTENDED_TIMEOUT_FACTOR));
+    _serverMap.put(serverName(counter), s);
+    counter++;
   }
 
   @AfterClass
@@ -121,7 +159,8 @@ public class TableTierReaderTest {
     }
   }
 
-  private HttpHandler createHandler(int status, Map<String, String> segTierMap, int sleepTimeMs) {
+  private HttpHandler createHandler(int status, Map<String, String> segTierMap, Set<String> mutableSegments,
+      int sleepTimeMs) {
     return httpExchange -> {
       if (sleepTimeMs > 0) {
         try {
@@ -130,7 +169,7 @@ public class TableTierReaderTest {
           LOGGER.info("Handler interrupted during sleep");
         }
       }
-      TableTierInfo tableInfo = new TableTierInfo("myTable", segTierMap);
+      TableTierInfo tableInfo = new TableTierInfo("myTable", segTierMap, mutableSegments);
       String json = JsonUtils.objectToString(tableInfo);
       httpExchange.sendResponseHeaders(status, json.length());
       OutputStream responseBody = httpExchange.getResponseBody();
@@ -144,17 +183,26 @@ public class TableTierReaderTest {
   }
 
   private static class FakeSizeServer extends FakeHttpServer {
+    Set<String> _mutableSegments;
     Map<String, String> _segTierMap;
 
     FakeSizeServer(Map<String, String> segTierMap) {
+      this(segTierMap, Collections.emptySet());
+    }
+
+    FakeSizeServer(Map<String, String> segTierMap, Set<String> mutableSegments) {
       _segTierMap = segTierMap;
+      _mutableSegments = mutableSegments;
     }
   }
 
   private Map<String, List<String>> subsetOfServerSegments(String... servers) {
     Map<String, List<String>> subset = new HashMap<>();
     for (String server : servers) {
-      subset.put(server, new ArrayList<>(_serverMap.get(server)._segTierMap.keySet()));
+      FakeSizeServer fakeSvr = _serverMap.get(server);
+      ArrayList<String> segmentsOnServer = new ArrayList<>(fakeSvr._segTierMap.keySet());
+      segmentsOnServer.addAll(fakeSvr._mutableSegments);
+      subset.put(server, segmentsOnServer);
     }
     return subset;
   }
@@ -186,7 +234,7 @@ public class TableTierReaderTest {
       throws InvalidConfigException {
     final String[] servers = {"server0", "server1"};
     TableTierReader.TableTierDetails tableTierDetails = testRunner(servers, "myTable_OFFLINE", null);
-    assertEquals(tableTierDetails.getSegmentTiers().size(), 2);
+    assertEquals(tableTierDetails.getSegmentTiers().size(), 3);
     Map<String, String> tiersByServer = tableTierDetails.getSegmentTiers().get("seg01");
     assertEquals(tiersByServer.size(), 2);
     assertNull(tiersByServer.get("server0"));
@@ -194,6 +242,9 @@ public class TableTierReaderTest {
     tiersByServer = tableTierDetails.getSegmentTiers().get("seg02");
     assertEquals(tiersByServer.size(), 1);
     assertEquals(tiersByServer.get("server0"), "someTier");
+    tiersByServer = tableTierDetails.getSegmentTiers().get("muSeg01");
+    assertEquals(tiersByServer.size(), 1);
+    assertEquals(tiersByServer.get("server0"), "NOT_IMMUTABLE_SEGMENT");
   }
 
   @Test
@@ -216,7 +267,7 @@ public class TableTierReaderTest {
     final String[] servers = {"server0", "server1", "server2", "server3", "server4", "server5"};
     TableTierReader.TableTierDetails tableTierDetails = testRunner(servers, "myTable_OFFLINE", null);
 
-    assertEquals(tableTierDetails.getSegmentTiers().size(), 4);
+    assertEquals(tableTierDetails.getSegmentTiers().size(), 5);
     Map<String, String> tiersByServer = tableTierDetails.getSegmentTiers().get("seg01");
     assertEquals(tiersByServer.size(), 2);
     assertNull(tiersByServer.get("server0"));
@@ -235,22 +286,26 @@ public class TableTierReaderTest {
     tiersByServer = tableTierDetails.getSegmentTiers().get("seg04");
     assertEquals(tiersByServer.size(), 1);
     assertEquals(tiersByServer.get("server5"), "NO_RESPONSE_FROM_SERVER");
+
+    tiersByServer = tableTierDetails.getSegmentTiers().get("muSeg01");
+    assertEquals(tiersByServer.size(), 1);
+    assertEquals(tiersByServer.get("server0"), "NOT_IMMUTABLE_SEGMENT");
   }
 
   @Test
   public void testGetSegmentTierInfoFromAllServers()
       throws InvalidConfigException {
-    final String[] servers = {"server0", "server1", "server2", "server3", "server4", "server5"};
-    TableTierReader.TableTierDetails tableTierDetails = testRunner(servers, "myTable_OFFLINE", "seg01");
-
+    final String[] servers = {"server6", "server7", "server8", "server9"};
+    TableTierReader.TableTierDetails tableTierDetails = testRunner(servers, "myTable_OFFLINE", "segX");
     assertEquals(tableTierDetails.getSegmentTiers().size(), 1);
-    Map<String, String> tiersByServer = tableTierDetails.getSegmentTiers().get("seg01");
-    assertEquals(tiersByServer.size(), 6);
-    assertNull(tiersByServer.get("server0"));
-    assertNull(tiersByServer.get("server1"));
-    assertEquals(tiersByServer.get("server2"), "NO_RESPONSE_FROM_SERVER");
-    assertEquals(tiersByServer.get("server3"), "SEGMENT_MISSED_ON_SERVER");
-    assertEquals(tiersByServer.get("server4"), "SEGMENT_MISSED_ON_SERVER");
-    assertEquals(tiersByServer.get("server5"), "NO_RESPONSE_FROM_SERVER");
+    Map<String, String> tiersByServer = tableTierDetails.getSegmentTiers().get("segX");
+    assertEquals(tiersByServer.size(), 4);
+    assertEquals(tiersByServer.get("server6"), "someTier");
+    assertEquals(tiersByServer.get("server7"), "SEGMENT_MISSED_ON_SERVER");
+    assertEquals(tiersByServer.get("server8"), "NO_RESPONSE_FROM_SERVER");
+    assertEquals(tiersByServer.get("server9"), "NO_RESPONSE_FROM_SERVER");
+    // Check a mutable segment segY.
+    tableTierDetails = testRunner(new String[]{"server6"}, "myTable_OFFLINE", "segY");
+    assertEquals(tableTierDetails.getSegmentTiers().get("segY").get("server6"), "NOT_IMMUTABLE_SEGMENT");
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableTierResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableTierResource.java
@@ -54,7 +54,7 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
 
 
 /**
- * API to get the storage tiers of immutable segments of the given table.
+ * A server-side API to get the storage tiers of immutable segments of the given table from the server being requested.
  */
 @Api(tags = "Table", authorizations = {@Authorization(value = SWAGGER_AUTHORIZATION_KEY)})
 @SwaggerDefinition(securityDefinition = @SecurityDefinition(apiKeyAuthDefinitions = @ApiKeyAuthDefinition(name =

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableTierResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableTierResource.java
@@ -67,14 +67,14 @@ public class TableTierResource {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
-  @Path("/tables/{tableName}/tier")
+  @Path("/tables/{tableName}/tiers")
   @ApiOperation(value = "Get storage tiers of immutable segments of the given table", notes = "Get storage tiers of "
       + "immutable segments of the given table")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error"),
       @ApiResponse(code = 404, message = "Table not found")
   })
-  public String getTableTier(
+  public String getTableTiers(
       @ApiParam(value = "Table Name with type", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "Provide detailed information") @DefaultValue("true") @QueryParam("detailed") boolean detailed)
       throws WebApplicationException {

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableTierResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableTierResource.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.api.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiKeyAuthDefinition;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.SecurityDefinition;
+import io.swagger.annotations.SwaggerDefinition;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.inject.Inject;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.pinot.common.restlet.resources.ResourceUtils;
+import org.apache.pinot.common.restlet.resources.TableTierInfo;
+import org.apache.pinot.core.data.manager.InstanceDataManager;
+import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
+import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
+import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.server.starter.ServerInstance;
+
+import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
+
+
+/**
+ * API to get the storage tiers of immutable segments of the given table.
+ */
+@Api(tags = "Table", authorizations = {@Authorization(value = SWAGGER_AUTHORIZATION_KEY)})
+@SwaggerDefinition(securityDefinition = @SecurityDefinition(apiKeyAuthDefinitions = @ApiKeyAuthDefinition(name =
+    HttpHeaders.AUTHORIZATION, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER, key = SWAGGER_AUTHORIZATION_KEY)))
+@Path("/")
+public class TableTierResource {
+
+  @Inject
+  private ServerInstance _serverInstance;
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/tables/{tableName}/tier")
+  @ApiOperation(value = "Get storage tiers of immutable segments of the given table", notes = "Get storage tiers of "
+      + "immutable segments of the given table")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error"),
+      @ApiResponse(code = 404, message = "Table not found")
+  })
+  public String getTableTier(
+      @ApiParam(value = "Table Name with type", required = true) @PathParam("tableName") String tableName,
+      @ApiParam(value = "Provide detailed information") @DefaultValue("true") @QueryParam("detailed") boolean detailed)
+      throws WebApplicationException {
+    InstanceDataManager instanceDataManager = _serverInstance.getInstanceDataManager();
+    if (instanceDataManager == null) {
+      throw new WebApplicationException("Invalid server initialization", Response.Status.INTERNAL_SERVER_ERROR);
+    }
+    TableDataManager tableDataManager = instanceDataManager.getTableDataManager(tableName);
+    if (tableDataManager == null) {
+      throw new WebApplicationException("Table: " + tableName + " is not found", Response.Status.NOT_FOUND);
+    }
+    Map<String, String> segmentTiers = new HashMap<>();
+    List<SegmentDataManager> segmentDataManagers = tableDataManager.acquireAllSegments();
+    try {
+      for (SegmentDataManager segmentDataManager : segmentDataManagers) {
+        if (segmentDataManager instanceof ImmutableSegmentDataManager) {
+          ImmutableSegment immutableSegment = (ImmutableSegment) segmentDataManager.getSegment();
+          segmentTiers.put(immutableSegment.getSegmentName(), immutableSegment.getTier());
+        }
+      }
+    } finally {
+      for (SegmentDataManager segmentDataManager : segmentDataManagers) {
+        tableDataManager.releaseSegment(segmentDataManager);
+      }
+    }
+    TableTierInfo tableTierInfo = new TableTierInfo(tableDataManager.getTableName(), segmentTiers);
+    return ResourceUtils.convertToJsonString(tableTierInfo);
+  }
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableTierResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableTierResource.java
@@ -69,23 +69,23 @@ public class TableTierResource {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
-  @Path("/tables/{tableName}/tiers")
+  @Path("/tables/{tableNameWithType}/tiers")
   @ApiOperation(value = "Get storage tiers of immutable segments of the given table", notes = "Get storage tiers of "
       + "immutable segments of the given table")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error"),
       @ApiResponse(code = 404, message = "Table not found")
   })
-  public String getTableTiers(
-      @ApiParam(value = "Table name with type", required = true) @PathParam("tableName") String tableName)
+  public String getTableTiers(@ApiParam(value = "Table name with type", required = true) @PathParam("tableNameWithType")
+      String tableNameWithType)
       throws WebApplicationException {
     InstanceDataManager instanceDataManager = _serverInstance.getInstanceDataManager();
     if (instanceDataManager == null) {
       throw new WebApplicationException("Invalid server initialization", Response.Status.INTERNAL_SERVER_ERROR);
     }
-    TableDataManager tableDataManager = instanceDataManager.getTableDataManager(tableName);
+    TableDataManager tableDataManager = instanceDataManager.getTableDataManager(tableNameWithType);
     if (tableDataManager == null) {
-      throw new WebApplicationException("Table: " + tableName + " is not found", Response.Status.NOT_FOUND);
+      throw new WebApplicationException("Table: " + tableNameWithType + " is not found", Response.Status.NOT_FOUND);
     }
     Set<String> mutableSegments = new HashSet<>();
     Map<String, String> segmentTiers = new HashMap<>();
@@ -110,7 +110,7 @@ public class TableTierResource {
 
   @GET
   @Produces(MediaType.APPLICATION_JSON)
-  @Path("/segments/{tableName}/{segmentName}/tiers")
+  @Path("/segments/{tableNameWithType}/{segmentName}/tiers")
   @ApiOperation(value = "Get storage tiers of the immutable segment of the given table", notes = "Get storage tiers "
       + "of the immutable segment of the given table")
   @ApiResponses(value = {
@@ -118,7 +118,8 @@ public class TableTierResource {
       @ApiResponse(code = 404, message = "Table or segment not found")
   })
   public String getTableSegmentTiers(
-      @ApiParam(value = "Table name with type", required = true) @PathParam("tableName") String tableName,
+      @ApiParam(value = "Table name with type", required = true) @PathParam("tableNameWithType")
+          String tableNameWithType,
       @ApiParam(value = "Name of the segment", required = true) @PathParam("segmentName") @Encoded String segmentName)
       throws WebApplicationException {
     segmentName = URIUtils.decode(segmentName);
@@ -126,13 +127,15 @@ public class TableTierResource {
     if (instanceDataManager == null) {
       throw new WebApplicationException("Invalid server initialization", Response.Status.INTERNAL_SERVER_ERROR);
     }
-    TableDataManager tableDataManager = instanceDataManager.getTableDataManager(tableName);
+    TableDataManager tableDataManager = instanceDataManager.getTableDataManager(tableNameWithType);
     if (tableDataManager == null) {
-      throw new WebApplicationException(String.format("Table: %s is not found", tableName), Response.Status.NOT_FOUND);
+      throw new WebApplicationException(String.format("Table: %s is not found", tableNameWithType),
+          Response.Status.NOT_FOUND);
     }
     SegmentDataManager segmentDataManager = tableDataManager.acquireSegment(segmentName);
     if (segmentDataManager == null) {
-      throw new WebApplicationException(String.format("Segment: %s is not found in table: %s", segmentName, tableName),
+      throw new WebApplicationException(
+          String.format("Segment: %s is not found in table: %s", segmentName, tableNameWithType),
           Response.Status.NOT_FOUND);
     }
     Set<String> mutableSegments = new HashSet<>();

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TableTierResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TableTierResourceTest.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.api;
+
+import java.util.Collections;
+import javax.ws.rs.core.Response;
+import org.apache.pinot.common.restlet.resources.TableTierInfo;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class TableTierResourceTest extends BaseResourceTest {
+  @Test
+  public void testTableNotFound() {
+    Response response = _webTarget.path("tables/unknownTable/tier").request().get(Response.class);
+    assertEquals(response.getStatus(), Response.Status.NOT_FOUND.getStatusCode());
+  }
+
+  @Test
+  public void testTableTierInfo() {
+    verifyTableTierInfo(TableNameBuilder.REALTIME.tableNameWithType(TABLE_NAME), _realtimeIndexSegments.get(0));
+    verifyTableTierInfo(TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME), _offlineIndexSegments.get(0));
+  }
+
+  private void verifyTableTierInfo(String expectedTableName, ImmutableSegment segment) {
+    String path = "/tables/" + expectedTableName + "/tier";
+    TableTierInfo tableTierInfo = _webTarget.path(path).request().get(TableTierInfo.class);
+    assertEquals(tableTierInfo.getTableName(), expectedTableName);
+    assertEquals(tableTierInfo.getSegmentTiers().size(), 1);
+    assertEquals(tableTierInfo.getSegmentTiers(),
+        Collections.singletonMap(segment.getSegmentName(), segment.getTier()));
+  }
+}

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TableTierResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TableTierResourceTest.java
@@ -31,7 +31,7 @@ import static org.testng.Assert.assertEquals;
 public class TableTierResourceTest extends BaseResourceTest {
   @Test
   public void testTableNotFound() {
-    Response response = _webTarget.path("tables/unknownTable/tier").request().get(Response.class);
+    Response response = _webTarget.path("tables/unknownTable/tiers").request().get(Response.class);
     assertEquals(response.getStatus(), Response.Status.NOT_FOUND.getStatusCode());
   }
 
@@ -42,7 +42,7 @@ public class TableTierResourceTest extends BaseResourceTest {
   }
 
   private void verifyTableTierInfo(String expectedTableName, ImmutableSegment segment) {
-    String path = "/tables/" + expectedTableName + "/tier";
+    String path = "/tables/" + expectedTableName + "/tiers";
     TableTierInfo tableTierInfo = _webTarget.path(path).request().get(TableTierInfo.class);
     assertEquals(tableTierInfo.getTableName(), expectedTableName);
     assertEquals(tableTierInfo.getSegmentTiers().size(), 1);


### PR DESCRIPTION
This PR adds two APIs to check immutable segment's current storage tier from servers. It's like how table size is calculated, reusing the multget util to get tier info from servers in parallel. 

## Release notes
Two new APIs to check immutable segment's storage tier.
1. /segments/{tableName}/{segmentName}/tier
2. /segments/{tableName}/tier