### PR TITLE
Upgrade zookeeper version (3.5.8 -> 3.5.10)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <helix.version>0.9.8</helix.version>
     <zkclient.version>0.7</zkclient.version>
     <jackson.version>2.12.7</jackson.version>
-    <zookeeper.version>3.5.8</zookeeper.version>
+    <zookeeper.version>3.5.10</zookeeper.version>
     <async-http-client.version>2.12.3</async-http-client.version>
     <jersey.version>2.35</jersey.version>
     <grizzly.version>2.4.4</grizzly.version>


### PR DESCRIPTION
This version upgrade removes high severity vulnerability (CVE-2020-10663).
