### PR TITLE
Enhance range index rule and flag invalid queries

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/io/InputManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/io/InputManager.java
@@ -172,11 +172,15 @@ public class InputManager {
         _queryOptimizer.optimize(pinotQuery, _schema);
         QueryContext queryContext = QueryContextConverterUtils.getQueryContext(pinotQuery);
 
-        //Flag the queries having in filter columns not appear in schema
+        // Flag the queries having in filter columns not appear in schema
+        // to exclude user input like select i from tableName where a = xyz and t > 500
         Set<String> filterColumns = new HashSet<>();
         if (queryContext.getFilter() != null) {
+          // get in filter column names, excluding literals, etc
           queryContext.getFilter().getColumns(filterColumns);
+          // remove those appear in schema
           filterColumns.removeAll(_colNameToIntMap.keySet());
+          // flag if there are columns left
           if (!filterColumns.isEmpty()) {
             invalidQueries.add(queryString);
             _overWrittenConfigs.getFlaggedQueries().add(queryString, ERROR_INVALID_COLUMN + filterColumns);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/RangeIndexRule.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/RangeIndexRule.java
@@ -71,6 +71,7 @@ public class RangeIndexRule extends AbstractRule {
       // As currently, only numeric columns are selected in range index creation, we will skip non numeric columns
       if (((weights[i] / totalWeight.get()) > _params._thresholdMinPercentRangeIndex) && !_output.getIndexConfig()
           .getSortedColumn().equals(colName) && !_output.getIndexConfig().getInvertedIndexColumns().contains(colName)
+          && _input.getCardinality(colName) > _params._thresholdMinCardinalityRangeIndex
           && _input.getFieldType(colName).isNumeric()) {
         _output.getIndexConfig().getRangeIndexColumns().add(colName);
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/io/params/RangeIndexRuleParams.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/io/params/RangeIndexRuleParams.java
@@ -28,6 +28,17 @@ import com.fasterxml.jackson.annotation.Nulls;
 public class RangeIndexRuleParams {
   public Double _thresholdMinPercentRangeIndex =
       RecommenderConstants.RangeIndexRule.DEFAULT_THRESHOLD_MIN_PERCENT_RANGE_INDEX;
+  public Double _thresholdMinCardinalityRangeIndex =
+      RecommenderConstants.RangeIndexRule.DEFAULT_THRESHOLD_MIN_CARDINALITY_RANGE_INDEX;
+
+  public Double getThresholdMinCardinalityRangeIndex() {
+    return _thresholdMinCardinalityRangeIndex;
+  }
+
+  @JsonSetter(value = "THRESHOLD_MIN_CARDINALITY_RANGE_INDEX", nulls = Nulls.SKIP)
+  public void setThresholdMinCardinalityRangeIndex(Double thresholdMinCardinalityRangeIndex) {
+    _thresholdMinCardinalityRangeIndex = thresholdMinCardinalityRangeIndex;
+  }
 
   public Double getThresholdMinPercentRangeIndex() {
     return _thresholdMinPercentRangeIndex;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/io/params/RecommenderConstants.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/io/params/RecommenderConstants.java
@@ -71,6 +71,7 @@ public class RecommenderConstants {
 
   public static class RangeIndexRule {
     public static final double DEFAULT_THRESHOLD_MIN_PERCENT_RANGE_INDEX = 0.4;
+    public static final double DEFAULT_THRESHOLD_MIN_CARDINALITY_RANGE_INDEX = 2;
   }
 
   public static class NoDictionaryOnHeapDictionaryJointRule {
@@ -94,6 +95,9 @@ public class RecommenderConstants {
     public static final String WARNING_TOO_LONG_LIMIT =
         "Warning: Please verify if you need to pull out huge number of records for this query. Consider using smaller"
             + " limit than " + DEFAULT_THRESHOLD_MAX_LIMIT_SIZE;
+
+    public static final String ERROR_INVALID_COLUMN =
+        "ERROR: Query is filtering on columns not appearing in schema: ";
     public static final String ERROR_INVALID_QUERY = "Error: Invalid query syntax. Please fix the query";
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/recommender/TestConfigEngine.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/recommender/TestConfigEngine.java
@@ -133,6 +133,20 @@ public class TestConfigEngine {
   }
 
   @Test
+  void testInvalidColumnInFilterRule()
+      throws InvalidInputException, IOException {
+    loadInput("recommenderInput/InvalidColumnInFilterInput.json");
+    ConfigManager output = new ConfigManager();
+    AbstractRule abstractRule =
+        RulesToExecute.RuleFactory.getRule(RulesToExecute.Rule.InvertedSortedIndexJointRule, _input, output);
+    abstractRule.run();
+    assertEquals(output.getIndexConfig().getInvertedIndexColumns().toString(), "[]");
+    assertEquals(_input.getOverWrittenConfigs().getFlaggedQueries().getFlaggedQueries().toString(),
+        "{select i from tableName where a = xyz and t > 500=ERROR: "
+            + "Query is filtering on columns not appearing in schema: [xyz]}");
+  }
+
+  @Test
   void testSortedInvertedIndexJointRuleWithMetricAndDateTimeColumn()
       throws InvalidInputException, IOException {
     loadInput("recommenderInput/SortedInvertedIndexInputWithMetricAndDateTimeColumn.json");

--- a/pinot-controller/src/test/resources/recommenderInput/InvalidColumnInFilterInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/InvalidColumnInFilterInput.json
@@ -136,7 +136,9 @@
   },
   "queriesWithWeights":{
     "select i from tableName where a = xyz and t > 500": 1,
-    "select i from tableName where a = 43 and t > 500": 1
+    "select i from tableName where a = 43 and t > 500": 1,
+    "select i from tableName where a = 'xyz' and t > 500": 1,
+    "select i from tableName where a = b and t > 500": 1
   },
   "qps": 15000,
   "numMessagesPerSecInKafkaTopic":1000,

--- a/pinot-controller/src/test/resources/recommenderInput/InvalidColumnInFilterInput.json
+++ b/pinot-controller/src/test/resources/recommenderInput/InvalidColumnInFilterInput.json
@@ -1,0 +1,168 @@
+{
+  "schema":{
+    "schemaName": "tableSchema",
+    "dimensionFieldSpecs": [
+      {
+        "name": "a",
+        "dataType": "INT",
+        "cardinality":20,
+        "numValuesPerEntry":1
+      },
+      {
+        "name": "b",
+        "dataType": "DOUBLE",
+        "cardinality":6,
+        "singleValueField": false,
+        "numValuesPerEntry":1.5
+      },
+      {
+        "name": "c",
+        "dataType": "FLOAT",
+        "cardinality":7,
+        "numValuesPerEntry":1
+      },
+      {
+        "name": "d",
+        "dataType": "STRING",
+        "cardinality":41,
+        "singleValueField": false,
+        "numValuesPerEntry":2,
+        "averageLength" : 27
+      },
+      {
+        "name": "e",
+        "dataType": "LONG",
+        "cardinality":18,
+        "singleValueField": false,
+        "numValuesPerEntry":4
+      },
+      {
+        "name": "f",
+        "dataType": "DOUBLE",
+        "cardinality":13,
+        "singleValueField": false,
+        "numValuesPerEntry":3
+      },
+      {
+        "name": "g",
+        "dataType": "STRING",
+        "cardinality":6,
+        "singleValueField": false,
+        "numValuesPerEntry":2,
+        "averageLength" : 100
+      },
+      {
+        "name": "h",
+        "dataType": "BYTES",
+        "cardinality":12,
+        "numValuesPerEntry":1,
+        "averageLength" : 10
+      },
+      {
+        "name": "i",
+        "dataType": "STRING",
+        "singleValueField": false,
+        "cardinality":7,
+        "numValuesPerEntry":1,
+        "averageLength" : 25
+      },
+      {
+        "name": "j",
+        "dataType": "DOUBLE",
+        "cardinality":4,
+        "numValuesPerEntry":1.00000001
+      },
+      {
+        "name": "ja",
+        "dataType": "BOOLEAN"
+      },
+      {
+        "name": "jb",
+        "dataType": "BOOLEAN",
+        "numValuesPerEntry": 3
+      }
+    ],
+    "metricFieldSpecs": [
+      {
+        "name": "k",
+        "dataType": "DOUBLE",
+        "cardinality":10000,
+        "numValuesPerEntry":1,
+        "averageLength" : 100
+      },
+      {
+        "name": "l",
+        "dataType": "DOUBLE",
+        "cardinality":10000,
+        "numValuesPerEntry":1,
+        "averageLength" : 10
+      },
+      {
+        "name": "m",
+        "dataType": "BYTES",
+        "cardinality":10000,
+        "numValuesPerEntry":1,
+        "averageLength" : 25
+      },
+      {
+        "name": "n",
+        "dataType": "DOUBLE",
+        "cardinality":10000,
+        "numValuesPerEntry":1
+      },
+      {
+        "name": "o",
+        "dataType": "DOUBLE",
+        "cardinality":10000,
+        "numValuesPerEntry":1,
+        "averageLength" : 25
+      },
+      {
+        "name": "p",
+        "dataType": "DOUBLE",
+        "cardinality":10000,
+        "numValuesPerEntry":1
+      }
+    ],
+    "timeFieldSpec": {
+      "incomingGranularitySpec": {
+        "dataType": "INT",
+        "name": "t",
+        "timeType": "DAYS",
+        "cardinality":10000,
+        "numValuesPerEntry":1
+      }
+    }
+  },
+  "queriesWithWeights":{
+    "select i from tableName where a = xyz and t > 500": 1,
+    "select i from tableName where a = 43 and t > 500": 1
+  },
+  "qps": 15000,
+  "numMessagesPerSecInKafkaTopic":1000,
+  "numRecordsPerPush":1000000000,
+  "tableType": "HYBRID",
+  "latencySLA": 500,
+
+  "rulesToExecute": {
+    "recommendInvertedSortedIndexJoint": true
+  },
+  "partitionRuleParams": {
+    "THRESHOLD_MAX_LATENCY_SLA_PARTITION": 1001
+  },
+  "bloomFilterRuleParams": {
+    "THRESHOLD_MIN_PERCENT_EQ_BLOOMFILTER" : 0.51
+  },
+  "invertedSortedIndexJointRuleParams": {
+    "THRESHOLD_RATIO_MIN_GAIN_DIFF_BETWEEN_ITERATION" : 0.06
+  },
+  "noDictionaryOnHeapDictionaryJointRuleParams": {
+    "THRESHOLD_MIN_PERCENT_DICTIONARY_STORAGE_SAVE" : 0.96
+  },
+  "overWrittenConfigs": {
+    "indexConfig": {
+      "invertedIndexColumns": ["a","b"],
+      "rangeIndexColumns": ["f"]
+    }
+  }
+}


### PR DESCRIPTION
Enhance the config optimizer by:
1) not recommending range indices for very low cardinality columns
2) flagging queries that have `where col_A = xyz` where as it should be `where col_A = 'xyz'`