### PR TITLE
Ensure conversion of field specs to avro schema is ordered

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/util/SegmentProcessorAvroUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/SegmentProcessorAvroUtils.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.util;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.avro.Schema;

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/SegmentProcessorAvroUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/SegmentProcessorAvroUtils.java
@@ -75,8 +75,8 @@ public final class SegmentProcessorAvroUtils {
     SchemaBuilder.FieldAssembler<org.apache.avro.Schema> fieldAssembler = SchemaBuilder.record("record").fields();
 
     List<FieldSpec> orderedFieldSpecs = pinotSchema.getAllFieldSpecs().stream()
-        .sorted()
-        .collect(Collectors.toList());
+        .sorted(comparing(FieldSpec::getName))
+        .collect(toList());
     for (FieldSpec fieldSpec : orderedFieldSpecs) {
       String name = fieldSpec.getName();
       DataType storedType = fieldSpec.getDataType().getStoredType();

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/SegmentProcessorAvroUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/SegmentProcessorAvroUtils.java
@@ -74,7 +74,10 @@ public final class SegmentProcessorAvroUtils {
   public static Schema convertPinotSchemaToAvroSchema(org.apache.pinot.spi.data.Schema pinotSchema) {
     SchemaBuilder.FieldAssembler<org.apache.avro.Schema> fieldAssembler = SchemaBuilder.record("record").fields();
 
-    for (FieldSpec fieldSpec : pinotSchema.getAllFieldSpecs()) {
+    List<FieldSpec> orderedFieldSpecs = pinotSchema.getAllFieldSpecs().stream()
+        .sorted()
+        .collect(Collectors.toList());
+    for (FieldSpec fieldSpec : orderedFieldSpecs) {
       String name = fieldSpec.getName();
       DataType storedType = fieldSpec.getDataType().getStoredType();
       if (fieldSpec.isSingleValueField()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/SegmentProcessorAvroUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/SegmentProcessorAvroUtils.java
@@ -18,12 +18,11 @@
  */
 package org.apache.pinot.core.util;
 
-import static java.util.Comparator.comparing;
-import static java.util.stream.Collectors.toList;
-
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData;
@@ -78,8 +77,8 @@ public final class SegmentProcessorAvroUtils {
     SchemaBuilder.FieldAssembler<org.apache.avro.Schema> fieldAssembler = SchemaBuilder.record("record").fields();
 
     List<FieldSpec> orderedFieldSpecs = pinotSchema.getAllFieldSpecs().stream()
-        .sorted(comparing(FieldSpec::getName))
-        .collect(toList());
+        .sorted(Comparator.comparing(FieldSpec::getName))
+        .collect(Collectors.toList());
     for (FieldSpec fieldSpec : orderedFieldSpecs) {
       String name = fieldSpec.getName();
       DataType storedType = fieldSpec.getDataType().getStoredType();

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/SegmentProcessorAvroUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/SegmentProcessorAvroUtils.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.core.util;
 
+import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.toList;
+
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Set;


### PR DESCRIPTION
This is a bug fix for the SegmentProcessorAvroUtils during the conversion of a pinot schema to an avro schema. Since the field specs are a collection, order is not guaranteed. Avro schema rely on order, which means that multiple invocations of this method may result in different ordering, causing serialization to break.

This change ensures the avro schema produced is predictable on all invocations by ordering the field specs prior to iterating them.