### PR TITLE
Adding support to extract values from message header.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -384,6 +384,45 @@ public class StringFunctions {
   }
 
   /**
+   * @param bytes
+   * @param charsetName encoding
+   * @return bytearray to string
+   * returns null on exception
+   */
+  @ScalarFunction
+  public static String fromBytes(byte[] bytes, String charsetName) {
+    try {
+      return new String(bytes, charsetName);
+    } catch (UnsupportedEncodingException e) {
+      return null;
+    }
+  }
+
+  /**
+   * @param input
+   * @param charsetName encoding
+   * @return bytearray to string
+   * returns null on exception
+   */
+  @ScalarFunction
+  public static byte[] toBytes(String input, String charsetName) {
+    try {
+      return input.getBytes(charsetName);
+    } catch (UnsupportedEncodingException e) {
+      return null;
+    }
+  }
+
+  /**
+   * @param bytes
+   * @return bytearray to string
+   */
+  @ScalarFunction
+  public static String fromUtf8(byte[] bytes) {
+    return new String(bytes);
+  }
+
+  /**
    * @see StandardCharsets#UTF_8#encode(String)
    * @param input
    * @return bytes
@@ -546,7 +585,7 @@ public class StringFunctions {
   @ScalarFunction
   public static String encodeUrl(String input)
       throws UnsupportedEncodingException {
-      return URLEncoder.encode(input, StandardCharsets.UTF_8.toString());
+    return URLEncoder.encode(input, StandardCharsets.UTF_8.toString());
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -527,8 +527,14 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       RowMetadata msgMetadata = messagesAndOffsets.getMetadataAtIndex(index);
 
       GenericRow decodedRow = _messageDecoder
-          .decode(messagesAndOffsets.getMessageAtIndex(index), messagesAndOffsets.getMessageOffsetAtIndex(index),
+          .decode(messagesAndOffsets.getMessageAtIndex(index),
+              messagesAndOffsets.getMessageOffsetAtIndex(index),
               messagesAndOffsets.getMessageLengthAtIndex(index), reuse);
+      if (msgMetadata.getHeaders() != null) {
+        for (Map.Entry<String, Object> entrySet : msgMetadata.getHeaders().getFieldToValueMap().entrySet()) {
+          decodedRow.putValue(entrySet.getKey(), entrySet.getValue());
+        }
+      }
       if (decodedRow != null) {
         try {
           _transformPipeline.processRow(decodedRow, reusedResult);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -530,7 +530,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
           .decode(messagesAndOffsets.getMessageAtIndex(index),
               messagesAndOffsets.getMessageOffsetAtIndex(index),
               messagesAndOffsets.getMessageLengthAtIndex(index), reuse);
-      if (msgMetadata.getHeaders() != null) {
+      if (msgMetadata != null && msgMetadata.getHeaders() != null) {
         for (Map.Entry<String, Object> entrySet : msgMetadata.getHeaders().getFieldToValueMap().entrySet()) {
           decodedRow.putValue("header$" + entrySet.getKey(), entrySet.getValue());
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -532,7 +532,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
               messagesAndOffsets.getMessageLengthAtIndex(index), reuse);
       if (msgMetadata.getHeaders() != null) {
         for (Map.Entry<String, Object> entrySet : msgMetadata.getHeaders().getFieldToValueMap().entrySet()) {
-          decodedRow.putValue(entrySet.getKey(), entrySet.getValue());
+          decodedRow.putValue("header$" + entrySet.getKey(), entrySet.getValue());
         }
       }
       if (decodedRow != null) {

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -130,7 +130,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   }
 
   protected boolean useLlc() {
-    return false;
+    return true;
   }
 
   protected boolean useKafkaTransaction() {
@@ -335,6 +335,9 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
       streamConfigMap.put(KafkaStreamConfigProperties.constructStreamProperty(
               KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_BROKER_LIST),
           "localhost:" + _kafkaStarters.get(0).getPort());
+      streamConfigMap
+          .put(StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.METADATA_POPULATE),
+              "true");
       if (useKafkaTransaction()) {
         streamConfigMap.put(KafkaStreamConfigProperties.constructStreamProperty(
                 KafkaStreamConfigProperties.LowLevelConsumer.KAFKA_ISOLATION_LEVEL),

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/RowMetadataExtractor.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/RowMetadataExtractor.java
@@ -19,6 +19,9 @@
 package org.apache.pinot.plugin.stream.kafka20;
 
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.stream.RowMetadata;
 import org.apache.pinot.spi.stream.StreamMessageMetadata;
 
@@ -26,7 +29,25 @@ import org.apache.pinot.spi.stream.StreamMessageMetadata;
 @FunctionalInterface
 public interface RowMetadataExtractor {
   static RowMetadataExtractor build(boolean populateMetadata) {
-    return populateMetadata ? record -> new StreamMessageMetadata(record.timestamp()) : record -> null;
+    return record -> {
+      if (populateMetadata) {
+        return null;
+      } else {
+        StreamMessageMetadata streamMessageMetadata = new StreamMessageMetadata(record.timestamp());
+        Headers headers = record.headers();
+        if (headers != null) {
+          GenericRow headerGenericRow = new GenericRow();
+          if (headers != null) {
+            Header[] headersArray = headers.toArray();
+            for (Header header : headersArray) {
+              headerGenericRow.putValue(header.key(), header.value());
+            }
+          }
+          streamMessageMetadata.setHeaders(headerGenericRow);
+        }
+        return streamMessageMetadata;
+      }
+    };
   }
 
   RowMetadata extract(ConsumerRecord<?, ?> consumerRecord);

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/RowMetadataExtractor.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/RowMetadataExtractor.java
@@ -30,7 +30,7 @@ import org.apache.pinot.spi.stream.StreamMessageMetadata;
 public interface RowMetadataExtractor {
   static RowMetadataExtractor build(boolean populateMetadata) {
     return record -> {
-      if (populateMetadata) {
+      if (!populateMetadata) {
         return null;
       } else {
         StreamMessageMetadata streamMessageMetadata = new StreamMessageMetadata(record.timestamp());

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/RowMetadata.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/RowMetadata.java
@@ -20,6 +20,7 @@ package org.apache.pinot.spi.stream;
 
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;
+import org.apache.pinot.spi.data.readers.GenericRow;
 
 
 /**
@@ -40,4 +41,9 @@ public interface RowMetadata {
    *         Long.MIN_VALUE if not available
    */
   long getIngestionTimeMs();
