### PR TITLE
[UI] Add controller UI to use multi-stage engine

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -100,8 +100,6 @@ public class PinotClientRequest {
     try {
       ObjectNode requestJson = JsonUtils.newObjectNode();
       requestJson.put(Request.SQL, query);
-      String queryOptions = constructSqlQueryOptions(requestJson);
-      requestJson.put(Request.QUERY_OPTIONS, queryOptions);
       if (traceEnabled != null) {
         requestJson.put(Request.TRACE, traceEnabled);
       }
@@ -133,9 +131,7 @@ public class PinotClientRequest {
       if (!requestJson.has(Request.SQL)) {
         throw new IllegalStateException("Payload is missing the query string field 'sql'");
       }
-      String queryOptions = constructSqlQueryOptions(requestJson);
-      // the only query options as of now are sql related. do not allow any custom query options in sql endpoint
-      ObjectNode sqlRequestJson = ((ObjectNode) requestJson).put(Request.QUERY_OPTIONS, queryOptions);
+      ObjectNode sqlRequestJson = (ObjectNode) requestJson;
       BrokerResponse brokerResponse = executeSqlQuery(sqlRequestJson, makeHttpIdentity(requestContext), false);
       asyncResponse.resume(brokerResponse.toJsonString());
     } catch (Exception e) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -180,9 +180,7 @@ public class PinotClientRequest {
     if (requestJson.has("queryOptions")) {
       queryOptions = requestJson.get("queryOptions").asText() + ";";
     }
-    // TODO: Remove this SQL query options after releasing 0.11.0
-    return queryOptions + Request.QueryOptionKey.GROUP_BY_MODE + "=" + Request.SQL + ";"
-        + Request.QueryOptionKey.RESPONSE_FORMAT + "=" + Request.SQL;
+    return queryOptions;
   }
 
   private static HttpRequesterIdentity makeHttpIdentity(org.glassfish.grizzly.http.server.Request context) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -131,8 +131,8 @@ public class PinotClientRequest {
       if (!requestJson.has(Request.SQL)) {
         throw new IllegalStateException("Payload is missing the query string field 'sql'");
       }
-      ObjectNode sqlRequestJson = (ObjectNode) requestJson;
-      BrokerResponse brokerResponse = executeSqlQuery(sqlRequestJson, makeHttpIdentity(requestContext), false);
+      BrokerResponse brokerResponse = executeSqlQuery((ObjectNode) requestJson, makeHttpIdentity(requestContext),
+          false);
       asyncResponse.resume(brokerResponse.toJsonString());
     } catch (Exception e) {
       LOGGER.error("Caught exception while processing POST request", e);
@@ -170,15 +170,6 @@ public class PinotClientRequest {
             new UnsupportedOperationException("Unsupported SQL type - " + sqlType)));
     }
   }
-
-  private String constructSqlQueryOptions(JsonNode requestJson) {
-    String queryOptions = "";
-    if (requestJson.has("queryOptions")) {
-      queryOptions = requestJson.get("queryOptions").asText() + ";";
-    }
-    return queryOptions;
-  }
-
   private static HttpRequesterIdentity makeHttpIdentity(org.glassfish.grizzly.http.server.Request context) {
     Multimap<String, String> headers = ArrayListMultimap.create();
     context.getHeaderNames().forEach(key -> context.getHeaders(key).forEach(value -> headers.put(key, value)));

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1420,7 +1420,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     throw new BadQueryRequestException("Unknown columnName '" + columnName + "' found in the query");
   }
 
