### PR TITLE
Support SET key=value syntax

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -154,7 +154,7 @@ public class PinotClientRequest {
     } catch (Exception e) {
       return new BrokerResponseNative(QueryException.getException(QueryException.SQL_PARSING_ERROR, e));
     }
-    PinotSqlType sqlType = CalciteSqlParser.extractSqlType(sqlNodeAndOptions.getSqlNode());
+    PinotSqlType sqlType = sqlNodeAndOptions.getSqlType();
     if (onlyDql && sqlType != PinotSqlType.DQL) {
       return new BrokerResponseNative(QueryException.getException(QueryException.SQL_PARSING_ERROR,
           new UnsupportedOperationException("Unsupported SQL type - " + sqlType + ", GET API only supports DQL.")));

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BrokerRequestOptionsTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BrokerRequestOptionsTest.java
@@ -104,7 +104,7 @@ public class BrokerRequestOptionsTest {
     Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption1"), "foo");
 
     // Has queryOptions in query
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from testTable option(queryOption1=foo)");
+    pinotQuery = CalciteSqlParser.compileToPinotQuery("SET queryOption1='foo'; select * from testTable");
     BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
     Assert.assertNull(pinotQuery.getDebugOptions());
     Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1);
@@ -120,7 +120,7 @@ public class BrokerRequestOptionsTest {
 
     // Has query options in both json payload and pinotQuery, pinotQuery takes priority
     jsonRequest.put(Request.QUERY_OPTIONS, "queryOption1=bar;queryOption2=moo");
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from testTable option(queryOption1=foo)");
+    pinotQuery = CalciteSqlParser.compileToPinotQuery("SET queryOption1='foo'; select * from testTable;");
     BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
     Assert.assertNull(pinotQuery.getDebugOptions());
     Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 2);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryValidationTest.java
@@ -115,8 +115,8 @@ public class QueryValidationTest {
 
   @Test
   public void testReplicaGroupToQueryInvalidQuery() {
-    PinotQuery pinotQuery =
-        CalciteSqlParser.compileToPinotQuery("SELECT COUNT(*) FROM MY_TABLE OPTION(numReplicaGroupsToQuery=illegal)");
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+        "SET numReplicaGroupsToQuery='illegal'; SELECT COUNT(*) FROM MY_TABLE");
     Assert.assertThrows(IllegalStateException.class, () -> BaseBrokerRequestHandler.validateRequest(pinotQuery, 10));
   }
 

--- a/pinot-common/src/main/codegen/includes/parserImpls.ftl
+++ b/pinot-common/src/main/codegen/includes/parserImpls.ftl
@@ -73,7 +73,8 @@ SqlInsertFromFile SqlInsertFromFile() :
     }
 }
 
