### PR TITLE
Refector DateTime field specs to reduce overhead

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/TimeSegmentPruner.java
@@ -85,7 +85,7 @@ public class TimeSegmentPruner implements SegmentPruner {
     DateTimeFieldSpec dateTimeSpec = schema.getSpecForTimeColumn(_timeColumn);
     Preconditions.checkNotNull(dateTimeSpec, "Field spec must be specified in schema for time column: %s of table: %s",
         _timeColumn, _tableNameWithType);
-    _timeFormatSpec = new DateTimeFormatSpec(dateTimeSpec.getFormat());
+    _timeFormatSpec = dateTimeSpec.getFormatSpec();
   }
 
   @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManager.java
@@ -78,7 +78,7 @@ public class TimeBoundaryManager {
     DateTimeFieldSpec dateTimeSpec = schema.getSpecForTimeColumn(_timeColumn);
     Preconditions.checkNotNull(dateTimeSpec, "Field spec must be specified in schema for time column: %s of table: %s",
         _timeColumn, _offlineTableName);
-    _timeFormatSpec = new DateTimeFormatSpec(dateTimeSpec.getFormat());
+    _timeFormatSpec = dateTimeSpec.getFormatSpec();
     Preconditions.checkNotNull(_timeFormatSpec.getColumnUnit(),
         "Time unit must be configured in the field spec for time column: %s of table: %s", _timeColumn,
         _offlineTableName);
@@ -91,7 +91,7 @@ public class TimeBoundaryManager {
     _timeOffsetMs = isHourlyTable ? TimeUnit.HOURS.toMillis(1) : TimeUnit.DAYS.toMillis(1);
 
     LOGGER.info("Constructed TimeBoundaryManager with timeColumn: {}, timeFormat: {}, isHourlyTable: {} for table: {}",
-        _timeColumn, _timeFormatSpec.getFormat(), isHourlyTable, _offlineTableName);
+        _timeColumn, dateTimeSpec.getFormat(), isHourlyTable, _offlineTableName);
   }
 
   /**

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
@@ -35,9 +35,6 @@ import org.apache.pinot.controller.utils.SegmentMetadataMockUtils;
 import org.apache.pinot.core.routing.RoutingTable;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.data.DateTimeFieldSpec;
-import org.apache.pinot.spi.data.DateTimeFormatSpec;
-import org.apache.pinot.spi.data.DateTimeGranularitySpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -90,9 +87,7 @@ public class HelixBrokerStarterTest extends ControllerTest {
     addFakeServerInstancesToAutoJoinHelixCluster(NUM_SERVERS, true);
 
     Schema schema = new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME)
-        .addDateTime(TIME_COLUMN_NAME, FieldSpec.DataType.INT, new DateTimeFormatSpec(1, TimeUnit.DAYS.toString(),
-                DateTimeFieldSpec.TimeFormat.EPOCH.toString()).getFormat(),
-            new DateTimeGranularitySpec(1, TimeUnit.DAYS).getGranularity()).build();
+        .addDateTime(TIME_COLUMN_NAME, FieldSpec.DataType.INT, "EPOCH|DAYS", "1:DAYS").build();
     _helixResourceManager.addSchema(schema, true);
     TableConfig offlineTableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setTimeColumnName(TIME_COLUMN_NAME)

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/SegmentPrunerTest.java
@@ -543,8 +543,7 @@ public class SegmentPrunerTest extends ControllerTest {
 
     TimeSegmentPruner segmentPruner = new TimeSegmentPruner(tableConfig, _propertyStore);
     Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, RAW_TABLE_NAME);
-    DateTimeFormatSpec dateTimeFormatSpec =
-        new DateTimeFormatSpec(schema.getSpecForTimeColumn(TIME_COLUMN).getFormat());
+    DateTimeFormatSpec dateTimeFormatSpec = schema.getSpecForTimeColumn(TIME_COLUMN).getFormatSpec();
 
     Set<String> onlineSegments = new HashSet<>();
     String segment0 = "segment0";

--- a/pinot-common/src/test/java/org/apache/pinot/common/data/DateTimeFormatSpecTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/DateTimeFormatSpecTest.java
@@ -249,44 +249,45 @@ public class DateTimeFormatSpecTest {
     });
 
     entries.add(new Object[]{
-        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", 1, TimeUnit.DAYS, DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT,
+        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", 1, TimeUnit.MILLISECONDS, DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT,
         "yyyyMMdd", DateTimeZone.UTC
     });
 
     entries.add(new Object[]{
-        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd tz(IST)", 1, TimeUnit.DAYS, DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT,
-        "yyyyMMdd", DateTimeZone.forTimeZone(TimeZone.getTimeZone("IST"))
+        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd tz(IST)", 1, TimeUnit.MILLISECONDS,
+        DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT, "yyyyMMdd", DateTimeZone.forTimeZone(
+        TimeZone.getTimeZone("IST"))
     });
 
     entries.add(new Object[]{
-        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd          tz(IST)", 1, TimeUnit.DAYS,
+        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd          tz(IST)", 1, TimeUnit.MILLISECONDS,
         DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT, "yyyyMMdd",
         DateTimeZone.forTimeZone(TimeZone.getTimeZone("IST"))
     });
 
     entries.add(new Object[]{
-        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd tz  (   IST   )  ", 1, TimeUnit.DAYS,
+        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd tz  (   IST   )  ", 1, TimeUnit.MILLISECONDS,
         DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT, "yyyyMMdd",
         DateTimeZone.forTimeZone(TimeZone.getTimeZone("IST"))
     });
 
     entries.add(new Object[]{
-        "1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMdd HH", 1, TimeUnit.HOURS, DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT,
-        "yyyyMMdd HH", DateTimeZone.UTC
-    });
-
-    entries.add(new Object[]{
-        "1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMdd HH tz(dummy)", 1, TimeUnit.HOURS,
+        "1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMdd HH", 1, TimeUnit.MILLISECONDS,
         DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT, "yyyyMMdd HH", DateTimeZone.UTC
     });
 
     entries.add(new Object[]{
-        "1:HOURS:SIMPLE_DATE_FORMAT:M/d/yyyy h:mm:ss a", 1, TimeUnit.HOURS,
+        "1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMdd HH tz(dummy)", 1, TimeUnit.MILLISECONDS,
+        DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT, "yyyyMMdd HH", DateTimeZone.UTC
+    });
+
+    entries.add(new Object[]{
+        "1:HOURS:SIMPLE_DATE_FORMAT:M/d/yyyy h:mm:ss a", 1, TimeUnit.MILLISECONDS,
         DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT, "M/d/yyyy h:mm:ss a", DateTimeZone.UTC
     });
 
     entries.add(new Object[]{
-        "1:HOURS:SIMPLE_DATE_FORMAT:M/d/yyyy h:mm:ss a tz(Asia/Tokyo)", 1, TimeUnit.HOURS,
+        "1:HOURS:SIMPLE_DATE_FORMAT:M/d/yyyy h:mm:ss a tz(Asia/Tokyo)", 1, TimeUnit.MILLISECONDS,
         DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT, "M/d/yyyy h:mm:ss a",
         DateTimeZone.forTimeZone(TimeZone.getTimeZone("Asia/Tokyo"))
     });
@@ -304,96 +305,46 @@ public class DateTimeFormatSpecTest {
     });
 
     entries.add(new Object[]{
-        "SIMPLE_DATE_FORMAT|yyyyMMdd", 1, TimeUnit.DAYS, DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT,
+        "SIMPLE_DATE_FORMAT|yyyyMMdd", 1, TimeUnit.MILLISECONDS, DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT,
         "yyyyMMdd", DateTimeZone.UTC
     });
 
     entries.add(new Object[]{
-        "SIMPLE_DATE_FORMAT|yyyyMMdd|IST", 1, TimeUnit.DAYS, DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT,
+        "SIMPLE_DATE_FORMAT|yyyyMMdd|IST", 1, TimeUnit.MILLISECONDS, DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT,
         "yyyyMMdd", DateTimeZone.forTimeZone(TimeZone.getTimeZone("IST"))
     });
 
     entries.add(new Object[]{
-        "SIMPLE_DATE_FORMAT|yyyyMMdd|IST", 1, TimeUnit.DAYS,
+        "SIMPLE_DATE_FORMAT|yyyyMMdd|IST", 1, TimeUnit.MILLISECONDS,
         DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT, "yyyyMMdd",
         DateTimeZone.forTimeZone(TimeZone.getTimeZone("IST"))
     });
 
     entries.add(new Object[]{
-        "SIMPLE_DATE_FORMAT|yyyyMMdd|IST", 1, TimeUnit.DAYS,
+        "SIMPLE_DATE_FORMAT|yyyyMMdd|IST", 1, TimeUnit.MILLISECONDS,
         DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT, "yyyyMMdd",
         DateTimeZone.forTimeZone(TimeZone.getTimeZone("IST"))
     });
 
     entries.add(new Object[]{
-        "SIMPLE_DATE_FORMAT|yyyyMMdd HH", 1, TimeUnit.DAYS, DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT,
+        "SIMPLE_DATE_FORMAT|yyyyMMdd HH", 1, TimeUnit.MILLISECONDS, DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT,
         "yyyyMMdd HH", DateTimeZone.UTC
     });
 
     entries.add(new Object[]{
-        "SIMPLE_DATE_FORMAT|yyyyMMdd HH|dummy", 1, TimeUnit.DAYS,
+        "SIMPLE_DATE_FORMAT|yyyyMMdd HH|dummy", 1, TimeUnit.MILLISECONDS,
         DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT, "yyyyMMdd HH", DateTimeZone.UTC
     });
 
     entries.add(new Object[]{
-        "SIMPLE_DATE_FORMAT|M/d/yyyy h:mm:ss a", 1, TimeUnit.DAYS,
+        "SIMPLE_DATE_FORMAT|M/d/yyyy h:mm:ss a", 1, TimeUnit.MILLISECONDS,
         DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT, "M/d/yyyy h:mm:ss a", DateTimeZone.UTC
     });
 
     entries.add(new Object[]{
-        "SIMPLE_DATE_FORMAT|M/d/yyyy h:mm:ss a|Asia/Tokyo", 1, TimeUnit.DAYS,
+        "SIMPLE_DATE_FORMAT|M/d/yyyy h:mm:ss a|Asia/Tokyo", 1, TimeUnit.MILLISECONDS,
         DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT, "M/d/yyyy h:mm:ss a",
         DateTimeZone.forTimeZone(TimeZone.getTimeZone("Asia/Tokyo"))
-    });
-    return entries.toArray(new Object[entries.size()][]);
-  }
-
-  // Test construct format given its components
-  @Test(dataProvider = "testConstructFormatDataProvider")
-  public void testConstructFormat(int columnSize, TimeUnit columnUnit, String columnTimeFormat, String pattern,
-      DateTimeFormatSpec formatExpected1, DateTimeFormatSpec formatExpected2) {
-    DateTimeFormatSpec formatActual1 = null;
-    try {
-      formatActual1 = new DateTimeFormatSpec(columnSize, columnUnit.toString(), columnTimeFormat);
-    } catch (Exception e) {
-      // invalid arguments
-    }
-    Assert.assertEquals(formatActual1, formatExpected1);
-
-    DateTimeFormatSpec formatActual2 = null;
-    try {
-      formatActual2 = new DateTimeFormatSpec(columnSize, columnUnit.toString(), columnTimeFormat, pattern);
-    } catch (Exception e) {
-      // invalid arguments
-    }
-    Assert.assertEquals(formatActual2, formatExpected2);
-  }
-
-  @DataProvider(name = "testConstructFormatDataProvider")
-  public Object[][] provideTestConstructFormatData() {
-
-    List<Object[]> entries = new ArrayList<>();
-
-    entries.add(new Object[]{1, TimeUnit.HOURS, "EPOCH", null, new DateTimeFormatSpec("1:HOURS:EPOCH"), null});
-    entries.add(new Object[]{1, TimeUnit.HOURS, "EPOCH", "yyyyMMdd", new DateTimeFormatSpec("1:HOURS:EPOCH"), null});
-    entries.add(new Object[]{5, TimeUnit.MINUTES, "EPOCH", null, new DateTimeFormatSpec("5:MINUTES:EPOCH"), null});
-    entries.add(new Object[]{0, TimeUnit.HOURS, "EPOCH", null, null, null});
-    entries.add(new Object[]{1, null, "EPOCH", null, null, null});
-    entries.add(new Object[]{1, TimeUnit.HOURS, null, null, null, null});
-    entries.add(new Object[]{1, TimeUnit.HOURS, "DUMMY", "yyyyMMdd", null, null});
-    entries.add(new Object[]{
-        1, TimeUnit.HOURS, "SIMPLE_DATE_FORMAT", "yyyyMMdd", null,
-        new DateTimeFormatSpec("1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMdd")
-    });
-    entries.add(new Object[]{
-        1, TimeUnit.HOURS, "SIMPLE_DATE_FORMAT", "yyyyMMdd tz(America/Los_Angeles)", null,
-        new DateTimeFormatSpec("1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMdd tz(America/Los_Angeles)")
-    });
-    entries.add(new Object[]{1, TimeUnit.HOURS, "SIMPLE_DATE_FORMAT", null, null, null});
-    entries.add(new Object[]{-1, TimeUnit.HOURS, "SIMPLE_DATE_FORMAT", "yyyyMMDD", null, null});
-    entries.add(new Object[]{
-        1, TimeUnit.HOURS, "SIMPLE_DATE_FORMAT", "M/d/yyyy h:mm:ss a", null,
-        new DateTimeFormatSpec("1:HOURS:SIMPLE_DATE_FORMAT:M/d/yyyy h:mm:ss a")
     });
     return entries.toArray(new Object[entries.size()][]);
   }

--- a/pinot-common/src/test/java/org/apache/pinot/common/data/FieldSpecTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/FieldSpecTest.java
@@ -245,7 +245,7 @@ public class FieldSpecTest {
     boolean exceptionActual = false;
     try {
       dateTimeFieldActual = new DateTimeFieldSpec(name, dataType, format, granularity);
-    } catch (IllegalStateException e) {
+    } catch (IllegalArgumentException e) {
       exceptionActual = true;
     }
     Assert.assertEquals(exceptionActual, exceptionExpected);

--- a/pinot-common/src/test/resources/schemaTest.schema
+++ b/pinot-common/src/test/resources/schemaTest.schema
@@ -93,7 +93,7 @@
       "name": "dateTime3",
       "dataType": "TIMESTAMP",
       "format": "1:MILLISECONDS:TIMESTAMP",
-      "granularity": "1:SECOND"
+      "granularity": "1:SECONDS"
     }
   ],
   "schemaName": "schemaTest"

--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/StreamOp.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/StreamOp.java
@@ -226,8 +226,7 @@ public class StreamOp extends BaseOp {
           .sendGetRequest(ControllerRequestURLBuilder.baseUrl(ClusterDescriptor.getInstance().getControllerUrl())
               .forSchemaGet(schemaName));
       Schema schema = JsonUtils.stringToObject(schemaString, Schema.class);
-      DateTimeFormatSpec dateTimeFormatSpec =
-          new DateTimeFormatSpec(schema.getSpecForTimeColumn(timeColumn).getFormat());
+      DateTimeFormatSpec dateTimeFormatSpec = schema.getSpecForTimeColumn(timeColumn).getFormatSpec();
 
       try (RecordReader csvRecordReader = RecordReaderFactory
           .getRecordReader(FileFormat.CSV, localReplacedCSVFile, columnNames, recordReaderConfig)) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/AutoAddInvertedIndex.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/AutoAddInvertedIndex.java
@@ -41,7 +41,6 @@ import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
-import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -243,7 +242,7 @@ public class AutoAddInvertedIndex {
             tableNameWithType);
         continue;
       }
-      TimeUnit timeUnit = new DateTimeFormatSpec(dateTimeSpec.getFormat()).getColumnUnit();
+      TimeUnit timeUnit = dateTimeSpec.getFormatSpec().getColumnUnit();
       if (timeUnit != TimeUnit.DAYS) {
         LOGGER.warn("Table: {}, time column {] has non-DAYS time unit: {}", timeColumnName, timeUnit);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -47,7 +47,6 @@ import org.apache.pinot.segment.spi.creator.SegmentVersion;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
-import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.metrics.PinotMeter;
@@ -121,7 +120,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
             _tableNameWithType);
     DateTimeFieldSpec dateTimeFieldSpec = schema.getSpecForTimeColumn(_timeColumnName);
     Preconditions.checkNotNull(dateTimeFieldSpec, "Must provide field spec for time column {}", _timeColumnName);
-    _timeType = new DateTimeFormatSpec(dateTimeFieldSpec.getFormat()).getColumnUnit();
+    _timeType = dateTimeFieldSpec.getFormatSpec().getColumnUnit();
 
     List<String> sortedColumns = indexLoadingConfig.getSortedColumns();
     if (sortedColumns.isEmpty()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/timehandler/EpochTimeHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/timehandler/EpochTimeHandler.java
@@ -43,7 +43,7 @@ public class EpochTimeHandler implements TimeHandler {
       long roundBucketMs, long partitionBucketMs) {
     _timeColumn = fieldSpec.getName();
     _dataType = fieldSpec.getDataType();
-    _formatSpec = new DateTimeFormatSpec(fieldSpec.getFormat());
+    _formatSpec = fieldSpec.getFormatSpec();
     _startTimeMs = startTimeMs;
     _endTimeMs = endTimeMs;
     _negateWindowFilter = negateWindowFilter;

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
@@ -47,7 +47,6 @@ import static org.testng.Assert.assertThrows;
  * Tests schema validations
  */
 public class SchemaUtilsTest {
-
   private static final String TABLE_NAME = "testTable";
   private static final String TIME_COLUMN = "timeColumn";
 
@@ -209,21 +208,21 @@ public class SchemaUtilsTest {
   public void testValidateTimeFieldSpec() {
     Schema pinotSchema;
     // time field spec using same name for incoming and outgoing
-    pinotSchema = new Schema.SchemaBuilder()
-        .addTime(new TimeGranularitySpec(DataType.LONG, TimeUnit.MILLISECONDS, "time"),
+    pinotSchema =
+        new Schema.SchemaBuilder().addTime(new TimeGranularitySpec(DataType.LONG, TimeUnit.MILLISECONDS, "time"),
             new TimeGranularitySpec(DataType.INT, TimeUnit.DAYS, "time")).build();
     checkValidationFails(pinotSchema);
 
     // time field spec using SIMPLE_DATE_FORMAT, not allowed when conversion is needed
-    pinotSchema = new Schema.SchemaBuilder()
-        .addTime(new TimeGranularitySpec(DataType.LONG, TimeUnit.MILLISECONDS, "incoming"),
+    pinotSchema =
+        new Schema.SchemaBuilder().addTime(new TimeGranularitySpec(DataType.LONG, TimeUnit.MILLISECONDS, "incoming"),
             new TimeGranularitySpec(DataType.INT, TimeUnit.DAYS,
                 TimeGranularitySpec.TimeFormat.SIMPLE_DATE_FORMAT.toString(), "outgoing")).build();
     checkValidationFails(pinotSchema);
 
     // valid time field spec
-    pinotSchema = new Schema.SchemaBuilder()
-        .addTime(new TimeGranularitySpec(DataType.LONG, TimeUnit.MILLISECONDS, "incoming"),
+    pinotSchema =
+        new Schema.SchemaBuilder().addTime(new TimeGranularitySpec(DataType.LONG, TimeUnit.MILLISECONDS, "incoming"),
             new TimeGranularitySpec(DataType.INT, TimeUnit.DAYS, "outgoing")).build();
     SchemaUtils.validate(pinotSchema);
   }
@@ -232,19 +231,20 @@ public class SchemaUtilsTest {
   public void testValidateDateTimeFieldSpec() {
     Schema pinotSchema;
     // valid date time.
-    pinotSchema = new Schema.SchemaBuilder()
-        .addDateTime("datetime1", FieldSpec.DataType.STRING, "1:DAYS:SIMPLE_DATE_FORMAT:yyyy-MM-dd", "1:DAYS")
+    pinotSchema = new Schema.SchemaBuilder().addDateTime("datetime1", FieldSpec.DataType.STRING,
+            "1:DAYS:SIMPLE_DATE_FORMAT:yyyy-MM-dd", "1:DAYS")
         .addDateTime("datetime2", FieldSpec.DataType.STRING, "1:DAYS:SIMPLE_DATE_FORMAT:yyyy-MM-ww-dd", "1:DAYS")
         .build();
     SchemaUtils.validate(pinotSchema);
 
     // date time field spec using SIMPLE_DATE_FORMAT needs to be valid.
-    assertThrows(IllegalStateException.class, () -> new Schema.SchemaBuilder()
-        .addDateTime("datetime3", FieldSpec.DataType.STRING, "1:DAYS:SIMPLE_DATE_FORMAT:foo_bar", "1:DAYS").build());
+    assertThrows(IllegalArgumentException.class,
+        () -> new Schema.SchemaBuilder().addDateTime("datetime3", FieldSpec.DataType.STRING,
+            "1:DAYS:SIMPLE_DATE_FORMAT:foo_bar", "1:DAYS").build());
 
     // date time field spec using SIMPLE_DATE_FORMAT needs to be lexicographical order.
-    pinotSchema = new Schema.SchemaBuilder()
-        .addDateTime("datetime4", FieldSpec.DataType.STRING, "1:DAYS:SIMPLE_DATE_FORMAT:M/d/yyyy", "1:DAYS").build();
+    pinotSchema = new Schema.SchemaBuilder().addDateTime("datetime4", FieldSpec.DataType.STRING,
+        "1:DAYS:SIMPLE_DATE_FORMAT:M/d/yyyy", "1:DAYS").build();
     checkValidationFails(pinotSchema);
   }
 
@@ -252,17 +252,17 @@ public class SchemaUtilsTest {
   public void testValidatePrimaryKeyColumns() {
     Schema pinotSchema;
     // non-existing column used as primary key
-    pinotSchema = new Schema.SchemaBuilder()
-        .addTime(new TimeGranularitySpec(DataType.LONG, TimeUnit.MILLISECONDS, "incoming"),
-            new TimeGranularitySpec(DataType.INT, TimeUnit.DAYS, "outgoing"))
-        .addSingleValueDimension("col", DataType.INT).setPrimaryKeyColumns(Lists.newArrayList("test")).build();
+    pinotSchema =
+        new Schema.SchemaBuilder().addTime(new TimeGranularitySpec(DataType.LONG, TimeUnit.MILLISECONDS, "incoming"),
+                new TimeGranularitySpec(DataType.INT, TimeUnit.DAYS, "outgoing"))
+            .addSingleValueDimension("col", DataType.INT).setPrimaryKeyColumns(Lists.newArrayList("test")).build();
     checkValidationFails(pinotSchema);
 
     // valid primary key
-    pinotSchema = new Schema.SchemaBuilder()
-        .addTime(new TimeGranularitySpec(DataType.LONG, TimeUnit.MILLISECONDS, "incoming"),
-            new TimeGranularitySpec(DataType.INT, TimeUnit.DAYS, "outgoing"))
-        .addSingleValueDimension("col", DataType.INT).setPrimaryKeyColumns(Lists.newArrayList("col")).build();
+    pinotSchema =
+        new Schema.SchemaBuilder().addTime(new TimeGranularitySpec(DataType.LONG, TimeUnit.MILLISECONDS, "incoming"),
+                new TimeGranularitySpec(DataType.INT, TimeUnit.DAYS, "outgoing"))
+            .addSingleValueDimension("col", DataType.INT).setPrimaryKeyColumns(Lists.newArrayList("col")).build();
     SchemaUtils.validate(pinotSchema);
   }
 
@@ -298,54 +298,53 @@ public class SchemaUtilsTest {
   @Test
   public void testDateTimeFieldSpec()
       throws IOException {
-    Schema pinotSchema;
-    pinotSchema = Schema.fromString(
+    Schema schema = Schema.fromString(
         "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
             + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\",\"format\":\"x:HOURS:EPOCH\","
             + "\"granularity\":\"1:HOURS\"}]}");
-    checkValidationFails(pinotSchema);
+    checkValidationFails(schema);
 
-    pinotSchema = Schema.fromString(
+    schema = Schema.fromString(
         "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
             + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\",\"format\":\"1:DUMMY:EPOCH\","
             + "\"granularity\":\"1:HOURS\"}]}");
-    checkValidationFails(pinotSchema);
+    checkValidationFails(schema);
 
-    pinotSchema = Schema.fromString(
+    schema = Schema.fromString(
         "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
             + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\",\"format\":\"1:HOURS:DUMMY\","
             + "\"granularity\":\"1:HOURS\"}]}");
-    checkValidationFails(pinotSchema);
+    checkValidationFails(schema);
 
-    pinotSchema = Schema.fromString(
+    schema = Schema.fromString(
         "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
             + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\",\"format\":\"1:HOURS:EPOCH\","
             + "\"granularity\":\"x:HOURS\"}]}");
-    checkValidationFails(pinotSchema);
+    checkValidationFails(schema);
 
-    pinotSchema = Schema.fromString(
+    schema = Schema.fromString(
         "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
             + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\",\"format\":\"1:HOURS:EPOCH\","
             + "\"granularity\":\"1:DUMMY\"}]}");
-    checkValidationFails(pinotSchema);
+    checkValidationFails(schema);
 
-    pinotSchema = Schema.fromString(
+    schema = Schema.fromString(
         "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
             + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\","
             + "\"format\":\"1:DAYS:SIMPLE_DATE_FORMAT\",\"granularity\":\"1:DAYS\"}]}");
-    checkValidationFails(pinotSchema);
+    checkValidationFails(schema);
 
-    pinotSchema = Schema.fromString(
+    schema = Schema.fromString(
         "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
             + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\",\"format\":\"1:HOURS:EPOCH\","
             + "\"granularity\":\"1:HOURS\"}]}");
-    SchemaUtils.validate(pinotSchema);
+    SchemaUtils.validate(schema);
 
-    pinotSchema = Schema.fromString(
+    schema = Schema.fromString(
         "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
             + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\","
             + "\"format\":\"1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd\",\"granularity\":\"1:DAYS\"}]}");
-    SchemaUtils.validate(pinotSchema);
+    SchemaUtils.validate(schema);
   }
 
   /**
@@ -394,7 +393,7 @@ public class SchemaUtilsTest {
     try {
       SchemaUtils.validate(pinotSchema);
       Assert.fail("Schema validation should have failed.");
-    } catch (IllegalStateException e) {
+    } catch (IllegalArgumentException | IllegalStateException e) {
       // expected
     }
   }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
@@ -156,7 +156,7 @@ public class SegmentGenerationTaskRunner implements Serializable {
         if (timeColumnName != null) {
           DateTimeFieldSpec dateTimeFieldSpec = schema.getSpecForTimeColumn(timeColumnName);
           if (dateTimeFieldSpec != null) {
-            dateTimeFormatSpec = new DateTimeFormatSpec(dateTimeFieldSpec.getFormat());
+            dateTimeFormatSpec = dateTimeFieldSpec.getFormatSpec();
           }
         }
         return new NormalizedDateSegmentNameGenerator(tableName, segmentNameGeneratorConfigs.get(SEGMENT_NAME_PREFIX),

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/mappers/SegmentCreationMapper.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/mappers/SegmentCreationMapper.java
@@ -158,7 +158,7 @@ public class SegmentCreationMapper extends Mapper<LongWritable, Text, LongWritab
         if (timeColumnName != null) {
           DateTimeFieldSpec dateTimeFieldSpec = _schema.getSpecForTimeColumn(timeColumnName);
           if (dateTimeFieldSpec != null) {
-            dateTimeFormatSpec = new DateTimeFormatSpec(dateTimeFieldSpec.getFormat());
+            dateTimeFormatSpec = dateTimeFieldSpec.getFormatSpec();
           }
         }
         _segmentNameGenerator =

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/preprocess/DataPreprocessingHelper.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-hadoop/src/main/java/org/apache/pinot/hadoop/job/preprocess/DataPreprocessingHelper.java
@@ -201,7 +201,7 @@ public abstract class DataPreprocessingHelper {
       if (timeColumnName != null) {
         DateTimeFieldSpec dateTimeFieldSpec = _pinotTableSchema.getSpecForTimeColumn(timeColumnName);
         if (dateTimeFieldSpec != null) {
-          DateTimeFormatSpec formatSpec = new DateTimeFormatSpec(dateTimeFieldSpec.getFormat());
+          DateTimeFormatSpec formatSpec = dateTimeFieldSpec.getFormatSpec();
           job.getConfiguration().set(InternalConfigConstants.SEGMENT_TIME_TYPE, formatSpec.getColumnUnit().toString());
           job.getConfiguration()
               .set(InternalConfigConstants.SEGMENT_TIME_FORMAT, formatSpec.getTimeFormat().toString());

--- a/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-spark/src/main/java/org/apache/pinot/spark/jobs/SparkSegmentCreationFunction.java
+++ b/pinot-plugins/pinot-batch-ingestion/v0_deprecated/pinot-spark/src/main/java/org/apache/pinot/spark/jobs/SparkSegmentCreationFunction.java
@@ -125,7 +125,7 @@ public class SparkSegmentCreationFunction implements Serializable {
         if (timeColumnName != null) {
           DateTimeFieldSpec dateTimeFieldSpec = _schema.getSpecForTimeColumn(timeColumnName);
           if (dateTimeFieldSpec != null) {
-            dateTimeFormatSpec = new DateTimeFormatSpec(dateTimeFieldSpec.getFormat());
+            dateTimeFormatSpec = dateTimeFieldSpec.getFormatSpec();
           }
         }
         _segmentNameGenerator =
@@ -150,8 +150,8 @@ public class SparkSegmentCreationFunction implements Serializable {
       _logger.warn("Deleting existing file: {}", _localStagingDir);
       FileUtils.forceDelete(_localStagingDir);
     }
-    _logger
-        .info("Making local temporary directories: {}, {}, {}", _localStagingDir, _localInputDir, _localSegmentTarDir);
+    _logger.info("Making local temporary directories: {}, {}, {}", _localStagingDir, _localInputDir,
+        _localSegmentTarDir);
     Preconditions.checkState(_localStagingDir.mkdirs());
     Preconditions.checkState(_localInputDir.mkdir());
     Preconditions.checkState(_localSegmentDir.mkdir());
@@ -250,8 +250,9 @@ public class SparkSegmentCreationFunction implements Serializable {
 
     Path hdfsSegmentTarFile = new Path(_hdfsSegmentTarDir, segmentTarFileName);
     if (_useRelativePath) {
-      Path relativeOutputPath = SegmentCreationJob.getRelativeOutputPath(
-          new Path(_jobConf.get(JobConfigConstants.PATH_TO_INPUT)).toUri(), hdfsInputFile.toUri(), _hdfsSegmentTarDir);
+      Path relativeOutputPath =
+          SegmentCreationJob.getRelativeOutputPath(new Path(_jobConf.get(JobConfigConstants.PATH_TO_INPUT)).toUri(),
+              hdfsInputFile.toUri(), _hdfsSegmentTarDir);
       hdfsSegmentTarFile = new Path(relativeOutputPath, segmentTarFileName);
     }
     _logger.info("Copying segment tar file from: {} to: {}", localSegmentTarFile, hdfsSegmentTarFile);

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroUtils.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroUtils.java
@@ -34,8 +34,6 @@ import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
-import org.apache.pinot.spi.data.DateTimeFormatSpec;
-import org.apache.pinot.spi.data.DateTimeGranularitySpec;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -369,9 +367,11 @@ public class AvroUtils {
         case DATE_TIME:
           Preconditions.checkState(isSingleValueField, "Time field: %s cannot be multi-valued", name);
           Preconditions.checkNotNull(timeUnit, "Time unit cannot be null");
-          pinotSchema.addField(new DateTimeFieldSpec(name, dataType,
-              new DateTimeFormatSpec(1, timeUnit.toString(), DateTimeFieldSpec.TimeFormat.EPOCH.toString()).getFormat(),
-              new DateTimeGranularitySpec(1, timeUnit).getGranularity()));
+          // TODO: Switch to new format after releasing 0.11.0
+          //       "EPOCH|" + timeUnit.name()
+          String format = "1:" + timeUnit.name() + ":EPOCH";
+          String granularity = "1:" + timeUnit.name();
+          pinotSchema.addField(new DateTimeFieldSpec(name, dataType, format, granularity));
           break;
         default:
           throw new UnsupportedOperationException("Unsupported field type: " + fieldType + " for field: " + name);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/NullValueTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/NullValueTransformer.java
@@ -62,8 +62,7 @@ public class NullValueTransformer implements RecordTransformer {
           schema.getSchemaName());
 
       String defaultTimeString = timeColumnSpec.getDefaultNullValueString();
-      String timeFormat = timeColumnSpec.getFormat();
-      DateTimeFormatSpec dateTimeFormatSpec = new DateTimeFormatSpec(timeFormat);
+      DateTimeFormatSpec dateTimeFormatSpec = timeColumnSpec.getFormatSpec();
       try {
         long defaultTimeMs = dateTimeFormatSpec.fromFormatToMillis(defaultTimeString);
         if (TimeUtils.timeValueInValidRange(defaultTimeMs)) {
@@ -78,7 +77,7 @@ public class NullValueTransformer implements RecordTransformer {
       _defaultNullValues.put(timeColumnName, currentTime);
       LOGGER.info(
           "Default time: {} does not comply with format: {}, using current time: {} as the default time for table: {}",
-          defaultTimeString, timeFormat, currentTime, tableConfig.getTableName());
+          defaultTimeString, timeColumnSpec.getFormat(), currentTime, tableConfig.getTableName());
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
@@ -158,7 +158,7 @@ public final class IngestionUtils {
         if (timeColumnName != null) {
           DateTimeFieldSpec dateTimeFieldSpec = schema.getSpecForTimeColumn(timeColumnName);
           if (dateTimeFieldSpec != null) {
-            dateTimeFormatSpec = new DateTimeFormatSpec(dateTimeFieldSpec.getFormat());
+            dateTimeFormatSpec = dateTimeFieldSpec.getFormatSpec();
           }
         }
         return new NormalizedDateSegmentNameGenerator(rawTableName, batchConfig.getSegmentNamePrefix(),

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
@@ -48,6 +48,7 @@ public class SchemaUtils {
 
   // checker to ensure simple date format matches lexicographic ordering.
   private static final Map<Character, Integer> DATETIME_PATTERN_ORDERING = new HashMap<>();
+
   static {
     char[] patternOrdering = new char[]{'y', 'M', 'd', 'H', 'm', 's', 'S'};
     for (int i = 0; i < patternOrdering.length; i++) {
@@ -120,10 +121,10 @@ public class SchemaUtils {
           }
         }
         if (fieldSpec.getFieldType().equals(FieldSpec.FieldType.TIME)) {
-          validateTimeFieldSpec(fieldSpec);
+          validateTimeFieldSpec((TimeFieldSpec) fieldSpec);
         }
         if (fieldSpec.getFieldType().equals(FieldSpec.FieldType.DATE_TIME)) {
-          validateDateTimeFieldSpec(fieldSpec);
+          validateDateTimeFieldSpec((DateTimeFieldSpec) fieldSpec);
         }
       }
     }
@@ -132,8 +133,8 @@ public class SchemaUtils {
         transformedColumns.retainAll(argumentColumns));
     if (schema.getPrimaryKeyColumns() != null) {
       for (String primaryKeyColumn : schema.getPrimaryKeyColumns()) {
-        Preconditions
-            .checkState(primaryKeyColumnCandidates.contains(primaryKeyColumn), "The primary key column must exist");
+        Preconditions.checkState(primaryKeyColumnCandidates.contains(primaryKeyColumn),
+            "The primary key column must exist");
       }
     }
   }
@@ -154,8 +155,7 @@ public class SchemaUtils {
   /**
    * Checks for valid incoming and outgoing granularity spec in the time field spec
    */
-  private static void validateTimeFieldSpec(FieldSpec fieldSpec) {
-    TimeFieldSpec timeFieldSpec = (TimeFieldSpec) fieldSpec;
+  private static void validateTimeFieldSpec(TimeFieldSpec timeFieldSpec) {
     TimeGranularitySpec incomingGranularitySpec = timeFieldSpec.getIncomingGranularitySpec();
     TimeGranularitySpec outgoingGranularitySpec = timeFieldSpec.getOutgoingGranularitySpec();
 
@@ -167,28 +167,21 @@ public class SchemaUtils {
       Preconditions.checkState(
           incomingGranularitySpec.getTimeFormat().equals(TimeGranularitySpec.TimeFormat.EPOCH.toString())
               && outgoingGranularitySpec.getTimeFormat().equals(TimeGranularitySpec.TimeFormat.EPOCH.toString()),
-          "Cannot perform time conversion for time format other than EPOCH. TimeFieldSpec: %s", fieldSpec);
+          "Cannot perform time conversion for time format other than EPOCH. TimeFieldSpec: %s", timeFieldSpec);
     }
   }
 
   /**
    * Checks for valid format and granularity string in dateTimeFieldSpec
    */
-  private static void validateDateTimeFieldSpec(FieldSpec fieldSpec) {
-    DateTimeFieldSpec dateTimeFieldSpec = (DateTimeFieldSpec) fieldSpec;
-    validateDateTimeFormat(dateTimeFieldSpec.getFormat());
-    DateTimeGranularitySpec.validateGranularity(dateTimeFieldSpec.getGranularity());
-  }
-
-  private static void validateDateTimeFormat(String format) {
-    DateTimeFormatSpec dateTimeFormatSpec;
+  private static void validateDateTimeFieldSpec(DateTimeFieldSpec dateTimeFieldSpec) {
+    DateTimeFormatSpec formatSpec;
     try {
-      dateTimeFormatSpec = new DateTimeFormatSpec(format);
+      formatSpec = dateTimeFieldSpec.getFormatSpec();
     } catch (Exception e) {
-      throw new IllegalStateException(String.format("invalid datetime format: %s", format), e);
+      throw new IllegalArgumentException("Invalid format: " + dateTimeFieldSpec.getFormat(), e);
     }
-    // validate the format is correct.
-    String sdfPattern = dateTimeFormatSpec.getSDFPattern();
+    String sdfPattern = formatSpec.getSDFPattern();
     if (sdfPattern != null) {
       // must be in "yyyy MM dd HH mm ss SSS" to make sure it is sorted by both lexicographical and datetime order.
       int[] maxIndexes = new int[]{-1, -1, -1, -1, -1, -1, -1, -1};
@@ -198,11 +191,19 @@ public class SchemaUtils {
       }
       // last index doesn't need to be checked.
       for (int idx = 0; idx < maxIndexes.length - 2; idx++) {
-        Preconditions.checkState(maxIndexes[idx] <= maxIndexes[idx + 1] || maxIndexes[idx + 1] == -1,
+        Preconditions.checkArgument(maxIndexes[idx] <= maxIndexes[idx + 1] || maxIndexes[idx + 1] == -1,
             String.format("SIMPLE_DATE_FORMAT pattern %s has to be sorted by both lexicographical and datetime order",
                 sdfPattern));
         maxIndexes[idx + 1] = Math.max(maxIndexes[idx + 1], maxIndexes[idx]);
       }
     }
+
+    DateTimeGranularitySpec granularitySpec;
+    try {
+      granularitySpec = dateTimeFieldSpec.getGranularitySpec();
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Invalid granularity: " + dateTimeFieldSpec.getGranularity(), e);
+    }
+    Preconditions.checkNotNull(granularitySpec);
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentUtil.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentUtil.java
@@ -33,7 +33,6 @@ import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationD
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
-import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
@@ -111,8 +110,7 @@ public class PinotSegmentUtil {
       TimeUnit unit = timeFieldSpec.getIncomingGranularitySpec().getTimeType();
       return generateTimeValue(random, unit);
     } else if (fieldSpec instanceof DateTimeFieldSpec) {
-      DateTimeFieldSpec dateTimeFieldSpec = (DateTimeFieldSpec) fieldSpec;
-      TimeUnit unit = new DateTimeFormatSpec(dateTimeFieldSpec.getFormat()).getColumnUnit();
+      TimeUnit unit = ((DateTimeFieldSpec) fieldSpec).getFormatSpec().getColumnUnit();
       return generateTimeValue(random, unit);
     } else {
       DataType storedType = fieldSpec.getDataType().getStoredType();

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -264,7 +264,7 @@ public class SegmentGeneratorConfig implements Serializable {
       DateTimeFieldSpec dateTimeFieldSpec = schema.getSpecForTimeColumn(timeColumnName);
       if (dateTimeFieldSpec != null) {
         setTimeColumnName(dateTimeFieldSpec.getName());
-        setDateTimeFormatSpec(new DateTimeFormatSpec(dateTimeFieldSpec.getFormat()));
+        setDateTimeFormatSpec(dateTimeFieldSpec.getFormatSpec());
       }
     }
   }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SegmentNameGeneratorFactory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SegmentNameGeneratorFactory.java
@@ -63,7 +63,7 @@ public class SegmentNameGeneratorFactory {
           DateTimeFieldSpec dateTimeFieldSpec = schema.getSpecForTimeColumn(timeColumnName);
           Preconditions.checkNotNull(dateTimeFieldSpec,
               "Schema does not contain the time column specified in the table config.");
-          dateTimeFormatSpec = new DateTimeFormatSpec(dateTimeFieldSpec.getFormat());
+          dateTimeFormatSpec = dateTimeFieldSpec.getFormatSpec();
         }
         return new NormalizedDateSegmentNameGenerator(tableName, prefix, excludeSequenceId,
             IngestionConfigUtils.getBatchSegmentIngestionType(tableConfig),

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGeneratorTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGeneratorTest.java
@@ -35,8 +35,6 @@ public class NormalizedDateSegmentNameGeneratorTest {
   private static final String MALFORMED_SEGMENT_NAME_POSTFIX = "my\\postfix";
   private static final String APPEND_PUSH_TYPE = "APPEND";
   private static final String REFRESH_PUSH_TYPE = "REFRESH";
-  private static final String EPOCH_TIME_FORMAT = "EPOCH";
-  private static final String SIMPLE_DATE_TIME_FORMAT = "SIMPLE_DATE_FORMAT";
   private static final String LONG_SIMPLE_DATE_FORMAT = "yyyyMMdd";
   private static final String STRING_SIMPLE_DATE_FORMAT = "yyyy-MM-dd";
   private static final String STRING_SLASH_DATE_FORMAT = "yyyy/MM/dd";
@@ -139,7 +137,7 @@ public class NormalizedDateSegmentNameGeneratorTest {
   public void testAppend() {
     SegmentNameGenerator segmentNameGenerator =
         new NormalizedDateSegmentNameGenerator(TABLE_NAME, null, false, APPEND_PUSH_TYPE, DAILY_PUSH_FREQUENCY,
-            new DateTimeFormatSpec(1, TimeUnit.DAYS.toString(), EPOCH_TIME_FORMAT), null);
+            DateTimeFormatSpec.forEpoch(TimeUnit.DAYS.name()), null);
     assertEquals(segmentNameGenerator.toString(),
         "NormalizedDateSegmentNameGenerator: segmentNamePrefix=myTable, appendPushType=true, outputSDF=yyyy-MM-dd, "
             + "inputTimeUnit=DAYS");
@@ -153,7 +151,7 @@ public class NormalizedDateSegmentNameGeneratorTest {
   public void testAppendWithSegmentNamePrefix() {
     SegmentNameGenerator segmentNameGenerator =
         new NormalizedDateSegmentNameGenerator(TABLE_NAME, SEGMENT_NAME_PREFIX, false, APPEND_PUSH_TYPE,
-            DAILY_PUSH_FREQUENCY, new DateTimeFormatSpec(1, TimeUnit.DAYS.toString(), EPOCH_TIME_FORMAT), null);
+            DAILY_PUSH_FREQUENCY, DateTimeFormatSpec.forEpoch(TimeUnit.DAYS.name()), null);
     assertEquals(segmentNameGenerator.toString(),
         "NormalizedDateSegmentNameGenerator: segmentNamePrefix=myTable_daily, appendPushType=true, "
             + "outputSDF=yyyy-MM-dd, inputTimeUnit=DAYS");
@@ -167,8 +165,7 @@ public class NormalizedDateSegmentNameGeneratorTest {
   public void testAppendWithSegmentNamePrefixPostfix() {
     SegmentNameGenerator segmentNameGenerator =
         new NormalizedDateSegmentNameGenerator(TABLE_NAME, SEGMENT_NAME_PREFIX, false, APPEND_PUSH_TYPE,
-            DAILY_PUSH_FREQUENCY, new DateTimeFormatSpec(1, TimeUnit.DAYS.toString(), EPOCH_TIME_FORMAT),
-            SEGMENT_NAME_POSTFIX);
+            DAILY_PUSH_FREQUENCY, DateTimeFormatSpec.forEpoch(TimeUnit.DAYS.name()), SEGMENT_NAME_POSTFIX);
     assertEquals(segmentNameGenerator.toString(),
         "NormalizedDateSegmentNameGenerator: segmentNamePrefix=myTable_daily, segmentNamePostfix=myPostfix, "
             + "appendPushType=true, outputSDF=yyyy-MM-dd, inputTimeUnit=DAYS");
@@ -182,7 +179,7 @@ public class NormalizedDateSegmentNameGeneratorTest {
   public void testHoursTimeType() {
     SegmentNameGenerator segmentNameGenerator =
         new NormalizedDateSegmentNameGenerator(TABLE_NAME, null, false, APPEND_PUSH_TYPE, DAILY_PUSH_FREQUENCY,
-            new DateTimeFormatSpec(1, TimeUnit.HOURS.toString(), EPOCH_TIME_FORMAT), null);
+            DateTimeFormatSpec.forEpoch(TimeUnit.HOURS.name()), null);
     assertEquals(segmentNameGenerator.toString(),
         "NormalizedDateSegmentNameGenerator: segmentNamePrefix=myTable, appendPushType=true, outputSDF=yyyy-MM-dd, "
             + "inputTimeUnit=HOURS");
@@ -196,8 +193,7 @@ public class NormalizedDateSegmentNameGeneratorTest {
   public void testLongSimpleDateFormat() {
     SegmentNameGenerator segmentNameGenerator =
         new NormalizedDateSegmentNameGenerator(TABLE_NAME, null, false, APPEND_PUSH_TYPE, DAILY_PUSH_FREQUENCY,
-            new DateTimeFormatSpec(1, TimeUnit.DAYS.toString(), SIMPLE_DATE_TIME_FORMAT, LONG_SIMPLE_DATE_FORMAT),
-            null);
+            DateTimeFormatSpec.forSimpleDateFormat(LONG_SIMPLE_DATE_FORMAT), null);
     assertEquals(segmentNameGenerator.toString(),
         "NormalizedDateSegmentNameGenerator: segmentNamePrefix=myTable, appendPushType=true, outputSDF=yyyy-MM-dd, "
             + "inputSDF=yyyyMMdd");
@@ -211,8 +207,7 @@ public class NormalizedDateSegmentNameGeneratorTest {
   public void testStringSimpleDateFormat() {
     SegmentNameGenerator segmentNameGenerator =
         new NormalizedDateSegmentNameGenerator(TABLE_NAME, null, false, APPEND_PUSH_TYPE, DAILY_PUSH_FREQUENCY,
-            new DateTimeFormatSpec(1, TimeUnit.DAYS.toString(), SIMPLE_DATE_TIME_FORMAT, STRING_SIMPLE_DATE_FORMAT),
-            null);
+            DateTimeFormatSpec.forSimpleDateFormat(STRING_SIMPLE_DATE_FORMAT), null);
     assertEquals(segmentNameGenerator.toString(),
         "NormalizedDateSegmentNameGenerator: segmentNamePrefix=myTable, appendPushType=true, outputSDF=yyyy-MM-dd, "
             + "inputSDF=yyyy-MM-dd");
@@ -224,26 +219,24 @@ public class NormalizedDateSegmentNameGeneratorTest {
 
   @Test
   public void testMalFormedTableNameAndSegmentNamePrefixPostfix() {
+    DateTimeFormatSpec dateTimeFormatSpec = DateTimeFormatSpec.forSimpleDateFormat(STRING_SLASH_DATE_FORMAT);
     try {
       new NormalizedDateSegmentNameGenerator(MALFORMED_TABLE_NAME, null, false, APPEND_PUSH_TYPE, DAILY_PUSH_FREQUENCY,
-          new DateTimeFormatSpec(1, TimeUnit.DAYS.toString(), SIMPLE_DATE_TIME_FORMAT, STRING_SLASH_DATE_FORMAT), null);
+          dateTimeFormatSpec, null);
       Assert.fail();
     } catch (IllegalArgumentException e) {
       // Expected
     }
     try {
       new NormalizedDateSegmentNameGenerator(TABLE_NAME, MALFORMED_SEGMENT_NAME_PREFIX, false, APPEND_PUSH_TYPE,
-          DAILY_PUSH_FREQUENCY,
-          new DateTimeFormatSpec(1, TimeUnit.DAYS.toString(), SIMPLE_DATE_TIME_FORMAT, STRING_SLASH_DATE_FORMAT), null);
+          DAILY_PUSH_FREQUENCY, dateTimeFormatSpec, null);
       Assert.fail();
     } catch (IllegalArgumentException e) {
       // Expected
     }
     try {
       new NormalizedDateSegmentNameGenerator(TABLE_NAME, SEGMENT_NAME_PREFIX, false, APPEND_PUSH_TYPE,
-          DAILY_PUSH_FREQUENCY,
-          new DateTimeFormatSpec(1, TimeUnit.DAYS.toString(), SIMPLE_DATE_TIME_FORMAT, STRING_SLASH_DATE_FORMAT),
-          MALFORMED_SEGMENT_NAME_POSTFIX);
+          DAILY_PUSH_FREQUENCY, dateTimeFormatSpec, MALFORMED_SEGMENT_NAME_POSTFIX);
       Assert.fail();
     } catch (IllegalArgumentException e) {
       // Expected
@@ -255,8 +248,7 @@ public class NormalizedDateSegmentNameGeneratorTest {
   public void testMalFormedDateFormatAndTimeValue() {
     SegmentNameGenerator segmentNameGenerator =
         new NormalizedDateSegmentNameGenerator(TABLE_NAME, null, false, APPEND_PUSH_TYPE, DAILY_PUSH_FREQUENCY,
-            new DateTimeFormatSpec(1, TimeUnit.DAYS.toString(), SIMPLE_DATE_TIME_FORMAT, STRING_SLASH_DATE_FORMAT),
-            null);
+            DateTimeFormatSpec.forSimpleDateFormat(STRING_SLASH_DATE_FORMAT), null);
     assertEquals(segmentNameGenerator.toString(), "NormalizedDateSegmentNameGenerator: segmentNamePrefix=myTable, "
         + "appendPushType=true, outputSDF=yyyy-MM-dd, inputSDF=yyyy/MM/dd");
     assertEquals(segmentNameGenerator.generateSegmentName(INVALID_SEQUENCE_ID, "1970/01/02", "1970/01/04"),
@@ -270,7 +262,7 @@ public class NormalizedDateSegmentNameGeneratorTest {
   public void testHourlyPushFrequency() {
     SegmentNameGenerator segmentNameGenerator =
         new NormalizedDateSegmentNameGenerator(TABLE_NAME, null, false, APPEND_PUSH_TYPE, HOURLY_PUSH_FREQUENCY,
-            new DateTimeFormatSpec(1, TimeUnit.DAYS.toString(), EPOCH_TIME_FORMAT), null);
+            DateTimeFormatSpec.forEpoch(TimeUnit.DAYS.name()), null);
     assertEquals(segmentNameGenerator.toString(),
         "NormalizedDateSegmentNameGenerator: segmentNamePrefix=myTable, appendPushType=true, outputSDF=yyyy-MM-dd-HH,"
             + " inputTimeUnit=DAYS");

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFieldSpec.java
@@ -31,6 +31,8 @@ import org.apache.pinot.spi.utils.EqualityUtils;
 public final class DateTimeFieldSpec extends FieldSpec {
   private String _format;
   private String _granularity;
+  private transient DateTimeFormatSpec _formatSpec;
+  private transient DateTimeGranularitySpec _granularitySpec;
 
   public enum TimeFormat {
     EPOCH, TIMESTAMP, SIMPLE_DATE_FORMAT
@@ -70,17 +72,11 @@ public final class DateTimeFieldSpec extends FieldSpec {
    */
   public DateTimeFieldSpec(String name, DataType dataType, String format, String granularity) {
     super(name, dataType, true);
-    Preconditions.checkNotNull(name);
-    Preconditions.checkNotNull(dataType);
-    if (Character.isDigit(format.charAt(0))) {
-      DateTimeFormatSpec.validateFormat(format);
-    } else {
-      DateTimeFormatSpec.validatePipeFormat(format);
-    }
-    DateTimeGranularitySpec.validateGranularity(granularity);
 
     _format = format;
     _granularity = granularity;
+    _formatSpec = new DateTimeFormatSpec(format);
+    _granularitySpec = new DateTimeGranularitySpec(granularity);
   }
 
   /**
@@ -116,6 +112,16 @@ public final class DateTimeFieldSpec extends FieldSpec {
     _format = format;
   }
 
+  @JsonIgnore
+  public DateTimeFormatSpec getFormatSpec() {
+    DateTimeFormatSpec formatSpec = _formatSpec;
+    if (formatSpec == null) {
+      formatSpec = new DateTimeFormatSpec(_format);
+      _formatSpec = formatSpec;
+    }
+    return formatSpec;
+  }
+
   public String getGranularity() {
     return _granularity;
   }
@@ -123,6 +129,16 @@ public final class DateTimeFieldSpec extends FieldSpec {
   // Required by JSON de-serializer. DO NOT REMOVE.
   public void setGranularity(String granularity) {
     _granularity = granularity;
+  }
+
+  @JsonIgnore
+  public DateTimeGranularitySpec getGranularitySpec() {
+    DateTimeGranularitySpec granularitySpec = _granularitySpec;
+    if (granularitySpec == null) {
+      granularitySpec = new DateTimeGranularitySpec(_granularity);
+      _granularitySpec = granularitySpec;
+    }
+    return granularitySpec;
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatPatternSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatPatternSpec.java
@@ -20,66 +20,95 @@ package org.apache.pinot.spi.data;
 
 import com.google.common.base.Preconditions;
 import java.util.Locale;
+import java.util.Objects;
 import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.annotation.Nullable;
-import org.apache.pinot.spi.utils.EqualityUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.spi.data.DateTimeFieldSpec.TimeFormat;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
 
 public class DateTimeFormatPatternSpec {
+  public static final DateTimeZone DEFAULT_DATE_TIME_ZONE = DateTimeZone.UTC;
+  public static final Locale DEFAULT_LOCALE = Locale.ENGLISH;
+
+  public static final DateTimeFormatPatternSpec EPOCH = new DateTimeFormatPatternSpec(TimeFormat.EPOCH);
+  public static final DateTimeFormatPatternSpec TIMESTAMP = new DateTimeFormatPatternSpec(TimeFormat.TIMESTAMP);
 
   /** eg: yyyyMMdd tz(CST) or yyyyMMdd HH tz(GMT+0700) or yyyyMMddHH tz(America/Chicago) **/
   private static final Pattern SDF_PATTERN_WITH_TIMEZONE = Pattern.compile("^(.+)( tz[ ]*\\((.+)\\))[ ]*");
   private static final int SDF_PATTERN_GROUP = 1;
-  private static final int TIMEZONE_GROUP = 3;
-  public static final DateTimeZone DEFAULT_DATETIMEZONE = DateTimeZone.UTC;
-  public static final Locale DEFAULT_LOCALE = Locale.ENGLISH;
+  private static final int TIME_ZONE_GROUP = 3;
 
-  private final DateTimeFieldSpec.TimeFormat _timeFormat;
-  private String _sdfPattern = null;
-  private DateTimeZone _dateTimeZone = DEFAULT_DATETIMEZONE;
-  private transient DateTimeFormatter _dateTimeFormatter;
+  private final TimeFormat _timeFormat;
+  private final String _sdfPattern;
+  private final DateTimeZone _dateTimeZone;
+  private transient final DateTimeFormatter _dateTimeFormatter;
 
-  public DateTimeFormatPatternSpec(String timeFormat) {
+  public DateTimeFormatPatternSpec(TimeFormat timeFormat) {
     this(timeFormat, null);
   }
 
-  public DateTimeFormatPatternSpec(String timeFormat, @Nullable String sdfPatternWithTz) {
-    _timeFormat = DateTimeFieldSpec.TimeFormat.valueOf(timeFormat);
-    if (_timeFormat.equals(DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT)) {
-      Preconditions.checkNotNull(sdfPatternWithTz, String.format(
-          "Must provide simple date format pattern with time format type: %s", timeFormat));
+  public DateTimeFormatPatternSpec(TimeFormat timeFormat, @Nullable String sdfPatternWithTz) {
+    _timeFormat = timeFormat;
+    if (timeFormat == TimeFormat.SIMPLE_DATE_FORMAT) {
+      Preconditions.checkArgument(StringUtils.isNotEmpty(sdfPatternWithTz), "Must provide SIMPLE_DATE_FORMAT pattern");
       Matcher m = SDF_PATTERN_WITH_TIMEZONE.matcher(sdfPatternWithTz);
       if (m.find()) {
         _sdfPattern = m.group(SDF_PATTERN_GROUP).trim();
-        String timezoneString = m.group(TIMEZONE_GROUP).trim();
-        _dateTimeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(timezoneString));
+        String timeZone = m.group(TIME_ZONE_GROUP).trim();
+        try {
+          _dateTimeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(timeZone));
+        } catch (Exception e) {
+          throw new IllegalArgumentException("Invalid time zone: " + timeZone);
+        }
       } else {
         _sdfPattern = sdfPatternWithTz;
+        _dateTimeZone = DEFAULT_DATE_TIME_ZONE;
       }
-      _dateTimeFormatter = DateTimeFormat.forPattern(_sdfPattern).withZone(_dateTimeZone).withLocale(DEFAULT_LOCALE);
+      try {
+        _dateTimeFormatter = DateTimeFormat.forPattern(_sdfPattern).withZone(_dateTimeZone).withLocale(DEFAULT_LOCALE);
+      } catch (Exception e) {
+        throw new IllegalArgumentException("Invalid SIMPLE_DATE_FORMAT pattern: " + _sdfPattern);
+      }
+    } else {
+      _sdfPattern = null;
+      _dateTimeZone = DEFAULT_DATE_TIME_ZONE;
+      _dateTimeFormatter = null;
     }
   }
 
-  public DateTimeFormatPatternSpec(DateTimeFieldSpec.TimeFormat timeFormat, @Nullable String sdfPattern,
-      @Nullable String timeZone) {
+  public DateTimeFormatPatternSpec(TimeFormat timeFormat, @Nullable String sdfPattern, @Nullable String timeZone) {
     _timeFormat = timeFormat;
-    if (_timeFormat.equals(DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT)) {
-      if (timeZone != null) {
-        _dateTimeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(timeZone));
-      }
-      _dateTimeFormatter = DateTimeFormat.forPattern(sdfPattern).
-          withZone(_dateTimeZone).
-          withLocale(DEFAULT_LOCALE);
+    if (_timeFormat == TimeFormat.SIMPLE_DATE_FORMAT) {
+      Preconditions.checkArgument(StringUtils.isNotEmpty(sdfPattern), "Must provide SIMPLE_DATE_FORMAT pattern");
       _sdfPattern = sdfPattern;
+      if (timeZone != null) {
+        try {
+          _dateTimeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(timeZone));
+        } catch (Exception e) {
+          throw new IllegalArgumentException("Invalid time zone: " + timeZone);
+        }
+      } else {
+        _dateTimeZone = DEFAULT_DATE_TIME_ZONE;
+      }
+      try {
+        _dateTimeFormatter = DateTimeFormat.forPattern(_sdfPattern).withZone(_dateTimeZone).withLocale(DEFAULT_LOCALE);
+      } catch (Exception e) {
+        throw new IllegalArgumentException("Invalid SIMPLE_DATE_FORMAT pattern: " + _sdfPattern);
+      }
+    } else {
+      _sdfPattern = null;
+      _dateTimeZone = DEFAULT_DATE_TIME_ZONE;
+      _dateTimeFormatter = null;
     }
   }
 
-  public DateTimeFieldSpec.TimeFormat getTimeFormat() {
+  public TimeFormat getTimeFormat() {
     return _timeFormat;
   }
 
@@ -95,54 +124,27 @@ public class DateTimeFormatPatternSpec {
     return _dateTimeFormatter;
   }
 
-  /**
-   * Validates the sdf pattern
-   */
-  public static void validateFormat(String sdfPatternWithTz) {
-    try {
-      String sdfPattern;
-      Matcher m = SDF_PATTERN_WITH_TIMEZONE.matcher(sdfPatternWithTz);
-      if (m.find()) {
-        sdfPattern = m.group(SDF_PATTERN_GROUP).trim();
-        String timezoneString = m.group(TIMEZONE_GROUP).trim();
-        DateTimeZone dateTimeZone = DateTimeZone.forTimeZone(TimeZone.getTimeZone(timezoneString));
-        DateTimeFormat.forPattern(sdfPattern).withZone(dateTimeZone);
-      } else {
-        sdfPattern = sdfPatternWithTz;
-        DateTimeFormat.forPattern(sdfPattern);
-      }
-    } catch (Exception e) {
-      throw new IllegalStateException("Unsupported simple date format pattern or time zone: " + sdfPatternWithTz);
-    }
-  }
-
   @Override
   public boolean equals(Object o) {
-    if (EqualityUtils.isSameReference(this, o)) {
+    if (this == o) {
       return true;
     }
-
-    if (EqualityUtils.isNullOrNotSameClass(this, o)) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
     DateTimeFormatPatternSpec that = (DateTimeFormatPatternSpec) o;
-
-    return EqualityUtils.isEqual(_timeFormat, that._timeFormat) && EqualityUtils.isEqual(_sdfPattern, that._sdfPattern)
-        && EqualityUtils.isEqual(_dateTimeZone, that._dateTimeZone);
+    return _timeFormat == that._timeFormat && Objects.equals(_sdfPattern, that._sdfPattern) && _dateTimeZone.equals(
+        that._dateTimeZone);
   }
 
   @Override
   public int hashCode() {
-    int result = EqualityUtils.hashCodeOf(_timeFormat);
-    result = EqualityUtils.hashCodeOf(result, _sdfPattern);
-    result = EqualityUtils.hashCodeOf(result, _dateTimeZone);
-    return result;
+    return Objects.hash(_timeFormat, _sdfPattern, _dateTimeZone);
   }
 
   @Override
   public String toString() {
     return "DateTimeFormatPatternSpec{" + "_timeFormat=" + _timeFormat + ", _sdfPattern='" + _sdfPattern + '\''
-        + ", _dateTimeZone=" + _dateTimeZone + ", _dateTimeFormatter=" + _dateTimeFormatter + '}';
+        + ", _dateTimeZone=" + _dateTimeZone + '}';
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatUnitSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatUnitSpec.java
@@ -19,9 +19,9 @@
 package org.apache.pinot.spi.data;
 
 import com.google.common.base.Preconditions;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.EnumUtils;
-import org.apache.pinot.spi.utils.EqualityUtils;
 import org.joda.time.DurationFieldType;
 import org.joda.time.chrono.ISOChronology;
 
@@ -98,17 +98,24 @@ public class DateTimeFormatUnitSpec {
     public abstract long fromMillis(long millisSinceEpoch);
   }
 
-  private TimeUnit _timeUnit = null;
-  private DateTimeTransformUnit _dateTimeTransformUnit = null;
+  public static final DateTimeFormatUnitSpec MILLISECONDS = new DateTimeFormatUnitSpec(TimeUnit.MILLISECONDS.name());
+
+  private final TimeUnit _timeUnit;
+  private final DateTimeTransformUnit _dateTimeTransformUnit;
 
   public DateTimeFormatUnitSpec(String unit) {
-    validateUnitSpec(unit);
     if (EnumUtils.isValidEnum(TimeUnit.class, unit)) {
       _timeUnit = TimeUnit.valueOf(unit);
+    } else {
+      _timeUnit = null;
     }
     if (EnumUtils.isValidEnum(DateTimeTransformUnit.class, unit)) {
       _dateTimeTransformUnit = DateTimeTransformUnit.valueOf(unit);
+    } else {
+      _dateTimeTransformUnit = null;
     }
+    Preconditions.checkArgument(_timeUnit != null || _dateTimeTransformUnit != null,
+        "Unit must belong to enum TimeUnit or DateTimeTransformUnit, got: %s", unit);
   }
 
   public TimeUnit getTimeUnit() {
@@ -119,32 +126,20 @@ public class DateTimeFormatUnitSpec {
     return _dateTimeTransformUnit;
   }
 
-  public static void validateUnitSpec(String unit) {
-    Preconditions.checkState(
-        EnumUtils.isValidEnum(TimeUnit.class, unit) || EnumUtils.isValidEnum(DateTimeTransformUnit.class, unit),
-        "Unit: %s must belong to enum TimeUnit or DateTimeTransformUnit", unit);
-  }
-
   @Override
   public boolean equals(Object o) {
-    if (EqualityUtils.isSameReference(this, o)) {
+    if (this == o) {
       return true;
     }
-
-    if (EqualityUtils.isNullOrNotSameClass(this, o)) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
-
     DateTimeFormatUnitSpec that = (DateTimeFormatUnitSpec) o;
-
-    return EqualityUtils.isEqual(_timeUnit, that._timeUnit) && EqualityUtils
-        .isEqual(_dateTimeTransformUnit, that._dateTimeTransformUnit);
+    return _timeUnit == that._timeUnit && _dateTimeTransformUnit == that._dateTimeTransformUnit;
   }
 
   @Override
   public int hashCode() {
-    int result = EqualityUtils.hashCodeOf(_timeUnit);
-    result = EqualityUtils.hashCodeOf(result, _dateTimeTransformUnit);
-    return result;
+    return Objects.hash(_timeUnit, _dateTimeTransformUnit);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
@@ -55,8 +55,6 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
-import org.apache.pinot.spi.data.DateTimeFormatSpec;
-import org.apache.pinot.spi.data.DateTimeGranularitySpec;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -598,9 +596,11 @@ public class JsonUtils {
         case DATE_TIME:
           Preconditions.checkState(isSingleValueField, "Time field: %s cannot be multi-valued", name);
           Preconditions.checkNotNull(timeUnit, "Time unit cannot be null");
-          pinotSchema.addField(new DateTimeFieldSpec(name, dataType,
-              new DateTimeFormatSpec(1, timeUnit.toString(), DateTimeFieldSpec.TimeFormat.EPOCH.toString()).getFormat(),
-              new DateTimeGranularitySpec(1, timeUnit).getGranularity()));
+          // TODO: Switch to new format after releasing 0.11.0
+          //       "EPOCH|" + timeUnit.name()
+          String format = "1:" + timeUnit.name() + ":EPOCH";
+          String granularity = "1:" + timeUnit.name();
+          pinotSchema.addField(new DateTimeFieldSpec(name, dataType, format, granularity));
           break;
         default:
           throw new UnsupportedOperationException("Unsupported field type: " + fieldType + " for field: " + name);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/StringUtil.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/StringUtil.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.spi.utils;
 
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.lang.ArrayUtils;
 import org.apache.commons.lang.StringUtils;
 
 
@@ -33,6 +36,35 @@ public class StringUtil {
    */
   public static String join(String separator, String... keys) {
     return StringUtils.join(keys, separator);
+  }
+
+  /**
+   * Splits the given string with the separator, returns an array with the given max length. When max <= 0, no limit is
+   * applied.
+   */
+  public static String[] split(String str, char separator, int max) {
+    int length = str.length();
+    if (length == 0) {
+      return ArrayUtils.EMPTY_STRING_ARRAY;
+    }
+    if (max == 1) {
+      return new String[]{str};
+    }
+    List<String> list = new ArrayList<>(max);
+    int start = 0;
+    int end = 0;
+    while (end < length) {
+      if (str.charAt(end) == separator) {
+        list.add(str.substring(start, end));
+        start = end + 1;
+        if (list.size() == max - 1) {
+          break;
+        }
+      }
+      end++;
+    }
+    list.add(str.substring(start, length));
+    return list.toArray(new String[0]);
   }
 
   /**

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/DateTimeFormatPatternSpecTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/DateTimeFormatPatternSpecTest.java
@@ -18,26 +18,72 @@
  */
 package org.apache.pinot.spi.data;
 
+import java.util.TimeZone;
+import org.apache.pinot.spi.data.DateTimeFieldSpec.TimeFormat;
+import org.joda.time.DateTimeZone;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
+
 
 public class DateTimeFormatPatternSpecTest {
 
   @Test
   public void testValidateFormat() {
-    DateTimeFormatPatternSpec.validateFormat("yyyy-MM-dd");
-    DateTimeFormatPatternSpec.validateFormat("yyyyMMdd tz(CST)");
-    DateTimeFormatPatternSpec.validateFormat("yyyyMMdd HH tz(GMT+0700)");
-    DateTimeFormatPatternSpec.validateFormat("yyyyMMddHH tz(America/Chicago)");
+    DateTimeFormatPatternSpec dateTimeFormatPatternSpec =
+        new DateTimeFormatPatternSpec(TimeFormat.SIMPLE_DATE_FORMAT, "yyyy-MM-dd");
+    assertEquals(dateTimeFormatPatternSpec.getSdfPattern(), "yyyy-MM-dd");
+    assertEquals(dateTimeFormatPatternSpec.getDateTimeZone(), DateTimeZone.UTC);
+    assertEquals(dateTimeFormatPatternSpec,
+        new DateTimeFormatPatternSpec(TimeFormat.SIMPLE_DATE_FORMAT, "yyyy-MM-dd", null));
 
-    // Unknown tz is treated as UTC
-    DateTimeFormatPatternSpec.validateFormat("yyyyMMdd tz(CSEMT)");
-    DateTimeFormatPatternSpec.validateFormat("yyyyMMdd tz(GMT+5000)");
-    DateTimeFormatPatternSpec.validateFormat("yyyyMMddHH tz(HAHA/Chicago)");
+    dateTimeFormatPatternSpec = new DateTimeFormatPatternSpec(TimeFormat.SIMPLE_DATE_FORMAT, "yyyyMMdd tz(CST)");
+    assertEquals(dateTimeFormatPatternSpec.getSdfPattern(), "yyyyMMdd");
+    assertEquals(dateTimeFormatPatternSpec.getDateTimeZone(), DateTimeZone.forTimeZone(TimeZone.getTimeZone("CST")));
+    assertEquals(dateTimeFormatPatternSpec,
+        new DateTimeFormatPatternSpec(TimeFormat.SIMPLE_DATE_FORMAT, "yyyyMMdd", "CST"));
 
-    // invalid chars will throw
-    assertThrows(IllegalStateException.class, () -> DateTimeFormatPatternSpec.validateFormat("yyyc-MM-dd"));
-    assertThrows(IllegalStateException.class, () -> DateTimeFormatPatternSpec.validateFormat("yyyy-MM-dd ff(a)"));
+    dateTimeFormatPatternSpec =
+        new DateTimeFormatPatternSpec(TimeFormat.SIMPLE_DATE_FORMAT, "yyyyMMdd HH tz(GMT+0700)");
+    assertEquals(dateTimeFormatPatternSpec.getSdfPattern(), "yyyyMMdd HH");
+    assertEquals(dateTimeFormatPatternSpec.getDateTimeZone(),
+        DateTimeZone.forTimeZone(TimeZone.getTimeZone("GMT+0700")));
+    assertEquals(dateTimeFormatPatternSpec,
+        new DateTimeFormatPatternSpec(TimeFormat.SIMPLE_DATE_FORMAT, "yyyyMMdd HH", "GMT+0700"));
+
+    dateTimeFormatPatternSpec =
+        new DateTimeFormatPatternSpec(TimeFormat.SIMPLE_DATE_FORMAT, "yyyyMMddHH tz(America/Chicago)");
+    assertEquals(dateTimeFormatPatternSpec.getSdfPattern(), "yyyyMMddHH");
+    assertEquals(dateTimeFormatPatternSpec.getDateTimeZone(),
+        DateTimeZone.forTimeZone(TimeZone.getTimeZone("America/Chicago")));
+    assertEquals(dateTimeFormatPatternSpec,
+        new DateTimeFormatPatternSpec(TimeFormat.SIMPLE_DATE_FORMAT, "yyyyMMddHH", "America/Chicago"));
+
+    // Unknown time zone is treated as UTC
+    dateTimeFormatPatternSpec = new DateTimeFormatPatternSpec(TimeFormat.SIMPLE_DATE_FORMAT, "yyyyMMdd tz(CSEMT)");
+    assertEquals(dateTimeFormatPatternSpec.getSdfPattern(), "yyyyMMdd");
+    assertEquals(dateTimeFormatPatternSpec.getDateTimeZone(), DateTimeZone.UTC);
+    assertEquals(dateTimeFormatPatternSpec,
+        new DateTimeFormatPatternSpec(TimeFormat.SIMPLE_DATE_FORMAT, "yyyyMMdd", "CSEMT"));
+
+    dateTimeFormatPatternSpec = new DateTimeFormatPatternSpec(TimeFormat.SIMPLE_DATE_FORMAT, "yyyyMMdd tz(GMT+5000)");
+    assertEquals(dateTimeFormatPatternSpec.getSdfPattern(), "yyyyMMdd");
+    assertEquals(dateTimeFormatPatternSpec.getDateTimeZone(), DateTimeZone.UTC);
+    assertEquals(dateTimeFormatPatternSpec,
+        new DateTimeFormatPatternSpec(TimeFormat.SIMPLE_DATE_FORMAT, "yyyyMMdd", "GMT+5000"));
+
+    dateTimeFormatPatternSpec =
+        new DateTimeFormatPatternSpec(TimeFormat.SIMPLE_DATE_FORMAT, "yyyyMMdd tz(HAHA/Chicago)");
+    assertEquals(dateTimeFormatPatternSpec.getSdfPattern(), "yyyyMMdd");
+    assertEquals(dateTimeFormatPatternSpec.getDateTimeZone(), DateTimeZone.UTC);
+    assertEquals(dateTimeFormatPatternSpec,
+        new DateTimeFormatPatternSpec(TimeFormat.SIMPLE_DATE_FORMAT, "yyyyMMdd", "HAHA/Chicago"));
+
+    // Invalid pattern
+    assertThrows(IllegalArgumentException.class,
+        () -> new DateTimeFormatPatternSpec(TimeFormat.SIMPLE_DATE_FORMAT, "yyyc-MM-dd"));
+    assertThrows(IllegalArgumentException.class,
+        () -> new DateTimeFormatPatternSpec(TimeFormat.SIMPLE_DATE_FORMAT, "yyyy-MM-dd ff(a)"));
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/DateTimeFormatSpecTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/DateTimeFormatSpecTest.java
@@ -18,24 +18,75 @@
  */
 package org.apache.pinot.spi.data;
 
+import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
+import org.joda.time.DateTimeZone;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertThrows;
 
 
 public class DateTimeFormatSpecTest {
 
   @Test
-  public void testValidateFormat() {
-    DateTimeFormatSpec.validateFormat("1:DAYS:EPOCH");
-    DateTimeFormatSpec.validateFormat("1:DAYS:TIMESTAMP");
-    DateTimeFormatSpec.validateFormat("1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd");
-    assertThrows(IllegalStateException.class, () -> DateTimeFormatSpec.validateFormat("1:DAY"));
-    assertThrows(IllegalStateException.class, () -> DateTimeFormatSpec.validateFormat("one:DAYS:EPOCH"));
-    assertThrows(IllegalStateException.class, () -> DateTimeFormatSpec.validateFormat("1:DAY:EPOCH"));
-    assertThrows(IllegalStateException.class, () -> DateTimeFormatSpec.validateFormat("1:DAY:EPOCH:yyyyMMdd"));
-    assertThrows(IllegalStateException.class, () -> DateTimeFormatSpec.validateFormat("1:DAY:TIMESTAMP:yyyyMMdd"));
-    assertThrows(IllegalStateException.class,
-        () -> DateTimeFormatSpec.validateFormat("1:DAY:SIMPLE_DATE_FORMAT:yyycMMdd"));
+  public void testDateTimeFormatSpec() {
+    DateTimeFormatSpec dateTimeFormatSpec = new DateTimeFormatSpec("5:DAYS:EPOCH");
+    assertEquals(dateTimeFormatSpec.getTimeFormat(), DateTimeFieldSpec.TimeFormat.EPOCH);
+    assertEquals(dateTimeFormatSpec.getColumnSize(), 5);
+    assertEquals(dateTimeFormatSpec.getColumnUnit(), TimeUnit.DAYS);
+    assertEquals(dateTimeFormatSpec.getColumnDateTimeTransformUnit(),
+        DateTimeFormatUnitSpec.DateTimeTransformUnit.DAYS);
+    assertNull(dateTimeFormatSpec.getSDFPattern());
+
+    assertEquals(new DateTimeFormatSpec("EPOCH|DAYS|5"), dateTimeFormatSpec);
+
+    dateTimeFormatSpec = new DateTimeFormatSpec("1:DAYS:TIMESTAMP");
+    assertEquals(dateTimeFormatSpec.getTimeFormat(), DateTimeFieldSpec.TimeFormat.TIMESTAMP);
+    assertEquals(dateTimeFormatSpec.getColumnSize(), 1);
+    assertEquals(dateTimeFormatSpec.getColumnUnit(), TimeUnit.MILLISECONDS);
+    assertEquals(dateTimeFormatSpec.getColumnDateTimeTransformUnit(),
+        DateTimeFormatUnitSpec.DateTimeTransformUnit.MILLISECONDS);
+    assertNull(dateTimeFormatSpec.getSDFPattern());
+
+    assertEquals(new DateTimeFormatSpec("TIMESTAMP"), dateTimeFormatSpec);
+
+    dateTimeFormatSpec = new DateTimeFormatSpec("1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd");
+    assertEquals(dateTimeFormatSpec.getTimeFormat(), DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT);
+    assertEquals(dateTimeFormatSpec.getColumnSize(), 1);
+    assertEquals(dateTimeFormatSpec.getColumnUnit(), TimeUnit.MILLISECONDS);
+    assertEquals(dateTimeFormatSpec.getColumnDateTimeTransformUnit(),
+        DateTimeFormatUnitSpec.DateTimeTransformUnit.MILLISECONDS);
+    assertEquals(dateTimeFormatSpec.getSDFPattern(), "yyyyMMdd");
+    assertEquals(dateTimeFormatSpec.getDateTimezone(), DateTimeZone.UTC);
+
+    assertEquals(new DateTimeFormatSpec("SIMPLE_DATE_FORMAT|yyyyMMdd"), dateTimeFormatSpec);
+
+    dateTimeFormatSpec = new DateTimeFormatSpec("1:DAYS:SIMPLE_DATE_FORMAT:yyyy-MM-dd tz(CST)");
+    assertEquals(dateTimeFormatSpec.getTimeFormat(), DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT);
+    assertEquals(dateTimeFormatSpec.getColumnSize(), 1);
+    assertEquals(dateTimeFormatSpec.getColumnUnit(), TimeUnit.MILLISECONDS);
+    assertEquals(dateTimeFormatSpec.getColumnDateTimeTransformUnit(),
+        DateTimeFormatUnitSpec.DateTimeTransformUnit.MILLISECONDS);
+    assertEquals(dateTimeFormatSpec.getSDFPattern(), "yyyy-MM-dd");
+    assertEquals(dateTimeFormatSpec.getDateTimezone(), DateTimeZone.forTimeZone(TimeZone.getTimeZone("CST")));
+
+    assertEquals(new DateTimeFormatSpec("SIMPLE_DATE_FORMAT|yyyy-MM-dd|CST"), dateTimeFormatSpec);
+
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeFormatSpec("1:DAY"));
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeFormatSpec("EPOCH"));
+
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeFormatSpec("one:DAYS:EPOCH"));
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeFormatSpec("EPOCH|DAYS|one"));
+
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeFormatSpec("1:DAY:EPOCH"));
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeFormatSpec("EPOCH|DAY"));
+
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeFormatSpec("1:DAY:EPOCH:yyyyMMdd"));
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeFormatSpec("EPOCH|yyyyMMdd"));
+
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeFormatSpec("1:DAY:SIMPLE_DATE_FORMAT:yyycMMdd"));
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeFormatSpec("SIMPLE_DATE_FORMAT|yyycMMdd"));
   }
 }


### PR DESCRIPTION
- Integrate the validation logic into the constructor to avoid the overhead of extra validation and regex match
- Remove the unnecessary format reconstruction
- Cache `DateTimeFormatSpec` and `DateTimeGranularitySpec` within `DateTimeFieldSpec` to avoid parsing the spec string multiple times
- Use the new introduced pattern format in #8632 
- This can improve the performance of the `dateTimeConvert` function