### PR TITLE
Add k8s resource request by default

### DIFF
--- a/kubernetes/helm/pinot/values.yaml
+++ b/kubernetes/helm/pinot/values.yaml
@@ -99,7 +99,7 @@ controller:
     host: pinot-controller
     port: 9000
 
-  jvmOpts: "-Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-controller.log"
+  jvmOpts: "-XX=ActiveProcessorCount=2 -Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-controller.log"
 
   log4j2ConfFile: /opt/pinot/conf/log4j2.xml
   pluginsDir: /opt/pinot/plugins
@@ -134,7 +134,6 @@ controller:
 
   resources:
     requests:
-      cpu: "2000m"
       memory: "1.25Gi"
 
   nodeSelector: {}
@@ -180,7 +179,7 @@ broker:
     # fsGroup: 2000
   securityContext: {}
 
-  jvmOpts: "-Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-broker.log"
+  jvmOpts: "-XX=ActiveProcessorCount=2 -Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-broker.log"
 
   log4j2ConfFile: /opt/pinot/conf/log4j2.xml
   pluginsDir: /opt/pinot/plugins
@@ -228,7 +227,6 @@ broker:
 
   resources:
     requests:
-      cpu: "2000m"
       memory: "1.25Gi"
 
   nodeSelector: {}
@@ -313,7 +311,6 @@ server:
 
   resources:
     requests:
-      cpu: "2000m"
       memory: "1.25Gi"
 
   nodeSelector: {}
@@ -367,7 +364,7 @@ minion:
     readinessEnabled: true
 
   dataDir: /var/pinot/minion/data
-  jvmOpts: "-Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-minion.log"
+  jvmOpts: "-XX=ActiveProcessorCount=2 -Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-minion.log"
 
   log4j2ConfFile: /opt/pinot/conf/log4j2.xml
   pluginsDir: /opt/pinot/plugins
@@ -396,7 +393,6 @@ minion:
 
   resources:
     requests:
-      cpu: "2000m"
       memory: "1.25Gi"
 
   nodeSelector: {}
@@ -448,7 +444,7 @@ minionStateless:
     readinessEnabled: true
 
   dataDir: /var/pinot/minion/data
-  jvmOpts: "-Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-minion.log"
+  jvmOpts: "-XX=ActiveProcessorCount=2 -Xms256M -Xmx1G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xlog:gc*:file=/opt/pinot/gc-pinot-minion.log"
 
   log4j2ConfFile: /opt/pinot/conf/log4j2.xml
   pluginsDir: /opt/pinot/plugins
@@ -471,7 +467,6 @@ minionStateless:
 
   resources:
     requests:
-      cpu: "2000m"
       memory: "1.25Gi"
 
   nodeSelector: {}

--- a/kubernetes/helm/pinot/values.yaml
+++ b/kubernetes/helm/pinot/values.yaml
@@ -516,7 +516,9 @@ zookeeper:
 
   ## Configure Zookeeper resource requests and limits
   ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
-  resources: {}
+  resources:
+    requests:
+      memory: "1.25Gi"
 
   ## Replicas
   replicaCount: 1
@@ -531,10 +533,9 @@ zookeeper:
     ## The most recent snapshots amount (and corresponding transaction logs) to retain
     snapRetainCount: 5
 
-  ## Environmental variables to set in Zookeeper
-  env:
-    ## The JVM heap size to allocate to Zookeeper
-    ZK_HEAP_SIZE: "256M"
+  ## Size (in MB) for the Java Heap options (Xmx and Xms)
+  ## This env var is ignored if Xmx an Xms are configured via `zookeeper.jvmFlags`
+  heapSize: "1024"
 
   persistence:
     enabled: true

--- a/kubernetes/helm/pinot/values.yaml
+++ b/kubernetes/helm/pinot/values.yaml
@@ -132,7 +132,10 @@ controller:
     v1:
       enabled: false
 
-  resources: {}
+  resources:
+    requests:
+      cpu: "2000m"
+      memory: "1.25Gi"
 
   nodeSelector: {}
 
@@ -223,7 +226,10 @@ broker:
     v1:
       enabled: false
 
-  resources: {}
+  resources:
+    requests:
+      cpu: "2000m"
+      memory: "1.25Gi"
 
   nodeSelector: {}
 
@@ -305,7 +311,10 @@ server:
     nodePort: ""
     protocol: TCP
 
-  resources: {}
+  resources:
+    requests:
+      cpu: "2000m"
+      memory: "1.25Gi"
 
   nodeSelector: {}
 
@@ -385,7 +394,10 @@ minion:
     protocol: TCP
     name: minion
 
-  resources: {}
+  resources:
+    requests:
+      cpu: "2000m"
+      memory: "1.25Gi"
 
   nodeSelector: {}
 
@@ -457,7 +469,10 @@ minionStateless:
     protocol: TCP
     name: minion
 
-  resources: {}
+  resources:
+    requests:
+      cpu: "2000m"
+      memory: "1.25Gi"
 
   nodeSelector: {}
 


### PR DESCRIPTION
This PR adds an opinionated default resource requests to helm chart.

As explained in #8944, the request in CPU is necessary. Otherwise the JVM by default will optimize its parallelism to only use a single CPU, which impacts in the GC but also in the different executors Pinot uses. The memory request is set to 1.25Gi to leave some extra space from the 1G value used by default in -xmx.

Anyway, it should be recommended to customize these values on each environment, either by increasing the CPU resources or using `-XX=ActiveProcessorCount`