### PR TITLE
fix bug in segmentDetails table name parsing; style the new indexes table

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -329,7 +329,7 @@ export default function CustomizedTables({
   }, [data]);
 
   const styleCell = (str: string) => {
-    if (str === 'Good' || str.toLowerCase() === 'online' || str.toLowerCase() === 'alive') {
+    if (str === 'Good' || str.toLowerCase() === 'online' || str.toLowerCase() === 'alive' || str.toLowerCase() === 'true') {
       return (
         <StyledChip
           label={str}
@@ -338,7 +338,7 @@ export default function CustomizedTables({
         />
       );
     }
-    if (str === 'Bad' || str.toLowerCase() === 'offline' || str.toLowerCase() === 'dead') {
+    if (str === 'Bad' || str.toLowerCase() === 'offline' || str.toLowerCase() === 'dead' || str.toLowerCase() === 'false') {
       return (
         <StyledChip
           label={str}

--- a/pinot-controller/src/main/resources/app/pages/SegmentDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/SegmentDetails.tsx
@@ -121,7 +121,6 @@ const SegmentDetails = ({ match }: RouteComponentProps<Props>) => {
   const [value, setValue] = useState('');
   const fetchData = async () => {
     const result = await PinotMethodUtils.getSegmentDetails(tableName, segmentName);
-    console.log("result", result)
     setSegmentSummary(result.summary);
     setIndexes(result.indexes);
     setReplica(result.replicaSet);

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -535,16 +535,17 @@ const getTableDetails = (tableName) => {
   });
 };
 
-// This method is used to display summary of a particular segment, replia set as well as JSON format of a tenant table
+// This method is used to display summary of a particular segment, replica set as well as JSON format of a tenant table
 // API: /tables/tableName/externalview
 //      /segments/:tableName/:segmentName/metadata
 // Expected Output: {columns: [], records: []}
 const getSegmentDetails = (tableName, segmentName) => {
-  const tableInfo = tableName.split('_');
+  let baseTableName = tableName.substring(0, tableName.lastIndexOf("_"));
+  let tableType = tableName.substring(tableName.lastIndexOf("_") + 1, tableName.length);
   const promiseArr = [];
   promiseArr.push(getExternalView(tableName));
   promiseArr.push(getSegmentMetadata(tableName, segmentName));
-  promiseArr.push(getSegmentDebugInfo(tableInfo[0], tableInfo[1].toLowerCase()));
+  promiseArr.push(getSegmentDebugInfo(baseTableName, tableType.toLowerCase()));
 
   return Promise.all(promiseArr).then((results) => {
     const obj = results[0].data.OFFLINE || results[0].data.REALTIME;


### PR DESCRIPTION
label: `ui`

This first fixes a bug in how table name and type were parsed for the segmentDetails page. This has never worked right for tables with `_` in the name, but for some reason the latest upstream pull caused that page to break for us now.

This also styles the new indexes table with some colors so it's easier to tell at a glance what indexes are there or not.
<img width="1258" alt="image" src="https://user-images.githubusercontent.com/89398120/175180102-7b104d7d-7e0a-46dd-ae9f-1cbcce5d5429.png">