-/* define the rest of the sql into SqlStmtList
+/**
+ * define the rest of the sql into SqlStmtList
  */
 private void SqlStatementList(SqlNodeList list) :
 {

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.sql.parsers;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -28,7 +29,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.sql.SqlBasicCall;
@@ -43,6 +43,7 @@ import org.apache.calcite.sql.SqlNumericLiteral;
 import org.apache.calcite.sql.SqlOrderBy;
 import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.SqlSelectKeyword;
+import org.apache.calcite.sql.SqlSetOption;
 import org.apache.calcite.sql.fun.SqlBetweenOperator;
 import org.apache.calcite.sql.fun.SqlCase;
 import org.apache.calcite.sql.fun.SqlLikeOperator;
@@ -112,30 +113,49 @@ public class CalciteSqlParser {
     // Remove the terminating semicolon from the query
     sql = removeTerminatingSemicolon(sql);
 
-    // Extract OPTION statements from sql as Calcite Parser doesn't parse it.
-    List<String> options = extractOptionsFromSql(sql);
-    if (!options.isEmpty()) {
-      sql = removeOptionsFromSql(sql);
-    }
-
     try (StringReader inStream = new StringReader(sql)) {
       SqlParserImpl sqlParser = newSqlParser(inStream);
-      return new SqlNodeAndOptions(sqlParser.parseSqlStmtEof(), options);
+      SqlNodeList sqlNodeList = sqlParser.SqlStmtsEof();
+      // Extract OPTION statements from sql.
+      return extractSqlNodeAndOptions(sqlNodeList);
     } catch (Throwable e) {
       throw new SqlCompilationException("Caught exception while parsing query: " + sql, e);
     }
   }
 
-  public static PinotSqlType extractSqlType(SqlNode sqlNode) {
-    switch (sqlNode.getKind()) {
-      case OTHER_DDL:
-        if (sqlNode instanceof SqlInsertFromFile) {
-          return PinotSqlType.DML;
+  public static SqlNodeAndOptions extractSqlNodeAndOptions(SqlNodeList sqlNodeList) {
+    PinotSqlType sqlType = null;
+    SqlNode statementNode = null;
+    Map<String, String> options = new HashMap<>();
+    for (SqlNode sqlNode : sqlNodeList) {
+      if (sqlNode instanceof SqlInsertFromFile) {
+        // extract insert statement (execution statement)
+        if (sqlType == null) {
+          sqlType = PinotSqlType.DML;
+          statementNode = sqlNode;
+        } else {
+          throw new SqlCompilationException("SqlNode with statement already exist with type: " + sqlType);
         }
-        throw new SqlCompilationException("Unsupported SqlNode type - " + sqlNode.getKind());
-      default:
-        return PinotSqlType.DQL;
+      } else if (sqlNode instanceof SqlSetOption) {
+        // extract options, these are non-execution statements
+        List<SqlNode> operandList = ((SqlSetOption) sqlNode).getOperandList();
+        SqlIdentifier key = (SqlIdentifier) operandList.get(1);
+        SqlLiteral value = (SqlLiteral) operandList.get(2);
+        options.put(key.getSimple(), value.toValue());
+      } else {
+        // default extract query statement (execution statement)
+        if (sqlType == null) {
+          sqlType = PinotSqlType.DQL;
+          statementNode = sqlNode;
+        } else {
+          throw new SqlCompilationException("SqlNode with statement already exist with type: " + sqlType);
+        }
+      }
     }
+    if (sqlType == null) {
+      throw new SqlCompilationException("SqlNode with statement not found!");
+    }
+    return new SqlNodeAndOptions(statementNode, sqlType, options);
   }
 
   public static PinotQuery compileToPinotQuery(String sql)
@@ -146,25 +166,24 @@ public class CalciteSqlParser {
     // Remove the terminating semicolon from the query
     sql = removeTerminatingSemicolon(sql);
 
-    // Extract OPTION statements from sql as Calcite Parser doesn't parse it.
-    List<String> options = extractOptionsFromSql(sql);
-    if (!options.isEmpty()) {
-      sql = removeOptionsFromSql(sql);
-    }
-
-    SqlNode sqlNode;
+    SqlNodeAndOptions sqlNodeAndOptions;
     try (StringReader inStream = new StringReader(sql)) {
       SqlParserImpl sqlParser = newSqlParser(inStream);
-      sqlNode = sqlParser.parseSqlStmtEof();
+      SqlNodeList sqlNodeList = sqlParser.SqlStmtsEof();
+      sqlNodeAndOptions = extractSqlNodeAndOptions(sqlNodeList);
+      // Extract OPTION statements from sql as Calcite Parser doesn't parse it.
     } catch (Throwable e) {
       throw new SqlCompilationException("Caught exception while parsing query: " + sql, e);
     }
 
     // Compile Sql without OPTION statements.
-    PinotQuery pinotQuery = compileSqlNodeToPinotQuery(sqlNode);
+    PinotQuery pinotQuery = compileSqlNodeToPinotQuery(sqlNodeAndOptions.getSqlNode());
 
     // Set Option statements to PinotQuery.
-    setOptions(pinotQuery, options);
+    Map<String, String> options = sqlNodeAndOptions.getOptions();
+    if (!options.isEmpty()) {
+      pinotQuery.setQueryOptions(options);
+    }
     return pinotQuery;
   }
 
@@ -355,27 +374,6 @@ public class CalciteSqlParser {
     return sqlParser;
   }
 
-  public static Map<String, String> extractOptionsMap(List<String> optionsStatements) {
-    Map<String, String> options = new HashMap<>();
-    for (String optionsStatement : optionsStatements) {
-      for (String option : optionsStatement.split(",")) {
-        final String[] splits = option.split("=");
-        if (splits.length != 2) {
-          throw new SqlCompilationException("OPTION statement requires two parts separated by '='");
-        }
-        options.put(splits[0].trim(), splits[1].trim());
-      }
-    }
-    return options;
-  }
-
-  private static void setOptions(PinotQuery pinotQuery, List<String> optionsStatements) {
-    if (optionsStatements.isEmpty()) {
-      return;
-    }
-    pinotQuery.setQueryOptions(extractOptionsMap(optionsStatements));
-  }
-
   public static PinotQuery compileSqlNodeToPinotQuery(SqlNode sqlNode) {
     PinotQuery pinotQuery = new PinotQuery();
     if (sqlNode instanceof SqlExplain) {
@@ -458,20 +456,6 @@ public class CalciteSqlParser {
     }
     // Validate
     validate(pinotQuery);
-  }
-
-  private static List<String> extractOptionsFromSql(String sql) {
-    List<String> results = new ArrayList<>();
-    Matcher matcher = OPTIONS_REGEX_PATTEN.matcher(sql);
-    while (matcher.find()) {
-      results.add(matcher.group(1));
-    }
-    return results;
-  }
-
-  private static String removeOptionsFromSql(String sql) {
-    Matcher matcher = OPTIONS_REGEX_PATTEN.matcher(sql);
-    return matcher.replaceAll("");
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -145,7 +145,7 @@ public class CalciteSqlParser {
           sqlType = PinotSqlType.DML;
           statementNode = sqlNode;
         } else {
-          throw new SqlCompilationException("SqlNode with statement already exist with type: " + sqlType);
+          throw new SqlCompilationException("SqlNode with executable statement already exist with type: " + sqlType);
         }
       } else if (sqlNode instanceof SqlSetOption) {
         // extract options, these are non-execution statements
@@ -159,12 +159,12 @@ public class CalciteSqlParser {
           sqlType = PinotSqlType.DQL;
           statementNode = sqlNode;
         } else {
-          throw new SqlCompilationException("SqlNode with statement already exist with type: " + sqlType);
+          throw new SqlCompilationException("SqlNode with executable statement already exist with type: " + sqlType);
         }
       }
     }
     if (sqlType == null) {
-      throw new SqlCompilationException("SqlNode with statement not found!");
+      throw new SqlCompilationException("SqlNode with executable statement not found!");
     }
     return new SqlNodeAndOptions(statementNode, sqlType, options);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -115,7 +115,9 @@ public class CalciteSqlParser {
 
     // extract and remove OPTIONS string
     List<String> options = extractOptionsFromSql(sql);
-    sql = removeOptionsFromSql(sql);
+    if (!options.isEmpty()) {
+      sql = removeOptionsFromSql(sql);
+    }
 
     try (StringReader inStream = new StringReader(sql)) {
       SqlParserImpl sqlParser = newSqlParser(inStream);
@@ -124,7 +126,6 @@ public class CalciteSqlParser {
       SqlNodeAndOptions sqlNodeAndOptions = extractSqlNodeAndOptions(sqlNodeList);
       // add legacy OPTIONS keyword-based options
       if (options.size() > 0) {
-        LOGGER.warn("Usage of 'OPTIONS(key=value)' is deprecated, use `SET key = value` instead!");
         sqlNodeAndOptions.setExtraOptions(extractOptionsMap(options));
       }
       return sqlNodeAndOptions;

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/SqlNodeAndOptions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/SqlNodeAndOptions.java
@@ -18,16 +18,19 @@
  */
 package org.apache.pinot.sql.parsers;
 
-import java.util.List;
+import java.util.Map;
 import org.apache.calcite.sql.SqlNode;
 
 
 public class SqlNodeAndOptions {
   private final SqlNode _sqlNode;
-  private final List<String> _options;
+  private final PinotSqlType _sqlType;
+  // TODO: support option literals other than STRING
+  private final Map<String, String> _options;
 
-  public SqlNodeAndOptions(SqlNode sqlNode, List<String> options) {
+  public SqlNodeAndOptions(SqlNode sqlNode, PinotSqlType sqlType, Map<String, String> options) {
     _sqlNode = sqlNode;
+    _sqlType = sqlType;
     _options = options;
   }
 
@@ -35,7 +38,11 @@ public class SqlNodeAndOptions {
     return _sqlNode;
   }
 
-  public List<String> getOptions() {
+  public Map<String, String> getOptions() {
     return _options;
+  }
+
+  public PinotSqlType getSqlType() {
+    return _sqlType;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/SqlNodeAndOptions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/SqlNodeAndOptions.java
@@ -45,4 +45,8 @@ public class SqlNodeAndOptions {
   public PinotSqlType getSqlType() {
     return _sqlType;
   }
+
+  public void setExtraOptions(Map<String, String> extractOptionsMap) {
+    _options.putAll(extractOptionsMap);
+  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/dml/InsertIntoFile.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/dml/InsertIntoFile.java
@@ -26,7 +26,6 @@ import org.apache.calcite.sql.SqlNodeList;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.spi.config.task.AdhocTaskConfig;
-import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
 import org.apache.pinot.sql.parsers.parser.SqlInsertFromFile;
 
@@ -69,7 +68,7 @@ public class InsertIntoFile implements DataManipulationStatement {
     String tableName = operandList.get(0) != null ? StringUtils.joinWith(",", operandList.get(0), operandList.get(1))
         : operandList.get(1).toString();
     // Set Options
-    Map<String, String> optionsMap = CalciteSqlParser.extractOptionsMap(sqlNodeAndOptions.getOptions());
+    Map<String, String> optionsMap = sqlNodeAndOptions.getOptions();
     List<String> inputDirList = new ArrayList<>();
     ((SqlNodeList) operandList.get(2)).getList()
         .forEach(sqlNode1 -> inputDirList.add(sqlNode1.toString().replace("'", "")));

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -784,6 +784,14 @@ public class CalciteSqlCompilerTest {
     } catch (SqlCompilationException sce) {
       // expected.
     }
+
+    try {
+      CalciteSqlParser.compileToPinotQuery("select * from vegetables where name <> 'Brussels sprouts'; "
+          + "SET (delicious='yes', foo=1234); select * from meat");
+      Assert.fail("SQL should not be compiled");
+    } catch (SqlCompilationException sce) {
+      // expected.
+    }
   }
 
   @Test

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/dml/InsertIntoFileTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/dml/InsertIntoFileTest.java
@@ -31,12 +31,12 @@ public class InsertIntoFileTest {
   public void testInsertIntoStatementParser()
       throws Exception {
     String insertIntoSql = "INSERT INTO \"baseballStats\"\n"
-        + "FROM FILE 's3://my-bucket/path/to/data/'\n"
-        + "OPTION(taskName=myTask-1,"
-        + "input.fs.className=org.apache.pinot.plugin.filesystem.S3PinotFS,"
-        + "input.fs.prop.accessKey=my-access-key,"
-        + "input.fs.prop.secretKey=my-secret-key,"
-        + "input.fs.prop.region=us-west-2)";
+        + "FROM FILE 's3://my-bucket/path/to/data/';\n"
+        + "SET taskName = 'myTask-1';\n"
+        + "SET \"input.fs.className\" = 'org.apache.pinot.plugin.filesystem.S3PinotFS';\n"
+        + "SET \"input.fs.prop.accessKey\" = 'my-access-key';\n"
+        + "SET \"input.fs.prop.secretKey\" = 'my-secret-key';\n"
+        + "SET \"input.fs.prop.region\" = 'us-west-2';";
     InsertIntoFile insertIntoFile = InsertIntoFile.parse(CalciteSqlParser.compileToSqlNodeAndOptions(insertIntoSql));
     Assert.assertEquals(insertIntoFile.getTable(), "baseballStats");
     Assert.assertEquals(insertIntoFile.getExecutionType(), DataManipulationStatement.ExecutionType.MINION);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -108,7 +108,7 @@ public class PinotQueryResource {
       String queryOptions)
       throws Exception {
     SqlNodeAndOptions sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sqlQuery);
-    PinotSqlType sqlType = CalciteSqlParser.extractSqlType(sqlNodeAndOptions.getSqlNode());
+    PinotSqlType sqlType = sqlNodeAndOptions.getSqlType();
     switch (sqlType) {
       case DQL:
         return getQueryResponse(sqlQuery, sqlNodeAndOptions.getSqlNode(), traceEnabled, queryOptions, httpHeaders);
@@ -130,7 +130,7 @@ public class PinotQueryResource {
     try {
       LOGGER.debug("Trace: {}, Running query: {}", traceEnabled, sqlQuery);
       SqlNodeAndOptions sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sqlQuery);
-      PinotSqlType sqlType = CalciteSqlParser.extractSqlType(sqlNodeAndOptions.getSqlNode());
+      PinotSqlType sqlType = sqlNodeAndOptions.getSqlType();
       if (sqlType == PinotSqlType.DQL) {
         return getQueryResponse(sqlQuery, sqlNodeAndOptions.getSqlNode(), traceEnabled, queryOptions, httpHeaders);
       }


### PR DESCRIPTION
Background
===
context: #8906 

Description
===
This PR introduces a new way to set environmental options for executing a SQL query on Pinot. 

Syntax examples for single and multiple environment options:
```
SET skipUpsert = 'false';
SELECT count(*) FROM tbl
```
```
SET foo = 'bar';
SET some_key = 'some_value';
SELECT * FROM tbl
```

Details
===
- `;` at the end of the SET statement indicate it is an end of a statement; However, Pinot doesn't support multiple statements, thus all `SET` statement(s) are only valid within the SQL query string context. 
  - this means first executing `ALTER SESSION SET key = 'value';` and then executing another query won't affect the query.
  - this also means, effectively one pinot query string is one individual, isolated user session.
- we allow multiple `SET` statements within a single query string
