### PR TITLE
Adding minion adhoc as a k8s deployment for minion deployment

### DIFF
--- a/kubernetes/helm/pinot/requirements.lock
+++ b/kubernetes/helm/pinot/requirements.lock
@@ -20,6 +20,6 @@
 dependencies:
 - name: zookeeper
   repository: https://charts.bitnami.com/bitnami
-  version: 7.0.0
-digest: sha256:db1ecacbb7016e8c0d9c6642c917461d6190ef88fb9a2a5147b2230e94c64eab
-generated: "2021-12-22T12:04:57.707437-08:00"
+  version: 9.2.7
+digest: sha256:a5da7ddd352d63b0a0e1e5bd85e90e304ae5d0fa7759d5cb7ffb39f61adef1e9
+generated: "2022-06-20T14:57:34.981883-07:00"

--- a/kubernetes/helm/pinot/requirements.yaml
+++ b/kubernetes/helm/pinot/requirements.yaml
@@ -19,6 +19,6 @@
 
 dependencies:
   - name: zookeeper
-    version: 7.0.0
+    version: 9.x.x
     repository: https://charts.bitnami.com/bitnami
     condition: pinot.zookeeper.enabled,zookeeper.enabled

--- a/kubernetes/helm/pinot/templates/_helpers.tpl
+++ b/kubernetes/helm/pinot/templates/_helpers.tpl
@@ -100,6 +100,14 @@ component: {{ .Values.minion.name }}
 {{- end }}
 
 {{/*
+minionStateless labels
+*/}}
+{{- define "pinot.minionStatelessLabels" -}}
+{{- include "pinot.labels" . }}
+component: {{ .Values.minionStateless.name }}
+{{- end }}
+
+{{/*
 Server labels
 */}}
 {{- define "pinot.serverLabels" -}}
@@ -132,6 +140,15 @@ Minion Match Selector labels
 {{- define "pinot.minionMatchLabels" -}}
 {{- include "pinot.matchLabels" . }}
 component: {{ .Values.minion.name }}
+{{- end }}
+
+
+{{/*
+MinionStateless Match Selector labels
+*/}}
+{{- define "pinot.minionStatelessMatchLabels" -}}
+{{- include "pinot.matchLabels" . }}
+component: {{ .Values.minionStateless.name }}
 {{- end }}
 
 
@@ -217,6 +234,15 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{ template "pinot.fullname" . }}-{{ .Values.minion.name }}
 {{- end -}}
 
+
+{{/*
+Create a default fully qualified pinot minion stateless name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "pinot.minionStateless.fullname" -}}
+{{ template "pinot.fullname" . }}-{{ .Values.minionStateless.name }}
+{{- end -}}
+
 {{/*
 The name of the pinot controller headless service.
 */}}
