### PR TITLE
Enhance upsert metadata handling

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -42,6 +42,7 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   REALTIME_PARTITION_MISMATCH("mismatch", false),
   REALTIME_DEDUP_DROPPED("rows", false),
   PARTIAL_UPSERT_OUT_OF_ORDER("rows", false),
+  PARTIAL_UPSERT_ROWS_NOT_REPLACED("rows", false),
   ROWS_WITH_ERRORS("rows", false),
   LLC_CONTROLLER_RESPONSE_NOT_SENT("messages", true),
   LLC_CONTROLLER_RESPONSE_COMMIT("messages", true),

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -125,8 +125,8 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     ServerMetrics serverMetrics = Mockito.mock(ServerMetrics.class);
     _upsertIndexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
     ((ImmutableSegmentImpl) _upsertIndexSegment).enableUpsert(
-        new PartitionUpsertMetadataManager("testTable_REALTIME", 0, serverMetrics, null,
-            HashFunction.NONE, Collections.emptyList()), new ThreadSafeMutableRoaringBitmap());
+        new PartitionUpsertMetadataManager("testTable_REALTIME", 0, Collections.singletonList("column6"),
+            "daysSinceEpoch", HashFunction.NONE, null, serverMetrics), new ThreadSafeMutableRoaringBitmap());
   }
 
   @AfterClass

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/QueryOverrideWithHintsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/QueryOverrideWithHintsTest.java
@@ -42,7 +42,6 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.testng.annotations.Test;
 
@@ -95,7 +94,8 @@ public class QueryOverrideWithHintsTest {
     }
 
     @Override
