### PR TITLE
Retry validateJobs for a while to avoid flaky errors

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
@@ -257,7 +257,7 @@ public class PinotTaskManagerStatelessTest extends ControllerTest {
         LOGGER.warn("Unexpected cron expression. Hasn't been replicated yet?", assertionError);
       }
       return true;
-    }, TIMEOUT_IN_MS, 500L,"Cron expression didn't change to " + cronExpression);
+    }, TIMEOUT_IN_MS, 500L, "Cron expression didn't change to " + cronExpression);
   }
 
   @AfterClass

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
@@ -245,17 +245,19 @@ public class PinotTaskManagerStatelessTest extends ControllerTest {
 
     // There is no guarantee that previous changes have been applied, therefore we need to
     // retry the check for a bit
-    TestUtils.waitForResult(() -> {
+    TestUtils.waitForCondition(aVoid -> {
       try {
         List<? extends Trigger> triggersOfJob = scheduler.getTriggersOfJob(jobKey);
         Trigger trigger = triggersOfJob.iterator().next();
         assertTrue(trigger instanceof CronTrigger);
         assertEquals(((CronTrigger) trigger).getCronExpression(), cronExpression);
+      } catch (SchedulerException ex) {
+        throw new RuntimeException(ex);
       } catch (AssertionError assertionError) {
         LOGGER.warn("Unexpected cron expression. Hasn't been replicated yet?", assertionError);
       }
-      return null;
-    }, TIMEOUT_IN_MS);
+      return true;
+    }, TIMEOUT_IN_MS, 500L,"Cron expression didn't change to " + cronExpression);
   }
 
   @AfterClass

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
@@ -41,6 +41,8 @@ import org.quartz.Scheduler;
 import org.quartz.SchedulerException;
 import org.quartz.Trigger;
 import org.quartz.impl.matchers.GroupMatcher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -53,6 +55,7 @@ public class PinotTaskManagerStatelessTest extends ControllerTest {
   private static final String RAW_TABLE_NAME = "myTable";
   private static final String OFFLINE_TABLE_NAME = TableNameBuilder.OFFLINE.tableNameWithType(RAW_TABLE_NAME);
   private static final long TIMEOUT_IN_MS = 10_000L;
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotTaskManagerStatelessTest.class);
 
   @BeforeClass
   public void setUp()
@@ -239,10 +242,20 @@ public class PinotTaskManagerStatelessTest extends ControllerTest {
         throw new RuntimeException(e);
       }
     }, TIMEOUT_IN_MS, "JobDetail exiting but missing JobTrigger");
-    List<? extends Trigger> triggersOfJob = scheduler.getTriggersOfJob(jobKey);
-    Trigger trigger = triggersOfJob.iterator().next();
-    assertTrue(trigger instanceof CronTrigger);
-    assertEquals(((CronTrigger) trigger).getCronExpression(), cronExpression);
+
+    // There is no guarantee that previous changes have been applied, therefore we need to
+    // retry the check for a bit
+    TestUtils.waitForResult(() -> {
+      try {
+        List<? extends Trigger> triggersOfJob = scheduler.getTriggersOfJob(jobKey);
+        Trigger trigger = triggersOfJob.iterator().next();
+        assertTrue(trigger instanceof CronTrigger);
+        assertEquals(((CronTrigger) trigger).getCronExpression(), cronExpression);
+      } catch (AssertionError assertionError) {
+        LOGGER.warn("Unexpected cron expression. Hasn't been replicated yet?", assertionError);
+      }
+      return null;
+    }, TIMEOUT_IN_MS);
   }
 
   @AfterClass


### PR DESCRIPTION
This PR tries to fix #8776.

What the test does is to modify the state in helix and then verify that the result is correct. IICU Helix, there is no read-after-write guarantee in Helix, so there is a race condition between the update and the read. In normal cases, Helix will change the state faster and therefore the test doesn't fail. But that is not guaranteed and in some executions it may happen that the change is not applied when the validate is done.

Sequence diagram when everything works as expected:
```mermaid

sequenceDiagram
    Test->>+Controller: update table config (0 */20 * ? * * *)
    Controller->>+Helix: update table config (0 */20 * ? * * *)
    Helix->>Helix: Change ideal state to (0 */20 * ? * * *)
    Helix->>-Controller: Ok
    Controller->>-Test: Ok
    
    Test->>+Controller: get job info
    Controller->>+Helix: get job info
    Helix->>-Controller: updated job info (0 */20 * ? * * *)
    Controller->>-Test: updated job info (0 */20 * ? * * *)
    
```

Sequence diagram when the change is not seen:

```mermaid

sequenceDiagram
    Test->>+Controller: update table config (0 */20 * ? * * *)
    Controller->>+Helix: update table config (0 */20 * ? * * *)
    Helix->>Controller: Ok
    Controller->>-Test: Ok
    
    Test->>+Controller: get job info
    Controller->>+Helix: get job info
    Helix->>-Controller: updated job info (0 */10 * ? * * *)
    
    Helix->>-Helix: Change ideal state (0 */20 * ? * * *)
    
    Controller->>-Test: updated job info (0 */10 * ? * * *)
    
```

The only solution know is to retry the validation with some timeout.