-  private static Map<String, String> getOptionsFromJson(JsonNode request, String optionsKey) {
+  public static Map<String, String> getOptionsFromJson(JsonNode request, String optionsKey) {
     return Splitter.on(';').omitEmptyStrings().trimResults().withKeyValueSeparator('=')
         .split(request.get(optionsKey).asText());
   }
@@ -1449,9 +1449,6 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   @VisibleForTesting
   static void setOptions(PinotQuery pinotQuery, long requestId, String query, JsonNode jsonRequest) {
     Map<String, String> queryOptions = new HashMap<>();
-    // TODO: Remove the SQL query options after releasing 0.11.0
-    queryOptions.put(Broker.Request.QueryOptionKey.GROUP_BY_MODE, Broker.Request.SQL);
-    queryOptions.put(Broker.Request.QueryOptionKey.RESPONSE_FORMAT, Broker.Request.SQL);
     if (jsonRequest.has(Broker.Request.DEBUG_OPTIONS)) {
       Map<String, String> debugOptions = getOptionsFromJson(jsonRequest, Broker.Request.DEBUG_OPTIONS);
       if (!debugOptions.isEmpty()) {
@@ -1480,6 +1477,10 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     if (!queryOptions.isEmpty()) {
       LOGGER.debug("Query options are set to: {} for request {}: {}", queryOptions, requestId, query);
     }
+    // TODO: Remove the SQL query options after releasing 0.11.0
+    // The query engine will break if these 2 options are missing during version upgrade.
+    queryOptions.put(Broker.Request.QueryOptionKey.GROUP_BY_MODE, Broker.Request.SQL);
+    queryOptions.put(Broker.Request.QueryOptionKey.RESPONSE_FORMAT, Broker.Request.SQL);
   }
 
   /**

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1449,6 +1449,9 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   @VisibleForTesting
   static void setOptions(PinotQuery pinotQuery, long requestId, String query, JsonNode jsonRequest) {
     Map<String, String> queryOptions = new HashMap<>();
+    // TODO: Remove the SQL query options after releasing 0.11.0
+    queryOptions.put(Broker.Request.QueryOptionKey.GROUP_BY_MODE, Broker.Request.SQL);
+    queryOptions.put(Broker.Request.QueryOptionKey.RESPONSE_FORMAT, Broker.Request.SQL);
     if (jsonRequest.has(Broker.Request.DEBUG_OPTIONS)) {
       Map<String, String> debugOptions = getOptionsFromJson(jsonRequest, Broker.Request.DEBUG_OPTIONS);
       if (!debugOptions.isEmpty()) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
@@ -74,9 +74,11 @@ public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
       RequestContext requestContext)
       throws Exception {
     if (_isMultiStageQueryEngineEnabled && _multiStageWorkerRequestHandler != null) {
-      JsonNode node = request.get(CommonConstants.Broker.Request.QueryOptionKey.USE_MULTISTAGE_ENGINE);
-      if (node != null && node.asBoolean()) {
-        return _multiStageWorkerRequestHandler.handleRequest(request, requesterIdentity, requestContext);
+      if (request.has("queryOptions")) {
+        String queryOptions = request.get("queryOptions").asText();
+        if (queryOptions.contains(CommonConstants.Broker.Request.QueryOptionKey.USE_MULTISTAGE_ENGINE)) {
+          return _multiStageWorkerRequestHandler.handleRequest(request, requesterIdentity, requestContext);
+        }
       }
     }
     return _singleStageBrokerRequestHandler.handleRequest(request, requesterIdentity, requestContext);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
@@ -77,8 +77,8 @@ public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
     if (_isMultiStageQueryEngineEnabled && _multiStageWorkerRequestHandler != null) {
       if (request.has("queryOptions")) {
         Map<String, String> queryOptionMap = BaseBrokerRequestHandler.getOptionsFromJson(request, "queryOptions");
-        if ("true".equalsIgnoreCase(queryOptionMap.getOrDefault(
-            CommonConstants.Broker.Request.QueryOptionKey.USE_MULTISTAGE_ENGINE, "false"))) {
+        if (Boolean.parseBoolean(queryOptionMap.get(
+            CommonConstants.Broker.Request.QueryOptionKey.USE_MULTISTAGE_ENGINE))) {
           return _multiStageWorkerRequestHandler.handleRequest(request, requesterIdentity, requestContext);
         }
       }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.broker.requesthandler;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.broker.api.RequesterIdentity;
 import org.apache.pinot.common.response.BrokerResponse;
@@ -75,8 +76,9 @@ public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
       throws Exception {
     if (_isMultiStageQueryEngineEnabled && _multiStageWorkerRequestHandler != null) {
       if (request.has("queryOptions")) {
-        String queryOptions = request.get("queryOptions").asText();
-        if (queryOptions.contains(CommonConstants.Broker.Request.QueryOptionKey.USE_MULTISTAGE_ENGINE)) {
+        Map<String, String> queryOptionMap = BaseBrokerRequestHandler.getOptionsFromJson(request, "queryOptions");
+        if ("true".equalsIgnoreCase(queryOptionMap.getOrDefault(
+            CommonConstants.Broker.Request.QueryOptionKey.USE_MULTISTAGE_ENGINE, "false"))) {
           return _multiStageWorkerRequestHandler.handleRequest(request, requesterIdentity, requestContext);
         }
       }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BrokerRequestOptionsTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BrokerRequestOptionsTest.java
@@ -33,6 +33,8 @@ import org.testng.annotations.Test;
  * Tests the various options set in the broker request
  */
 public class BrokerRequestOptionsTest {
+  // TODO: remove this legacy option size checker after 0.11 release cut.
+  private static final int LEGACY_PQL_QUERY_OPTION_SIZE = 2;
 
   @Test
   public void testSetOptions() {
@@ -44,7 +46,7 @@ public class BrokerRequestOptionsTest {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
     Assert.assertNull(pinotQuery.getDebugOptions());
-    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 0);
+    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 0 + LEGACY_PQL_QUERY_OPTION_SIZE);
 
     // TRACE
     // Has trace false
@@ -52,14 +54,14 @@ public class BrokerRequestOptionsTest {
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
     Assert.assertNull(pinotQuery.getDebugOptions());
-    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 0);
+    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 0 + LEGACY_PQL_QUERY_OPTION_SIZE);
 
     // Has trace true
     jsonRequest.put(Request.TRACE, true);
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
     Assert.assertNull(pinotQuery.getDebugOptions());
-    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1);
+    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1 + LEGACY_PQL_QUERY_OPTION_SIZE);
     Assert.assertEquals(pinotQuery.getQueryOptions().get(Request.TRACE), "true");
 
     // DEBUG_OPTIONS (debug options will also be included as query options)
@@ -70,7 +72,6 @@ public class BrokerRequestOptionsTest {
     BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
     Assert.assertEquals(pinotQuery.getDebugOptionsSize(), 1);
     Assert.assertEquals(pinotQuery.getDebugOptions().get("debugOption1"), "foo");
-    Assert.assertEquals(pinotQuery.getQueryOptions(), pinotQuery.getDebugOptions());
 
     // Has multiple debugOptions
     jsonRequest.put(Request.DEBUG_OPTIONS, "debugOption1=foo;debugOption2=bar");
@@ -79,7 +80,6 @@ public class BrokerRequestOptionsTest {
     Assert.assertEquals(pinotQuery.getDebugOptionsSize(), 2);
     Assert.assertEquals(pinotQuery.getDebugOptions().get("debugOption1"), "foo");
     Assert.assertEquals(pinotQuery.getDebugOptions().get("debugOption2"), "bar");
-    Assert.assertEquals(pinotQuery.getQueryOptions(), pinotQuery.getDebugOptions());
 
     // Invalid debug options
     jsonRequest.put(Request.DEBUG_OPTIONS, "debugOption1");
@@ -100,14 +100,14 @@ public class BrokerRequestOptionsTest {
     pinotQuery.setQueryOptions(queryOptions);
     BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
     Assert.assertNull(pinotQuery.getDebugOptions());
-    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1);
+    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1 + LEGACY_PQL_QUERY_OPTION_SIZE);
     Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption1"), "foo");
 
     // Has queryOptions in query
     pinotQuery = CalciteSqlParser.compileToPinotQuery("SET queryOption1='foo'; select * from testTable");
     BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
     Assert.assertNull(pinotQuery.getDebugOptions());
-    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1);
+    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1 + LEGACY_PQL_QUERY_OPTION_SIZE);
     Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption1"), "foo");
 
     // Has query options in json payload
