### PR TITLE
Renaming the response metadata key which was misrepresenting

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataTable.java
@@ -103,7 +103,7 @@ public interface DataTable {
     NUM_SEGMENTS_QUERIED("numSegmentsQueried", MetadataValueType.INT),
     NUM_SEGMENTS_PROCESSED("numSegmentsProcessed", MetadataValueType.INT),
     NUM_SEGMENTS_MATCHED("numSegmentsMatched", MetadataValueType.INT),
-    NUM_CONSUMING_SEGMENTS_PROCESSED("numConsumingSegmentsProcessed", MetadataValueType.INT),
+    NUM_CONSUMING_SEGMENTS_QUERIED("numConsumingSegmentsQueried", MetadataValueType.INT),
     MIN_CONSUMING_FRESHNESS_TIME_MS("minConsumingFreshnessTimeMs", MetadataValueType.LONG),
     TOTAL_DOCS("totalDocs", MetadataValueType.LONG),
     NUM_GROUPS_LIMIT_REACHED("numGroupsLimitReached", MetadataValueType.STRING),

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -196,12 +196,12 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
     }
 
     // Gather stats for realtime consuming segments
-    int numConsumingSegments = 0;
+    int numConsumingSegmentsQueried = 0;
     long minIndexTimeMs = Long.MAX_VALUE;
     long minIngestionTimeMs = Long.MAX_VALUE;
     for (IndexSegment indexSegment : indexSegments) {
       if (indexSegment instanceof MutableSegment) {
-        numConsumingSegments += 1;
+        numConsumingSegmentsQueried += 1;
         SegmentMetadata segmentMetadata = indexSegment.getSegmentMetadata();
         long indexTimeMs = segmentMetadata.getLastIndexedTimestamp();
         if (indexTimeMs != Long.MIN_VALUE && indexTimeMs < minIndexTimeMs) {
@@ -263,11 +263,11 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       _serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_MISSING_SEGMENTS, numMissingSegments);
     }
 
-    if (numConsumingSegments > 0) {
+    if (numConsumingSegmentsQueried > 0) {
       long minConsumingFreshnessTimeMs = minIngestionTimeMs != Long.MAX_VALUE ? minIngestionTimeMs : minIndexTimeMs;
       LOGGER.debug("Request {} queried {} consuming segments with minConsumingFreshnessTimeMs: {}", requestId,
-          numConsumingSegments, minConsumingFreshnessTimeMs);
-      metadata.put(MetadataKey.NUM_CONSUMING_SEGMENTS_PROCESSED.getName(), Integer.toString(numConsumingSegments));
+          numConsumingSegmentsQueried, minConsumingFreshnessTimeMs);
+      metadata.put(MetadataKey.NUM_CONSUMING_SEGMENTS_QUERIED.getName(), Integer.toString(numConsumingSegmentsQueried));
       metadata.put(MetadataKey.MIN_CONSUMING_FRESHNESS_TIME_MS.getName(), Long.toString(minConsumingFreshnessTimeMs));
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseReduceService.java
@@ -132,7 +132,7 @@ public abstract class BaseReduceService {
     private long _numSegmentsQueried = 0L;
     private long _numSegmentsProcessed = 0L;
     private long _numSegmentsMatched = 0L;
-    private long _numConsumingSegmentsProcessed = 0L;
+    private long _numConsumingSegmentsQueried = 0L;
     private long _minConsumingFreshnessTimeMs = Long.MAX_VALUE;
     private long _numTotalDocs = 0L;
     private long _offlineThreadCpuTimeNs = 0L;
@@ -195,9 +195,9 @@ public abstract class BaseReduceService {
         _numSegmentsMatched += Long.parseLong(numSegmentsMatchedString);
       }
 
-      String numConsumingString = metadata.get(MetadataKey.NUM_CONSUMING_SEGMENTS_PROCESSED.getName());
-      if (numConsumingString != null) {
-        _numConsumingSegmentsProcessed += Long.parseLong(numConsumingString);
+      String numConsumingSegmentsQueriedString = metadata.get(MetadataKey.NUM_CONSUMING_SEGMENTS_QUERIED.getName());
+      if (numConsumingSegmentsQueriedString != null) {
+        _numConsumingSegmentsQueried += Long.parseLong(numConsumingSegmentsQueriedString);
       }
 
       String minConsumingFreshnessTimeMsString = metadata.get(MetadataKey.MIN_CONSUMING_FRESHNESS_TIME_MS.getName());
@@ -296,8 +296,8 @@ public abstract class BaseReduceService {
       brokerResponseNative.setNumSegmentsPrunedByValue(_numSegmentsPrunedByValue);
       brokerResponseNative.setExplainPlanNumEmptyFilterSegments(_explainPlanNumEmptyFilterSegments);
       brokerResponseNative.setExplainPlanNumMatchAllFilterSegments(_explainPlanNumMatchAllFilterSegments);
-      if (_numConsumingSegmentsProcessed > 0) {
-        brokerResponseNative.setNumConsumingSegmentsQueried(_numConsumingSegmentsProcessed);
+      if (_numConsumingSegmentsQueried > 0) {
+        brokerResponseNative.setNumConsumingSegmentsQueried(_numConsumingSegmentsQueried);
         brokerResponseNative.setMinConsumingFreshnessTimeMs(_minConsumingFreshnessTimeMs);
       }
 
@@ -326,7 +326,7 @@ public abstract class BaseReduceService {
         brokerMetrics.addTimedTableValue(rawTableName, BrokerTimer.REALTIME_TOTAL_CPU_TIME_NS, _realtimeTotalCpuTimeNs,
             TimeUnit.NANOSECONDS);
 
-        if (_numConsumingSegmentsProcessed > 0 && _minConsumingFreshnessTimeMs > 0) {
+        if (_numConsumingSegmentsQueried > 0 && _minConsumingFreshnessTimeMs > 0) {
           brokerMetrics.addTimedTableValue(rawTableName, BrokerTimer.FRESHNESS_LAG_MS,
               System.currentTimeMillis() - _minConsumingFreshnessTimeMs, TimeUnit.MILLISECONDS);
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
@@ -185,7 +185,7 @@ public abstract class QueryScheduler {
         dataTableMetadata.getOrDefault(
             MetadataKey.NUM_SEGMENTS_PRUNED_BY_VALUE.getName(), INVALID_SEGMENTS_COUNT));
     long numSegmentsConsuming = Long.parseLong(
-        dataTableMetadata.getOrDefault(MetadataKey.NUM_CONSUMING_SEGMENTS_PROCESSED.getName(), INVALID_SEGMENTS_COUNT));
+        dataTableMetadata.getOrDefault(MetadataKey.NUM_CONSUMING_SEGMENTS_QUERIED.getName(), INVALID_SEGMENTS_COUNT));
     long minConsumingFreshnessMs = Long.parseLong(
         dataTableMetadata.getOrDefault(MetadataKey.MIN_CONSUMING_FRESHNESS_TIME_MS.getName(), INVALID_FRESHNESS_MS));
     int numResizes =

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datatable/DataTableSerDeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datatable/DataTableSerDeTest.java
@@ -80,7 +80,7 @@ public class DataTableSerDeTest {
           .put(MetadataKey.NUM_SEGMENTS_QUERIED.getName(), String.valueOf(6))
           .put(MetadataKey.NUM_SEGMENTS_PROCESSED.getName(), String.valueOf(6))
           .put(MetadataKey.NUM_SEGMENTS_MATCHED.getName(), String.valueOf(1))
-          .put(MetadataKey.NUM_CONSUMING_SEGMENTS_PROCESSED.getName(), String.valueOf(1))
+          .put(MetadataKey.NUM_CONSUMING_SEGMENTS_QUERIED.getName(), String.valueOf(1))
           .put(MetadataKey.MIN_CONSUMING_FRESHNESS_TIME_MS.getName(), String.valueOf(100L))
           .put(MetadataKey.TOTAL_DOCS.getName(), String.valueOf(200L))
           .put(MetadataKey.NUM_GROUPS_LIMIT_REACHED.getName(), "true")


### PR DESCRIPTION
Partial Fix #7144

This PR will handle the naming mismatch mentioned in the issue description. Can we merge this first I will raise a separate PR in the following week to add the extra meta data values ?

I tried doing in the same PR it was so confusing 😕 
