### PR TITLE
Add multi-value noDict APIs and their implementation for querying immutable and mutable fixed-width segment types

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
@@ -53,6 +53,7 @@ public class DataFetcher {
   //       ChunkReaderContext should be closed explicitly to release the off-heap buffer
   private final Map<String, ColumnValueReader> _columnValueReaderMap;
   private final int[] _reusableMVDictIds;
+  private final int _maxNumValuesPerMVEntry;
 
   /**
    * Constructor for DataFetcher.
@@ -74,6 +75,7 @@ public class DataFetcher {
       }
     }
     _reusableMVDictIds = new int[maxNumValuesPerMVEntry];
+    _maxNumValuesPerMVEntry = maxNumValuesPerMVEntry;
   }
 
   /**
@@ -636,7 +638,7 @@ public class DataFetcher {
           valuesBuffer[i] = values;
         }
       } else {
-        _reader.readValuesMV(docIds, length, valuesBuffer, getReaderContext());
+        _reader.readValuesMV(docIds, length, _maxNumValuesPerMVEntry, valuesBuffer, getReaderContext());
       }
     }
 
@@ -656,7 +658,7 @@ public class DataFetcher {
           valuesBuffer[i] = values;
         }
       } else {
-        _reader.readValuesMV(docIds, length, valuesBuffer, getReaderContext());
+        _reader.readValuesMV(docIds, length, _maxNumValuesPerMVEntry, valuesBuffer, getReaderContext());
       }
     }
 
@@ -676,7 +678,7 @@ public class DataFetcher {
           valuesBuffer[i] = values;
         }
       } else {
-        _reader.readValuesMV(docIds, length, valuesBuffer, getReaderContext());
+        _reader.readValuesMV(docIds, length, _maxNumValuesPerMVEntry, valuesBuffer, getReaderContext());
       }
     }
 
@@ -696,7 +698,7 @@ public class DataFetcher {
           valuesBuffer[i] = values;
         }
       } else {
-        _reader.readValuesMV(docIds, length, valuesBuffer, getReaderContext());
+        _reader.readValuesMV(docIds, length, _maxNumValuesPerMVEntry, valuesBuffer, getReaderContext());
       }
     }
 
@@ -716,7 +718,7 @@ public class DataFetcher {
           valuesBuffer[i] = values;
         }
       } else {
-        _reader.readValuesMV(docIds, length, valuesBuffer, getReaderContext());
+        _reader.readValuesMV(docIds, length, _maxNumValuesPerMVEntry, valuesBuffer, getReaderContext());
       }
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
@@ -628,12 +628,15 @@ public class DataFetcher {
 
     void readIntValuesMV(int[] docIds, int length, int[][] valuesBuffer) {
       Tracing.activeRecording().setInputDataType(_dataType, _singleValue);
-      assert _dictionary != null;
-      for (int i = 0; i < length; i++) {
-        int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, getReaderContext());
-        int[] values = new int[numValues];
-        _dictionary.readIntValues(_reusableMVDictIds, numValues, values);
-        valuesBuffer[i] = values;
+      if (_dictionary != null) {
+        for (int i = 0; i < length; i++) {
+          int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, getReaderContext());
+          int[] values = new int[numValues];
+          _dictionary.readIntValues(_reusableMVDictIds, numValues, values);
+          valuesBuffer[i] = values;
+        }
+      } else {
+        _reader.readValuesMV(docIds, length, valuesBuffer, getReaderContext());
       }
     }
 
@@ -645,12 +648,15 @@ public class DataFetcher {
 
     void readLongValuesMV(int[] docIds, int length, long[][] valuesBuffer) {
       Tracing.activeRecording().setInputDataType(_dataType, _singleValue);
-      assert _dictionary != null;
-      for (int i = 0; i < length; i++) {
-        int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, getReaderContext());
-        long[] values = new long[numValues];
-        _dictionary.readLongValues(_reusableMVDictIds, numValues, values);
-        valuesBuffer[i] = values;
+      if (_dictionary != null) {
+        for (int i = 0; i < length; i++) {
+          int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, getReaderContext());
+          long[] values = new long[numValues];
+          _dictionary.readLongValues(_reusableMVDictIds, numValues, values);
+          valuesBuffer[i] = values;
+        }
+      } else {
+        _reader.readValuesMV(docIds, length, valuesBuffer, getReaderContext());
       }
     }
 
@@ -662,12 +668,15 @@ public class DataFetcher {
 
     void readFloatValuesMV(int[] docIds, int length, float[][] valuesBuffer) {
       Tracing.activeRecording().setInputDataType(_dataType, _singleValue);
-      assert _dictionary != null;
-      for (int i = 0; i < length; i++) {
-        int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, getReaderContext());
-        float[] values = new float[numValues];
-        _dictionary.readFloatValues(_reusableMVDictIds, numValues, values);
-        valuesBuffer[i] = values;
+      if (_dictionary != null) {
+        for (int i = 0; i < length; i++) {
+          int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, getReaderContext());
+          float[] values = new float[numValues];
+          _dictionary.readFloatValues(_reusableMVDictIds, numValues, values);
+          valuesBuffer[i] = values;
+        }
+      } else {
+        _reader.readValuesMV(docIds, length, valuesBuffer, getReaderContext());
       }
     }
 
@@ -679,12 +688,15 @@ public class DataFetcher {
 
     void readDoubleValuesMV(int[] docIds, int length, double[][] valuesBuffer) {
       Tracing.activeRecording().setInputDataType(_dataType, _singleValue);
-      assert _dictionary != null;
-      for (int i = 0; i < length; i++) {
-        int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, getReaderContext());
-        double[] values = new double[numValues];
-        _dictionary.readDoubleValues(_reusableMVDictIds, numValues, values);
-        valuesBuffer[i] = values;
+      if (_dictionary != null) {
+        for (int i = 0; i < length; i++) {
+          int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, getReaderContext());
+          double[] values = new double[numValues];
+          _dictionary.readDoubleValues(_reusableMVDictIds, numValues, values);
+          valuesBuffer[i] = values;
+        }
+      } else {
+        _reader.readValuesMV(docIds, length, valuesBuffer, getReaderContext());
       }
     }
 
@@ -696,12 +708,15 @@ public class DataFetcher {
 
     void readStringValuesMV(int[] docIds, int length, String[][] valuesBuffer) {
       Tracing.activeRecording().setInputDataType(_dataType, _singleValue);
-      assert _dictionary != null;
-      for (int i = 0; i < length; i++) {
-        int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, getReaderContext());
-        String[] values = new String[numValues];
-        _dictionary.readStringValues(_reusableMVDictIds, numValues, values);
-        valuesBuffer[i] = values;
+      if (_dictionary != null) {
+        for (int i = 0; i < length; i++) {
+          int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, getReaderContext());
+          String[] values = new String[numValues];
+          _dictionary.readStringValues(_reusableMVDictIds, numValues, values);
+          valuesBuffer[i] = values;
+        }
+      } else {
+        _reader.readValuesMV(docIds, length, valuesBuffer, getReaderContext());
       }
     }
 
@@ -714,7 +729,7 @@ public class DataFetcher {
     public void readNumValuesMV(int[] docIds, int length, int[] numValuesBuffer) {
       Tracing.activeRecording().setInputDataType(_dataType, _singleValue);
       for (int i = 0; i < length; i++) {
-        numValuesBuffer[i] = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, getReaderContext());
+        numValuesBuffer[i] = _reader.getNumValuesMV(docIds[i], getReaderContext());
       }
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/MultiValueRawQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/MultiValueRawQueriesTest.java
@@ -1,0 +1,810 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+// TODO: Add tests for more query patterns when additional fixes for MV raw columns are made
+public class MultiValueRawQueriesTest extends BaseQueriesTest {
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "MultiValueRawQueriesTest");
+
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String SEGMENT_NAME_1 = "testSegment1";
+  private static final String SEGMENT_NAME_2 = "testSegment2";
+
+  private static final int NUM_UNIQUE_RECORDS_PER_SEGMENT = 10;
+  private static final int NUM_DUPLICATES_PER_RECORDS = 2;
+  private static final int MV_OFFSET = 100;
+  private static final int BASE_VALUE_1 = 0;
+  private static final int BASE_VALUE_2 = 1000;
+
+  private final static String SV_INT_COL = "svIntCol";
+  private final static String MV_INT_COL = "mvIntCol";
+  private final static String MV_LONG_COL = "mvLongCol";
+  private final static String MV_FLOAT_COL = "mvFloatCol";
+  private final static String MV_DOUBLE_COL = "mvDoubleCol";
+  private final static String MV_STRING_COL = "mvStringCol";
+  private final static String MV_RAW_INT_COL = "mvRawIntCol";
+  private final static String MV_RAW_LONG_COL = "mvRawLongCol";
+  private final static String MV_RAW_FLOAT_COL = "mvRawFloatCol";
+  private final static String MV_RAW_DOUBLE_COL = "mvRawDoubleCol";
+  private final static String MV_RAW_STRING_COL = "mvRawStringCol";
+
+  private static final Schema SCHEMA = new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME)
+      .addSingleValueDimension(SV_INT_COL, FieldSpec.DataType.INT)
+      .addMultiValueDimension(MV_INT_COL, FieldSpec.DataType.INT)
+      .addMultiValueDimension(MV_LONG_COL, FieldSpec.DataType.LONG)
+      .addMultiValueDimension(MV_FLOAT_COL, FieldSpec.DataType.FLOAT)
+      .addMultiValueDimension(MV_DOUBLE_COL, FieldSpec.DataType.DOUBLE)
+      .addMultiValueDimension(MV_STRING_COL, FieldSpec.DataType.STRING)
+      .addMultiValueDimension(MV_RAW_INT_COL, FieldSpec.DataType.INT)
+      .addMultiValueDimension(MV_RAW_LONG_COL, FieldSpec.DataType.LONG)
+      .addMultiValueDimension(MV_RAW_FLOAT_COL, FieldSpec.DataType.FLOAT)
+      .addMultiValueDimension(MV_RAW_DOUBLE_COL, FieldSpec.DataType.DOUBLE)
+      .addMultiValueDimension(MV_RAW_STRING_COL, FieldSpec.DataType.STRING)
+      .build();
+
+  private static final DataSchema DATA_SCHEMA = new DataSchema(new String[]{"mvDoubleCol", "mvFloatCol", "mvIntCol",
+      "mvLongCol", "mvRawDoubleCol", "mvRawFloatCol", "mvRawIntCol", "mvRawLongCol", "mvRawStringCol", "mvStringCol",
+      "svIntCol"},
+      new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.FLOAT_ARRAY,
+          DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.LONG_ARRAY,
+          DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.FLOAT_ARRAY,
+          DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.LONG_ARRAY,
+          DataSchema.ColumnDataType.STRING_ARRAY, DataSchema.ColumnDataType.STRING_ARRAY,
+          DataSchema.ColumnDataType.INT});
+
+  private static final TableConfig TABLE = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
+      .setNoDictionaryColumns(
+          Arrays.asList(MV_RAW_INT_COL, MV_RAW_LONG_COL, MV_RAW_FLOAT_COL, MV_RAW_DOUBLE_COL, MV_RAW_STRING_COL))
+      .build();
+
+  private IndexSegment _indexSegment;
+  private List<IndexSegment> _indexSegments;
+
+  @Override
+  protected String getFilter() {
+    return "";
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteQuietly(INDEX_DIR);
+
+    ImmutableSegment segment1 = createSegment(generateRecords(BASE_VALUE_1), SEGMENT_NAME_1);
+    ImmutableSegment segment2 = createSegment(generateRecords(BASE_VALUE_2), SEGMENT_NAME_2);
+    _indexSegment = segment1;
+    _indexSegments = Arrays.asList(segment1, segment2);
+  }
+
+  @AfterClass
+  public void tearDown() {
+    for (IndexSegment indexSegment : _indexSegments) {
+      indexSegment.destroy();
+    }
+
+    FileUtils.deleteQuietly(INDEX_DIR);
+  }
+
+  /**
+   * Helper method to generate records based on the given base value.
+   *
+   * All columns will have the same value but different data types (BYTES values are encoded STRING values).
+   * For the {i}th unique record, the value will be {baseValue + i}.
+   */
+  private List<GenericRow> generateRecords(int baseValue) {
+    List<GenericRow> uniqueRecords = new ArrayList<>(NUM_UNIQUE_RECORDS_PER_SEGMENT);
+    for (int i = 0; i < NUM_UNIQUE_RECORDS_PER_SEGMENT; i++) {
+      int value = baseValue + i;
+      GenericRow record = new GenericRow();
+      record.putValue(SV_INT_COL, value);
+      Integer[] mvValue = new Integer[]{value, value + MV_OFFSET};
+      record.putValue(MV_INT_COL, mvValue);
+      record.putValue(MV_LONG_COL, mvValue);
+      record.putValue(MV_FLOAT_COL, mvValue);
+      record.putValue(MV_DOUBLE_COL, mvValue);
+      record.putValue(MV_STRING_COL, mvValue);
+      record.putValue(MV_RAW_INT_COL, mvValue);
+      record.putValue(MV_RAW_LONG_COL, mvValue);
+      record.putValue(MV_RAW_FLOAT_COL, mvValue);
+      record.putValue(MV_RAW_DOUBLE_COL, mvValue);
+      record.putValue(MV_RAW_STRING_COL, mvValue);
+      uniqueRecords.add(record);
+    }
+
+    List<GenericRow> records = new ArrayList<>(NUM_UNIQUE_RECORDS_PER_SEGMENT * NUM_DUPLICATES_PER_RECORDS);
+    for (int i = 0; i < NUM_DUPLICATES_PER_RECORDS; i++) {
+      records.addAll(uniqueRecords);
+    }
+    return records;
+  }
+
+  private ImmutableSegment createSegment(List<GenericRow> records, String segmentName)
+      throws Exception {
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE, SCHEMA);
+    segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
+    segmentGeneratorConfig.setSegmentName(segmentName);
+    segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records));
+    driver.build();
+
+    return ImmutableSegmentLoader.load(new File(INDEX_DIR, segmentName), ReadMode.mmap);
+  }
+
+  @Test
+  public void testSelectQueries() {
+    {
+      // Select * query
+      String query = "SELECT * from testTable ORDER BY svIntCol LIMIT 40";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      assertEquals(resultTable.getDataSchema(), DATA_SCHEMA);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 40);
+
+      Set<Integer> expectedValuesFirst = new HashSet<>();
+      Set<Integer> expectedValuesSecond = new HashSet<>();
+      for (int i = 0; i < NUM_UNIQUE_RECORDS_PER_SEGMENT; i++) {
+        expectedValuesFirst.add(i);
+        expectedValuesSecond.add(i + MV_OFFSET);
+      }
+
+      Set<Integer> actualValuesFirst = new HashSet<>();
+      Set<Integer> actualValuesSecond = new HashSet<>();
+      for (int i = 0; i < 40; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 11);
+        int svIntValue = (int) values[10];
+        int[] intValues = (int[]) values[2];
+        assertEquals(intValues[1] - intValues[0], MV_OFFSET);
+        assertEquals(svIntValue, intValues[0]);
+
+        int[] intValuesRaw = (int[]) values[6];
+        assertEquals(intValues[0], intValuesRaw[0]);
+        assertEquals(intValues[1], intValuesRaw[1]);
+
+        long[] longValues = (long[]) values[3];
+        long[] longValuesRaw = (long[]) values[7];
+        assertEquals(longValues[0], intValues[0]);
+        assertEquals(longValues[1], intValues[1]);
+        assertEquals(longValues[0], longValuesRaw[0]);
+        assertEquals(longValues[1], longValuesRaw[1]);
+
+        float[] floatValues = (float[]) values[1];
+        float[] floatValuesRaw = (float[]) values[5];
+        assertEquals(floatValues[0], (float) intValues[0]);
+        assertEquals(floatValues[1], (float) intValues[1]);
+        assertEquals(floatValues[0], floatValuesRaw[0]);
+        assertEquals(floatValues[1], floatValuesRaw[1]);
+
+        double[] doubleValues = (double[]) values[0];
+        double[] doubleValuesRaw = (double[]) values[4];
+        assertEquals(doubleValues[0], (double) intValues[0]);
+        assertEquals(doubleValues[1], (double) intValues[1]);
+        assertEquals(doubleValues[0], doubleValuesRaw[0]);
+        assertEquals(doubleValues[1], doubleValuesRaw[1]);
+
+        String[] stringValues = (String[]) values[8];
+        String[] stringValuesRaw = (String[]) values[9];
+        assertEquals(Integer.parseInt(stringValues[0]), intValues[0]);
+        assertEquals(Integer.parseInt(stringValues[1]), intValues[1]);
+        assertEquals(stringValues[0], stringValuesRaw[0]);
+        assertEquals(stringValues[1], stringValuesRaw[1]);
+
+        actualValuesFirst.add(intValues[0]);
+        actualValuesSecond.add(intValues[1]);
+      }
+      assertTrue(actualValuesFirst.containsAll(expectedValuesFirst));
+      assertTrue(actualValuesSecond.containsAll(expectedValuesSecond));
+    }
+    {
+      // Select some dict based MV and some raw MV columns. Validate that the values match for the corresponding rows
+      String query = "SELECT mvIntCol, mvDoubleCol, mvStringCol, mvRawIntCol, mvRawDoubleCol, mvRawStringCol, svIntCol "
+          + "from testTable ORDER BY svIntCol LIMIT 40";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "mvIntCol", "mvDoubleCol", "mvStringCol", "mvRawIntCol", "mvRawDoubleCol", "mvRawStringCol", "svIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.INT_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY,
+          DataSchema.ColumnDataType.STRING_ARRAY, DataSchema.ColumnDataType.INT_ARRAY,
+          DataSchema.ColumnDataType.DOUBLE_ARRAY, DataSchema.ColumnDataType.STRING_ARRAY,
+          DataSchema.ColumnDataType.INT
+      });
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 40);
+
+      Set<Integer> expectedValuesFirst = new HashSet<>();
+      Set<Integer> expectedValuesSecond = new HashSet<>();
+      for (int i = 0; i < NUM_UNIQUE_RECORDS_PER_SEGMENT; i++) {
+        expectedValuesFirst.add(i);
+        expectedValuesSecond.add(i + MV_OFFSET);
+      }
+
+      Set<Integer> actualValuesFirst = new HashSet<>();
+      Set<Integer> actualValuesSecond = new HashSet<>();
+      for (int i = 0; i < 40; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 7);
+        int[] intValues = (int[]) values[0];
+        assertEquals(intValues[1] - intValues[0], MV_OFFSET);
+
+        int[] intValuesRaw = (int[]) values[3];
+        assertEquals(intValues[0], intValuesRaw[0]);
+        assertEquals(intValues[1], intValuesRaw[1]);
+
+        double[] doubleValues = (double[]) values[1];
+        double[] doubleValuesRaw = (double[]) values[4];
+        assertEquals(doubleValues[0], (double) intValues[0]);
+        assertEquals(doubleValues[1], (double) intValues[1]);
+        assertEquals(doubleValues[0], doubleValuesRaw[0]);
+        assertEquals(doubleValues[1], doubleValuesRaw[1]);
+
+        String[] stringValues = (String[]) values[2];
+        String[] stringValuesRaw = (String[]) values[5];
+        assertEquals(Integer.parseInt(stringValues[0]), intValues[0]);
+        assertEquals(Integer.parseInt(stringValues[1]), intValues[1]);
+        assertEquals(stringValues[0], stringValuesRaw[0]);
+        assertEquals(stringValues[1], stringValuesRaw[1]);
+
+        assertEquals(intValues[0], (int) values[6]);
+        assertEquals(intValuesRaw[0], (int) values[6]);
+
+        actualValuesFirst.add(intValues[0]);
+        actualValuesSecond.add(intValues[1]);
+      }
+      assertTrue(actualValuesFirst.containsAll(expectedValuesFirst));
+      assertTrue(actualValuesSecond.containsAll(expectedValuesSecond));
+    }
+    {
+      // Test a select with a ARRAYLENGTH transform function
+      String query = "SELECT ARRAYLENGTH(mvRawLongCol), ARRAYLENGTH(mvLongCol) from testTable LIMIT 10";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+      assertNotNull(resultTable);
+      DataSchema dataSchema = new DataSchema(new String[]{"arraylength(mvRawLongCol)", "arraylength(mvLongCol)"},
+          new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT});
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 10);
+
+      for (int i = 0; i < 10; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 2);
+        int intRawVal = (int) values[0];
+        int intVal = (int) values[1];
+        assertEquals(intRawVal, 2);
+        assertEquals(intVal, intRawVal);
+        assertEquals(intVal, intRawVal);
+      }
+    }
+  }
+
+  @Test
+  public void testSimpleAggregateQueries() {
+    {
+      // Aggregation on int columns
+      String query = "SELECT COUNTMV(mvIntCol), COUNTMV(mvRawIntCol), SUMMV(mvIntCol), SUMMV(mvRawIntCol), "
+          + "MINMV(mvIntCol), MINMV(mvRawIntCol), MAXMV(mvIntCol), MAXMV(mvRawIntCol), AVGMV(mvIntCol), "
+          + "AVGMV(mvRawIntCol) from testTable";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvIntCol)", "countmv(mvRawIntCol)", "summv(mvIntCol)", "summv(mvRawIntCol)", "minmv(mvIntCol)",
+          "minmv(mvRawIntCol)", "maxmv(mvIntCol)", "maxmv(mvRawIntCol)", "avgmv(mvIntCol)", "avgmv(mvRawIntCol)"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE
+      });
+      validateSimpleAggregateQueryResults(resultTable, dataSchema);
+    }
+    {
+      // Aggregation on long columns
+      String query = "SELECT COUNTMV(mvLongCol), COUNTMV(mvRawLongCol), SUMMV(mvLongCol), SUMMV(mvRawLongCol), "
+          + "MINMV(mvLongCol), MINMV(mvRawLongCol), MAXMV(mvLongCol), MAXMV(mvRawLongCol), AVGMV(mvLongCol), "
+          + "AVGMV(mvRawLongCol) from testTable";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvLongCol)", "countmv(mvRawLongCol)", "summv(mvLongCol)", "summv(mvRawLongCol)", "minmv(mvLongCol)",
+          "minmv(mvRawLongCol)", "maxmv(mvLongCol)", "maxmv(mvRawLongCol)", "avgmv(mvLongCol)", "avgmv(mvRawLongCol)"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE
+      });
+      validateSimpleAggregateQueryResults(resultTable, dataSchema);
+    }
+    {
+      // Aggregation on float columns
+      String query = "SELECT COUNTMV(mvFloatCol), COUNTMV(mvRawFloatCol), SUMMV(mvFloatCol), SUMMV(mvRawFloatCol), "
+          + "MINMV(mvFloatCol), MINMV(mvRawFloatCol), MAXMV(mvFloatCol), MAXMV(mvRawFloatCol), AVGMV(mvFloatCol), "
+          + "AVGMV(mvRawFloatCol) from testTable";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvFloatCol)", "countmv(mvRawFloatCol)", "summv(mvFloatCol)", "summv(mvRawFloatCol)",
+          "minmv(mvFloatCol)", "minmv(mvRawFloatCol)", "maxmv(mvFloatCol)", "maxmv(mvRawFloatCol)",
+          "avgmv(mvFloatCol)", "avgmv(mvRawFloatCol)"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE
+      });
+      validateSimpleAggregateQueryResults(resultTable, dataSchema);
+    }
+    {
+      // Aggregation on double columns
+      String query = "SELECT COUNTMV(mvDoubleCol), COUNTMV(mvRawDoubleCol), SUMMV(mvDoubleCol), SUMMV(mvRawDoubleCol), "
+          + "MINMV(mvDoubleCol), MINMV(mvRawDoubleCol), MAXMV(mvDoubleCol), MAXMV(mvRawDoubleCol), AVGMV(mvDoubleCol), "
+          + "AVGMV(mvRawDoubleCol) from testTable";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvDoubleCol)", "countmv(mvRawDoubleCol)", "summv(mvDoubleCol)", "summv(mvRawDoubleCol)",
+          "minmv(mvDoubleCol)", "minmv(mvRawDoubleCol)", "maxmv(mvDoubleCol)", "maxmv(mvRawDoubleCol)",
+          "avgmv(mvDoubleCol)", "avgmv(mvRawDoubleCol)"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE
+      });
+      validateSimpleAggregateQueryResults(resultTable, dataSchema);
+    }
+    {
+      // Aggregation on string columns
+      String query = "SELECT COUNTMV(mvStringCol), COUNTMV(mvRawStringCol), SUMMV(mvStringCol), SUMMV(mvRawStringCol), "
+          + "MINMV(mvStringCol), MINMV(mvRawStringCol), MAXMV(mvStringCol), MAXMV(mvRawStringCol), AVGMV(mvStringCol), "
+          + "AVGMV(mvRawStringCol) from testTable";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvStringCol)", "countmv(mvRawStringCol)", "summv(mvStringCol)", "summv(mvRawStringCol)",
+          "minmv(mvStringCol)", "minmv(mvRawStringCol)", "maxmv(mvStringCol)", "maxmv(mvRawStringCol)",
+          "avgmv(mvStringCol)", "avgmv(mvRawStringCol)"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE
+      });
+      validateSimpleAggregateQueryResults(resultTable, dataSchema);
+    }
+  }
+
+  private void validateSimpleAggregateQueryResults(ResultTable resultTable, DataSchema expectedDataSchema) {
+    assertNotNull(resultTable);
+    assertEquals(resultTable.getDataSchema(), expectedDataSchema);
+    List<Object[]> recordRows = resultTable.getRows();
+    assertEquals(recordRows.size(), 1);
+
+    Object[] values = recordRows.get(0);
+    long countInt = (long) values[0];
+    long countIntRaw = (long) values[1];
+    assertEquals(countInt, 160);
+    assertEquals(countInt, countIntRaw);
+
+    double sumInt = (double) values[2];
+    double sumIntRaw = (double) values[3];
+    assertEquals(sumInt, 88720.0);
+    assertEquals(sumInt, sumIntRaw);
+
+    double minInt = (double) values[4];
+    double minIntRaw = (double) values[5];
+    assertEquals(minInt, 0.0);
+    assertEquals(minInt, minIntRaw);
+
+    double maxInt = (double) values[6];
+    double maxIntRaw = (double) values[7];
+    assertEquals(maxInt, 1109.0);
+    assertEquals(maxInt, maxIntRaw);
+
+    double avgInt = (double) values[8];
+    double avgIntRaw = (double) values[9];
+    assertEquals(avgInt, 554.5);
+    assertEquals(avgInt, avgIntRaw);
+  }
+
+  @Test
+  public void testAggregateWithGroupByQueries() {
+    {
+      // Aggregation on int columns with group by
+      String query = "SELECT COUNTMV(mvIntCol), COUNTMV(mvRawIntCol), SUMMV(mvIntCol), SUMMV(mvRawIntCol), "
+          + "MINMV(mvIntCol), MINMV(mvRawIntCol), MAXMV(mvIntCol), MAXMV(mvRawIntCol), AVGMV(mvIntCol), "
+          + "AVGMV(mvRawIntCol), svIntCol, mvRawLongCol from testTable GROUP BY svIntCol, mvRawLongCol "
+          + "ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvIntCol)", "countmv(mvRawIntCol)", "summv(mvIntCol)", "summv(mvRawIntCol)", "minmv(mvIntCol)",
+          "minmv(mvRawIntCol)", "maxmv(mvIntCol)", "maxmv(mvRawIntCol)", "avgmv(mvIntCol)", "avgmv(mvRawIntCol)",
+          "svIntCol", "mvRawLongCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG
+      });
+      validateAggregateWithGroupByQueryResults(resultTable, dataSchema, false);
+    }
+    {
+      // Aggregation on long columns with group by
+      String query = "SELECT COUNTMV(mvLongCol), COUNTMV(mvRawLongCol), SUMMV(mvLongCol), SUMMV(mvRawLongCol), "
+          + "MINMV(mvLongCol), MINMV(mvRawLongCol), MAXMV(mvLongCol), MAXMV(mvRawLongCol), AVGMV(mvLongCol), "
+          + "AVGMV(mvRawLongCol), svIntCol, mvRawIntCol from testTable GROUP BY svIntCol, mvRawIntCol "
+          + "ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvLongCol)", "countmv(mvRawLongCol)", "summv(mvLongCol)", "summv(mvRawLongCol)", "minmv(mvLongCol)",
+          "minmv(mvRawLongCol)", "maxmv(mvLongCol)", "maxmv(mvRawLongCol)", "avgmv(mvLongCol)", "avgmv(mvRawLongCol)",
+          "svIntCol", "mvRawIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT
+      });
+      validateAggregateWithGroupByQueryResults(resultTable, dataSchema, false);
+    }
+    {
+      // Aggregation on float columns with group by
+      String query = "SELECT COUNTMV(mvFloatCol), COUNTMV(mvRawFloatCol), SUMMV(mvFloatCol), SUMMV(mvRawFloatCol), "
+          + "MINMV(mvFloatCol), MINMV(mvRawFloatCol), MAXMV(mvFloatCol), MAXMV(mvRawFloatCol), AVGMV(mvFloatCol), "
+          + "AVGMV(mvRawFloatCol), svIntCol, mvRawIntCol from testTable GROUP BY svIntCol, mvRawIntCol "
+          + "ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvFloatCol)", "countmv(mvRawFloatCol)", "summv(mvFloatCol)", "summv(mvRawFloatCol)",
+          "minmv(mvFloatCol)", "minmv(mvRawFloatCol)", "maxmv(mvFloatCol)", "maxmv(mvRawFloatCol)",
+          "avgmv(mvFloatCol)", "avgmv(mvRawFloatCol)", "svIntCol", "mvRawIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT
+      });
+      validateAggregateWithGroupByQueryResults(resultTable, dataSchema, false);
+    }
+    {
+      // Aggregation on double columns with group by
+      String query = "SELECT COUNTMV(mvDoubleCol), COUNTMV(mvRawDoubleCol), SUMMV(mvDoubleCol), SUMMV(mvRawDoubleCol), "
+          + "MINMV(mvDoubleCol), MINMV(mvRawDoubleCol), MAXMV(mvDoubleCol), MAXMV(mvRawDoubleCol), AVGMV(mvDoubleCol), "
+          + "AVGMV(mvRawDoubleCol), svIntCol, mvRawIntCol from testTable GROUP BY svIntCol, mvRawIntCol "
+          + "ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvDoubleCol)", "countmv(mvRawDoubleCol)", "summv(mvDoubleCol)", "summv(mvRawDoubleCol)",
+          "minmv(mvDoubleCol)", "minmv(mvRawDoubleCol)", "maxmv(mvDoubleCol)", "maxmv(mvRawDoubleCol)",
+          "avgmv(mvDoubleCol)", "avgmv(mvRawDoubleCol)", "svIntCol", "mvRawIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT
+      });
+      validateAggregateWithGroupByQueryResults(resultTable, dataSchema, false);
+    }
+    {
+      // Aggregation on string columns with group by
+      String query = "SELECT COUNTMV(mvStringCol), COUNTMV(mvRawStringCol), SUMMV(mvStringCol), SUMMV(mvRawStringCol), "
+          + "MINMV(mvStringCol), MINMV(mvRawStringCol), MAXMV(mvStringCol), MAXMV(mvRawStringCol), AVGMV(mvStringCol), "
+          + "AVGMV(mvRawStringCol), svIntCol, mvRawIntCol from testTable GROUP BY svIntCol, mvRawIntCol "
+          + "ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvStringCol)", "countmv(mvRawStringCol)", "summv(mvStringCol)", "summv(mvRawStringCol)",
+          "minmv(mvStringCol)", "minmv(mvRawStringCol)", "maxmv(mvStringCol)", "maxmv(mvRawStringCol)",
+          "avgmv(mvStringCol)", "avgmv(mvRawStringCol)", "svIntCol", "mvRawIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT
+      });
+      validateAggregateWithGroupByQueryResults(resultTable, dataSchema, false);
+    }
+    {
+      // Aggregation on int columns with group by on 3 columns
+      String query = "SELECT COUNTMV(mvIntCol), COUNTMV(mvRawIntCol), SUMMV(mvIntCol), SUMMV(mvRawIntCol), "
+          + "MINMV(mvIntCol), MINMV(mvRawIntCol), MAXMV(mvIntCol), MAXMV(mvRawIntCol), AVGMV(mvIntCol), "
+          + "AVGMV(mvRawIntCol), svIntCol, mvLongCol, mvRawLongCol from testTable GROUP BY svIntCol, mvLongCol, "
+          + "mvRawLongCol ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvIntCol)", "countmv(mvRawIntCol)", "summv(mvIntCol)", "summv(mvRawIntCol)", "minmv(mvIntCol)",
+          "minmv(mvRawIntCol)", "maxmv(mvIntCol)", "maxmv(mvRawIntCol)", "avgmv(mvIntCol)", "avgmv(mvRawIntCol)",
+          "svIntCol", "mvLongCol", "mvRawLongCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG,
+          DataSchema.ColumnDataType.LONG
+      });
+      validateAggregateWithGroupByQueryResults(resultTable, dataSchema, true);
+    }
+    {
+      // Aggregation on long columns with group by on 3 columns
+      String query = "SELECT COUNTMV(mvLongCol), COUNTMV(mvRawLongCol), SUMMV(mvLongCol), SUMMV(mvRawLongCol), "
+          + "MINMV(mvLongCol), MINMV(mvRawLongCol), MAXMV(mvLongCol), MAXMV(mvRawLongCol), AVGMV(mvLongCol), "
+          + "AVGMV(mvRawLongCol), svIntCol, mvIntCol, mvRawIntCol from testTable GROUP BY svIntCol, mvIntCol, "
+          + "mvRawIntCol ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvLongCol)", "countmv(mvRawLongCol)", "summv(mvLongCol)", "summv(mvRawLongCol)", "minmv(mvLongCol)",
+          "minmv(mvRawLongCol)", "maxmv(mvLongCol)", "maxmv(mvRawLongCol)", "avgmv(mvLongCol)", "avgmv(mvRawLongCol)",
+          "svIntCol", "mvIntCol", "mvRawIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT,
+          DataSchema.ColumnDataType.INT
+      });
+      validateAggregateWithGroupByQueryResults(resultTable, dataSchema, true);
+    }
+    {
+      // Aggregation on float columns with group by on 3 columns
+      String query = "SELECT COUNTMV(mvFloatCol), COUNTMV(mvRawFloatCol), SUMMV(mvFloatCol), SUMMV(mvRawFloatCol), "
+          + "MINMV(mvFloatCol), MINMV(mvRawFloatCol), MAXMV(mvFloatCol), MAXMV(mvRawFloatCol), AVGMV(mvFloatCol), "
+          + "AVGMV(mvRawFloatCol), svIntCol, mvIntCol, mvRawIntCol  from testTable GROUP BY svIntCol, mvIntCol, "
+          + "mvRawIntCol ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvFloatCol)", "countmv(mvRawFloatCol)", "summv(mvFloatCol)", "summv(mvRawFloatCol)",
+          "minmv(mvFloatCol)", "minmv(mvRawFloatCol)", "maxmv(mvFloatCol)", "maxmv(mvRawFloatCol)",
+          "avgmv(mvFloatCol)", "avgmv(mvRawFloatCol)", "svIntCol", "mvIntCol", "mvRawIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT,
+          DataSchema.ColumnDataType.INT
+      });
+      validateAggregateWithGroupByQueryResults(resultTable, dataSchema, true);
+    }
+    {
+      // Aggregation on double columns with group by on 3 columns
+      String query = "SELECT COUNTMV(mvDoubleCol), COUNTMV(mvRawDoubleCol), SUMMV(mvDoubleCol), SUMMV(mvRawDoubleCol), "
+          + "MINMV(mvDoubleCol), MINMV(mvRawDoubleCol), MAXMV(mvDoubleCol), MAXMV(mvRawDoubleCol), AVGMV(mvDoubleCol), "
+          + "AVGMV(mvRawDoubleCol), svIntCol, mvIntCol, mvRawIntCol from testTable GROUP BY svIntCol, mvIntCol, "
+          + "mvRawIntCol ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvDoubleCol)", "countmv(mvRawDoubleCol)", "summv(mvDoubleCol)", "summv(mvRawDoubleCol)",
+          "minmv(mvDoubleCol)", "minmv(mvRawDoubleCol)", "maxmv(mvDoubleCol)", "maxmv(mvRawDoubleCol)",
+          "avgmv(mvDoubleCol)", "avgmv(mvRawDoubleCol)", "svIntCol", "mvIntCol", "mvRawIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT,
+          DataSchema.ColumnDataType.INT
+      });
+      validateAggregateWithGroupByQueryResults(resultTable, dataSchema, true);
+    }
+    {
+      // Aggregation on string columns with group by on 3 columns
+      String query = "SELECT COUNTMV(mvStringCol), COUNTMV(mvRawStringCol), SUMMV(mvStringCol), SUMMV(mvRawStringCol), "
+          + "MINMV(mvStringCol), MINMV(mvRawStringCol), MAXMV(mvStringCol), MAXMV(mvRawStringCol), AVGMV(mvStringCol), "
+          + "AVGMV(mvRawStringCol), svIntCol, mvIntCol, mvRawIntCol from testTable GROUP BY svIntCol, mvIntCol,"
+          + "mvRawIntCol ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvStringCol)", "countmv(mvRawStringCol)", "summv(mvStringCol)", "summv(mvRawStringCol)",
+          "minmv(mvStringCol)", "minmv(mvRawStringCol)", "maxmv(mvStringCol)", "maxmv(mvRawStringCol)",
+          "avgmv(mvStringCol)", "avgmv(mvRawStringCol)", "svIntCol", "mvIntCol", "mvRawIntCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT,
+          DataSchema.ColumnDataType.INT
+      });
+      validateAggregateWithGroupByQueryResults(resultTable, dataSchema, true);
+    }
+    {
+      // Aggregation on int columns with group by on 3 columns, two of them RAW
+      String query = "SELECT COUNTMV(mvIntCol), COUNTMV(mvRawIntCol), SUMMV(mvIntCol), SUMMV(mvRawIntCol), "
+          + "MINMV(mvIntCol), MINMV(mvRawIntCol), MAXMV(mvIntCol), MAXMV(mvRawIntCol), AVGMV(mvIntCol), "
+          + "AVGMV(mvRawIntCol), svIntCol, mvRawLongCol, mvRawFloatCol from testTable GROUP BY svIntCol, mvRawLongCol, "
+          + "mvRawFloatCol ORDER BY svIntCol";
+      ResultTable resultTable = getBrokerResponse(query).getResultTable();
+
+      DataSchema dataSchema = new DataSchema(new String[]{
+          "countmv(mvIntCol)", "countmv(mvRawIntCol)", "summv(mvIntCol)", "summv(mvRawIntCol)", "minmv(mvIntCol)",
+          "minmv(mvRawIntCol)", "maxmv(mvIntCol)", "maxmv(mvRawIntCol)", "avgmv(mvIntCol)", "avgmv(mvRawIntCol)",
+          "svIntCol", "mvRawLongCol", "mvRawFloatCol"
+      }, new DataSchema.ColumnDataType[]{
+          DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE,
+          DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG,
+          DataSchema.ColumnDataType.FLOAT
+      });
+      assertNotNull(resultTable);
+      assertEquals(resultTable.getDataSchema(), dataSchema);
+      List<Object[]> recordRows = resultTable.getRows();
+      assertEquals(recordRows.size(), 10);
+
+      int[] expectedSVIntValues;
+      expectedSVIntValues = new int[]{0, 0, 0, 0, 1, 1, 1, 1, 2, 2};
+
+      for (int i = 0; i < 10; i++) {
+        Object[] values = recordRows.get(i);
+        assertEquals(values.length, 13);
+
+        long count = (long) values[0];
+        long countRaw = (long) values[1];
+        assertEquals(count, 8);
+        assertEquals(count, countRaw);
+
+        double sum = (double) values[2];
+        double sumRaw = (double) values[3];
+        assertEquals(sum, sumRaw);
+
+        double min = (double) values[4];
+        double minRaw = (double) values[5];
+        assertEquals(min, minRaw);
+
+        double max = (double) values[6];
+        double maxRaw = (double) values[7];
+        assertEquals(max, maxRaw);
+
+        assertEquals(max - min, (double) MV_OFFSET);
+
+        double avg = (double) values[8];
+        double avgRaw = (double) values[9];
+        assertEquals(avg, avgRaw);
+
+        assertEquals((int) values[10], expectedSVIntValues[i]);
+
+        assertTrue((long) values[11] == expectedSVIntValues[i]
+            || (long) values[11] == expectedSVIntValues[i] + MV_OFFSET);
+
+        assertTrue((float) values[12] == (float) expectedSVIntValues[i]
+            || (float) values[12] == (float) (expectedSVIntValues[i] + MV_OFFSET));
+      }
+    }
+  }
+
+  private void validateAggregateWithGroupByQueryResults(ResultTable resultTable, DataSchema expectedDataSchema,
+      boolean isThreeColumnGroupBy) {
+    assertNotNull(resultTable);
+    assertEquals(resultTable.getDataSchema(), expectedDataSchema);
+    List<Object[]> recordRows = resultTable.getRows();
+    assertEquals(recordRows.size(), 10);
+
+    int[] expectedSVIntValues;
+
+    if (isThreeColumnGroupBy) {
+      expectedSVIntValues = new int[]{0, 0, 0, 0, 1, 1, 1, 1, 2, 2};
+    } else {
+      expectedSVIntValues = new int[]{0, 0, 1, 1, 2, 2, 3, 3, 4, 4};
+    }
+
+    for (int i = 0; i < 10; i++) {
+      Object[] values = recordRows.get(i);
+      if (isThreeColumnGroupBy) {
+        assertEquals(values.length, 13);
+      } else {
+        assertEquals(values.length, 12);
+      }
+
+      long count = (long) values[0];
+      long countRaw = (long) values[1];
+      assertEquals(count, 8);
+      assertEquals(count, countRaw);
+
+      double sum = (double) values[2];
+      double sumRaw = (double) values[3];
+      assertEquals(sum, sumRaw);
+
+      double min = (double) values[4];
+      double minRaw = (double) values[5];
+      assertEquals(min, minRaw);
+
+      double max = (double) values[6];
+      double maxRaw = (double) values[7];
+      assertEquals(max, maxRaw);
+
+      assertEquals(max - min, (double) MV_OFFSET);
+
+      double avg = (double) values[8];
+      double avgRaw = (double) values[9];
+      assertEquals(avg, avgRaw);
+
+      assertEquals((int) values[10], expectedSVIntValues[i]);
+
+      if (expectedDataSchema.getColumnDataType(11) == DataSchema.ColumnDataType.LONG) {
+        assertTrue((long) values[11] == expectedSVIntValues[i]
+            || (long) values[11] == expectedSVIntValues[i] + MV_OFFSET);
+      } else {
+        assertTrue((int) values[11] == expectedSVIntValues[i]
+            || (int) values[11] == expectedSVIntValues[i] + MV_OFFSET);
+      }
+
+      if (isThreeColumnGroupBy) {
+        if (expectedDataSchema.getColumnDataType(12) == DataSchema.ColumnDataType.LONG) {
+          assertTrue((long) values[12] == expectedSVIntValues[i]
+              || (long) values[12] == expectedSVIntValues[i] + MV_OFFSET);
+        } else {
+          assertTrue((int) values[12] == expectedSVIntValues[i]
+              || (int) values[12] == expectedSVIntValues[i] + MV_OFFSET);
+        }
+      }
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/IntermediateSegment.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/IntermediateSegment.java
@@ -153,7 +153,7 @@ public class IntermediateSegment implements MutableSegment {
         // TODO: Start with a smaller capacity on FixedByteMVForwardIndexReaderWriter and let it expand
         forwardIndex =
             new FixedByteMVMutableForwardIndex(MAX_MULTI_VALUES_PER_ROW, DEFAULT_AVG_MULTI_VALUE_COUNT, _capacity,
-                Integer.BYTES, _memoryManager, allocationContext);
+                Integer.BYTES, _memoryManager, allocationContext, true, DataType.INT);
       }
 
       _indexContainerMap.put(column,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -436,8 +436,8 @@ public class MutableSegmentImpl implements MutableSegment {
             column, dataType.toString());
         return false;
       }
-      // So don't create dictionary if the column (1) is member of noDictionary, and (2) is single-value or multi-value with a
-      // fixed-width field, and (3) doesn't have an inverted index
+      // So don't create dictionary if the column (1) is member of noDictionary, and (2) is single-value or multi-value
+      // with a fixed-width field, and (3) doesn't have an inverted index
       return (fieldSpec.isSingleValueField() || fieldSpec.getDataType().isFixedWidth())
           && !invertedIndexColumns.contains(column);
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -436,9 +436,10 @@ public class MutableSegmentImpl implements MutableSegment {
             column, dataType.toString());
         return false;
       }
