### PR TITLE
Shade org.apache.avro package for pinot plugins

### DIFF
--- a/pinot-distribution/pom.xml
+++ b/pinot-distribution/pom.xml
@@ -197,7 +197,7 @@
                 </relocation>
                 <relocation>
                   <pattern>org.apache.commons</pattern>
-                  <shadedPattern>shaded.org.apache.commons</shadedPattern>
+                  <shadedPattern>${shade.prefix}.org.apache.commons</shadedPattern>
                 </relocation>
               </relocations>
             </configuration>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -144,7 +144,11 @@
                     </relocation>
                     <relocation>
                       <pattern>org.apache.commons</pattern>
-                      <shadedPattern>shaded.org.apache.commons</shadedPattern>
+                      <shadedPattern>${shade.prefix}.org.apache.commons</shadedPattern>
+                    </relocation>
+                    <relocation>
+                      <pattern>org.apache.avro</pattern>
+                      <shadedPattern>${shade.prefix}.org.apache.avro</shadedPattern>
                     </relocation>
                   </relocations>
                 </configuration>


### PR DESCRIPTION
E.g. `pinot-parquet` has a dependency on Avro libs, so need to shade `org.apache.avro` package.
