### PR TITLE
Null check for partitionGroupSmallestOffset and metric for failure in RealtimeSegmentValidationManager

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
@@ -117,6 +117,13 @@ rules:
   labels:
     table: "$1"
     tableType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.(\\w+)_(\\w+).(\\w+).periodicTaskError\"><>(\\w+)"
+  name: "pinot_controller_periodicTaskError_$4"
+  cache: true
+  labels:
+    table: "$1"
+    tableType: "$2"
+    periodicTask: "$3"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.tableStorageQuotaUtilization.(\\w+)_(\\w+)\"><>(\\w+)"
   name: "pinot_controller_tableStorageQuotaUtilization_$3"
   cache: true

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -46,6 +46,7 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   LLC_STREAM_DATA_LOSS("dataLoss", false),
   CONTROLLER_PERIODIC_TASK_RUN("periodicTaskRun", false),
   CONTROLLER_PERIODIC_TASK_ERROR("periodicTaskError", false),
+  PERIODIC_TASK_ERROR("periodicTaskError", false),
   NUMBER_TIMES_SCHEDULE_TASKS_CALLED("tasks", true),
   NUMBER_TASKS_SUBMITTED("tasks", false),
   NUMBER_SEGMENT_UPLOAD_TIMEOUT_EXCEEDED("SegmentUploadTimeouts", true),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
@@ -116,6 +116,8 @@ public abstract class ControllerPeriodicTask<C> extends BasePeriodicTask {
         processTable(tableNameWithType, context);
       } catch (Exception e) {
         LOGGER.error("Caught exception while processing table: {} in task: {}", tableNameWithType, _taskName, e);
+        _controllerMetrics.addMeteredTableValue(tableNameWithType + "." + _taskName,
+            ControllerMeter.PERIODIC_TASK_ERROR, 1L);
       }
       numTablesProcessed++;
     }


### PR DESCRIPTION
Recently saw an exception in RealtimeValidationManager, wherein the partitionGroupSmallestOffset was returned as null (when trying to fix a segment which was marked OFFLINE). As a result, the periodic task encounters NPE and exits.
In this PR
1. Handling the null value gracefully
2. Adding a metric for catching errors in PeriodicTasks