### PR TITLE
allow unpacked content in transferable block

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
@@ -188,7 +188,8 @@ public class DataBlockBuilder {
     return buildRowBlock(rowBuilder);
   }
 
-  public static ColumnarDataBlock buildFromColumns(List<Object[]> columns, DataSchema dataSchema)
+  public static ColumnarDataBlock buildFromColumns(List<Object[]> columns, @Nullable RoaringBitmap[] colNullBitmaps,
+      DataSchema dataSchema)
       throws IOException {
     DataBlockBuilder columnarBuilder = new DataBlockBuilder(dataSchema, BaseDataBlock.Type.COLUMNAR);
     for (int i = 0; i < columns.size(); i++) {
@@ -302,6 +303,12 @@ public class DataBlockBuilder {
                   columnarBuilder._dataSchema.getColumnName(i)));
       }
       columnarBuilder._fixedSizeDataByteArrayOutputStream.write(byteBuffer.array(), 0, byteBuffer.position());
+    }
+    // Write null bitmaps after writing data.
+    if (colNullBitmaps != null) {
+      for (RoaringBitmap nullBitmap : colNullBitmaps) {
+        columnarBuilder.setNullRowIds(nullBitmap);
+      }
     }
     return buildColumnarBlock(columnarBuilder);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockUtils.java
@@ -20,6 +20,8 @@ package org.apache.pinot.core.common.datablock;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.common.utils.DataSchema;
@@ -72,6 +74,68 @@ public final class DataBlockUtils {
       default:
         throw new UnsupportedOperationException("Unsupported data table version: " + version + " with type: " + type);
     }
