### PR TITLE
add a util method to sanity check time size instead of using regex

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatSpec.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.spi.data.DateTimeFieldSpec.TimeFormat;
 import org.apache.pinot.spi.utils.EqualityUtils;
+import org.apache.pinot.spi.utils.TimeUtils;
 import org.apache.pinot.spi.utils.TimestampUtils;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormatter;
@@ -34,8 +35,6 @@ import org.joda.time.format.DateTimeFormatter;
  * Class to represent format from {@link DateTimeFieldSpec}
  */
 public class DateTimeFormatSpec {
-
-  public static final String NUMBER_REGEX = "[1-9][0-9]*";
   public static final String COLON_SEPARATOR = ":";
   public static final String PIPE_SEPARATOR = "|";
 
@@ -225,7 +224,7 @@ public class DateTimeFormatSpec {
     String[] formatTokens = StringUtils.split(format, COLON_SEPARATOR, MAX_FORMAT_TOKENS);
     Preconditions.checkState(formatTokens.length >= MIN_FORMAT_TOKENS && formatTokens.length <= MAX_FORMAT_TOKENS,
         "Incorrect format: %s. Must be of format 'size:timeunit:timeformat(:pattern)'", format);
-    Preconditions.checkState(formatTokens[FORMAT_SIZE_POSITION].matches(NUMBER_REGEX),
+    Preconditions.checkState(TimeUtils.isTimeSize(formatTokens[FORMAT_SIZE_POSITION]),
         "Incorrect format size: %s in format: %s. Must be of format '[0-9]+:<TimeUnit>:<TimeFormat>(:pattern)'",
         formatTokens[FORMAT_SIZE_POSITION], format);
 
@@ -264,11 +263,11 @@ public class DateTimeFormatSpec {
               || formatTokens[FORMAT_SIZE_POSITION].equals(TimeFormat.SIMPLE_DATE_FORMAT.toString()),
           "Incorrect format %s. Must be of 'EPOCH|<timeUnit>(|<size>)' or" + "'SDF|<timeFormat>(|<timezone>)'");
 
-      if (formatTokens.length == MAX_FORMAT_TOKENS_PIPE
-          && formatTokens[FORMAT_SIZE_POSITION].equals(TimeFormat.EPOCH.toString())) {
-          Preconditions.checkState(formatTokens[EPOCH_SIZE_POSITION].matches(NUMBER_REGEX),
-              "Incorrect format size: %s in format: %s. Must be of format 'EPOCH|<timeUnit>|[0-9]+'",
-              formatTokens[EPOCH_SIZE_POSITION], format);
+      if (formatTokens.length == MAX_FORMAT_TOKENS_PIPE && formatTokens[FORMAT_SIZE_POSITION]
+          .equals(TimeFormat.EPOCH.toString())) {
+        Preconditions.checkState(TimeUtils.isTimeSize(formatTokens[EPOCH_SIZE_POSITION]),
+            "Incorrect format size: %s in format: %s. Must be of format 'EPOCH|<timeUnit>|[0-9]+'",
+            formatTokens[EPOCH_SIZE_POSITION], format);
       }
     }
     return formatTokens;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeGranularitySpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeGranularitySpec.java
@@ -23,15 +23,13 @@ import com.google.common.base.Preconditions;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.EnumUtils;
 import org.apache.pinot.spi.utils.EqualityUtils;
+import org.apache.pinot.spi.utils.TimeUtils;
 
 
 /**
  * Class to represent granularity from {@link DateTimeFieldSpec}
  */
 public class DateTimeGranularitySpec {
-
-  public static final String NUMBER_REGEX = "[1-9][0-9]*";
-
   public static final String COLON_SEPARATOR = ":";
 
   /* DateTimeFieldSpec granularity is of format size:timeUnit */
@@ -101,7 +99,7 @@ public class DateTimeGranularitySpec {
     String[] granularityTokens = granularity.split(COLON_SEPARATOR);
     Preconditions.checkState(granularityTokens.length == MAX_GRANULARITY_TOKENS,
         "Incorrect granularity: %s. Must be of format 'size:timeunit'", granularity);
-    Preconditions.checkState(granularityTokens[GRANULARITY_SIZE_POSITION].matches(NUMBER_REGEX),
+    Preconditions.checkState(TimeUtils.isTimeSize(granularityTokens[GRANULARITY_SIZE_POSITION]),
         "Incorrect granularity size: %s. Must be of format '[0-9]+:<TimeUnit>'",
         granularityTokens[GRANULARITY_SIZE_POSITION]);
     Preconditions.checkState(EnumUtils.isValidEnum(TimeUnit.class, granularityTokens[GRANULARITY_UNIT_POSITION]),

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/TimeUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/TimeUtils.java
@@ -194,4 +194,29 @@ public class TimeUtils {
       return false;
     }
   }
+
+  /**
+   * Check if a string value matches regex `[1-9][0-9]*`. This check is used when converting date times and date time
+   * conversion is a common transforms applied when generating segments, thus this check is on its critical path.
+   * Based on benchmarks, this util method is about 3x faster than compiled regex and about 10x faster than calling
+   * String.matches(regex) directly.
+   *
+   * @param value the String value to check
+   * @return true if the value matches `[1-9][0-9]*`
+   */
+  public static boolean isTimeSize(String value) {
+    if (value == null || value.length() == 0) {
+      return false;
+    }
+    char[] digits = value.toCharArray();
+    if (digits[0] < '1' || digits[0] > '9') {
+      return false;
+    }
+    for (int i = 1; i < digits.length; i++) {
+      if (digits[i] < '0' || digits[i] > '9') {
+        return false;
+      }
+    }
+    return true;
+  }
 }


### PR DESCRIPTION
This PR adds a util method to replace the regex matches based sanity check on `time size` in date time spec. The regex matches can be very costly when converting date time values for segment generation. 