### PR TITLE
Do not use PartitionUpsertMetadataManager.replaceSegment

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -430,7 +430,12 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       _logger.info("Added new immutable segment: {} to upsert-enabled table: {}", segmentName, _tableNameWithType);
     } else {
       IndexSegment oldSegment = oldSegmentManager.getSegment();
-      partitionUpsertMetadataManager.replaceSegment(immutableSegment, oldSegment);
+      partitionUpsertMetadataManager.addSegment(immutableSegment);
+      // TODO: Fix the following issue about replacing segment in upsert metadata
+      //   - We cannot directly invalidate the docs in the replaced segment because query might still running against it
+      //   - We should track the valid docs in the replaced segment separately. Currently the docs won't be invalidate
+      //     in the replaced segment due to the reason above, and will cause wrong logs/metrics emitted.
+      // partitionUpsertMetadataManager.replaceSegment(immutableSegment, oldSegment);
       _logger.info("Replaced {} segment: {} of upsert-enabled table: {}",
           oldSegment instanceof ImmutableSegment ? "immutable" : "mutable", segmentName, _tableNameWithType);
       releaseSegment(oldSegmentManager);


### PR DESCRIPTION
#9095 introduced `PartitionUpsertMetadataManager.replaceSegment()`, but can potentially cause inconsistent query result and wrong logs/metrics.
This PR changes it back to use `addSegment()`, and we may use `replaceSegment()` once the issues are fixed.