+
+  default GenericRow getHeaders(){
+    return null;
+  }
+
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataProducer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataProducer.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import javax.annotation.Nullable;
+import org.apache.pinot.spi.data.readers.GenericRow;
 
 
 /**
@@ -34,6 +35,10 @@ public interface StreamDataProducer {
 
   void produce(String topic, byte[] key, byte[] payload);
 
+  default void produce(String topic, byte[] key, byte[] payload, GenericRow headers) {
+    produce(topic, key, payload);
+  }
+
   void close();
 
   /**
@@ -43,7 +48,7 @@ public interface StreamDataProducer {
    * @param rows the rows
    */
   default void produceBatch(String topic, List<byte[]> rows) {
-    for (byte[] row: rows) {
+    for (byte[] row : rows) {
       produce(topic, row);
     }
   }
@@ -55,7 +60,7 @@ public interface StreamDataProducer {
    * @param payloadWithKey the payload rows with key
    */
   default void produceKeyedBatch(String topic, List<RowWithKey> payloadWithKey) {
-    for (RowWithKey rowWithKey: payloadWithKey) {
+    for (RowWithKey rowWithKey : payloadWithKey) {
       if (rowWithKey.getKey() == null) {
         produce(topic, rowWithKey.getPayload());
       } else {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessageMetadata.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessageMetadata.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.spi.stream;
 
+import org.apache.pinot.spi.data.readers.GenericRow;
+
+
 /**
  * A class that provides metadata associated with the message of a stream, for e.g.,
  * ingestion-timestamp of the message.
@@ -25,6 +28,8 @@ package org.apache.pinot.spi.stream;
 public class StreamMessageMetadata implements RowMetadata {
 
   private final long _ingestionTimeMs;
+
+  GenericRow _headers;
 
   /**
    * Construct the stream based message/row message metadata
@@ -39,5 +44,14 @@ public class StreamMessageMetadata implements RowMetadata {
   @Override
   public long getIngestionTimeMs() {
     return _ingestionTimeMs;
+  }
+
+  @Override
+  public GenericRow getHeaders() {
+    return _headers;
+  }
+
+  public void setHeaders(GenericRow headers) {
+    _headers = headers;
   }
 }


### PR DESCRIPTION
Most stream systems have started having an envelope over the actual message. For e.g. Kafka has headers and pubsub supports attributes.

Today, we dont have a way to extract values from headers.  This PR adds support for these headers.

Right now it's only supporting Kafka and leverages the existing rowmetadata implementation. I am trying to keep the PR simple. let me know if there is a better way to support this.

Will add test case shortly

Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