-      // So don't create dictionary if the column is member of noDictionary, is single-value
-      // and doesn't have an inverted index
-      return fieldSpec.isSingleValueField() && !invertedIndexColumns.contains(column);
+      // So don't create dictionary if the column is member of noDictionary, is single-value or multi-value with a
+      // fixed-width field and doesn't have an inverted index
+      return (fieldSpec.isSingleValueField() || fieldSpec.getDataType().isFixedWidth())
+          && !invertedIndexColumns.contains(column);
     }
     // column is not a part of noDictionary set, so create dictionary
     return false;
@@ -764,25 +765,74 @@ public class MutableSegmentImpl implements MutableSegment {
           }
         }
       } else {
-        // Multi-value column (always dictionary-encoded)
+        // Multi-value column
 
         int[] dictIds = indexContainer._dictIds;
 
-        // Update numValues info
-        indexContainer._numValuesInfo.updateMVEntry(dictIds.length);
+        if (dictIds != null) {
+          // Dictionary encoded
+          // Update numValues info
+          indexContainer._numValuesInfo.updateMVEntry(dictIds.length);
 
-        // Update forward index
-        indexContainer._forwardIndex.setDictIdMV(docId, dictIds);
+          // Update forward index
+          indexContainer._forwardIndex.setDictIdMV(docId, dictIds);
 
-        // Update inverted index
-        MutableInvertedIndex invertedIndex = indexContainer._invertedIndex;
-        if (invertedIndex != null) {
-          for (int dictId : dictIds) {
-            try {
-              invertedIndex.add(dictId, docId);
-            } catch (Exception e) {
-              recordIndexingError(FieldConfig.IndexType.INVERTED, e);
+          // Update inverted index
+          MutableInvertedIndex invertedIndex = indexContainer._invertedIndex;
+          if (invertedIndex != null) {
+            for (int dictId : dictIds) {
+              try {
+                invertedIndex.add(dictId, docId);
+              } catch (Exception e) {
+                recordIndexingError(FieldConfig.IndexType.INVERTED, e);
+              }
             }
+          }
+        } else {
+          // Raw MV columns
+
+          // Update forward index and numValues info
+          DataType dataType = fieldSpec.getDataType();
+          switch (dataType.getStoredType()) {
+            case INT:
+              Object[] values = (Object[]) value;
+              int[] intValues = new int[values.length];
+              for (int i = 0; i < values.length; i++) {
+                intValues[i] = (Integer) values[i];
+              }
+              indexContainer._forwardIndex.setIntMV(docId, intValues);
+              indexContainer._numValuesInfo.updateMVEntry(intValues.length);
+              break;
+            case LONG:
+              values = (Object[]) value;
+              long[] longValues = new long[values.length];
+              for (int i = 0; i < values.length; i++) {
+                longValues[i] = (Long) values[i];
+              }
+              indexContainer._forwardIndex.setLongMV(docId, longValues);
+              indexContainer._numValuesInfo.updateMVEntry(longValues.length);
+              break;
+            case FLOAT:
+              values = (Object[]) value;
+              float[] floatValues = new float[values.length];
+              for (int i = 0; i < values.length; i++) {
+                floatValues[i] = (Float) values[i];
+              }
+              indexContainer._forwardIndex.setFloatMV(docId, floatValues);
+              indexContainer._numValuesInfo.updateMVEntry(floatValues.length);
+              break;
+            case DOUBLE:
+              values = (Object[]) value;
+              double[] doubleValues = new double[values.length];
+              for (int i = 0; i < values.length; i++) {
+                doubleValues[i] = (Double) values[i];
+              }
+              indexContainer._forwardIndex.setDoubleMV(docId, doubleValues);
+              indexContainer._numValuesInfo.updateMVEntry(doubleValues.length);
+              break;
+            default:
+              throw new UnsupportedOperationException(
+                  "Unsupported data type: " + dataType + " for MV no-dictionary column: " + column);
           }
         }
       }
@@ -982,24 +1032,66 @@ public class MutableSegmentImpl implements MutableSegment {
       }
     } else {
       // Raw index based
-      // TODO: support multi-valued column
-      switch (forwardIndex.getValueType()) {
-        case INT:
-          return forwardIndex.getInt(docId);
-        case LONG:
-          return forwardIndex.getLong(docId);
-        case FLOAT:
-          return forwardIndex.getFloat(docId);
-        case DOUBLE:
-          return forwardIndex.getDouble(docId);
-        case BIG_DECIMAL:
-          return forwardIndex.getBigDecimal(docId);
-        case STRING:
-          return forwardIndex.getString(docId);
-        case BYTES:
-          return forwardIndex.getBytes(docId);
-        default:
-          throw new IllegalStateException();
+      if (forwardIndex.isSingleValue()) {
+        switch (forwardIndex.getValueType()) {
+          case INT:
+            return forwardIndex.getInt(docId);
+          case LONG:
+            return forwardIndex.getLong(docId);
+          case FLOAT:
+            return forwardIndex.getFloat(docId);
+          case DOUBLE:
+            return forwardIndex.getDouble(docId);
+          case BIG_DECIMAL:
+            return forwardIndex.getBigDecimal(docId);
+          case STRING:
+            return forwardIndex.getString(docId);
+          case BYTES:
+            return forwardIndex.getBytes(docId);
+          default:
+            throw new IllegalStateException();
+        }
+      } else {
+        // TODO: support multi-valued column for variable length column types (big decimal, string, bytes)
+        int numValues;
+        Object[] value;
+        switch (forwardIndex.getValueType()) {
+          case INT:
+            int[] intValues = forwardIndex.getIntMV(docId);
+            numValues = intValues.length;
+            value = new Object[numValues];
+            for (int i = 0; i < numValues; i++) {
+              value[i] = intValues[i];
+            }
+            return value;
+          case LONG:
+            long[] longValues = forwardIndex.getLongMV(docId);
+            numValues = longValues.length;
+            value = new Object[numValues];
+            for (int i = 0; i < numValues; i++) {
+              value[i] = longValues[i];
+            }
+            return value;
+          case FLOAT:
+            float[] floatValues = forwardIndex.getFloatMV(docId);
+            numValues = floatValues.length;
+            value = new Object[numValues];
+            for (int i = 0; i < numValues; i++) {
+              value[i] = floatValues[i];
+            }
+            return value;
+          case DOUBLE:
+            double[] doubleValues = forwardIndex.getDoubleMV(docId);
+            numValues = doubleValues.length;
+            value = new Object[numValues];
+            for (int i = 0; i < numValues; i++) {
+              value[i] = doubleValues[i];
+            }
+            return value;
+          default:
+            throw new IllegalStateException("No support for MV no dictionary column of type "
+                + forwardIndex.getValueType());
+        }
       }
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -436,8 +436,8 @@ public class MutableSegmentImpl implements MutableSegment {
             column, dataType.toString());
         return false;
       }
-      // So don't create dictionary if the column is member of noDictionary, is single-value or multi-value with a
-      // fixed-width field and doesn't have an inverted index
+      // So don't create dictionary if the column (1) is member of noDictionary, and (2) is single-value or multi-value with a
+      // fixed-width field, and (3) doesn't have an inverted index
       return (fieldSpec.isSingleValueField() || fieldSpec.getDataType().isFixedWidth())
           && !invertedIndexColumns.contains(column);
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteMVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteMVMutableForwardIndex.java
@@ -26,6 +26,7 @@ import org.apache.pinot.segment.local.io.writer.impl.FixedByteSingleValueMultiCo
 import org.apache.pinot.segment.spi.index.mutable.MutableForwardIndex;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -114,6 +115,8 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
   private final int _rowCountPerChunk;
   private final PinotDataBufferMemoryManager _memoryManager;
   private final String _context;
+  private final boolean _isDictionaryEncoded;
+  private final FieldSpec.DataType _valueType;
 
   private FixedByteSingleValueMultiColWriter _curHeaderWriter;
   private FixedByteSingleValueMultiColWriter _currentDataWriter;
@@ -122,7 +125,8 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
   private int _prevRowLength = 0;  // Number of values in the column for the last row added.
 
   public FixedByteMVMutableForwardIndex(int maxNumberOfMultiValuesPerRow, int avgMultiValueCount, int rowCountPerChunk,
-      int columnSizeInBytes, PinotDataBufferMemoryManager memoryManager, String context) {
+      int columnSizeInBytes, PinotDataBufferMemoryManager memoryManager, String context, boolean isDictionaryEncoded,
+      FieldSpec.DataType valueType) {
     _memoryManager = memoryManager;
     _context = context;
     int initialCapacity = Math.max(maxNumberOfMultiValuesPerRow, rowCountPerChunk * avgMultiValueCount);
@@ -137,6 +141,8 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
     _incrementalCapacity = incrementalCapacity;
     addDataBuffer(initialCapacity);
     //init(_rowCountPerChunk, _columnSizeInBytes, _maxNumberOfMultiValuesPerRow, initialCapacity, _incrementalCapacity);
+    _isDictionaryEncoded = isDictionaryEncoded;
+    _valueType = valueType;
   }
 
   private void addHeaderBuffer() {
@@ -206,12 +212,9 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
     return newStartIndex;
   }
 
-  /**
-   * TODO: Currently we only support dictionary-encoded forward index on multi-value columns.
-   */
   @Override
   public boolean isDictionaryEncoded() {
-    return true;
+    return _isDictionaryEncoded;
   }
 
   @Override
@@ -221,7 +224,7 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
 
   @Override
   public DataType getValueType() {
-    return DataType.INT;
+    return _valueType;
   }
 
   @Override
@@ -249,8 +252,28 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
   }
 
   @Override
+  public int[] getDictIdMV(int docId) {
+    FixedByteSingleValueMultiColReader headerReader = getCurrentReader(docId);
+    int rowInCurrentHeader = getRowInCurrentHeader(docId);
+    int bufferIndex = headerReader.getInt(rowInCurrentHeader, 0);
+    int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
+    int length = headerReader.getInt(rowInCurrentHeader, 2);
+    FixedByteSingleValueMultiColReader dataReader = _dataReaders.get(bufferIndex);
+    int[] dictIdBuffer = new int[length];
+    for (int i = 0; i < length; i++) {
+      dictIdBuffer[i] = dataReader.getInt(startIndex + i, 0);
+    }
+    return dictIdBuffer;
+  }
+
+  @Override
   public int getIntMV(int docId, int[] valueBuffer) {
     return getDictIdMV(docId, valueBuffer);
+  }
+
+  @Override
+  public int[] getIntMV(int docId) {
+    return getDictIdMV(docId);
   }
 
   @Override
@@ -268,6 +291,21 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
   }
 
   @Override
+  public long[] getLongMV(int docId) {
+    FixedByteSingleValueMultiColReader headerReader = getCurrentReader(docId);
+    int rowInCurrentHeader = getRowInCurrentHeader(docId);
+    int bufferIndex = headerReader.getInt(rowInCurrentHeader, 0);
+    int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
+    int length = headerReader.getInt(rowInCurrentHeader, 2);
+    FixedByteSingleValueMultiColReader dataReader = _dataReaders.get(bufferIndex);
+    long[] valueBuffer = new long[length];
+    for (int i = 0; i < length; i++) {
+      valueBuffer[i] = dataReader.getLong(startIndex + i, 0);
+    }
+    return valueBuffer;
+  }
+
+  @Override
   public int getFloatMV(int docId, float[] valueBuffer) {
     FixedByteSingleValueMultiColReader headerReader = getCurrentReader(docId);
     int rowInCurrentHeader = getRowInCurrentHeader(docId);
@@ -282,6 +320,21 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
   }
 
   @Override
+  public float[] getFloatMV(int docId) {
+    FixedByteSingleValueMultiColReader headerReader = getCurrentReader(docId);
+    int rowInCurrentHeader = getRowInCurrentHeader(docId);
+    int bufferIndex = headerReader.getInt(rowInCurrentHeader, 0);
+    int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
+    int length = headerReader.getInt(rowInCurrentHeader, 2);
+    FixedByteSingleValueMultiColReader dataReader = _dataReaders.get(bufferIndex);
+    float[] valueBuffer = new float[length];
+    for (int i = 0; i < length; i++) {
+      valueBuffer[i] = dataReader.getFloat(startIndex + i, 0);
+    }
+    return valueBuffer;
+  }
+
+  @Override
   public int getDoubleMV(int docId, double[] valueBuffer) {
     FixedByteSingleValueMultiColReader headerReader = getCurrentReader(docId);
     int rowInCurrentHeader = getRowInCurrentHeader(docId);
@@ -293,6 +346,28 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
       valueBuffer[i] = dataReader.getDouble(startIndex + i, 0);
     }
     return length;
+  }
+
+  @Override
+  public double[] getDoubleMV(int docId) {
+    FixedByteSingleValueMultiColReader headerReader = getCurrentReader(docId);
+    int rowInCurrentHeader = getRowInCurrentHeader(docId);
+    int bufferIndex = headerReader.getInt(rowInCurrentHeader, 0);
+    int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
+    int length = headerReader.getInt(rowInCurrentHeader, 2);
+    FixedByteSingleValueMultiColReader dataReader = _dataReaders.get(bufferIndex);
+    double[] valueBuffer = new double[length];
+    for (int i = 0; i < length; i++) {
+      valueBuffer[i] = dataReader.getDouble(startIndex + i, 0);
+    }
+    return valueBuffer;
+  }
+
+  @Override
+  public int getNumValuesMV(int docId) {
+    FixedByteSingleValueMultiColReader headerReader = getCurrentReader(docId);
+    int rowInCurrentHeader = getRowInCurrentHeader(docId);
+    return headerReader.getInt(rowInCurrentHeader, 2);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueFixedByteRawIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueFixedByteRawIndexCreator.java
@@ -77,7 +77,8 @@ public class MultiValueFixedByteRawIndexCreator implements ForwardIndexCreator {
       boolean deriveNumDocsPerChunk, int writerVersion)
       throws IOException {
     File file = new File(baseIndexDir, column + Indexes.RAW_MV_FORWARD_INDEX_FILE_EXTENSION);
-    int totalMaxLength = maxNumberOfMultiValueElements * valueType.getStoredType().size();
+    // Store the length followed by the values
+    int totalMaxLength = Integer.BYTES + (maxNumberOfMultiValueElements * valueType.getStoredType().size());
     int numDocsPerChunk =
         deriveNumDocsPerChunk ? Math.max(TARGET_MAX_CHUNK_SIZE / (totalMaxLength
             + VarByteChunkSVForwardIndexWriter.CHUNK_HEADER_ENTRY_ROW_OFFSET_SIZE), 1) : DEFAULT_NUM_DOCS_PER_CHUNK;
@@ -152,7 +153,7 @@ public class MultiValueFixedByteRawIndexCreator implements ForwardIndexCreator {
   public void putDoubleMV(final double[] values) {
 
     byte[] bytes = new byte[Integer.BYTES
-        + values.length * Long.BYTES]; //numValues, bytes required to store the content
+        + values.length * Double.BYTES]; //numValues, bytes required to store the content
     ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
     //write the length
     byteBuffer.putInt(values.length);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/constant/ConstantMVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/constant/ConstantMVForwardIndexReader.java
@@ -50,6 +50,16 @@ public final class ConstantMVForwardIndexReader implements ForwardIndexReader<Fo
   }
 
   @Override
+  public int[] getDictIdMV(int docId, ForwardIndexReaderContext context) {
+    return new int[]{0};
+  }
+
+  @Override
+  public int getNumValuesMV(int docId, ForwardIndexReaderContext context) {
+    return 1;
+  }
+
+  @Override
   public void close() {
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedByteChunkMVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedByteChunkMVForwardIndexReader.java
@@ -30,14 +30,14 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
  * fixed length data type (INT, LONG, FLOAT, DOUBLE).
  * <p>For data layout, please refer to the documentation for {@link VarByteChunkSVForwardIndexWriter}
  */
-public final class FixedByteChunkMVForwardIndexReader extends BaseChunkSVForwardIndexReader {
+public final class FixedByteChunkMVForwardIndexReader extends BaseChunkForwardIndexReader {
 
   private static final int ROW_OFFSET_SIZE = VarByteChunkSVForwardIndexWriter.CHUNK_HEADER_ENTRY_ROW_OFFSET_SIZE;
 
   private final int _maxChunkSize;
 
-  public FixedByteChunkMVForwardIndexReader(PinotDataBuffer dataBuffer, DataType valueType) {
-    super(dataBuffer, valueType);
+  public FixedByteChunkMVForwardIndexReader(PinotDataBuffer dataBuffer, DataType storedType) {
+    super(dataBuffer, storedType, false);
     _maxChunkSize = _numDocsPerChunk * (ROW_OFFSET_SIZE + _lengthOfLongestEntry);
   }
 
@@ -62,6 +62,17 @@ public final class FixedByteChunkMVForwardIndexReader extends BaseChunkSVForward
   }
 
   @Override
+  public int[] getIntMV(int docId, ChunkReaderContext context) {
+    ByteBuffer byteBuffer = slice(docId, context);
+    int numValues = byteBuffer.getInt();
+    int[] valueBuffer = new int[numValues];
+    for (int i = 0; i < numValues; i++) {
+      valueBuffer[i] = byteBuffer.getInt();
+    }
+    return valueBuffer;
+  }
+
+  @Override
   public int getLongMV(int docId, long[] valueBuffer, ChunkReaderContext context) {
     ByteBuffer byteBuffer = slice(docId, context);
     int numValues = byteBuffer.getInt();
@@ -69,6 +80,17 @@ public final class FixedByteChunkMVForwardIndexReader extends BaseChunkSVForward
       valueBuffer[i] = byteBuffer.getLong();
     }
     return numValues;
+  }
+
+  @Override
+  public long[] getLongMV(int docId, ChunkReaderContext context) {
+    ByteBuffer byteBuffer = slice(docId, context);
+    int numValues = byteBuffer.getInt();
+    long[] valueBuffer = new long[numValues];
+    for (int i = 0; i < numValues; i++) {
+      valueBuffer[i] = byteBuffer.getLong();
+    }
+    return valueBuffer;
   }
 
   @Override
@@ -82,6 +104,17 @@ public final class FixedByteChunkMVForwardIndexReader extends BaseChunkSVForward
   }
 
   @Override
+  public float[] getFloatMV(int docId, ChunkReaderContext context) {
+    ByteBuffer byteBuffer = slice(docId, context);
+    int numValues = byteBuffer.getInt();
+    float[] valueBuffer = new float[numValues];
+    for (int i = 0; i < numValues; i++) {
+      valueBuffer[i] = byteBuffer.getFloat();
+    }
+    return valueBuffer;
+  }
+
+  @Override
   public int getDoubleMV(int docId, double[] valueBuffer, ChunkReaderContext context) {
     ByteBuffer byteBuffer = slice(docId, context);
     int numValues = byteBuffer.getInt();
@@ -89,6 +122,23 @@ public final class FixedByteChunkMVForwardIndexReader extends BaseChunkSVForward
       valueBuffer[i] = byteBuffer.getDouble();
     }
     return numValues;
+  }
+
+  @Override
+  public double[] getDoubleMV(int docId, ChunkReaderContext context) {
+    ByteBuffer byteBuffer = slice(docId, context);
+    int numValues = byteBuffer.getInt();
+    double[] valueBuffer = new double[numValues];
+    for (int i = 0; i < numValues; i++) {
+      valueBuffer[i] = byteBuffer.getDouble();
+    }
+    return valueBuffer;
+  }
+
+  @Override
+  public int getNumValuesMV(int docId, ChunkReaderContext context) {
+    ByteBuffer byteBuffer = slice(docId, context);
+    return byteBuffer.getInt();
   }
 
   private ByteBuffer slice(int docId, ChunkReaderContext context) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedByteChunkSVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedByteChunkSVForwardIndexReader.java
@@ -30,11 +30,11 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
  * LONG, FLOAT, DOUBLE).
  * <p>For data layout, please refer to the documentation for {@link FixedByteChunkSVForwardIndexWriter}
  */
-public final class FixedByteChunkSVForwardIndexReader extends BaseChunkSVForwardIndexReader {
+public final class FixedByteChunkSVForwardIndexReader extends BaseChunkForwardIndexReader {
   private final int _chunkSize;
 
   public FixedByteChunkSVForwardIndexReader(PinotDataBuffer dataBuffer, DataType valueType) {
-    super(dataBuffer, valueType);
+    super(dataBuffer, valueType, true);
     _chunkSize = _numDocsPerChunk * _lengthOfLongestEntry;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBytePower2ChunkSVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBytePower2ChunkSVForwardIndexReader.java
@@ -30,13 +30,13 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
  * LONG, FLOAT, DOUBLE).
  * <p>For data layout, please refer to the documentation for {@link FixedByteChunkSVForwardIndexWriter}
  */
-public final class FixedBytePower2ChunkSVForwardIndexReader extends BaseChunkSVForwardIndexReader {
+public final class FixedBytePower2ChunkSVForwardIndexReader extends BaseChunkForwardIndexReader {
   public static final int VERSION = 4;
 
   private final int _shift;
 
   public FixedBytePower2ChunkSVForwardIndexReader(PinotDataBuffer dataBuffer, DataType valueType) {
-    super(dataBuffer, valueType);
+    super(dataBuffer, valueType, true);
     _shift = Integer.numberOfTrailingZeros(_numDocsPerChunk);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkSVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkSVForwardIndexReader.java
@@ -34,7 +34,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * (BIG_DECIMAL, STRING, BYTES).
  * <p>For data layout, please refer to the documentation for {@link VarByteChunkSVForwardIndexWriter}
  */
-public final class VarByteChunkSVForwardIndexReader extends BaseChunkSVForwardIndexReader {
+public final class VarByteChunkSVForwardIndexReader extends BaseChunkForwardIndexReader {
   private static final int ROW_OFFSET_SIZE = VarByteChunkSVForwardIndexWriter.CHUNK_HEADER_ENTRY_ROW_OFFSET_SIZE;
 
   private final int _maxChunkSize;
@@ -43,7 +43,7 @@ public final class VarByteChunkSVForwardIndexReader extends BaseChunkSVForwardIn
   private final ThreadLocal<byte[]> _reusableBytes = ThreadLocal.withInitial(() -> new byte[_lengthOfLongestEntry]);
 
   public VarByteChunkSVForwardIndexReader(PinotDataBuffer dataBuffer, DataType valueType) {
-    super(dataBuffer, valueType);
+    super(dataBuffer, valueType, true);
     _maxChunkSize = _numDocsPerChunk * (ROW_OFFSET_SIZE + _lengthOfLongestEntry);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeLoaderUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeLoaderUtils.java
@@ -25,7 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.segment.local.aggregator.ValueAggregatorFactory;
-import org.apache.pinot.segment.local.segment.index.readers.forward.BaseChunkSVForwardIndexReader;
+import org.apache.pinot.segment.local.segment.index.readers.forward.BaseChunkForwardIndexReader;
 import org.apache.pinot.segment.local.segment.index.readers.forward.FixedBitSVForwardIndexReaderV2;
 import org.apache.pinot.segment.local.segment.index.readers.forward.FixedByteChunkSVForwardIndexReader;
 import org.apache.pinot.segment.local.segment.index.readers.forward.VarByteChunkSVForwardIndexReader;
@@ -98,7 +98,7 @@ public class StarTreeLoaderUtils {
         PinotDataBuffer forwardIndexDataBuffer = dataBuffer.view(start, end, ByteOrder.BIG_ENDIAN);
         DataType dataType = ValueAggregatorFactory.getAggregatedValueType(functionColumnPair.getFunctionType());
         FieldSpec fieldSpec = new MetricFieldSpec(metric, dataType);
-        BaseChunkSVForwardIndexReader forwardIndex;
+        BaseChunkForwardIndexReader forwardIndex;
         if (dataType == DataType.BYTES) {
           forwardIndex = new VarByteChunkSVForwardIndexReader(forwardIndexDataBuffer, DataType.BYTES);
         } else {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplRawMVTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplRawMVTest.java
@@ -1,0 +1,266 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.indexsegment.mutable;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.SegmentTestUtils;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.virtualcolumn.VirtualColumnProviderFactory;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.FileFormat;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.data.readers.RecordReaderFactory;
+import org.apache.pinot.spi.stream.StreamMessageMetadata;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+
+public class MutableSegmentImplRawMVTest {
+  private static final String AVRO_FILE = "data/test_data-mv.avro";
+  private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "MutableSegmentImplRawMVTest");
+
+  private Schema _schema;
+  private MutableSegmentImpl _mutableSegmentImpl;
+  private ImmutableSegment _immutableSegment;
+  private long _lastIndexedTs;
+  private long _lastIngestionTimeMs;
+  private long _startTimeMs;
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteQuietly(TEMP_DIR);
+
+    URL resourceUrl = MutableSegmentImplTest.class.getClassLoader().getResource(AVRO_FILE);
+    Assert.assertNotNull(resourceUrl);
+    File avroFile = new File(resourceUrl.getFile());
+
+    SegmentGeneratorConfig config =
+        SegmentTestUtils.getSegmentGeneratorConfigWithoutTimeColumn(avroFile, TEMP_DIR, "testTable");
+    SegmentIndexCreationDriver driver = new SegmentIndexCreationDriverImpl();
+
+    _schema = config.getSchema();
+    Set<String> noDictionaryColumns = new HashSet<>();
+    List<String> noDictionaryColumnsList = new ArrayList<>();
+    for (FieldSpec fieldSpec : _schema.getAllFieldSpecs()) {
+      if (!fieldSpec.isSingleValueField() && fieldSpec.getDataType().isFixedWidth()) {
+        noDictionaryColumns.add(fieldSpec.getName());
+        noDictionaryColumnsList.add(fieldSpec.getName());
+      }
+    }
+    config.setRawIndexCreationColumns(noDictionaryColumnsList);
+    assertEquals(noDictionaryColumns.size(), 2);
+
+    driver.init(config);
+    driver.build();
+    _immutableSegment = ImmutableSegmentLoader.load(new File(TEMP_DIR, driver.getSegmentName()), ReadMode.mmap);
+
+    VirtualColumnProviderFactory.addBuiltInVirtualColumnsToSegmentSchema(_schema, "testSegment");
+    _mutableSegmentImpl = MutableSegmentImplTestUtils
+        .createMutableSegmentImpl(_schema, noDictionaryColumns, Collections.emptySet(), Collections.emptySet(),
+            false);
+    _lastIngestionTimeMs = System.currentTimeMillis();
+    StreamMessageMetadata defaultMetadata = new StreamMessageMetadata(_lastIngestionTimeMs);
+    _startTimeMs = System.currentTimeMillis();
+
+    try (RecordReader recordReader = RecordReaderFactory
+        .getRecordReader(FileFormat.AVRO, avroFile, _schema.getColumnNames(), null)) {
+      GenericRow reuse = new GenericRow();
+      while (recordReader.hasNext()) {
+        _mutableSegmentImpl.index(recordReader.next(reuse), defaultMetadata);
+        _lastIndexedTs = System.currentTimeMillis();
+      }
+    }
+  }
+
+  @Test
+  public void testMetadata() {
+    SegmentMetadata actualSegmentMetadata = _mutableSegmentImpl.getSegmentMetadata();
+    SegmentMetadata expectedSegmentMetadata = _immutableSegment.getSegmentMetadata();
+    assertEquals(actualSegmentMetadata.getTotalDocs(), expectedSegmentMetadata.getTotalDocs());
+
+    // assert that the last indexed timestamp is close to what we expect
+    long actualTs = _mutableSegmentImpl.getSegmentMetadata().getLastIndexedTimestamp();
+    Assert.assertTrue(actualTs >= _startTimeMs);
+    Assert.assertTrue(actualTs <= _lastIndexedTs);
+
+    assertEquals(_mutableSegmentImpl.getSegmentMetadata().getLatestIngestionTimestamp(), _lastIngestionTimeMs);
+
+    for (FieldSpec fieldSpec : _schema.getAllFieldSpecs()) {
+      String column = fieldSpec.getName();
+      DataSourceMetadata actualDataSourceMetadata = _mutableSegmentImpl.getDataSource(column).getDataSourceMetadata();
+      DataSourceMetadata expectedDataSourceMetadata = _immutableSegment.getDataSource(column).getDataSourceMetadata();
+      assertEquals(actualDataSourceMetadata.getDataType(), expectedDataSourceMetadata.getDataType());
+      assertEquals(actualDataSourceMetadata.isSingleValue(), expectedDataSourceMetadata.isSingleValue());
+      assertEquals(actualDataSourceMetadata.getNumDocs(), expectedDataSourceMetadata.getNumDocs());
+      if (!expectedDataSourceMetadata.isSingleValue()) {
+        assertEquals(actualDataSourceMetadata.getMaxNumValuesPerMVEntry(),
+            expectedDataSourceMetadata.getMaxNumValuesPerMVEntry());
+      }
+    }
+  }
+
+  @Test
+  public void testDataSourceForSVColumns()
+      throws IOException {
+    for (FieldSpec fieldSpec : _schema.getAllFieldSpecs()) {
+      if (fieldSpec.isSingleValueField()) {
+        String column = fieldSpec.getName();
+        DataSource actualDataSource = _mutableSegmentImpl.getDataSource(column);
+        DataSource expectedDataSource = _immutableSegment.getDataSource(column);
+
+        int actualNumDocs = actualDataSource.getDataSourceMetadata().getNumDocs();
+        int expectedNumDocs = expectedDataSource.getDataSourceMetadata().getNumDocs();
+        assertEquals(actualNumDocs, expectedNumDocs);
+
+        Dictionary actualDictionary = actualDataSource.getDictionary();
+        Dictionary expectedDictionary = expectedDataSource.getDictionary();
+        assertEquals(actualDictionary.length(), expectedDictionary.length());
+
+        // Allow the segment name to be different
+        if (column.equals(CommonConstants.Segment.BuiltInVirtualColumn.SEGMENTNAME)) {
+          continue;
+        }
+
+        ForwardIndexReader actualReader = actualDataSource.getForwardIndex();
+        ForwardIndexReader expectedReader = expectedDataSource.getForwardIndex();
+        try (ForwardIndexReaderContext actualReaderContext = actualReader.createContext();
+            ForwardIndexReaderContext expectedReaderContext = expectedReader.createContext()) {
+          for (int docId = 0; docId < expectedNumDocs; docId++) {
+            int actualDictId = actualReader.getDictId(docId, actualReaderContext);
+            int expectedDictId = expectedReader.getDictId(docId, expectedReaderContext);
+            assertEquals(actualDictionary.get(actualDictId), expectedDictionary.get(expectedDictId));
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testDataSourceForMVColumns()
+      throws IOException {
+    for (FieldSpec fieldSpec : _schema.getAllFieldSpecs()) {
+      if (!fieldSpec.isSingleValueField()) {
+        String column = fieldSpec.getName();
+        DataSource actualDataSource = _mutableSegmentImpl.getDataSource(column);
+        DataSource expectedDataSource = _immutableSegment.getDataSource(column);
+
+        int actualNumDocs = actualDataSource.getDataSourceMetadata().getNumDocs();
+        int expectedNumDocs = expectedDataSource.getDataSourceMetadata().getNumDocs();
+        assertEquals(actualNumDocs, expectedNumDocs);
+
+        Dictionary actualDictionary = actualDataSource.getDictionary();
+        Dictionary expectedDictionary = expectedDataSource.getDictionary();
+        assertNull(actualDictionary);
+        assertNull(expectedDictionary);
+
+        int maxNumValuesPerMVEntry = expectedDataSource.getDataSourceMetadata().getMaxNumValuesPerMVEntry();
+
+        ForwardIndexReader actualReader = actualDataSource.getForwardIndex();
+        ForwardIndexReader expectedReader = expectedDataSource.getForwardIndex();
+        try (ForwardIndexReaderContext actualReaderContext = actualReader.createContext();
+            ForwardIndexReaderContext expectedReaderContext = expectedReader.createContext()) {
+          for (int docId = 0; docId < expectedNumDocs; docId++) {
+            switch (fieldSpec.getDataType()) {
+              case INT:
+                int[] actualInts = new int[maxNumValuesPerMVEntry];
+                int[] expectedInts = new int[maxNumValuesPerMVEntry];
+                int actualLength = actualReader.getIntMV(docId, actualInts, actualReaderContext);
+                int expectedLength = expectedReader.getIntMV(docId, expectedInts, expectedReaderContext);
+                assertEquals(actualLength, expectedLength);
+
+                for (int i = 0; i < actualLength; i++) {
+                  assertEquals(actualInts[i], expectedInts[i]);
+                }
+                break;
+              case LONG:
+                long[] actualLongs = new long[maxNumValuesPerMVEntry];
+                long[] expectedLongs = new long[maxNumValuesPerMVEntry];
+                actualLength = actualReader.getLongMV(docId, actualLongs, actualReaderContext);
+                expectedLength = expectedReader.getLongMV(docId, expectedLongs, expectedReaderContext);
+                assertEquals(actualLength, expectedLength);
+
+                for (int i = 0; i < actualLength; i++) {
+                  assertEquals(actualLongs[i], expectedLongs[i]);
+                }
+                break;
+              case FLOAT:
+                float[] actualFloats = new float[maxNumValuesPerMVEntry];
+                float[] expectedFloats = new float[maxNumValuesPerMVEntry];
+                actualLength = actualReader.getFloatMV(docId, actualFloats, actualReaderContext);
+                expectedLength = expectedReader.getFloatMV(docId, expectedFloats, expectedReaderContext);
+                assertEquals(actualLength, expectedLength);
+
+                for (int i = 0; i < actualLength; i++) {
+                  assertEquals(actualFloats[i], expectedFloats[i]);
+                }
+                break;
+              case DOUBLE:
+                double[] actualDoubles = new double[maxNumValuesPerMVEntry];
+                double[] expectedDoubles = new double[maxNumValuesPerMVEntry];
+                actualLength = actualReader.getDoubleMV(docId, actualDoubles, actualReaderContext);
+                expectedLength = expectedReader.getDoubleMV(docId, expectedDoubles, expectedReaderContext);
+                assertEquals(actualLength, expectedLength);
+
+                for (int i = 0; i < actualLength; i++) {
+                  assertEquals(actualDoubles[i], expectedDoubles[i]);
+                }
+                break;
+              default:
+                // TODO: add support for byte, string, and big decimal type MV raw columns
+                throw new UnsupportedOperationException("No support for raw MV variable length columns yet");
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @AfterClass
+  public void tearDown() {
+    FileUtils.deleteQuietly(TEMP_DIR);
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/MultiValueFixedByteRawIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/MultiValueFixedByteRawIndexCreatorTest.java
@@ -125,7 +125,8 @@ public class MultiValueFixedByteRawIndexCreatorTest {
     //read
     final PinotDataBuffer buffer = PinotDataBuffer
         .mapFile(file, true, 0, file.length(), ByteOrder.BIG_ENDIAN, "");
-    FixedByteChunkMVForwardIndexReader reader = new FixedByteChunkMVForwardIndexReader(buffer, DataType.BYTES);
+    FixedByteChunkMVForwardIndexReader reader = new FixedByteChunkMVForwardIndexReader(buffer,
+        dataType.getStoredType());
     final ChunkReaderContext context = reader.createContext();
     T valueBuffer = constructor.apply(maxElements);
     for (int i = 0; i < numDocs; i++) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/mutable/FixedByteMVMutableForwardIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/mutable/FixedByteMVMutableForwardIndexTest.java
@@ -50,15 +50,18 @@ public class FixedByteMVMutableForwardIndexTest {
     Random r = new Random();
     final long seed = r.nextLong();
     try {
-      testIntArray(seed);
-      testWithZeroSize(seed);
+      testIntArray(seed, true);
+      testIntArray(seed, false);
+      testWithZeroSize(seed, true);
+      testWithZeroSize(seed, false);
     } catch (Throwable e) {
       e.printStackTrace();
       Assert.fail("Failed with seed " + seed);
     }
     for (int mvs = 10; mvs < 1000; mvs += 10) {
       try {
-        testIntArrayFixedSize(mvs, seed);
+        testIntArrayFixedSize(mvs, seed, true);
+        testIntArrayFixedSize(mvs, seed, false);
       } catch (Throwable e) {
         e.printStackTrace();
         Assert.fail("Failed with seed " + seed + ", mvs " + mvs);
@@ -66,7 +69,7 @@ public class FixedByteMVMutableForwardIndexTest {
     }
   }
 
-  public void testIntArray(final long seed)
+  public void testIntArray(final long seed, boolean isDictionaryEncoded)
       throws IOException {
     FixedByteMVMutableForwardIndex readerWriter;
     int rows = 1000;
@@ -74,7 +77,7 @@ public class FixedByteMVMutableForwardIndexTest {
     int maxNumberOfMultiValuesPerRow = 2000;
     readerWriter =
         new FixedByteMVMutableForwardIndex(maxNumberOfMultiValuesPerRow, 2, rows / 2, columnSizeInBytes, _memoryManager,
-            "IntArray");
+            "IntArray", isDictionaryEncoded, FieldSpec.DataType.INT);
 
     Random r = new Random(seed);
     int[][] data = new int[rows][];
@@ -94,7 +97,7 @@ public class FixedByteMVMutableForwardIndexTest {
     readerWriter.close();
   }
 
-  public void testIntArrayFixedSize(int multiValuesPerRow, long seed)
+  public void testIntArrayFixedSize(int multiValuesPerRow, long seed, boolean isDictionaryEncoded)
       throws IOException {
     FixedByteMVMutableForwardIndex readerWriter;
     int rows = 1000;
@@ -102,7 +105,7 @@ public class FixedByteMVMutableForwardIndexTest {
     // Keep the rowsPerChunk as a multiple of multiValuesPerRow to check the cases when both data and header buffers
     // transition to new ones
     readerWriter = new FixedByteMVMutableForwardIndex(multiValuesPerRow, multiValuesPerRow, multiValuesPerRow * 2,
-        columnSizeInBytes, _memoryManager, "IntArrayFixedSize");
+        columnSizeInBytes, _memoryManager, "IntArrayFixedSize", isDictionaryEncoded, FieldSpec.DataType.INT);
 
     Random r = new Random(seed);
     int[][] data = new int[rows][];
@@ -122,7 +125,7 @@ public class FixedByteMVMutableForwardIndexTest {
     readerWriter.close();
   }
 
-  public void testWithZeroSize(long seed)
+  public void testWithZeroSize(long seed, boolean isDictionaryEncoded)
       throws IOException {
     FixedByteMVMutableForwardIndex readerWriter;
     final int maxNumberOfMultiValuesPerRow = 5;
@@ -131,7 +134,7 @@ public class FixedByteMVMutableForwardIndexTest {
     Random r = new Random(seed);
     readerWriter =
         new FixedByteMVMutableForwardIndex(maxNumberOfMultiValuesPerRow, 3, r.nextInt(rows) + 1, columnSizeInBytes,
-            _memoryManager, "ZeroSize");
+            _memoryManager, "ZeroSize", isDictionaryEncoded, FieldSpec.DataType.INT);
 
     int[][] data = new int[rows][];
     for (int i = 0; i < rows; i++) {
@@ -156,12 +159,12 @@ public class FixedByteMVMutableForwardIndexTest {
   }
 
   private FixedByteMVMutableForwardIndex createReaderWriter(FieldSpec.DataType dataType, Random r, int rows,
-      int maxNumberOfMultiValuesPerRow) {
+      int maxNumberOfMultiValuesPerRow, boolean isDictionaryEncoded) {
     final int avgMultiValueCount = r.nextInt(maxNumberOfMultiValuesPerRow) + 1;
     final int rowCountPerChunk = r.nextInt(rows) + 1;
 
     return new FixedByteMVMutableForwardIndex(maxNumberOfMultiValuesPerRow, avgMultiValueCount, rowCountPerChunk,
-        dataType.size(), _memoryManager, "ReaderWriter");
+        dataType.size(), _memoryManager, "ReaderWriter", isDictionaryEncoded, dataType);
   }
 
   private long generateSeed() {
@@ -172,12 +175,18 @@ public class FixedByteMVMutableForwardIndexTest {
   @Test
   public void testLongArray()
       throws IOException {
+    testLongArray(true);
+    testLongArray(false);
+  }
+
+  private void testLongArray(boolean isDictionaryEncoded)
+      throws IOException {
     final long seed = generateSeed();
     Random r = new Random(seed);
     int rows = 1000;
     final int maxNumberOfMultiValuesPerRow = r.nextInt(100) + 1;
     FixedByteMVMutableForwardIndex readerWriter =
-        createReaderWriter(FieldSpec.DataType.LONG, r, rows, maxNumberOfMultiValuesPerRow);
+        createReaderWriter(FieldSpec.DataType.LONG, r, rows, maxNumberOfMultiValuesPerRow, isDictionaryEncoded);
 
     long[][] data = new long[rows][];
     for (int i = 0; i < rows; i++) {
@@ -204,12 +213,18 @@ public class FixedByteMVMutableForwardIndexTest {
   @Test
   public void testFloatArray()
       throws IOException {
+    testFloatArray(true);
+    testFloatArray(false);
+  }
+
+  private void testFloatArray(boolean isDictoinaryEncoded)
+      throws IOException {
     final long seed = generateSeed();
     Random r = new Random(seed);
     int rows = 1000;
     final int maxNumberOfMultiValuesPerRow = r.nextInt(100) + 1;
     FixedByteMVMutableForwardIndex readerWriter =
-        createReaderWriter(FieldSpec.DataType.FLOAT, r, rows, maxNumberOfMultiValuesPerRow);
+        createReaderWriter(FieldSpec.DataType.FLOAT, r, rows, maxNumberOfMultiValuesPerRow, isDictoinaryEncoded);
 
     float[][] data = new float[rows][];
     for (int i = 0; i < rows; i++) {
@@ -236,12 +251,18 @@ public class FixedByteMVMutableForwardIndexTest {
   @Test
   public void testDoubleArray()
       throws IOException {
+    testDoubleArray(true);
+    testDoubleArray(false);
+  }
+
+  private void testDoubleArray(boolean isDictonaryEncoded)
+      throws IOException {
     final long seed = generateSeed();
     Random r = new Random(seed);
     int rows = 1000;
     final int maxNumberOfMultiValuesPerRow = r.nextInt(100) + 1;
     FixedByteMVMutableForwardIndex readerWriter =
-        createReaderWriter(FieldSpec.DataType.DOUBLE, r, rows, maxNumberOfMultiValuesPerRow);
+        createReaderWriter(FieldSpec.DataType.DOUBLE, r, rows, maxNumberOfMultiValuesPerRow, isDictonaryEncoded);
 
     double[][] data = new double[rows][];
     for (int i = 0; i < rows; i++) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/mutable/MutableForwardIndex.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/mutable/MutableForwardIndex.java
@@ -92,9 +92,24 @@ public interface MutableForwardIndex extends ForwardIndexReader<ForwardIndexRead
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Reads the dictionary ids for a multi-value column at the given document id into a buffer and returns the buffer.
+   *
+   * @param docId Document id
+   * @return A buffer containing the multi-value entries
+   */
+  default int[] getDictIdMV(int docId) {
+    throw new UnsupportedOperationException();
+  }
+
   @Override
   default int getDictIdMV(int docId, int[] dictIdBuffer, ForwardIndexReaderContext context) {
     return getDictIdMV(docId, dictIdBuffer);
+  }
+
+  @Override
+  default int[] getDictIdMV(int docId, ForwardIndexReaderContext context) {
+    return getDictIdMV(docId);
   }
 
   /**
@@ -321,9 +336,24 @@ public interface MutableForwardIndex extends ForwardIndexReader<ForwardIndexRead
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Reads the INT type multi-value at the given document id into a buffer and returns the buffer.
+   *
+   * @param docId Document id
+   * @return A buffer containing the multi-value entries
+   */
+  default int[] getIntMV(int docId) {
+    throw new UnsupportedOperationException();
+  }
+
   @Override
   default int getIntMV(int docId, int[] valueBuffer, ForwardIndexReaderContext context) {
     return getIntMV(docId, valueBuffer);
+  }
+
+  @Override
+  default int[] getIntMV(int docId, ForwardIndexReaderContext context) {
+    return getIntMV(docId);
   }
 
   /**
@@ -339,9 +369,24 @@ public interface MutableForwardIndex extends ForwardIndexReader<ForwardIndexRead
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Reads the LONG type multi-value at the given document id into a buffer and returns the buffer.
+   *
+   * @param docId Document id
+   * @return A buffer containing the multi-value entries
+   */
+  default long[] getLongMV(int docId) {
+    throw new UnsupportedOperationException();
+  }
+
   @Override
   default int getLongMV(int docId, long[] valueBuffer, ForwardIndexReaderContext context) {
     return getLongMV(docId, valueBuffer);
+  }
+
+  @Override
+  default long[] getLongMV(int docId, ForwardIndexReaderContext context) {
+    return getLongMV(docId);
   }
 
   /**
@@ -357,9 +402,24 @@ public interface MutableForwardIndex extends ForwardIndexReader<ForwardIndexRead
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Reads the FLOAT type multi-value at the given document id into a buffer and returns the buffer.
+   *
+   * @param docId Document id
+   * @return A buffer containing the multi-value entries
+   */
+  default float[] getFloatMV(int docId) {
+    throw new UnsupportedOperationException();
+  }
+
   @Override
   default int getFloatMV(int docId, float[] valueBuffer, ForwardIndexReaderContext context) {
     return getFloatMV(docId, valueBuffer);
+  }
+
+  @Override
+  default float[] getFloatMV(int docId, ForwardIndexReaderContext context) {
+    return getFloatMV(docId);
   }
 
   /**
@@ -375,9 +435,24 @@ public interface MutableForwardIndex extends ForwardIndexReader<ForwardIndexRead
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Reads the DOUBLE type multi-value at the given document id into a buffer and returns the buffer.
+   *
+   * @param docId Document id
+   * @return A buffer containing the multi-value entries
+   */
+  default double[] getDoubleMV(int docId) {
+    throw new UnsupportedOperationException();
+  }
+
   @Override
   default int getDoubleMV(int docId, double[] valueBuffer, ForwardIndexReaderContext context) {
     return getDoubleMV(docId, valueBuffer);
+  }
+
+  @Override
+  default double[] getDoubleMV(int docId, ForwardIndexReaderContext context) {
+    return getDoubleMV(docId);
   }
 
   /**
@@ -393,9 +468,39 @@ public interface MutableForwardIndex extends ForwardIndexReader<ForwardIndexRead
     throw new UnsupportedOperationException();
   }
 
+  /**
+   * Reads the STRING type multi-value at the given document id into a buffer and returns the buffer.
+   *
+   * @param docId Document id
+   * @return A buffer containing the multi-value entries
+   */
+  default String[] getStringMV(int docId) {
+    throw new UnsupportedOperationException();
+  }
+
   @Override
   default int getStringMV(int docId, String[] valueBuffer, ForwardIndexReaderContext context) {
     return getStringMV(docId, valueBuffer);
+  }
+
+  @Override
+  default String[] getStringMV(int docId, ForwardIndexReaderContext context) {
+    return getStringMV(docId);
+  }
+
+  /**
+   * Gets the number of multi-values at a given document id and returns it.
+   *
+   * @param docId Document id
+   * @return Number of values within the multi-value entry
+   */
+  default int getNumValuesMV(int docId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  default int getNumValuesMV(int docId, ForwardIndexReaderContext context) {
+    return getNumValuesMV(docId);
   }
 
   /**

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
@@ -101,6 +101,17 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
   }
 
   /**
+   * Reads the dictionary ids for a multi-value column at the given document id into a buffer and returns the buffer.
+   *
+   * @param docId Document id
+   * @param context Reader context
+   * @return A buffer containing the multi-value entries
+   */
+  default int[] getDictIdMV(int docId, T context) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * SINGLE-VALUE COLUMN RAW INDEX APIs
    */
 
@@ -410,8 +421,302 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
 
   /**
    * MULTI-VALUE COLUMN RAW INDEX APIs
-   * TODO: Not supported yet
    */
+
+  /**
+   * Fills the values
+   * @param docIds Array containing the document ids to read
+   * @param length Number of values to read
+   * @param values Values to fill
+   * @param context Reader context
+   */
+  default void readValuesMV(int[] docIds, int length, int[][] values, T context) {
+    switch (getValueType()) {
+      case INT:
+        for (int i = 0; i < length; i++) {
+          values[i] = getIntMV(docIds[i], context);
+        }
+        break;
+      case LONG:
+        for (int i = 0; i < length; i++) {
+          long[] longValueBuffer = getLongMV(docIds[i], context);
+          int numValues = longValueBuffer.length;
+          values[i] = new int[numValues];
+          for (int j = 0; j < numValues; j++) {
+            values[i][j] = (int) longValueBuffer[j];
+          }
+        }
+        break;
+      case FLOAT:
+        for (int i = 0; i < length; i++) {
+          float[] floatValueBuffer = getFloatMV(docIds[i], context);
+          int numValues = floatValueBuffer.length;
+          values[i] = new int[numValues];
+          for (int j = 0; j < numValues; j++) {
+            values[i][j] = (int) floatValueBuffer[j];
+          }
+        }
+        break;
+      case DOUBLE:
+        for (int i = 0; i < length; i++) {
+          double[] doubleValueBuffer = getDoubleMV(docIds[i], context);
+          int numValues = doubleValueBuffer.length;
+          values[i] = new int[numValues];
+          for (int j = 0; j < numValues; j++) {
+            values[i][j] = (int) doubleValueBuffer[j];
+          }
+        }
+        break;
+      case STRING:
+        for (int i = 0; i < length; i++) {
+          String[] stringValueBuffer = getStringMV(docIds[i], context);
+          int numValues = stringValueBuffer.length;
+          values[i] = new int[numValues];
+          for (int j = 0; j < numValues; j++) {
+            values[i][j] = Integer.parseInt(stringValueBuffer[j]);
+          }
+        }
+        break;
+      default:
+        throw new IllegalArgumentException("readValuesMV not supported for type " + getValueType());
+    }
+  }
+
+  /**
+   * Fills the values
+   * @param docIds Array containing the document ids to read
+   * @param length Number of values to read
+   * @param values Values to fill
+   * @param context Reader context
+   */
+  default void readValuesMV(int[] docIds, int length, long[][] values, T context) {
+    switch (getValueType()) {
+      case INT:
+        for (int i = 0; i < length; i++) {
+          int[] intValueBuffer = getIntMV(docIds[i], context);
+          int numValues = intValueBuffer.length;
+          values[i] = new long[numValues];
+          for (int j = 0; j < numValues; j++) {
+            values[i][j] = intValueBuffer[j];
+          }
+        }
+        break;
+      case LONG:
+        for (int i = 0; i < length; i++) {
+          values[i] = getLongMV(docIds[i], context);
+        }
+        break;
+      case FLOAT:
+        for (int i = 0; i < length; i++) {
+          float[] floatValueBuffer = getFloatMV(docIds[i], context);
+          int numValues = floatValueBuffer.length;
+          values[i] = new long[numValues];
+          for (int j = 0; j < numValues; j++) {
+            values[i][j] = (long) floatValueBuffer[j];
+          }
+        }
+        break;
+      case DOUBLE:
+        for (int i = 0; i < length; i++) {
+          double[] doubleValueBuffer = getDoubleMV(docIds[i], context);
+          int numValues = doubleValueBuffer.length;
+          values[i] = new long[numValues];
+          for (int j = 0; j < numValues; j++) {
+            values[i][j] = (long) doubleValueBuffer[j];
+          }
+        }
+        break;
+      case STRING:
+        for (int i = 0; i < length; i++) {
+          String[] stringValueBuffer = getStringMV(docIds[i], context);
+          int numValues = stringValueBuffer.length;
+          values[i] = new long[numValues];
+          for (int j = 0; j < numValues; j++) {
+            values[i][j] = Long.parseLong(stringValueBuffer[j]);
+          }
+        }
+        break;
+      default:
+        throw new IllegalArgumentException("readValuesMV not supported for type " + getValueType());
+    }
+  }
+
+  /**
+   * Fills the values
+   * @param docIds Array containing the document ids to read
+   * @param length Number of values to read
+   * @param values Values to fill
+   * @param context Reader context
+   */
+  default void readValuesMV(int[] docIds, int length, float[][] values, T context) {
+    switch (getValueType()) {
+      case INT:
+        for (int i = 0; i < length; i++) {
+          int[] intValueBuffer = getIntMV(docIds[i], context);
+          int numValues = intValueBuffer.length;
+          values[i] = new float[numValues];
+          for (int j = 0; j < numValues; j++) {
+            values[i][j] = intValueBuffer[j];
+          }
+        }
+        break;
+      case LONG:
+        for (int i = 0; i < length; i++) {
+          long[] longValueBuffer = getLongMV(docIds[i], context);
+          int numValues = longValueBuffer.length;
+          values[i] = new float[numValues];
+          for (int j = 0; j < numValues; j++) {
+            values[i][j] = longValueBuffer[j];
+          }
+        }
+        break;
+      case FLOAT:
+        for (int i = 0; i < length; i++) {
+          values[i] = getFloatMV(docIds[i], context);
+        }
+        break;
+      case DOUBLE:
+        for (int i = 0; i < length; i++) {
+          double[] doubleValueBuffer = getDoubleMV(docIds[i], context);
+          int numValues = doubleValueBuffer.length;
+          values[i] = new float[numValues];
+          for (int j = 0; j < numValues; j++) {
+            values[i][j] = (float) doubleValueBuffer[j];
+          }
+        }
+        break;
+      case STRING:
+        for (int i = 0; i < length; i++) {
+          String[] stringValueBuffer = getStringMV(docIds[i], context);
+          int numValues = stringValueBuffer.length;
+          values[i] = new float[numValues];
+          for (int j = 0; j < numValues; j++) {
+            values[i][j] = Float.parseFloat(stringValueBuffer[j]);
+          }
+        }
+        break;
+      default:
+        throw new IllegalArgumentException("readValuesMV not supported for type " + getValueType());
+    }
+  }
+
+  /**
+   * Fills the values
+   * @param docIds Array containing the document ids to read
+   * @param length Number of values to read
+   * @param values Values to fill
+   * @param context Reader context
+   */
+  default void readValuesMV(int[] docIds, int length, double[][] values, T context) {
+    switch (getValueType()) {
+      case INT:
+        for (int i = 0; i < length; i++) {
+          int[] intValueBuffer = getIntMV(docIds[i], context);
+          int numValues = intValueBuffer.length;
+          values[i] = new double[numValues];
+          for (int j = 0; j < numValues; j++) {
+            values[i][j] = intValueBuffer[j];
+          }
+        }
+        break;
+      case LONG:
+        for (int i = 0; i < length; i++) {
+          long[] longValueBuffer = getLongMV(docIds[i], context);
+          int numValues = longValueBuffer.length;
+          values[i] = new double[numValues];
+          for (int j = 0; j < numValues; j++) {
+            values[i][j] = longValueBuffer[j];
+          }
+        }
+        break;
+      case FLOAT:
+        for (int i = 0; i < length; i++) {
+          float[] floatValueBuffer = getFloatMV(docIds[i], context);
+          int numValues = floatValueBuffer.length;
+          values[i] = new double[numValues];
+          for (int j = 0; j < numValues; j++) {
+            values[i][j] = floatValueBuffer[j];
+          }
+        }
+        break;
+      case DOUBLE:
+        for (int i = 0; i < length; i++) {
+          values[i] = getDoubleMV(docIds[i], context);
+        }
+        break;
+      case STRING:
+        for (int i = 0; i < length; i++) {
+          String[] stringValueBuffer = getStringMV(docIds[i], context);
+          int numValues = stringValueBuffer.length;
+          values[i] = new double[numValues];
+          for (int j = 0; j < numValues; j++) {
+            values[i][j] = Double.parseDouble(stringValueBuffer[j]);
+          }
+        }
+        break;
+      default:
+        throw new IllegalArgumentException("readValuesMV not supported for type " + getValueType());
+    }
+  }
+
+  /**
+   * Fills the values
+   * @param docIds Array containing the document ids to read
+   * @param length Number of values to read
+   * @param values Values to fill
+   * @param context Reader context
+   */
+  default void readValuesMV(int[] docIds, int length, String[][] values, T context) {
+    switch (getValueType()) {
+      case INT:
+        for (int i = 0; i < length; i++) {
+          int[] intValueBuffer = getIntMV(docIds[i], context);
+          int numValues = intValueBuffer.length;
+          values[i] = new String[numValues];
+          for (int j = 0; j < numValues; j++) {
+            values[i][j] = String.valueOf(intValueBuffer[j]);
+          }
+        }
+        break;
+      case LONG:
+        for (int i = 0; i < length; i++) {
+          long[] longValueBuffer = getLongMV(docIds[i], context);
+          int numValues = longValueBuffer.length;
+          values[i] = new String[numValues];
+          for (int j = 0; j < numValues; j++) {
+            values[i][j] = String.valueOf(longValueBuffer[j]);
+          }
+        }
+        break;
+      case FLOAT:
+        for (int i = 0; i < length; i++) {
+          float[] floatValueBuffer = getFloatMV(docIds[i], context);
+          int numValues = floatValueBuffer.length;
+          values[i] = new String[numValues];
+          for (int j = 0; j < numValues; j++) {
+            values[i][j] = String.valueOf(floatValueBuffer[j]);
+          }
+        }
+        break;
+      case DOUBLE:
+        for (int i = 0; i < length; i++) {
+          double[] doubleValueBuffer = getDoubleMV(docIds[i], context);
+          int numValues = doubleValueBuffer.length;
+          values[i] = new String[numValues];
+          for (int j = 0; j < numValues; j++) {
+            values[i][j] = String.valueOf(doubleValueBuffer[j]);
+          }
+        }
+        break;
+      case STRING:
+        for (int i = 0; i < length; i++) {
+          values[i] = getStringMV(docIds[i], context);
+        }
+        break;
+      default:
+        throw new IllegalArgumentException("readValuesMV not supported for type " + getValueType());
+    }
+  }
 
   /**
    * Reads the INT type multi-value at the given document id into the passed in value buffer (the buffer size must be
@@ -424,6 +729,17 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * @return Number of values within the multi-value entry
    */
   default int getIntMV(int docId, int[] valueBuffer, T context) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Reads the INT type multi-value at the given document id into a buffer and returns the buffer.
+   *
+   * @param docId Document id
+   * @param context Reader context
+   * @return A buffer containing the multi-value entries
+   */
+  default int[] getIntMV(int docId, T context) {
     throw new UnsupportedOperationException();
   }
 
@@ -442,6 +758,17 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
   }
 
   /**
+   * Reads the LONG type multi-value at the given document id into a buffer and returns the buffer.
+   *
+   * @param docId Document id
+   * @param context Reader context
+   * @return A buffer containing the multi-value entries
+   */
+  default long[] getLongMV(int docId, T context) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Reads the FLOAT type multi-value at the given document id into the passed in value buffer (the buffer size must be
    * enough to hold all the values for the multi-value entry) and returns the number of values within the multi-value
    * entry.
@@ -452,6 +779,17 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * @return Number of values within the multi-value entry
    */
   default int getFloatMV(int docId, float[] valueBuffer, T context) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Reads the FLOAT type multi-value at the given document id into a buffer and returns the buffer.
+   *
+   * @param docId Document id
+   * @param context Reader context
+   * @return A buffer containing the multi-value entries
+   */
+  default float[] getFloatMV(int docId, T context) {
     throw new UnsupportedOperationException();
   }
 
@@ -470,6 +808,17 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
   }
 
   /**
+   * Reads the DOUBLE type multi-value at the given document id into a buffer and returns the buffer.
+   *
+   * @param docId Document id
+   * @param context Reader context
+   * @return A buffer containing the multi-value entries
+   */
+  default double[] getDoubleMV(int docId, T context) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Reads the STRING type multi-value at the given document id into the passed in value buffer (the buffer size must
    * be enough to hold all the values for the multi-value entry) and returns the number of values within the multi-value
    * entry.
@@ -484,6 +833,17 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
   }
 
   /**
+   * Reads the STRING type multi-value at the given document id into a buffer and returns the buffer.
+   *
+   * @param docId Document id
+   * @param context Reader context
+   * @return A buffer containing the multi-value entries
+   */
+  default String[] getStringMV(int docId, T context) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Reads the bytes type multi-value at the given document id into the passed in value buffer (the buffer size must
    * be enough to hold all the values for the multi-value entry) and returns the number of values within the multi-value
    * entry.
@@ -494,6 +854,28 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * @return Number of values within the multi-value entry
    */
   default int getBytesMV(int docId, byte[][] valueBuffer, T context) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Reads the bytes type multi-value at the given document id into a buffer and returns the buffer.
+   *
+   * @param docId Document id
+   * @param context Reader context
+   * @return A buffer containing the multi-value entries
+   */
+  default byte[][] getBytesMV(int docId, T context) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Gets the number of multi-values at a given document id and returns it.
+   *
+   * @param docId Document id
+   * @param context Reader context
+   * @return Number of values within the multi-value entry
+   */
+  default int getNumValuesMV(int docId, T context) {
     throw new UnsupportedOperationException();
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
@@ -101,11 +101,11 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
   }
 
   /**
-   * Reads the dictionary ids for a multi-value column at the given document id into a buffer and returns the buffer.
+   * Reads the dictionary ids for a multi-value column at the given document id.
    *
    * @param docId Document id
    * @param context Reader context
-   * @return A buffer containing the multi-value entries
+   * @return Dictionary ids at the given document id
    */
   default int[] getDictIdMV(int docId, T context) {
     throw new UnsupportedOperationException();
@@ -427,10 +427,11 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * Fills the values
    * @param docIds Array containing the document ids to read
    * @param length Number of values to read
+   * @param maxNumValuesPerMVEntry Maximum number of values per MV entry
    * @param values Values to fill
    * @param context Reader context
    */
-  default void readValuesMV(int[] docIds, int length, int[][] values, T context) {
+  default void readValuesMV(int[] docIds, int length, int maxNumValuesPerMVEntry, int[][] values, T context) {
     switch (getValueType()) {
       case INT:
         for (int i = 0; i < length; i++) {
@@ -438,9 +439,9 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       case LONG:
+        long[] longValueBuffer = new long[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
-          long[] longValueBuffer = getLongMV(docIds[i], context);
-          int numValues = longValueBuffer.length;
+          int numValues = getLongMV(docIds[i], longValueBuffer, context);
           values[i] = new int[numValues];
           for (int j = 0; j < numValues; j++) {
             values[i][j] = (int) longValueBuffer[j];
@@ -448,9 +449,9 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       case FLOAT:
+        float[] floatValueBuffer = new float[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
-          float[] floatValueBuffer = getFloatMV(docIds[i], context);
-          int numValues = floatValueBuffer.length;
+          int numValues = getFloatMV(docIds[i], floatValueBuffer, context);
           values[i] = new int[numValues];
           for (int j = 0; j < numValues; j++) {
             values[i][j] = (int) floatValueBuffer[j];
@@ -458,9 +459,9 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       case DOUBLE:
+        double[] doubleValueBuffer = new double[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
-          double[] doubleValueBuffer = getDoubleMV(docIds[i], context);
-          int numValues = doubleValueBuffer.length;
+          int numValues = getDoubleMV(docIds[i], doubleValueBuffer, context);
           values[i] = new int[numValues];
           for (int j = 0; j < numValues; j++) {
             values[i][j] = (int) doubleValueBuffer[j];
@@ -468,9 +469,9 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       case STRING:
+        String[] stringValueBuffer = new String[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
-          String[] stringValueBuffer = getStringMV(docIds[i], context);
-          int numValues = stringValueBuffer.length;
+          int numValues = getStringMV(docIds[i], stringValueBuffer, context);
           values[i] = new int[numValues];
           for (int j = 0; j < numValues; j++) {
             values[i][j] = Integer.parseInt(stringValueBuffer[j]);
@@ -486,15 +487,16 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * Fills the values
    * @param docIds Array containing the document ids to read
    * @param length Number of values to read
+   * @param maxNumValuesPerMVEntry Maximum number of values per MV entry
    * @param values Values to fill
    * @param context Reader context
    */
-  default void readValuesMV(int[] docIds, int length, long[][] values, T context) {
+  default void readValuesMV(int[] docIds, int length, int maxNumValuesPerMVEntry, long[][] values, T context) {
     switch (getValueType()) {
       case INT:
+        int[] intValueBuffer = new int[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
-          int[] intValueBuffer = getIntMV(docIds[i], context);
-          int numValues = intValueBuffer.length;
+          int numValues = getIntMV(docIds[i], intValueBuffer, context);
           values[i] = new long[numValues];
           for (int j = 0; j < numValues; j++) {
             values[i][j] = intValueBuffer[j];
@@ -507,9 +509,9 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       case FLOAT:
+        float[] floatValueBuffer = new float[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
-          float[] floatValueBuffer = getFloatMV(docIds[i], context);
-          int numValues = floatValueBuffer.length;
+          int numValues = getFloatMV(docIds[i], floatValueBuffer, context);
           values[i] = new long[numValues];
           for (int j = 0; j < numValues; j++) {
             values[i][j] = (long) floatValueBuffer[j];
@@ -517,9 +519,9 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       case DOUBLE:
+        double[] doubleValueBuffer = new double[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
-          double[] doubleValueBuffer = getDoubleMV(docIds[i], context);
-          int numValues = doubleValueBuffer.length;
+          int numValues = getDoubleMV(docIds[i], doubleValueBuffer, context);
           values[i] = new long[numValues];
           for (int j = 0; j < numValues; j++) {
             values[i][j] = (long) doubleValueBuffer[j];
@@ -527,9 +529,9 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       case STRING:
+        String[] stringValueBuffer = new String[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
-          String[] stringValueBuffer = getStringMV(docIds[i], context);
-          int numValues = stringValueBuffer.length;
+          int numValues = getStringMV(docIds[i], stringValueBuffer, context);
           values[i] = new long[numValues];
           for (int j = 0; j < numValues; j++) {
             values[i][j] = Long.parseLong(stringValueBuffer[j]);
@@ -545,15 +547,16 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * Fills the values
    * @param docIds Array containing the document ids to read
    * @param length Number of values to read
+   * @param maxNumValuesPerMVEntry Maximum number of values per MV entry
    * @param values Values to fill
    * @param context Reader context
    */
-  default void readValuesMV(int[] docIds, int length, float[][] values, T context) {
+  default void readValuesMV(int[] docIds, int length, int maxNumValuesPerMVEntry, float[][] values, T context) {
     switch (getValueType()) {
       case INT:
+        int[] intValueBuffer = new int[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
-          int[] intValueBuffer = getIntMV(docIds[i], context);
-          int numValues = intValueBuffer.length;
+          int numValues = getIntMV(docIds[i], intValueBuffer, context);
           values[i] = new float[numValues];
           for (int j = 0; j < numValues; j++) {
             values[i][j] = intValueBuffer[j];
@@ -561,9 +564,9 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       case LONG:
+        long[] longValueBuffer = new long[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
-          long[] longValueBuffer = getLongMV(docIds[i], context);
-          int numValues = longValueBuffer.length;
+          int numValues = getLongMV(docIds[i], longValueBuffer, context);
           values[i] = new float[numValues];
           for (int j = 0; j < numValues; j++) {
             values[i][j] = longValueBuffer[j];
@@ -576,9 +579,9 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       case DOUBLE:
+        double[] doubleValueBuffer = new double[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
-          double[] doubleValueBuffer = getDoubleMV(docIds[i], context);
-          int numValues = doubleValueBuffer.length;
+          int numValues = getDoubleMV(docIds[i], doubleValueBuffer, context);
           values[i] = new float[numValues];
           for (int j = 0; j < numValues; j++) {
             values[i][j] = (float) doubleValueBuffer[j];
@@ -586,9 +589,9 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       case STRING:
+        String[] stringValueBuffer = new String[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
-          String[] stringValueBuffer = getStringMV(docIds[i], context);
-          int numValues = stringValueBuffer.length;
+          int numValues = getStringMV(docIds[i], stringValueBuffer, context);
           values[i] = new float[numValues];
           for (int j = 0; j < numValues; j++) {
             values[i][j] = Float.parseFloat(stringValueBuffer[j]);
@@ -604,15 +607,16 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * Fills the values
    * @param docIds Array containing the document ids to read
    * @param length Number of values to read
+   * @param maxNumValuesPerMVEntry Maximum number of values per MV entry
    * @param values Values to fill
    * @param context Reader context
    */
-  default void readValuesMV(int[] docIds, int length, double[][] values, T context) {
+  default void readValuesMV(int[] docIds, int length, int maxNumValuesPerMVEntry, double[][] values, T context) {
     switch (getValueType()) {
       case INT:
+        int[] intValueBuffer = new int[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
-          int[] intValueBuffer = getIntMV(docIds[i], context);
-          int numValues = intValueBuffer.length;
+          int numValues = getIntMV(docIds[i], intValueBuffer, context);
           values[i] = new double[numValues];
           for (int j = 0; j < numValues; j++) {
             values[i][j] = intValueBuffer[j];
@@ -620,9 +624,9 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       case LONG:
+        long[] longValueBuffer = new long[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
-          long[] longValueBuffer = getLongMV(docIds[i], context);
-          int numValues = longValueBuffer.length;
+          int numValues = getLongMV(docIds[i], longValueBuffer, context);
           values[i] = new double[numValues];
           for (int j = 0; j < numValues; j++) {
             values[i][j] = longValueBuffer[j];
@@ -630,9 +634,9 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       case FLOAT:
+        float[] floatValueBuffer = new float[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
-          float[] floatValueBuffer = getFloatMV(docIds[i], context);
-          int numValues = floatValueBuffer.length;
+          int numValues = getFloatMV(docIds[i], floatValueBuffer, context);
           values[i] = new double[numValues];
           for (int j = 0; j < numValues; j++) {
             values[i][j] = floatValueBuffer[j];
@@ -645,9 +649,9 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       case STRING:
+        String[] stringValueBuffer = new String[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
-          String[] stringValueBuffer = getStringMV(docIds[i], context);
-          int numValues = stringValueBuffer.length;
+          int numValues = getStringMV(docIds[i], stringValueBuffer, context);
           values[i] = new double[numValues];
           for (int j = 0; j < numValues; j++) {
             values[i][j] = Double.parseDouble(stringValueBuffer[j]);
@@ -663,15 +667,16 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * Fills the values
    * @param docIds Array containing the document ids to read
    * @param length Number of values to read
+   * @param maxNumValuesPerMVEntry Maximum number of values per MV entry
    * @param values Values to fill
    * @param context Reader context
    */
-  default void readValuesMV(int[] docIds, int length, String[][] values, T context) {
+  default void readValuesMV(int[] docIds, int length, int maxNumValuesPerMVEntry, String[][] values, T context) {
     switch (getValueType()) {
       case INT:
+        int[] intValueBuffer = new int[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
-          int[] intValueBuffer = getIntMV(docIds[i], context);
-          int numValues = intValueBuffer.length;
+          int numValues = getIntMV(docIds[i], intValueBuffer, context);
           values[i] = new String[numValues];
           for (int j = 0; j < numValues; j++) {
             values[i][j] = String.valueOf(intValueBuffer[j]);
@@ -679,9 +684,9 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       case LONG:
+        long[] longValueBuffer = new long[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
-          long[] longValueBuffer = getLongMV(docIds[i], context);
-          int numValues = longValueBuffer.length;
+          int numValues = getLongMV(docIds[i], longValueBuffer, context);
           values[i] = new String[numValues];
           for (int j = 0; j < numValues; j++) {
             values[i][j] = String.valueOf(longValueBuffer[j]);
@@ -689,9 +694,9 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       case FLOAT:
+        float[] floatValueBuffer = new float[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
-          float[] floatValueBuffer = getFloatMV(docIds[i], context);
-          int numValues = floatValueBuffer.length;
+          int numValues = getFloatMV(docIds[i], floatValueBuffer, context);
           values[i] = new String[numValues];
           for (int j = 0; j < numValues; j++) {
             values[i][j] = String.valueOf(floatValueBuffer[j]);
@@ -699,9 +704,9 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       case DOUBLE:
+        double[] doubleValueBuffer = new double[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
-          double[] doubleValueBuffer = getDoubleMV(docIds[i], context);
-          int numValues = doubleValueBuffer.length;
+          int numValues = getDoubleMV(docIds[i], doubleValueBuffer, context);
           values[i] = new String[numValues];
           for (int j = 0; j < numValues; j++) {
             values[i][j] = String.valueOf(doubleValueBuffer[j]);
@@ -733,11 +738,11 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
   }
 
   /**
-   * Reads the INT type multi-value at the given document id into a buffer and returns the buffer.
+   * Reads the INT type multi-value at the given document id.
    *
    * @param docId Document id
    * @param context Reader context
-   * @return A buffer containing the multi-value entries
+   * @return INT values at the given document id
    */
   default int[] getIntMV(int docId, T context) {
     throw new UnsupportedOperationException();
@@ -758,11 +763,11 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
   }
 
   /**
-   * Reads the LONG type multi-value at the given document id into a buffer and returns the buffer.
+   * Reads the LONG type multi-value at the given document id.
    *
    * @param docId Document id
    * @param context Reader context
-   * @return A buffer containing the multi-value entries
+   * @return LONG values at the given document id
    */
   default long[] getLongMV(int docId, T context) {
     throw new UnsupportedOperationException();
@@ -783,11 +788,11 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
   }
 
   /**
-   * Reads the FLOAT type multi-value at the given document id into a buffer and returns the buffer.
+   * Reads the FLOAT type multi-value at the given document id.
    *
    * @param docId Document id
    * @param context Reader context
-   * @return A buffer containing the multi-value entries
+   * @return FLOAT values at the given document id
    */
   default float[] getFloatMV(int docId, T context) {
     throw new UnsupportedOperationException();
@@ -808,11 +813,11 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
   }
 
   /**
-   * Reads the DOUBLE type multi-value at the given document id into a buffer and returns the buffer.
+   * Reads the DOUBLE type multi-value at the given document id.
    *
    * @param docId Document id
    * @param context Reader context
-   * @return A buffer containing the multi-value entries
+   * @return DOUBLE values at the given document id
    */
   default double[] getDoubleMV(int docId, T context) {
     throw new UnsupportedOperationException();
@@ -833,11 +838,11 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
   }
 
   /**
-   * Reads the STRING type multi-value at the given document id into a buffer and returns the buffer.
+   * Reads the STRING type multi-value at the given document id.
    *
    * @param docId Document id
    * @param context Reader context
-   * @return A buffer containing the multi-value entries
+   * @return STRING values at the given document id
    */
   default String[] getStringMV(int docId, T context) {
     throw new UnsupportedOperationException();
@@ -858,11 +863,11 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
   }
 
   /**
-   * Reads the bytes type multi-value at the given document id into a buffer and returns the buffer.
+   * Reads the bytes type multi-value at the given document id.
    *
    * @param docId Document id
    * @param context Reader context
-   * @return A buffer containing the multi-value entries
+   * @return BYTE values at the given document id
    */
   default byte[][] getBytesMV(int docId, T context) {
     throw new UnsupportedOperationException();


### PR DESCRIPTION
Support to create segments with multi-value columns with dictionary disabled already existed. On trying to create a multi-value RAW column and querying it, we ran into this issue: https://github.com/apache/pinot/issues/8875

Original PR that adds complete support for querying MV raw columns - https://github.com/apache/pinot/pull/8917

This PR is split from the above PR per discussion on that one for easy review etc. Follow-up PRs will also come. This PR adds MV RAW APIs and their implementation for the following types of columns:

- Immutable segments with MV columns of types INT, LONG, FLOAT, DOUBLE, and STRING
- Mutable (realtime) segments with MV columns of INT, LONG, FLOAT, and DOUBLE

Follow-up PRs split from original one - Make group by, filter, etc work correctly with MV raw columns

TODO - Support for variable length MV RAW columns for Mutable segments will be added in the future as it requires a mutable variable length writer. Was a TODO in original PR as well. 

Test cases for various types of queries that are currently supported have been added.

cc @siddharthteotia @Jackie-Jiang 