### PR TITLE
Update minion task metadata ZNode path

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpreselector/SegmentPreSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpreselector/SegmentPreSelectorTest.java
@@ -26,12 +26,12 @@ import java.util.Set;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
-import org.apache.pinot.broker.util.FakePropertyStore;
 import org.apache.pinot.common.lineage.LineageEntry;
 import org.apache.pinot.common.lineage.LineageEntryState;
 import org.apache.pinot.common.lineage.SegmentLineage;
 import org.apache.pinot.common.lineage.SegmentLineageAccessHelper;
 import org.apache.pinot.common.lineage.SegmentLineageUtils;
+import org.apache.pinot.common.utils.helix.FakePropertyStore;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -66,8 +66,7 @@ public class ZKMetadataProvider {
   private static final String PROPERTYSTORE_MINION_TASK_METADATA_PREFIX = "/MINION_TASK_METADATA";
 
   public static void setUserConfig(ZkHelixPropertyStore<ZNRecord> propertyStore, String username, ZNRecord znRecord) {
-    propertyStore
-        .set(constructPropertyStorePathForUserConfig(username), znRecord, AccessOption.PERSISTENT);
+    propertyStore.set(constructPropertyStorePathForUserConfig(username), znRecord, AccessOption.PERSISTENT);
   }
 
   public static void setRealtimeTableConfig(ZkHelixPropertyStore<ZNRecord> propertyStore, String realtimeTableName,
@@ -130,13 +129,12 @@ public class ZKMetadataProvider {
     return StringUtil.join("/", PROPERTYSTORE_SEGMENT_LINEAGE, tableNameWithType);
   }
 
-  public static String constructPropertyStorePathForMinionTaskMetadataNewFormat(
-      String taskType, String tableNameWithType) {
+  public static String constructPropertyStorePathForMinionTaskMetadataNewFormat(String taskType,
+      String tableNameWithType) {
     return StringUtil.join("/", PROPERTYSTORE_MINION_TASK_METADATA_PREFIX, tableNameWithType, taskType);
   }
 
-  public static String constructPropertyStorePathForMinionTaskMetadata(
-      String taskType, String tableNameWithType) {
+  public static String constructPropertyStorePathForMinionTaskMetadata(String taskType, String tableNameWithType) {
     return StringUtil.join("/", PROPERTYSTORE_MINION_TASK_METADATA_PREFIX, taskType, tableNameWithType);
   }
 
@@ -162,8 +160,7 @@ public class ZKMetadataProvider {
     }
   }
 
-  public static void removeUserConfigFromPropertyStore(ZkHelixPropertyStore<ZNRecord> propertyStore,
-      String username) {
+  public static void removeUserConfigFromPropertyStore(ZkHelixPropertyStore<ZNRecord> propertyStore, String username) {
     String propertyStorePath = constructPropertyStorePathForUserConfig(username);
     if (propertyStore.exists(propertyStorePath, AccessOption.PERSISTENT)) {
       propertyStore.remove(propertyStorePath, AccessOption.PERSISTENT);
@@ -230,8 +227,8 @@ public class ZKMetadataProvider {
 
   @Nullable
   public static UserConfig getUserConfig(ZkHelixPropertyStore<ZNRecord> propertyStore, String username) {
-    ZNRecord znRecord = propertyStore
-        .get(constructPropertyStorePathForUserConfig(username), null, AccessOption.PERSISTENT);
+    ZNRecord znRecord =
+        propertyStore.get(constructPropertyStorePathForUserConfig(username), null, AccessOption.PERSISTENT);
     if (znRecord == null) {
       return null;
     }
@@ -246,14 +243,13 @@ public class ZKMetadataProvider {
 
   @Nullable
   public static List<UserConfig> getAllUserConfig(ZkHelixPropertyStore<ZNRecord> propertyStore) {
-    List<ZNRecord> znRecordss = propertyStore
-        .getChildren(PROPERTYSTORE_USER_CONFIGS_PREFIX, null, AccessOption.PERSISTENT);
+    List<ZNRecord> znRecordss =
+        propertyStore.getChildren(PROPERTYSTORE_USER_CONFIGS_PREFIX, null, AccessOption.PERSISTENT);
 
     try {
-      return Optional.ofNullable(znRecordss)
-          .orElseGet(() -> {
-            return new ArrayList<>();
-          }).stream().map(AccessControlUserConfigUtils::fromZNRecord).collect(Collectors.toList());
+      return Optional.ofNullable(znRecordss).orElseGet(() -> {
+        return new ArrayList<>();
+      }).stream().map(AccessControlUserConfigUtils::fromZNRecord).collect(Collectors.toList());
     } catch (Exception e) {
       LOGGER.error("Caught exception while getting user list configuration", e);
       return null;
@@ -262,8 +258,7 @@ public class ZKMetadataProvider {
 
   @Nullable
   public static List<String> getAllUserName(ZkHelixPropertyStore<ZNRecord> propertyStore) {
-    return propertyStore
-        .getChildNames(PROPERTYSTORE_USER_CONFIGS_PREFIX, AccessOption.PERSISTENT);
+    return propertyStore.getChildNames(PROPERTYSTORE_USER_CONFIGS_PREFIX, AccessOption.PERSISTENT);
   }
 
   @Nullable

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -131,6 +131,11 @@ public class ZKMetadataProvider {
   }
 
   public static String constructPropertyStorePathForMinionTaskMetadata(String taskType, String tableNameWithType) {
+    return StringUtil.join("/", PROPERTYSTORE_MINION_TASK_METADATA_PREFIX, tableNameWithType, taskType);
+  }
+
+  public static String constructPropertyStorePathForMinionTaskMetadataOldFormat(
+      String taskType, String tableNameWithType) {
     return StringUtil.join("/", PROPERTYSTORE_MINION_TASK_METADATA_PREFIX, taskType, tableNameWithType);
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -129,12 +129,13 @@ public class ZKMetadataProvider {
     return StringUtil.join("/", PROPERTYSTORE_SEGMENT_LINEAGE, tableNameWithType);
   }
 
-  public static String constructPropertyStorePathForMinionTaskMetadataNewFormat(String taskType,
-      String tableNameWithType) {
+  public static String constructPropertyStorePathForMinionTaskMetadata(String taskType, String tableNameWithType) {
     return StringUtil.join("/", PROPERTYSTORE_MINION_TASK_METADATA_PREFIX, tableNameWithType, taskType);
   }
 
-  public static String constructPropertyStorePathForMinionTaskMetadata(String taskType, String tableNameWithType) {
+  @Deprecated
+  public static String constructPropertyStorePathForMinionTaskMetadataDeprecated(String taskType,
+      String tableNameWithType) {
     return StringUtil.join("/", PROPERTYSTORE_MINION_TASK_METADATA_PREFIX, taskType, tableNameWithType);
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -129,7 +129,7 @@ public class ZKMetadataProvider {
     return StringUtil.join("/", PROPERTYSTORE_SEGMENT_LINEAGE, tableNameWithType);
   }
 
-  public static String constructPropertyStorePathForMinionTaskMetadata(String taskType, String tableNameWithType) {
+  public static String constructPropertyStorePathForMinionTaskMetadata(String tableNameWithType, String taskType) {
     return StringUtil.join("/", PROPERTYSTORE_MINION_TASK_METADATA_PREFIX, tableNameWithType, taskType);
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -130,11 +130,12 @@ public class ZKMetadataProvider {
     return StringUtil.join("/", PROPERTYSTORE_SEGMENT_LINEAGE, tableNameWithType);
   }
 
-  public static String constructPropertyStorePathForMinionTaskMetadata(String taskType, String tableNameWithType) {
+  public static String constructPropertyStorePathForMinionTaskMetadataNewFormat(
+      String taskType, String tableNameWithType) {
     return StringUtil.join("/", PROPERTYSTORE_MINION_TASK_METADATA_PREFIX, tableNameWithType, taskType);
   }
 
-  public static String constructPropertyStorePathForMinionTaskMetadataOldFormat(
+  public static String constructPropertyStorePathForMinionTaskMetadata(
       String taskType, String tableNameWithType) {
     return StringUtil.join("/", PROPERTYSTORE_MINION_TASK_METADATA_PREFIX, taskType, tableNameWithType);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/BaseTaskMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/BaseTaskMetadata.java
@@ -27,7 +27,7 @@ import org.apache.pinot.spi.utils.JsonUtils;
  * Base abstract class for minion task metadata.
  *
  * This metadata gets serialized and stored in zookeeper under the path:
- * MINION_TASK_METADATA/${taskName}/${tableNameWithType}
+ * MINION_TASK_METADATA/${tableNameWithType}/${taskName}
  */
 public abstract class BaseTaskMetadata {
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/MergeRollupTaskMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/MergeRollupTaskMetadata.java
@@ -28,7 +28,7 @@ import org.apache.helix.ZNRecord;
  * The <code>watermarkMap</code> denotes the time (exclusive) upto which tasks have been executed for the bucket
  * granularity.
  *
- * This gets serialized and stored in zookeeper under the path MINION_TASK_METADATA/MergeRollupTask/tableNameWithType
+ * This gets serialized and stored in zookeeper under the path MINION_TASK_METADATA/tableNameWithType/MergeRollupTask
  */
 public class MergeRollupTaskMetadata extends BaseTaskMetadata {
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/MergeRollupTaskMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/MergeRollupTaskMetadata.java
@@ -28,7 +28,7 @@ import org.apache.helix.ZNRecord;
  * The <code>watermarkMap</code> denotes the time (exclusive) upto which tasks have been executed for the bucket
  * granularity.
  *
- * This gets serialized and stored in zookeeper under the path MINION_TASK_METADATA/tableNameWithType/MergeRollupTask
+ * This gets serialized and stored in zookeeper under the path MINION_TASK_METADATA/${tableNameWithType}/MergeRollupTask
  */
 public class MergeRollupTaskMetadata extends BaseTaskMetadata {
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
@@ -43,7 +43,7 @@ public final class MinionTaskMetadataUtils {
   @Nullable
   public static ZNRecord fetchTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore, String taskType,
       String tableNameWithType) {
-    String newPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(taskType, tableNameWithType);
+    String newPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(tableNameWithType, taskType);
     if (propertyStore.exists(newPath, AccessOption.PERSISTENT)) {
       return fetchTaskMetadata(propertyStore, newPath);
     } else {
@@ -69,7 +69,7 @@ public final class MinionTaskMetadataUtils {
    */
   public static void deleteTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore, String taskType,
       String tableNameWithType) {
-    String newPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(taskType, tableNameWithType);
+    String newPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(tableNameWithType, taskType);
     String oldPath =
         ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataDeprecated(taskType, tableNameWithType);
     boolean newPathDeleted = propertyStore.remove(newPath, AccessOption.PERSISTENT);
@@ -90,8 +90,9 @@ public final class MinionTaskMetadataUtils {
    */
   public static void persistTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore, String taskType,
       BaseTaskMetadata taskMetadata, int expectedVersion) {
-    String newPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(taskType,
-        taskMetadata.getTableNameWithType());
+    String newPath =
+        ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(taskMetadata.getTableNameWithType(),
+            taskType);
     String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataDeprecated(taskType,
         taskMetadata.getTableNameWithType());
     if (propertyStore.exists(newPath, AccessOption.PERSISTENT) || !propertyStore.exists(oldPath,

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
@@ -43,8 +43,7 @@ public final class MinionTaskMetadataUtils {
   @Nullable
   public static ZNRecord fetchTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore, String taskType,
       String tableNameWithType) {
-    String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(
-        taskType, tableNameWithType);
+    String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(taskType, tableNameWithType);
     if (propertyStore.exists(oldPath, AccessOption.PERSISTENT)) {
       return fetchTaskMetadata(propertyStore, oldPath);
     } else {
@@ -70,12 +69,11 @@ public final class MinionTaskMetadataUtils {
    */
   public static void deleteTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore, String taskType,
       String tableNameWithType) {
-    String newPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataNewFormat(
-        taskType, tableNameWithType);
-    String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(
-        taskType, tableNameWithType);
-    if (!propertyStore.remove(newPath, AccessOption.PERSISTENT)
-        || !propertyStore.remove(oldPath, AccessOption.PERSISTENT)) {
+    String newPath =
+        ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataNewFormat(taskType, tableNameWithType);
+    String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(taskType, tableNameWithType);
+    if (!propertyStore.remove(newPath, AccessOption.PERSISTENT) || !propertyStore.remove(oldPath,
+        AccessOption.PERSISTENT)) {
       throw new ZkException("Failed to delete task metadata: " + taskType + ", " + tableNameWithType);
     }
   }
@@ -91,21 +89,20 @@ public final class MinionTaskMetadataUtils {
    */
   public static void persistTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore, String taskType,
       BaseTaskMetadata taskMetadata, int expectedVersion) {
-    String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(
-        taskType, taskMetadata.getTableNameWithType());
+    String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(taskType,
+        taskMetadata.getTableNameWithType());
     if (propertyStore.exists(oldPath, AccessOption.PERSISTENT)) {
       persistTaskMetadata(oldPath, propertyStore, taskType, taskMetadata, expectedVersion);
     } else {
-      String newPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataNewFormat(
-          taskType, taskMetadata.getTableNameWithType());
+      String newPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataNewFormat(taskType,
+          taskMetadata.getTableNameWithType());
       persistTaskMetadata(newPath, propertyStore, taskType, taskMetadata, expectedVersion);
     }
   }
 
-  private static void persistTaskMetadata(String path, HelixPropertyStore<ZNRecord> propertyStore,
-      String taskType, BaseTaskMetadata taskMetadata, int expectedVersion) {
-    if (!propertyStore
-        .set(path, taskMetadata.toZNRecord(), expectedVersion, AccessOption.PERSISTENT)) {
+  private static void persistTaskMetadata(String path, HelixPropertyStore<ZNRecord> propertyStore, String taskType,
+      BaseTaskMetadata taskMetadata, int expectedVersion) {
+    if (!propertyStore.set(path, taskMetadata.toZNRecord(), expectedVersion, AccessOption.PERSISTENT)) {
       throw new ZkException(
           "Failed to persist minion metadata for task: " + taskType + " and metadata: " + taskMetadata);
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
@@ -43,12 +43,12 @@ public final class MinionTaskMetadataUtils {
   @Nullable
   public static ZNRecord fetchTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore, String taskType,
       String tableNameWithType) {
-    String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(taskType, tableNameWithType);
+    String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataDeprecated(taskType, tableNameWithType);
     if (propertyStore.exists(oldPath, AccessOption.PERSISTENT)) {
       return fetchTaskMetadata(propertyStore, oldPath);
     } else {
       return fetchTaskMetadata(propertyStore,
-          ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataNewFormat(taskType, tableNameWithType));
+          ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(taskType, tableNameWithType));
     }
   }
 
@@ -70,8 +70,8 @@ public final class MinionTaskMetadataUtils {
   public static void deleteTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore, String taskType,
       String tableNameWithType) {
     String newPath =
-        ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataNewFormat(taskType, tableNameWithType);
-    String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(taskType, tableNameWithType);
+        ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(taskType, tableNameWithType);
+    String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataDeprecated(taskType, tableNameWithType);
     if (!propertyStore.remove(newPath, AccessOption.PERSISTENT) || !propertyStore.remove(oldPath,
         AccessOption.PERSISTENT)) {
       throw new ZkException("Failed to delete task metadata: " + taskType + ", " + tableNameWithType);
@@ -89,12 +89,12 @@ public final class MinionTaskMetadataUtils {
    */
   public static void persistTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore, String taskType,
       BaseTaskMetadata taskMetadata, int expectedVersion) {
-    String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(taskType,
+    String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataDeprecated(taskType,
         taskMetadata.getTableNameWithType());
     if (propertyStore.exists(oldPath, AccessOption.PERSISTENT)) {
       persistTaskMetadata(oldPath, propertyStore, taskType, taskMetadata, expectedVersion);
     } else {
-      String newPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataNewFormat(taskType,
+      String newPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(taskType,
           taskMetadata.getTableNameWithType());
       persistTaskMetadata(newPath, propertyStore, taskType, taskMetadata, expectedVersion);
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
@@ -43,13 +43,13 @@ public final class MinionTaskMetadataUtils {
   @Nullable
   public static ZNRecord fetchTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore, String taskType,
       String tableNameWithType) {
-    String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataOldFormat(
+    String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(
         taskType, tableNameWithType);
     if (propertyStore.exists(oldPath, AccessOption.PERSISTENT)) {
       return fetchTaskMetadata(propertyStore, oldPath);
     } else {
       return fetchTaskMetadata(propertyStore,
-          ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(taskType, tableNameWithType));
+          ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataNewFormat(taskType, tableNameWithType));
     }
   }
 
@@ -70,9 +70,9 @@ public final class MinionTaskMetadataUtils {
    */
   public static void deleteTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore, String taskType,
       String tableNameWithType) {
-    String newPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(
+    String newPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataNewFormat(
         taskType, tableNameWithType);
-    String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataOldFormat(
+    String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(
         taskType, tableNameWithType);
     if (!propertyStore.remove(newPath, AccessOption.PERSISTENT)
         || !propertyStore.remove(oldPath, AccessOption.PERSISTENT)) {
@@ -91,12 +91,12 @@ public final class MinionTaskMetadataUtils {
    */
   public static void persistTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore, String taskType,
       BaseTaskMetadata taskMetadata, int expectedVersion) {
-    String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataOldFormat(
+    String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(
         taskType, taskMetadata.getTableNameWithType());
     if (propertyStore.exists(oldPath, AccessOption.PERSISTENT)) {
       persistTaskMetadata(oldPath, propertyStore, taskType, taskMetadata, expectedVersion);
     } else {
-      String newPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(
+      String newPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataNewFormat(
           taskType, taskMetadata.getTableNameWithType());
       persistTaskMetadata(newPath, propertyStore, taskType, taskMetadata, expectedVersion);
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
@@ -36,12 +36,25 @@ public final class MinionTaskMetadataUtils {
   }
 
   /**
-   * Fetches the ZNRecord for the given minion task and tableName, from MINION_TASK_METADATA/taskName/tableNameWthType
+   * Fetches the ZNRecord for the given minion task and tableName. Fetch from the old path
+   * MINION_TASK_METADATA/${taskType}/${tableNameWthType} if it exists; otherwise, fetch from the new path
+   * MINION_TASK_METADATA/${tableNameWthType}/{taskType}.
    */
   @Nullable
   public static ZNRecord fetchTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore, String taskType,
       String tableNameWithType) {
-    String path = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(taskType, tableNameWithType);
+    String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataOldFormat(
+        taskType, tableNameWithType);
+    if (propertyStore.exists(oldPath, AccessOption.PERSISTENT)) {
+      return fetchTaskMetadata(propertyStore, oldPath);
+    } else {
+      return fetchTaskMetadata(propertyStore,
+          ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(taskType, tableNameWithType));
+    }
+  }
+
+  @Nullable
+  private static ZNRecord fetchTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore, String path) {
     Stat stat = new Stat();
     ZNRecord znRecord = propertyStore.get(path, stat, AccessOption.PERSISTENT);
     if (znRecord != null) {
@@ -51,27 +64,46 @@ public final class MinionTaskMetadataUtils {
   }
 
   /**
-   * Deletes the ZNRecord for the given minion task and tableName, from MINION_TASK_METADATA/taskName/tableNameWthType
+   * Deletes the ZNRecord for the given minion task and tableName, from both the new path
+   * MINION_TASK_METADATA/${tableNameWthType}/${taskType} and the old path
+   * MINION_TASK_METADATA/${taskType}/${tableNameWthType}.
    */
   public static void deleteTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore, String taskType,
       String tableNameWithType) {
-    String path = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(taskType, tableNameWithType);
-    if (!propertyStore.remove(path, AccessOption.PERSISTENT)) {
+    String newPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(
+        taskType, tableNameWithType);
+    String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataOldFormat(
+        taskType, tableNameWithType);
+    if (!propertyStore.remove(newPath, AccessOption.PERSISTENT)
+        || !propertyStore.remove(oldPath, AccessOption.PERSISTENT)) {
       throw new ZkException("Failed to delete task metadata: " + taskType + ", " + tableNameWithType);
     }
   }
 
   /**
-   * Generic method for persisting {@link BaseTaskMetadata} to MINION_TASK_METADATA. The metadata will be saved in the
-   * ZNode under the path: /MINION_TASK_METADATA/${taskType}/${tableNameWithType}
+   * Generic method for persisting {@link BaseTaskMetadata} to MINION_TASK_METADATA. The metadata will
+   * be saved in the ZNode under the old path /MINION_TASK_METADATA/${taskType}/${tableNameWithType} if
+   * the old path already exists; otherwise, it will be saved in the ZNode under the new path
+   * /MINION_TASK_METADATA/${tableNameWithType}/${taskType}.
    *
    * Will fail if expectedVersion does not match.
    * Set expectedVersion -1 to override version check.
    */
   public static void persistTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore, String taskType,
       BaseTaskMetadata taskMetadata, int expectedVersion) {
-    String path = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(taskType,
-        taskMetadata.getTableNameWithType());
+    String oldPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataOldFormat(
+        taskType, taskMetadata.getTableNameWithType());
+    if (propertyStore.exists(oldPath, AccessOption.PERSISTENT)) {
+      persistTaskMetadata(oldPath, propertyStore, taskType, taskMetadata, expectedVersion);
+    } else {
+      String newPath = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(
+          taskType, taskMetadata.getTableNameWithType());
+      persistTaskMetadata(newPath, propertyStore, taskType, taskMetadata, expectedVersion);
+    }
+  }
+
+  private static void persistTaskMetadata(String path, HelixPropertyStore<ZNRecord> propertyStore,
+      String taskType, BaseTaskMetadata taskMetadata, int expectedVersion) {
     if (!propertyStore
         .set(path, taskMetadata.toZNRecord(), expectedVersion, AccessOption.PERSISTENT)) {
       throw new ZkException(

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/RealtimeToOfflineSegmentsTaskMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/RealtimeToOfflineSegmentsTaskMetadata.java
@@ -26,7 +26,7 @@ import org.apache.helix.ZNRecord;
  * The <code>watermarkMs</code> denotes the time (exclusive) upto which tasks have been executed.
  *
  * This gets serialized and stored in zookeeper under the path
- * MINION_TASK_METADATA/tableNameWithType/RealtimeToOfflineSegmentsTask
+ * MINION_TASK_METADATA/${tableNameWithType}/RealtimeToOfflineSegmentsTask
  *
  * PinotTaskGenerator:
  * The <code>watermarkMs</code>> is used by the <code>RealtimeToOfflineSegmentsTaskGenerator</code>,

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/RealtimeToOfflineSegmentsTaskMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/RealtimeToOfflineSegmentsTaskMetadata.java
@@ -26,7 +26,7 @@ import org.apache.helix.ZNRecord;
  * The <code>watermarkMs</code> denotes the time (exclusive) upto which tasks have been executed.
  *
  * This gets serialized and stored in zookeeper under the path
- * MINION_TASK_METADATA/RealtimeToOfflineSegmentsTask/tableNameWithType
+ * MINION_TASK_METADATA/tableNameWithType/RealtimeToOfflineSegmentsTask
  *
  * PinotTaskGenerator:
  * The <code>watermarkMs</code>> is used by the <code>RealtimeToOfflineSegmentsTaskGenerator</code>,

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/FakePropertyStore.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/FakePropertyStore.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.broker.util;
+package org.apache.pinot.common.utils.helix;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -38,6 +38,11 @@ public class FakePropertyStore extends ZkHelixPropertyStore<ZNRecord> {
   @Override
   public ZNRecord get(String path, Stat stat, int options) {
     return _contents.get(path);
+  }
+
+  @Override
+  public boolean exists(String path, int options) {
+    return _contents.containsKey(path);
   }
 
   @Override
@@ -63,6 +68,12 @@ public class FakePropertyStore extends ZkHelixPropertyStore<ZNRecord> {
     } catch (Exception e) {
       return false;
     }
+  }
+
+  @Override
+  public boolean remove(String path, int options) {
+    _contents.remove(path);
+    return true;
   }
 
   public void setContents(String path, ZNRecord contents)

--- a/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
@@ -22,50 +22,165 @@ import org.I0Itec.zkclient.exception.ZkException;
 import org.apache.helix.AccessOption;
 import org.apache.helix.ZNRecord;
 import org.apache.helix.store.HelixPropertyStore;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.utils.helix.FakePropertyStore;
+import org.apache.zookeeper.data.Stat;
+import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.fail;
+import static org.testng.Assert.*;
 
 
 /**
  * Tests for {@link MinionTaskMetadataUtils}
  */
 public class MinionTaskMetadataUtilsTest {
+  private static final String TABLE_NAME_WITH_TYPE = "TestTable_OFFLINE";
+  private static final String TASK_TYPE = "TestTaskType";
+  private static final String NEW_MINION_METADATA_PATH =
+      ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataNewFormat(TASK_TYPE, TABLE_NAME_WITH_TYPE);
+  private static final String OLD_MINION_METADATA_PATH =
+      ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(TASK_TYPE, TABLE_NAME_WITH_TYPE);
+  private static final DummyTaskMetadata NEW_TASK_METADATA = new DummyTaskMetadata(TABLE_NAME_WITH_TYPE, 1000);
+  private static final DummyTaskMetadata OLD_TASK_METADATA = new DummyTaskMetadata(TABLE_NAME_WITH_TYPE, 100);
+  private static final int EXPECTED_VERSION = -1;
+  private static final int ACCESS_OPTION = AccessOption.PERSISTENT;
+
+  @Test
+  public void testFetchTaskMetadata() {
+    // no metadata path exists
+    HelixPropertyStore<ZNRecord> propertyStore = new FakePropertyStore();
+    assertNull(MinionTaskMetadataUtils.fetchTaskMetadata(propertyStore, TASK_TYPE, TABLE_NAME_WITH_TYPE));
+
+    // only the old metadata path exists
+    propertyStore = new FakePropertyStore();
+    propertyStore.set(OLD_MINION_METADATA_PATH, OLD_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
+    assertEquals(MinionTaskMetadataUtils.fetchTaskMetadata(propertyStore, TASK_TYPE, TABLE_NAME_WITH_TYPE),
+        OLD_TASK_METADATA.toZNRecord());
+
+    // only the new metadata path exists
+    propertyStore = new FakePropertyStore();
+    propertyStore.set(NEW_MINION_METADATA_PATH, NEW_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
+    assertEquals(MinionTaskMetadataUtils.fetchTaskMetadata(propertyStore, TASK_TYPE, TABLE_NAME_WITH_TYPE),
+        NEW_TASK_METADATA.toZNRecord());
+
+    // if two metadata paths exist at the same time, the old one will be used.
+    propertyStore = new FakePropertyStore();
+    propertyStore.set(OLD_MINION_METADATA_PATH, OLD_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
+    propertyStore.set(NEW_MINION_METADATA_PATH, NEW_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
+    assertEquals(MinionTaskMetadataUtils.fetchTaskMetadata(propertyStore, TASK_TYPE, TABLE_NAME_WITH_TYPE),
+        OLD_TASK_METADATA.toZNRecord());
+  }
+
+  @Test
+  public void testDeleteTaskMetadata() {
+    // no error
+    HelixPropertyStore<ZNRecord> propertyStore = new FakePropertyStore();
+    MinionTaskMetadataUtils.deleteTaskMetadata(propertyStore, TASK_TYPE, TABLE_NAME_WITH_TYPE);
+
+    // both metadata paths will be removed
+    propertyStore = new FakePropertyStore();
+    propertyStore.set(OLD_MINION_METADATA_PATH, OLD_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
+    propertyStore.set(NEW_MINION_METADATA_PATH, NEW_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
+    assertTrue(propertyStore.exists(OLD_MINION_METADATA_PATH, ACCESS_OPTION));
+    assertTrue(propertyStore.exists(NEW_MINION_METADATA_PATH, ACCESS_OPTION));
+    MinionTaskMetadataUtils.deleteTaskMetadata(propertyStore, TASK_TYPE, TABLE_NAME_WITH_TYPE);
+    assertFalse(propertyStore.exists(OLD_MINION_METADATA_PATH, ACCESS_OPTION));
+    assertFalse(propertyStore.exists(NEW_MINION_METADATA_PATH, ACCESS_OPTION));
+  }
+
+  @Test
+  public void testDeleteTaskMetadataWithException() {
+    // Test happy path. No exceptions thrown.
+    HelixPropertyStore<ZNRecord> mockPropertyStore = Mockito.mock(HelixPropertyStore.class);
+    when(mockPropertyStore.remove(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(true);
+    MinionTaskMetadataUtils.deleteTaskMetadata(mockPropertyStore, TASK_TYPE, TABLE_NAME_WITH_TYPE);
+
+    // Test exception thrown
+    when(mockPropertyStore.remove(ArgumentMatchers.anyString(), ArgumentMatchers.anyInt())).thenReturn(false);
+    try {
+      MinionTaskMetadataUtils.deleteTaskMetadata(mockPropertyStore, TASK_TYPE, TABLE_NAME_WITH_TYPE);
+      fail("ZkException should have been thrown");
+    } catch (ZkException e) {
+      assertEquals(e.getMessage(), "Failed to delete task metadata: TestTaskType, TestTable_OFFLINE");
+    }
+  }
 
   @Test
   public void testPersistTaskMetadata() {
-    DummyTaskMetadata taskMetadata = new DummyTaskMetadata("TestTable_OFFLINE", 1000);
+    DummyTaskMetadata taskMetadata = new DummyTaskMetadata(TABLE_NAME_WITH_TYPE, 2000);
+
+    // the metadata will be written to the new path
+    HelixPropertyStore<ZNRecord> propertyStore = new FakePropertyStore();
+    MinionTaskMetadataUtils.persistTaskMetadata(propertyStore, TASK_TYPE, taskMetadata, EXPECTED_VERSION);
+    assertTrue(propertyStore.exists(NEW_MINION_METADATA_PATH, ACCESS_OPTION));
+    assertFalse(propertyStore.exists(OLD_MINION_METADATA_PATH, ACCESS_OPTION));
+    assertEquals(MinionTaskMetadataUtils.fetchTaskMetadata(propertyStore, TASK_TYPE, TABLE_NAME_WITH_TYPE),
+        taskMetadata.toZNRecord());
+
+    // the metadata will be written to the old path if only the old path exists
+    propertyStore = new FakePropertyStore();
+    propertyStore.set(OLD_MINION_METADATA_PATH, OLD_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
+    MinionTaskMetadataUtils.persistTaskMetadata(propertyStore, TASK_TYPE, taskMetadata, EXPECTED_VERSION);
+    assertFalse(propertyStore.exists(NEW_MINION_METADATA_PATH, ACCESS_OPTION));
+    assertTrue(propertyStore.exists(OLD_MINION_METADATA_PATH, ACCESS_OPTION));
+    assertEquals(MinionTaskMetadataUtils.fetchTaskMetadata(propertyStore, TASK_TYPE, TABLE_NAME_WITH_TYPE),
+        taskMetadata.toZNRecord());
+
+    // the metadata will be written to the new path if only the new path exists
+    propertyStore = new FakePropertyStore();
+    propertyStore.set(NEW_MINION_METADATA_PATH, NEW_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
+    MinionTaskMetadataUtils.persistTaskMetadata(propertyStore, TASK_TYPE, taskMetadata, EXPECTED_VERSION);
+    assertTrue(propertyStore.exists(NEW_MINION_METADATA_PATH, ACCESS_OPTION));
+    assertFalse(propertyStore.exists(OLD_MINION_METADATA_PATH, ACCESS_OPTION));
+    assertEquals(MinionTaskMetadataUtils.fetchTaskMetadata(propertyStore, TASK_TYPE, TABLE_NAME_WITH_TYPE),
+        taskMetadata.toZNRecord());
+
+    // the metadata will be written to old new path if both paths exist
+    propertyStore = new FakePropertyStore();
+    propertyStore.set(OLD_MINION_METADATA_PATH, OLD_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
+    propertyStore.set(NEW_MINION_METADATA_PATH, NEW_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
+    MinionTaskMetadataUtils.persistTaskMetadata(propertyStore, TASK_TYPE, taskMetadata, EXPECTED_VERSION);
+    assertTrue(propertyStore.exists(NEW_MINION_METADATA_PATH, ACCESS_OPTION));
+    assertTrue(propertyStore.exists(OLD_MINION_METADATA_PATH, ACCESS_OPTION));
+    assertEquals(propertyStore.get(OLD_MINION_METADATA_PATH, new Stat(), ACCESS_OPTION), taskMetadata.toZNRecord());
+    assertEquals(MinionTaskMetadataUtils.fetchTaskMetadata(propertyStore, TASK_TYPE, TABLE_NAME_WITH_TYPE),
+        taskMetadata.toZNRecord());
+  }
+
+
+  @Test
+  public void testPersistTaskMetadataWithException() {
+    DummyTaskMetadata taskMetadata = new DummyTaskMetadata(TABLE_NAME_WITH_TYPE, 1000);
     HelixPropertyStore<ZNRecord> mockPropertyStore = Mockito.mock(HelixPropertyStore.class);
-    String expectedPath = "/MINION_TASK_METADATA/TestTable_OFFLINE/TestTaskType";
-    int expectedVersion = -1;
+    String expectedPath = NEW_MINION_METADATA_PATH;
 
     // Test happy path. No exceptions thrown.
-    when(mockPropertyStore.set(expectedPath, taskMetadata.toZNRecord(), expectedVersion,
-        AccessOption.PERSISTENT)).thenReturn(true);
-    MinionTaskMetadataUtils.persistTaskMetadata(mockPropertyStore, "TestTaskType", taskMetadata, expectedVersion);
-    verify(mockPropertyStore, times(1)).set(expectedPath, taskMetadata.toZNRecord(), expectedVersion,
-        AccessOption.PERSISTENT);
+    when(mockPropertyStore.set(expectedPath, taskMetadata.toZNRecord(), EXPECTED_VERSION,
+        ACCESS_OPTION)).thenReturn(true);
+    MinionTaskMetadataUtils.persistTaskMetadata(mockPropertyStore, TASK_TYPE, taskMetadata, EXPECTED_VERSION);
+    verify(mockPropertyStore, times(1)).set(expectedPath, taskMetadata.toZNRecord(), EXPECTED_VERSION,
+        ACCESS_OPTION);
 
     // Test exception thrown
-    when(mockPropertyStore.set(expectedPath, taskMetadata.toZNRecord(), -1, AccessOption.PERSISTENT))
+    when(mockPropertyStore.set(expectedPath, taskMetadata.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION))
         .thenReturn(false);
     try {
-      MinionTaskMetadataUtils.persistTaskMetadata(mockPropertyStore, "TestTaskType", taskMetadata, expectedVersion);
+      MinionTaskMetadataUtils.persistTaskMetadata(mockPropertyStore, TASK_TYPE, taskMetadata, EXPECTED_VERSION);
       fail("ZkException should have been thrown");
     } catch (ZkException e) {
-      verify(mockPropertyStore, times(2)).set(expectedPath, taskMetadata.toZNRecord(), expectedVersion,
-          AccessOption.PERSISTENT);
+      verify(mockPropertyStore, times(2)).set(expectedPath, taskMetadata.toZNRecord(), EXPECTED_VERSION,
+          ACCESS_OPTION);
       assertEquals(e.getMessage(), "Failed to persist minion metadata for task: TestTaskType and metadata:"
           + " {\"tableNameWithType\":\"TestTable_OFFLINE\"}");
     }
   }
 
-  public class DummyTaskMetadata extends BaseTaskMetadata {
+  public static class DummyTaskMetadata extends BaseTaskMetadata {
 
     private final String _tableNameWithType;
     private final long _metadataVal;

--- a/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
@@ -41,7 +41,7 @@ public class MinionTaskMetadataUtilsTest {
   public void testPersistTaskMetadata() {
     DummyTaskMetadata taskMetadata = new DummyTaskMetadata("TestTable_OFFLINE", 1000);
     HelixPropertyStore<ZNRecord> mockPropertyStore = Mockito.mock(HelixPropertyStore.class);
-    String expectedPath = "/MINION_TASK_METADATA/TestTaskType/TestTable_OFFLINE";
+    String expectedPath = "/MINION_TASK_METADATA/TestTable_OFFLINE/TestTaskType";
     int expectedVersion = -1;
 
     // Test happy path. No exceptions thrown.

--- a/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
@@ -152,7 +152,6 @@ public class MinionTaskMetadataUtilsTest {
         taskMetadata.toZNRecord());
   }
 
-
   @Test
   public void testPersistTaskMetadataWithException() {
     DummyTaskMetadata taskMetadata = new DummyTaskMetadata(TABLE_NAME_WITH_TYPE, 1000);
@@ -160,21 +159,19 @@ public class MinionTaskMetadataUtilsTest {
     String expectedPath = NEW_MINION_METADATA_PATH;
 
     // Test happy path. No exceptions thrown.
-    when(mockPropertyStore.set(expectedPath, taskMetadata.toZNRecord(), EXPECTED_VERSION,
-        ACCESS_OPTION)).thenReturn(true);
+    when(mockPropertyStore.set(expectedPath, taskMetadata.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION)).thenReturn(
+        true);
     MinionTaskMetadataUtils.persistTaskMetadata(mockPropertyStore, TASK_TYPE, taskMetadata, EXPECTED_VERSION);
-    verify(mockPropertyStore, times(1)).set(expectedPath, taskMetadata.toZNRecord(), EXPECTED_VERSION,
-        ACCESS_OPTION);
+    verify(mockPropertyStore, times(1)).set(expectedPath, taskMetadata.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
 
     // Test exception thrown
-    when(mockPropertyStore.set(expectedPath, taskMetadata.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION))
-        .thenReturn(false);
+    when(mockPropertyStore.set(expectedPath, taskMetadata.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION)).thenReturn(
+        false);
     try {
       MinionTaskMetadataUtils.persistTaskMetadata(mockPropertyStore, TASK_TYPE, taskMetadata, EXPECTED_VERSION);
       fail("ZkException should have been thrown");
     } catch (ZkException e) {
-      verify(mockPropertyStore, times(2)).set(expectedPath, taskMetadata.toZNRecord(), EXPECTED_VERSION,
-          ACCESS_OPTION);
+      verify(mockPropertyStore, times(2)).set(expectedPath, taskMetadata.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
       assertEquals(e.getMessage(), "Failed to persist minion metadata for task: TestTaskType and metadata:"
           + " {\"tableNameWithType\":\"TestTable_OFFLINE\"}");
     }

--- a/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
@@ -42,7 +42,7 @@ public class MinionTaskMetadataUtilsTest {
   private static final String TABLE_NAME_WITH_TYPE = "TestTable_OFFLINE";
   private static final String TASK_TYPE = "TestTaskType";
   private static final String NEW_MINION_METADATA_PATH =
-      ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(TASK_TYPE, TABLE_NAME_WITH_TYPE);
+      ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(TABLE_NAME_WITH_TYPE, TASK_TYPE);
   private static final String OLD_MINION_METADATA_PATH =
       ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataDeprecated(TASK_TYPE, TABLE_NAME_WITH_TYPE);
   private static final DummyTaskMetadata NEW_TASK_METADATA = new DummyTaskMetadata(TABLE_NAME_WITH_TYPE, 1000);

--- a/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
@@ -68,12 +68,12 @@ public class MinionTaskMetadataUtilsTest {
     assertEquals(MinionTaskMetadataUtils.fetchTaskMetadata(propertyStore, TASK_TYPE, TABLE_NAME_WITH_TYPE),
         NEW_TASK_METADATA.toZNRecord());
 
-    // if two metadata paths exist at the same time, the old one will be used.
+    // if two metadata paths exist at the same time, the new one will be used.
     propertyStore = new FakePropertyStore();
     propertyStore.set(OLD_MINION_METADATA_PATH, OLD_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
     propertyStore.set(NEW_MINION_METADATA_PATH, NEW_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
     assertEquals(MinionTaskMetadataUtils.fetchTaskMetadata(propertyStore, TASK_TYPE, TABLE_NAME_WITH_TYPE),
-        OLD_TASK_METADATA.toZNRecord());
+        NEW_TASK_METADATA.toZNRecord());
   }
 
   @Test
@@ -140,14 +140,14 @@ public class MinionTaskMetadataUtilsTest {
     assertEquals(MinionTaskMetadataUtils.fetchTaskMetadata(propertyStore, TASK_TYPE, TABLE_NAME_WITH_TYPE),
         taskMetadata.toZNRecord());
 
-    // the metadata will be written to old new path if both paths exist
+    // the metadata will be written to the new path if both paths exist
     propertyStore = new FakePropertyStore();
     propertyStore.set(OLD_MINION_METADATA_PATH, OLD_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
     propertyStore.set(NEW_MINION_METADATA_PATH, NEW_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
     MinionTaskMetadataUtils.persistTaskMetadata(propertyStore, TASK_TYPE, taskMetadata, EXPECTED_VERSION);
     assertTrue(propertyStore.exists(NEW_MINION_METADATA_PATH, ACCESS_OPTION));
     assertTrue(propertyStore.exists(OLD_MINION_METADATA_PATH, ACCESS_OPTION));
-    assertEquals(propertyStore.get(OLD_MINION_METADATA_PATH, new Stat(), ACCESS_OPTION), taskMetadata.toZNRecord());
+    assertEquals(propertyStore.get(NEW_MINION_METADATA_PATH, new Stat(), ACCESS_OPTION), taskMetadata.toZNRecord());
     assertEquals(MinionTaskMetadataUtils.fetchTaskMetadata(propertyStore, TASK_TYPE, TABLE_NAME_WITH_TYPE),
         taskMetadata.toZNRecord());
   }

--- a/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
@@ -42,9 +42,9 @@ public class MinionTaskMetadataUtilsTest {
   private static final String TABLE_NAME_WITH_TYPE = "TestTable_OFFLINE";
   private static final String TASK_TYPE = "TestTaskType";
   private static final String NEW_MINION_METADATA_PATH =
-      ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataNewFormat(TASK_TYPE, TABLE_NAME_WITH_TYPE);
-  private static final String OLD_MINION_METADATA_PATH =
       ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(TASK_TYPE, TABLE_NAME_WITH_TYPE);
+  private static final String OLD_MINION_METADATA_PATH =
+      ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataDeprecated(TASK_TYPE, TABLE_NAME_WITH_TYPE);
   private static final DummyTaskMetadata NEW_TASK_METADATA = new DummyTaskMetadata(TABLE_NAME_WITH_TYPE, 1000);
   private static final DummyTaskMetadata OLD_TASK_METADATA = new DummyTaskMetadata(TABLE_NAME_WITH_TYPE, 100);
   private static final int EXPECTED_VERSION = -1;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
@@ -95,7 +95,8 @@ public class ClusterInfoAccessor {
   }
 
   /**
-   * Fetches the ZNRecord under MINION_TASK_METADATA/${taskType} for the given taskType and tableNameWithType
+   * Fetches the ZNRecord under MINION_TASK_METADATA/${tableNameWithType}/${taskType} for the given
+   * taskType and tableNameWithType
    *
    * @param taskType The type of the minion task
    * @param tableNameWithType Table name with type

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/executor/MinionTaskZkMetadataManager.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/executor/MinionTaskZkMetadataManager.java
@@ -37,7 +37,8 @@ public class MinionTaskZkMetadataManager {
   }
 
   /**
-   * Fetch the ZNRecord under MINION_TASK_METADATA/RealtimeToOfflineSegmentsTask for the given tableNameWithType
+   * Fetch the ZNRecord under MINION_TASK_METADATA/${tableNameWithType}/RealtimeToOfflineSegmentsTask for
+   * the given tableNameWithType
    */
   public ZNRecord getRealtimeToOfflineSegmentsTaskZNRecord(String tableNameWithType) {
     return MinionTaskMetadataUtils
@@ -47,7 +48,7 @@ public class MinionTaskZkMetadataManager {
 
   /**
    * Sets the {@link RealtimeToOfflineSegmentsTaskMetadata} into the ZNode at
-   * MINION_TASK_METADATA/RealtimeToOfflineSegmentsTask
+   * MINION_TASK_METADATA/${tableNameWithType}/RealtimeToOfflineSegmentsTask
    * for the corresponding tableNameWithType
    * @param expectedVersion Version expected to be updating, failing the call if there's a mismatch
    */

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
@@ -77,7 +77,7 @@ import org.slf4j.LoggerFactory;
  *    - Repeat until k time buckets get created or we loop through all the candidate segments:
  *      - Calculate merge/roll-up bucket:
  *        - Read watermarkMs from the {@link MergeRollupTaskMetadata} ZNode found at
- *          {@code MINION_TASK_METADATA/MergeRollupTask/<tableNameWithType>}
+ *          {@code MINION_TASK_METADATA/<tableNameWithType>/MergeRollupTask}
  *          In case of cold-start, no ZNode will exist.
  *          A new ZNode will be created, with watermarkMs as the smallest time found in all segments truncated to the
  *          closest bucket start time.

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
@@ -77,7 +77,7 @@ import org.slf4j.LoggerFactory;
  *    - Repeat until k time buckets get created or we loop through all the candidate segments:
  *      - Calculate merge/roll-up bucket:
  *        - Read watermarkMs from the {@link MergeRollupTaskMetadata} ZNode found at
- *          {@code MINION_TASK_METADATA/<tableNameWithType>/MergeRollupTask}
+ *          MINION_TASK_METADATA/${tableNameWithType}/MergeRollupTask
  *          In case of cold-start, no ZNode will exist.
  *          A new ZNode will be created, with watermarkMs as the smallest time found in all segments truncated to the
  *          closest bucket start time.

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
  * 5. Sort records if sorting is enabled in the table config
  *
  * Before beginning the task, the <code>watermarkMs</code> is checked in the minion task metadata ZNode,
- * located at MINION_TASK_METADATA/<tableNameWithType>/RealtimeToOfflineSegmentsTask
+ * located at MINION_TASK_METADATA/${tableNameWithType}/RealtimeToOfflineSegmentsTask
  * It should match the <code>windowStartMs</code>.
  * The version of the znode is cached.
  *

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
@@ -59,7 +59,7 @@ import org.slf4j.LoggerFactory;
  * 5. Sort records if sorting is enabled in the table config
  *
  * Before beginning the task, the <code>watermarkMs</code> is checked in the minion task metadata ZNode,
- * located at MINION_TASK_METADATA/RealtimeToOfflineSegmentsTask/<tableNameWithType>
+ * located at MINION_TASK_METADATA/<tableNameWithType>/RealtimeToOfflineSegmentsTask
  * It should match the <code>windowStartMs</code>.
  * The version of the znode is cached.
  *

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
@@ -57,7 +57,7 @@ import org.slf4j.LoggerFactory;
  *
  * Steps:
  *  - The watermarkMs is read from the {@link RealtimeToOfflineSegmentsTaskMetadata} ZNode
- *  found at MINION_TASK_METADATA/tableNameWithType/RealtimeToOfflineSegmentsTask
+ *  found at MINION_TASK_METADATA/${tableNameWithType}/RealtimeToOfflineSegmentsTask
  *  In case of cold-start, no ZNode will exist.
  *  A new ZNode will be created, with watermarkMs as the smallest time found in the COMPLETED segments
  *

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
@@ -57,7 +57,7 @@ import org.slf4j.LoggerFactory;
  *
  * Steps:
  *  - The watermarkMs is read from the {@link RealtimeToOfflineSegmentsTaskMetadata} ZNode
- *  found at MINION_TASK_METADATA/RealtimeToOfflineSegmentsTask/tableNameWithType
+ *  found at MINION_TASK_METADATA/tableNameWithType/RealtimeToOfflineSegmentsTask
  *  In case of cold-start, no ZNode will exist.
  *  A new ZNode will be created, with watermarkMs as the smallest time found in the COMPLETED segments
  *


### PR DESCRIPTION
## What does this PR do?

This PR updates minion task metadata ZNode path from `/MINION_TASK_METADATA/${taskType}/${tableNameWithType}` to `/MINION_TASK_METADATA/${tableNameWithType}/${taskType}`.

The logic is backward compatible: if there exists minion task metadata in ZNode path `/MINION_TASK_METADATA/${tableNameWithType}/${taskType}`, it keeps using it; otherwise, it uses the new ZNode path.

## How was the code tested?
1. It was tested by unit tests
2. It was tested in a local Pinot cluster: in the case that (1) there exists minion task metadata in ZNode path `/MINION_TASK_METADATA/${taskType}/${tableNameWithType}`, and (2) there does not exists minion task metadata.
