### PR TITLE
save task generator info to ZK

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -64,6 +64,7 @@ public class ZKMetadataProvider {
   private static final String PROPERTYSTORE_CLUSTER_CONFIGS_PREFIX = "/CONFIGS/CLUSTER";
   private static final String PROPERTYSTORE_SEGMENT_LINEAGE = "/SEGMENT_LINEAGE";
   private static final String PROPERTYSTORE_MINION_TASK_METADATA_PREFIX = "/MINION_TASK_METADATA";
+  private static final String PROPERTYSTORE_MINION_TASK_GENERATOR_INFO_PREFIX = "/MINION_TASK_GENERATOR_INFO";
 
   public static void setUserConfig(ZkHelixPropertyStore<ZNRecord> propertyStore, String username, ZNRecord znRecord) {
     propertyStore.set(constructPropertyStorePathForUserConfig(username), znRecord, AccessOption.PERSISTENT);
@@ -137,6 +138,10 @@ public class ZKMetadataProvider {
   public static String constructPropertyStorePathForMinionTaskMetadataDeprecated(String taskType,
       String tableNameWithType) {
     return StringUtil.join("/", PROPERTYSTORE_MINION_TASK_METADATA_PREFIX, taskType, tableNameWithType);
+  }
+
+  public static String constructPropertyStorePathForTaskGeneratorInfo(String tableNameWithType, String taskType) {
+    return StringUtil.join("/", PROPERTYSTORE_MINION_TASK_GENERATOR_INFO_PREFIX, tableNameWithType, taskType);
   }
 
   public static boolean isSegmentExisted(ZkHelixPropertyStore<ZNRecord> propertyStore, String resourceNameForResource,

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/BaseTaskGeneratorInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/BaseTaskGeneratorInfo.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.minion;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.helix.ZNRecord;
+import org.apache.pinot.spi.utils.JsonUtils;
+
+
+/**
+ * Base abstract class for task generator info.
+ *
+ * This info gets serialized and stored in zookeeper under the path:
+ * MINION_TASK_GENERATOR_INFO/${tableNameWithType}/${taskName} if it's associated with a table, or
+ * MINION_TASK_GENERATOR_INFO/${taskName} if it's not associated with a table.
+ */
+public abstract class BaseTaskGeneratorInfo {
+  /**
+   * @return task type
+   */
+  public abstract String getTaskType();
+
+  /**
+   * @return {@link ZNRecord} containing the task generator info
+   */
+  public abstract ZNRecord toZNRecord();
+
+  /**
+   * @return task generator info as a Json string
+   */
+  public String toJsonString() {
+    try {
+      return JsonUtils.objectToString(this);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException(e);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return toJsonString();
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/TaskGeneratorInfoUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/TaskGeneratorInfoUtils.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.minion;
+
+import javax.annotation.Nullable;
+import org.I0Itec.zkclient.exception.ZkException;
+import org.apache.helix.AccessOption;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.HelixPropertyStore;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.zookeeper.data.Stat;
+
+
+/**
+ * Helper methods to fetch/persist ZNRecord for task generator info
+ */
+public final class TaskGeneratorInfoUtils {
+  private TaskGeneratorInfoUtils() {
+  }
+  /**
+   * Fetches the {@link ZNRecord} for the given tableName and taskType, from
+   * MINION_TASK_GENERATOR_INFO/tableNameWthType/taskName
+   *
+   * @param propertyStore the {@link HelixPropertyStore} to fetch {@link ZNRecord} from
+   * @param tableNameWithType the table name with type
+   * @param taskType the task type
+   * @return the {@link ZNRecord}
+   */
+  @Nullable
+  public static ZNRecord fetchTaskGeneratorInfo(HelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType,
+      String taskType) {
+    String path = ZKMetadataProvider.constructPropertyStorePathForTaskGeneratorInfo(tableNameWithType, taskType);
+    Stat stat = new Stat();
+    ZNRecord znRecord = propertyStore.get(path, stat, AccessOption.PERSISTENT);
+    if (znRecord != null) {
+      znRecord.setVersion(stat.getVersion());
+    }
+    return znRecord;
+  }
+
+  /**
+   * Persists the {@link BaseTaskGeneratorInfo} for the given tableName and taskType, to
+   * MINION_TASK_GENERATOR_INFO/tableNameWthType/taskName
+   *
+   * @param propertyStore the {@link HelixPropertyStore} to save {@link BaseTaskGeneratorInfo} into
+   * @param tableNameWithType the table name with type
+   * @param taskGeneratorInfo the {@link BaseTaskGeneratorInfo}
+   * @param expectedVersion the expected {@link ZNRecord} version
+   */
+  public static void persistTaskGeneratorInfo(HelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType,
+      BaseTaskGeneratorInfo taskGeneratorInfo, int expectedVersion) {
+    String path = ZKMetadataProvider.constructPropertyStorePathForTaskGeneratorInfo(tableNameWithType,
+        taskGeneratorInfo.getTaskType());
+    if (!propertyStore.set(path, taskGeneratorInfo.toZNRecord(), expectedVersion, AccessOption.PERSISTENT)) {
+      throw new ZkException(
+          "Failed to persist task generator info for task: " + taskGeneratorInfo.getClass() + " and info: "
+              + taskGeneratorInfo);
+    }
+  }
+
+  /**
+   * Delete the {@link ZNRecord} for the given tableName and taskTyp, from
+   * MINION_TASK_GENERATOR_INFO/tableNameWthType/taskName
+   *
+   * @param propertyStore the {@link HelixPropertyStore} to delete
+   * @param tableNameWithType the table name with type
+   * @param taskType the task type
+   */
+  public static void deleteTaskGeneratorInfo(HelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType,
+      String taskType) {
+    String path = ZKMetadataProvider.constructPropertyStorePathForTaskGeneratorInfo(tableNameWithType, taskType);
+    if (!propertyStore.remove(path, AccessOption.PERSISTENT)) {
+      throw new ZkException("Failed to delete task generator info: " + tableNameWithType + ", " + taskType);
+    }
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/TaskGeneratorMostRecentRunInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/TaskGeneratorMostRecentRunInfo.java
@@ -1,0 +1,198 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.minion;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.PriorityQueue;
+import java.util.Queue;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import org.apache.helix.ZNRecord;
+
+
+/**
+ * a task generator running history which keeps the most recent several success run timestamp and the most recent
+ * several error run
+ * message.
+ */
+public class TaskGeneratorMostRecentRunInfo extends BaseTaskGeneratorInfo {
+  @VisibleForTesting
+  static final String ZNRECORD_DELIMITER = "__";
+  @VisibleForTesting
+  static final int MAX_NUM_OF_HISTORY_TO_KEEP = 5;
+  @VisibleForTesting
+  static final String MOST_RECENT_SUCCESS_RUN_TS = "mostRecentSuccessRunTs";
+  @VisibleForTesting
+  static final String MOST_RECENT_ERROR_RUN_MESSAGE = "mostRecentErrorRunMessage";
+
+  private final String _taskType;
+  private final String _tableNameWithType;
+  // the timestamp to error message map of the most recent several error runs
+  @Nonnull
+  private final TreeMap<Long, String> _mostRecentErrorRunMessage;
+  // the timestamp of the most recent several success runs
+  @Nonnull
+  private final List<Long> _mostRecentSuccessRunTS;
+  private final int _version;
+
+  private TaskGeneratorMostRecentRunInfo(String tableNameWithType, String taskType,
+      Map<Long, String> mostRecentErrorRunMessage, List<Long> mostRecentSuccessRunTS, int version) {
+    _tableNameWithType = tableNameWithType;
+    _taskType = taskType;
+    // sort and keep the most recent several error messages
+    _mostRecentErrorRunMessage = new TreeMap<>();
+    mostRecentErrorRunMessage.forEach((k, v) -> {
+      _mostRecentErrorRunMessage.put(k, v);
+      if (_mostRecentErrorRunMessage.size() > MAX_NUM_OF_HISTORY_TO_KEEP) {
+        _mostRecentErrorRunMessage.remove(_mostRecentErrorRunMessage.firstKey());
+      }
+    });
+    // sort and keep the most recent several timestamp
+    Queue<Long> sortedTs = new PriorityQueue<>();
+    mostRecentSuccessRunTS.forEach(e -> {
+      sortedTs.offer(e);
+      if (sortedTs.size() > MAX_NUM_OF_HISTORY_TO_KEEP) {
+        sortedTs.poll();
+      }
+    });
+    _mostRecentSuccessRunTS = new ArrayList<>();
+    while (!sortedTs.isEmpty()) {
+      _mostRecentSuccessRunTS.add(sortedTs.poll());
+    }
+    _version = version;
+  }
+
+  /**
+   * Returns the table name with type
+   */
+  public String getTableNameWithType() {
+    return _tableNameWithType;
+  }
+
+  @Override
+  public String getTaskType() {
+    return _taskType;
+  }
+
+  /**
+   * Gets the timestamp to error message map of the most recent several error runs
+   */
+  public TreeMap<Long, String> getMostRecentErrorRunMessage() {
+    return _mostRecentErrorRunMessage;
+  }
+
+  /**
+   * Adds an error run message
+   * @param ts A timestamp
+   * @param message An error message.
+   */
+  public void addErrorRunMessage(long ts, String message) {
+    _mostRecentErrorRunMessage.put(ts, message);
+    if (_mostRecentErrorRunMessage.size() > MAX_NUM_OF_HISTORY_TO_KEEP) {
+      _mostRecentErrorRunMessage.remove(_mostRecentErrorRunMessage.firstKey());
+    }
+  }
+
+  /**
+   * Gets the timestamp of the most recent several success runs
+   */
+  public List<Long> getMostRecentSuccessRunTS() {
+    return _mostRecentSuccessRunTS;
+  }
+
+  /**
+   * Adds a success task generating run timestamp
+   * @param ts A timestamp
+   */
+  public void addSuccessRunTs(long ts) {
+    _mostRecentSuccessRunTS.add(ts);
+    if (_mostRecentSuccessRunTS.size() > MAX_NUM_OF_HISTORY_TO_KEEP) {
+      // sort first in case the given timestamp is not the largest one.
+      Collections.sort(_mostRecentSuccessRunTS);
+      _mostRecentSuccessRunTS.remove(0);
+    }
+  }
+
+  /**
+   * Returns the current information version, it should be consistent with the corresponding {@link ZNRecord} version.
+   */
+  public int getVersion() {
+    return _version;
+  }
+
+  @Override
+  public ZNRecord toZNRecord() {
+    ZNRecord znRecord = new ZNRecord(constructZNRecordId(_tableNameWithType, _taskType));
+    znRecord.setVersion(_version);
+    List<String> mostRecentSuccessTsStringList =
+        _mostRecentSuccessRunTS.stream().map(e -> Long.toString(e)).collect(Collectors.toList());
+    znRecord.setListField(MOST_RECENT_SUCCESS_RUN_TS, mostRecentSuccessTsStringList);
+    Map<String, String> mostRecentErrorsTsStringMap = _mostRecentErrorRunMessage.entrySet().stream()
+        .collect(Collectors.toMap(e -> Long.toString(e.getKey()), Map.Entry::getValue));
+    znRecord.setMapField(MOST_RECENT_ERROR_RUN_MESSAGE, mostRecentErrorsTsStringMap);
+    return znRecord;
+  }
+
+  /**
+   * Creates a {@link TaskGeneratorMostRecentRunInfo} instance from a {@link ZNRecord}
+   * @param znRecord a {@link ZNRecord}
+   * @return a {@link TaskGeneratorMostRecentRunInfo}
+   */
+  public static TaskGeneratorMostRecentRunInfo fromZNRecord(ZNRecord znRecord, String tableNameWithType,
+      String taskType) {
+    Preconditions.checkArgument(Objects.equals(znRecord.getId(), constructZNRecordId(tableNameWithType, taskType)),
+        String.format("the provided ZNRecord is not for table %s and task type %s", tableNameWithType, taskType));
+    List<String> mostRecentSuccessTsStringList = znRecord.getListField(MOST_RECENT_SUCCESS_RUN_TS);
+    if (mostRecentSuccessTsStringList == null) {
+      mostRecentSuccessTsStringList = Collections.EMPTY_LIST;
+    }
+    Map<String, String> mostRecentErrorsTsStringMap = znRecord.getMapField(MOST_RECENT_ERROR_RUN_MESSAGE);
+    if (mostRecentErrorsTsStringMap == null) {
+      mostRecentErrorsTsStringMap = Collections.EMPTY_MAP;
+    }
+
+    return new TaskGeneratorMostRecentRunInfo(tableNameWithType, taskType,
+        mostRecentErrorsTsStringMap.entrySet().stream()
+            .collect(Collectors.toMap(e -> Long.parseLong(e.getKey()), Map.Entry::getValue)),
+        mostRecentSuccessTsStringList.stream().map(Long::parseLong).collect(Collectors.toList()),
+        znRecord.getVersion());
+  }
+
+  /**
+   * Creates a new empty {@link TaskGeneratorMostRecentRunInfo}
+   * @param tableNameWithType the table name with type
+   * @param taskType the task type.
+   * @return a new empty {@link TaskGeneratorMostRecentRunInfo}
+   */
+  public static TaskGeneratorMostRecentRunInfo newInstance(String tableNameWithType, String taskType) {
+    return new TaskGeneratorMostRecentRunInfo(tableNameWithType, taskType, Collections.EMPTY_MAP,
+        Collections.EMPTY_LIST, -1);
+  }
+
+  private static String constructZNRecordId(String tableNameWithType, String taskType) {
+    return tableNameWithType + ZNRECORD_DELIMITER + taskType;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/TaskGeneratorMostRecentRunInfoUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/TaskGeneratorMostRecentRunInfoUtils.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.minion;
+
+import java.util.function.Consumer;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.HelixPropertyStore;
+
+
+/**
+ * TaskGeneratorMostRecentRunInfoUtils is a tool used to save PinotTaskGenerator success run timestamp or error run
+ * messages to ZK.
+ */
+public class TaskGeneratorMostRecentRunInfoUtils {
+  private TaskGeneratorMostRecentRunInfoUtils() {
+  }
+  /**
+   * Saves a success run timestamp to ZK path MINION_TASK_GENERATOR_INFO/tableNameWthType/taskName.
+   * @param propertyStore the {@link HelixPropertyStore} to save {@link BaseTaskGeneratorInfo} into
+   * @param tableNameWithType the table name with type
+   * @param taskType the task type
+   * @param ts the timestamp
+   */
+  public static void saveSuccessRunTsToZk(HelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType,
+      String taskType, long ts) {
+    saveToZk(propertyStore, tableNameWithType, taskType,
+        taskGeneratorMostRecentRunInfo -> taskGeneratorMostRecentRunInfo.addSuccessRunTs(ts));
+  }
+
+  /**
+   * Saves an error run message to ZK path MINION_TASK_GENERATOR_INFO/tableNameWthType/taskName.
+   * @param propertyStore the {@link HelixPropertyStore} to save {@link BaseTaskGeneratorInfo} into
+   * @param tableNameWithType  the table name with type
+   * @param taskType the task type
+   * @param ts the timestamp
+   * @param message the error message
+   */
+  public static void saveErrorRunMessageToZk(HelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType,
+      String taskType, long ts, String message) {
+    saveToZk(propertyStore, tableNameWithType, taskType,
+        taskGeneratorMostRecentRunInfo -> taskGeneratorMostRecentRunInfo.addErrorRunMessage(ts, message));
+  }
+
+  private static void saveToZk(HelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType, String taskType,
+      Consumer<TaskGeneratorMostRecentRunInfo> taskGeneratorMostRecentRunInfoUpdater) {
+    ZNRecord znRecord = TaskGeneratorInfoUtils.fetchTaskGeneratorInfo(propertyStore, tableNameWithType, taskType);
+    TaskGeneratorMostRecentRunInfo taskGeneratorMostRecentRunInfo;
+    if (znRecord != null) {
+      taskGeneratorMostRecentRunInfo =
+          TaskGeneratorMostRecentRunInfo.fromZNRecord(znRecord, tableNameWithType, taskType);
+    } else {
+      taskGeneratorMostRecentRunInfo = TaskGeneratorMostRecentRunInfo.newInstance(tableNameWithType, taskType);
+    }
+    taskGeneratorMostRecentRunInfoUpdater.accept(taskGeneratorMostRecentRunInfo);
+    TaskGeneratorInfoUtils.persistTaskGeneratorInfo(propertyStore, tableNameWithType, taskGeneratorMostRecentRunInfo,
+        taskGeneratorMostRecentRunInfo.getVersion());
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/FakePropertyStore.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/FakePropertyStore.java
@@ -37,7 +37,13 @@ public class FakePropertyStore extends ZkHelixPropertyStore<ZNRecord> {
 
   @Override
   public ZNRecord get(String path, Stat stat, int options) {
-    return _contents.get(path);
+    ZNRecord znRecord = _contents.get(path);
+    if (znRecord != null) {
+      stat.setVersion(znRecord.getVersion());
+    } else {
+      stat.setVersion(-1);
+    }
+    return znRecord;
   }
 
   @Override

--- a/pinot-common/src/test/java/org/apache/pinot/common/minion/TaskGeneratorInfoUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/minion/TaskGeneratorInfoUtilsTest.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.minion;
+
+import org.I0Itec.zkclient.exception.ZkException;
+import org.apache.helix.AccessOption;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.HelixPropertyStore;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.utils.helix.FakePropertyStore;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+
+/**
+ * Tests for {@link TaskGeneratorInfoUtils}
+ */
+public class TaskGeneratorInfoUtilsTest {
+  private static final String TABLE_NAME_WITH_TYPE = "table_OFFLINE";
+  private static final String TASK_TYPE = "taskType";
+
+  @Test
+  public void testFetchTaskGeneratorInfo() {
+    // ZNRecord does not exist
+    HelixPropertyStore<ZNRecord> fakePropertyStore = new FakePropertyStore();
+    assertNull(TaskGeneratorInfoUtils.fetchTaskGeneratorInfo(fakePropertyStore, TABLE_NAME_WITH_TYPE, TASK_TYPE));
+    // ZNRecord exists
+    ZNRecord znRecord =
+        new ZNRecord(TABLE_NAME_WITH_TYPE + TaskGeneratorMostRecentRunInfo.ZNRECORD_DELIMITER + TASK_TYPE);
+    fakePropertyStore.set(
+        ZKMetadataProvider.constructPropertyStorePathForTaskGeneratorInfo(TABLE_NAME_WITH_TYPE, TASK_TYPE), znRecord,
+        AccessOption.PERSISTENT);
+    assertEquals(TaskGeneratorInfoUtils.fetchTaskGeneratorInfo(fakePropertyStore, TABLE_NAME_WITH_TYPE, TASK_TYPE),
+        znRecord);
+  }
+
+  @Test
+  public void testPersistTaskGeneratorInfo() {
+    HelixPropertyStore<ZNRecord> fakePropertyStore = new FakePropertyStore();
+    TaskGeneratorInfoUtils.persistTaskGeneratorInfo(fakePropertyStore, TABLE_NAME_WITH_TYPE,
+        TaskGeneratorMostRecentRunInfo.newInstance(TABLE_NAME_WITH_TYPE, TASK_TYPE), -1);
+  }
+
+  @Test(expectedExceptions = ZkException.class)
+  public void testPersistTaskGeneratorInfoThrows() {
+    HelixPropertyStore<ZNRecord> mockedPropertyStore = mock(HelixPropertyStore.class);
+    TaskGeneratorInfoUtils.persistTaskGeneratorInfo(mockedPropertyStore, TABLE_NAME_WITH_TYPE,
+        TaskGeneratorMostRecentRunInfo.newInstance(TABLE_NAME_WITH_TYPE, TASK_TYPE), -1);
+  }
+
+  @Test
+  public void testDeleteTaskGeneratorInfo() {
+    HelixPropertyStore<ZNRecord> fakePropertyStore = new FakePropertyStore();
+    TaskGeneratorInfoUtils.deleteTaskGeneratorInfo(fakePropertyStore, TABLE_NAME_WITH_TYPE, TASK_TYPE);
+  }
+
+  @Test(expectedExceptions = ZkException.class)
+  public void testDeleteTaskGeneratorInfoThrows() {
+    HelixPropertyStore<ZNRecord> mockedPropertyStore = mock(HelixPropertyStore.class);
+    TaskGeneratorInfoUtils.deleteTaskGeneratorInfo(mockedPropertyStore, TABLE_NAME_WITH_TYPE, TASK_TYPE);
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/minion/TaskGeneratorMostRecentRunInfoTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/minion/TaskGeneratorMostRecentRunInfoTest.java
@@ -1,0 +1,198 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.minion;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.helix.ZNRecord;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Tests for {@link TaskGeneratorMostRecentRunInfo}
+ */
+public class TaskGeneratorMostRecentRunInfoTest {
+  private static final String TABLE_NAME_WITH_TYPE = "table_OFFLINE";
+  private static final String TASK_TYPE = "taskType";
+
+  @Test
+  public void testNewInstance() {
+    TaskGeneratorMostRecentRunInfo taskGeneratorMostRecentRunInfo =
+        TaskGeneratorMostRecentRunInfo.newInstance(TABLE_NAME_WITH_TYPE, TASK_TYPE);
+    assertEquals(taskGeneratorMostRecentRunInfo.getTableNameWithType(), TABLE_NAME_WITH_TYPE);
+    assertEquals(taskGeneratorMostRecentRunInfo.getTaskType(), TASK_TYPE);
+    assertEquals(taskGeneratorMostRecentRunInfo.getVersion(), -1);
+    assertTrue(taskGeneratorMostRecentRunInfo.getMostRecentSuccessRunTS().isEmpty());
+    assertTrue(taskGeneratorMostRecentRunInfo.getMostRecentErrorRunMessage().isEmpty());
+
+    ZNRecord znRecord = taskGeneratorMostRecentRunInfo.toZNRecord();
+    assertEquals(znRecord.getId(),
+        TABLE_NAME_WITH_TYPE + TaskGeneratorMostRecentRunInfo.ZNRECORD_DELIMITER + TASK_TYPE);
+    assertEquals(znRecord.getListFields().size(), 1);
+    assertTrue(znRecord.getListField(TaskGeneratorMostRecentRunInfo.MOST_RECENT_SUCCESS_RUN_TS).isEmpty());
+    assertEquals(znRecord.getMapFields().size(), 1);
+    assertTrue(znRecord.getMapField(TaskGeneratorMostRecentRunInfo.MOST_RECENT_ERROR_RUN_MESSAGE).isEmpty());
+  }
+
+  @Test
+  public void testAddSuccessRunTs() {
+    TaskGeneratorMostRecentRunInfo taskGeneratorMostRecentRunInfo =
+        TaskGeneratorMostRecentRunInfo.newInstance(TABLE_NAME_WITH_TYPE, TASK_TYPE);
+    for (long i = 0; i < TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP; i++) {
+      taskGeneratorMostRecentRunInfo.addSuccessRunTs(i);
+      List<Long> mostRecentSuccessRunTS = taskGeneratorMostRecentRunInfo.getMostRecentSuccessRunTS();
+      assertEquals(mostRecentSuccessRunTS.size(), i + 1);
+      for (long j = i; j >= 0; j--) {
+        assertTrue(mostRecentSuccessRunTS.contains(j));
+      }
+    }
+
+    // add another 2 timestamp in order
+    taskGeneratorMostRecentRunInfo.addSuccessRunTs(TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP + 10);
+    List<Long> mostRecentSuccessRunTS = taskGeneratorMostRecentRunInfo.getMostRecentSuccessRunTS();
+    assertEquals(mostRecentSuccessRunTS.size(), TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP);
+    taskGeneratorMostRecentRunInfo.addSuccessRunTs(TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP + 20);
+    mostRecentSuccessRunTS = taskGeneratorMostRecentRunInfo.getMostRecentSuccessRunTS();
+    assertEquals(mostRecentSuccessRunTS.size(), TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP);
+    for (long i = 2; i < TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP; i++) {
+      assertTrue(mostRecentSuccessRunTS.contains(i));
+    }
+    assertTrue(mostRecentSuccessRunTS.contains((long) TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP + 10));
+    assertTrue(mostRecentSuccessRunTS.contains((long) TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP + 20));
+
+    // add 0 again should not change the success ts list
+    taskGeneratorMostRecentRunInfo.addSuccessRunTs(0);
+    mostRecentSuccessRunTS = taskGeneratorMostRecentRunInfo.getMostRecentSuccessRunTS();
+    assertEquals(mostRecentSuccessRunTS.size(), TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP);
+    assertFalse(mostRecentSuccessRunTS.contains(0L));
+
+    // add the one in middle will remove the smallest one
+    taskGeneratorMostRecentRunInfo.addSuccessRunTs(TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP + 15);
+    mostRecentSuccessRunTS = taskGeneratorMostRecentRunInfo.getMostRecentSuccessRunTS();
+    assertEquals(mostRecentSuccessRunTS.size(), TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP);
+    // 2 was removed
+    assertFalse(mostRecentSuccessRunTS.contains(2L));
+    assertTrue(mostRecentSuccessRunTS.contains((long) TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP + 15));
+  }
+
+  @Test
+  public void testErrorRunMessage() {
+    String errorMessage = "error";
+    TaskGeneratorMostRecentRunInfo taskGeneratorMostRecentRunInfo =
+        TaskGeneratorMostRecentRunInfo.newInstance(TABLE_NAME_WITH_TYPE, TASK_TYPE);
+    for (long i = 0; i < TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP; i++) {
+      taskGeneratorMostRecentRunInfo.addErrorRunMessage(i, errorMessage);
+      Map<Long, String> mostRecentErrorRunMessage = taskGeneratorMostRecentRunInfo.getMostRecentErrorRunMessage();
+      assertEquals(mostRecentErrorRunMessage.size(), i + 1);
+      for (long j = i; j >= 0; j--) {
+        assertTrue(mostRecentErrorRunMessage.containsKey(j));
+      }
+    }
+
+    // add another 2 error messages in order
+    taskGeneratorMostRecentRunInfo.addErrorRunMessage(TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP + 10,
+        errorMessage);
+    Map<Long, String> mostRecentErrorRunMessage = taskGeneratorMostRecentRunInfo.getMostRecentErrorRunMessage();
+    assertEquals(mostRecentErrorRunMessage.size(), TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP);
+    taskGeneratorMostRecentRunInfo.addErrorRunMessage(TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP + 20,
+        errorMessage);
+    mostRecentErrorRunMessage = taskGeneratorMostRecentRunInfo.getMostRecentErrorRunMessage();
+    assertEquals(mostRecentErrorRunMessage.size(), TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP);
+    for (long i = 2; i < TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP; i++) {
+      assertTrue(mostRecentErrorRunMessage.containsKey(i));
+    }
+    assertTrue(
+        mostRecentErrorRunMessage.containsKey((long) TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP + 10));
+    assertTrue(
+        mostRecentErrorRunMessage.containsKey((long) TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP + 20));
+
+    // add 0 again should not change the success ts list
+    taskGeneratorMostRecentRunInfo.addErrorRunMessage(0, errorMessage);
+    mostRecentErrorRunMessage = taskGeneratorMostRecentRunInfo.getMostRecentErrorRunMessage();
+    assertEquals(mostRecentErrorRunMessage.size(), TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP);
+    assertFalse(mostRecentErrorRunMessage.containsKey(0L));
+
+    // add the one in middle will remove the smallest one
+    taskGeneratorMostRecentRunInfo.addErrorRunMessage(TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP + 15,
+        errorMessage);
+    mostRecentErrorRunMessage = taskGeneratorMostRecentRunInfo.getMostRecentErrorRunMessage();
+    assertEquals(mostRecentErrorRunMessage.size(), TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP);
+    // 2 was removed
+    assertFalse(mostRecentErrorRunMessage.containsKey(2L));
+    assertTrue(
+        mostRecentErrorRunMessage.containsKey((long) TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP + 15));
+  }
+
+  @Test
+  public void testFromAndToZNRecord() {
+    String errorMessage = "error";
+    ZNRecord znRecord =
+        new ZNRecord(TABLE_NAME_WITH_TYPE + TaskGeneratorMostRecentRunInfo.ZNRECORD_DELIMITER + TASK_TYPE);
+    znRecord.setVersion(10);
+    List<String> successTsList = new ArrayList<>();
+    for (long i = 0; i < TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP + 5; i++) {
+      successTsList.add(Long.toString(i));
+    }
+    znRecord.setListField(TaskGeneratorMostRecentRunInfo.MOST_RECENT_SUCCESS_RUN_TS, successTsList);
+    Map<String, String> errorMessageMap = new HashMap<>();
+    for (long i = 0; i < TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP + 5; i++) {
+      errorMessageMap.put(Long.toString(i), errorMessage);
+    }
+    znRecord.setMapField(TaskGeneratorMostRecentRunInfo.MOST_RECENT_ERROR_RUN_MESSAGE, errorMessageMap);
+    // check the TaskGeneratorMostRecentRunInfo converted from the ZNRecord
+    TaskGeneratorMostRecentRunInfo taskGeneratorMostRecentRunInfo =
+        TaskGeneratorMostRecentRunInfo.fromZNRecord(znRecord, TABLE_NAME_WITH_TYPE, TASK_TYPE);
+    assertEquals(taskGeneratorMostRecentRunInfo.getTableNameWithType(), TABLE_NAME_WITH_TYPE);
+    assertEquals(taskGeneratorMostRecentRunInfo.getTaskType(), TASK_TYPE);
+    assertEquals(taskGeneratorMostRecentRunInfo.getVersion(), 10);
+    assertEquals(taskGeneratorMostRecentRunInfo.getMostRecentSuccessRunTS().size(),
+        TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP);
+    assertEquals(taskGeneratorMostRecentRunInfo.getMostRecentErrorRunMessage().size(),
+        TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP);
+
+    // convert it back to ZNREcord
+    ZNRecord znRecordConverted = taskGeneratorMostRecentRunInfo.toZNRecord();
+    ZNRecord expectedZNRecord = new ZNRecord(TASK_TYPE);
+    expectedZNRecord.setVersion(10);
+    List<String> expectedSuccessTsList = new ArrayList<>();
+    for (long i = 5; i < TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP + 5; i++) {
+      expectedSuccessTsList.add(Long.toString(i));
+    }
+    expectedZNRecord.setListField(TaskGeneratorMostRecentRunInfo.MOST_RECENT_SUCCESS_RUN_TS, expectedSuccessTsList);
+    Map<String, String> expectedErrorMessageMap = new HashMap<>();
+    for (long i = 5; i < TaskGeneratorMostRecentRunInfo.MAX_NUM_OF_HISTORY_TO_KEEP + 5; i++) {
+      expectedErrorMessageMap.put(Long.toString(i), errorMessage);
+    }
+    expectedZNRecord.setMapField(TaskGeneratorMostRecentRunInfo.MOST_RECENT_ERROR_RUN_MESSAGE, expectedErrorMessageMap);
+    assertEquals(znRecordConverted, expectedZNRecord);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testFromZNRecordThrows() {
+    ZNRecord znRecord = new ZNRecord("random");
+    znRecord.setVersion(10);
+    TaskGeneratorMostRecentRunInfo.fromZNRecord(znRecord, TABLE_NAME_WITH_TYPE, TASK_TYPE);
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/minion/TaskGeneratorMostRecentRunInfoUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/minion/TaskGeneratorMostRecentRunInfoUtilsTest.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.minion;
+
+import org.apache.helix.AccessOption;
+import org.apache.helix.ZNRecord;
+import org.apache.helix.store.HelixPropertyStore;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.utils.helix.FakePropertyStore;
+import org.apache.zookeeper.data.Stat;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Tests for {@link TaskGeneratorMostRecentRunInfoUtils}
+ */
+public class TaskGeneratorMostRecentRunInfoUtilsTest {
+  private static final String TABLE_NAME_WITH_TYPE = "table_OFFLINE";
+  private static final String TASK_TYPE = "taskType";
+  private static final String ZNODE_PATH =
+      ZKMetadataProvider.constructPropertyStorePathForTaskGeneratorInfo(TABLE_NAME_WITH_TYPE, TASK_TYPE);
+  private HelixPropertyStore<ZNRecord> _propertyStore;
+
+  @BeforeMethod
+  public void setUp() {
+    _propertyStore = new FakePropertyStore();
+  }
+
+  @Test
+  public void testSaveSuccessRunTsToZkWithoutInitialZNode() {
+    saveAndCheckSuccessRunTs(-1);
+  }
+
+  @Test
+  public void testSaveSuccessRunTsToZkWithInitialZNode() {
+    initializeZNRecord();
+    saveAndCheckSuccessRunTs(10);
+  }
+
+  private void saveAndCheckSuccessRunTs(int expectedVersion) {
+    TaskGeneratorMostRecentRunInfoUtils.saveSuccessRunTsToZk(_propertyStore, TABLE_NAME_WITH_TYPE, TASK_TYPE, 10);
+    ZNRecord znRecord = _propertyStore.get(ZNODE_PATH, new Stat(), AccessOption.PERSISTENT);
+    assertEquals(znRecord.getId(),
+        TABLE_NAME_WITH_TYPE + TaskGeneratorMostRecentRunInfo.ZNRECORD_DELIMITER + TASK_TYPE);
+    assertEquals(znRecord.getVersion(), expectedVersion);
+    assertEquals(znRecord.getListFields().size(), 1);
+    assertEquals(znRecord.getListField(TaskGeneratorMostRecentRunInfo.MOST_RECENT_SUCCESS_RUN_TS).size(), 1);
+    assertTrue(znRecord.getListField(TaskGeneratorMostRecentRunInfo.MOST_RECENT_SUCCESS_RUN_TS).contains("10"));
+    assertEquals(znRecord.getMapFields().size(), 1);
+    assertTrue(znRecord.getMapFields().containsKey(TaskGeneratorMostRecentRunInfo.MOST_RECENT_ERROR_RUN_MESSAGE));
+    assertTrue(znRecord.getMapField(TaskGeneratorMostRecentRunInfo.MOST_RECENT_ERROR_RUN_MESSAGE).isEmpty());
+  }
+
+  @Test
+  public void testSaveErrorRunMessageToZkWithoutInitialZNode() {
+    saveAndCheckErrorRunMessage(-1);
+  }
+
+  @Test
+  public void testSaveErrorRunMessageToZkWithInitialZNode() {
+    initializeZNRecord();
+    saveAndCheckErrorRunMessage(10);
+  }
+
+  private void saveAndCheckErrorRunMessage(int expectedVersion) {
+    TaskGeneratorMostRecentRunInfoUtils.saveErrorRunMessageToZk(_propertyStore, TABLE_NAME_WITH_TYPE, TASK_TYPE, 10,
+        "error");
+    ZNRecord znRecordUpdated = _propertyStore.get(ZNODE_PATH, new Stat(), AccessOption.PERSISTENT);
+    assertEquals(znRecordUpdated.getId(),
+        TABLE_NAME_WITH_TYPE + TaskGeneratorMostRecentRunInfo.ZNRECORD_DELIMITER + TASK_TYPE);
+    assertEquals(znRecordUpdated.getVersion(), expectedVersion);
+    assertEquals(znRecordUpdated.getMapFields().size(), 1);
+    assertEquals(znRecordUpdated.getMapField(TaskGeneratorMostRecentRunInfo.MOST_RECENT_ERROR_RUN_MESSAGE).size(), 1);
+    assertTrue(
+        znRecordUpdated.getMapField(TaskGeneratorMostRecentRunInfo.MOST_RECENT_ERROR_RUN_MESSAGE).containsKey("10"));
+    assertEquals(znRecordUpdated.getListFields().size(), 1);
+    assertTrue(znRecordUpdated.getListFields().containsKey(TaskGeneratorMostRecentRunInfo.MOST_RECENT_SUCCESS_RUN_TS));
+    assertTrue(znRecordUpdated.getListField(TaskGeneratorMostRecentRunInfo.MOST_RECENT_SUCCESS_RUN_TS).isEmpty());
+  }
+
+  private void initializeZNRecord() {
+    ZNRecord znRecord =
+        new ZNRecord(TABLE_NAME_WITH_TYPE + TaskGeneratorMostRecentRunInfo.ZNRECORD_DELIMITER + TASK_TYPE);
+    znRecord.setVersion(10);
+    _propertyStore.set(ZNODE_PATH, znRecord, 10, AccessOption.PERSISTENT);
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/plugin/minion/tasks/TestTaskGenerator.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/plugin/minion/tasks/TestTaskGenerator.java
@@ -29,8 +29,6 @@ import org.apache.pinot.integration.tests.SimpleMinionClusterIntegrationTest;
 import org.apache.pinot.spi.annotations.minion.TaskGenerator;
 import org.apache.pinot.spi.config.table.TableConfig;
 
-import static org.testng.Assert.assertEquals;
-
 
 /**
  * Task generator for {@link SimpleMinionClusterIntegrationTest}.

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/plugin/minion/tasks/TestTaskGenerator.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/plugin/minion/tasks/TestTaskGenerator.java
@@ -45,8 +45,6 @@ public class TestTaskGenerator extends BaseTaskGenerator {
 
   @Override
   public List<PinotTaskConfig> generateTasks(List<TableConfig> tableConfigs) {
-    assertEquals(tableConfigs.size(), SimpleMinionClusterIntegrationTest.NUM_TASKS);
-
     // Generate at most 2 tasks
     if (_clusterInfoAccessor.getTaskStates(SimpleMinionClusterIntegrationTest.TASK_TYPE).size()
         >= SimpleMinionClusterIntegrationTest.NUM_TASKS) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/plugin/minion/tasks/TestTaskGenerator.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/plugin/minion/tasks/TestTaskGenerator.java
@@ -29,6 +29,8 @@ import org.apache.pinot.integration.tests.SimpleMinionClusterIntegrationTest;
 import org.apache.pinot.spi.annotations.minion.TaskGenerator;
 import org.apache.pinot.spi.config.table.TableConfig;
 
+import static org.testng.Assert.assertEquals;
+
 
 /**
  * Task generator for {@link SimpleMinionClusterIntegrationTest}.
@@ -43,6 +45,7 @@ public class TestTaskGenerator extends BaseTaskGenerator {
 
   @Override
   public List<PinotTaskConfig> generateTasks(List<TableConfig> tableConfigs) {
+    assertEquals(tableConfigs.size(), SimpleMinionClusterIntegrationTest.NUM_TASKS);
     // Generate at most 2 tasks
     if (_clusterInfoAccessor.getTaskStates(SimpleMinionClusterIntegrationTest.TASK_TYPE).size()
         >= SimpleMinionClusterIntegrationTest.NUM_TASKS) {


### PR DESCRIPTION
## Changes
Save task generator info to ZK to help with task generator debug. Specifically
1/ the ZK path is `/MINION_TASK_GENERATOR_INFO/${tableNameWithType}/${taskType}`. We don't reuse the `/MINION_TASK_METADATA/${tableNameWithType}/${taskType}` because we don't want to mess up the existing ZNodes.
2/ save the most recent 5 success task generation run timestamp to ZK
3/ save the most recent 5 error task generation run timestamp and message to ZK

This logic change is not on the main data or control path, so it should be safe.