### PR TITLE
Fix segment pruning that can break server subquery

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -276,6 +276,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
     return dataTable;
   }
 
+  // NOTE: This method might change indexSegments. Do not use it after calling this method.
   private DataTable processQuery(List<IndexSegment> indexSegments, QueryContext queryContext, TimerContext timerContext,
       ExecutorService executorService, @Nullable StreamObserver<Server.ServerResponse> responseObserver,
       boolean enableStreaming)
@@ -568,7 +569,9 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
           subqueryExpression.getLiteral());
       // Execute the subquery
       subquery.setEndTimeMs(endTimeMs);
-      DataTable dataTable = processQuery(indexSegments, subquery, timerContext, executorService, null, false);
+      // Make a clone of indexSegments because the method might modify the list
+      DataTable dataTable =
+          processQuery(new ArrayList<>(indexSegments), subquery, timerContext, executorService, null, false);
       IdSet idSet = dataTable.getObject(0, 0);
       String serializedIdSet = idSet.toBase64String();
       // Rewrite the expression

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SegmentPruner.java
@@ -42,6 +42,7 @@ public interface SegmentPruner {
    * <p>Override this method for the pruner logic.
    *
    * @param segments The list of segments to be pruned. Implementations must not modify the list.
+   *                 TODO: Revisit this because the caller doesn't require not changing the input segments
    */
   List<IndexSegment> prune(List<IndexSegment> segments, QueryContext query);
 }


### PR DESCRIPTION
#8790 reduces the overhead of segment pruning by reusing the segment list. Currently server will re-use the segment list when executing subquery, which will break if the segment list is modified. This PR fixes the issue by making a clone of the segment list when executing the subquery.