### PR TITLE
Add support for querying noDict MV columns for offline (all data types) and realtime (fixed width) segments

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/evaluators/DefaultJsonPathEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/evaluators/DefaultJsonPathEvaluator.java
@@ -90,7 +90,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
@@ -123,7 +123,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
@@ -156,7 +156,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
@@ -189,7 +189,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
@@ -223,7 +223,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
@@ -256,7 +256,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
@@ -288,7 +288,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
@@ -320,7 +320,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
@@ -352,7 +352,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
@@ -384,7 +384,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
@@ -416,7 +416,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
@@ -39,27 +39,32 @@ public final class MVScanDocIdIterator implements ScanBasedDocIdIterator {
   // TODO: Figure out a way to close the reader context
   private final ForwardIndexReaderContext _readerContext;
   private final int _numDocs;
-  private final int[] _dictIdBuffer;
+  private final int _maxNumValuesPerMVEntry;
+  private final ValueMatcher _valueMatcher;
 
   private int _nextDocId = 0;
   private long _numEntriesScanned = 0L;
 
   public MVScanDocIdIterator(PredicateEvaluator predicateEvaluator, ForwardIndexReader reader, int numDocs,
-      int maxNumEntriesPerValue) {
+      int maxNumValuesPerMVEntry) {
     _predicateEvaluator = predicateEvaluator;
     _reader = reader;
     _readerContext = reader.createContext();
     _numDocs = numDocs;
-    _dictIdBuffer = new int[maxNumEntriesPerValue];
+    _maxNumValuesPerMVEntry = maxNumValuesPerMVEntry;
+    _valueMatcher = getValueMatcher();
   }
 
   @Override
   public int next() {
     while (_nextDocId < _numDocs) {
       int nextDocId = _nextDocId++;
-      int length = _reader.getDictIdMV(nextDocId, _dictIdBuffer, _readerContext);
-      _numEntriesScanned += length;
-      if (_predicateEvaluator.applyMV(_dictIdBuffer, length)) {
+      int[] length = new int[]{0};
+      // TODO: The performance can be improved by batching the docID lookups similar to how it's done in
+      //       SVScanDocIdIterator
+      boolean doesValueMatch = _valueMatcher.doesValueMatch(nextDocId, length);
+      _numEntriesScanned += length[0];
+      if (doesValueMatch) {
         return nextDocId;
       }
     }
@@ -85,9 +90,12 @@ public final class MVScanDocIdIterator implements ScanBasedDocIdIterator {
       int limit = docIdIterator.nextBatch(buffer);
       for (int i = 0; i < limit; i++) {
         int nextDocId = buffer[i];
-        int length = _reader.getDictIdMV(nextDocId, _dictIdBuffer, _readerContext);
-        _numEntriesScanned += length;
-        if (_predicateEvaluator.applyMV(_dictIdBuffer, length)) {
+        int[] length = new int[]{0};
+        // TODO: The performance can be improved by batching the docID lookups similar to how it's done in
+        //       SVScanDocIdIterator
+        boolean doesValueMatch = _valueMatcher.doesValueMatch(nextDocId, length);
+        _numEntriesScanned += length[0];
+        if (doesValueMatch) {
           result.add(nextDocId);
         }
       }
@@ -98,5 +106,114 @@ public final class MVScanDocIdIterator implements ScanBasedDocIdIterator {
   @Override
   public long getNumEntriesScanned() {
     return _numEntriesScanned;
+  }
+
+  private ValueMatcher getValueMatcher() {
+    if (_reader.isDictionaryEncoded()) {
+      return new DictIdMatcher();
+    } else {
+      switch (_reader.getStoredType()) {
+        case INT:
+          return new IntMatcher();
+        case LONG:
+          return new LongMatcher();
+        case FLOAT:
+          return new FloatMatcher();
+        case DOUBLE:
+          return new DoubleMatcher();
+        case STRING:
+          return new StringMatcher();
+        case BYTES:
+          return new BytesMatcher();
+        default:
+          throw new UnsupportedOperationException("MV Scan not supported for raw MV columns of type "
+              + _reader.getStoredType());
+      }
+    }
+  }
+
+  private interface ValueMatcher {
+
+    /**
+     * Returns {@code true} if the value for the given document id matches the predicate, {@code false} Otherwise.
+     */
+    boolean doesValueMatch(int docId, int[] length);
+  }
+
+  private class DictIdMatcher implements ValueMatcher {
+
+    private final int[] _buffer = new int[_maxNumValuesPerMVEntry];
+
+    @Override
+    public boolean doesValueMatch(int docId, int[] length) {
+      length[0] = _reader.getDictIdMV(docId, _buffer, _readerContext);
+      return _predicateEvaluator.applyMV(_buffer, length[0]);
+    }
+  }
+
+  private class IntMatcher implements ValueMatcher {
+
+    private final int[] _buffer = new int[_maxNumValuesPerMVEntry];
+
+    @Override
+    public boolean doesValueMatch(int docId, int[] length) {
+      length[0] = _reader.getIntMV(docId, _buffer, _readerContext);
+      return _predicateEvaluator.applyMV(_buffer, length[0]);
+    }
+  }
+
+  private class LongMatcher implements ValueMatcher {
+
+    private final long[] _buffer = new long[_maxNumValuesPerMVEntry];
+
+    @Override
+    public boolean doesValueMatch(int docId, int[] length) {
+      length[0] = _reader.getLongMV(docId, _buffer, _readerContext);
+      return _predicateEvaluator.applyMV(_buffer, length[0]);
+    }
+  }
+
+  private class FloatMatcher implements ValueMatcher {
+
+    private final float[] _buffer = new float[_maxNumValuesPerMVEntry];
+
+    @Override
+    public boolean doesValueMatch(int docId, int[] length) {
+      length[0] = _reader.getFloatMV(docId, _buffer, _readerContext);
+      return _predicateEvaluator.applyMV(_buffer, length[0]);
+    }
+  }
+
+  private class DoubleMatcher implements ValueMatcher {
+
+    private final double[] _buffer = new double[_maxNumValuesPerMVEntry];
+
+    @Override
+    public boolean doesValueMatch(int docId, int[] length) {
+      length[0] = _reader.getDoubleMV(docId, _buffer, _readerContext);
+      return _predicateEvaluator.applyMV(_buffer, length[0]);
+    }
+  }
+
+  private class StringMatcher implements ValueMatcher {
+
+    private final String[] _buffer = new String[_maxNumValuesPerMVEntry];
+
+    @Override
+    public boolean doesValueMatch(int docId, int[] length) {
+      length[0] = _reader.getStringMV(docId, _buffer, _readerContext);
+      return _predicateEvaluator.applyMV(_buffer, length[0]);
+    }
+  }
+
+  private class BytesMatcher implements ValueMatcher {
+
+    private final byte[][] _buffer = new byte[_maxNumValuesPerMVEntry][];
+
+    @Override
+    public boolean doesValueMatch(int docId, int[] length) {
+      length[0] = _reader.getBytesMV(docId, _buffer, _readerContext);
+      return _predicateEvaluator.applyMV(_buffer, length[0]);
+    }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
@@ -126,7 +126,7 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
     if (_reader.isDictionaryEncoded()) {
       return new DictIdMatcher();
     } else {
-      switch (_reader.getValueType()) {
+      switch (_reader.getStoredType()) {
         case INT:
           return new IntMatcher();
         case LONG:

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionarySingleColumnGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionarySingleColumnGroupKeyGenerator.java
@@ -51,6 +51,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
   private final DataType _storedType;
   private final Map _groupKeyMap;
   private final int _globalGroupIdUpperBound;
+  private final boolean _isSingleValueExpression;
 
   private int _numGroups = 0;
 
@@ -60,6 +61,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
     _storedType = transformOperator.getResultMetadata(_groupByExpression).getDataType().getStoredType();
     _groupKeyMap = createGroupKeyMap(_storedType);
     _globalGroupIdUpperBound = numGroupsLimit;
+    _isSingleValueExpression = transformOperator.getResultMetadata(groupByExpression).isSingleValue();
   }
 
   @Override
@@ -164,8 +166,113 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
 
   @Override
   public void generateKeysForBlock(TransformBlock transformBlock, int[][] groupKeys) {
-    // TODO: Support generating keys for multi-valued columns.
-    throw new UnsupportedOperationException("Operation not supported");
+    int numDocs = transformBlock.getNumDocs();
+    BlockValSet blockValSet = transformBlock.getBlockValueSet(_groupByExpression);
+
+    if (_isSingleValueExpression) {
+      switch (_storedType) {
+        case INT:
+          int[] intValues = blockValSet.getIntValuesSV();
+          for (int i = 0; i < numDocs; i++) {
+            groupKeys[i] = new int[]{getKeyForValue(intValues[i])};
+          }
+          break;
+        case LONG:
+          long[] longValues = blockValSet.getLongValuesSV();
+          for (int i = 0; i < numDocs; i++) {
+            groupKeys[i] = new int[]{getKeyForValue(longValues[i])};
+          }
+          break;
+        case FLOAT:
+          float[] floatValues = blockValSet.getFloatValuesSV();
+          for (int i = 0; i < numDocs; i++) {
+            groupKeys[i] = new int[]{getKeyForValue(floatValues[i])};
+          }
+          break;
+        case DOUBLE:
+          double[] doubleValues = blockValSet.getDoubleValuesSV();
+          for (int i = 0; i < numDocs; i++) {
+            groupKeys[i] = new int[]{getKeyForValue(doubleValues[i])};
+          }
+          break;
+        case STRING:
+          String[] stringValues = blockValSet.getStringValuesSV();
+          for (int i = 0; i < numDocs; i++) {
+            groupKeys[i] = new int[]{getKeyForValue(stringValues[i])};
+          }
+          break;
+        case BYTES:
+          byte[][] byteValues = blockValSet.getBytesValuesSV();
+          for (int i = 0; i < numDocs; i++) {
+            groupKeys[i] = new int[]{getKeyForValue(new ByteArray(byteValues[i]))};
+          }
+          break;
+        default:
+          throw new IllegalArgumentException(
+              "Illegal data type for no-dictionary key generator: " + _storedType);
+      }
+    } else {
+      switch (_storedType) {
+        case INT:
+          int[][] intValues = blockValSet.getIntValuesMV();
+          for (int i = 0; i < numDocs; i++) {
+            int mvSize = intValues[i].length;
+            int[] mvKeys = new int[mvSize];
+            for (int j = 0; j < mvSize; j++) {
+              mvKeys[j] = getKeyForValue(intValues[i][j]);
+            }
+            groupKeys[i] = mvKeys;
+          }
+          break;
+        case LONG:
+          long[][] longValues = blockValSet.getLongValuesMV();
+          for (int i = 0; i < numDocs; i++) {
+            int mvSize = longValues[i].length;
+            int[] mvKeys = new int[mvSize];
+            for (int j = 0; j < mvSize; j++) {
+              mvKeys[j] = getKeyForValue(longValues[i][j]);
+            }
+            groupKeys[i] = mvKeys;
+          }
+          break;
+        case FLOAT:
+          float[][] floatValues = blockValSet.getFloatValuesMV();
+          for (int i = 0; i < numDocs; i++) {
+            int mvSize = floatValues[i].length;
+            int[] mvKeys = new int[mvSize];
+            for (int j = 0; j < mvSize; j++) {
+              mvKeys[j] = getKeyForValue(floatValues[i][j]);
+            }
+            groupKeys[i] = mvKeys;
+          }
+          break;
+        case DOUBLE:
+          double[][] doubleValues = blockValSet.getDoubleValuesMV();
+          for (int i = 0; i < numDocs; i++) {
+            int mvSize = doubleValues[i].length;
+            int[] mvKeys = new int[mvSize];
+            for (int j = 0; j < mvSize; j++) {
+              mvKeys[j] = getKeyForValue(doubleValues[i][j]);
+            }
+            groupKeys[i] = mvKeys;
+          }
+          break;
+        case STRING:
+          String[][] stringValues = blockValSet.getStringValuesMV();
+          for (int i = 0; i < numDocs; i++) {
+            int mvSize = stringValues[i].length;
+            int[] mvKeys = new int[mvSize];
+            for (int j = 0; j < mvSize; j++) {
+              mvKeys[j] = getKeyForValue(stringValues[i][j]);
+            }
+            groupKeys[i] = mvKeys;
+          }
+          break;
+        default:
+          throw new IllegalArgumentException(
+              "Illegal data type for no-dictionary key generator: " + _storedType);
+      }
+    }
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseMultiValueRawQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseMultiValueRawQueriesTest.java
@@ -1,0 +1,157 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.io.File;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.TimeGranularitySpec;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeTest;
+
+import static org.testng.Assert.assertNotNull;
+
+
+/**
+ * The <code>BaseMultiValueQueriesTest</code> class sets up the index segment for the multi-value queries test.
+ * <p>There are totally 14 columns, 100000 records inside the original Avro file where 10 columns are selected to build
+ * the index segment. Selected columns information are as following:
+ * <ul>
+ *   ColumnName, FieldType, DataType, Cardinality, IsSorted, HasInvertedIndex, IsMultiValueRaw
+ *   <li>column1, METRIC, INT, 51594, F, F, F</li>
+ *   <li>column2, METRIC, INT, 42242, F, F, F</li>
+ *   <li>column3, DIMENSION, STRING, 5, F, T, F</li>
+ *   <li>column5, DIMENSION, STRING, 9, F, F, F</li>
+ *   <li>column6, DIMENSION, INT, 18499, F, F, T</li>
+ *   <li>column7, DIMENSION, INT, 359, F, F, T</li>
+ *   <li>column8, DIMENSION, INT, 850, F, T, F</li>
+ *   <li>column9, METRIC, INT, 146, F, T, F</li>
+ *   <li>column10, METRIC, INT, 3960, F, F, F</li>
+ *   <li>daysSinceEpoch, TIME, INT, 1, T, F, F</li>
+ * </ul>
+ */
+public class BaseMultiValueRawQueriesTest extends BaseQueriesTest {
+  private static final String AVRO_DATA = "data" + File.separator + "test_data-mv.avro";
+  private static final String SEGMENT_NAME = "testTable_1756015683_1756015683";
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "MultiValueRawQueriesTest");
+
+  // Hard-coded query filter.
+  protected static final String FILTER = " WHERE column1 > 100000000"
+      + " AND column2 BETWEEN 20000000 AND 1000000000"
+      + " AND column3 <> 'w'"
+      + " AND (column6 < 500000 OR column7 NOT IN (225, 407))"
+      + " AND daysSinceEpoch = 1756015683";
+
+  private IndexSegment _indexSegment;
+  // Contains 2 identical index segments.
+  private List<IndexSegment> _indexSegments;
+
+  @BeforeTest
+  public void buildSegment()
+      throws Exception {
+    FileUtils.deleteQuietly(INDEX_DIR);
+
+    // Get resource file path.
+    URL resource = getClass().getClassLoader().getResource(AVRO_DATA);
+    assertNotNull(resource);
+    String filePath = resource.getFile();
+
+    // Build the segment schema.
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable").addMetric("column1", FieldSpec.DataType.INT)
+        .addMetric("column2", FieldSpec.DataType.INT).addSingleValueDimension("column3", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("column5", FieldSpec.DataType.STRING)
+        .addMultiValueDimension("column6", FieldSpec.DataType.INT)
+        .addMultiValueDimension("column7", FieldSpec.DataType.INT)
+        .addSingleValueDimension("column8", FieldSpec.DataType.INT).addMetric("column9", FieldSpec.DataType.INT)
+        .addMetric("column10", FieldSpec.DataType.INT)
+        .addTime(new TimeGranularitySpec(FieldSpec.DataType.INT, TimeUnit.DAYS, "daysSinceEpoch"), null).build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable")
+        .setTimeColumnName("daysSinceEpoch").setNoDictionaryColumns(Arrays.asList("column5", "column6", "column7"))
+        .build();
+
+    // Create the segment generator config.
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
+    segmentGeneratorConfig.setInputFilePath(filePath);
+    segmentGeneratorConfig.setTableName("testTable");
+    segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
+    segmentGeneratorConfig.setInvertedIndexCreationColumns(Arrays.asList("column3", "column8", "column9"));
+    segmentGeneratorConfig.setRawIndexCreationColumns(Arrays.asList("column5", "column6", "column7"));
+    // The segment generation code in SegmentColumnarIndexCreator will throw
+    // exception if start and end time in time column are not in acceptable
+    // range. For this test, we first need to fix the input avro data
+    // to have the time column values in allowed range. Until then, the check
+    // is explicitly disabled
+    segmentGeneratorConfig.setSkipTimeValueCheck(true);
+
+    // Build the index segment.
+    SegmentIndexCreationDriver driver = new SegmentIndexCreationDriverImpl();
+    driver.init(segmentGeneratorConfig);
+    driver.build();
+  }
+
+  @BeforeClass
+  public void loadSegment()
+      throws Exception {
+    ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
+    _indexSegment = immutableSegment;
+    _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
+  }
+
+  @AfterClass
+  public void destroySegment() {
+    _indexSegment.destroy();
+  }
+
+  @AfterTest
+  public void deleteSegment() {
+    FileUtils.deleteQuietly(INDEX_DIR);
+  }
+
+  @Override
+  protected String getFilter() {
+    return FILTER;
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationMultiValueRawQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationMultiValueRawQueriesTest.java
@@ -1,0 +1,159 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
+import org.apache.pinot.core.operator.query.AggregationGroupByOrderByOperator;
+import org.apache.pinot.core.operator.query.AggregationOperator;
+import org.testng.annotations.Test;
+
+
+@SuppressWarnings("ConstantConditions")
+public class InnerSegmentAggregationMultiValueRawQueriesTest extends BaseMultiValueRawQueriesTest {
+  private static final String AGGREGATION_QUERY =
+      "SELECT COUNT(*), SUM(column1), MAX(column2), MIN(column8), AVG(column9) FROM testTable";
+  private static final String MULTI_VALUE_AGGREGATION_QUERY =
+      "SELECT COUNTMV(column6), SUMMV(column7), MAXMV(column6), MINMV(column7), AVGMV(column6) FROM testTable";
+
+  // ARRAY_BASED
+  private static final String SMALL_GROUP_BY = " GROUP BY column7";
+  // INT_MAP_BASED
+  private static final String MEDIUM_GROUP_BY = " GROUP BY column3, column6, column7";
+  // LONG_MAP_BASED
+  private static final String LARGE_GROUP_BY = " GROUP BY column1, column3, column6, column7";
+  // ARRAY_MAP_BASED
+  private static final String VERY_LARGE_GROUP_BY =
+      " GROUP BY column1, column2, column6, column7, column8, column9, column10";
+
+  @Test
+  public void testAggregationOnly() {
+    // Test query without filter.
+    AggregationOperator aggregationOperator = getOperator(AGGREGATION_QUERY);
+    IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 100000L, 0L,
+        400000L, 100000L);
+    QueriesTestUtils.testInnerSegmentAggregationResult(resultsBlock.getAggregationResult(), 100000L, 100991525475000L,
+        2147434110, 1182655, 83439903673981L, 100000L);
+
+    // Test query with filter.
+    aggregationOperator = getOperator(AGGREGATION_QUERY + FILTER);
+    resultsBlock = aggregationOperator.nextBlock();
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 15620L, 275416,
+        62480L, 100000L);
+    QueriesTestUtils.testInnerSegmentAggregationResult(resultsBlock.getAggregationResult(), 15620L, 17287754700747L,
+        999943053, 1182655, 11017594448983L, 15620L);
+  }
+
+  @Test
+  public void testMultiValueAggregationOnly() {
+    // Test query without filter.
+    AggregationOperator aggregationOperator = getOperator(MULTI_VALUE_AGGREGATION_QUERY);
+    IntermediateResultsBlock resultsBlock = aggregationOperator.nextBlock();
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 100000L, 0L,
+        200000L, 100000L);
+    QueriesTestUtils.testInnerSegmentAggregationResult(resultsBlock.getAggregationResult(), 106688L, 107243218420671L,
+        2147483647, 201, 121081150452570L, 106688L);
+
+    // Test query with filter.
+    aggregationOperator = getOperator(MULTI_VALUE_AGGREGATION_QUERY + FILTER);
+    resultsBlock = aggregationOperator.nextBlock();
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 15620L, 275416L,
+        31240L, 100000L);
+    QueriesTestUtils.testInnerSegmentAggregationResult(resultsBlock.getAggregationResult(), 15620L, 28567975886777L,
+        2147483647, 203, 28663153397978L, 15620L);
+  }
+
+  @Test
+  public void testSmallAggregationGroupBy() {
+    // Test query without filter.
+    AggregationGroupByOrderByOperator groupByOperator = getOperator(AGGREGATION_QUERY + SMALL_GROUP_BY);
+    IntermediateResultsBlock resultsBlock = groupByOperator.nextBlock();
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(groupByOperator.getExecutionStatistics(), 100000L, 0L, 500000L,
+        100000L);
+    QueriesTestUtils.testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(),
+        new Object[]{201}, 26L, 32555949195L, 2100941020, 117939666, 23061775005L, 26L);
+
+    // Test query with filter.
+    groupByOperator = getOperator(AGGREGATION_QUERY + FILTER + SMALL_GROUP_BY);
+    resultsBlock = groupByOperator.nextBlock();
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(groupByOperator.getExecutionStatistics(), 15620L, 275416L,
+        78100L, 100000L);
+    QueriesTestUtils.testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(),
+        new Object[]{203}, 1L, 185436225L, 987549258, 674022574, 674022574L, 1L);
+  }
+
+  @Test
+  public void testMediumAggregationGroupBy() {
+    // Test query without filter.
+    AggregationGroupByOrderByOperator groupByOperator = getOperator(AGGREGATION_QUERY + MEDIUM_GROUP_BY);
+    IntermediateResultsBlock resultsBlock = groupByOperator.nextBlock();
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(groupByOperator.getExecutionStatistics(), 100000L, 0L, 700000L,
+        100000L);
+    QueriesTestUtils.testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(),
+        new Object[]{"w", 3818, 369}, 1L, 1095214422L, 1547156787, 528554902, 52058876L, 1L);
+
+    // Test query with filter.
+    groupByOperator = getOperator(AGGREGATION_QUERY + FILTER + MEDIUM_GROUP_BY);
+    resultsBlock = groupByOperator.nextBlock();
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(groupByOperator.getExecutionStatistics(), 15620L, 275416L,
+        109340L, 100000L);
+    QueriesTestUtils.testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(),
+        new Object[]{"L", 306633, 2147483647}, 1L, 131154783L, 952002176, 674022574, 674022574L, 1L);
+  }
+
+  @Test
+  public void testLargeAggregationGroupBy() {
+    // Test query without filter.
+    AggregationGroupByOrderByOperator groupByOperator = getOperator(AGGREGATION_QUERY + LARGE_GROUP_BY);
+    IntermediateResultsBlock resultsBlock = groupByOperator.nextBlock();
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(groupByOperator.getExecutionStatistics(), 100000L, 0L, 700000L,
+        100000L);
+    QueriesTestUtils.testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(),
+        new Object[]{240129976, "L", 2147483647, 2147483647}, 1L, 240129976L, 1649812746, 2077178039, 1952924139L, 1L);
+
+    // Test query with filter.
+    groupByOperator = getOperator(AGGREGATION_QUERY + FILTER + LARGE_GROUP_BY);
+    resultsBlock = groupByOperator.nextBlock();
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(groupByOperator.getExecutionStatistics(), 15620L, 275416L,
+        109340L, 100000L);
+    QueriesTestUtils.testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(),
+        new Object[]{903461357, "L", 2147483647, 388}, 2L, 1806922714L, 652024397, 674022574, 870535054L, 2L);
+  }
+
+  @Test
+  public void testVeryLargeAggregationGroupBy() {
+    // Test query without filter.
+    AggregationGroupByOrderByOperator groupByOperator = getOperator(AGGREGATION_QUERY + VERY_LARGE_GROUP_BY);
+    IntermediateResultsBlock resultsBlock = groupByOperator.nextBlock();
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(groupByOperator.getExecutionStatistics(), 100000L, 0L, 700000L,
+        100000L);
+    QueriesTestUtils.testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(),
+        new Object[]{1118965780, 1848116124, 8599, 504, 1597666851, 675163196, 607034543}, 1L, 1118965780L, 1848116124,
+        1597666851, 675163196L, 1L);
+
+    // Test query with filter.
+    groupByOperator = getOperator(AGGREGATION_QUERY + FILTER + VERY_LARGE_GROUP_BY);
+    resultsBlock = groupByOperator.nextBlock();
+    QueriesTestUtils.testInnerSegmentExecutionStatistics(groupByOperator.getExecutionStatistics(), 15620L, 275416L,
+        109340L, 100000L);
+    QueriesTestUtils.testInnerSegmentAggregationGroupByResult(resultsBlock.getAggregationGroupByResult(),
+        new Object[]{949960647, 238753654, 2147483647, 2147483647, 674022574, 674022574, 674022574}, 2L, 1899921294L,
+        238753654, 674022574, 1348045148L, 2L);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionMultiValueRawQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionMultiValueRawQueriesTest.java
@@ -1,0 +1,247 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.operator.BaseOperator;
+import org.apache.pinot.core.operator.ExecutionStatistics;
+import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
+import org.apache.pinot.core.operator.query.EmptySelectionOperator;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+@SuppressWarnings("ConstantConditions")
+public class InnerSegmentSelectionMultiValueRawQueriesTest extends BaseMultiValueRawQueriesTest {
+  private static final String SELECT_STAR_QUERY = "SELECT * FROM testTable";
+  private static final String SELECTION_QUERY = "SELECT column1, column5, column6 FROM testTable";
+  private static final String ORDER_BY = " ORDER BY column5, column9";
+
+  @Test
+  public void testSelectLimitZero() {
+    String limit = " LIMIT 0";
+
+    // Test query without filter
+    EmptySelectionOperator emptySelectionOperator = getOperator(SELECT_STAR_QUERY + limit);
+    IntermediateResultsBlock resultsBlock = emptySelectionOperator.nextBlock();
+    ExecutionStatistics executionStatistics = emptySelectionOperator.getExecutionStatistics();
+    assertEquals(executionStatistics.getNumDocsScanned(), 0L);
+    assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 0L);
+    assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 0L);
+    assertEquals(executionStatistics.getNumTotalDocs(), 100000L);
+    DataSchema selectionDataSchema = resultsBlock.getDataSchema();
+    Map<String, Integer> columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
+
+    assertEquals(selectionDataSchema.size(), 10);
+    assertTrue(columnIndexMap.containsKey("column1"));
+    assertTrue(columnIndexMap.containsKey("column6"));
+    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), DataSchema.ColumnDataType.INT);
+    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")),
+        DataSchema.ColumnDataType.INT_ARRAY);
+    assertTrue(resultsBlock.getSelectionResult().isEmpty());
+
+    // Test query with filter
+    emptySelectionOperator = getOperator(SELECT_STAR_QUERY + FILTER + limit);
+    resultsBlock = emptySelectionOperator.nextBlock();
+    executionStatistics = emptySelectionOperator.getExecutionStatistics();
+    assertEquals(executionStatistics.getNumDocsScanned(), 0L);
+    assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 0L);
+    assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 0L);
+    assertEquals(executionStatistics.getNumTotalDocs(), 100000L);
+    selectionDataSchema = resultsBlock.getDataSchema();
+    columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
+    assertEquals(selectionDataSchema.size(), 10);
+    assertTrue(columnIndexMap.containsKey("column1"));
+    assertTrue(columnIndexMap.containsKey("column6"));
+    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), DataSchema.ColumnDataType.INT);
+    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")),
+        DataSchema.ColumnDataType.INT_ARRAY);
+    assertTrue(resultsBlock.getSelectionResult().isEmpty());
+  }
+
+  @Test
+  public void testSelectStar() {
+    // Test query without filter
+    BaseOperator<IntermediateResultsBlock> selectionOnlyOperator = getOperator(SELECT_STAR_QUERY);
+    IntermediateResultsBlock resultsBlock = selectionOnlyOperator.nextBlock();
+    ExecutionStatistics executionStatistics = selectionOnlyOperator.getExecutionStatistics();
+    assertEquals(executionStatistics.getNumDocsScanned(), 10L);
+    assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 0L);
+    assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 100L);
+    assertEquals(executionStatistics.getNumTotalDocs(), 100000L);
+    DataSchema selectionDataSchema = resultsBlock.getDataSchema();
+    Map<String, Integer> columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
+
+    assertEquals(selectionDataSchema.size(), 10);
+    assertTrue(columnIndexMap.containsKey("column1"));
+    assertTrue(columnIndexMap.containsKey("column6"));
+    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), DataSchema.ColumnDataType.INT);
+    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")),
+        DataSchema.ColumnDataType.INT_ARRAY);
+    List<Object[]> selectionResult = (List<Object[]>) resultsBlock.getSelectionResult();
+    assertEquals(selectionResult.size(), 10);
+    Object[] firstRow = selectionResult.get(0);
+    assertEquals(firstRow.length, 10);
+    assertEquals(((Integer) firstRow[columnIndexMap.get("column1")]).intValue(), 890282370);
+    assertEquals(firstRow[columnIndexMap.get("column6")], new int[]{2147483647});
+
+    // Test query with filter
+    selectionOnlyOperator = getOperator(SELECT_STAR_QUERY + FILTER);
+    resultsBlock = selectionOnlyOperator.nextBlock();
+    executionStatistics = selectionOnlyOperator.getExecutionStatistics();
+    assertEquals(executionStatistics.getNumDocsScanned(), 10L);
+    assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 79L);
+    assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 100L);
+    assertEquals(executionStatistics.getNumTotalDocs(), 100000L);
+    selectionDataSchema = resultsBlock.getDataSchema();
+    columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
+
+    assertEquals(selectionDataSchema.size(), 10);
+    assertTrue(columnIndexMap.containsKey("column1"));
+    assertTrue(columnIndexMap.containsKey("column6"));
+    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), DataSchema.ColumnDataType.INT);
+    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")),
+        DataSchema.ColumnDataType.INT_ARRAY);
+    selectionResult = (List<Object[]>) resultsBlock.getSelectionResult();
+    assertEquals(selectionResult.size(), 10);
+    firstRow = selectionResult.get(0);
+    assertEquals(firstRow.length, 10);
+    assertEquals(((Integer) firstRow[columnIndexMap.get("column1")]).intValue(), 890282370);
+    assertEquals(firstRow[columnIndexMap.get("column6")], new int[]{2147483647});
+  }
+
+  @Test
+  public void testSelectionOnly() {
+    // Test query without filter
+    BaseOperator<IntermediateResultsBlock> selectionOnlyOperator = getOperator(SELECTION_QUERY);
+    IntermediateResultsBlock resultsBlock = selectionOnlyOperator.nextBlock();
+    ExecutionStatistics executionStatistics = selectionOnlyOperator.getExecutionStatistics();
+    assertEquals(executionStatistics.getNumDocsScanned(), 10L);
+    assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 0L);
+    assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 30L);
+    assertEquals(executionStatistics.getNumTotalDocs(), 100000L);
+    DataSchema selectionDataSchema = resultsBlock.getDataSchema();
+    Map<String, Integer> columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
+
+    assertEquals(selectionDataSchema.size(), 3);
+    assertTrue(columnIndexMap.containsKey("column1"));
+    assertTrue(columnIndexMap.containsKey("column6"));
+    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), DataSchema.ColumnDataType.INT);
+    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")),
+        DataSchema.ColumnDataType.INT_ARRAY);
+    List<Object[]> selectionResult = (List<Object[]>) resultsBlock.getSelectionResult();
+    assertEquals(selectionResult.size(), 10);
+    Object[] firstRow = selectionResult.get(0);
+    assertEquals(firstRow.length, 3);
+    assertEquals(((Integer) firstRow[columnIndexMap.get("column1")]).intValue(), 890282370);
+    assertEquals(firstRow[columnIndexMap.get("column6")], new int[]{2147483647});
+
+    // Test query with filter
+    selectionOnlyOperator = getOperator(SELECTION_QUERY + FILTER);
+    resultsBlock = selectionOnlyOperator.nextBlock();
+    executionStatistics = selectionOnlyOperator.getExecutionStatistics();
+    assertEquals(executionStatistics.getNumDocsScanned(), 10L);
+    assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 79L);
+    assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 30L);
+    assertEquals(executionStatistics.getNumTotalDocs(), 100000L);
+    selectionDataSchema = resultsBlock.getDataSchema();
+    columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
+
+    assertEquals(selectionDataSchema.size(), 3);
+    assertTrue(columnIndexMap.containsKey("column1"));
+    assertTrue(columnIndexMap.containsKey("column6"));
+    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), DataSchema.ColumnDataType.INT);
+    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")),
+        DataSchema.ColumnDataType.INT_ARRAY);
+    selectionResult = (List<Object[]>) resultsBlock.getSelectionResult();
+    assertEquals(selectionResult.size(), 10);
+    firstRow = selectionResult.get(0);
+    assertEquals(firstRow.length, 3);
+    assertEquals(((Integer) firstRow[columnIndexMap.get("column1")]).intValue(), 890282370);
+    assertEquals(firstRow[columnIndexMap.get("column6")], new int[]{2147483647});
+  }
+
+  @Test
+  public void testSelectionOrderBy() {
+    // Test query without filter
+    BaseOperator<IntermediateResultsBlock> selectionOrderByOperator = getOperator(SELECTION_QUERY + ORDER_BY);
+    IntermediateResultsBlock resultsBlock = selectionOrderByOperator.nextBlock();
+    ExecutionStatistics executionStatistics = selectionOrderByOperator.getExecutionStatistics();
+    assertEquals(executionStatistics.getNumDocsScanned(), 100000L);
+    assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 0L);
+    // 100000 * (2 order-by columns) + 10 * (2 non-order-by columns)
+    assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 200020L);
+    assertEquals(executionStatistics.getNumTotalDocs(), 100000L);
+    DataSchema selectionDataSchema = resultsBlock.getDataSchema();
+    Map<String, Integer> columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
+
+    assertEquals(selectionDataSchema.size(), 4);
+    assertTrue(columnIndexMap.containsKey("column1"));
+    assertTrue(columnIndexMap.containsKey("column6"));
+    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), DataSchema.ColumnDataType.INT);
+    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")),
+        DataSchema.ColumnDataType.INT_ARRAY);
+    PriorityQueue<Object[]> selectionResult = (PriorityQueue<Object[]>) resultsBlock.getSelectionResult();
+    assertEquals(selectionResult.size(), 10);
+    Object[] lastRow = selectionResult.peek();
+    assertEquals(lastRow.length, 4);
+    assertEquals((String) lastRow[columnIndexMap.get("column5")], "AKXcXcIqsqOJFsdwxZ");
+    assertEquals(lastRow[columnIndexMap.get("column6")], new int[]{1252});
+
+    // Test query with filter
+    selectionOrderByOperator = getOperator(SELECTION_QUERY + FILTER + ORDER_BY);
+    resultsBlock = selectionOrderByOperator.nextBlock();
+    executionStatistics = selectionOrderByOperator.getExecutionStatistics();
+    assertEquals(executionStatistics.getNumDocsScanned(), 15620L);
+    assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 275416L);
+    // 15620 * (2 order-by columns) + 10 * (2 non-order-by columns)
+    assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 31260L);
+    assertEquals(executionStatistics.getNumTotalDocs(), 100000L);
+    selectionDataSchema = resultsBlock.getDataSchema();
+    columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
+
+    assertEquals(selectionDataSchema.size(), 4);
+    assertTrue(columnIndexMap.containsKey("column1"));
+    assertTrue(columnIndexMap.containsKey("column6"));
+    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), DataSchema.ColumnDataType.INT);
+    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")),
+        DataSchema.ColumnDataType.INT_ARRAY);
+    selectionResult = (PriorityQueue<Object[]>) resultsBlock.getSelectionResult();
+    assertEquals(selectionResult.size(), 10);
+    lastRow = selectionResult.peek();
+    assertEquals(lastRow.length, 4);
+    assertEquals((String) lastRow[columnIndexMap.get("column5")], "AKXcXcIqsqOJFsdwxZ");
+    assertEquals(lastRow[columnIndexMap.get("column6")], new int[]{2147483647});
+  }
+
+  private Map<String, Integer> computeColumnNameToIndexMap(DataSchema dataSchema) {
+    Map<String, Integer> columnIndexMap = new HashMap<>();
+
+    for (int i = 0; i < dataSchema.size(); i++) {
+      columnIndexMap.put(dataSchema.getColumnName(i), i);
+    }
+    return columnIndexMap;
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationMultiValueRawQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationMultiValueRawQueriesTest.java
@@ -1,0 +1,572 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Function;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
+import org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2;
+import org.apache.pinot.spi.utils.BytesUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+public class InterSegmentAggregationMultiValueRawQueriesTest extends BaseMultiValueRawQueriesTest {
+  private static final String SV_GROUP_BY = " GROUP BY column8 ORDER BY value DESC LIMIT 1";
+  private static final String MV_GROUP_BY = " GROUP BY column7 ORDER BY value DESC LIMIT 1";
+
+  // Allow 5% quantile error due to the randomness of TDigest merge
+  private static final double PERCENTILE_TDIGEST_DELTA = 0.05 * Integer.MAX_VALUE;
+
+  @Test
+  public void testCountMV() {
+    String query = "SELECT COUNTMV(column6) FROM testTable";
+
+    BrokerResponseNative brokerResponse = getBrokerResponse(query);
+    DataSchema expectedDataSchema =
+        new DataSchema(new String[]{"countmv(column6)"}, new DataSchema.ColumnDataType[]
+            {DataSchema.ColumnDataType.LONG});
+    Object[] expectedResults = new Object[]{426752L};
+    ResultTable expectedResultTable = new ResultTable(expectedDataSchema, Collections.singletonList(expectedResults));
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 400000L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER);
+    expectedResults[0] = 62480L;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 62480L, 400000L, expectedResultTable);
+
+    String svGroupBy = " GROUP BY column8 ORDER BY COUNTMV(column6) DESC LIMIT 1";
+    brokerResponse = getBrokerResponse(query + svGroupBy);
+    expectedResults[0] = 231056L;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER + svGroupBy);
+    expectedResults[0] = 58440L;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable);
+
+    String mvGroupBy = " GROUP BY column7 ORDER BY COUNTMV(column6) DESC LIMIT 1";
+    brokerResponse = getBrokerResponse(query + mvGroupBy);
+    expectedResults[0] = 199896L;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER + mvGroupBy);
+    expectedResults[0] = 53212L;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable);
+
+    query = "SELECT VALUEIN(column7, 363, 469, 246, 100000), COUNTMV(column6) FROM testTable"
+        + " GROUP BY VALUEIN(column7, 363, 469, 246, 100000) ORDER BY COUNTMV(column6)";
+    brokerResponse = getBrokerResponse(query);
+    expectedDataSchema = new DataSchema(new String[]{"valuein(column7,'363','469','246','100000')", "countmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG});
+    expectedResultTable = new ResultTable(expectedDataSchema,
+        Arrays.asList(new Object[]{246, 24300L}, new Object[]{469, 33576L}, new Object[]{363, 35436L}));
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+    query = "SELECT VALUEIN(column7, 363, 469, 246, 100000) AS key, COUNTMV(column6) AS value FROM testTable"
+        + " GROUP BY key ORDER BY value";
+    brokerResponse = getBrokerResponse(query);
+    expectedDataSchema =
+        new DataSchema(new String[]{"key", "value"}, new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT,
+            DataSchema.ColumnDataType.LONG});
+    expectedResultTable = new ResultTable(expectedDataSchema,
+        Arrays.asList(new Object[]{246, 24300L}, new Object[]{469, 33576L}, new Object[]{363, 35436L}));
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + " DESC");
+    expectedResultTable = new ResultTable(expectedDataSchema,
+        Arrays.asList(new Object[]{363, 35436L}, new Object[]{469, 33576L}, new Object[]{246, 24300L}));
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+    query = "SELECT daysSinceEpoch, COUNTMV(column6) FROM testTable GROUP BY daysSinceEpoch";
+    brokerResponse = getBrokerResponse(query);
+    expectedDataSchema = new DataSchema(new String[]{"daysSinceEpoch", "countmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG});
+    expectedResultTable =
+        new ResultTable(expectedDataSchema, Collections.singletonList(new Object[]{1756015683, 426752L}));
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+    query = "SELECT TIMECONVERT(daysSinceEpoch, 'DAYS', 'HOURS') AS key, COUNTMV(column6) FROM testTable"
+        + " GROUP BY key ORDER BY COUNTMV(column6) DESC";
+    brokerResponse = getBrokerResponse(query);
+    expectedDataSchema = new DataSchema(new String[]{"key", "countmv(column6)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG});
+    expectedResultTable =
+        new ResultTable(expectedDataSchema, Collections.singletonList(new Object[]{42144376392L, 426752L}));
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+  }
+
+  @Test
+  public void testMaxMV() {
+    String query = "SELECT MAXMV(column6) AS value FROM testTable";
+
+    // Without filter, query should be answered by DictionaryBasedAggregationOperator (numEntriesScannedPostFilter = 0)
+    BrokerResponseNative brokerResponse = getBrokerResponse(query);
+    DataSchema expectedDataSchema = new DataSchema(new String[]{"value"}, new DataSchema.ColumnDataType[]
+        {DataSchema.ColumnDataType.DOUBLE});
+    ResultTable expectedResultTable =
+        new ResultTable(expectedDataSchema, Collections.singletonList(new Object[]{2147483647.0}));
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 0L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER);
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 62480L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + SV_GROUP_BY);
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER + SV_GROUP_BY);
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + MV_GROUP_BY);
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER + MV_GROUP_BY);
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable);
+  }
+
+  @Test
+  public void testMinMV() {
+    String query = "SELECT MINMV(column6) AS value FROM testTable";
+
+    // Without filter, query should be answered by DictionaryBasedAggregationOperator (numEntriesScannedPostFilter = 0)
+    BrokerResponseNative brokerResponse = getBrokerResponse(query);
+    DataSchema expectedDataSchema = new DataSchema(new String[]{"value"}, new DataSchema.ColumnDataType[]
+        {DataSchema.ColumnDataType.DOUBLE});
+    Object[] expectedResults = new Object[]{1001.0};
+    ResultTable expectedResultTable = new ResultTable(expectedDataSchema, Collections.singletonList(expectedResults));
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 0L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER);
+    expectedResults[0] = 1009.0;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 62480L, 400000L, expectedResultTable);
+
+    String svGroupBy = " GROUP BY column8 ORDER BY value LIMIT 1";
+    brokerResponse = getBrokerResponse(query + svGroupBy);
+    expectedResults[0] = 1001.0;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER + svGroupBy);
+    expectedResults[0] = 1009.0;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable);
+
+    String mvGroupBy = " GROUP BY column7 ORDER BY value LIMIT 1";
+    brokerResponse = getBrokerResponse(query + mvGroupBy);
+    expectedResults[0] = 1001.0;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER + mvGroupBy);
+    expectedResults[0] = 1009.0;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable);
+  }
+
+  @Test
+  public void testSumMV() {
+    String query = "SELECT SUMMV(column6) AS value FROM testTable";
+
+    BrokerResponseNative brokerResponse = getBrokerResponse(query);
+    DataSchema expectedDataSchema = new DataSchema(new String[]{"value"}, new DataSchema.ColumnDataType[]
+        {DataSchema.ColumnDataType.DOUBLE});
+    Object[] expectedResults = new Object[]{484324601810280.0};
+    ResultTable expectedResultTable = new ResultTable(expectedDataSchema, Collections.singletonList(expectedResults));
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 400000L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER);
+    expectedResults[0] = 114652613591912.0;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 62480L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + SV_GROUP_BY);
+    expectedResults[0] = 402591409613620.0;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER + SV_GROUP_BY);
+    expectedResults[0] = 105976779658032.0;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + MV_GROUP_BY);
+    expectedResults[0] = 393483780531788.0;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER + MV_GROUP_BY);
+    expectedResults[0] = 106216645956692.0;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable);
+  }
+
+  @Test
+  public void testAvgMV() {
+    String query = "SELECT AVGMV(column6) AS value FROM testTable";
+
+    BrokerResponseNative brokerResponse = getBrokerResponse(query);
+    DataSchema expectedDataSchema = new DataSchema(new String[]{"value"}, new DataSchema.ColumnDataType[]
+        {DataSchema.ColumnDataType.DOUBLE});
+    Object[] expectedResults = new Object[]{1134908803.7321};
+    ResultTable expectedResultTable = new ResultTable(expectedDataSchema, Collections.singletonList(expectedResults));
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 400000L, 400000L, expectedResultTable, 1e-5);
+
+    brokerResponse = getBrokerResponse(query + FILTER);
+    expectedResults[0] = 1835029026.75916;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 62480L, 400000L, expectedResultTable,
+        1e-5);
+
+    brokerResponse = getBrokerResponse(query + SV_GROUP_BY);
+    expectedResults[0] = 2147483647.0;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER + SV_GROUP_BY);
+    expectedResults[0] = 2147483647.0;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + MV_GROUP_BY);
+    expectedResults[0] = 2147483647.0;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER + MV_GROUP_BY);
+    expectedResults[0] = 2147483647.0;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable);
+  }
+
+  @Test
+  public void testMinMaxRangeMV() {
+    String query = "SELECT MINMAXRANGEMV(column6) AS value FROM testTable";
+
+    // Without filter, query should be answered by DictionaryBasedAggregationOperator (numEntriesScannedPostFilter = 0)
+    BrokerResponseNative brokerResponse = getBrokerResponse(query);
+    DataSchema expectedDataSchema = new DataSchema(new String[]{"value"}, new DataSchema.ColumnDataType[]
+        {DataSchema.ColumnDataType.DOUBLE});
+    Object[] expectedResults = new Object[]{2147482646.0};
+    ResultTable expectedResultTable = new ResultTable(expectedDataSchema, Collections.singletonList(expectedResults));
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 0L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER);
+    expectedResults[0] = 2147482638.0;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 62480L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + SV_GROUP_BY);
+    expectedResults[0] = 2147482646.0;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER + SV_GROUP_BY);
+    expectedResults[0] = 2147482638.0;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + MV_GROUP_BY);
+    expectedResults[0] = 2147482646.0;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER + MV_GROUP_BY);
+    expectedResults[0] = 2147482638.0;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable);
+  }
+
+  @Test
+  public void testDistinctCountMV() {
+    String query = "SELECT DISTINCTCOUNTMV(column6) AS value FROM testTable";
+
+    // Without filter, query should be answered by DictionaryBasedAggregationOperator (numEntriesScannedPostFilter = 0)
+    BrokerResponseNative brokerResponse = getBrokerResponse(query);
+    DataSchema expectedDataSchema = new DataSchema(new String[]{"value"}, new DataSchema.ColumnDataType[]
+        {DataSchema.ColumnDataType.INT});
+    Object[] expectedResults = new Object[]{18499};
+    ResultTable expectedResultTable = new ResultTable(expectedDataSchema, Collections.singletonList(expectedResults));
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 400000L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER);
+    expectedResults[0] = 1186;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 62480L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + SV_GROUP_BY);
+    expectedResults[0] = 4784;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER + SV_GROUP_BY);
+    expectedResults[0] = 1186;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + MV_GROUP_BY);
+    expectedResults[0] = 3434;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER + MV_GROUP_BY);
+    expectedResults[0] = 583;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable);
+  }
+
+  @Test
+  public void testDistinctCountHLLMV() {
+    String query = "SELECT DISTINCTCOUNTHLLMV(column6) AS value FROM testTable";
+
+    // Without filter, query should be answered by DictionaryBasedAggregationOperator (numEntriesScannedPostFilter = 0)
+    BrokerResponseNative brokerResponse = getBrokerResponse(query);
+    DataSchema expectedDataSchema = new DataSchema(new String[]{"value"}, new DataSchema.ColumnDataType[]
+        {DataSchema.ColumnDataType.LONG});
+    Object[] expectedResults = new Object[]{20039L};
+    ResultTable expectedResultTable = new ResultTable(expectedDataSchema, Collections.singletonList(expectedResults));
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 400000L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER);
+    expectedResults[0] = 1296L;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 62480L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + SV_GROUP_BY);
+    expectedResults[0] = 4715L;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER + SV_GROUP_BY);
+    expectedResults[0] = 1296L;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + MV_GROUP_BY);
+    expectedResults[0] = 3490L;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+    brokerResponse = getBrokerResponse(query + FILTER + MV_GROUP_BY);
+    expectedResults[0] = 606L;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable);
+  }
+
+  @Test
+  public void testDistinctCountRawHLLMV() {
+    String query = "SELECT DISTINCTCOUNTRAWHLLMV(column6) AS value FROM testTable";
+    Function<Object, Object> cardinalityExtractor =
+        value -> ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(BytesUtils.toBytes((String) value)).cardinality();
+
+    // Without filter, query should be answered by DictionaryBasedAggregationOperator (numEntriesScannedPostFilter = 0)
+    BrokerResponseNative brokerResponse = getBrokerResponse(query);
+    DataSchema expectedDataSchema = new DataSchema(new String[]{"value"}, new DataSchema.ColumnDataType[]
+        {DataSchema.ColumnDataType.LONG});
+    Object[] expectedResults = new Object[]{20039L};
+    ResultTable expectedResultTable = new ResultTable(expectedDataSchema, Collections.singletonList(expectedResults));
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 400000L, 400000L, expectedResultTable,
+        cardinalityExtractor);
+
+    brokerResponse = getBrokerResponse(query + FILTER);
+    expectedResults[0] = 1296L;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 62480L, 400000L, expectedResultTable,
+        cardinalityExtractor);
+
+    brokerResponse = getBrokerResponse(query + SV_GROUP_BY);
+    expectedResults[0] = 4715L;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable,
+        cardinalityExtractor);
+
+    brokerResponse = getBrokerResponse(query + FILTER + SV_GROUP_BY);
+    expectedResults[0] = 1296L;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable,
+        cardinalityExtractor);
+
+    brokerResponse = getBrokerResponse(query + MV_GROUP_BY);
+    expectedResults[0] = 3490L;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable,
+        cardinalityExtractor);
+
+    brokerResponse = getBrokerResponse(query + FILTER + MV_GROUP_BY);
+    expectedResults[0] = 606L;
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable,
+        cardinalityExtractor);
+  }
+
+  @Test
+  public void testPercentileMV() {
+    List<String> queries = Arrays.asList("SELECT PERCENTILE50MV(column6) AS value FROM testTable",
+        "SELECT PERCENTILEMV(column6, 50) AS value FROM testTable",
+        "SELECT PERCENTILEMV(column6, '50') AS value FROM testTable",
+        "SELECT PERCENTILE90MV(column6) AS value FROM testTable",
+        "SELECT PERCENTILE95MV(column6) AS value FROM testTable",
+        "SELECT PERCENTILE99MV(column6) AS value FROM testTable");
+
+    DataSchema expectedDataSchema = new DataSchema(new String[]{"value"}, new DataSchema.ColumnDataType[]
+        {DataSchema.ColumnDataType.DOUBLE});
+    ResultTable expectedResultTable =
+        new ResultTable(expectedDataSchema, Collections.singletonList(new Object[]{2147483647.0}));
+    for (String query : queries) {
+      BrokerResponseNative brokerResponse = getBrokerResponse(query);
+      QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 400000L, 400000L, expectedResultTable);
+
+      brokerResponse = getBrokerResponse(query + FILTER);
+      QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 62480L, 400000L, expectedResultTable);
+
+      brokerResponse = getBrokerResponse(query + SV_GROUP_BY);
+      QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+      brokerResponse = getBrokerResponse(query + FILTER + SV_GROUP_BY);
+      QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable);
+
+      brokerResponse = getBrokerResponse(query + MV_GROUP_BY);
+      QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+      brokerResponse = getBrokerResponse(query + FILTER + MV_GROUP_BY);
+      QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable);
+    }
+  }
+
+  @Test
+  public void testPercentileEstMV() {
+    List<String> queries = Arrays.asList("SELECT PERCENTILEEST50MV(column6) AS value FROM testTable",
+        "SELECT PERCENTILEESTMV(column6, 50) AS value FROM testTable",
+        "SELECT PERCENTILEESTMV(column6, '50') AS value FROM testTable",
+        "SELECT PERCENTILEEST90MV(column6) AS value FROM testTable",
+        "SELECT PERCENTILEEST95MV(column6) AS value FROM testTable",
+        "SELECT PERCENTILEEST99MV(column6) AS value FROM testTable");
+
+    for (String query : queries) {
+      BrokerResponseNative brokerResponse = getBrokerResponse(query);
+      DataSchema expectedDataSchema = new DataSchema(new String[]{"value"}, new DataSchema.ColumnDataType[]
+          {DataSchema.ColumnDataType.LONG});
+      ResultTable expectedResultTable =
+          new ResultTable(expectedDataSchema, Collections.singletonList(new Object[]{2147483647L}));
+      QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 400000L, 400000L, expectedResultTable);
+
+      brokerResponse = getBrokerResponse(query + FILTER);
+      QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 62480L, 400000L, expectedResultTable);
+
+      brokerResponse = getBrokerResponse(query + SV_GROUP_BY);
+      QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+      brokerResponse = getBrokerResponse(query + FILTER + SV_GROUP_BY);
+      QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable);
+
+      brokerResponse = getBrokerResponse(query + MV_GROUP_BY);
+      QueriesTestUtils.testInterSegmentsResult(brokerResponse, 400000L, 0L, 800000L, 400000L, expectedResultTable);
+
+      brokerResponse = getBrokerResponse(query + FILTER + MV_GROUP_BY);
+      QueriesTestUtils.testInterSegmentsResult(brokerResponse, 62480L, 1101664L, 124960L, 400000L, expectedResultTable);
+    }
+  }
+
+  @Test
+  public void testPercentileRawEstMV() {
+    testPercentileRawEstMV(50);
+    testPercentileRawEstMV(90);
+    testPercentileRawEstMV(95);
+    testPercentileRawEstMV(99);
+  }
+
+  private void testPercentileRawEstMV(int percentile) {
+    Function<Object, Object> quantileExtractor =
+        value -> ObjectSerDeUtils.QUANTILE_DIGEST_SER_DE.deserialize(BytesUtils.toBytes((String) value))
+            .getQuantile(percentile / 100.0);
+
+    String rawQuery = String.format("SELECT PERCENTILERAWEST%dMV(column6) AS value FROM testTable", percentile);
+    String regularQuery = String.format("SELECT PERCENTILEEST%dMV(column6) AS value FROM testTable", percentile);
+    QueriesTestUtils.testInterSegmentsResult(getBrokerResponse(rawQuery), getBrokerResponse(regularQuery),
+        quantileExtractor);
+    QueriesTestUtils.testInterSegmentsResult(getBrokerResponse(rawQuery + FILTER),
+        getBrokerResponse(regularQuery + FILTER), quantileExtractor);
+    QueriesTestUtils.testInterSegmentsResult(getBrokerResponse(rawQuery + SV_GROUP_BY),
+        getBrokerResponse(regularQuery + SV_GROUP_BY), quantileExtractor);
+    QueriesTestUtils.testInterSegmentsResult(getBrokerResponse(rawQuery + FILTER + SV_GROUP_BY),
+        getBrokerResponse(regularQuery + FILTER + SV_GROUP_BY), quantileExtractor);
+    QueriesTestUtils.testInterSegmentsResult(getBrokerResponse(rawQuery + MV_GROUP_BY),
+        getBrokerResponse(regularQuery + MV_GROUP_BY), quantileExtractor);
+    QueriesTestUtils.testInterSegmentsResult(getBrokerResponse(rawQuery + FILTER + MV_GROUP_BY),
+        getBrokerResponse(regularQuery + FILTER + MV_GROUP_BY), quantileExtractor);
+  }
+
+  @Test
+  public void testPercentileRawTDigestMV() {
+    testPercentileRawTDigestMV(50);
+    testPercentileRawTDigestMV(90);
+    testPercentileRawTDigestMV(95);
+    testPercentileRawTDigestMV(99);
+  }
+
+  private void testPercentileRawTDigestMV(int percentile) {
+    Function<Object, Object> quantileExtractor =
+        value -> ObjectSerDeUtils.TDIGEST_SER_DE.deserialize(BytesUtils.toBytes((String) value))
+            .quantile(percentile / 100.0);
+
+    String rawQuery = String.format("SELECT PERCENTILERAWTDIGEST%dMV(column6) AS value FROM testTable", percentile);
+    String regularQuery = String.format("SELECT PERCENTILETDIGEST%dMV(column6) AS value FROM testTable", percentile);
+    QueriesTestUtils.testInterSegmentsResult(getBrokerResponse(rawQuery), getBrokerResponse(regularQuery),
+        quantileExtractor, PERCENTILE_TDIGEST_DELTA);
+    QueriesTestUtils.testInterSegmentsResult(getBrokerResponse(rawQuery + FILTER),
+        getBrokerResponse(regularQuery + FILTER), quantileExtractor, PERCENTILE_TDIGEST_DELTA);
+    QueriesTestUtils.testInterSegmentsResult(getBrokerResponse(rawQuery + SV_GROUP_BY),
+        getBrokerResponse(regularQuery + SV_GROUP_BY), quantileExtractor, PERCENTILE_TDIGEST_DELTA);
+    QueriesTestUtils.testInterSegmentsResult(getBrokerResponse(rawQuery + FILTER + SV_GROUP_BY),
+        getBrokerResponse(regularQuery + FILTER + SV_GROUP_BY), quantileExtractor, PERCENTILE_TDIGEST_DELTA);
+    QueriesTestUtils.testInterSegmentsResult(getBrokerResponse(rawQuery + MV_GROUP_BY),
+        getBrokerResponse(regularQuery + MV_GROUP_BY), quantileExtractor, PERCENTILE_TDIGEST_DELTA);
+    QueriesTestUtils.testInterSegmentsResult(getBrokerResponse(rawQuery + FILTER + MV_GROUP_BY),
+        getBrokerResponse(regularQuery + FILTER + MV_GROUP_BY), quantileExtractor, PERCENTILE_TDIGEST_DELTA);
+  }
+
+  @Test
+  public void testNumGroupsLimit() {
+    String query = "SELECT COUNT(*) FROM testTable GROUP BY column6";
+
+    BrokerResponseNative brokerResponse = getBrokerResponse(query);
+    assertFalse(brokerResponse.isNumGroupsLimitReached());
+
+    brokerResponse = getBrokerResponse(query,
+        new InstancePlanMakerImplV2(1000, 1000, InstancePlanMakerImplV2.DEFAULT_MIN_SEGMENT_GROUP_TRIM_SIZE,
+            InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
+            InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD));
+    assertTrue(brokerResponse.isNumGroupsLimitReached());
+  }
+
+  @Test
+  public void testFilteredAggregations() {
+    String query = "SELECT COUNT(*) FILTER(WHERE column1 > 5) FROM testTable WHERE column3 > 0";
+    BrokerResponseNative brokerResponse = getBrokerResponse(query);
+    DataSchema expectedDataSchema = new DataSchema(new String[]{"count(*)"}, new DataSchema.ColumnDataType[]
+        {DataSchema.ColumnDataType.LONG});
+    ResultTable expectedResultTable =
+        new ResultTable(expectedDataSchema, Collections.singletonList(new Object[]{370236L}));
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 740472L, 400000L, 0L, 400000L, expectedResultTable);
+  }
+
+  @Test
+  public void testGroupByMVColumns() {
+    String query = "SELECT COUNT(*), column7 FROM testTable GROUP BY column7 LIMIT 1000";
+    BrokerResponseNative brokerResponse = getBrokerResponse(query);
+    assertEquals(brokerResponse.getResultTable().getRows().size(), 359);
+
+    query = "SELECT COUNT(*), column5 FROM testTable GROUP BY column5 LIMIT 1000";
+    brokerResponse = getBrokerResponse(query);
+    assertEquals(brokerResponse.getResultTable().getRows().size(), 9);
+
+    query = "SELECT COUNT(*), column3 FROM testTable GROUP BY column3 LIMIT 1000";
+    brokerResponse = getBrokerResponse(query);
+    assertEquals(brokerResponse.getResultTable().getRows().size(), 5);
+
+    // Test group-by with one multi-value column and one non-dictionary single value column
+    query = "SELECT COUNT(*), column7, column5 FROM testTable GROUP BY column7, column5 LIMIT 1000";
+    brokerResponse = getBrokerResponse(query);
+    assertEquals(brokerResponse.getResultTable().getRows().size(), 1000);
+
+    query = "SELECT COUNT(*), column7, column5 FROM testTable GROUP BY column5, column7 LIMIT 1000";
+    brokerResponse = getBrokerResponse(query);
+    assertEquals(brokerResponse.getResultTable().getRows().size(), 1000);
+
+    // Test group-by with one multi-value column and one single value column
+    query = "SELECT COUNT(*), column3, column5 FROM testTable GROUP BY column3, column5 LIMIT 1000";
+    brokerResponse = getBrokerResponse(query);
+    assertEquals(brokerResponse.getResultTable().getRows().size(), 41);
+
+    query = "SELECT COUNT(*), column3, column5 FROM testTable GROUP BY column5, column3 LIMIT 1000";
+    brokerResponse = getBrokerResponse(query);
+    assertEquals(brokerResponse.getResultTable().getRows().size(), 41);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentGroupByMultiValueRawQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentGroupByMultiValueRawQueriesTest.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests order by queries with MV RAW index
+ */
+public class InterSegmentGroupByMultiValueRawQueriesTest extends BaseMultiValueRawQueriesTest {
+  private static final InstancePlanMakerImplV2 TRIM_ENABLED_PLAN_MAKER =
+      new InstancePlanMakerImplV2(InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY,
+          InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, 1,
+          InstancePlanMakerImplV2.DEFAULT_MIN_SERVER_GROUP_TRIM_SIZE,
+          InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD);
+
+  @Test(dataProvider = "groupByOrderByDataProvider")
+  public void testGroupByOrderBy(String query, long expectedNumEntriesScannedPostFilter,
+      ResultTable expectedResultTable) {
+    QueriesTestUtils.testInterSegmentsResult(getBrokerResponse(query), 400000L, 0L, expectedNumEntriesScannedPostFilter,
+        400000L, expectedResultTable);
+  }
+
+  @Test(dataProvider = "groupByOrderByDataProvider")
+  public void testGroupByOrderByWithTrim(String query, long expectedNumEntriesScannedPostFilter,
+      ResultTable expectedResultTable) {
+    QueriesTestUtils.testInterSegmentsResult(getBrokerResponse(query, TRIM_ENABLED_PLAN_MAKER), 400000L, 0L,
+        expectedNumEntriesScannedPostFilter, 400000L, expectedResultTable);
+  }
+
+  /**
+   * Provides various combinations of order by.
+   * In order to calculate the expected results, the results from a group by were taken, and then ordered accordingly.
+   */
+  @DataProvider
+  public Object[][] groupByOrderByDataProvider() {
+    List<Object[]> entries = new ArrayList<>();
+
+    String query = "SELECT column3, SUMMV(column7) FROM testTable GROUP BY column3 ORDER BY column3";
+    DataSchema dataSchema = new DataSchema(new String[]{"column3", "summv(column7)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    List<Object[]> results = Arrays.asList(new Object[]{"", 63917703269308.0}, new Object[]{"L", 33260235267900.0},
+        new Object[]{"P", 212961658305696.0}, new Object[]{"PbQd", 2001454759004.0},
+        new Object[]{"w", 116831822080776.0});
+    entries.add(new Object[]{query, 800000L, new ResultTable(dataSchema, results)});
+
+    query = "SELECT column5, sumMV(column7) FROM testTable GROUP BY column5 ORDER BY column5 DESC LIMIT 4";
+    dataSchema = new DataSchema(new String[]{"column5", "summv(column7)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    results =
+        Arrays.asList(new Object[]{"yQkJTLOQoOqqhkAClgC", 61100215182228.0}, new Object[]{"mhoVvrJm", 5806796153884.0},
+            new Object[]{"kCMyNVGCASKYDdQbftOPaqVMWc", 51891832239248.0}, new Object[]{"PbQd", 36532997335388.0});
+    entries.add(new Object[]{query, 800000L, new ResultTable(dataSchema, results)});
+
+    query = "SELECT column5, SUMMV(column7) FROM testTable GROUP BY column5 ORDER BY sumMV(column7) LIMIT 5";
+    results = Arrays.asList(new Object[]{"NCoFku", 489626381288.0}, new Object[]{"mhoVvrJm", 5806796153884.0},
+        new Object[]{"JXRmGakTYafZFPm", 18408231081808.0}, new Object[]{"PbQd", 36532997335388.0},
+        new Object[]{"OKyOqU", 51067166589176.0});
+    entries.add(new Object[]{query, 800000L, new ResultTable(dataSchema, results)});
+
+    // aggregation in order-by but not in select
+    query = "SELECT column5 FROM testTable GROUP BY column5 ORDER BY sumMV(column7) LIMIT 5";
+    dataSchema = new DataSchema(new String[]{"column5"}, new DataSchema.ColumnDataType[]
+        {DataSchema.ColumnDataType.STRING});
+    results = Arrays.asList(new Object[]{"NCoFku"}, new Object[]{"mhoVvrJm"}, new Object[]{"JXRmGakTYafZFPm"},
+        new Object[]{"PbQd"}, new Object[]{"OKyOqU"});
+    entries.add(new Object[]{query, 800000L, new ResultTable(dataSchema, results)});
+
+    // group-by column not in select
+    query = "SELECT SUMMV(column7) FROM testTable GROUP BY column5 ORDER BY sumMV(column7) LIMIT 5";
+    dataSchema = new DataSchema(new String[]{"summv(column7)"}, new DataSchema.ColumnDataType[]
+        {DataSchema.ColumnDataType.DOUBLE});
+    results = Arrays.asList(new Object[]{489626381288.0}, new Object[]{5806796153884.0}, new Object[]{18408231081808.0},
+        new Object[]{36532997335388.0}, new Object[]{51067166589176.0});
+    entries.add(new Object[]{query, 800000L, new ResultTable(dataSchema, results)});
+
+    // object type aggregations
+    query = "SELECT column5, MINMAXRANGEMV(column7) FROM testTable GROUP BY column5 ORDER BY column5";
+    dataSchema = new DataSchema(new String[]{"column5", "minmaxrangemv(column7)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    results = Arrays.asList(new Object[]{"AKXcXcIqsqOJFsdwxZ", 2147483446.0}, new Object[]{"EOFxevm", 2147483446.0},
+        new Object[]{"JXRmGakTYafZFPm", 2147483443.0}, new Object[]{"NCoFku", 2147483436.0},
+        new Object[]{"OKyOqU", 2147483443.0}, new Object[]{"PbQd", 2147483443.0},
+        new Object[]{"kCMyNVGCASKYDdQbftOPaqVMWc", 2147483446.0}, new Object[]{"mhoVvrJm", 2147483438.0},
+        new Object[]{"yQkJTLOQoOqqhkAClgC", 2147483446.0});
+    entries.add(new Object[]{query, 800000L, new ResultTable(dataSchema, results)});
+
+    // object type aggregations
+    query = "SELECT column5, minmaxrangemv(column7) FROM testTable"
+        + " GROUP BY column5 ORDER BY minMaxRangeMV(column7), column5 desc";
+    results = Arrays.asList(new Object[]{"NCoFku", 2147483436.0}, new Object[]{"mhoVvrJm", 2147483438.0},
+        new Object[]{"PbQd", 2147483443.0}, new Object[]{"OKyOqU", 2147483443.0},
+        new Object[]{"JXRmGakTYafZFPm", 2147483443.0}, new Object[]{"yQkJTLOQoOqqhkAClgC", 2147483446.0},
+        new Object[]{"kCMyNVGCASKYDdQbftOPaqVMWc", 2147483446.0}, new Object[]{"EOFxevm", 2147483446.0},
+        new Object[]{"AKXcXcIqsqOJFsdwxZ", 2147483446.0});
+    entries.add(new Object[]{query, 800000L, new ResultTable(dataSchema, results)});
+
+    // object type aggregations - non comparable intermediate results
+    query = "SELECT column5, DISTINCTCOUNTMV(column7) FROM testTable"
+        + " GROUP BY column5 ORDER BY distinctCountMV(column7) LIMIT 5";
+    dataSchema = new DataSchema(new String[]{"column5", "distinctcountmv(column7)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
+    results =
+        Arrays.asList(new Object[]{"NCoFku", 26}, new Object[]{"mhoVvrJm", 65}, new Object[]{"JXRmGakTYafZFPm", 126},
+            new Object[]{"PbQd", 211}, new Object[]{"OKyOqU", 216});
+    entries.add(new Object[]{query, 800000L, new ResultTable(dataSchema, results)});
+
+    // percentile
+    query = "SELECT column5, PERCENTILE90MV(column7) FROM testTable"
+        + " GROUP BY column5 ORDER BY percentile90mv(column7), column5 DESC LIMIT 5";
+    dataSchema = new DataSchema(new String[]{"column5", "percentile90mv(column7)"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE});
+    results = Arrays.asList(new Object[]{"yQkJTLOQoOqqhkAClgC", 2.147483647E9}, new Object[]{"mhoVvrJm", 2.147483647E9},
+        new Object[]{"kCMyNVGCASKYDdQbftOPaqVMWc", 2.147483647E9}, new Object[]{"PbQd", 2.147483647E9},
+        new Object[]{"OKyOqU", 2.147483647E9});
+    entries.add(new Object[]{query, 800000L, new ResultTable(dataSchema, results)});
+
+    return entries.toArray(new Object[0][]);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/MultiValueRawQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/MultiValueRawQueriesTest.java
@@ -1,0 +1,1602 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class MultiValueRawQueriesTest extends BaseQueriesTest {
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "MultiValueRawQueriesTest");
+
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String SEGMENT_NAME_1 = "testSegment1";
+  private static final String SEGMENT_NAME_2 = "testSegment2";
+
+  private static final int NUM_UNIQUE_RECORDS_PER_SEGMENT = 10;
+  private static final int NUM_DUPLICATES_PER_RECORDS = 2;
+  private static final int MV_OFFSET = 100;
+  private static final int BASE_VALUE_1 = 0;
+  private static final int BASE_VALUE_2 = 1000;
+
+  private final static String SV_INT_COL = "svIntCol";
+  private final static String MV_INT_COL = "mvIntCol";
+  private final static String MV_LONG_COL = "mvLongCol";
+  private final static String MV_FLOAT_COL = "mvFloatCol";
+  private final static String MV_DOUBLE_COL = "mvDoubleCol";
+  private final static String MV_STRING_COL = "mvStringCol";
+  private final static String MV_RAW_INT_COL = "mvRawIntCol";
+  private final static String MV_RAW_LONG_COL = "mvRawLongCol";
+  private final static String MV_RAW_FLOAT_COL = "mvRawFloatCol";
+  private final static String MV_RAW_DOUBLE_COL = "mvRawDoubleCol";
+  private final static String MV_RAW_STRING_COL = "mvRawStringCol";
+
+  private static final Schema SCHEMA = new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME)
+      .addSingleValueDimension(SV_INT_COL, FieldSpec.DataType.INT)
+      .addMultiValueDimension(MV_INT_COL, FieldSpec.DataType.INT)
+      .addMultiValueDimension(MV_LONG_COL, FieldSpec.DataType.LONG)
+      .addMultiValueDimension(MV_FLOAT_COL, FieldSpec.DataType.FLOAT)
+      .addMultiValueDimension(MV_DOUBLE_COL, FieldSpec.DataType.DOUBLE)
+      .addMultiValueDimension(MV_STRING_COL, FieldSpec.DataType.STRING)
+      .addMultiValueDimension(MV_RAW_INT_COL, FieldSpec.DataType.INT)
+      .addMultiValueDimension(MV_RAW_LONG_COL, FieldSpec.DataType.LONG)
+      .addMultiValueDimension(MV_RAW_FLOAT_COL, FieldSpec.DataType.FLOAT)
+      .addMultiValueDimension(MV_RAW_DOUBLE_COL, FieldSpec.DataType.DOUBLE)
+      .addMultiValueDimension(MV_RAW_STRING_COL, FieldSpec.DataType.STRING)
+      .build();
+
+  private static final DataSchema DATA_SCHEMA = new DataSchema(new String[]{"mvDoubleCol", "mvFloatCol", "mvIntCol",
+      "mvLongCol", "mvRawDoubleCol", "mvRawFloatCol", "mvRawIntCol", "mvRawLongCol", "mvRawStringCol", "mvStringCol",
+      "svIntCol"},
+      new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.FLOAT_ARRAY,
+          DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.LONG_ARRAY,
+          DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.FLOAT_ARRAY,
+          DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.LONG_ARRAY,
+          DataSchema.ColumnDataType.STRING_ARRAY, DataSchema.ColumnDataType.STRING_ARRAY,
+          DataSchema.ColumnDataType.INT});
+
+  private static final TableConfig TABLE = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
+      .setNoDictionaryColumns(
+          Arrays.asList(MV_RAW_INT_COL, MV_RAW_LONG_COL, MV_RAW_FLOAT_COL, MV_RAW_DOUBLE_COL, MV_RAW_STRING_COL))
+      .build();
+
+  private IndexSegment _indexSegment;
+  private List<IndexSegment> _indexSegments;
+
+  @Override
+  protected String getFilter() {
+    return "";
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteQuietly(INDEX_DIR);
+
+    ImmutableSegment segment1 = createSegment(generateRecords(BASE_VALUE_1), SEGMENT_NAME_1);
+    ImmutableSegment segment2 = createSegment(generateRecords(BASE_VALUE_2), SEGMENT_NAME_2);
+    _indexSegment = segment1;
+    _indexSegments = Arrays.asList(segment1, segment2);
+  }
+
+  @AfterClass
+  public void tearDown() {
+    for (IndexSegment indexSegment : _indexSegments) {
+      indexSegment.destroy();
+    }
+
+    FileUtils.deleteQuietly(INDEX_DIR);
+  }
+
+  /**
+   * Helper method to generate records based on the given base value.
+   *
+   * All columns will have the same value but different data types (BYTES values are encoded STRING values).
+   * For the {i}th unique record, the value will be {baseValue + i}.
+   */
+  private List<GenericRow> generateRecords(int baseValue) {
+    List<GenericRow> uniqueRecords = new ArrayList<>(NUM_UNIQUE_RECORDS_PER_SEGMENT);
+    for (int i = 0; i < NUM_UNIQUE_RECORDS_PER_SEGMENT; i++) {
+      int value = baseValue + i;
+      GenericRow record = new GenericRow();
+      record.putValue(SV_INT_COL, value);
+      Integer[] mvValue = new Integer[]{value, value + MV_OFFSET};
+      record.putValue(MV_INT_COL, mvValue);
+      record.putValue(MV_LONG_COL, mvValue);
+      record.putValue(MV_FLOAT_COL, mvValue);
+      record.putValue(MV_DOUBLE_COL, mvValue);
+      record.putValue(MV_STRING_COL, mvValue);
+      record.putValue(MV_RAW_INT_COL, mvValue);
+      record.putValue(MV_RAW_LONG_COL, mvValue);
+      record.putValue(MV_RAW_FLOAT_COL, mvValue);
+      record.putValue(MV_RAW_DOUBLE_COL, mvValue);
+      record.putValue(MV_RAW_STRING_COL, mvValue);
+      uniqueRecords.add(record);
+    }
+
+    List<GenericRow> records = new ArrayList<>(NUM_UNIQUE_RECORDS_PER_SEGMENT * NUM_DUPLICATES_PER_RECORDS);
+    for (int i = 0; i < NUM_DUPLICATES_PER_RECORDS; i++) {
+      records.addAll(uniqueRecords);
+    }
+    return records;
+  }
+
+  private ImmutableSegment createSegment(List<GenericRow> records, String segmentName)
+      throws Exception {
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE, SCHEMA);
+    segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
+    segmentGeneratorConfig.setSegmentName(segmentName);
+    segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records));
+    driver.build();
+
+    return ImmutableSegmentLoader.load(new File(INDEX_DIR, segmentName), ReadMode.mmap);
+  }
+
+  @Test
+  public void testSelectQueries() {
+    {
+      // Select * query
+      String query = "SELECT * from testTable ORDER BY svIntCol LIMIT 40";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      assertEquals(resultTable.getDataSchema(), DATA_SCHEMA);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 40);
+
+      Set<Integer> expectedValuesFirst = new HashSet<>();
+      Set<Integer> expectedValuesSecond = new HashSet<>();
+      for (int i = 0; i < NUM_UNIQUE_RECORDS_PER_SEGMENT; i++) {
+        expectedValuesFirst.add(i);
+        expectedValuesSecond.add(i + MV_OFFSET);
+      }
+
+      Set<Integer> actualValuesFirst = new HashSet<>();
+      Set<Integer> actualValuesSecond = new HashSet<>();
+      for (int i = 0; i < 40; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 11);
+        int svIntValue = (int) values[10];
+        int[] intValues = (int[]) values[2];
+        assertEquals(intValues[1] - intValues[0], MV_OFFSET);
+        assertEquals(svIntValue, intValues[0]);
+
+        int[] intValuesRaw = (int[]) values[6];
+        assertEquals(intValues[0], intValuesRaw[0]);
+        assertEquals(intValues[1], intValuesRaw[1]);
+
+        long[] longValues = (long[]) values[3];
+        long[] longValuesRaw = (long[]) values[7];
+        assertEquals(longValues[0], intValues[0]);
+        assertEquals(longValues[1], intValues[1]);
+        assertEquals(longValues[0], longValuesRaw[0]);
+        assertEquals(longValues[1], longValuesRaw[1]);
+
+        float[] floatValues = (float[]) values[1];
+        float[] floatValuesRaw = (float[]) values[5];
+        assertEquals(floatValues[0], (float) intValues[0]);
+        assertEquals(floatValues[1], (float) intValues[1]);
+        assertEquals(floatValues[0], floatValuesRaw[0]);
+        assertEquals(floatValues[1], floatValuesRaw[1]);
+
+        double[] doubleValues = (double[]) values[0];
+        double[] doubleValuesRaw = (double[]) values[4];
+        assertEquals(doubleValues[0], (double) intValues[0]);
+        assertEquals(doubleValues[1], (double) intValues[1]);
+        assertEquals(doubleValues[0], doubleValuesRaw[0]);
+        assertEquals(doubleValues[1], doubleValuesRaw[1]);
+
+        String[] stringValues = (String[]) values[8];
+        String[] stringValuesRaw = (String[]) values[9];
+        assertEquals(Integer.parseInt(stringValues[0]), intValues[0]);
+        assertEquals(Integer.parseInt(stringValues[1]), intValues[1]);
+        assertEquals(stringValues[0], stringValuesRaw[0]);
+        assertEquals(stringValues[1], stringValuesRaw[1]);
+
+        actualValuesFirst.add(intValues[0]);
+        actualValuesSecond.add(intValues[1]);
+      }
+      assertTrue(actualValuesFirst.containsAll(expectedValuesFirst));
+      assertTrue(actualValuesSecond.containsAll(expectedValuesSecond));
+    }
+    {
+      // Select some dict based MV and some raw MV columns. Validate that the values match for the corresponding rows
+      String query = "SELECT mvIntCol, mvDoubleCol, mvStringCol, mvRawIntCol, mvRawDoubleCol, mvRawStringCol, svIntCol "
+          + "from testTable ORDER BY svIntCol LIMIT 40";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "mvIntCol", "mvDoubleCol", "mvStringCol", "mvRawIntCol", "mvRawDoubleCol", "mvRawStringCol", "svIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY,
+          DataSchema.ColumnDataType.STRING_ARRAY, DataSchema.ColumnDataType.INT_ARRAY,
+          DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.STRING_ARRAY,
+          DataSchema.ColumnDataType.INT
+      });
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 40);
+
+      Set<Integer> expectedValuesFirst = new HashSet<>();
+      Set<Integer> expectedValuesSecond = new HashSet<>();
+      for (int i = 0; i < NUM_UNIQUE_RECORDS_PER_SEGMENT; i++) {
+        expectedValuesFirst.add(i);
+        expectedValuesSecond.add(i + MV_OFFSET);
+      }
+
+      Set<Integer> actualValuesFirst = new HashSet<>();
+      Set<Integer> actualValuesSecond = new HashSet<>();
+      for (int i = 0; i < 40; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 7);
+        int[] intValues = (int[]) values[0];
+        assertEquals(intValues[1] - intValues[0], MV_OFFSET);
+
+        int[] intValuesRaw = (int[]) values[3];
+        assertEquals(intValues[0], intValuesRaw[0]);
+        assertEquals(intValues[1], intValuesRaw[1]);
+
+        double[] doubleValues = (double[]) values[1];
+        double[] doubleValuesRaw = (double[]) values[4];
+        assertEquals(doubleValues[0], (double) intValues[0]);
+        assertEquals(doubleValues[1], (double) intValues[1]);
+        assertEquals(doubleValues[0], doubleValuesRaw[0]);
+        assertEquals(doubleValues[1], doubleValuesRaw[1]);
+
+        String[] stringValues = (String[]) values[2];
+        String[] stringValuesRaw = (String[]) values[5];
+        assertEquals(Integer.parseInt(stringValues[0]), intValues[0]);
+        assertEquals(Integer.parseInt(stringValues[1]), intValues[1]);
+        assertEquals(stringValues[0], stringValuesRaw[0]);
+        assertEquals(stringValues[1], stringValuesRaw[1]);
+
+        assertEquals(intValues[0], (int) values[6]);
+        assertEquals(intValuesRaw[0], (int) values[6]);
+
+        actualValuesFirst.add(intValues[0]);
+        actualValuesSecond.add(intValues[1]);
+      }
+      assertTrue(actualValuesFirst.containsAll(expectedValuesFirst));
+      assertTrue(actualValuesSecond.containsAll(expectedValuesSecond));
+    }
+    {
+      // Test a select with a ARRAYLENGTH transform function
+      String query = "SELECT ARRAYLENGTH(mvRawLongCol), ARRAYLENGTH(mvLongCol) from testTable LIMIT 10";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      DataSchema dataSchema = new DataSchema(new String[]{"arraylength(mvRawLongCol)", "arraylength(mvLongCol)"},
+          new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT});
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 10);
+
+      for (int i = 0; i < 10; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 2);
+        int intRawVal = (int) values[0];
+        int intVal = (int) values[1];
+        assertEquals(intRawVal, 2);
+        assertEquals(intVal, intRawVal);
+        assertEquals(intVal, intRawVal);
+      }
+    }
+  }
+
+  @Test
+  public void testNonAggregateMVGroupBY() {
+    {
+      // TODO: Today ORDER BY on MV columns (irrespective of whether it's dictionary based or raw) doesn't work
+      //       Fix ORDER BY only for MV columns
+      String query = "SELECT mvFloatCol from testTable WHERE mvFloatCol < 5 ORDER BY mvFloatCol LIMIT 10";
+      BrokerResponseNative brokerResponseNative = getBrokerResponse(query);
+      assertEquals(brokerResponseNative.getProcessingExceptions().size(), 2);
+    }
+    {
+      // Test a group by query on some raw MV rows. Order by on SV column added for determinism
+      String query = "SELECT svIntCol, mvRawFloatCol, mvRawDoubleCol, mvRawStringCol from testTable GROUP BY "
+          + "svIntCol, mvRawFloatCol, mvRawDoubleCol, mvRawStringCol ORDER BY svIntCol LIMIT 10";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "svIntCol", "mvRawFloatCol", "mvRawDoubleCol", "mvRawStringCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.FLOAT, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.STRING
+      });
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 10);
+
+      int[] expectedSVInts = new int[]{0, 0, 0, 0, 0, 0, 0, 0, 1, 1};
+
+      for (int i = 0; i < 10; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 4);
+        assertEquals((int) values[0], expectedSVInts[i]);
+      }
+    }
+    {
+      // Test a group by order by query on some raw MV rows (order by on int and double)
+      String query = "SELECT mvRawIntCol, mvRawDoubleCol, mvRawStringCol from testTable GROUP BY mvRawIntCol, "
+          + "mvRawDoubleCol, mvRawStringCol ORDER BY mvRawIntCol, mvRawDoubleCol LIMIT 20";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "mvRawIntCol", "mvRawDoubleCol", "mvRawStringCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.STRING
+      });
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 20);
+
+      int intValue = -1;
+      double doubleValue = -1;
+      for (int i = 0; i < 20; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 3);
+        int intValueCur = (int) values[0];
+        double doubleValueCur = (double) values[1];
+        assertTrue(intValueCur >= intValue);
+        if (intValueCur == intValue) {
+          assertTrue(doubleValueCur >= doubleValue);
+        }
+
+        intValue = intValueCur;
+        doubleValue = doubleValueCur;
+      }
+    }
+    {
+      // Test a group by order by query on some raw MV rows (order by on string)
+      String query = "SELECT mvRawIntCol, mvRawDoubleCol, mvRawStringCol from testTable GROUP BY mvRawIntCol, "
+          + "mvRawDoubleCol, mvRawStringCol ORDER BY mvRawStringCol LIMIT 10";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "mvRawIntCol", "mvRawDoubleCol", "mvRawStringCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.STRING
+      });
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 10);
+
+      String stringVal = null;
+      for (int i = 0; i < 10; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 3);
+        String stringValueCur = (String) values[2];
+        if (stringVal != null && !stringValueCur.equals(stringVal)) {
+          assertTrue(stringValueCur.compareTo(stringVal) > 0);
+        }
+        stringVal = stringValueCur;
+      }
+    }
+    {
+      // Test a select with a VALUEIN transform function with group by
+      String query = "SELECT VALUEIN(mvRawIntCol, '0') from testTable WHERE mvRawIntCol IN (0) GROUP BY "
+          + "VALUEIN(mvRawIntCol, '0') LIMIT 10";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      DataSchema dataSchema = new DataSchema(new String[]{"valuein(mvRawIntCol,'0')"},
+          new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT});
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 1);
+      Object[] values = recordRows.get(0);
+      assertEquals(values.length, 1);
+      int intRawVal = (int) values[0];
+      assertEquals(intRawVal, 0);
+    }
+    {
+      // Test a select with a VALUEIN transform function with group by order by
+      String query = "SELECT VALUEIN(mvRawDoubleCol, '0.0') from testTable WHERE mvRawDoubleCol IN (0.0) GROUP BY "
+          + "VALUEIN(mvRawDoubleCol, '0.0') ORDER BY VALUEIN(mvRawDoubleCol, '0.0') LIMIT 10";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      DataSchema dataSchema = new DataSchema(new String[]{"valuein(mvRawDoubleCol,'0.0')"},
+          new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 1);
+      Object[] values = recordRows.get(0);
+      assertEquals(values.length, 1);
+      double doubleRawVal = (double) values[0];
+      assertEquals(doubleRawVal, 0.0);
+    }
+  }
+
+  @Test
+  public void testSelectWithFilterQueries() {
+    {
+      // Test a select with filter query on a MV raw column identifier
+      String query = "SELECT mvRawIntCol, mvRawDoubleCol, mvRawStringCol from testTable where mvRawIntCol < 5 LIMIT 10";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "mvRawIntCol", "mvRawDoubleCol", "mvRawStringCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY,
+          DataSchema.ColumnDataType.STRING_ARRAY
+      });
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 10);
+
+      for (int i = 0; i < 10; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 3);
+        int[] intVal = (int[]) values[0];
+        assertEquals(intVal[1] - intVal[0], MV_OFFSET);
+        assertEquals(intVal[0], i % 5);
+        assertEquals(intVal[1], (i % 5) + MV_OFFSET);
+
+        double[] doubleVal = (double[]) values[1];
+        assertEquals(doubleVal[0], (double) i % 5);
+        assertEquals(doubleVal[1], (double) (i % 5) + MV_OFFSET);
+
+        String[] stringVal = (String[]) values[2];
+        assertEquals(Integer.parseInt(stringVal[0]), i % 5);
+        assertEquals(Integer.parseInt(stringVal[1]), (i % 5) + MV_OFFSET);
+      }
+    }
+    {
+      // Test a select with filter query (OR) on two MV raw column identifiers (int and double)
+      String query = "SELECT mvRawIntCol, mvRawDoubleCol, mvRawStringCol from testTable where mvRawIntCol < 5 "
+          + "OR mvRawDoubleCol > 1104.0 LIMIT 10";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "mvRawIntCol", "mvRawDoubleCol", "mvRawStringCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY,
+          DataSchema.ColumnDataType.STRING_ARRAY
+      });
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 10);
+
+      for (int i = 0; i < 10; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 3);
+        int[] intVal = (int[]) values[0];
+        assertEquals(intVal[1] - intVal[0], MV_OFFSET);
+        double[] doubleVal = (double[]) values[1];
+        assertTrue(intVal[0] < 5 || intVal[1] < 5 || doubleVal[0] > 1104.0 || doubleVal[1] > 1104.0);
+      }
+    }
+    {
+      // Test a select with filter query on a long MV raw column identifier
+      String query = "SELECT mvRawLongCol from testTable where mvRawLongCol > 1100 LIMIT 10";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "mvRawLongCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG_ARRAY
+      });
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 10);
+
+      for (int i = 0; i < 10; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 1);
+        long[] longVal = (long[]) values[0];
+        assertEquals(longVal[1] - longVal[0], MV_OFFSET);
+        assertTrue(longVal[0] > 1100 || longVal[1] > 1100);
+      }
+    }
+    {
+      // Test a select with filter = query on a string MV raw column identifier
+      String query = "SELECT mvRawStringCol from testTable where mvRawStringCol = '1100' LIMIT 10";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "mvRawStringCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.STRING_ARRAY
+      });
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 4);
+
+      for (int i = 0; i < 4; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 1);
+        String[] stringVal = (String[]) values[0];
+        assertEquals(Integer.parseInt(stringVal[1]) - Integer.parseInt(stringVal[0]), MV_OFFSET);
+        assertTrue(Integer.parseInt(stringVal[0]) == 1100 || Integer.parseInt(stringVal[1]) == 1100);
+      }
+    }
+    {
+      // Test a select with filter = query on int, float, long, and double MV raw column identifiers
+      String query = "SELECT mvRawIntCol, mvRawFloatCol, mvRawLongCol, mvRawDoubleCol from testTable where "
+          + "mvRawIntCol = '1100' AND mvRawFloatCol = '1100.0' AND mvRawLongCol = '1100' AND mvRawDoubleCol = '1100.0' "
+          + "LIMIT 10";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "mvRawIntCol", "mvRawFloatCol", "mvRawLongCol", "mvRawDoubleCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.FLOAT_ARRAY,
+          DataSchema.ColumnDataType.LONG_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY
+      });
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 4);
+
+      for (int i = 0; i < 4; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 4);
+        int[] intVal = (int[]) values[0];
+        assertEquals(intVal[1] - intVal[0], MV_OFFSET);
+        assertTrue(intVal[0] == 1100 || intVal[1] == 1100);
+
+        float[] floatVal = (float[]) values[1];
+        assertEquals(floatVal[1] - floatVal[0], (float) MV_OFFSET);
+        assertTrue(floatVal[0] == 1100.0F || floatVal[1] == 1100.0F);
+
+        long[] longVal = (long[]) values[2];
+        assertEquals(longVal[1] - longVal[0], MV_OFFSET);
+        assertTrue(longVal[0] == 1100L || longVal[1] == 1100L);
+
+        double[] doubleVal = (double[]) values[3];
+        assertEquals(doubleVal[1] - doubleVal[0], (double) MV_OFFSET);
+        assertTrue(doubleVal[0] == 1100.0 || doubleVal[1] == 1100.0);
+      }
+    }
+    {
+      // Test a select with filter query (AND) on two MV raw column identifiers (one int and another double) such that
+      // the values in the filter are mutually exclusive
+      // No match should be found
+      String query = "SELECT mvRawIntCol, mvRawDoubleCol, mvRawStringCol from testTable where mvRawIntCol < 5 "
+          + "AND mvRawDoubleCol > 1104.0 LIMIT 10";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "mvRawIntCol", "mvRawDoubleCol", "mvRawStringCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY,
+          DataSchema.ColumnDataType.STRING_ARRAY
+      });
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 0);
+    }
+    {
+      // Test a select with filter IN query on int, float, long, and double MV raw column identifiers
+      String query = "SELECT mvRawIntCol, mvRawFloatCol, mvRawLongCol, mvRawDoubleCol from testTable where "
+          + "mvRawIntCol IN (1100, 1101) AND mvRawFloatCol IN (1100.0, 1101.0) AND mvRawLongCol "
+          + "IN (1100, 1101) AND mvRawDoubleCol IN (1100.0, 1101.0) LIMIT 10";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "mvRawIntCol", "mvRawFloatCol", "mvRawLongCol", "mvRawDoubleCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.FLOAT_ARRAY,
+          DataSchema.ColumnDataType.LONG_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY
+      });
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 8);
+
+      for (int i = 0; i < 4; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 4);
+        int[] intVal = (int[]) values[0];
+        assertEquals(intVal[1] - intVal[0], MV_OFFSET);
+        assertTrue(intVal[0] == 1100 || intVal[1] == 1100 || intVal[0] == 1101 || intVal[1] == 1101);
+
+        float[] floatVal = (float[]) values[1];
+        assertEquals(floatVal[1] - floatVal[0], (float) MV_OFFSET);
+        assertTrue(floatVal[0] == 1100.0F || floatVal[1] == 1100.0F || floatVal[0] == 1101.0F
+            || floatVal[1] == 1101.0F);
+
+        long[] longVal = (long[]) values[2];
+        assertEquals(longVal[1] - longVal[0], MV_OFFSET);
+        assertTrue(longVal[0] == 1100L || longVal[1] == 1100L || longVal[0] == 1101L || longVal[1] == 1101L);
+
+        double[] doubleVal = (double[]) values[3];
+        assertEquals(doubleVal[1] - doubleVal[0], (double) MV_OFFSET);
+        assertTrue(doubleVal[0] == 1100.0 || doubleVal[1] == 1100.0 || doubleVal[0] == 1101.0
+            || doubleVal[1] == 1101.0);
+      }
+    }
+    {
+      // Test a select with filter IN query on the string MV raw column identifier
+      String query = "SELECT mvRawStringCol from testTable where mvRawStringCol IN ('1100', '1101') LIMIT 10";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "mvRawStringCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.STRING_ARRAY
+      });
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 8);
+
+      for (int i = 0; i < 4; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 1);
+        String[] stringVal = (String[]) values[0];
+        assertEquals(Integer.parseInt(stringVal[1]) - Integer.parseInt(stringVal[0]), MV_OFFSET);
+        assertTrue(Integer.parseInt(stringVal[0]) == 1100 || Integer.parseInt(stringVal[1]) == 1100
+            || Integer.parseInt(stringVal[0]) == 1101 || Integer.parseInt(stringVal[1]) == 1101);
+      }
+    }
+    {
+      // Test a select with filter query on an arraylength transform function
+      String query = "SELECT mvRawIntCol, mvRawDoubleCol, mvRawStringCol from testTable where "
+          + "ARRAYLENGTH(mvRawIntCol) < 5 LIMIT 10";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "mvRawIntCol", "mvRawDoubleCol", "mvRawStringCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY,
+          DataSchema.ColumnDataType.STRING_ARRAY
+      });
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 10);
+
+      for (int i = 0; i < 10; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 3);
+        int[] intVal = (int[]) values[0];
+        assertEquals(intVal[1] - intVal[0], MV_OFFSET);
+
+        double[] doubleVal = (double[]) values[1];
+        assertEquals(doubleVal[0], (double) intVal[0]);
+        assertEquals(doubleVal[1], (double) intVal[1]);
+
+        String[] stringVal = (String[]) values[2];
+        assertEquals(Integer.parseInt(stringVal[0]), intVal[0]);
+        assertEquals(Integer.parseInt(stringVal[1]), intVal[1]);
+      }
+    }
+    {
+      // Test a select with filter = query on an arraylength transform function
+      String query = "SELECT mvRawIntCol, mvRawDoubleCol, mvRawStringCol from testTable where "
+          + "ARRAYLENGTH(mvRawDoubleCol) = 2 LIMIT 10";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "mvRawIntCol", "mvRawDoubleCol", "mvRawStringCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY,
+          DataSchema.ColumnDataType.STRING_ARRAY
+      });
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 10);
+
+      for (int i = 0; i < 10; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 3);
+        int[] intVal = (int[]) values[0];
+        assertEquals(intVal[1] - intVal[0], MV_OFFSET);
+
+        double[] doubleVal = (double[]) values[1];
+        assertEquals(doubleVal[0], (double) intVal[0]);
+        assertEquals(doubleVal[1], (double) intVal[1]);
+
+        String[] stringVal = (String[]) values[2];
+        assertEquals(Integer.parseInt(stringVal[0]), intVal[0]);
+        assertEquals(Integer.parseInt(stringVal[1]), intVal[1]);
+      }
+    }
+    {
+      // Test a select with filter IN query on an arraylength transform function
+      String query = "SELECT mvRawIntCol, mvRawDoubleCol, mvRawStringCol from testTable where "
+          + "ARRAYLENGTH(mvRawStringCol) IN (2, 5) LIMIT 10";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "mvRawIntCol", "mvRawDoubleCol", "mvRawStringCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY,
+          DataSchema.ColumnDataType.STRING_ARRAY
+      });
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 10);
+
+      for (int i = 0; i < 10; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 3);
+        int[] intVal = (int[]) values[0];
+        assertEquals(intVal[1] - intVal[0], MV_OFFSET);
+
+        double[] doubleVal = (double[]) values[1];
+        assertEquals(doubleVal[0], (double) intVal[0]);
+        assertEquals(doubleVal[1], (double) intVal[1]);
+
+        String[] stringVal = (String[]) values[2];
+        assertEquals(Integer.parseInt(stringVal[0]), intVal[0]);
+        assertEquals(Integer.parseInt(stringVal[1]), intVal[1]);
+      }
+    }
+  }
+
+  @Test
+  public void testSimpleAggregateQueries() {
+    {
+      // Aggregation on int columns
+      String query = "SELECT COUNTMV(mvIntCol), COUNTMV(mvRawIntCol), SUMMV(mvIntCol), SUMMV(mvRawIntCol), "
+          + "MINMV(mvIntCol), MINMV(mvRawIntCol), MAXMV(mvIntCol), MAXMV(mvRawIntCol), AVGMV(mvIntCol), "
+          + "AVGMV(mvRawIntCol) from testTable";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvIntCol)", "countmv(mvRawIntCol)", "summv(mvIntCol)", "summv(mvRawIntCol)", "minmv(mvIntCol)",
+          "minmv(mvRawIntCol)", "maxmv(mvIntCol)", "maxmv(mvRawIntCol)", "avgmv(mvIntCol)", "avgmv(mvRawIntCol)"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE
+      });
+      validateSimpleAggregateQueryResults(resultTable, dataSchema);
+    }
+    {
+      // Aggregation on long columns
+      String query = "SELECT COUNTMV(mvLongCol), COUNTMV(mvRawLongCol), SUMMV(mvLongCol), SUMMV(mvRawLongCol), "
+          + "MINMV(mvLongCol), MINMV(mvRawLongCol), MAXMV(mvLongCol), MAXMV(mvRawLongCol), AVGMV(mvLongCol), "
+          + "AVGMV(mvRawLongCol) from testTable";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvLongCol)", "countmv(mvRawLongCol)", "summv(mvLongCol)", "summv(mvRawLongCol)", "minmv(mvLongCol)",
+          "minmv(mvRawLongCol)", "maxmv(mvLongCol)", "maxmv(mvRawLongCol)", "avgmv(mvLongCol)", "avgmv(mvRawLongCol)"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE
+      });
+      validateSimpleAggregateQueryResults(resultTable, dataSchema);
+    }
+    {
+      // Aggregation on float columns
+      String query = "SELECT COUNTMV(mvFloatCol), COUNTMV(mvRawFloatCol), SUMMV(mvFloatCol), SUMMV(mvRawFloatCol), "
+          + "MINMV(mvFloatCol), MINMV(mvRawFloatCol), MAXMV(mvFloatCol), MAXMV(mvRawFloatCol), AVGMV(mvFloatCol), "
+          + "AVGMV(mvRawFloatCol) from testTable";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvFloatCol)", "countmv(mvRawFloatCol)", "summv(mvFloatCol)", "summv(mvRawFloatCol)",
+          "minmv(mvFloatCol)", "minmv(mvRawFloatCol)", "maxmv(mvFloatCol)", "maxmv(mvRawFloatCol)",
+          "avgmv(mvFloatCol)", "avgmv(mvRawFloatCol)"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE
+      });
+      validateSimpleAggregateQueryResults(resultTable, dataSchema);
+    }
+    {
+      // Aggregation on double columns
+      String query = "SELECT COUNTMV(mvDoubleCol), COUNTMV(mvRawDoubleCol), SUMMV(mvDoubleCol), SUMMV(mvRawDoubleCol), "
+          + "MINMV(mvDoubleCol), MINMV(mvRawDoubleCol), MAXMV(mvDoubleCol), MAXMV(mvRawDoubleCol), AVGMV(mvDoubleCol), "
+          + "AVGMV(mvRawDoubleCol) from testTable";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvDoubleCol)", "countmv(mvRawDoubleCol)", "summv(mvDoubleCol)", "summv(mvRawDoubleCol)",
+          "minmv(mvDoubleCol)", "minmv(mvRawDoubleCol)", "maxmv(mvDoubleCol)", "maxmv(mvRawDoubleCol)",
+          "avgmv(mvDoubleCol)", "avgmv(mvRawDoubleCol)"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE
+      });
+      validateSimpleAggregateQueryResults(resultTable, dataSchema);
+    }
+    {
+      // Aggregation on string columns
+      String query = "SELECT COUNTMV(mvStringCol), COUNTMV(mvRawStringCol), SUMMV(mvStringCol), SUMMV(mvRawStringCol), "
+          + "MINMV(mvStringCol), MINMV(mvRawStringCol), MAXMV(mvStringCol), MAXMV(mvRawStringCol), AVGMV(mvStringCol), "
+          + "AVGMV(mvRawStringCol) from testTable";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvStringCol)", "countmv(mvRawStringCol)", "summv(mvStringCol)", "summv(mvRawStringCol)",
+          "minmv(mvStringCol)", "minmv(mvRawStringCol)", "maxmv(mvStringCol)", "maxmv(mvRawStringCol)",
+          "avgmv(mvStringCol)", "avgmv(mvRawStringCol)"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE
+      });
+      validateSimpleAggregateQueryResults(resultTable, dataSchema);
+    }
+  }
+
+  private void validateSimpleAggregateQueryResults(ResultTable resultTable, DataSchema expectedDataSchema) {
+    assertNotNull(resultTable);
+    assertEquals(resultTable.getDataSchema(), expectedDataSchema);
+    List<Object[]> recordRows = resultTable.getRows();
+    assertEquals(recordRows.size(), 1);
+
+    Object[] values = recordRows.get(0);
+    long countInt = (long) values[0];
+    long countIntRaw = (long) values[1];
+    assertEquals(countInt, 160);
+    assertEquals(countInt, countIntRaw);
+
+    double sumInt = (double) values[2];
+    double sumIntRaw = (double) values[3];
+    assertEquals(sumInt, 88720.0);
+    assertEquals(sumInt, sumIntRaw);
+
+    double minInt = (double) values[4];
+    double minIntRaw = (double) values[5];
+    assertEquals(minInt, 0.0);
+    assertEquals(minInt, minIntRaw);
+
+    double maxInt = (double) values[6];
+    double maxIntRaw = (double) values[7];
+    assertEquals(maxInt, 1109.0);
+    assertEquals(maxInt, maxIntRaw);
+
+    double avgInt = (double) values[8];
+    double avgIntRaw = (double) values[9];
+    assertEquals(avgInt, 554.5);
+    assertEquals(avgInt, avgIntRaw);
+  }
+
+  @Test
+  public void testAggregateWithFilterQueries() {
+    {
+      // Aggregation on int columns with filter
+      String query = "SELECT COUNTMV(mvIntCol), COUNTMV(mvRawIntCol), SUMMV(mvIntCol), SUMMV(mvRawIntCol), "
+          + "MINMV(mvIntCol), MINMV(mvRawIntCol), MAXMV(mvIntCol), MAXMV(mvRawIntCol), AVGMV(mvIntCol), "
+          + "AVGMV(mvRawIntCol) from testTable WHERE mvRawIntCol > 1000";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvIntCol)", "countmv(mvRawIntCol)", "summv(mvIntCol)", "summv(mvRawIntCol)", "minmv(mvIntCol)",
+          "minmv(mvRawIntCol)", "maxmv(mvIntCol)", "maxmv(mvRawIntCol)", "avgmv(mvIntCol)", "avgmv(mvRawIntCol)"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE
+      });
+      validateAggregateWithFilterQueryResults(resultTable, dataSchema);
+    }
+    {
+      // Aggregation on double columns with filter
+      String query = "SELECT COUNTMV(mvDoubleCol), COUNTMV(mvRawDoubleCol), SUMMV(mvDoubleCol), SUMMV(mvRawDoubleCol), "
+          + "MINMV(mvDoubleCol), MINMV(mvRawDoubleCol), MAXMV(mvDoubleCol), MAXMV(mvRawDoubleCol), AVGMV(mvDoubleCol), "
+          + "AVGMV(mvRawDoubleCol) from testTable WHERE mvRawDoubleCol > 1000.0";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvDoubleCol)", "countmv(mvRawDoubleCol)", "summv(mvDoubleCol)", "summv(mvRawDoubleCol)",
+          "minmv(mvDoubleCol)", "minmv(mvRawDoubleCol)", "maxmv(mvDoubleCol)", "maxmv(mvRawDoubleCol)",
+          "avgmv(mvDoubleCol)", "avgmv(mvRawDoubleCol)"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE
+      });
+      validateAggregateWithFilterQueryResults(resultTable, dataSchema);
+    }
+  }
+
+  private void validateAggregateWithFilterQueryResults(ResultTable resultTable, DataSchema expectedDataSchema) {
+    assertNotNull(resultTable);
+    assertEquals(resultTable.getDataSchema(), expectedDataSchema);
+    List<Object[]> recordRows = resultTable.getRows();
+    assertEquals(recordRows.size(), 1);
+
+    Object[] values = recordRows.get(0);
+    long count = (long) values[0];
+    long countRaw = (long) values[1];
+    assertEquals(count, 80);
+    assertEquals(count, countRaw);
+
+    double sum = (double) values[2];
+    double sumRaw = (double) values[3];
+    assertEquals(sum, 84360.0);
+    assertEquals(sum, sumRaw);
+
+    double min = (double) values[4];
+    double minRaw = (double) values[5];
+    assertEquals(min, 1000.0);
+    assertEquals(min, minRaw);
+
+    double max = (double) values[6];
+    double maxRaw = (double) values[7];
+    assertEquals(max, 1109.0);
+    assertEquals(max, maxRaw);
+
+    double avg = (double) values[8];
+    double avgRaw = (double) values[9];
+    assertEquals(avg, 1054.5);
+    assertEquals(avg, avgRaw);
+  }
+
+  @Test
+  public void testAggregateWithGroupByQueries() {
+    {
+      // Aggregation on int columns with group by
+      String query = "SELECT COUNTMV(mvIntCol), COUNTMV(mvRawIntCol), SUMMV(mvIntCol), SUMMV(mvRawIntCol), "
+          + "MINMV(mvIntCol), MINMV(mvRawIntCol), MAXMV(mvIntCol), MAXMV(mvRawIntCol), AVGMV(mvIntCol), "
+          + "AVGMV(mvRawIntCol), svIntCol, mvRawLongCol from testTable GROUP BY svIntCol, mvRawLongCol "
+          + "ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvIntCol)", "countmv(mvRawIntCol)", "summv(mvIntCol)", "summv(mvRawIntCol)", "minmv(mvIntCol)",
+          "minmv(mvRawIntCol)", "maxmv(mvIntCol)", "maxmv(mvRawIntCol)", "avgmv(mvIntCol)", "avgmv(mvRawIntCol)",
+          "svIntCol", "mvRawLongCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG
+      });
+      validateAggregateWithGroupByQueryResults(resultTable, dataSchema, false);
+    }
+    {
+      // Aggregation on long columns with group by
+      String query = "SELECT COUNTMV(mvLongCol), COUNTMV(mvRawLongCol), SUMMV(mvLongCol), SUMMV(mvRawLongCol), "
+          + "MINMV(mvLongCol), MINMV(mvRawLongCol), MAXMV(mvLongCol), MAXMV(mvRawLongCol), AVGMV(mvLongCol), "
+          + "AVGMV(mvRawLongCol), svIntCol, mvRawIntCol from testTable GROUP BY svIntCol, mvRawIntCol "
+          + "ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvLongCol)", "countmv(mvRawLongCol)", "summv(mvLongCol)", "summv(mvRawLongCol)", "minmv(mvLongCol)",
+          "minmv(mvRawLongCol)", "maxmv(mvLongCol)", "maxmv(mvRawLongCol)", "avgmv(mvLongCol)", "avgmv(mvRawLongCol)",
+          "svIntCol", "mvRawIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT
+      });
+      validateAggregateWithGroupByQueryResults(resultTable, dataSchema, false);
+    }
+    {
+      // Aggregation on float columns with group by
+      String query = "SELECT COUNTMV(mvFloatCol), COUNTMV(mvRawFloatCol), SUMMV(mvFloatCol), SUMMV(mvRawFloatCol), "
+          + "MINMV(mvFloatCol), MINMV(mvRawFloatCol), MAXMV(mvFloatCol), MAXMV(mvRawFloatCol), AVGMV(mvFloatCol), "
+          + "AVGMV(mvRawFloatCol), svIntCol, mvRawIntCol from testTable GROUP BY svIntCol, mvRawIntCol "
+          + "ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvFloatCol)", "countmv(mvRawFloatCol)", "summv(mvFloatCol)", "summv(mvRawFloatCol)",
+          "minmv(mvFloatCol)", "minmv(mvRawFloatCol)", "maxmv(mvFloatCol)", "maxmv(mvRawFloatCol)",
+          "avgmv(mvFloatCol)", "avgmv(mvRawFloatCol)", "svIntCol", "mvRawIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT
+      });
+      validateAggregateWithGroupByQueryResults(resultTable, dataSchema, false);
+    }
+    {
+      // Aggregation on double columns with group by
+      String query = "SELECT COUNTMV(mvDoubleCol), COUNTMV(mvRawDoubleCol), SUMMV(mvDoubleCol), SUMMV(mvRawDoubleCol), "
+          + "MINMV(mvDoubleCol), MINMV(mvRawDoubleCol), MAXMV(mvDoubleCol), MAXMV(mvRawDoubleCol), AVGMV(mvDoubleCol), "
+          + "AVGMV(mvRawDoubleCol), svIntCol, mvRawIntCol from testTable GROUP BY svIntCol, mvRawIntCol "
+          + "ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvDoubleCol)", "countmv(mvRawDoubleCol)", "summv(mvDoubleCol)", "summv(mvRawDoubleCol)",
+          "minmv(mvDoubleCol)", "minmv(mvRawDoubleCol)", "maxmv(mvDoubleCol)", "maxmv(mvRawDoubleCol)",
+          "avgmv(mvDoubleCol)", "avgmv(mvRawDoubleCol)", "svIntCol", "mvRawIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT
+      });
+      validateAggregateWithGroupByQueryResults(resultTable, dataSchema, false);
+    }
+    {
+      // Aggregation on string columns with group by
+      String query = "SELECT COUNTMV(mvStringCol), COUNTMV(mvRawStringCol), SUMMV(mvStringCol), SUMMV(mvRawStringCol), "
+          + "MINMV(mvStringCol), MINMV(mvRawStringCol), MAXMV(mvStringCol), MAXMV(mvRawStringCol), AVGMV(mvStringCol), "
+          + "AVGMV(mvRawStringCol), svIntCol, mvRawIntCol from testTable GROUP BY svIntCol, mvRawIntCol "
+          + "ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvStringCol)", "countmv(mvRawStringCol)", "summv(mvStringCol)", "summv(mvRawStringCol)",
+          "minmv(mvStringCol)", "minmv(mvRawStringCol)", "maxmv(mvStringCol)", "maxmv(mvRawStringCol)",
+          "avgmv(mvStringCol)", "avgmv(mvRawStringCol)", "svIntCol", "mvRawIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT
+      });
+      validateAggregateWithGroupByQueryResults(resultTable, dataSchema, false);
+    }
+    {
+      // Aggregation on int columns with group by on 3 columns
+      String query = "SELECT COUNTMV(mvIntCol), COUNTMV(mvRawIntCol), SUMMV(mvIntCol), SUMMV(mvRawIntCol), "
+          + "MINMV(mvIntCol), MINMV(mvRawIntCol), MAXMV(mvIntCol), MAXMV(mvRawIntCol), AVGMV(mvIntCol), "
+          + "AVGMV(mvRawIntCol), svIntCol, mvLongCol, mvRawLongCol from testTable GROUP BY svIntCol, mvLongCol, "
+          + "mvRawLongCol ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvIntCol)", "countmv(mvRawIntCol)", "summv(mvIntCol)", "summv(mvRawIntCol)", "minmv(mvIntCol)",
+          "minmv(mvRawIntCol)", "maxmv(mvIntCol)", "maxmv(mvRawIntCol)", "avgmv(mvIntCol)", "avgmv(mvRawIntCol)",
+          "svIntCol", "mvLongCol", "mvRawLongCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG,
+          DataSchema.ColumnDataType.LONG
+      });
+      validateAggregateWithGroupByQueryResults(resultTable, dataSchema, true);
+    }
+    {
+      // Aggregation on long columns with group by on 3 columns
+      String query = "SELECT COUNTMV(mvLongCol), COUNTMV(mvRawLongCol), SUMMV(mvLongCol), SUMMV(mvRawLongCol), "
+          + "MINMV(mvLongCol), MINMV(mvRawLongCol), MAXMV(mvLongCol), MAXMV(mvRawLongCol), AVGMV(mvLongCol), "
+          + "AVGMV(mvRawLongCol), svIntCol, mvIntCol, mvRawIntCol from testTable GROUP BY svIntCol, mvIntCol, "
+          + "mvRawIntCol ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvLongCol)", "countmv(mvRawLongCol)", "summv(mvLongCol)", "summv(mvRawLongCol)", "minmv(mvLongCol)",
+          "minmv(mvRawLongCol)", "maxmv(mvLongCol)", "maxmv(mvRawLongCol)", "avgmv(mvLongCol)", "avgmv(mvRawLongCol)",
+          "svIntCol", "mvIntCol", "mvRawIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT,
+          DataSchema.ColumnDataType.INT
+      });
+      validateAggregateWithGroupByQueryResults(resultTable, dataSchema, true);
+    }
+    {
+      // Aggregation on float columns with group by on 3 columns
+      String query = "SELECT COUNTMV(mvFloatCol), COUNTMV(mvRawFloatCol), SUMMV(mvFloatCol), SUMMV(mvRawFloatCol), "
+          + "MINMV(mvFloatCol), MINMV(mvRawFloatCol), MAXMV(mvFloatCol), MAXMV(mvRawFloatCol), AVGMV(mvFloatCol), "
+          + "AVGMV(mvRawFloatCol), svIntCol, mvIntCol, mvRawIntCol  from testTable GROUP BY svIntCol, mvIntCol, "
+          + "mvRawIntCol ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvFloatCol)", "countmv(mvRawFloatCol)", "summv(mvFloatCol)", "summv(mvRawFloatCol)",
+          "minmv(mvFloatCol)", "minmv(mvRawFloatCol)", "maxmv(mvFloatCol)", "maxmv(mvRawFloatCol)",
+          "avgmv(mvFloatCol)", "avgmv(mvRawFloatCol)", "svIntCol", "mvIntCol", "mvRawIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT,
+          DataSchema.ColumnDataType.INT
+      });
+      validateAggregateWithGroupByQueryResults(resultTable, dataSchema, true);
+    }
+    {
+      // Aggregation on double columns with group by on 3 columns
+      String query = "SELECT COUNTMV(mvDoubleCol), COUNTMV(mvRawDoubleCol), SUMMV(mvDoubleCol), SUMMV(mvRawDoubleCol), "
+          + "MINMV(mvDoubleCol), MINMV(mvRawDoubleCol), MAXMV(mvDoubleCol), MAXMV(mvRawDoubleCol), AVGMV(mvDoubleCol), "
+          + "AVGMV(mvRawDoubleCol), svIntCol, mvIntCol, mvRawIntCol from testTable GROUP BY svIntCol, mvIntCol, "
+          + "mvRawIntCol ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvDoubleCol)", "countmv(mvRawDoubleCol)", "summv(mvDoubleCol)", "summv(mvRawDoubleCol)",
+          "minmv(mvDoubleCol)", "minmv(mvRawDoubleCol)", "maxmv(mvDoubleCol)", "maxmv(mvRawDoubleCol)",
+          "avgmv(mvDoubleCol)", "avgmv(mvRawDoubleCol)", "svIntCol", "mvIntCol", "mvRawIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT,
+          DataSchema.ColumnDataType.INT
+      });
+      validateAggregateWithGroupByQueryResults(resultTable, dataSchema, true);
+    }
+    {
+      // Aggregation on string columns with group by on 3 columns
+      String query = "SELECT COUNTMV(mvStringCol), COUNTMV(mvRawStringCol), SUMMV(mvStringCol), SUMMV(mvRawStringCol), "
+          + "MINMV(mvStringCol), MINMV(mvRawStringCol), MAXMV(mvStringCol), MAXMV(mvRawStringCol), AVGMV(mvStringCol), "
+          + "AVGMV(mvRawStringCol), svIntCol, mvIntCol, mvRawIntCol from testTable GROUP BY svIntCol, mvIntCol,"
+          + "mvRawIntCol ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvStringCol)", "countmv(mvRawStringCol)", "summv(mvStringCol)", "summv(mvRawStringCol)",
+          "minmv(mvStringCol)", "minmv(mvRawStringCol)", "maxmv(mvStringCol)", "maxmv(mvRawStringCol)",
+          "avgmv(mvStringCol)", "avgmv(mvRawStringCol)", "svIntCol", "mvIntCol", "mvRawIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT,
+          DataSchema.ColumnDataType.INT
+      });
+      validateAggregateWithGroupByQueryResults(resultTable, dataSchema, true);
+    }
+    {
+      // Aggregation on int columns with group by on 3 columns, two of them RAW
+      String query = "SELECT COUNTMV(mvIntCol), COUNTMV(mvRawIntCol), SUMMV(mvIntCol), SUMMV(mvRawIntCol), "
+          + "MINMV(mvIntCol), MINMV(mvRawIntCol), MAXMV(mvIntCol), MAXMV(mvRawIntCol), AVGMV(mvIntCol), "
+          + "AVGMV(mvRawIntCol), svIntCol, mvRawLongCol, mvRawFloatCol from testTable GROUP BY svIntCol, mvRawLongCol, "
+          + "mvRawFloatCol ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvIntCol)", "countmv(mvRawIntCol)", "summv(mvIntCol)", "summv(mvRawIntCol)", "minmv(mvIntCol)",
+          "minmv(mvRawIntCol)", "maxmv(mvIntCol)", "maxmv(mvRawIntCol)", "avgmv(mvIntCol)", "avgmv(mvRawIntCol)",
+          "svIntCol", "mvRawLongCol", "mvRawFloatCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG,
+          DataSchema.ColumnDataType.FLOAT
+      });
+      assertNotNull(resultTable);
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 10);
+
+      int[] expectedSVIntValues;
+      expectedSVIntValues = new int[]{0, 0, 0, 0, 1, 1, 1, 1, 2, 2};
+
+      for (int i = 0; i < 10; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 13);
+
+        long count = (long) values[0];
+        long countRaw = (long) values[1];
+        assertEquals(count, 8);
+        assertEquals(count, countRaw);
+
+        double sum = (double) values[2];
+        double sumRaw = (double) values[3];
+        assertEquals(sum, sumRaw);
+
+        double min = (double) values[4];
+        double minRaw = (double) values[5];
+        assertEquals(min, minRaw);
+
+        double max = (double) values[6];
+        double maxRaw = (double) values[7];
+        assertEquals(max, maxRaw);
+
+        assertEquals(max - min, (double) MV_OFFSET);
+
+        double avg = (double) values[8];
+        double avgRaw = (double) values[9];
+        assertEquals(avg, avgRaw);
+
+        assertEquals((int) values[10], expectedSVIntValues[i]);
+
+        assertTrue((long) values[11] == expectedSVIntValues[i]
+            || (long) values[11] == expectedSVIntValues[i] + MV_OFFSET);
+
+        assertTrue((float) values[12] == (float) expectedSVIntValues[i]
+            || (float) values[12] == (float) (expectedSVIntValues[i] + MV_OFFSET));
+      }
+    }
+  }
+
+  private void validateAggregateWithGroupByQueryResults(ResultTable resultTable, DataSchema expectedDataSchema,
+      boolean isThreeColumnGroupBy) {
+    assertNotNull(resultTable);
+    assertEquals(resultTable.getDataSchema(), expectedDataSchema);
+    List<Object[]> recordRows = resultTable.getRows();
+    assertEquals(recordRows.size(), 10);
+
+    int[] expectedSVIntValues;
+
+    if (isThreeColumnGroupBy) {
+      expectedSVIntValues = new int[]{0, 0, 0, 0, 1, 1, 1, 1, 2, 2};
+    } else {
+      expectedSVIntValues = new int[]{0, 0, 1, 1, 2, 2, 3, 3, 4, 4};
+    }
+
+    for (int i = 0; i < 10; i++) {
+      Object[] values = recordRows.get(i);
+      if (isThreeColumnGroupBy) {
+        assertEquals(values.length, 13);
+      } else {
+        assertEquals(values.length, 12);
+      }
+
+      long count = (long) values[0];
+      long countRaw = (long) values[1];
+      assertEquals(count, 8);
+      assertEquals(count, countRaw);
+
+      double sum = (double) values[2];
+      double sumRaw = (double) values[3];
+      assertEquals(sum, sumRaw);
+
+      double min = (double) values[4];
+      double minRaw = (double) values[5];
+      assertEquals(min, minRaw);
+
+      double max = (double) values[6];
+      double maxRaw = (double) values[7];
+      assertEquals(max, maxRaw);
+
+      assertEquals(max - min, (double) MV_OFFSET);
+
+      double avg = (double) values[8];
+      double avgRaw = (double) values[9];
+      assertEquals(avg, avgRaw);
+
+      assertEquals((int) values[10], expectedSVIntValues[i]);
+
+      if (expectedDataSchema.getColumnDataType(11) == DataSchema.ColumnDataType.LONG) {
+        assertTrue((long) values[11] == expectedSVIntValues[i]
+            || (long) values[11] == expectedSVIntValues[i] + MV_OFFSET);
+      } else {
+        assertTrue((int) values[11] == expectedSVIntValues[i]
+            || (int) values[11] == expectedSVIntValues[i] + MV_OFFSET);
+      }
+
+      if (isThreeColumnGroupBy) {
+        if (expectedDataSchema.getColumnDataType(12) == DataSchema.ColumnDataType.LONG) {
+          assertTrue((long) values[12] == expectedSVIntValues[i]
+              || (long) values[12] == expectedSVIntValues[i] + MV_OFFSET);
+        } else {
+          assertTrue((int) values[12] == expectedSVIntValues[i]
+              || (int) values[12] == expectedSVIntValues[i] + MV_OFFSET);
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testAggregateWithGroupByOrderByQueries() {
+    {
+      // Aggregation on int columns with group by order by
+      String query = "SELECT COUNTMV(mvIntCol), COUNTMV(mvRawIntCol), SUMMV(mvIntCol), SUMMV(mvRawIntCol), "
+          + "MINMV(mvIntCol), MINMV(mvRawIntCol), MAXMV(mvIntCol), MAXMV(mvRawIntCol), AVGMV(mvIntCol), "
+          + "AVGMV(mvRawIntCol), mvRawLongCol from testTable GROUP BY mvRawLongCol ORDER BY mvRawLongCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvIntCol)", "countmv(mvRawIntCol)", "summv(mvIntCol)", "summv(mvRawIntCol)", "minmv(mvIntCol)",
+          "minmv(mvRawIntCol)", "maxmv(mvIntCol)", "maxmv(mvRawIntCol)", "avgmv(mvIntCol)", "avgmv(mvRawIntCol)",
+          "mvRawLongCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.LONG
+      });
+      validateAggregateWithGroupByOrderByQueryResults(resultTable, dataSchema);
+    }
+    {
+      // Aggregation on long columns with order by (same results as simple aggregation)
+      String query = "SELECT COUNTMV(mvLongCol), COUNTMV(mvRawLongCol), SUMMV(mvLongCol), SUMMV(mvRawLongCol), "
+          + "MINMV(mvLongCol), MINMV(mvRawLongCol), MAXMV(mvLongCol), MAXMV(mvRawLongCol), AVGMV(mvLongCol), "
+          + "AVGMV(mvRawLongCol), mvRawIntCol from testTable GROUP BY mvRawIntCol ORDER BY mvRawIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvLongCol)", "countmv(mvRawLongCol)", "summv(mvLongCol)", "summv(mvRawLongCol)", "minmv(mvLongCol)",
+          "minmv(mvRawLongCol)", "maxmv(mvLongCol)", "maxmv(mvRawLongCol)", "avgmv(mvLongCol)", "avgmv(mvRawLongCol)",
+          "mvRawIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT
+      });
+      validateAggregateWithGroupByOrderByQueryResults(resultTable, dataSchema);
+    }
+    {
+      // Aggregation on float columns with order by (same results as simple aggregation)
+      String query = "SELECT COUNTMV(mvFloatCol), COUNTMV(mvRawFloatCol), SUMMV(mvFloatCol), SUMMV(mvRawFloatCol), "
+          + "MINMV(mvFloatCol), MINMV(mvRawFloatCol), MAXMV(mvFloatCol), MAXMV(mvRawFloatCol), AVGMV(mvFloatCol), "
+          + "AVGMV(mvRawFloatCol), mvRawIntCol from testTable GROUP BY mvRawIntCol ORDER BY mvRawIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvFloatCol)", "countmv(mvRawFloatCol)", "summv(mvFloatCol)", "summv(mvRawFloatCol)",
+          "minmv(mvFloatCol)", "minmv(mvRawFloatCol)", "maxmv(mvFloatCol)", "maxmv(mvRawFloatCol)",
+          "avgmv(mvFloatCol)", "avgmv(mvRawFloatCol)", "mvRawIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT
+      });
+      validateAggregateWithGroupByOrderByQueryResults(resultTable, dataSchema);
+    }
+    {
+      // Aggregation on double columns with order by (same results as simple aggregation)
+      String query = "SELECT COUNTMV(mvDoubleCol), COUNTMV(mvRawDoubleCol), SUMMV(mvDoubleCol), SUMMV(mvRawDoubleCol), "
+          + "MINMV(mvDoubleCol), MINMV(mvRawDoubleCol), MAXMV(mvDoubleCol), MAXMV(mvRawDoubleCol), AVGMV(mvDoubleCol), "
+          + "AVGMV(mvRawDoubleCol), mvRawIntCol from testTable GROUP BY mvRawIntCol ORDER BY mvRawIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvDoubleCol)", "countmv(mvRawDoubleCol)", "summv(mvDoubleCol)", "summv(mvRawDoubleCol)",
+          "minmv(mvDoubleCol)", "minmv(mvRawDoubleCol)", "maxmv(mvDoubleCol)", "maxmv(mvRawDoubleCol)",
+          "avgmv(mvDoubleCol)", "avgmv(mvRawDoubleCol)", "mvRawIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT
+      });
+      validateAggregateWithGroupByOrderByQueryResults(resultTable, dataSchema);
+    }
+    {
+      // Aggregation on string columns with order by (same results as simple aggregation)
+      String query = "SELECT COUNTMV(mvStringCol), COUNTMV(mvRawStringCol), SUMMV(mvStringCol), SUMMV(mvRawStringCol), "
+          + "MINMV(mvStringCol), MINMV(mvRawStringCol), MAXMV(mvStringCol), MAXMV(mvRawStringCol), AVGMV(mvStringCol), "
+          + "AVGMV(mvRawStringCol), mvRawIntCol from testTable GROUP BY mvRawIntCol ORDER BY mvRawIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvStringCol)", "countmv(mvRawStringCol)", "summv(mvStringCol)", "summv(mvRawStringCol)",
+          "minmv(mvStringCol)", "minmv(mvRawStringCol)", "maxmv(mvStringCol)", "maxmv(mvRawStringCol)",
+          "avgmv(mvStringCol)", "avgmv(mvRawStringCol)", "mvRawIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT
+      });
+      validateAggregateWithGroupByOrderByQueryResults(resultTable, dataSchema);
+    }
+    {
+      // Aggregation on int columns with group by order by with order by agg
+      String query = "SELECT COUNTMV(mvIntCol), COUNTMV(mvRawIntCol), SUMMV(mvIntCol), SUMMV(mvRawIntCol), "
+          + "MINMV(mvIntCol), MINMV(mvRawIntCol), MAXMV(mvIntCol), MAXMV(mvRawIntCol), AVGMV(mvIntCol), "
+          + "AVGMV(mvRawIntCol), mvRawIntCol from testTable GROUP BY mvRawIntCol ORDER BY mvRawIntCol DESC, "
+          + "SUMMV(mvRawIntCol) DESC";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvIntCol)", "countmv(mvRawIntCol)", "summv(mvIntCol)", "summv(mvRawIntCol)", "minmv(mvIntCol)",
+          "minmv(mvRawIntCol)", "maxmv(mvIntCol)", "maxmv(mvRawIntCol)", "avgmv(mvIntCol)", "avgmv(mvRawIntCol)",
+          "mvRawIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT
+      });
+      assertNotNull(resultTable);
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 10);
+
+      double[] expectedSumValues = new double[]{8472.0, 8464.0, 8456.0, 8448.0, 8440.0, 8432.0, 8424.0, 8416.0, 8408.0,
+          8400.0};
+      double[] expectedMinValues = new double[]{1009.0, 1008.0, 1007.0, 1006.0, 1005.0, 1004.0, 1003.0, 1002.0, 1001.0,
+          1000.0};
+      double[] expectedMaxValues = new double[]{1109.0, 1108.0, 1107.0, 1106.0, 1105.0, 1104.0, 1103.0, 1102.0, 1101.0,
+          1100.0};
+      double[] expectedAvgValues = new double[]{1059.0, 1058.0, 1057.0, 1056.0, 1055.0, 1054.0, 1053.0, 1052.0, 1051.0,
+          1050.0};
+
+      for (int i = 0; i < 10; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 11);
+        long count = (long) values[0];
+        long countRaw = (long) values[1];
+        assertEquals(count, 8);
+        assertEquals(count, countRaw);
+
+        double sum = (double) values[2];
+        double sumRaw = (double) values[3];
+        assertEquals(sum, sumRaw);
+        assertEquals(sum, expectedSumValues[i]);
+
+        double min = (double) values[4];
+        double minRaw = (double) values[5];
+        assertEquals(min, minRaw);
+        assertEquals(min, expectedMinValues[i]);
+
+        double max = (double) values[6];
+        double maxRaw = (double) values[7];
+        assertEquals(max, maxRaw);
+        assertEquals(max, expectedMaxValues[i]);
+
+        double avg = (double) values[8];
+        double avgRaw = (double) values[9];
+        assertEquals(avg, avgRaw);
+        assertEquals(avg, expectedAvgValues[i]);
+
+        assertEquals((int) values[10], (int) max);
+      }
+    }
+  }
+
+  private void validateAggregateWithGroupByOrderByQueryResults(ResultTable resultTable, DataSchema expectedDataSchema) {
+    assertNotNull(resultTable);
+    assertEquals(resultTable.getDataSchema(), expectedDataSchema);
+    List<Object[]> recordRows = resultTable.getRows();
+    assertEquals(recordRows.size(), 10);
+
+    double[] expectedSumValues = new double[]{400.0, 408.0, 416.0, 424.0, 432.0, 440.0, 448.0, 456.0, 464.0, 472.0};
+    double[] expectedMinValues = new double[]{0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0};
+    double[] expectedMaxValues = new double[]{100.0, 101.0, 102.0, 103.0, 104.0, 105.0, 106.0, 107.0, 108.0, 109.0};
+    double[] expectedAvgValues = new double[]{50.0, 51.0, 52.0, 53.0, 54.0, 55.0, 56.0, 57.0, 58.0, 59.0};
+
+    for (int i = 0; i < 10; i++) {
+      Object[] values = recordRows.get(i);
+      assertEquals(values.length, 11);
+      long count = (long) values[0];
+      long countRaw = (long) values[1];
+      assertEquals(count, 8);
+      assertEquals(count, countRaw);
+
+      double sum = (double) values[2];
+      double sumRaw = (double) values[3];
+      assertEquals(sum, sumRaw);
+      assertEquals(sum, expectedSumValues[i]);
+
+      double min = (double) values[4];
+      double minRaw = (double) values[5];
+      assertEquals(min, minRaw);
+      assertEquals(min, expectedMinValues[i]);
+
+      double max = (double) values[6];
+      double maxRaw = (double) values[7];
+      assertEquals(max, maxRaw);
+      assertEquals(max, expectedMaxValues[i]);
+
+      double avg = (double) values[8];
+      double avgRaw = (double) values[9];
+      assertEquals(avg, avgRaw);
+      assertEquals(avg, expectedAvgValues[i]);
+
+      if (expectedDataSchema.getColumnDataType(10) == DataSchema.ColumnDataType.LONG) {
+        assertEquals((long) values[10], i);
+      } else {
+        assertEquals((int) values[10], i);
+      }
+    }
+  }
+
+  @Test
+  public void testTransformInsideAggregateQueries() {
+    {
+      // Transform within aggregation for raw int MV
+      String query = "SELECT SUMMV(VALUEIN(mvRawIntCol, '0', '5')) from testTable WHERE mvRawIntCol IN (0, 5)";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{"summv(valuein(mvRawIntCol,'0','5'))"},
+          new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+
+      assertEquals(resultTable.getRows().size(), 1);
+      Object[] value = resultTable.getRows().get(0);
+      assertEquals(value[0], 20.0);
+    }
+    {
+      // Transform within aggregation for raw long MV
+      String query = "SELECT SUMMV(VALUEIN(mvRawLongCol, '0', '5')) from testTable WHERE mvRawLongCol IN (0, 5)";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{"summv(valuein(mvRawLongCol,'0','5'))"},
+          new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+
+      assertEquals(resultTable.getRows().size(), 1);
+      Object[] value = resultTable.getRows().get(0);
+      assertEquals(value[0], 20.0);
+    }
+    {
+      // Transform within aggregation for raw float MV
+      String query = "SELECT SUMMV(VALUEIN(mvRawFloatCol, '0', '5')) from testTable WHERE mvRawFloatCol IN (0, 5)";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{"summv(valuein(mvRawFloatCol,'0','5'))"},
+          new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+
+      assertEquals(resultTable.getRows().size(), 1);
+      Object[] value = resultTable.getRows().get(0);
+      assertEquals(value[0], 20.0);
+    }
+    {
+      // Transform within aggregation for raw double MV
+      String query = "SELECT SUMMV(VALUEIN(mvRawDoubleCol, '0', '5')) from testTable WHERE mvRawDoubleCol IN (0, 5)";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{"summv(valuein(mvRawDoubleCol,'0','5'))"},
+          new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+
+      assertEquals(resultTable.getRows().size(), 1);
+      Object[] value = resultTable.getRows().get(0);
+      assertEquals(value[0], 20.0);
+    }
+    {
+      // Transform within aggregation for raw String MV
+      String query = "SELECT SUMMV(VALUEIN(mvRawStringCol, '0', '5')) from testTable WHERE mvRawStringCol "
+          + "IN ('0', '5')";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{"summv(valuein(mvRawStringCol,'0','5'))"},
+          new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE});
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+
+      assertEquals(resultTable.getRows().size(), 1);
+      Object[] value = resultTable.getRows().get(0);
+      assertEquals(value[0], 20.0);
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/IntermediateSegment.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/IntermediateSegment.java
@@ -153,7 +153,7 @@ public class IntermediateSegment implements MutableSegment {
         // TODO: Start with a smaller capacity on FixedByteMVForwardIndexReaderWriter and let it expand
         forwardIndex =
             new FixedByteMVMutableForwardIndex(MAX_MULTI_VALUES_PER_ROW, DEFAULT_AVG_MULTI_VALUE_COUNT, _capacity,
-                Integer.BYTES, _memoryManager, allocationContext);
+                Integer.BYTES, _memoryManager, allocationContext, true, DataType.INT);
       }
 
       _indexContainerMap.put(column,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
@@ -90,7 +90,7 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
   }
 
   @Override