@@ -285,4 +311,11 @@ The name of the pinot minion config.
 */}}
 {{- define "pinot.minion.config" -}}
 {{- printf "%s-config" (include "pinot.minion.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+The name of the pinot minion stateless config.
+*/}}
+{{- define "pinot.minionStateless.config" -}}
+{{- printf "%s-config" (include "pinot.minionStateless.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/kubernetes/helm/pinot/templates/minion-stateless/configmap.yaml
+++ b/kubernetes/helm/pinot/templates/minion-stateless/configmap.yaml
@@ -17,19 +17,16 @@
 # under the License.
 #
 
-{{- if .Values.minion.enabled }}
+{{- if .Values.minionStateless.enabled }}
 apiVersion: v1
-kind: Service
+kind: ConfigMap
 metadata:
-  name: {{ template "pinot.minion.headless" . }}
-  labels:
-    {{- include "pinot.minionLabels" . | nindent 4 }}
-spec:
-  clusterIP: None
-  ports:
-    # [pod_name].[service_name].[namespace].svc.cluster.local
-    - name: {{ .Values.minion.service.name }}
-      port: {{ .Values.minion.service.port }}
-  selector:
-    {{- include "pinot.minionMatchLabels" . | nindent 4 }}
+  name: {{ include "pinot.minionStateless.config" . }}
+data:
+  pinot-minion-stateless.conf: |-
+    pinot.minion.port={{ .Values.minionStateless.service.port }}
+    {{- if .Values.minionStateless.dataDir }}
+    dataDir={{ .Values.minionStateless.dataDir }}
+    {{- end }}
+{{ .Values.minionStateless.extra.configs | indent 4 }}
 {{- end }}

--- a/kubernetes/helm/pinot/templates/minion-stateless/deployment.yml
+++ b/kubernetes/helm/pinot/templates/minion-stateless/deployment.yml
@@ -1,0 +1,121 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+{{- if .Values.minionStateless.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "pinot.minionStateless.fullname" . }}
+  labels:
+    {{- include "pinot.minionStatelessLabels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "pinot.minionStatelessMatchLabels" . | nindent 6 }}
+  replicas: {{ .Values.minionStateless.replicaCount }}
+  template:
+    metadata:
+      labels:
+        {{- include "pinot.minionStatelessLabels" . | nindent 8 }}
+      annotations:
+{{ toYaml .Values.minionStateless.podAnnotations | indent 8 }}
+    spec:
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      securityContext:
+        {{- toYaml .Values.minionStateless.podSecurityContext | nindent 8 }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      nodeSelector:
+{{ toYaml .Values.minionStateless.nodeSelector | indent 8 }}
+      affinity:
+{{ toYaml .Values.minionStateless.affinity | indent 8 }}
+      tolerations:
+{{ toYaml .Values.minionStateless.tolerations | indent 8 }}
+      containers:
+      - name: minion-stateless
+        securityContext:
+          {{- toYaml .Values.minionStateless.securityContext | nindent 10 }}
+        image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        args: [
+          "StartMinion",
+          "-clusterName", "{{ .Values.cluster.name }}",
+          "-zkAddress", {{ include "zookeeper.url" . | quote }},
+          "-configFileName", "/var/pinot/minion/config/pinot-minion-stateless.conf"
+        ]
+        env:
+          - name: JAVA_OPTS
+            value: "{{ .Values.minionStateless.jvmOpts }} -Dlog4j2.configurationFile={{ .Values.minionStateless.log4j2ConfFile }} -Dplugins.dir={{ .Values.minionStateless.pluginsDir }}"
+{{- if .Values.minionStateless.extraEnv }}
+{{ toYaml .Values.minionStateless.extraEnv | indent 10 }}
+{{- end }}
+        envFrom:
+{{ toYaml .Values.minionStateless.envFrom | indent 10 }}
+        ports:
+          - containerPort: {{ .Values.minionStateless.service.port }}
+            protocol: {{ .Values.minionStateless.service.protocol }}
+            name: {{ .Values.minionStateless.service.name }}
+        {{- if .Values.minionStateless.probes.livenessEnabled }}
+        livenessProbe:
+          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          periodSeconds: {{ .Values.probes.periodSeconds }}
+          httpGet:
+            path: {{ .Values.minionStateless.probes.endpoint }}
+            port: {{ .Values.minionStateless.service.port }}
+        {{- end }}
+        {{- if .Values.minionStateless.probes.readinessEnabled }}
+        readinessProbe:
+          initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
+          periodSeconds: {{ .Values.probes.periodSeconds }}
+          httpGet:
+            path: {{ .Values.minionStateless.probes.endpoint }}
+            port: {{ .Values.minionStateless.service.port }}
+        {{- end }}
+        volumeMounts:
+          - name: config
+            mountPath: /var/pinot/minion/config
+          {{- if .Values.minionStateless.persistence.enabled }}
+          - name: data
+            mountPath: "{{ .Values.minionStateless.persistence.mountPath }}"
+          {{- end }}
+          {{- if ne (len .Values.minionStateless.persistence.extraVolumeMounts) 0 }}
+{{ toYaml .Values.minionStateless.persistence.extraVolumeMounts | indent 10 }}
+          {{- end }}
+        resources:
+{{ toYaml .Values.minionStateless.resources | indent 12 }}
+      restartPolicy: Always
+      volumes:
+        - name: config
+          configMap:
+            name: {{ include "pinot.minionStateless.config" . }}
+      {{- if not .Values.minionStateless.persistence.enabled }}
+        - name: data
+          emptyDir: {}
+      {{- end }}
+      {{- if .Values.minionStateless.persistence.enabled }}
+        - name: data
+          persistentVolumeClaim:
+            claimName: {{ .Values.minionStateless.persistence.pvcName }}
+      {{- end }}
+      {{- if ne (len .Values.minionStateless.persistence.extraVolumes) 0 }}
+{{ toYaml .Values.minionStateless.persistence.extraVolumes | indent 8 }}
+      {{- end }}
+{{- end }}

--- a/kubernetes/helm/pinot/templates/minion-stateless/pvc.yaml
+++ b/kubernetes/helm/pinot/templates/minion-stateless/pvc.yaml
@@ -17,19 +17,24 @@
 # under the License.
 #
 
-{{- if .Values.minion.enabled }}
+{{- if .Values.minionStateless.enabled }}
+{{- if .Values.minionStateless.persistence.enabled }}
+kind: PersistentVolumeClaim
 apiVersion: v1
-kind: Service
 metadata:
-  name: {{ template "pinot.minion.headless" . }}
-  labels:
-    {{- include "pinot.minionLabels" . | nindent 4 }}
+  name: {{ .Values.minionStateless.persistence.pvcName }}
 spec:
-  clusterIP: None
-  ports:
-    # [pod_name].[service_name].[namespace].svc.cluster.local
-    - name: {{ .Values.minion.service.name }}
-      port: {{ .Values.minion.service.port }}
-  selector:
-    {{- include "pinot.minionMatchLabels" . | nindent 4 }}
+  accessModes:
+    - {{ .Values.minionStateless.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.minionStateless.persistence.size }}
+{{- if .Values.minionStateless.persistence.storageClass }}
+{{- if (eq "-" .Values.minionStateless.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: {{ .Values.minionStateless.persistence.storageClass }}
+{{- end }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/kubernetes/helm/pinot/templates/minion/configmap.yaml
+++ b/kubernetes/helm/pinot/templates/minion/configmap.yaml
@@ -17,6 +17,7 @@
 # under the License.
 #
 
+{{- if .Values.minion.enabled }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -28,3 +29,4 @@ data:
     dataDir={{ .Values.minion.dataDir }}
     {{- end }}
 {{ .Values.minion.extra.configs | indent 4 }}
+{{- end }}

--- a/kubernetes/helm/pinot/templates/minion/service.yaml
+++ b/kubernetes/helm/pinot/templates/minion/service.yaml
@@ -17,6 +17,7 @@
 # under the License.
 #
 
+{{- if .Values.minion.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -33,3 +34,4 @@ spec:
       port: {{ .Values.minion.service.port }}
   selector:
     {{- include "pinot.minionMatchLabels" . | nindent 4 }}
+{{- end }}

--- a/kubernetes/helm/pinot/templates/minion/statefulset.yml
+++ b/kubernetes/helm/pinot/templates/minion/statefulset.yml
@@ -17,6 +17,7 @@
 # under the License.
 #
 
+{{- if .Values.minion.enabled }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -135,3 +136,4 @@ spec:
           requests:
             storage: {{ .Values.minion.persistence.size }}
   {{ end }}
+{{- end }}

--- a/kubernetes/helm/pinot/values.yaml
+++ b/kubernetes/helm/pinot/values.yaml
@@ -344,8 +344,9 @@ server:
 # Pinot Minion:
 # ------------------------------------------------------------------------------
 minion:
+  enabled: false
   name: minion
-  replicaCount: 1
+  replicaCount: 0
   podManagementPolicy: Parallel
   podSecurityContext: {}
     # fsGroup: 2000
@@ -396,6 +397,75 @@ minion:
 
   updateStrategy:
     type: RollingUpdate
+
+  # Use envFrom to define all of the ConfigMap or Secret data as container environment variables.
+  # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables
+  # ref: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
+  envFrom: []
+  #  - configMapRef:
+  #      name: special-config
+  #  - secretRef:
+  #      name: test-secret
+
+  # Use extraEnv to add individual key value pairs as container environment variables.
+  # ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
+  extraEnv: []
+  #  - name: PINOT_CUSTOM_ENV
+  #    value: custom-value
+
+  # Extra configs will be appended to pinot-minion.conf file
+  extra:
+    configs: |-
+      pinot.set.instance.id.to.hostname=true
+
+
+# ------------------------------------------------------------------------------
+# Pinot Minion Stateless:
+# ------------------------------------------------------------------------------
+minionStateless:
+  enabled: true
+  name: minion-stateless
+  replicaCount: 1
+  podSecurityContext: {}
+    # fsGroup: 2000
+  securityContext: {}
+
+  probes:
+    endpoint: "/health"
+    livenessEnabled: true
+    readinessEnabled: true
+
+  dataDir: /var/pinot/minion/data
+  jvmOpts: "-Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-minion.log"
+
+  log4j2ConfFile: /opt/pinot/conf/log4j2.xml
+  pluginsDir: /opt/pinot/plugins
+
+  persistence:
+    enabled: false
+    pvcName: minion-data-vol
+    accessMode: ReadWriteOnce
+    size: 4G
+    mountPath: /var/pinot/minion/data
+    storageClass: ""
+    #storageClass: "ssd"
+    extraVolumes: []
+    extraVolumeMounts: []
+
+  service:
+    port: 9514
+    protocol: TCP
+    name: minion
+
+  resources: {}
+
+  nodeSelector: {}
+
+  affinity: {}
+
+  tolerations: []
+
+  podAnnotations: {}
 
   # Use envFrom to define all of the ConfigMap or Secret data as container environment variables.
   # ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/#configure-all-key-value-pairs-in-a-configmap-as-container-environment-variables


### PR DESCRIPTION
Adding k8s `deployment.apps/pinot-minion-stateless` for minion stateless deployment.

This deployment by default uses a local disk for temp persistence.


The new deployment looks like this:
```
➜  kubectl get all -n pinot
NAME                                          READY   STATUS    RESTARTS      AGE
pod/pinot-broker-0                            1/1     Running   1 (88s ago)   113s
pod/pinot-controller-0                        1/1     Running   0             113s
pod/pinot-minion-stateless-5765bcc487-jr8fn   1/1     Running   1 (72s ago)   113s
pod/pinot-server-0                            1/1     Running   1 (71s ago)   113s
pod/pinot-zookeeper-0                         1/1     Running   0             113s

NAME                                TYPE           CLUSTER-IP       EXTERNAL-IP   PORT(S)                      AGE
service/pinot-broker                ClusterIP      10.110.116.28    <none>        8099/TCP                     114s
service/pinot-broker-external       LoadBalancer   10.110.57.63     <pending>     8099:31622/TCP               114s
service/pinot-broker-headless       ClusterIP      None             <none>        8099/TCP                     114s
service/pinot-controller            ClusterIP      10.107.127.32    <none>        9000/TCP                     114s
service/pinot-controller-external   LoadBalancer   10.109.193.170   <pending>     9000:31333/TCP               114s
service/pinot-controller-headless   ClusterIP      None             <none>        9000/TCP                     114s
service/pinot-server                ClusterIP      10.100.68.224    <none>        8098/TCP,80/TCP              114s
service/pinot-server-headless       ClusterIP      None             <none>        8098/TCP,80/TCP              114s
service/pinot-zookeeper             ClusterIP      10.97.195.107    <none>        2181/TCP,2888/TCP,3888/TCP   114s
service/pinot-zookeeper-headless    ClusterIP      None             <none>        2181/TCP,2888/TCP,3888/TCP   114s

NAME                                     READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/pinot-minion-stateless   1/1     1            1           114s

NAME                                                DESIRED   CURRENT   READY   AGE
replicaset.apps/pinot-minion-stateless-5765bcc487   1         1         1       114s

NAME                                READY   AGE
statefulset.apps/pinot-broker       1/1     113s
statefulset.apps/pinot-controller   1/1     113s
statefulset.apps/pinot-server       1/1     113s
statefulset.apps/pinot-zookeeper    1/1     113s
```