@@ -115,7 +115,7 @@ public class BrokerRequestOptionsTest {
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
     Assert.assertNull(pinotQuery.getDebugOptions());
-    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1);
+    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1 + LEGACY_PQL_QUERY_OPTION_SIZE);
     Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption1"), "foo");
 
     // Has query options in both json payload and pinotQuery, pinotQuery takes priority
@@ -123,7 +123,7 @@ public class BrokerRequestOptionsTest {
     pinotQuery = CalciteSqlParser.compileToPinotQuery("SET queryOption1='foo'; select * from testTable;");
     BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
     Assert.assertNull(pinotQuery.getDebugOptions());
-    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 2);
+    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 2 + LEGACY_PQL_QUERY_OPTION_SIZE);
     Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption1"), "foo");
     Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption2"), "moo");
 
@@ -136,7 +136,7 @@ public class BrokerRequestOptionsTest {
     BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
     Assert.assertEquals(pinotQuery.getDebugOptionsSize(), 1);
     Assert.assertEquals(pinotQuery.getDebugOptions().get("debugOption1"), "foo");
-    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 4);
+    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 4 + LEGACY_PQL_QUERY_OPTION_SIZE);
     Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption1"), "bar");
     Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption2"), "moo");
     Assert.assertEquals(pinotQuery.getQueryOptions().get(Request.TRACE), "true");

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -124,7 +124,13 @@ public class PinotQueryResource {
       String queryOptions)
       throws Exception {
     if (queryOptions != null && queryOptions.contains(QueryOptionKey.USE_MULTISTAGE_ENGINE)) {
-      return getMultiStageQueryResponse(sqlQuery, queryOptions, httpHeaders);
+      if (_controllerConf.getProperty(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_ENABLED,
+          CommonConstants.Helix.DEFAULT_MULTI_STAGE_ENGINE_ENABLED)) {
+        return getMultiStageQueryResponse(sqlQuery, queryOptions, httpHeaders);
+      } else {
+        throw new UnsupportedOperationException("V2 Multi-Stage query engine not enabled. "
+            + "Please see https://docs.pinot.apache.org/ for instruction to enable V2 engine.");
+      }
     } else {
       SqlNodeAndOptions sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sqlQuery);
       PinotSqlType sqlType = sqlNodeAndOptions.getSqlType();

--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -317,8 +317,8 @@ const QueryPage = () => {
          + `Please reload the table in order to refresh these segments to the new schema.`);
     }
     if (checked.useMSE) {
-      warnings.push(`Using Multi-Stage Query Engine is an experimental feature. Please report any bugs to `
-          + `Apache Pinot Slack channel`);
+      warnings.push(`Using Multi-Stage Query Engine/s. This is an experimental feature. Please report any bugs to `
+          + `Apache Pinot Slack channel.`);
     }
     return warnings;
   }

