### PR TITLE
Fix thread safety issue with java client

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ConnectionFactory.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ConnectionFactory.java
@@ -28,8 +28,7 @@ import java.util.Properties;
  * Creates connections to Pinot, given various initialization methods.
  */
 public class ConnectionFactory {
-  private static volatile PinotClientTransport _defaultTransport;
-  private static final Object TRANSPORT_LOCK = new Object();
+  private static PinotClientTransport _defaultTransport;
 
   private ConnectionFactory() {
   }
@@ -174,7 +173,7 @@ public class ConnectionFactory {
 
   private static PinotClientTransport getDefault() {
     if (_defaultTransport == null) {
-      synchronized (TRANSPORT_LOCK) {
+      synchronized (ConnectionFactory.class) {
         if (_defaultTransport == null) {
           _defaultTransport = new JsonAsyncHttpPinotClientTransportFactory().buildTransport();
         }

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ConnectionFactory.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ConnectionFactory.java
@@ -28,7 +28,8 @@ import java.util.Properties;
  * Creates connections to Pinot, given various initialization methods.
  */
 public class ConnectionFactory {
-  private static PinotClientTransport _defaultTransport;
+  private static volatile PinotClientTransport _defaultTransport;
+  private static final Object TRANSPORT_LOCK = new Object();
 
   private ConnectionFactory() {
   }
@@ -173,7 +174,11 @@ public class ConnectionFactory {
 
   private static PinotClientTransport getDefault() {
     if (_defaultTransport == null) {
-      _defaultTransport = new JsonAsyncHttpPinotClientTransportFactory().buildTransport();
+      synchronized (TRANSPORT_LOCK) {
+        if (_defaultTransport == null) {
+          _defaultTransport = new JsonAsyncHttpPinotClientTransportFactory().buildTransport();
+        }
+      }
     }
     return _defaultTransport;
   }


### PR DESCRIPTION
There is possibility of > 1 PinotClientTransport (and thereby > 1 AHC clients) getting created if `public static Connection fromZookeeper(String zkUrl)` is invoked by multiple threads concurrently. This PR fixes it