-  public DataType getValueType() {
+  public DataType getStoredType() {
     return _valueType;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/VarByteSVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/VarByteSVMutableForwardIndex.java
@@ -58,7 +58,7 @@ public class VarByteSVMutableForwardIndex implements MutableForwardIndex {
   }
 
   @Override
-  public DataType getValueType() {
+  public DataType getStoredType() {
     return _valueType;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueFixedByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueFixedByteRawIndexCreator.java
@@ -77,7 +77,8 @@ public class MultiValueFixedByteRawIndexCreator implements ForwardIndexCreator {
       boolean deriveNumDocsPerChunk, int writerVersion)
       throws IOException {
     File file = new File(baseIndexDir, column + Indexes.RAW_MV_FORWARD_INDEX_FILE_EXTENSION);
-    int totalMaxLength = maxNumberOfMultiValueElements * valueType.getStoredType().size();
+    // Store the length followed by the values
+    int totalMaxLength = Integer.BYTES + (maxNumberOfMultiValueElements * valueType.getStoredType().size());
     int numDocsPerChunk =
         deriveNumDocsPerChunk ? Math.max(TARGET_MAX_CHUNK_SIZE / (totalMaxLength
             + VarByteChunkSVForwardIndexWriter.CHUNK_HEADER_ENTRY_ROW_OFFSET_SIZE), 1) : DEFAULT_NUM_DOCS_PER_CHUNK;
@@ -152,7 +153,7 @@ public class MultiValueFixedByteRawIndexCreator implements ForwardIndexCreator {
   public void putDoubleMV(final double[] values) {
 
     byte[] bytes = new byte[Integer.BYTES
-        + values.length * Long.BYTES]; //numValues, bytes required to store the content
+        + values.length * Double.BYTES]; //numValues, bytes required to store the content
     ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
     //write the length
     byteBuffer.putInt(values.length);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/constant/ConstantMVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/constant/ConstantMVForwardIndexReader.java
@@ -39,7 +39,7 @@ public final class ConstantMVForwardIndexReader implements ForwardIndexReader<Fo
   }
 
   @Override
-  public DataType getValueType() {
+  public DataType getStoredType() {
     return DataType.INT;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/BaseChunkForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/BaseChunkForwardIndexReader.java
@@ -37,13 +37,13 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * Base implementation for chunk-based single-value raw (non-dictionary-encoded) forward index reader.
+ * Base implementation for chunk-based raw (non-dictionary-encoded) forward index reader.
  */
-public abstract class BaseChunkSVForwardIndexReader implements ForwardIndexReader<ChunkReaderContext> {
-  private static final Logger LOGGER = LoggerFactory.getLogger(BaseChunkSVForwardIndexReader.class);
+public abstract class BaseChunkForwardIndexReader implements ForwardIndexReader<ChunkReaderContext> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BaseChunkForwardIndexReader.class);
 
   protected final PinotDataBuffer _dataBuffer;
-  protected final DataType _valueType;
+  protected final DataType _storedType;
   protected final int _numChunks;
   protected final int _numDocsPerChunk;
   protected final int _lengthOfLongestEntry;
@@ -52,10 +52,11 @@ public abstract class BaseChunkSVForwardIndexReader implements ForwardIndexReade
   protected final PinotDataBuffer _dataHeader;
   protected final int _headerEntryChunkOffsetSize;
   protected final PinotDataBuffer _rawData;
+  protected final boolean _isSingleValue;
 
-  public BaseChunkSVForwardIndexReader(PinotDataBuffer dataBuffer, DataType valueType) {
+  public BaseChunkForwardIndexReader(PinotDataBuffer dataBuffer, DataType storedType, boolean isSingleValue) {
     _dataBuffer = dataBuffer;
-    _valueType = valueType;
+    _storedType = storedType;
 
     int headerOffset = 0;
     int version = _dataBuffer.getInt(headerOffset);
@@ -68,8 +69,8 @@ public abstract class BaseChunkSVForwardIndexReader implements ForwardIndexReade
     headerOffset += Integer.BYTES;
 
     _lengthOfLongestEntry = _dataBuffer.getInt(headerOffset);
-    if (valueType.isFixedWidth()) {
-      Preconditions.checkState(_lengthOfLongestEntry == valueType.size());
+    if (storedType.isFixedWidth() && isSingleValue) {
+      Preconditions.checkState(_lengthOfLongestEntry == storedType.size());
     }
     headerOffset += Integer.BYTES;
 
@@ -98,6 +99,8 @@ public abstract class BaseChunkSVForwardIndexReader implements ForwardIndexReade
 
     // Useful for uncompressed data.
     _rawData = _dataBuffer.view(rawDataStart, _dataBuffer.size());
+
+    _isSingleValue = isSingleValue;
   }
 
   /**
@@ -163,18 +166,18 @@ public abstract class BaseChunkSVForwardIndexReader implements ForwardIndexReade
 
   @Override
   public boolean isSingleValue() {
-    return true;
+    return _isSingleValue;
   }
 
   @Override
-  public DataType getValueType() {
-    return _valueType;
+  public DataType getStoredType() {
+    return _storedType;
   }
 
   @Override
   public void readValuesSV(int[] docIds, int length, int[] values, ChunkReaderContext context) {
-    if (getValueType().isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
-      switch (getValueType()) {
+    if (_storedType.isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
+      switch (_storedType) {
         case INT: {
           int minOffset = docIds[0] * Integer.BYTES;
           IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();
@@ -215,8 +218,8 @@ public abstract class BaseChunkSVForwardIndexReader implements ForwardIndexReade
 
   @Override
   public void readValuesSV(int[] docIds, int length, long[] values, ChunkReaderContext context) {
-    if (getValueType().isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
-      switch (getValueType()) {
+    if (_storedType.isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
+      switch (_storedType) {
         case INT: {
           int minOffset = docIds[0] * Integer.BYTES;
           IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();
@@ -257,8 +260,8 @@ public abstract class BaseChunkSVForwardIndexReader implements ForwardIndexReade
 
   @Override
   public void readValuesSV(int[] docIds, int length, float[] values, ChunkReaderContext context) {
-    if (getValueType().isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
-      switch (getValueType()) {
+    if (_storedType.isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
+      switch (_storedType) {
         case INT: {
           int minOffset = docIds[0] * Integer.BYTES;
           IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();
@@ -299,8 +302,8 @@ public abstract class BaseChunkSVForwardIndexReader implements ForwardIndexReade
 
   @Override
   public void readValuesSV(int[] docIds, int length, double[] values, ChunkReaderContext context) {
-    if (getValueType().isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
-      switch (getValueType()) {
+    if (_storedType.isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
+      switch (_storedType) {
         case INT: {
           int minOffset = docIds[0] * Integer.BYTES;
           IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitMVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitMVForwardIndexReader.java
@@ -84,7 +84,7 @@ public final class FixedBitMVForwardIndexReader implements ForwardIndexReader<Fi
   }
 
   @Override
-  public DataType getValueType() {
+  public DataType getStoredType() {
     return DataType.INT;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitSVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitSVForwardIndexReader.java
@@ -47,7 +47,7 @@ public final class FixedBitSVForwardIndexReader implements ForwardIndexReader<Fo
   }
 
   @Override
-  public DataType getValueType() {
+  public DataType getStoredType() {
     return DataType.INT;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitSVForwardIndexReaderV2.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitSVForwardIndexReaderV2.java
@@ -49,7 +49,7 @@ public final class FixedBitSVForwardIndexReaderV2 implements ForwardIndexReader<
   }
 
   @Override
-  public DataType getValueType() {
+  public DataType getStoredType() {
     return DataType.INT;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedByteChunkMVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedByteChunkMVForwardIndexReader.java
@@ -30,14 +30,14 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
  * fixed length data type (INT, LONG, FLOAT, DOUBLE).
  * <p>For data layout, please refer to the documentation for {@link VarByteChunkSVForwardIndexWriter}
  */
-public final class FixedByteChunkMVForwardIndexReader extends BaseChunkSVForwardIndexReader {
+public final class FixedByteChunkMVForwardIndexReader extends BaseChunkForwardIndexReader {
 
   private static final int ROW_OFFSET_SIZE = VarByteChunkSVForwardIndexWriter.CHUNK_HEADER_ENTRY_ROW_OFFSET_SIZE;
 
   private final int _maxChunkSize;
 
-  public FixedByteChunkMVForwardIndexReader(PinotDataBuffer dataBuffer, DataType valueType) {
-    super(dataBuffer, valueType);
+  public FixedByteChunkMVForwardIndexReader(PinotDataBuffer dataBuffer, DataType storedType) {
+    super(dataBuffer, storedType, false);
     _maxChunkSize = _numDocsPerChunk * (ROW_OFFSET_SIZE + _lengthOfLongestEntry);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedByteChunkSVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedByteChunkSVForwardIndexReader.java
@@ -30,11 +30,11 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
  * LONG, FLOAT, DOUBLE).
  * <p>For data layout, please refer to the documentation for {@link FixedByteChunkSVForwardIndexWriter}
  */
-public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForwardIndexReader {
+public final class FixedByteChunkSVForwardIndexReader extends BaseChunkForwardIndexReader {
   private final int _chunkSize;
 
-  public FixedByteChunkSVForwardIndexReader(PinotDataBuffer dataBuffer, DataType valueType) {
-    super(dataBuffer, valueType);
+  public FixedByteChunkSVForwardIndexReader(PinotDataBuffer dataBuffer, DataType storedType) {
+    super(dataBuffer, storedType, true);
     _chunkSize = _numDocsPerChunk * _lengthOfLongestEntry;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBytePower2ChunkSVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBytePower2ChunkSVForwardIndexReader.java
@@ -30,13 +30,13 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
  * LONG, FLOAT, DOUBLE).
  * <p>For data layout, please refer to the documentation for {@link FixedByteChunkSVForwardIndexWriter}
  */
-public final class FixedBytePower2ChunkSVForwardIndexReader extends BaseChunkSVForwardIndexReader {
+public final class FixedBytePower2ChunkSVForwardIndexReader extends BaseChunkForwardIndexReader {
   public static final int VERSION = 4;
 
   private final int _shift;
 
-  public FixedBytePower2ChunkSVForwardIndexReader(PinotDataBuffer dataBuffer, DataType valueType) {
-    super(dataBuffer, valueType);
+  public FixedBytePower2ChunkSVForwardIndexReader(PinotDataBuffer dataBuffer, DataType storedType) {
+    super(dataBuffer, storedType, true);
     _shift = Integer.numberOfTrailingZeros(_numDocsPerChunk);
   }
 
@@ -44,7 +44,7 @@ public final class FixedBytePower2ChunkSVForwardIndexReader extends BaseChunkSVF
   @Override
   public ChunkReaderContext createContext() {
     if (_isCompressed) {
-      return new ChunkReaderContext(_numDocsPerChunk * _valueType.size());
+      return new ChunkReaderContext(_numDocsPerChunk * _storedType.size());
     } else {
       return null;
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkMVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkMVForwardIndexReader.java
@@ -32,14 +32,14 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
  * (STRING, BYTES).
  * <p>For data layout, please refer to the documentation for {@link VarByteChunkSVForwardIndexWriter}
  */
-public final class VarByteChunkMVForwardIndexReader extends BaseChunkSVForwardIndexReader {
+public final class VarByteChunkMVForwardIndexReader extends BaseChunkForwardIndexReader {
 
   private static final int ROW_OFFSET_SIZE = VarByteChunkSVForwardIndexWriter.CHUNK_HEADER_ENTRY_ROW_OFFSET_SIZE;
 
   private final int _maxChunkSize;
 
-  public VarByteChunkMVForwardIndexReader(PinotDataBuffer dataBuffer, DataType valueType) {
-    super(dataBuffer, valueType);
+  public VarByteChunkMVForwardIndexReader(PinotDataBuffer dataBuffer, DataType storedType) {
+    super(dataBuffer, storedType, false);
     _maxChunkSize = _numDocsPerChunk * (ROW_OFFSET_SIZE + _lengthOfLongestEntry);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkSVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkSVForwardIndexReader.java
@@ -34,7 +34,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * (BIG_DECIMAL, STRING, BYTES).
  * <p>For data layout, please refer to the documentation for {@link VarByteChunkSVForwardIndexWriter}
  */
-public final class VarByteChunkSVForwardIndexReader extends BaseChunkSVForwardIndexReader {
+public final class VarByteChunkSVForwardIndexReader extends BaseChunkForwardIndexReader {
   private static final int ROW_OFFSET_SIZE = VarByteChunkSVForwardIndexWriter.CHUNK_HEADER_ENTRY_ROW_OFFSET_SIZE;
 
   private final int _maxChunkSize;
@@ -42,8 +42,8 @@ public final class VarByteChunkSVForwardIndexReader extends BaseChunkSVForwardIn
   // Thread local (reusable) byte[] to read bytes from data file.
   private final ThreadLocal<byte[]> _reusableBytes = ThreadLocal.withInitial(() -> new byte[_lengthOfLongestEntry]);
 
-  public VarByteChunkSVForwardIndexReader(PinotDataBuffer dataBuffer, DataType valueType) {
-    super(dataBuffer, valueType);
+  public VarByteChunkSVForwardIndexReader(PinotDataBuffer dataBuffer, DataType storedType) {
+    super(dataBuffer, storedType, true);
     _maxChunkSize = _numDocsPerChunk * (ROW_OFFSET_SIZE + _lengthOfLongestEntry);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkSVForwardIndexReaderV4.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkSVForwardIndexReaderV4.java
@@ -79,7 +79,7 @@ public class VarByteChunkSVForwardIndexReaderV4
   }
 
   @Override
-  public FieldSpec.DataType getValueType() {
+  public FieldSpec.DataType getStoredType() {
     return _valueType;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentColumnReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentColumnReader.java
@@ -97,7 +97,7 @@ public class PinotSegmentColumnReader implements Closeable {
       // NOTE: Only support single-value raw index
       assert _forwardIndexReader.isSingleValue();
 
-      switch (_forwardIndexReader.getValueType()) {
+      switch (_forwardIndexReader.getStoredType()) {
         case INT:
           return _forwardIndexReader.getInt(docId, _forwardIndexReaderContext);
         case LONG:

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeLoaderUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeLoaderUtils.java
@@ -25,7 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.segment.local.aggregator.ValueAggregatorFactory;
-import org.apache.pinot.segment.local.segment.index.readers.forward.BaseChunkSVForwardIndexReader;
+import org.apache.pinot.segment.local.segment.index.readers.forward.BaseChunkForwardIndexReader;
 import org.apache.pinot.segment.local.segment.index.readers.forward.FixedBitSVForwardIndexReaderV2;
 import org.apache.pinot.segment.local.segment.index.readers.forward.FixedByteChunkSVForwardIndexReader;
 import org.apache.pinot.segment.local.segment.index.readers.forward.VarByteChunkSVForwardIndexReader;
@@ -98,7 +98,7 @@ public class StarTreeLoaderUtils {
         PinotDataBuffer forwardIndexDataBuffer = dataBuffer.view(start, end, ByteOrder.BIG_ENDIAN);
         DataType dataType = ValueAggregatorFactory.getAggregatedValueType(functionColumnPair.getFunctionType());
         FieldSpec fieldSpec = new MetricFieldSpec(metric, dataType);
-        BaseChunkSVForwardIndexReader forwardIndex;
+        BaseChunkForwardIndexReader forwardIndex;
         if (dataType == DataType.BYTES) {
           forwardIndex = new VarByteChunkSVForwardIndexReader(forwardIndexDataBuffer, DataType.BYTES);
         } else {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplRawMVTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplRawMVTest.java
@@ -1,0 +1,266 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.indexsegment.mutable;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.SegmentTestUtils;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.virtualcolumn.VirtualColumnProviderFactory;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.FileFormat;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.data.readers.RecordReaderFactory;
+import org.apache.pinot.spi.stream.StreamMessageMetadata;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+
+public class MutableSegmentImplRawMVTest {
+  private static final String AVRO_FILE = "data/test_data-mv.avro";
+  private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "MutableSegmentImplRawMVTest");
+
+  private Schema _schema;
+  private MutableSegmentImpl _mutableSegmentImpl;
+  private ImmutableSegment _immutableSegment;
+  private long _lastIndexedTs;
+  private long _lastIngestionTimeMs;
+  private long _startTimeMs;
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteQuietly(TEMP_DIR);
+
+    URL resourceUrl = MutableSegmentImplTest.class.getClassLoader().getResource(AVRO_FILE);
+    Assert.assertNotNull(resourceUrl);
+    File avroFile = new File(resourceUrl.getFile());
+
+    SegmentGeneratorConfig config =
+        SegmentTestUtils.getSegmentGeneratorConfigWithoutTimeColumn(avroFile, TEMP_DIR, "testTable");
+    SegmentIndexCreationDriver driver = new SegmentIndexCreationDriverImpl();
+
+    _schema = config.getSchema();
+    Set<String> noDictionaryColumns = new HashSet<>();
+    List<String> noDictionaryColumnsList = new ArrayList<>();
+    for (FieldSpec fieldSpec : _schema.getAllFieldSpecs()) {
+      if (!fieldSpec.isSingleValueField() && fieldSpec.getDataType().isFixedWidth()) {
+        noDictionaryColumns.add(fieldSpec.getName());
+        noDictionaryColumnsList.add(fieldSpec.getName());
+      }
+    }
+    config.setRawIndexCreationColumns(noDictionaryColumnsList);
+    assertEquals(noDictionaryColumns.size(), 2);
+
+    driver.init(config);
+    driver.build();
+    _immutableSegment = ImmutableSegmentLoader.load(new File(TEMP_DIR, driver.getSegmentName()), ReadMode.mmap);
+
+    VirtualColumnProviderFactory.addBuiltInVirtualColumnsToSegmentSchema(_schema, "testSegment");
+    _mutableSegmentImpl = MutableSegmentImplTestUtils
+        .createMutableSegmentImpl(_schema, noDictionaryColumns, Collections.emptySet(), Collections.emptySet(),
+            false);
+    _lastIngestionTimeMs = System.currentTimeMillis();
+    StreamMessageMetadata defaultMetadata = new StreamMessageMetadata(_lastIngestionTimeMs);
+    _startTimeMs = System.currentTimeMillis();
+
+    try (RecordReader recordReader = RecordReaderFactory
+        .getRecordReader(FileFormat.AVRO, avroFile, _schema.getColumnNames(), null)) {
+      GenericRow reuse = new GenericRow();
+      while (recordReader.hasNext()) {
+        _mutableSegmentImpl.index(recordReader.next(reuse), defaultMetadata);
+        _lastIndexedTs = System.currentTimeMillis();
+      }
+    }
+  }
+
+  @Test
+  public void testMetadata() {
+    SegmentMetadata actualSegmentMetadata = _mutableSegmentImpl.getSegmentMetadata();
+    SegmentMetadata expectedSegmentMetadata = _immutableSegment.getSegmentMetadata();
+    assertEquals(actualSegmentMetadata.getTotalDocs(), expectedSegmentMetadata.getTotalDocs());
+
+    // assert that the last indexed timestamp is close to what we expect
+    long actualTs = _mutableSegmentImpl.getSegmentMetadata().getLastIndexedTimestamp();
+    Assert.assertTrue(actualTs >= _startTimeMs);
+    Assert.assertTrue(actualTs <= _lastIndexedTs);
+
+    assertEquals(_mutableSegmentImpl.getSegmentMetadata().getLatestIngestionTimestamp(), _lastIngestionTimeMs);
+
+    for (FieldSpec fieldSpec : _schema.getAllFieldSpecs()) {
+      String column = fieldSpec.getName();
+      DataSourceMetadata actualDataSourceMetadata = _mutableSegmentImpl.getDataSource(column).getDataSourceMetadata();
+      DataSourceMetadata expectedDataSourceMetadata = _immutableSegment.getDataSource(column).getDataSourceMetadata();
+      assertEquals(actualDataSourceMetadata.getDataType(), expectedDataSourceMetadata.getDataType());
+      assertEquals(actualDataSourceMetadata.isSingleValue(), expectedDataSourceMetadata.isSingleValue());
+      assertEquals(actualDataSourceMetadata.getNumDocs(), expectedDataSourceMetadata.getNumDocs());
+      if (!expectedDataSourceMetadata.isSingleValue()) {
+        assertEquals(actualDataSourceMetadata.getMaxNumValuesPerMVEntry(),
+            expectedDataSourceMetadata.getMaxNumValuesPerMVEntry());
+      }
+    }
+  }
+
+  @Test
+  public void testDataSourceForSVColumns()
+      throws IOException {
+    for (FieldSpec fieldSpec : _schema.getAllFieldSpecs()) {
+      if (fieldSpec.isSingleValueField()) {
+        String column = fieldSpec.getName();
+        DataSource actualDataSource = _mutableSegmentImpl.getDataSource(column);
+        DataSource expectedDataSource = _immutableSegment.getDataSource(column);
+
+        int actualNumDocs = actualDataSource.getDataSourceMetadata().getNumDocs();
+        int expectedNumDocs = expectedDataSource.getDataSourceMetadata().getNumDocs();
+        assertEquals(actualNumDocs, expectedNumDocs);
+
+        Dictionary actualDictionary = actualDataSource.getDictionary();
+        Dictionary expectedDictionary = expectedDataSource.getDictionary();
+        assertEquals(actualDictionary.length(), expectedDictionary.length());
+
+        // Allow the segment name to be different
+        if (column.equals(CommonConstants.Segment.BuiltInVirtualColumn.SEGMENTNAME)) {
+          continue;
+        }
+
+        ForwardIndexReader actualReader = actualDataSource.getForwardIndex();
+        ForwardIndexReader expectedReader = expectedDataSource.getForwardIndex();
+        try (ForwardIndexReaderContext actualReaderContext = actualReader.createContext();
+            ForwardIndexReaderContext expectedReaderContext = expectedReader.createContext()) {
+          for (int docId = 0; docId < expectedNumDocs; docId++) {
+            int actualDictId = actualReader.getDictId(docId, actualReaderContext);
+            int expectedDictId = expectedReader.getDictId(docId, expectedReaderContext);
+            assertEquals(actualDictionary.get(actualDictId), expectedDictionary.get(expectedDictId));
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testDataSourceForMVColumns()
+      throws IOException {
+    for (FieldSpec fieldSpec : _schema.getAllFieldSpecs()) {
+      if (!fieldSpec.isSingleValueField()) {
+        String column = fieldSpec.getName();
+        DataSource actualDataSource = _mutableSegmentImpl.getDataSource(column);
+        DataSource expectedDataSource = _immutableSegment.getDataSource(column);
+
+        int actualNumDocs = actualDataSource.getDataSourceMetadata().getNumDocs();
+        int expectedNumDocs = expectedDataSource.getDataSourceMetadata().getNumDocs();
+        assertEquals(actualNumDocs, expectedNumDocs);
+
+        Dictionary actualDictionary = actualDataSource.getDictionary();
+        Dictionary expectedDictionary = expectedDataSource.getDictionary();
+        assertNull(actualDictionary);
+        assertNull(expectedDictionary);
+
+        int maxNumValuesPerMVEntry = expectedDataSource.getDataSourceMetadata().getMaxNumValuesPerMVEntry();
+
+        ForwardIndexReader actualReader = actualDataSource.getForwardIndex();
+        ForwardIndexReader expectedReader = expectedDataSource.getForwardIndex();
+        try (ForwardIndexReaderContext actualReaderContext = actualReader.createContext();
+            ForwardIndexReaderContext expectedReaderContext = expectedReader.createContext()) {
+          for (int docId = 0; docId < expectedNumDocs; docId++) {
+            switch (fieldSpec.getDataType()) {
+              case INT:
+                int[] actualInts = new int[maxNumValuesPerMVEntry];
+                int[] expectedInts = new int[maxNumValuesPerMVEntry];
+                int actualLength = actualReader.getIntMV(docId, actualInts, actualReaderContext);
+                int expectedLength = expectedReader.getIntMV(docId, expectedInts, expectedReaderContext);
+                assertEquals(actualLength, expectedLength);
+
+                for (int i = 0; i < actualLength; i++) {
+                  assertEquals(actualInts[i], expectedInts[i]);
+                }
+                break;
+              case LONG:
+                long[] actualLongs = new long[maxNumValuesPerMVEntry];
+                long[] expectedLongs = new long[maxNumValuesPerMVEntry];
+                actualLength = actualReader.getLongMV(docId, actualLongs, actualReaderContext);
+                expectedLength = expectedReader.getLongMV(docId, expectedLongs, expectedReaderContext);
+                assertEquals(actualLength, expectedLength);
+
+                for (int i = 0; i < actualLength; i++) {
+                  assertEquals(actualLongs[i], expectedLongs[i]);
+                }
+                break;
+              case FLOAT:
+                float[] actualFloats = new float[maxNumValuesPerMVEntry];
+                float[] expectedFloats = new float[maxNumValuesPerMVEntry];
+                actualLength = actualReader.getFloatMV(docId, actualFloats, actualReaderContext);
+                expectedLength = expectedReader.getFloatMV(docId, expectedFloats, expectedReaderContext);
+                assertEquals(actualLength, expectedLength);
+
+                for (int i = 0; i < actualLength; i++) {
+                  assertEquals(actualFloats[i], expectedFloats[i]);
+                }
+                break;
+              case DOUBLE:
+                double[] actualDoubles = new double[maxNumValuesPerMVEntry];
+                double[] expectedDoubles = new double[maxNumValuesPerMVEntry];
+                actualLength = actualReader.getDoubleMV(docId, actualDoubles, actualReaderContext);
+                expectedLength = expectedReader.getDoubleMV(docId, expectedDoubles, expectedReaderContext);
+                assertEquals(actualLength, expectedLength);
+
+                for (int i = 0; i < actualLength; i++) {
+                  assertEquals(actualDoubles[i], expectedDoubles[i]);
+                }
+                break;
+              default:
+                // TODO: add support for byte, string, and big decimal type MV raw columns
+                throw new UnsupportedOperationException("No support for raw MV variable length columns yet");
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @AfterClass
+  public void tearDown() {
+    FileUtils.deleteQuietly(TEMP_DIR);
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/MultiValueFixedByteRawIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/MultiValueFixedByteRawIndexCreatorTest.java
@@ -125,7 +125,8 @@ public class MultiValueFixedByteRawIndexCreatorTest {
     //read
     final PinotDataBuffer buffer = PinotDataBuffer
         .mapFile(file, true, 0, file.length(), ByteOrder.BIG_ENDIAN, "");
-    FixedByteChunkMVForwardIndexReader reader = new FixedByteChunkMVForwardIndexReader(buffer, DataType.BYTES);
+    FixedByteChunkMVForwardIndexReader reader = new FixedByteChunkMVForwardIndexReader(buffer,
+        dataType.getStoredType());
     final ChunkReaderContext context = reader.createContext();
     T valueBuffer = constructor.apply(maxElements);
     for (int i = 0; i < numDocs; i++) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/RawIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/RawIndexCreatorTest.java
@@ -361,7 +361,7 @@ public class RawIndexCreatorTest {
    */
   private Object readValueFromIndex(FixedByteChunkSVForwardIndexReader rawIndexReader, ChunkReaderContext readerContext,
       int docId) {
-    switch (rawIndexReader.getValueType()) {
+    switch (rawIndexReader.getStoredType()) {
       case INT:
         return rawIndexReader.getInt(docId, readerContext);
       case LONG:
@@ -372,7 +372,7 @@ public class RawIndexCreatorTest {
         return rawIndexReader.getDouble(docId, readerContext);
       default:
         throw new IllegalArgumentException(
-            "Illegal data type for fixed width raw index reader: " + rawIndexReader.getValueType());
+            "Illegal data type for fixed width raw index reader: " + rawIndexReader.getStoredType());
     }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/mutable/FixedByteMVMutableForwardIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/mutable/FixedByteMVMutableForwardIndexTest.java
@@ -50,15 +50,18 @@ public class FixedByteMVMutableForwardIndexTest {
     Random r = new Random();
     final long seed = r.nextLong();
     try {
-      testIntArray(seed);
-      testWithZeroSize(seed);
+      testIntArray(seed, true);
+      testIntArray(seed, false);
+      testWithZeroSize(seed, true);
+      testWithZeroSize(seed, false);
     } catch (Throwable e) {
       e.printStackTrace();
       Assert.fail("Failed with seed " + seed);
     }
     for (int mvs = 10; mvs < 1000; mvs += 10) {
       try {
-        testIntArrayFixedSize(mvs, seed);
+        testIntArrayFixedSize(mvs, seed, true);
+        testIntArrayFixedSize(mvs, seed, false);
       } catch (Throwable e) {
         e.printStackTrace();
         Assert.fail("Failed with seed " + seed + ", mvs " + mvs);
@@ -66,7 +69,7 @@ public class FixedByteMVMutableForwardIndexTest {
     }
   }
 
-  public void testIntArray(final long seed)
+  public void testIntArray(final long seed, boolean isDictionaryEncoded)
       throws IOException {
     FixedByteMVMutableForwardIndex readerWriter;
     int rows = 1000;
@@ -74,7 +77,7 @@ public class FixedByteMVMutableForwardIndexTest {
     int maxNumberOfMultiValuesPerRow = 2000;
     readerWriter =
         new FixedByteMVMutableForwardIndex(maxNumberOfMultiValuesPerRow, 2, rows / 2, columnSizeInBytes, _memoryManager,
-            "IntArray");
+            "IntArray", isDictionaryEncoded, FieldSpec.DataType.INT);
 
     Random r = new Random(seed);
     int[][] data = new int[rows][];
@@ -94,7 +97,7 @@ public class FixedByteMVMutableForwardIndexTest {
     readerWriter.close();
   }
 
-  public void testIntArrayFixedSize(int multiValuesPerRow, long seed)
+  public void testIntArrayFixedSize(int multiValuesPerRow, long seed, boolean isDictionaryEncoded)
       throws IOException {
     FixedByteMVMutableForwardIndex readerWriter;
     int rows = 1000;
@@ -102,7 +105,7 @@ public class FixedByteMVMutableForwardIndexTest {
     // Keep the rowsPerChunk as a multiple of multiValuesPerRow to check the cases when both data and header buffers
     // transition to new ones
     readerWriter = new FixedByteMVMutableForwardIndex(multiValuesPerRow, multiValuesPerRow, multiValuesPerRow * 2,
-        columnSizeInBytes, _memoryManager, "IntArrayFixedSize");
+        columnSizeInBytes, _memoryManager, "IntArrayFixedSize", isDictionaryEncoded, FieldSpec.DataType.INT);
 
     Random r = new Random(seed);
     int[][] data = new int[rows][];
@@ -122,7 +125,7 @@ public class FixedByteMVMutableForwardIndexTest {
     readerWriter.close();
   }
 
-  public void testWithZeroSize(long seed)
+  public void testWithZeroSize(long seed, boolean isDictionaryEncoded)
       throws IOException {
     FixedByteMVMutableForwardIndex readerWriter;
     final int maxNumberOfMultiValuesPerRow = 5;
@@ -131,7 +134,7 @@ public class FixedByteMVMutableForwardIndexTest {
     Random r = new Random(seed);
     readerWriter =
         new FixedByteMVMutableForwardIndex(maxNumberOfMultiValuesPerRow, 3, r.nextInt(rows) + 1, columnSizeInBytes,
-            _memoryManager, "ZeroSize");
+            _memoryManager, "ZeroSize", isDictionaryEncoded, FieldSpec.DataType.INT);
 
     int[][] data = new int[rows][];
     for (int i = 0; i < rows; i++) {
@@ -156,12 +159,12 @@ public class FixedByteMVMutableForwardIndexTest {
   }
 
   private FixedByteMVMutableForwardIndex createReaderWriter(FieldSpec.DataType dataType, Random r, int rows,
-      int maxNumberOfMultiValuesPerRow) {
+      int maxNumberOfMultiValuesPerRow, boolean isDictionaryEncoded) {
     final int avgMultiValueCount = r.nextInt(maxNumberOfMultiValuesPerRow) + 1;
     final int rowCountPerChunk = r.nextInt(rows) + 1;
 
     return new FixedByteMVMutableForwardIndex(maxNumberOfMultiValuesPerRow, avgMultiValueCount, rowCountPerChunk,
-        dataType.size(), _memoryManager, "ReaderWriter");
+        dataType.size(), _memoryManager, "ReaderWriter", isDictionaryEncoded, dataType);
   }
 
   private long generateSeed() {
@@ -172,12 +175,18 @@ public class FixedByteMVMutableForwardIndexTest {
   @Test
   public void testLongArray()
       throws IOException {
+    testLongArray(true);
+    testLongArray(false);
+  }
+
+  private void testLongArray(boolean isDictionaryEncoded)
+      throws IOException {
     final long seed = generateSeed();
     Random r = new Random(seed);
     int rows = 1000;
     final int maxNumberOfMultiValuesPerRow = r.nextInt(100) + 1;
     FixedByteMVMutableForwardIndex readerWriter =
-        createReaderWriter(FieldSpec.DataType.LONG, r, rows, maxNumberOfMultiValuesPerRow);
+        createReaderWriter(FieldSpec.DataType.LONG, r, rows, maxNumberOfMultiValuesPerRow, isDictionaryEncoded);
 
     long[][] data = new long[rows][];
     for (int i = 0; i < rows; i++) {
@@ -204,12 +213,18 @@ public class FixedByteMVMutableForwardIndexTest {
   @Test
   public void testFloatArray()
       throws IOException {
+    testFloatArray(true);
+    testFloatArray(false);
+  }
+
+  private void testFloatArray(boolean isDictoinaryEncoded)
+      throws IOException {
     final long seed = generateSeed();
     Random r = new Random(seed);
     int rows = 1000;
     final int maxNumberOfMultiValuesPerRow = r.nextInt(100) + 1;
     FixedByteMVMutableForwardIndex readerWriter =
-        createReaderWriter(FieldSpec.DataType.FLOAT, r, rows, maxNumberOfMultiValuesPerRow);
+        createReaderWriter(FieldSpec.DataType.FLOAT, r, rows, maxNumberOfMultiValuesPerRow, isDictoinaryEncoded);
 
     float[][] data = new float[rows][];
     for (int i = 0; i < rows; i++) {
@@ -236,12 +251,18 @@ public class FixedByteMVMutableForwardIndexTest {
   @Test
   public void testDoubleArray()
       throws IOException {
+    testDoubleArray(true);
+    testDoubleArray(false);
+  }
+
+  private void testDoubleArray(boolean isDictonaryEncoded)
+      throws IOException {
     final long seed = generateSeed();
     Random r = new Random(seed);
     int rows = 1000;
     final int maxNumberOfMultiValuesPerRow = r.nextInt(100) + 1;
     FixedByteMVMutableForwardIndex readerWriter =
-        createReaderWriter(FieldSpec.DataType.DOUBLE, r, rows, maxNumberOfMultiValuesPerRow);
+        createReaderWriter(FieldSpec.DataType.DOUBLE, r, rows, maxNumberOfMultiValuesPerRow, isDictonaryEncoded);
 
     double[][] data = new double[rows][];
     for (int i = 0; i < rows; i++) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/SortedIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/SortedIndexReader.java
@@ -45,7 +45,7 @@ public interface SortedIndexReader<T extends ForwardIndexReaderContext>
   }
 
   @Override
-  default DataType getValueType() {
+  default DataType getStoredType() {
     return DataType.INT;
   }
 }


### PR DESCRIPTION
This PR adds support for querying multi-value columns in RAW format (without dictionary). Support to create segments with multi-value columns with dictionary disabled already existed. On trying to create a multi-value RAW column and querying it, we ran into this issue: https://github.com/apache/pinot/issues/8875

This PR adds MV RAW support for the following types of columns:

- Offline segments with MV columns of types INT, LONG, FLOAT, DOUBLE, and STRING
- Mutable (realtime) segments with MV columns of INT, LONG, FLOAT, and DOUBLE

TODO - Support for variable length MV RAW columns for Mutable segments will be added in the future as it requires a mutable variable length writer.

Test cases for various types of queries have been added to ensure that MV RAW columns can be supported.

cc @siddharthteotia  