### PR TITLE
Adding auth zk basic quickstart

### DIFF
--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -91,6 +91,27 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-common</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-hdfs</artifactId>
+      <scope>compile</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>xml-apis</groupId>
+      <artifactId>xml-apis</artifactId>
+      <scope>compile</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-parquet</artifactId>
       <version>${project.version}</version>

--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -470,6 +470,16 @@
               </jvmSettings>
             </program>
             <program>
+              <mainClass>org.apache.pinot.tools.AuthZkBasicQuickstart</mainClass>
+              <name>quick-start-auth-zk</name>
+              <jvmSettings>
+                <initialMemorySize>4G</initialMemorySize>
+                <extraArguments>
+                  <extraArgument>-Dlog4j2.configurationFile=conf/quickstart-log4j2.xml</extraArgument>
+                </extraArguments>
+              </jvmSettings>
+            </program>
+            <program>
               <mainClass>org.apache.pinot.tools.perf.QueryRunner</mainClass>
               <name>query-runner</name>
               <jvmSettings>

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/AuthZkBasicQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/AuthZkBasicQuickstart.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.auth.AuthProviderUtils;
+import org.apache.pinot.core.auth.BasicAuthUtils;
+import org.apache.pinot.spi.auth.AuthProvider;
+import org.apache.pinot.spi.plugin.PluginManager;
+
+
+public class AuthZkBasicQuickstart extends Quickstart {
+  @Override
+  public List<String> types() {
+    return Collections.singletonList("AUTH-ZK");
+  }
+
+  @Override
+  public AuthProvider getAuthProvider() {
+    return AuthProviderUtils.makeAuthProvider(BasicAuthUtils.toBasicAuthToken("admin", "verysecret"));
+  }
+
+  @Override
+  public Map<String, Object> getConfigOverrides() {
+    Map<String, Object> properties = new HashMap<>(super.getConfigOverrides());
+
+    // controller
+    properties.put("pinot.controller.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("controller.admin.access.control.factory.class",
+        "org.apache.pinot.controller.api.access.ZkBasicAuthAccessControlFactory");
+    properties.put("access.control.init.username", "admin");
+    properties.put("access.control.init.password", "verysecret");
+
+    // broker
+    properties.put("pinot.broker.access.control.class",
+        "org.apache.pinot.broker.broker.ZkBasicAuthAccessControlFactory");
+
+    // server
+    properties.put("pinot.server.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("pinot.server.segment.uploader.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+
+    // minion
+    properties.put("segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("task.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+
+    return properties;
+  }
+
+  public static void main(String[] args)
+      throws Exception {
+    PluginManager.get().init();
+    new AuthZkBasicQuickstart().execute();
+    printStatus(Color.GREEN, "Default login credential to login controller is admin/verysecret.");
+  }
+}


### PR DESCRIPTION
Adding AuthZkBasicQuickstart, which uses `controller.admin.access.control.factory.class=org.apache.pinot.controller.api.access.ZkBasicAuthAccessControlFactory`
 and 
`pinot.broker.access.control.class=org.apache.pinot.broker.broker.ZkBasicAuthAccessControlFactory`.

The default credential is `admin`/`verysecret`.

<img width="492" alt="image" src="https://user-images.githubusercontent.com/1202120/178087152-231a6a54-b84a-4254-b3da-1d9fb64840f1.png">

<img width="1781" alt="image" src="https://user-images.githubusercontent.com/1202120/178087158-743098ec-5d78-4697-9888-fb3c88bd2baa.png">
