### PR TITLE
Change Helm chart to log info to console by default

### DIFF
--- a/docker/images/pinot/etc/conf/pinot-broker-log4j2.xml
+++ b/docker/images/pinot/etc/conf/pinot-broker-log4j2.xml
@@ -49,7 +49,7 @@
   <Loggers>
     <Root level="info" additivity="false">
       <!-- Display warnings on the console -->
-      <AppenderRef ref="console" level="warn"/>
+      <AppenderRef ref="console" level="${env:LOG4J_CONSOLE_LEVEL:-warn}"/>
       <!-- Direct most logs to the log file -->
       <AppenderRef ref="brokerLog"/>
     </Root>

--- a/docker/images/pinot/etc/conf/pinot-controller-log4j2.xml
+++ b/docker/images/pinot/etc/conf/pinot-controller-log4j2.xml
@@ -48,7 +48,7 @@
   <Loggers>
     <Root level="info" additivity="false">
       <!-- Display warnings on the console -->
-      <AppenderRef ref="console" level="warn"/>
+      <AppenderRef ref="console" level="${env:LOG4J_CONSOLE_LEVEL:-warn}"/>
       <!-- Direct most logs to the log file -->
       <AppenderRef ref="controllerLog"/>
     </Root>

--- a/docker/images/pinot/etc/conf/pinot-server-log4j2.xml
+++ b/docker/images/pinot/etc/conf/pinot-server-log4j2.xml
@@ -48,7 +48,7 @@
   <Loggers>
     <Root level="info" additivity="false">
       <!-- Display warnings on the console -->
-      <AppenderRef ref="console" level="warn"/>
+      <AppenderRef ref="console" level="${env:LOG4J_CONSOLE_LEVEL:-warn}"/>
       <!-- Direct most logs to the log file -->
       <AppenderRef ref="serverLog"/>
     </Root>

--- a/kubernetes/helm/pinot/values.yaml
+++ b/kubernetes/helm/pinot/values.yaml
@@ -156,7 +156,9 @@ controller:
 
   # Use extraEnv to add individual key value pairs as container environment variables.
   # ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
-  extraEnv: []
+  extraEnv:
+    - name: LOG4J_CONSOLE_LEVEL
+      value: info
   #  - name: PINOT_CUSTOM_ENV
   #    value: custom-value
 
@@ -247,7 +249,9 @@ broker:
 
   # Use extraEnv to add individual key value pairs as container environment variables.
   # ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
-  extraEnv: []
+  extraEnv:
+    - name: LOG4J_CONSOLE_LEVEL
+      value: info
   #  - name: PINOT_CUSTOM_ENV
   #    value: custom-value
 
@@ -329,7 +333,9 @@ server:
 
   # Use extraEnv to add individual key value pairs as container environment variables.
   # ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
-  extraEnv: []
+  extraEnv:
+    - name: LOG4J_CONSOLE_LEVEL
+      value: info
   #  - name: PINOT_CUSTOM_ENV
   #    value: custom-value
 
@@ -409,7 +415,9 @@ minion:
 
   # Use extraEnv to add individual key value pairs as container environment variables.
   # ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
-  extraEnv: []
+  extraEnv:
+    - name: LOG4J_CONSOLE_LEVEL
+      value: info
   #  - name: PINOT_CUSTOM_ENV
   #    value: custom-value
 
@@ -478,7 +486,9 @@ minionStateless:
 
   # Use extraEnv to add individual key value pairs as container environment variables.
   # ref: https://kubernetes.io/docs/tasks/inject-data-application/define-environment-variable-container/
-  extraEnv: []
+  extraEnv:
+    - name: LOG4J_CONSOLE_LEVEL
+      value: info
   #  - name: PINOT_CUSTOM_ENV
   #    value: custom-value
 

--- a/pinot-tools/src/main/resources/conf/log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/log4j2.xml
@@ -40,7 +40,7 @@
   <Loggers>
     <Root level="info" additivity="false">
       <AppenderRef ref="pinotLog"/>
-      <AppenderRef ref="console"/>
+      <AppenderRef ref="console" level="${env:LOG4J_CONSOLE_LEVEL:-info}"/>
     </Root>
     <Logger name="org.apache.pinot.tools.admin" level="info" additivity="false">
       <AppenderRef ref="console"/>


### PR DESCRIPTION
Issue #8944 was divided in two different parts:
- Establishing k8s resources
- Be able to read logs with `kubectl logs`.

PR #9012 solves the former while this PR solves the later.

The change is quite simple:
- Each pod type (servers, controllers, etc) uses different `log4j2.xml` files that are included in the docker image. These files have been changed to read a new env variable called `LOG4J_CONSOLE_LEVEL`. That variable is used to determine the minimum level that will be redirected to stdout.
   - In case the variable is not found, `warn` will be used. That was the previous value, so if the variable is not specified the behavior will not change.
- The chart has been modified to set `LOG4J_CONSOLE_LEVEL` to `info` by default. By doing that when the chart is installed without modifying that env variable error, warn and info logs will be printed in the stdout, so they will be shown by `kubectl logs`.

Rino Kadijk asked me to add the ability to log the info as json. To do so I would need to add a new dependency, so I'm going to do it on another PR in case we don't want to add dependencies.
