### PR TITLE
[hotfix] cross-merge issue on spark jackson version

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-2.4/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-2.4/pom.xml
@@ -120,17 +120,14 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>${spark2.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>${spark2.jackson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-annotations</artifactId>
-      <version>${spark2.jackson.version}</version>
     </dependency>
     <!-- For testing import of csv files -->
     <dependency>


### PR DESCRIPTION
#9067 and #9073 

since jackson version were cleaned in #9067, the extra tagging on #9073 is no longer needed.