### PR TITLE
remove duplicated server queries metric report

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/PriorityScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/PriorityScheduler.java
@@ -75,7 +75,6 @@ public abstract class PriorityScheduler extends QueryScheduler {
       LOGGER.error("Out of capacity for table {}, message: {}", queryRequest.getTableNameWithType(), e.getMessage());
       return immediateErrorResponse(queryRequest, QueryException.SERVER_OUT_OF_CAPACITY_ERROR);
     }
-    _serverMetrics.addMeteredTableValue(queryRequest.getTableNameWithType(), ServerMeter.QUERIES, 1);
     return schedQueryContext.getResultFuture();
   }
 


### PR DESCRIPTION
## Description
Remove duplicated server queries metric. This metric is already reported at https://github.com/apache/pinot/blob/master/pinot-core/src/main/java/org/apache/pinot/core/transport/InstanceRequestHandler.java#L111. I confirmed that the number of queries is doubled the real value on the dashboard.