### PR TITLE
reduce GHA runner JVM mem footprint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <activeByDefault>false</activeByDefault>
       </activation>
       <properties>
-        <argLine>-Xms8g -Xmx8g -Dlog4j2.configurationFile=log4j2.xml</argLine>
+        <argLine>-Xms2g -Xmx2g -Dlog4j2.configurationFile=log4j2.xml</argLine>
       </properties>
     </profile>
     <!-- jfim: this profile is overridden in pinot-integration-tests -->

--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
         <activeByDefault>false</activeByDefault>
       </activation>
       <properties>
-        <argLine>-Xms2g -Xmx2g -Dlog4j2.configurationFile=log4j2.xml</argLine>
+        <argLine>-Xms4g -Xmx4g -Dlog4j2.configurationFile=log4j2.xml</argLine>
       </properties>
     </profile>
     <!-- jfim: this profile is overridden in pinot-integration-tests -->


### PR DESCRIPTION
`ubuntu-latest` linux runner only has 7GB of ram. see: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

changing the GHA profile running size so that meaningful JVM error will print out.

Currently process will be terminated by Linux OOM killer with useless log:
```
Error:  Error occurred in starting fork, check output in log
Error:  Process Exit Code: 137
Error:  Crashed tests:
...
```

relate to #8968 