### PR TITLE
add firing time in /task/scheduler/jobDetails API response

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -412,6 +412,8 @@ public class PinotTaskRestletResource {
           triggerMap.put("RepeatInterval", simpleTrigger.getRepeatInterval());
           triggerMap.put("RepeatCount", simpleTrigger.getRepeatCount());
           triggerMap.put("TimesTriggered", simpleTrigger.getTimesTriggered());
+          triggerMap.put("NextFireTime", simpleTrigger.getNextFireTime());
+          triggerMap.put("PreviousFireTime", simpleTrigger.getPreviousFireTime());
         } else if (trigger instanceof CronTrigger) {
           CronTrigger cronTrigger = (CronTrigger) trigger;
           triggerMap.put("TriggerType", CronTrigger.class.getSimpleName());


### PR DESCRIPTION
## Changes
Add firing time in /task/scheduler/jobDetails API response to help debugging. 

Specifically, "NextFireTime" and "PreviousFireTime" are added when for trigger type `SimpleTrigger`. (Those two fields already exist for trigger type `CronTrigger`)