### PR TITLE
Remove disabled partitions when instance starts

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -360,10 +360,11 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
 
   private void updateInstanceConfigAndBrokerResourceIfNeeded() {
     InstanceConfig instanceConfig = HelixHelper.getInstanceConfig(_participantHelixManager, _instanceId);
-    boolean instanceConfigUpdated = HelixHelper.updateHostnamePort(instanceConfig, _hostname, _port);
+    boolean updated = HelixHelper.updateHostnamePort(instanceConfig, _hostname, _port);
     if (_tlsPort > 0) {
       HelixHelper.updateTlsPort(instanceConfig, _tlsPort);
     }
+    updated |= HelixHelper.removeDisabledPartitions(instanceConfig);
     boolean shouldUpdateBrokerResource = false;
     String brokerTag = null;
     List<String> instanceTags = instanceConfig.getTags();
@@ -376,9 +377,9 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
         brokerTag = Helix.UNTAGGED_BROKER_INSTANCE;
       }
       instanceConfig.addTag(brokerTag);
-      instanceConfigUpdated = true;
+      updated = true;
     }
-    if (instanceConfigUpdated) {
+    if (updated) {
       HelixHelper.updateInstanceConfig(_participantHelixManager, instanceConfig);
     }
     if (shouldUpdateBrokerResource) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -667,4 +667,17 @@ public class HelixHelper {
     }
     return false;
   }
+
+  /**
+   * Removes the disabled partitions from the instance config. Sometimes a partition can be accidentally disabled, and
+   * not re-enabled for some reason. When an instance is restarted, we should remove these disabled partitions so that
+   * they can be processed.
+   */
+  public static boolean removeDisabledPartitions(InstanceConfig instanceConfig) {
+    ZNRecord record = instanceConfig.getRecord();
+    String disabledPartitionsKey = InstanceConfig.InstanceConfigProperty.HELIX_DISABLED_PARTITION.name();
+    boolean listUpdated = record.getListFields().remove(disabledPartitionsKey) != null;
+    boolean mapUpdated = record.getMapFields().remove(disabledPartitionsKey) != null;
+    return listUpdated | mapUpdated;
+  }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/helix/HelixHelperTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/helix/HelixHelperTest.java
@@ -62,7 +62,7 @@ public class HelixHelperTest {
 
   @Test
   public void testAddDefaultTags() {
-    String instanceId = "myInstance";
+    String instanceId = "Server_myInstance";
     InstanceConfig instanceConfig = new InstanceConfig(instanceId);
     List<String> defaultTags = Arrays.asList("tag1", "tag2");
     assertTrue(HelixHelper.addDefaultTags(instanceConfig, () -> defaultTags));
@@ -74,5 +74,18 @@ public class HelixHelperTest {
     List<String> otherTags = Arrays.asList("tag3", "tag4");
     assertFalse(HelixHelper.addDefaultTags(instanceConfig, () -> otherTags));
     assertEquals(instanceConfig.getTags(), defaultTags);
+  }
+
+  @Test
+  public void testRemoveDisabledPartitions() {
+    String instanceId = "Server_myInstance";
+    InstanceConfig instanceConfig = new InstanceConfig(instanceId);
+    assertTrue(instanceConfig.getDisabledPartitionsMap().isEmpty());
+    assertFalse(HelixHelper.removeDisabledPartitions(instanceConfig));
+
+    instanceConfig.setInstanceEnabledForPartition("myResource", "myPartition", false);
+    assertFalse(instanceConfig.getDisabledPartitionsMap().isEmpty());
+    assertTrue(HelixHelper.removeDisabledPartitions(instanceConfig));
+    assertTrue(instanceConfig.getDisabledPartitionsMap().isEmpty());
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -617,8 +617,9 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     if (_tlsPort > 0) {
       updated |= HelixHelper.updateTlsPort(instanceConfig, _tlsPort);
     }
-    updated |= HelixHelper
-        .addDefaultTags(instanceConfig, () -> Collections.singletonList(CommonConstants.Helix.CONTROLLER_INSTANCE));
+    updated |= HelixHelper.addDefaultTags(instanceConfig,
+        () -> Collections.singletonList(CommonConstants.Helix.CONTROLLER_INSTANCE));
+    updated |= HelixHelper.removeDisabledPartitions(instanceConfig);
     if (updated) {
       HelixHelper.updateInstanceConfig(_helixParticipantManager, instanceConfig);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2244,6 +2244,7 @@ public class PinotHelixResourceManager {
       if (externalViewStateMap == null || !SegmentStateModel.ERROR.equals(externalViewStateMap.get(instance))) {
         LOGGER.info("Disabling segment: {} of table: {}", segmentName, tableNameWithType);
         // enablePartition takes a segment which is NOT in ERROR state, to OFFLINE state
+        // TODO: If the controller fails to re-enable the partition, it will be left in disabled state
         _helixAdmin.enablePartition(false, _helixClusterName, instance, tableNameWithType,
             Lists.newArrayList(segmentName));
       } else {
@@ -2323,6 +2324,7 @@ public class PinotHelixResourceManager {
     }
     for (Map.Entry<String, Set<String>> entry : instanceToDisableSegmentsMap.entrySet()) {
       // enablePartition takes a segment which is NOT in ERROR state, to OFFLINE state
+      // TODO: If the controller fails to re-enable the partition, it will be left in disabled state
       _helixAdmin.enablePartition(false, _helixClusterName, entry.getKey(), tableNameWithType,
           Lists.newArrayList(entry.getValue()));
     }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
@@ -287,6 +287,7 @@ public abstract class BaseMinionStarter implements ServiceStartable {
     boolean updated = HelixHelper.updateHostnamePort(instanceConfig, _hostname, _port);
     updated |= HelixHelper.addDefaultTags(instanceConfig,
         () -> Collections.singletonList(CommonConstants.Helix.UNTAGGED_MINION_INSTANCE));
+    updated |= HelixHelper.removeDisabledPartitions(instanceConfig);
     if (updated) {
       HelixHelper.updateInstanceConfig(_helixManager, instanceConfig);
     }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -310,6 +310,9 @@ public abstract class BaseServerStarter implements ServiceStartable {
       }
     });
 
+    // Remove disabled partitions
+    updated |= HelixHelper.removeDisabledPartitions(instanceConfig);
+
     // Update admin HTTP/HTTPS port
     int adminHttpPort = Integer.MIN_VALUE;
     int adminHttpsPort = Integer.MIN_VALUE;


### PR DESCRIPTION
As described in #8919, there is a bug which can cause partitions being disabled on some instances. This PR provides a workaround to always remove these disabled partitions when an instance starts.