### PR TITLE
[multistage] add more query types for testing

### DIFF
--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
@@ -56,7 +56,10 @@ public class QueryEnvironmentTestBase {
             + " GROUP BY a.col1, a.col2"},
         new Object[]{"SELECT a.col1, AVG(b.col3) FROM a JOIN b ON a.col1 = b.col2 "
             + " WHERE a.col3 >= 0 AND a.col2 = 'a' AND b.col3 < 0 GROUP BY a.col1"},
-        new Object[]{"SELECT a.col1, a.col3, b.col3 FROM a JOIN b ON MOD(a.col3, 2) = MOD(b.col3, 2)"}
+        new Object[]{"SELECT a.col1, a.col3, b.col3 FROM a JOIN b ON MOD(a.col3, 2) = MOD(b.col3, 2)"},
+        new Object[]{"SELECT a.col1, a.col3, i.maxVal FROM a JOIN "
+            + "  (SELECT b.col1 AS joinKey, MAX(b.col3) AS maxVal FROM b GROUP BY b.col1) AS i "
+            + "  ON a.col1 = i.joinKey"},
     };
   }
 }

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
@@ -56,6 +56,7 @@ public class QueryEnvironmentTestBase {
             + " GROUP BY a.col1, a.col2"},
         new Object[]{"SELECT a.col1, AVG(b.col3) FROM a JOIN b ON a.col1 = b.col2 "
             + " WHERE a.col3 >= 0 AND a.col2 = 'a' AND b.col3 < 0 GROUP BY a.col1"},
+        new Object[]{"SELECT a.col1, a.col3, b.col3 FROM a JOIN b ON MOD(a.col3, 2) = MOD(b.col3, 2)"}
     };
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
@@ -159,6 +159,11 @@ public class QueryRunnerTest {
         // thus the final JOIN result will be 15 x 1 = 15.
         new Object[]{"SELECT * FROM a JOIN b on a.col1 = b.col1", 15},
 
+        // Query with function in JOIN keys, table A and B are both (1, 2, 42, 1, 2), with table A cycling 3 times.
+        // Final result would have 6 x 2 = 12 (6 (1)s on with MOD result 1, on both tables)
+        //     + 9 x 1 = 9 (6 (2)s & 3 (42)s on table A MOD 2 = 0, 1 (42)s on table B MOD 3 = 0): 21 rows in total.
+        new Object[]{"SELECT a.col1, a.col3, b.col3 FROM a JOIN b ON MOD(a.col3, 2) = MOD(b.col3, 3)", 21},
+
         // Specifically table A has 15 rows (10 on server1 and 5 on server2) and table B has 5 rows (all on server1),
         // thus the final JOIN result will be 15 x 1 = 15.
         new Object[]{"SELECT * FROM a JOIN b on a.col1 = b.col1 AND a.col2 = b.col2", 15},

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
@@ -169,10 +169,6 @@ public class QueryRunnerTest {
         new Object[]{"SELECT * FROM a JOIN b on a.col1 = b.col1 AND a.col2 = b.col2", 15},
 
         // Specifically table A has 15 rows (10 on server1 and 5 on server2) and table B has 5 rows (all on server1),
-        // thus the final JOIN result will be 15 x 1 = 15.
-        new Object[]{"SELECT * FROM a JOIN b on a.col1 = b.col1 AND a.col2 = b.col2", 15},
-
-        // Specifically table A has 15 rows (10 on server1 and 5 on server2) and table B has 5 rows (all on server1),
         // but only 1 out of 5 rows from table A will be selected out; and all in table B will be selected.
         // thus the final JOIN result will be 1 x 3 x 1 = 3.
         new Object[]{"SELECT a.col1, a.ts, b.col2, b.col3 FROM a JOIN b ON a.col1 = b.col2 "
@@ -211,6 +207,11 @@ public class QueryRunnerTest {
         // only 3 GROUP BY key exist because b.col2 cycles between "foo", "bar", "alice".
         new Object[]{"SELECT a.col1, SUM(b.col3) FROM a JOIN b ON a.col1 = b.col2 "
             + " WHERE a.col3 >= 0 GROUP BY a.col1", 3},
+
+        // Sub-query
+        new Object[]{"SELECT b.col1, b.col3, i.maxVal FROM b JOIN "
+            + "  (SELECT a.col2 AS joinKey, MAX(a.col3) AS maxVal FROM a GROUP BY a.col2) AS i "
+            + "  ON b.col1 = i.joinKey", 3}
     };
   }
 }


### PR DESCRIPTION
* sub-query 
```
SELECT a.k, a.v, t.cnt 
FROM a JOIN (
  SELECT k, count(*) AS cnt FROM b) AS t 
  ON a.k = t.k
```
* function on JOIN key
```
SELECT a.*, b.* FROM a JOIN b ON a.col1 + a.col2 = b.col3 + b.col4
```

TODO
===
- [ ] validate optimized query plan should minimized number of cross exchanges (e.g. sub-query should run with single stage group by exchange)