### PR TITLE
fix instance details page loading table for tenant

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/InstanceDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/InstanceDetails.tsx
@@ -35,6 +35,7 @@ import EditConfigOp from '../components/Homepage/Operations/EditConfigOp';
 import { NotificationContext } from '../components/Notification/NotificationContext';
 import _ from 'lodash';
 import Confirm from '../components/Confirm';
+import Utils from "../utils/Utils";
 
 const useStyles = makeStyles((theme) => ({
   codeMirrorDiv: {
@@ -146,7 +147,8 @@ const InstanceDetails = ({ match }: RouteComponentProps<Props>) => {
         tag.search('_REALTIME') !== -1 ||
         tag.search('_OFFLINE') !== -1
       ){
-        tenantsList.push(tag.split('_')[0]);
+        let [baseTag, ] = Utils.splitStringByLastUnderscore(tag);
+        tenantsList.push(baseTag);
       }
     });
     return _.uniq(tenantsList);

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -540,8 +540,7 @@ const getTableDetails = (tableName) => {
 //      /segments/:tableName/:segmentName/metadata
 // Expected Output: {columns: [], records: []}
 const getSegmentDetails = (tableName, segmentName) => {
-  let baseTableName = tableName.substring(0, tableName.lastIndexOf("_"));
-  let tableType = tableName.substring(tableName.lastIndexOf("_") + 1, tableName.length);
+  let [baseTableName, tableType] = Utils.splitStringByLastUnderscore(tableName)
   const promiseArr = [];
   promiseArr.push(getExternalView(tableName));
   promiseArr.push(getSegmentMetadata(tableName, segmentName));

--- a/pinot-controller/src/main/resources/app/utils/Utils.tsx
+++ b/pinot-controller/src/main/resources/app/utils/Utils.tsx
@@ -336,6 +336,15 @@ const formatBytes = (bytes, decimals = 2) => {
   return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
 }
 
+const splitStringByLastUnderscore = (str: string) => {
+  if (!str.includes('_')) {
+    return [str, ''];
+  }
+  let beforeUnderscore = str.substring(0, str.lastIndexOf("_"));
+  let afterUnderscore = str.substring(str.lastIndexOf("_") + 1, str.length);
+  return [beforeUnderscore, afterUnderscore];
+}
+
 export default {
   sortArray,
   tableFormat,
@@ -346,5 +355,6 @@ export default {
   navigateToPreviousPage,
   syncTableSchemaData,
   encodeString,
-  formatBytes
+  formatBytes,
+  splitStringByLastUnderscore
 };


### PR DESCRIPTION
Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
`bugfix`
`ui`

This fixes another case where the UI assumed a tenant name can't have an underscore in it. So tenants named `a_b_c` were just getting parsed as `a` in the table lookup. 

I manually changed the meetupRSVP table to be in `Default_Tenant` and made sure it still appeared in the instance details page
<img width="1222" alt="image" src="https://user-images.githubusercontent.com/4760722/178112844-81e89339-8486-4acd-a1fe-0d3f3117f44a.png">
