### PR TITLE
Change indexing exception log level to debug

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -840,7 +840,7 @@ public class MutableSegmentImpl implements MutableSegment {
   }
 
   private void recordIndexingError(FieldConfig.IndexType indexType, Exception exception) {
-    _logger.error("failed to index value with {}", indexType, exception);
+    _logger.debug("failed to index value with {}", indexType, exception);
     if (_serverMetrics != null) {
       String metricKeyName = _realtimeTableName + "-" + indexType + "-indexingError";
       _serverMetrics.addMeteredTableValue(metricKeyName, ServerMeter.INDEXING_FAILURES, 1);
@@ -848,7 +848,7 @@ public class MutableSegmentImpl implements MutableSegment {
   }
 
   private void recordIndexingError(String indexType) {
-    _logger.error("failed to index value with {}", indexType);
+    _logger.debug("failed to index value with {}", indexType);
     if (_serverMetrics != null) {
       String metricKeyName = _realtimeTableName + "-" + indexType + "-indexingError";
       _serverMetrics.addMeteredTableValue(metricKeyName, ServerMeter.INDEXING_FAILURES, 1);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -840,7 +840,7 @@ public class MutableSegmentImpl implements MutableSegment {
   }
 
   private void recordIndexingError(FieldConfig.IndexType indexType, Exception exception) {
-    _logger.debug("failed to index value with {}", indexType, exception);
+    _logger.error("failed to index value with {}", indexType, exception);
     if (_serverMetrics != null) {
       String metricKeyName = _realtimeTableName + "-" + indexType + "-indexingError";
       _serverMetrics.addMeteredTableValue(metricKeyName, ServerMeter.INDEXING_FAILURES, 1);


### PR DESCRIPTION
A certain column value being `null` is a valid scenario during realtime ingestion. This PR fixes the log level for indexing exception arising due to null values / truncated String fields.
There's already a metric being emitted in the same function if at all users need a view of the indexing errors causes due to this.