### PR TITLE
[backward compat] fix catalog skipping

### DIFF
--- a/pinot-common/src/main/codegen/config.fmpp
+++ b/pinot-common/src/main/codegen/config.fmpp
@@ -164,7 +164,7 @@ data: {
       "DEC"
       "DECIMAL"
       "DECLARE"
-#     "DEFAULT"
+      "DEFAULT_"
       "DEFERRABLE"
       "DEFERRED"
 #     "DEFINE"

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -2502,6 +2502,16 @@ public class CalciteSqlCompilerTest {
   }
 
   @Test
+  public void testCatalogNameResolvedToDefault() {
+    // Pinot doesn't support catalog. However, for backward compatibility, if a catalog is provided, we will resolve
+    // the table from our default catalog. this means `a.foo` will be equivalent to `foo`.
+    PinotQuery randomCatalogQuery = CalciteSqlParser.compileToPinotQuery("SELECT count(*) FROM rand_catalog.foo");
+    PinotQuery defaultCatalogQuery = CalciteSqlParser.compileToPinotQuery("SELECT count(*) FROM default.foo");
+    Assert.assertEquals(randomCatalogQuery.getDataSource().getTableName(), "rand_catalog.foo");
+    Assert.assertEquals(defaultCatalogQuery.getDataSource().getTableName(), "default.foo");
+  }
+
+  @Test
   public void testInvalidQueryWithSemicolon() {
     Assert.expectThrows(SqlCompilationException.class, () -> CalciteSqlParser.compileToPinotQuery(";"));
 


### PR DESCRIPTION
Previously Pinot SQL allows catalog but redirect the result back to default using the table name. 
recent change out of BABLE parser breaks this. This PR fixes it 