### PR TITLE
Allow broker list to be passed to JDBC

### DIFF
--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotConnection.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotConnection.java
@@ -23,6 +23,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import org.apache.pinot.client.base.AbstractBaseConnection;
@@ -39,14 +40,7 @@ public class PinotConnection extends AbstractBaseConnection {
   private boolean _closed;
   private String _controllerURL;
   private PinotControllerTransport _controllerTransport;
-
-  PinotConnection(String controllerURL, PinotClientTransport transport, String tenant) {
-    this(new Properties(), controllerURL, transport, tenant, null);
-  }
-
-  PinotConnection(Properties properties, String controllerURL, PinotClientTransport transport, String tenant) {
-    this(properties, controllerURL, transport, tenant, null);
-  }
+  public static final String BROKER_LIST = "brokers";
 
   PinotConnection(String controllerURL, PinotClientTransport transport, String tenant,
       PinotControllerTransport controllerTransport) {
@@ -62,7 +56,12 @@ public class PinotConnection extends AbstractBaseConnection {
     } else {
       _controllerTransport = controllerTransport;
     }
-    List<String> brokers = getBrokerList(controllerURL, tenant);
+    List<String> brokers;
+    if (properties.containsKey(BROKER_LIST)) {
+      brokers = Arrays.asList(properties.getProperty(BROKER_LIST).split(";"));
+    } else {
+      brokers = getBrokerList(controllerURL, tenant);
+    }
     _session = new org.apache.pinot.client.Connection(properties, brokers, transport);
   }
 

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotDriver.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotDriver.java
@@ -82,6 +82,10 @@ public class PinotDriver implements Driver {
       throws SQLException {
     try {
       LOGGER.info("Initiating connection to database for url: " + url);
+
+      Map<String, String> urlParams = DriverUtils.getURLParams(url);
+      info.putAll(urlParams);
+
       JsonAsyncHttpPinotClientTransportFactory factory = new JsonAsyncHttpPinotClientTransportFactory();
       PinotControllerTransportFactory pinotControllerTransportFactory = new PinotControllerTransportFactory();
 
@@ -101,7 +105,7 @@ public class PinotDriver implements Driver {
 
       Map<String, String> headers = getHeadersFromProperties(info);
 
-      DriverUtils.handleAuth(url, info, headers);
+      DriverUtils.handleAuth(info, headers);
 
       if (!headers.isEmpty()) {
         factory.setHeaders(headers);

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/Constants.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/Constants.java
@@ -25,7 +25,7 @@ public class Constants {
   public static final String DRIVER_NAME = "APACHE_PINOT_DRIVER";
   public static final String DRIVER_VERSION = "1.0";
   public static final String PRODUCT_NAME = "APACHE_PINOT";
-  public static final String PINOT_VERSION = "0.5"; //This needs to be changed as per the project maven version
+  public static final String PINOT_VERSION = "0.10"; //This needs to be changed as per the project maven version
 
   public static final String[] CATALOG_COLUMNS = {"TABLE_CAT"};
   public static final String[] CATALOG_COLUMNS_DTYPES = {"STRING"};

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
@@ -68,10 +68,8 @@ public class DriverUtils {
     return TlsUtils.getSslContext();
   }
 
-  public static void handleAuth(String url, Properties info, Map<String, String> headers)
+  public static void handleAuth(Properties info, Map<String, String> headers)
       throws SQLException {
-    Map<String, String> urlParams = DriverUtils.getURLParams(url);
-    info.putAll(urlParams);
 
     if (info.contains(USER_PROPERTY) && !headers.containsKey(AUTH_HEADER)) {
       String username = info.getProperty(USER_PROPERTY);


### PR DESCRIPTION
Currently, JDBC driver fetches the brokers from the controller. However, the broker list returned by controller contains hostname and ports of brokers which might be unresolvable from the environment in which the driver is running.

To solve this, we can allow users to pass broker urls explicitly. This allow users to pass public urls or urls accessible from their VPCs.  

Users need to take care though to specify the correct brokers for the tenant they are using to query. The driver doesn't implement any checks to take care of this.