### PR TITLE
make all search bars full width

### DIFF
--- a/pinot-controller/src/main/resources/app/components/SearchBar.tsx
+++ b/pinot-controller/src/main/resources/app/components/SearchBar.tsx
@@ -78,6 +78,7 @@ const SearchBar = (props) => {
           input: classes.inputInput,
         }}
         inputProps={{ 'aria-label': 'search' }}
+        fullWidth
       />
     </div>
   );


### PR DESCRIPTION
This makes all search bars full width. They're always on their own line, so now searches don't get truncated

label: `ui`. it doesn't seem like I can add labels

<img width="1240" alt="image" src="https://user-images.githubusercontent.com/89398120/175173627-21994e2d-a0e7-4c91-abc3-602184d1568c.png">
<img width="1222" alt="image" src="https://user-images.githubusercontent.com/89398120/175173711-7e6820fb-3527-4e7b-811f-e8ad26f2589e.png">
