### PR TITLE
fixing orc missing class issue when running quickstart

### DIFF
--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -91,6 +91,27 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>xml-apis</groupId>
+      <artifactId>xml-apis</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-parquet</artifactId>
       <version>${project.version}</version>


### PR DESCRIPTION
Seeing this exception when ingestion orc file:
```
2022/07/08 00:12:08.441 ERROR [TaskRunner] [TaskStateModelFactory-task_thread-1] Problem running the task, report task as FAILED.
java.lang.NoClassDefFoundError: org/apache/hadoop/fs/FileSystem
	at java.lang.Class.getDeclaredConstructors0(Native Method) ~[?:?]
	at java.lang.Class.privateGetDeclaredConstructors(Class.java:3137) ~[?:?]
	at java.lang.Class.getConstructor0(Class.java:3342) ~[?:?]
	at java.lang.Class.getConstructor(Class.java:2151) ~[?:?]
	at org.apache.pinot.spi.plugin.PluginManager.createInstance(PluginManager.java:356) ~[classes/:?]
	at org.apache.pinot.spi.plugin.PluginManager.createInstance(PluginManager.java:325) ~[classes/:?]
	at org.apache.pinot.spi.plugin.PluginManager.createInstance(PluginManager.java:306) ~[classes/:?]
	at org.apache.pinot.spi.data.readers.RecordReaderFactory.getRecordReaderByClass(RecordReaderFactory.java:147) ~[classes/:?]
	at org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl.getRecordReader(SegmentIndexCreationDriverImpl.java:125) ~[classes/:?]
	at org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl.init(SegmentIndexCreationDriverImpl.java:101) ~[classes/:?]
	at org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationTaskRunner.run(SegmentGenerationTaskRunner.java:118) ~[classes/:?]
	at org.apache.pinot.plugin.minion.tasks.segmentgenerationandpush.SegmentGenerationAndPushTaskExecutor.generateAndPushSegment(SegmentGenerationAndPushTaskExecutor.java:132) ~[classes/:?]
	at org.apache.pinot.plugin.minion.tasks.segmentgenerationandpush.SegmentGenerationAndPushTaskExecutor.executeTask(SegmentGenerationAndPushTaskExecutor.java:118) ~[classes/:?]
	at org.apache.pinot.minion.taskfactory.TaskFactoryRegistry$1.runInternal(TaskFactoryRegistry.java:113) ~[classes/:?]
	at org.apache.pinot.minion.taskfactory.TaskFactoryRegistry$1.run(TaskFactoryRegistry.java:89) ~[classes/:?]
	at org.apache.helix.task.TaskRunner.run(TaskRunner.java:71) [helix-core-0.9.8.jar:0.9.8]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:264) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java) [?:?]
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:829) [?:?]
Caused by: java.lang.ClassNotFoundException: org.apache.hadoop.fs.FileSystem
	at jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581) ~[?:?]
```