--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -194,6 +194,7 @@ const QueryPage = () => {
 
   const [checked, setChecked] = React.useState({
     tracing: queryParam.get('tracing') === 'true',
+    useMSE: queryParam.get('useMSE') === 'true',
     showResultJSON: false,
   });
 
@@ -270,19 +271,24 @@ const QueryPage = () => {
     setQueryLoader(true);
     queryExecuted.current = true;
     let params;
-    let timeoutStr = '';
+    let queryOptions = '';
     if(queryTimeout){
-      timeoutStr = ` option(timeoutMs=${queryTimeout})`
+      queryOptions += `timeoutMs=${queryTimeout}`;
+    }
+    if(checked.useMSE){
+      queryOptions += `useMultistageEngine=true`;
     }
     const finalQuery = `${query || inputQuery.trim()}`;
     params = JSON.stringify({
-      sql: `${finalQuery}${timeoutStr}`,
+      sql: `${finalQuery}`,
       trace: checked.tracing,
+      queryOptions: `${queryOptions}`,
     });
 
     if(finalQuery !== ''){
       queryParam.set('query', finalQuery);
       queryParam.set('tracing', checked.tracing.toString());
+      queryParam.set('useMSE', checked.useMSE.toString());
       if(queryTimeout !== undefined && queryTimeout !== ''){
         queryParam.set('timeout', queryTimeout.toString());
       }
@@ -292,7 +298,7 @@ const QueryPage = () => {
       })
     }
 
-    const results = await PinotMethodUtils.getQueryResults(params, checked);
+    const results = await PinotMethodUtils.getQueryResults(params);
     setResultError(results.error || '');
     setResultData(results.result || { columns: [], records: [] });
     setQueryStats(results.queryStats || { columns: responseStatCols, records: [] });
@@ -309,6 +315,10 @@ const QueryPage = () => {
       warnings.push(`There are ${numSegmentsPrunedInvalid} invalid segment/s. This usually means that they were `
          + `created with an older schema. `
          + `Please reload the table in order to refresh these segments to the new schema.`);
+    }
+    if (checked.useMSE) {
+      warnings.push(`Using Multi-Stage Query Engine is an experimental feature. Please report any bugs to `
+          + `Apache Pinot Slack channel`);
     }
     return warnings;
   }
