### PR TITLE
Rename valueType to storedType in ForwardIndexReader

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
@@ -436,7 +436,7 @@ public class DataFetcher {
     ColumnValueReader(ForwardIndexReader reader, @Nullable Dictionary dictionary) {
       _reader = reader;
       _dictionary = dictionary;
-      _dataType = reader.getValueType();
+      _dataType = reader.getStoredType();
       _singleValue = reader.isSingleValue();
     }
 
@@ -552,7 +552,7 @@ public class DataFetcher {
         _reader.readDictIds(docIds, length, dictIdBuffer, readerContext);
         _dictionary.readStringValues(dictIdBuffer, length, valueBuffer);
       } else {
-        switch (_reader.getValueType()) {
+        switch (_reader.getStoredType()) {
           case INT:
             for (int i = 0; i < length; i++) {
               valueBuffer[i] = Integer.toString(_reader.getInt(docIds[i], readerContext));
@@ -603,7 +603,7 @@ public class DataFetcher {
         _reader.readDictIds(docIds, length, dictIdBuffer, readerContext);
         _dictionary.readBytesValues(dictIdBuffer, length, valueBuffer);
       } else {
-        switch (_reader.getValueType()) {
+        switch (_reader.getStoredType()) {
           case STRING:
             for (int i = 0; i < length; i++) {
               valueBuffer[i] = BytesUtils.toBytes(_reader.getString(docIds[i], readerContext));

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/evaluators/DefaultJsonPathEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/evaluators/DefaultJsonPathEvaluator.java
@@ -90,7 +90,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
@@ -123,7 +123,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
@@ -156,7 +156,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
@@ -189,7 +189,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
@@ -223,7 +223,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
@@ -256,7 +256,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
@@ -288,7 +288,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
@@ -320,7 +320,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
@@ -352,7 +352,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
@@ -384,7 +384,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
@@ -416,7 +416,7 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
         }
       }
     } else {
-      switch (reader.getValueType()) {
+      switch (reader.getStoredType()) {
         case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/evaluators/DefaultJsonPathEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/evaluators/DefaultJsonPathEvaluator.java
@@ -91,7 +91,6 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
       }
     } else {
       switch (reader.getStoredType()) {
-        case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
             processValue(i, extractFromString(reader, context, docIds[i]), defaultValue, valueBuffer);
@@ -124,7 +123,6 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
       }
     } else {
       switch (reader.getStoredType()) {
-        case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
             processValue(i, extractFromString(reader, context, docIds[i]), defaultValue, valueBuffer);
@@ -157,7 +155,6 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
       }
     } else {
       switch (reader.getStoredType()) {
-        case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
             processValue(i, extractFromString(reader, context, docIds[i]), defaultValue, valueBuffer);
@@ -190,7 +187,6 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
       }
     } else {
       switch (reader.getStoredType()) {
-        case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
             processValue(i, extractFromString(reader, context, docIds[i]), defaultValue, valueBuffer);
@@ -224,7 +220,6 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
       }
     } else {
       switch (reader.getStoredType()) {
-        case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
             processValue(i, extractFromStringWithExactBigDecimal(reader, context, docIds[i]), defaultValue,
@@ -257,7 +252,6 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
       }
     } else {
       switch (reader.getStoredType()) {
-        case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
             processValue(i, extractFromString(reader, context, docIds[i]), valueBuffer);
@@ -289,7 +283,6 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
       }
     } else {
       switch (reader.getStoredType()) {
-        case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
             processList(i, extractFromString(reader, context, docIds[i]), valueBuffer);
@@ -321,7 +314,6 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
       }
     } else {
       switch (reader.getStoredType()) {
-        case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
             processList(i, extractFromString(reader, context, docIds[i]), valueBuffer);
@@ -353,7 +345,6 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
       }
     } else {
       switch (reader.getStoredType()) {
-        case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
             processList(i, extractFromString(reader, context, docIds[i]), valueBuffer);
@@ -385,7 +376,6 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
       }
     } else {
       switch (reader.getStoredType()) {
-        case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
             processList(i, extractFromString(reader, context, docIds[i]), valueBuffer);
@@ -417,7 +407,6 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
       }
     } else {
       switch (reader.getStoredType()) {
-        case JSON:
         case STRING:
           for (int i = 0; i < length; i++) {
             processList(i, extractFromString(reader, context, docIds[i]), valueBuffer);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
@@ -108,7 +108,7 @@ public final class MVScanDocIdIterator implements ScanBasedDocIdIterator {
     if (_reader.isDictionaryEncoded()) {
       return new DictIdMatcher();
     } else {
-      switch (_reader.getValueType()) {
+      switch (_reader.getStoredType()) {
         case INT:
           return new IntMatcher();
         case LONG:
@@ -123,7 +123,7 @@ public final class MVScanDocIdIterator implements ScanBasedDocIdIterator {
           return new BytesMatcher();
         default:
           throw new UnsupportedOperationException("MV Scan not supported for raw MV columns of type "
-              + _reader.getValueType());
+              + _reader.getStoredType());
       }
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
@@ -126,7 +126,7 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
     if (_reader.isDictionaryEncoded()) {
       return new DictIdMatcher();
     } else {
-      switch (_reader.getValueType()) {
+      switch (_reader.getStoredType()) {
         case INT:
           return new IntMatcher();
         case LONG:

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -1033,7 +1033,7 @@ public class MutableSegmentImpl implements MutableSegment {
     } else {
       // Raw index based
       if (forwardIndex.isSingleValue()) {
-        switch (forwardIndex.getValueType()) {
+        switch (forwardIndex.getStoredType()) {
           case INT:
             return forwardIndex.getInt(docId);
           case LONG:
@@ -1055,7 +1055,7 @@ public class MutableSegmentImpl implements MutableSegment {
         // TODO: support multi-valued column for variable length column types (big decimal, string, bytes)
         int numValues;
         Object[] value;
-        switch (forwardIndex.getValueType()) {
+        switch (forwardIndex.getStoredType()) {
           case INT:
             int[] intValues = forwardIndex.getIntMV(docId);
             numValues = intValues.length;
@@ -1090,7 +1090,7 @@ public class MutableSegmentImpl implements MutableSegment {
             return value;
           default:
             throw new IllegalStateException("No support for MV no dictionary column of type "
-                + forwardIndex.getValueType());
+                + forwardIndex.getStoredType());
         }
       }
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteMVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteMVMutableForwardIndex.java
@@ -116,7 +116,7 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
   private final PinotDataBufferMemoryManager _memoryManager;
   private final String _context;
   private final boolean _isDictionaryEncoded;
-  private final FieldSpec.DataType _valueType;
+  private final FieldSpec.DataType _storedType;
 
   private FixedByteSingleValueMultiColWriter _curHeaderWriter;
   private FixedByteSingleValueMultiColWriter _currentDataWriter;
@@ -126,7 +126,7 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
 
   public FixedByteMVMutableForwardIndex(int maxNumberOfMultiValuesPerRow, int avgMultiValueCount, int rowCountPerChunk,
       int columnSizeInBytes, PinotDataBufferMemoryManager memoryManager, String context, boolean isDictionaryEncoded,
-      FieldSpec.DataType valueType) {
+      FieldSpec.DataType storedType) {
     _memoryManager = memoryManager;
     _context = context;
     int initialCapacity = Math.max(maxNumberOfMultiValuesPerRow, rowCountPerChunk * avgMultiValueCount);
@@ -142,7 +142,7 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
     addDataBuffer(initialCapacity);
     //init(_rowCountPerChunk, _columnSizeInBytes, _maxNumberOfMultiValuesPerRow, initialCapacity, _incrementalCapacity);
     _isDictionaryEncoded = isDictionaryEncoded;
-    _valueType = valueType;
+    _storedType = storedType;
   }
 
   private void addHeaderBuffer() {
@@ -223,8 +223,8 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
   }
 
   @Override
-  public DataType getValueType() {
-    return _valueType;
+  public DataType getStoredType() {
+    return _storedType;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
@@ -52,7 +52,7 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
   private final List<ReaderWithOffset> _readers = new ArrayList<>();
 
   private final boolean _dictionaryEncoded;
-  private final DataType _valueType;
+  private final DataType _storedType;
   private final int _valueSizeInBytes;
   private final int _numRowsPerChunk;
   private final long _chunkSizeInBytes;
@@ -62,16 +62,16 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
   private int _capacityInRows = 0;
 
   /**
-   * @param valueType Data type of the values
+   * @param storedType Data type of the values
    * @param numRowsPerChunk Number of rows to pack in one chunk before a new chunk is created.
    * @param memoryManager Memory manager to be used for allocating memory.
    * @param allocationContext Allocation allocationContext.
    */
-  public FixedByteSVMutableForwardIndex(boolean dictionaryEncoded, DataType valueType, int numRowsPerChunk,
+  public FixedByteSVMutableForwardIndex(boolean dictionaryEncoded, DataType storedType, int numRowsPerChunk,
       PinotDataBufferMemoryManager memoryManager, String allocationContext) {
     _dictionaryEncoded = dictionaryEncoded;
-    _valueType = valueType;
-    _valueSizeInBytes = valueType.size();
+    _storedType = storedType;
+    _valueSizeInBytes = storedType.size();
     _numRowsPerChunk = numRowsPerChunk;
     _chunkSizeInBytes = numRowsPerChunk * _valueSizeInBytes;
     _memoryManager = memoryManager;
@@ -90,8 +90,8 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
   }
 
   @Override
-  public DataType getValueType() {
-    return _valueType;
+  public DataType getStoredType() {
+    return _storedType;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/VarByteSVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/VarByteSVMutableForwardIndex.java
@@ -33,14 +33,14 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * Single-value forward index reader-writer for variable length values (STRING and BYTES).
  */
 public class VarByteSVMutableForwardIndex implements MutableForwardIndex {
-  private final DataType _valueType;
+  private final DataType _storedType;
   private final MutableOffHeapByteArrayStore _byteArrayStore;
   private int _lengthOfShortestElement;
   private int _lengthOfLongestElement;
 
-  public VarByteSVMutableForwardIndex(DataType valueType, PinotDataBufferMemoryManager memoryManager,
+  public VarByteSVMutableForwardIndex(DataType storedType, PinotDataBufferMemoryManager memoryManager,
       String allocationContext, int estimatedMaxNumberOfValues, int estimatedAverageStringLength) {
-    _valueType = valueType;
+    _storedType = storedType;
     _byteArrayStore = new MutableOffHeapByteArrayStore(memoryManager, allocationContext, estimatedMaxNumberOfValues,
         estimatedAverageStringLength);
     _lengthOfShortestElement = Integer.MAX_VALUE;
@@ -58,8 +58,8 @@ public class VarByteSVMutableForwardIndex implements MutableForwardIndex {
   }
 
   @Override
-  public DataType getValueType() {
-    return _valueType;
+  public DataType getStoredType() {
+    return _storedType;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/constant/ConstantMVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/constant/ConstantMVForwardIndexReader.java
@@ -39,7 +39,7 @@ public final class ConstantMVForwardIndexReader implements ForwardIndexReader<Fo
   }
 
   @Override
-  public DataType getValueType() {
+  public DataType getStoredType() {
     return DataType.INT;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/BaseChunkForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/BaseChunkForwardIndexReader.java
@@ -43,7 +43,7 @@ public abstract class BaseChunkForwardIndexReader implements ForwardIndexReader<
   private static final Logger LOGGER = LoggerFactory.getLogger(BaseChunkForwardIndexReader.class);
 
   protected final PinotDataBuffer _dataBuffer;
-  protected final DataType _valueType;
+  protected final DataType _storedType;
   protected final int _numChunks;
   protected final int _numDocsPerChunk;
   protected final int _lengthOfLongestEntry;
@@ -54,9 +54,9 @@ public abstract class BaseChunkForwardIndexReader implements ForwardIndexReader<
   protected final PinotDataBuffer _rawData;
   protected final boolean _isSingleValue;
 
-  public BaseChunkForwardIndexReader(PinotDataBuffer dataBuffer, DataType valueType, boolean isSingleValue) {
+  public BaseChunkForwardIndexReader(PinotDataBuffer dataBuffer, DataType storedType, boolean isSingleValue) {
     _dataBuffer = dataBuffer;
-    _valueType = valueType;
+    _storedType = storedType;
 
     int headerOffset = 0;
     int version = _dataBuffer.getInt(headerOffset);
@@ -69,8 +69,8 @@ public abstract class BaseChunkForwardIndexReader implements ForwardIndexReader<
     headerOffset += Integer.BYTES;
 
     _lengthOfLongestEntry = _dataBuffer.getInt(headerOffset);
-    if (valueType.isFixedWidth() && isSingleValue) {
-      Preconditions.checkState(_lengthOfLongestEntry == valueType.size());
+    if (storedType.isFixedWidth() && isSingleValue) {
+      Preconditions.checkState(_lengthOfLongestEntry == storedType.size());
     }
     headerOffset += Integer.BYTES;
 
@@ -170,14 +170,14 @@ public abstract class BaseChunkForwardIndexReader implements ForwardIndexReader<
   }
 
   @Override
-  public DataType getValueType() {
-    return _valueType;
+  public DataType getStoredType() {
+    return _storedType;
   }
 
   @Override
   public void readValuesSV(int[] docIds, int length, int[] values, ChunkReaderContext context) {
-    if (_valueType.isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
-      switch (_valueType) {
+    if (_storedType.isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
+      switch (_storedType) {
         case INT: {
           int minOffset = docIds[0] * Integer.BYTES;
           IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();
@@ -218,8 +218,8 @@ public abstract class BaseChunkForwardIndexReader implements ForwardIndexReader<
 
   @Override
   public void readValuesSV(int[] docIds, int length, long[] values, ChunkReaderContext context) {
-    if (_valueType.isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
-      switch (_valueType) {
+    if (_storedType.isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
+      switch (_storedType) {
         case INT: {
           int minOffset = docIds[0] * Integer.BYTES;
           IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();
@@ -260,8 +260,8 @@ public abstract class BaseChunkForwardIndexReader implements ForwardIndexReader<
 
   @Override
   public void readValuesSV(int[] docIds, int length, float[] values, ChunkReaderContext context) {
-    if (_valueType.isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
-      switch (_valueType) {
+    if (_storedType.isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
+      switch (_storedType) {
         case INT: {
           int minOffset = docIds[0] * Integer.BYTES;
           IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();
@@ -302,8 +302,8 @@ public abstract class BaseChunkForwardIndexReader implements ForwardIndexReader<
 
   @Override
   public void readValuesSV(int[] docIds, int length, double[] values, ChunkReaderContext context) {
-    if (_valueType.isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
-      switch (_valueType) {
+    if (_storedType.isFixedWidth() && !_isCompressed && isContiguousRange(docIds, length)) {
+      switch (_storedType) {
         case INT: {
           int minOffset = docIds[0] * Integer.BYTES;
           IntBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Integer.BYTES).asIntBuffer();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitMVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitMVForwardIndexReader.java
@@ -84,7 +84,7 @@ public final class FixedBitMVForwardIndexReader implements ForwardIndexReader<Fi
   }
 
   @Override
-  public DataType getValueType() {
+  public DataType getStoredType() {
     return DataType.INT;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitSVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitSVForwardIndexReader.java
@@ -47,7 +47,7 @@ public final class FixedBitSVForwardIndexReader implements ForwardIndexReader<Fo
   }
 
   @Override
-  public DataType getValueType() {
+  public DataType getStoredType() {
     return DataType.INT;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitSVForwardIndexReaderV2.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitSVForwardIndexReaderV2.java
@@ -49,7 +49,7 @@ public final class FixedBitSVForwardIndexReaderV2 implements ForwardIndexReader<
   }
 
   @Override
-  public DataType getValueType() {
+  public DataType getStoredType() {
     return DataType.INT;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBytePower2ChunkSVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBytePower2ChunkSVForwardIndexReader.java
@@ -44,7 +44,7 @@ public final class FixedBytePower2ChunkSVForwardIndexReader extends BaseChunkFor
   @Override
   public ChunkReaderContext createContext() {
     if (_isCompressed) {
-      return new ChunkReaderContext(_numDocsPerChunk * _valueType.size());
+      return new ChunkReaderContext(_numDocsPerChunk * _storedType.size());
     } else {
       return null;
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkSVForwardIndexReaderV4.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkSVForwardIndexReaderV4.java
@@ -45,7 +45,7 @@ public class VarByteChunkSVForwardIndexReaderV4
 
   private static final int METADATA_ENTRY_SIZE = 8;
 
-  private final FieldSpec.DataType _valueType;
+  private final FieldSpec.DataType _storedType;
   private final int _targetDecompressedChunkSize;
   private final ChunkDecompressor _chunkDecompressor;
   private final ChunkCompressionType _chunkCompressionType;
@@ -53,12 +53,12 @@ public class VarByteChunkSVForwardIndexReaderV4
   private final PinotDataBuffer _metadata;
   private final PinotDataBuffer _chunks;
 
-  public VarByteChunkSVForwardIndexReaderV4(PinotDataBuffer dataBuffer, FieldSpec.DataType valueType) {
+  public VarByteChunkSVForwardIndexReaderV4(PinotDataBuffer dataBuffer, FieldSpec.DataType storedType) {
     if (dataBuffer.getInt(0) < VarByteChunkSVForwardIndexWriterV4.VERSION) {
       throw new IllegalStateException("version " + dataBuffer.getInt(0) + " < "
           + VarByteChunkSVForwardIndexWriterV4.VERSION);
     }
-    _valueType = valueType;
+    _storedType = storedType;
     _targetDecompressedChunkSize = dataBuffer.getInt(4);
     _chunkCompressionType = ChunkCompressionType.valueOf(dataBuffer.getInt(8));
     _chunkDecompressor = ChunkCompressorFactory.getDecompressor(_chunkCompressionType);
@@ -79,8 +79,8 @@ public class VarByteChunkSVForwardIndexReaderV4
   }
 
   @Override
-  public FieldSpec.DataType getValueType() {
-    return _valueType;
+  public FieldSpec.DataType getStoredType() {
+    return _storedType;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentColumnReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentColumnReader.java
@@ -97,7 +97,7 @@ public class PinotSegmentColumnReader implements Closeable {
       // NOTE: Only support single-value raw index
       assert _forwardIndexReader.isSingleValue();
 
-      switch (_forwardIndexReader.getValueType()) {
+      switch (_forwardIndexReader.getStoredType()) {
         case INT:
           return _forwardIndexReader.getInt(docId, _forwardIndexReaderContext);
         case LONG:

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/RawIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/RawIndexCreatorTest.java
@@ -361,7 +361,7 @@ public class RawIndexCreatorTest {
    */
   private Object readValueFromIndex(FixedByteChunkSVForwardIndexReader rawIndexReader, ChunkReaderContext readerContext,
       int docId) {
-    switch (rawIndexReader.getValueType()) {
+    switch (rawIndexReader.getStoredType()) {
       case INT:
         return rawIndexReader.getInt(docId, readerContext);
       case LONG:
@@ -372,7 +372,7 @@ public class RawIndexCreatorTest {
         return rawIndexReader.getDouble(docId, readerContext);
       default:
         throw new IllegalArgumentException(
-            "Illegal data type for fixed width raw index reader: " + rawIndexReader.getValueType());
+            "Illegal data type for fixed width raw index reader: " + rawIndexReader.getStoredType());
     }
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
@@ -47,7 +47,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * Returns the data type of the values in the forward index. Returns {@link DataType#INT} for dictionary-encoded
    * forward index.
    */
-  DataType getValueType();
+  DataType getStoredType();
 
   /**
    * Creates a new {@link ForwardIndexReaderContext} of the reader which can be used to accelerate the reads.
@@ -123,7 +123,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * @param context Reader context
    */
   default void readValuesSV(int[] docIds, int length, int[] values, T context) {
-    switch (getValueType()) {
+    switch (getStoredType()) {
       case INT:
         for (int i = 0; i < length; i++) {
           values[i] = getInt(docIds[i], context);
@@ -167,7 +167,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * @param context Reader context
    */
   default void readValuesSV(int[] docIds, int length, long[] values, T context) {
-    switch (getValueType()) {
+    switch (getStoredType()) {
       case INT:
         for (int i = 0; i < length; i++) {
           values[i] = getInt(docIds[i], context);
@@ -211,7 +211,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * @param context Reader context
    */
   default void readValuesSV(int[] docIds, int length, float[] values, T context) {
-    switch (getValueType()) {
+    switch (getStoredType()) {
       case INT:
         for (int i = 0; i < length; i++) {
           values[i] = getInt(docIds[i], context);
@@ -255,7 +255,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * @param context Reader context
    */
   default void readValuesSV(int[] docIds, int length, double[] values, T context) {
-    switch (getValueType()) {
+    switch (getStoredType()) {
       case INT:
         for (int i = 0; i < length; i++) {
           values[i] = getInt(docIds[i], context);
@@ -301,7 +301,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
   default void readValuesSV(int[] docIds, int length, BigDecimal[] values, T context) {
     // todo(nhejazi): add raw index support to the BIG_DECIMAL type. In most of the cases, it will be more efficient
     //  to store big decimal as raw.
-    switch (getValueType()) {
+    switch (getStoredType()) {
       case INT:
         for (int i = 0; i < length; i++) {
           values[i] = BigDecimal.valueOf(getInt(docIds[i], context));
@@ -432,7 +432,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * @param context Reader context
    */
   default void readValuesMV(int[] docIds, int length, int maxNumValuesPerMVEntry, int[][] values, T context) {
-    switch (getValueType()) {
+    switch (getStoredType()) {
       case INT:
         for (int i = 0; i < length; i++) {
           values[i] = getIntMV(docIds[i], context);
@@ -479,7 +479,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       default:
-        throw new IllegalArgumentException("readValuesMV not supported for type " + getValueType());
+        throw new IllegalArgumentException("readValuesMV not supported for type " + getStoredType());
     }
   }
 
@@ -492,7 +492,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * @param context Reader context
    */
   default void readValuesMV(int[] docIds, int length, int maxNumValuesPerMVEntry, long[][] values, T context) {
-    switch (getValueType()) {
+    switch (getStoredType()) {
       case INT:
         int[] intValueBuffer = new int[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
@@ -539,7 +539,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       default:
-        throw new IllegalArgumentException("readValuesMV not supported for type " + getValueType());
+        throw new IllegalArgumentException("readValuesMV not supported for type " + getStoredType());
     }
   }
 
@@ -552,7 +552,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * @param context Reader context
    */
   default void readValuesMV(int[] docIds, int length, int maxNumValuesPerMVEntry, float[][] values, T context) {
-    switch (getValueType()) {
+    switch (getStoredType()) {
       case INT:
         int[] intValueBuffer = new int[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
@@ -599,7 +599,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       default:
-        throw new IllegalArgumentException("readValuesMV not supported for type " + getValueType());
+        throw new IllegalArgumentException("readValuesMV not supported for type " + getStoredType());
     }
   }
 
@@ -612,7 +612,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * @param context Reader context
    */
   default void readValuesMV(int[] docIds, int length, int maxNumValuesPerMVEntry, double[][] values, T context) {
-    switch (getValueType()) {
+    switch (getStoredType()) {
       case INT:
         int[] intValueBuffer = new int[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
@@ -659,7 +659,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       default:
-        throw new IllegalArgumentException("readValuesMV not supported for type " + getValueType());
+        throw new IllegalArgumentException("readValuesMV not supported for type " + getStoredType());
     }
   }
 
@@ -672,7 +672,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
    * @param context Reader context
    */
   default void readValuesMV(int[] docIds, int length, int maxNumValuesPerMVEntry, String[][] values, T context) {
-    switch (getValueType()) {
+    switch (getStoredType()) {
       case INT:
         int[] intValueBuffer = new int[maxNumValuesPerMVEntry];
         for (int i = 0; i < length; i++) {
@@ -719,7 +719,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       default:
-        throw new IllegalArgumentException("readValuesMV not supported for type " + getValueType());
+        throw new IllegalArgumentException("readValuesMV not supported for type " + getStoredType());
     }
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/SortedIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/SortedIndexReader.java
@@ -45,7 +45,7 @@ public interface SortedIndexReader<T extends ForwardIndexReaderContext>
   }
 
   @Override
-  default DataType getValueType() {
+  default DataType getStoredType() {
     return DataType.INT;
   }
 }


### PR DESCRIPTION
This PR renames valueType to storedType in ForwardIndexReader as a cleanup identified when fixing issue https://github.com/apache/pinot/issues/8875

cc @siddharthteotia @Jackie-Jiang @walterddr