### PR TITLE
Add Segment Lineage List API #9005

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -3275,6 +3275,15 @@ public class PinotHelixResourceManager {
   }
 
   /**
+   * List the segment lineage
+   *
+   * @param tableNameWithType
+   */
+  public SegmentLineage listSegmentLineage(String tableNameWithType) {
+      return SegmentLineageAccessHelper.getSegmentLineage(_propertyStore, tableNameWithType);
+  }
+
+  /**
    * Revert the segment replacement
    *
    * 1. Compute validation

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSegmentRestletResourceTest.java
@@ -18,7 +18,10 @@
  */
 package org.apache.pinot.controller.api;
 
+import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.controller.utils.SegmentMetadataMockUtils;
@@ -37,11 +40,81 @@ import org.testng.annotations.Test;
 public class PinotSegmentRestletResourceTest {
   private static final ControllerTest TEST_INSTANCE = ControllerTest.getInstance();
   private static final String TABLE_NAME = "pinotSegmentRestletResourceTestTable";
+  private static final String TABLE_NAME_OFFLINE = TABLE_NAME + "_OFFLINE";
 
   @BeforeClass
   public void setUp()
       throws Exception {
     TEST_INSTANCE.setupSharedStateAndValidate();
+  }
+
+  @Test
+  public void testListSegmentLineage()
+      throws Exception {
+    // Adding table
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setNumReplicas(1).build();
+    TEST_INSTANCE.getHelixResourceManager().addTable(tableConfig);
+
+    // Wait for the table addition
+    while (!TEST_INSTANCE.getHelixResourceManager().hasOfflineTable(TABLE_NAME)) {
+      Thread.sleep(100);
+    }
+
+    Map<String, SegmentMetadata> segmentMetadataTable = new HashMap<>();
+
+    // Upload Segments
+    for (int i = 0; i < 4; i++) {
+      SegmentMetadata segmentMetadata = SegmentMetadataMockUtils.mockSegmentMetadata(TABLE_NAME, "s" + i);
+      TEST_INSTANCE.getHelixResourceManager()
+          .addNewSegment(TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME), segmentMetadata, "downloadUrl");
+      segmentMetadataTable.put(segmentMetadata.getName(), segmentMetadata);
+    }
+
+    // There should be no segment lineage at this point.
+    String segmentLineageResponse = ControllerTest.sendGetRequest(TEST_INSTANCE.getControllerRequestURLBuilder()
+        .forListAllSegmentLineages(TABLE_NAME, TableType.OFFLINE.toString()));
+    Assert.assertEquals(segmentLineageResponse, "");
+
+    // Now starts to replace segments.
+    List<String> segmentsFrom = Arrays.asList("s0", "s1");
+    List<String> segmentsTo = Arrays.asList("some_segment");
+    String segmentLineageId = TEST_INSTANCE.getHelixResourceManager()
+        .startReplaceSegments(TABLE_NAME_OFFLINE, segmentsFrom, segmentsTo, false);
+
+    // Replace more segments to add another entry to segment lineage.
+    segmentsFrom = Arrays.asList("s2", "s3");
+    segmentsTo = Arrays.asList("another_segment");
+    String nextSegmentLineageId = TEST_INSTANCE.getHelixResourceManager()
+        .startReplaceSegments(TABLE_NAME_OFFLINE, segmentsFrom, segmentsTo, false);
+
+    // There should now be two segment lineage entries resulting from the operations above.
+    segmentLineageResponse = ControllerTest.sendGetRequest(TEST_INSTANCE.getControllerRequestURLBuilder()
+        .forListAllSegmentLineages(TABLE_NAME, TableType.OFFLINE.toString()));
+    Assert.assertTrue(segmentLineageResponse.contains("\"state\":\"IN_PROGRESS\""));
+    Assert.assertTrue(segmentLineageResponse.contains("\"segmentsFrom\":[\"s0\",\"s1\"]"));
+    Assert.assertTrue(segmentLineageResponse.contains("\"segmentsTo\":[\"some_segment\"]"));
+    Assert.assertTrue(segmentLineageResponse.contains("\"segmentsFrom\":[\"s2\",\"s3\"]"));
+    Assert.assertTrue(segmentLineageResponse.contains("\"segmentsTo\":[\"another_segment\"]"));
+    // Ensures the two entries are sorted in chronological order by timestamp.
+    Assert.assertTrue(
+        segmentLineageResponse.indexOf(segmentLineageId) < segmentLineageResponse.indexOf(nextSegmentLineageId));
+
+    // List segment lineage should fail for non-existing table
+    Assert.assertThrows(IOException.class, () -> ControllerTest.sendGetRequest(
+        TEST_INSTANCE.getControllerRequestURLBuilder()
+            .forListAllSegmentLineages("non-existing-table", TableType.OFFLINE.toString())));
+
+    // List segment lineage should also fail for invalid table type.
+    Assert.assertThrows(IOException.class, () -> ControllerTest.sendGetRequest(
+        TEST_INSTANCE.getControllerRequestURLBuilder().forListAllSegmentLineages(TABLE_NAME, "invalid-type")));
+
+    // Delete segments
+    TEST_INSTANCE.getHelixResourceManager().deleteSegment(TableNameBuilder.OFFLINE.tableNameWithType(TABLE_NAME),
+        segmentMetadataTable.values().iterator().next().getName());
+
+    // Delete offline table
+    TEST_INSTANCE.getHelixResourceManager().deleteOfflineTable(TABLE_NAME);
   }
 
   @Test