@@ -377,6 +387,7 @@ const QueryPage = () => {
       setInputQuery(query);
       setChecked({
         tracing: queryParam.get('tracing') === 'true',
+        useMSE: queryParam.get('useMse') === 'true',
         showResultJSON: checked.showResultJSON,
       });
       setQueryTimeout(Number(queryParam.get('timeout') || '') || '');
@@ -492,6 +503,16 @@ const QueryPage = () => {
                 Tracing
               </Grid>
 
+              <Grid item xs={2}>
+                <Checkbox
+                    name="useMSE"
+                    color="primary"
+                    onChange={handleChange}
+                    checked={checked.useMSE}
+                />
+                Use Multi-Stage Engine
+              </Grid>
+
               <Grid item xs={3}>
                 <FormControl fullWidth={true} className={classes.timeoutControl}>
                   <InputLabel htmlFor="my-input">Timeout (in Milliseconds)</InputLabel>
@@ -525,19 +546,20 @@ const QueryPage = () => {
                     </Grid>
                 ) : null}
 
+                {
+                  warnings.map(warn =>
+                                   <Alert severity="warning" className={classes.sqlError}>
+                                     {warn}
+                                   </Alert>
+                  )
+                }
+
                 {resultError ? (
                   <Alert severity="error" className={classes.sqlError}>
                     {resultError}
                   </Alert>
                 ) : (
                   <>
-                    {
-                    warnings.map(warn =>
-                        <Alert severity="warning" className={classes.sqlError}>
-                          {warn}
-                        </Alert>
-                      )
-                    }
                     <Grid item xs style={{ backgroundColor: 'white' }}>
                       {resultData.columns.length ? (
                         <>

--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -317,7 +317,7 @@ const QueryPage = () => {
          + `Please reload the table in order to refresh these segments to the new schema.`);
     }
     if (checked.useMSE) {
-      warnings.push(`Using Multi-Stage Query Engine/s. This is an experimental feature. Please report any bugs to `
+      warnings.push(`Using Multi-Stage Query Engine. This is an experimental feature. Please report any bugs to `
           + `Apache Pinot Slack channel.`);
     }
     return warnings;

--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -317,7 +317,7 @@ const QueryPage = () => {
          + `Please reload the table in order to refresh these segments to the new schema.`);
     }
     if (checked.useMSE) {
-      warnings.push(`Using Multi-Stage Query Engine. This is an experimental feature. Please report any bugs to `
+      warnings.push(`Using V2 Multi-Stage Query Engine. This is an experimental feature. Please report any bugs to `
           + `Apache Pinot Slack channel.`);
     }
     return warnings;
@@ -510,7 +510,7 @@ const QueryPage = () => {
                     onChange={handleChange}
                     checked={checked.useMSE}
                 />
-                Use Multi-Stage Engine
+                Use V2 Engine
               </Grid>
 
               <Grid item xs={3}>

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -254,7 +254,7 @@ const getAsObject = (str: SQLResult) => {
 // This method is used to display query output in tabular format as well as JSON format on query page
 // API: /:urlName (Eg: sql or pql)
 // Expected Output: {columns: [], records: []}
-const getQueryResults = (params, checkedOptions) => {
+const getQueryResults = (params) => {
   return getQueryResult(params).then(({ data }) => {
     let queryResponse = getAsObject(data);
 
@@ -268,46 +268,7 @@ const getQueryResults = (params, checkedOptions) => {
       errorStr = JSON.stringify(queryResponse.exceptions, null, 2);
     } else
     {
-      if (checkedOptions.querySyntaxPQL === true)
-      {
-        if (queryResponse)
-        {
-          if (queryResponse.selectionResults)
-          {
-            // Selection query
-            columnList = queryResponse.selectionResults.columns;
-            dataArray = queryResponse.selectionResults.results;
-          }
-          else if (!queryResponse.aggregationResults[0]?.groupByResult)
-          {
-            // Simple aggregation query
-            columnList = map(queryResponse.aggregationResults, (aggregationResult) => {
-              return {title: aggregationResult.function};
-            });
-
-            dataArray.push(map(queryResponse.aggregationResults, (aggregationResult) => {
-              return aggregationResult.value;
-            }));
-          }
-          else if (queryResponse.aggregationResults[0]?.groupByResult)
-          {
-            // Aggregation group by query
-            // TODO - Revisit
-            const columns = queryResponse.aggregationResults[0].groupByColumns;
-            columns.push(queryResponse.aggregationResults[0].function);
-            columnList = map(columns, (columnName) => {
-              return columnName;
-            });
-
-            dataArray = map(queryResponse.aggregationResults[0].groupByResult, (aggregationGroup) => {
-              const row = aggregationGroup.group;
-              row.push(aggregationGroup.value);
-              return row;
-            });
-          }
-        }
-      }
-      else if (queryResponse.resultTable?.dataSchema?.columnNames?.length)
+      if (queryResponse.resultTable?.dataSchema?.columnNames?.length)
       {
         columnList = queryResponse.resultTable.dataSchema.columnNames;
         dataArray = queryResponse.resultTable.rows;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -102,7 +102,8 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTest 
   public void testMultiStageQuery(String sql, int expectedNumOfRows, int expectedNumOfColumns)
       throws IOException {
     JsonNode multiStageResponse = JsonUtils.stringToJsonNode(
-        sendPostRequest(_brokerBaseApiUrl + "/query/sql", "{\"useMultistageEngine\": true, \"sql\":\"" + sql + "\"}"));
+        sendPostRequest(_brokerBaseApiUrl + "/query/sql",
+            "{\"queryOptions\":\"useMultistageEngine=true\", \"sql\":\"" + sql + "\"}"));
     Assert.assertTrue(multiStageResponse.has("resultTable"));
     ArrayNode jsonNode = (ArrayNode) multiStageResponse.get("resultTable").get("rows");
     // TODO: assert actual result data payload.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -273,14 +273,6 @@ public class CommonConstants {
         public static final String EXPLAIN_PLAN_VERBOSE = "explainPlanVerbose";
         public static final String USE_MULTISTAGE_ENGINE = "useMultistageEngine";
         public static final String ENABLE_NULL_HANDLING = "enableNullHandling";
-
-        // TODO: Remove these keys (only apply to PQL) after releasing 0.11.0
-        @Deprecated
-        public static final String PRESERVE_TYPE = "preserveType";
-        @Deprecated
-        public static final String RESPONSE_FORMAT = "responseFormat";
-        @Deprecated
-        public static final String GROUP_BY_MODE = "groupByMode";
       }
 
       public static class QueryOptionValue {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -273,6 +273,14 @@ public class CommonConstants {
         public static final String EXPLAIN_PLAN_VERBOSE = "explainPlanVerbose";
         public static final String USE_MULTISTAGE_ENGINE = "useMultistageEngine";
         public static final String ENABLE_NULL_HANDLING = "enableNullHandling";
+
+        // TODO: Remove these keys (only apply to PQL) after releasing 0.11.0
+        @Deprecated
+        public static final String PRESERVE_TYPE = "preserveType";
+        @Deprecated
+        public static final String RESPONSE_FORMAT = "responseFormat";
+        @Deprecated
+        public static final String GROUP_BY_MODE = "groupByMode";
       }
 
       public static class QueryOptionValue {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
@@ -97,7 +97,7 @@ public class MultistageEngineQuickStart extends QuickStartBase {
         CommonConstants.Broker.Request.QueryOptionKey.USE_MULTISTAGE_ENGINE + "=true");
 
     printStatus(Quickstart.Color.YELLOW, "***** Multi-stage engine quickstart setup complete *****");
-    String q1 = "SELECT count(*) FROM baseballStats_OFFLINE limit 1";
+    String q1 = "SELECT count(*) FROM baseballStats_OFFLINE";
     printStatus(Quickstart.Color.YELLOW, "Total number of documents in the table");
     printStatus(Quickstart.Color.CYAN, "Query : " + q1);
     printStatus(Quickstart.Color.YELLOW, prettyPrintResponse(runner.runQuery(q1, queryOptions)));
@@ -115,8 +115,8 @@ public class MultistageEngineQuickStart extends QuickStartBase {
     printStatus(Quickstart.Color.GREEN, "***************************************************");
     printStatus(Quickstart.Color.YELLOW, "Example query run completed.");
     printStatus(Quickstart.Color.GREEN, "***************************************************");
-    printStatus(Quickstart.Color.YELLOW, "Please use broker port for executing multistage queries.");
-    printStatus(Quickstart.Color.GREEN, "***************************************************");
+    printStatus(Quickstart.Color.GREEN,
+        "You can always go to http://localhost:9000 to play around in the query console");
   }
 
   public static void main(String[] args)

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
@@ -93,8 +93,8 @@ public class MultistageEngineQuickStart extends QuickStartBase {
 
     waitForBootstrapToComplete(null);
 
-    Map<String, String> queryOptions = Collections.singletonMap(
-        CommonConstants.Broker.Request.QueryOptionKey.USE_MULTISTAGE_ENGINE, "true");
+    Map<String, String> queryOptions = Collections.singletonMap("queryOptions",
+        CommonConstants.Broker.Request.QueryOptionKey.USE_MULTISTAGE_ENGINE + "=true");
 
     printStatus(Quickstart.Color.YELLOW, "***** Multi-stage engine quickstart setup complete *****");
     String q1 = "SELECT count(*) FROM baseballStats_OFFLINE limit 1";


### PR DESCRIPTION
This PR enables access to multi-stage query engine on Controller UI. See:
![JOIN query example](https://user-images.githubusercontent.com/3581352/180818368-062bb03e-2913-46e5-b844-60cedcba97cc.png)

- Normal query UI doesn't change 
- Querying with JOIN syntax throws exception as expected when not using multi-stage engine, or multi-stage engine not enabled.
- Querying with JOIN syntax works with multi-stage engine checkbox, result will also show a warning banner for the experimental feature.

