### PR TITLE
make default java version 11

### DIFF
--- a/docker/images/pinot/docker-build.sh
+++ b/docker/images/pinot/docker-build.sh
@@ -53,7 +53,7 @@ if [[ "$#" -gt 4 ]]
 then
   JAVA_VERSION=$5
 else
-  JAVA_VERSION=8
+  JAVA_VERSION=11
 fi
 
 echo "Trying to build Pinot docker image from Git URL: [ ${PINOT_GIT_URL} ] on branch: [ ${PINOT_BRANCH} ] and tag it as: [ ${DOCKER_TAG} ]. Kafka Dependencies: [ ${KAFKA_VERSION} ]. Java Version: [ ${JAVA_VERSION} ]."


### PR DESCRIPTION
On invoking `./docker-build.sh`, build fails with 
`executor failed running [/bin/sh -c git clone ${PINOT_GIT_URL} ${PINOT_BUILD_DIR} &&     cd ${PINOT_BUILD_DIR} &&     git checkout ${PINOT_BRANCH} &&     mvn install package -DskipTests -Pbin-dist -Pbuild-shaded-jar -Djdk.version=${JDK_VERSION} -T1C &&     mkdir -p ${PINOT_HOME}/configs &&     mkdir -p ${PINOT_HOME}/data &&     cp -r build/* ${PINOT_HOME}/. &&     chmod +x ${PINOT_HOME}/bin/*.sh]: exit code: 1` 

Building with java 11 by invoking `./docker-build.sh pinot:latest master https://github.com/apache/pinot.git 2.0 11` works without any issue. Hence making default java version 11 here.