### PR TITLE
properly shutdown query client with await termination

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/GrpcBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/GrpcBrokerRequestHandler.java
@@ -78,6 +78,7 @@ public class GrpcBrokerRequestHandler extends BaseBrokerRequestHandler {
 
   @Override
   public synchronized void shutDown() {
+    _streamingQueryClient.shutdown();
     _streamingReduceService.shutDown();
   }
 
@@ -145,6 +146,12 @@ public class GrpcBrokerRequestHandler extends BaseBrokerRequestHandler {
     private GrpcQueryClient getOrCreateGrpcQueryClient(String host, int port) {
       String key = String.format("%s_%d", host, port);
       return _grpcQueryClientMap.computeIfAbsent(key, k -> new GrpcQueryClient(host, port, _config));
+    }
+
+    public void shutdown() {
+      for (GrpcQueryClient client : _grpcQueryClientMap.values()) {
+        client.close();
+      }
     }
   }
 }


### PR DESCRIPTION
Previously we didn't shutdown GRPCQueryClient managed channel properly. 

This should fix https://github.com/apache/pinot/issues/8684
see stress test result in https://github.com/apache/pinot/pull/8767 (https://github.com/apache/pinot/runs/6948759053?check_suite_focus=true)