+  }
+
+  public static List<Object[]> extraRows(BaseDataBlock dataBlock) {
+    DataSchema dataSchema = dataBlock.getDataSchema();
+    DataSchema.ColumnDataType[] storedColumnDataTypes = dataSchema.getStoredColumnDataTypes();
+    int numRows = dataBlock.getNumberOfRows();
+    int numColumns = storedColumnDataTypes.length;
+
+    List<Object[]> rows = new ArrayList<>(numRows);
+    for (int i = 0; i < numRows; i++) {
+      Object[] row = new Object[numColumns];
+      for (int j = 0; j < numColumns; j++) {
+        switch (storedColumnDataTypes[j]) {
+          // Single-value column
+          case INT:
+            row[j] = dataBlock.getInt(i, j);
+            break;
+          case LONG:
+            row[j] = dataBlock.getLong(i, j);
+            break;
+          case FLOAT:
+            row[j] = dataBlock.getFloat(i, j);
+            break;
+          case DOUBLE:
+            row[j] = dataBlock.getDouble(i, j);
+            break;
+          case BIG_DECIMAL:
+            row[j] = dataBlock.getBigDecimal(i, j);
+            break;
+          case STRING:
+            row[j] = dataBlock.getString(i, j);
+            break;
+          case BYTES:
+            row[j] = dataBlock.getBytes(i, j);
+            break;
+
+          // Multi-value column
+          case INT_ARRAY:
+            row[j] = dataBlock.getIntArray(i, j);
+            break;
+          case LONG_ARRAY:
+            row[j] = dataBlock.getLongArray(i, j);
+            break;
+          case FLOAT_ARRAY:
+            row[j] = dataBlock.getFloatArray(i, j);
+            break;
+          case DOUBLE_ARRAY:
+            row[j] = dataBlock.getDoubleArray(i, j);
+            break;
+          case STRING_ARRAY:
+            row[j] = dataBlock.getStringArray(i, j);
+            break;
+
+          default:
+            throw new IllegalStateException(
+                String.format("Unsupported data type: %s for column: %s", storedColumnDataTypes[j],
+                    dataSchema.getColumnName(j)));
+        }
+      }
+      rows.add(row);
+    }
+    return rows;
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTest.java
@@ -110,7 +110,7 @@ public class DataBlockTest {
     List<Object[]> rows = DataBlockTestUtils.getRandomRows(dataSchema, TEST_ROW_COUNT);
     List<Object[]> columnars = DataBlockTestUtils.convertColumnar(dataSchema, rows);
     RowDataBlock rowBlock = DataBlockBuilder.buildFromRows(rows, null, dataSchema);
-    ColumnarDataBlock columnarBlock = DataBlockBuilder.buildFromColumns(columnars, dataSchema);
+    ColumnarDataBlock columnarBlock = DataBlockBuilder.buildFromColumns(columnars, null, dataSchema);
 
     for (int colId = 0; colId < dataSchema.getColumnNames().length; colId++) {
       DataSchema.ColumnDataType columnDataType = dataSchema.getColumnDataType(colId);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlock.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlock.java
@@ -40,11 +40,11 @@ import org.apache.pinot.core.common.datablock.RowDataBlock;
 public class TransferableBlock implements Block {
 
   private final BaseDataBlock.Type _type;
+  private final DataSchema _dataSchema;
 
   private BaseDataBlock _dataBlock;
 
   private List<Object[]> _container;
-  private DataSchema _dataSchema;
 
   public TransferableBlock(List<Object[]> container, DataSchema dataSchema, BaseDataBlock.Type containerType) {
     _container = container;
@@ -54,8 +54,13 @@ public class TransferableBlock implements Block {
 
   public TransferableBlock(BaseDataBlock dataBlock) {
     _dataBlock = dataBlock;
+    _dataSchema = dataBlock.getDataSchema();
     _type = dataBlock instanceof ColumnarDataBlock ? BaseDataBlock.Type.COLUMNAR
         : dataBlock instanceof RowDataBlock ? BaseDataBlock.Type.ROW : BaseDataBlock.Type.METADATA;
+  }
+
+  public DataSchema getDataSchema() {
+    return _dataSchema;
   }
 
   public List<Object[]> getContainer() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlock.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlock.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.query.runtime.blocks;
 
 import java.io.IOException;
+import java.util.List;
+import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Block;
 import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.common.BlockDocIdValueSet;
@@ -26,6 +28,8 @@ import org.apache.pinot.core.common.BlockMetadata;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.datablock.BaseDataBlock;
 import org.apache.pinot.core.common.datablock.ColumnarDataBlock;
+import org.apache.pinot.core.common.datablock.DataBlockBuilder;
+import org.apache.pinot.core.common.datablock.DataBlockUtils;
 import org.apache.pinot.core.common.datablock.RowDataBlock;
 
 
@@ -35,8 +39,18 @@ import org.apache.pinot.core.common.datablock.RowDataBlock;
  */
 public class TransferableBlock implements Block {
 
+  private final BaseDataBlock.Type _type;
+
   private BaseDataBlock _dataBlock;
-  private BaseDataBlock.Type _type;
+
+  private List<Object[]> _container;
+  private DataSchema _dataSchema;
+
+  public TransferableBlock(List<Object[]> container, DataSchema dataSchema, BaseDataBlock.Type containerType) {
+    _container = container;
+    _dataSchema = dataSchema;
+    _type = containerType;
+  }
 
   public TransferableBlock(BaseDataBlock dataBlock) {
     _dataBlock = dataBlock;
@@ -44,7 +58,37 @@ public class TransferableBlock implements Block {
         : dataBlock instanceof RowDataBlock ? BaseDataBlock.Type.ROW : BaseDataBlock.Type.METADATA;
   }
 
+  public List<Object[]> getContainer() {
+    if (_container == null) {
+      switch (_type) {
+        case ROW:
+          _container = DataBlockUtils.extraRows(_dataBlock);
+          break;
+        case COLUMNAR:
+        default:
+          throw new UnsupportedOperationException("Unable to extract from container with type: " + _type);
+      }
+    }
+    return _container;
+  }
+
   public BaseDataBlock getDataBlock() {
+    if (_dataBlock == null) {
+      try {
+        switch (_type) {
+          case ROW:
+            _dataBlock = DataBlockBuilder.buildFromRows(_container, null, _dataSchema);
+            break;
+          case COLUMNAR:
+            _dataBlock = DataBlockBuilder.buildFromColumns(_container, null, _dataSchema);
+            break;
+          default:
+            throw new UnsupportedOperationException("Unable to build from container with type: " + _type);
+        }
+      } catch (Exception e) {
+        throw new RuntimeException("Unable to create DataBlock");
+      }
+    }
     return _dataBlock;
   }
 


### PR DESCRIPTION
Previously transferable blocks are always packed into the serialized format. 

This PR
- Allow to hold unpacked in-memory container so that when executing non-cross-stage execution. no ser/de overhead is needed
- Prerequisite for Project/Transform/Filter operator as they can be chained.

