### PR TITLE
[8835] Fix for CSV files with spaces in column names / header

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
@@ -80,7 +80,7 @@ public class CSVRecordReader implements RecordReader {
         }
       }
       char delimiter = config.getDelimiter();
-      format = format.withDelimiter(delimiter);
+      format = format.withDelimiter(delimiter).withIgnoreSurroundingSpaces(true);
       String csvHeader = config.getHeader();
       if (csvHeader == null) {
         format = format.withHeader();

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordExtractorTest.java
@@ -105,6 +105,57 @@ public class CSVRecordExtractorTest extends AbstractRecordExtractorTest {
     }
   }
 
+  @Test
+  public void testRemovingSurroundingSpaces() throws IOException {
+    CSVRecordReaderConfig csvRecordReaderConfig = new CSVRecordReaderConfig();
+
+    // Create a CSV file where records have two values and the second value contains an extra space.
+    File spaceFile = new File(_tempDir, "space.csv");
+    BufferedWriter writer = new BufferedWriter(new FileWriter(spaceFile));
+    writer.write("col1 ,col2\n");
+    writer.write(" value11, value12");
+    writer.close();
+
+    CSVRecordReader csvRecordReader = new CSVRecordReader();
+    HashSet<String> fieldsToRead = new HashSet<>();
+    fieldsToRead.add("col1");
+    fieldsToRead.add("col2");
+    csvRecordReader.init(spaceFile, fieldsToRead, csvRecordReaderConfig);
+    GenericRow genericRow = new GenericRow();
+    csvRecordReader.rewind();
+
+    // check if parsing succeeded.
+    Assert.assertTrue(csvRecordReader.hasNext());
+    csvRecordReader.next(genericRow);
+    Assert.assertEquals(genericRow.getValue("col1"), "value11");
+    Assert.assertEquals(genericRow.getValue("col2"), "value12");
+  }
+
+  @Test
+  public void testIgnoringSurroundingSpaces() throws IOException {
+    CSVRecordReaderConfig csvRecordReaderConfig = new CSVRecordReaderConfig();
+
+    // Create a CSV file where records have two values and the second value contains an extra space.
+    File spaceFile = new File(_tempDir, "space.csv");
+    BufferedWriter writer = new BufferedWriter(new FileWriter(spaceFile));
+    writer.write("col1 ,col2\n");
+    writer.write("\"value11\",\" value12\"");
+    writer.close();
+
+    CSVRecordReader csvRecordReader = new CSVRecordReader();
+    HashSet<String> fieldsToRead = new HashSet<>();
+    fieldsToRead.add("col1");
+    fieldsToRead.add("col2");
+    csvRecordReader.init(spaceFile, fieldsToRead, csvRecordReaderConfig);
+    GenericRow genericRow = new GenericRow();
+    csvRecordReader.rewind();
+
+    // check if parsing succeeded.
+    Assert.assertTrue(csvRecordReader.hasNext());
+    csvRecordReader.next(genericRow);
+    Assert.assertEquals(genericRow.getValue("col1"), "value11");
+    Assert.assertEquals(genericRow.getValue("col2"), " value12");
+  }
   /**
    * Check if we can parse a CSV file that has escaped comma characters within fields.
    */
@@ -135,6 +186,6 @@ public class CSVRecordExtractorTest extends AbstractRecordExtractorTest {
     Assert.assertTrue(csvRecordReader.hasNext());
     csvRecordReader.next(genericRow);
     Assert.assertEquals(genericRow.getValue("first"), "string1");
-    Assert.assertEquals(genericRow.getValue("second"), " string2, string3");
+    Assert.assertEquals(genericRow.getValue("second"), "string2, string3");
   }
 }


### PR DESCRIPTION
Fix #8835 

Fixing the space issue in the column names, When we have space with quotes we aren't trimming them. I feel that behaviour was intentional by the user.