-    public void getPrimaryKey(int docId, PrimaryKey reuse) {
+    public Object getValue(int docId, String column) {
+      return null;
     }
 
     @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/EmptyIndexSegment.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/EmptyIndexSegment.java
@@ -33,7 +33,6 @@ import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.data.readers.PrimaryKey;
 
 
 /**
@@ -96,8 +95,8 @@ public class EmptyIndexSegment implements ImmutableSegment {
   }
 
   @Override
-  public void getPrimaryKey(int docId, PrimaryKey reuse) {
-    throw new UnsupportedOperationException("Cannot read primary key from empty segment");
+  public Object getValue(int docId, String column) {
+    throw new UnsupportedOperationException("Cannot read value from empty segment");
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -44,7 +44,6 @@ import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -138,8 +137,7 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
   public DataSource getDataSource(String column) {
     DataSource result = _dataSources.get(column);
     Preconditions.checkNotNull(result,
-        "DataSource for %s should not be null. Potentially invalid column name specified.",
-        column);
+        "DataSource for %s should not be null. Potentially invalid column name specified.", column);
     return result;
   }
 
@@ -236,15 +234,15 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
   }
 
   @Override
-  public void getPrimaryKey(int docId, PrimaryKey reuse) {
+  public Object getValue(int docId, String column) {
     try {
       if (_pinotSegmentRecordReader == null) {
         _pinotSegmentRecordReader = new PinotSegmentRecordReader();
         _pinotSegmentRecordReader.init(this);
       }
-      _pinotSegmentRecordReader.getPrimaryKey(docId, _partitionUpsertMetadataManager.getPrimaryKeyColumns(), reuse);
+      return _pinotSegmentRecordReader.getValue(docId, column);
     } catch (Exception e) {
-      throw new RuntimeException("Failed to use PinotSegmentRecordReader to read primary key from immutable segment");
+      throw new RuntimeException("Failed to use PinotSegmentRecordReader to read value from immutable segment");
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/IntermediateSegment.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/IntermediateSegment.java
@@ -55,7 +55,6 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.apache.pinot.spi.stream.RowMetadata;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.slf4j.Logger;
@@ -226,16 +225,10 @@ public class IntermediateSegment implements MutableSegment {
   }
 
   @Override
-  public void getPrimaryKey(int docId, PrimaryKey reuse) {
-    int numPrimaryKeyColumns = _schema.getPrimaryKeyColumns().size();
-    Object[] values = reuse.getValues();
-    for (int i = 0; i < numPrimaryKeyColumns; i++) {
-      IntermediateIndexContainer indexContainer = _indexContainerMap.get(
-          _schema.getPrimaryKeyColumns().get(i));
-      Object value = getValue(docId, indexContainer.getForwardIndex(), indexContainer.getDictionary(),
-          indexContainer.getNumValuesInfo().getMaxNumValuesPerMVEntry());
-      values[i] = value;
-    }
+  public Object getValue(int docId, String column) {
+    IntermediateIndexContainer indexContainer = _indexContainerMap.get(column);
+    return getValue(docId, indexContainer.getForwardIndex(), indexContainer.getDictionary(),
+        indexContainer.getNumValuesInfo().getMaxNumValuesPerMVEntry());
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -433,7 +433,7 @@ public class MutableSegmentImpl implements MutableSegment {
           || dataType == BYTES)) {
         _logger.info(
             "Aggregate metrics is enabled. Will create dictionary in consuming segment for column {} of type {}",
-            column, dataType.toString());
+            column, dataType);
         return false;
       }
       // So don't create dictionary if the column (1) is member of noDictionary, and (2) is single-value or multi-value
@@ -488,7 +488,7 @@ public class MutableSegmentImpl implements MutableSegment {
         }
       }
     }
-    _logger.info("Newly added columns: " + _newlyAddedColumnsFieldMap.toString());
+    _logger.info("Newly added columns: " + _newlyAddedColumnsFieldMap);
   }
 
   @Override
@@ -998,35 +998,34 @@ public class MutableSegmentImpl implements MutableSegment {
   @Override
   public GenericRow getRecord(int docId, GenericRow reuse) {
     for (Map.Entry<String, IndexContainer> entry : _indexContainerMap.entrySet()) {
+      String column = entry.getKey();
+      IndexContainer indexContainer = entry.getValue();
+      Object value;
       try {
-        String column = entry.getKey();
-        IndexContainer indexContainer = entry.getValue();
-        Object value = getValue(docId, indexContainer._forwardIndex, indexContainer._dictionary,
+        value = getValue(docId, indexContainer._forwardIndex, indexContainer._dictionary,
             indexContainer._numValuesInfo._maxNumValuesPerMVEntry);
-        if (_nullHandlingEnabled && indexContainer._nullValueVector.isNull(docId)) {
-          reuse.putDefaultNullValue(column, value);
-        } else {
-          reuse.putValue(column, value);
-        }
       } catch (Exception e) {
-        _logger.error("error encountered when getting record for {} on indexContainer: {}", docId, entry.getKey());
-        throw new RuntimeException("error encountered when getting record for " + docId + " on indexContainer: "
-            + entry.getKey(), e);
+        throw new RuntimeException(
+            String.format("Caught exception while reading value for docId: %d, column: %s", docId, column), e);
+      }
+      if (_nullHandlingEnabled && indexContainer._nullValueVector.isNull(docId)) {
+        reuse.putDefaultNullValue(column, value);
+      } else {
+        reuse.putValue(column, value);
       }
     }
     return reuse;
   }
 
   @Override
-  public void getPrimaryKey(int docId, PrimaryKey reuse) {
-    int numPrimaryKeyColumns = _partitionUpsertMetadataManager.getPrimaryKeyColumns().size();
-    Object[] values = reuse.getValues();
-    for (int i = 0; i < numPrimaryKeyColumns; i++) {
-      IndexContainer indexContainer = _indexContainerMap.get(
-          _partitionUpsertMetadataManager.getPrimaryKeyColumns().get(i));
-      Object value = getValue(docId, indexContainer._forwardIndex, indexContainer._dictionary,
+  public Object getValue(int docId, String column) {
+    try {
+      IndexContainer indexContainer = _indexContainerMap.get(column);
+      return getValue(docId, indexContainer._forwardIndex, indexContainer._dictionary,
           indexContainer._numValuesInfo._maxNumValuesPerMVEntry);
-      values[i] = value;
+    } catch (Exception e) {
+      throw new RuntimeException(
+          String.format("Caught exception while reading value for docId: %d, column: %s", docId, column), e);
     }
   }
 
@@ -1108,8 +1107,8 @@ public class MutableSegmentImpl implements MutableSegment {
             }
             return value;
           default:
-            throw new IllegalStateException("No support for MV no dictionary column of type "
-                + forwardIndex.getStoredType());
+            throw new IllegalStateException(
+                "No support for MV no dictionary column of type " + forwardIndex.getStoredType());
         }
       }
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentRecordReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentRecordReader.java
@@ -33,10 +33,8 @@ import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
-import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -232,17 +230,8 @@ public class PinotSegmentRecordReader implements RecordReader {
     }
   }
 
-  public void getPrimaryKey(int docId, List<String> primaryKeyColumns, PrimaryKey reuse) {
-    int numPrimaryKeyColumns = primaryKeyColumns.size();
-    Object[] values = reuse.getValues();
-    for (int i = 0; i < numPrimaryKeyColumns; i++) {
-      PinotSegmentColumnReader columnReader = _columnReaderMap.get(primaryKeyColumns.get(i));
-      Object value = columnReader.getValue(docId);
-      if (value instanceof byte[]) {
-        value = new ByteArray((byte[]) value);
-      }
-      values[i] = value;
-    }
+  public Object getValue(int docId, String column) {
+    return _columnReaderMap.get(column).getValue(docId);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.local.upsert;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
@@ -30,13 +31,18 @@ import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.segment.local.indexsegment.immutable.EmptyIndexSegment;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImpl;
 import org.apache.pinot.segment.local.utils.HashUtils;
 import org.apache.pinot.segment.local.utils.RecordInfo;
+import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
+import org.apache.pinot.spi.utils.ByteArray;
 import org.roaringbitmap.PeekableIntIterator;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.slf4j.Logger;
@@ -67,19 +73,19 @@ import org.slf4j.LoggerFactory;
  *   </li>
  * </ul>
  */
-@SuppressWarnings("unchecked")
+@SuppressWarnings({"rawtypes", "unchecked"})
 @ThreadSafe
 public class PartitionUpsertMetadataManager {
-  private static final Logger LOGGER = LoggerFactory.getLogger(PartitionUpsertMetadataManager.class);
-
   private static final long OUT_OF_ORDER_EVENT_MIN_REPORT_INTERVAL_NS = TimeUnit.MINUTES.toNanos(1);
 
   private final String _tableNameWithType;
   private final int _partitionId;
-  private final ServerMetrics _serverMetrics;
-  private final PartialUpsertHandler _partialUpsertHandler;
-  private final HashFunction _hashFunction;
   private final List<String> _primaryKeyColumns;
+  private final String _comparisonColumn;
+  private final HashFunction _hashFunction;
+  private final PartialUpsertHandler _partialUpsertHandler;
+  private final ServerMetrics _serverMetrics;
+  private final Logger _logger;
 
   // TODO(upsert): consider an off-heap KV store to persist this mapping to improve the recovery speed.
   @VisibleForTesting
@@ -91,17 +97,22 @@ public class PartitionUpsertMetadataManager {
   private long _lastOutOfOrderEventReportTimeNs = Long.MIN_VALUE;
   private int _numOutOfOrderEvents = 0;
 
-  public PartitionUpsertMetadataManager(String tableNameWithType, int partitionId, ServerMetrics serverMetrics,
-      @Nullable PartialUpsertHandler partialUpsertHandler, HashFunction hashFunction,
-      List<String> primaryKeyColumns) {
+  public PartitionUpsertMetadataManager(String tableNameWithType, int partitionId, List<String> primaryKeyColumns,
+      String comparisonColumn, HashFunction hashFunction, @Nullable PartialUpsertHandler partialUpsertHandler,
+      ServerMetrics serverMetrics) {
     _tableNameWithType = tableNameWithType;
     _partitionId = partitionId;
-    _serverMetrics = serverMetrics;
-    _partialUpsertHandler = partialUpsertHandler;
-    _hashFunction = hashFunction;
     _primaryKeyColumns = primaryKeyColumns;
+    _comparisonColumn = comparisonColumn;
+    _hashFunction = hashFunction;
+    _partialUpsertHandler = partialUpsertHandler;
+    _serverMetrics = serverMetrics;
+    _logger = LoggerFactory.getLogger(tableNameWithType + "-" + partitionId + "-" + getClass().getSimpleName());
   }
 
+  /**
+   * Returns the primary key columns.
+   */
   public List<String> getPrimaryKeyColumns() {
     return _primaryKeyColumns;
   }
@@ -109,11 +120,70 @@ public class PartitionUpsertMetadataManager {
   /**
    * Initializes the upsert metadata for the given immutable segment.
    */
-  public void addSegment(IndexSegment segment, Iterator<RecordInfo> recordInfoIterator) {
+  public void addSegment(ImmutableSegment segment) {
     String segmentName = segment.getSegmentName();
-    LOGGER.info("Adding upsert metadata for segment: {}", segmentName);
+    _logger.info("Adding upsert metadata for segment: {}, primary key count: {}", segmentName,
+        _primaryKeyToRecordLocationMap.size());
 
-    ThreadSafeMutableRoaringBitmap validDocIds = Objects.requireNonNull(segment.getValidDocIds());
+    if (segment instanceof EmptyIndexSegment) {
+      _logger.info("Skip adding upsert metadata for empty segment: {}", segmentName);
+      return;
+    }
+
+    Preconditions.checkArgument(segment instanceof ImmutableSegmentImpl,
+        "Got unsupported segment implementation: {} for segment: {}, table: {}", segment.getClass(), segmentName,
+        _tableNameWithType);
+    addSegment((ImmutableSegmentImpl) segment, new ThreadSafeMutableRoaringBitmap(), getRecordInfoIterator(segment));
+
+    // Update metrics
+    int numPrimaryKeys = _primaryKeyToRecordLocationMap.size();
+    _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId, ServerGauge.UPSERT_PRIMARY_KEYS_COUNT,
+        numPrimaryKeys);
+
+    _logger.info("Finish adding upsert metadata for segment: {}, primary key count: {}", segmentName, numPrimaryKeys);
+  }
+
+  private Iterator<RecordInfo> getRecordInfoIterator(ImmutableSegment segment) {
+    int numTotalDocs = segment.getSegmentMetadata().getTotalDocs();
+    return new Iterator<RecordInfo>() {
+      private int _docId = 0;
+
+      @Override
+      public boolean hasNext() {
+        return _docId < numTotalDocs;
+      }
+
+      @Override
+      public RecordInfo next() {
+        PrimaryKey primaryKey = new PrimaryKey(new Object[_primaryKeyColumns.size()]);
+        getPrimaryKey(segment, _docId, primaryKey);
+
+        Object comparisonValue = segment.getValue(_docId, _comparisonColumn);
+        if (comparisonValue instanceof byte[]) {
+          comparisonValue = new ByteArray((byte[]) comparisonValue);
+        }
+        return new RecordInfo(primaryKey, _docId++, (Comparable) comparisonValue);
+      }
+    };
+  }
+
+  private void getPrimaryKey(IndexSegment segment, int docId, PrimaryKey buffer) {
+    Object[] values = buffer.getValues();
+    int numPrimaryKeyColumns = values.length;
+    for (int i = 0; i < numPrimaryKeyColumns; i++) {
+      Object value = segment.getValue(docId, _primaryKeyColumns.get(i));
+      if (value instanceof byte[]) {
+        value = new ByteArray((byte[]) value);
+      }
+      values[i] = value;
+    }
+  }
+
+  @VisibleForTesting
+  void addSegment(ImmutableSegmentImpl segment, ThreadSafeMutableRoaringBitmap validDocIds,
+      Iterator<RecordInfo> recordInfoIterator) {
+    String segmentName = segment.getSegmentName();
+    segment.enableUpsert(this, validDocIds);
     while (recordInfoIterator.hasNext()) {
       RecordInfo recordInfo = recordInfoIterator.next();
       _primaryKeyToRecordLocationMap.compute(HashUtils.hashPrimaryKey(recordInfo.getPrimaryKey(), _hashFunction),
@@ -172,15 +242,12 @@ public class PartitionUpsertMetadataManager {
             }
           });
     }
-    // Update metrics
-    _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId, ServerGauge.UPSERT_PRIMARY_KEYS_COUNT,
-        _primaryKeyToRecordLocationMap.size());
   }
 
   /**
    * Updates the upsert metadata for a new consumed record in the given consuming segment.
    */
-  public void addRecord(IndexSegment segment, RecordInfo recordInfo) {
+  public void addRecord(MutableSegment segment, RecordInfo recordInfo) {
     ThreadSafeMutableRoaringBitmap validDocIds = Objects.requireNonNull(segment.getValidDocIds());
     _primaryKeyToRecordLocationMap.compute(HashUtils.hashPrimaryKey(recordInfo.getPrimaryKey(), _hashFunction),
         (primaryKey, currentRecordLocation) -> {
@@ -208,9 +275,80 @@ public class PartitionUpsertMetadataManager {
             return new RecordLocation(segment, recordInfo.getDocId(), recordInfo.getComparisonValue());
           }
         });
+
     // Update metrics
     _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId, ServerGauge.UPSERT_PRIMARY_KEYS_COUNT,
         _primaryKeyToRecordLocationMap.size());
+  }
+
+  /**
+   * Replaces the upsert metadata for the old segment with the new immutable segment.
+   */
+  public void replaceSegment(ImmutableSegment newSegment, IndexSegment oldSegment) {
+    String segmentName = newSegment.getSegmentName();
+    Preconditions.checkArgument(segmentName.equals(oldSegment.getSegmentName()),
+        "Cannot replace segment with different name for table: {}, old segment: {}, new segment: {}",
+        _tableNameWithType, oldSegment.getSegmentName(), segmentName);
+    _logger.info("Replacing upsert metadata for {} segment: {}",
+        oldSegment instanceof ImmutableSegment ? "immutable" : "mutable", segmentName);
+
+    addSegment(newSegment);
+
+    MutableRoaringBitmap validDocIds =
+        oldSegment.getValidDocIds() != null ? oldSegment.getValidDocIds().getMutableRoaringBitmap() : null;
+    if (validDocIds != null && !validDocIds.isEmpty()) {
+      int numDocsNotReplaced = validDocIds.getCardinality();
+      if (_partialUpsertHandler != null) {
+        _logger.error("Got {} primary keys not replaced when replacing segment: {} for partial upsert table. This can "
+            + "potentially cause inconsistency between replicas", numDocsNotReplaced, segmentName);
+        _serverMetrics.addMeteredTableValue(_tableNameWithType, ServerMeter.PARTIAL_UPSERT_ROWS_NOT_REPLACED,
+            numDocsNotReplaced);
+      } else {
+        _logger.info("Got {} primary keys not replaced when replacing segment: {}", numDocsNotReplaced, segmentName);
+      }
+      removeSegment(oldSegment);
+    }
+
+    _logger.info("Finish replacing upsert metadata for segment: {}", segmentName);
+  }
+
+  /**
+   * Removes the upsert metadata for the given segment.
+   */
+  public void removeSegment(IndexSegment segment) {
+    String segmentName = segment.getSegmentName();
+    _logger.info("Removing upsert metadata for segment: {}, primary key count: {}", segmentName,
+        _primaryKeyToRecordLocationMap.size());
+
+    MutableRoaringBitmap validDocIds =
+        segment.getValidDocIds() != null ? segment.getValidDocIds().getMutableRoaringBitmap() : null;
+    if (validDocIds == null || validDocIds.isEmpty()) {
+      _logger.info("Skipping removing upsert metadata for segment without valid docs: {}", segmentName);
+      return;
+    }
+
+    _logger.info("Trying to remove {} primary keys from upsert metadata for segment: {}", validDocIds.getCardinality(),
+        segmentName);
+    PrimaryKey primaryKey = new PrimaryKey(new Object[_primaryKeyColumns.size()]);
+    PeekableIntIterator iterator = validDocIds.getIntIterator();
+    while (iterator.hasNext()) {
+      int docId = iterator.next();
+      getPrimaryKey(segment, docId, primaryKey);
+      _primaryKeyToRecordLocationMap.computeIfPresent(HashUtils.hashPrimaryKey(primaryKey, _hashFunction),
+          (pk, recordLocation) -> {
+            if (recordLocation.getSegment() == segment) {
+              return null;
+            }
+            return recordLocation;
+          });
+    }
+
+    // Update metrics
+    int numPrimaryKeys = _primaryKeyToRecordLocationMap.size();
+    _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId, ServerGauge.UPSERT_PRIMARY_KEYS_COUNT,
+        numPrimaryKeys);
+
+    _logger.info("Finish removing upsert metadata for segment: {}, primary key count: {}", segmentName, numPrimaryKeys);
   }
 
   /**
@@ -236,10 +374,9 @@ public class PartitionUpsertMetadataManager {
         _numOutOfOrderEvents++;
         long currentTimeNs = System.nanoTime();
         if (currentTimeNs - _lastOutOfOrderEventReportTimeNs > OUT_OF_ORDER_EVENT_MIN_REPORT_INTERVAL_NS) {
-          LOGGER.warn("Skipped {} out-of-order events for partial-upsert table: {} "
-                  + "(the last event has current comparison value: {}, record comparison value: {})",
-              _numOutOfOrderEvents,
-              _tableNameWithType, currentRecordLocation.getComparisonValue(), recordInfo.getComparisonValue());
+          _logger.warn("Skipped {} out-of-order events for partial-upsert table (the last event has current comparison "
+                  + "value: {}, record comparison value: {})", _numOutOfOrderEvents,
+              currentRecordLocation.getComparisonValue(), recordInfo.getComparisonValue());
           _lastOutOfOrderEventReportTimeNs = currentTimeNs;
           _numOutOfOrderEvents = 0;
         }
@@ -249,36 +386,5 @@ public class PartitionUpsertMetadataManager {
       // New primary key
       return record;
     }
-  }
-
-  /**
-   * Removes the upsert metadata for the given immutable segment. No need to remove the upsert metadata for the
-   * consuming segment because it should be replaced by the committed segment.
-   */
-  public void removeSegment(IndexSegment segment) {
-    String segmentName = segment.getSegmentName();
-    LOGGER.info("Removing upsert metadata for segment: {}", segmentName);
-
-    MutableRoaringBitmap mutableRoaringBitmap =
-        Objects.requireNonNull(segment.getValidDocIds()).getMutableRoaringBitmap();
-
-    if (!mutableRoaringBitmap.isEmpty()) {
-      PrimaryKey reuse = new PrimaryKey(new Object[_primaryKeyColumns.size()]);
-      PeekableIntIterator iterator = mutableRoaringBitmap.getIntIterator();
-      while (iterator.hasNext()) {
-        int docId = iterator.next();
-        segment.getPrimaryKey(docId, reuse);
-        _primaryKeyToRecordLocationMap.computeIfPresent(HashUtils.hashPrimaryKey(reuse, _hashFunction),
-            (pk, recordLocation) -> {
-              if (recordLocation.getSegment() == segment) {
-                return null;
-              }
-              return recordLocation;
-        });
-      }
-    }
-    // Update metrics
-    _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId, ServerGauge.UPSERT_PRIMARY_KEYS_COUNT,
-        _primaryKeyToRecordLocationMap.size());
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
@@ -34,25 +34,26 @@ import org.apache.pinot.spi.config.table.HashFunction;
 public class TableUpsertMetadataManager {
   private final Map<Integer, PartitionUpsertMetadataManager> _partitionMetadataManagerMap = new ConcurrentHashMap<>();
   private final String _tableNameWithType;
-  private final ServerMetrics _serverMetrics;
-  private final PartialUpsertHandler _partialUpsertHandler;
-  private final HashFunction _hashFunction;
   private final List<String> _primaryKeyColumns;
+  private final String _comparisonColumn;
+  private final HashFunction _hashFunction;
+  private final PartialUpsertHandler _partialUpsertHandler;
+  private final ServerMetrics _serverMetrics;
 
-  public TableUpsertMetadataManager(String tableNameWithType, ServerMetrics serverMetrics,
-      @Nullable PartialUpsertHandler partialUpsertHandler, HashFunction hashFunction,
-      List<String> primaryKeyColumns) {
+  public TableUpsertMetadataManager(String tableNameWithType, List<String> primaryKeyColumns, String comparisonColumn,
+      HashFunction hashFunction, @Nullable PartialUpsertHandler partialUpsertHandler, ServerMetrics serverMetrics) {
     _tableNameWithType = tableNameWithType;
-    _serverMetrics = serverMetrics;
-    _partialUpsertHandler = partialUpsertHandler;
-    _hashFunction = hashFunction;
     _primaryKeyColumns = primaryKeyColumns;
+    _comparisonColumn = comparisonColumn;
+    _hashFunction = hashFunction;
+    _partialUpsertHandler = partialUpsertHandler;
+    _serverMetrics = serverMetrics;
   }
 
   public PartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId) {
     return _partitionMetadataManagerMap.computeIfAbsent(partitionId,
-        k -> new PartitionUpsertMetadataManager(_tableNameWithType, k, _serverMetrics, _partialUpsertHandler,
-            _hashFunction, _primaryKeyColumns));
+        k -> new PartitionUpsertMetadataManager(_tableNameWithType, k, _primaryKeyColumns, _comparisonColumn,
+            _hashFunction, _partialUpsertHandler, _serverMetrics));
   }
 
   public boolean isPartialUpsertEnabled() {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
@@ -35,11 +35,12 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderFactory;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
-import org.mockito.Mockito;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
 
 
 public class MutableSegmentImplUpsertComparisonColTest {
@@ -62,15 +63,15 @@ public class MutableSegmentImplUpsertComparisonColTest {
     _recordTransformer = CompositeTransformer.getDefaultTransformer(_tableConfig, _schema);
     File jsonFile = new File(dataResourceUrl.getFile());
     _partitionUpsertMetadataManager =
-        new TableUpsertMetadataManager("testTable_REALTIME", Mockito.mock(ServerMetrics.class), null,
-            HashFunction.NONE, _schema.getPrimaryKeyColumns()).getOrCreatePartitionManager(0);
-    _mutableSegmentImpl = MutableSegmentImplTestUtils
-        .createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(), Collections.emptySet(),
-            false, true, new UpsertConfig(UpsertConfig.Mode.FULL, null, null, "offset", null), "secondsSinceEpoch",
-            _partitionUpsertMetadataManager, null);
+        new TableUpsertMetadataManager("testTable_REALTIME", _schema.getPrimaryKeyColumns(), "offset",
+            HashFunction.NONE, null, mock(ServerMetrics.class)).getOrCreatePartitionManager(0);
+    _mutableSegmentImpl =
+        MutableSegmentImplTestUtils.createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(),
+            Collections.emptySet(), false, true, new UpsertConfig(UpsertConfig.Mode.FULL, null, null, "offset", null),
+            "secondsSinceEpoch", _partitionUpsertMetadataManager, null);
     GenericRow reuse = new GenericRow();
-    try (RecordReader recordReader = RecordReaderFactory
-        .getRecordReader(FileFormat.JSON, jsonFile, _schema.getColumnNames(), null)) {
+    try (RecordReader recordReader = RecordReaderFactory.getRecordReader(FileFormat.JSON, jsonFile,
+        _schema.getColumnNames(), null)) {
       while (recordReader.hasNext()) {
         recordReader.next(reuse);
         GenericRow transformedRow = _recordTransformer.transform(reuse);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
@@ -35,10 +35,11 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderFactory;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
-import org.mockito.Mockito;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
 
 
 public class MutableSegmentImplUpsertTest {
@@ -60,12 +61,12 @@ public class MutableSegmentImplUpsertTest {
     _recordTransformer = CompositeTransformer.getDefaultTransformer(_tableConfig, _schema);
     File jsonFile = new File(dataResourceUrl.getFile());
     _partitionUpsertMetadataManager =
-        new TableUpsertMetadataManager("testTable_REALTIME", Mockito.mock(ServerMetrics.class), null, hashFunction,
-            _schema.getPrimaryKeyColumns())
-            .getOrCreatePartitionManager(0);
-    _mutableSegmentImpl = MutableSegmentImplTestUtils
-        .createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(), Collections.emptySet(),
-            false, true, new UpsertConfig(UpsertConfig.Mode.FULL, null, null, null, hashFunction), "secondsSinceEpoch",
+        new TableUpsertMetadataManager("testTable_REALTIME", _schema.getPrimaryKeyColumns(), "secondsSinceEpoch",
+            hashFunction, null, mock(ServerMetrics.class)).getOrCreatePartitionManager(0);
+    _mutableSegmentImpl =
+        MutableSegmentImplTestUtils.createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(),
+            Collections.emptySet(), false, true,
+            new UpsertConfig(UpsertConfig.Mode.FULL, null, null, null, hashFunction), "secondsSinceEpoch",
             _partitionUpsertMetadataManager, null);
 
     GenericRow reuse = new GenericRow();

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/IndexSegment.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/IndexSegment.java
@@ -26,7 +26,6 @@ import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.data.readers.PrimaryKey;
 
 
 @InterfaceAudience.Private
@@ -88,13 +87,9 @@ public interface IndexSegment {
   GenericRow getRecord(int docId, GenericRow reuse);
 
   /**
-   * Returns the primaryKey for a given docId
-   *
-   * @param docId Document Id
-   * @param reuse Reusable buffer for the primary key
-   * @return Primary key for the given document Id
+   * Returns the value for the column at the document id. Returns byte[] for BYTES data type.
    */
-  void getPrimaryKey(int docId, PrimaryKey reuse);
+  Object getValue(int docId, String column);
 
   /**
    * Hints the segment to begin prefetching buffers for specified columns.


### PR DESCRIPTION
Make the following enhancement to the upsert metadata manager:
- Add replace segment support
  - Log error and emit metric (`PARTIAL_UPSERT_ROWS_NOT_REPLACED`) for segment not fully replaced, which can potentially cause inconsistency between replicas for partial upsert table
  - Remove the remaining primary keys from the replaced segment immediately so that new consuming segment is not affected
- Handle empty segment properly
- Enhance the log to log the table name, partition id and primary key count
- Clean up the code and move the upsert related logic into the metadata manager, such as creating the record info iterator
- In `IndexSegment`, replace `getPrimaryKey()` with `getValue()` which is more general and can be used to read the comparison column as well
- Fix the bug of assuming the first primary key column is the partition column when fetching the partition id of the segment
- Fix the bug of using `byte[]` as primary key when the column type is `BYTES`

## Release Notes
Added a metric `PARTIAL_UPSERT_ROWS_NOT_REPLACED` to track the rows not replaced for partial upsert table