@@ -81,11 +154,10 @@ public class PinotSegmentRestletResourceTest {
     Assert.assertEquals(fetchedMetadata.get("segment.download.url"), "downloadUrl");
 
     // use table name with table type
-    resp = ControllerTest.sendGetRequest(TEST_INSTANCE.getControllerRequestURLBuilder()
-        .forSegmentMetadata(TABLE_NAME + "_OFFLINE", entry.getKey()));
+    resp = ControllerTest.sendGetRequest(
+        TEST_INSTANCE.getControllerRequestURLBuilder().forSegmentMetadata(TABLE_NAME + "_OFFLINE", entry.getKey()));
     fetchedMetadata = JsonUtils.stringToObject(resp, Map.class);
     Assert.assertEquals(fetchedMetadata.get("segment.download.url"), "downloadUrl");
-
 
     // Add more segments
     for (int i = 0; i < 5; i++) {
@@ -104,6 +176,9 @@ public class PinotSegmentRestletResourceTest {
 
     // Check crc api
     checkCrcRequest(segmentMetadataTable, 9);
+
+    // Delete offline table
+    TEST_INSTANCE.getHelixResourceManager().deleteOfflineTable(TABLE_NAME);
   }
 
   private void checkCrcRequest(Map<String, SegmentMetadata> metadataTable, int expectedSize)

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
@@ -344,6 +344,10 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", _baseUrl, "segments", tableName, encode(segmentName), "metadata");
   }
 
+  public String forListAllSegmentLineages(String tableName, String tableType) {
+    return StringUtil.join("/", _baseUrl, "segments", tableName, "lineage?type=" + tableType);
+  }
+
   public String forListAllCrcInformationForTable(String tableName) {
     return StringUtil.join("/", _baseUrl, "tables", tableName, "segments", "crc");
   }


### PR DESCRIPTION
# Description

This PR adds support for listing segment lineage entries. The following endpoint on the controller can be used to retrieve such entries in chronological order of timestamp for a particular table.

- _segments/{tableName}/lineage_

# Testing Done

Added new Junit test in `PinotSegmentRestletResourceTest.java` 

Manual verification 
1. With valid table type combination. 
<img width="902" alt="image" src="https://user-images.githubusercontent.com/25168272/178166875-4edf1aa9-48bd-4442-9c02-9add9094a480.png">

2. Invalid `type` parameter.
<img width="572" alt="image" src="https://user-images.githubusercontent.com/25168272/176795230-8ece4702-477f-4090-8765-369492342ff7.png">
3. Invalid table
<img width="579" alt="image" src="https://user-images.githubusercontent.com/25168272/176795304-922030a6-f2cd-4f86-bebc-7cb78911a788.png">

# Labels 
feature

