### PR TITLE
Upgrade apache commons lib version

### DIFF
--- a/pinot-distribution/pom.xml
+++ b/pinot-distribution/pom.xml
@@ -195,10 +195,6 @@
                   <pattern>org.apache.parquet</pattern>
                   <shadedPattern>${shade.prefix}.org.apache.parquet</shadedPattern>
                 </relocation>
-                <relocation>
-                  <pattern>org.apache.commons</pattern>
-                  <shadedPattern>${shade.prefix}.org.apache.commons</shadedPattern>
-                </relocation>
               </relocations>
             </configuration>
           </execution>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -142,10 +142,6 @@
                       <pattern>org.apache.kafka</pattern>
                       <shadedPattern>${shade.prefix}.org.apache.kafka</shadedPattern>
                     </relocation>
-                    <relocation>
-                      <pattern>org.apache.commons</pattern>
-                      <shadedPattern>${shade.prefix}.org.apache.commons</shadedPattern>
-                    </relocation>
                   </relocations>
                 </configuration>
               </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -471,7 +471,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.5</version>
+        <version>3.11</version>
       </dependency>
       <dependency>
         <groupId>commons-collections</groupId>


### PR DESCRIPTION
With the introduction of Spark 3.X, the current apache commons lang3 version causes issue when used with Java 11.  The error is due no Enums being present for Java 11 in SystemUtils class. The fix is either to shade the commons lang lib in all the plugins (not just spark plugin) or upgrade the lib.

https://stackoverflow.com/questions/65118291/how-to-fix-nullpointerexception-org-apache-commons-lang3-systemutils-java-speci