### PR TITLE
Fail spark application in case of no input files

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-2.4/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-2.4/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
@@ -193,7 +193,7 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
 
     if (filteredFiles.isEmpty()) {
       throw new RuntimeException(
-          String.format("No files found in the input directory %s matching includeFileNamePattern: %s,"
+          String.format("No file found in the input directory: %s matching includeFileNamePattern: %s,"
                   + " excludeFileNamePattern: %s", _spec.getInputDirURI(), _spec.getIncludeFileNamePattern(),
               _spec.getExcludeFileNamePattern()));
     }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-2.4/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-2.4/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
@@ -191,6 +191,13 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
       }
     }
 
+    if (filteredFiles.isEmpty()) {
+      throw new RuntimeException(
+          String.format("No files found in the input directory %s matching includeFileNamePattern: %s,"
+                  + " excludeFileNamePattern: %s", _spec.getInputDirURI(), _spec.getIncludeFileNamePattern(),
+              _spec.getExcludeFileNamePattern()));
+    }
+
     LOGGER.info("Found {} files to create Pinot segments!", filteredFiles.size());
     try {
       JavaSparkContext sparkContext = JavaSparkContext.fromSparkContext(SparkContext.getOrCreate());
@@ -234,6 +241,7 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
       if (jobParallelism <= 0 || jobParallelism > numDataFiles) {
         jobParallelism = numDataFiles;
       }
+
       JavaRDD<String> pathRDD = sparkContext.parallelize(pathAndIdxList, jobParallelism);
 
       final String pluginsInclude =

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3.2/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3.2/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunner.java
@@ -193,7 +193,7 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
 
     if (filteredFiles.isEmpty()) {
       throw new RuntimeException(
-          String.format("No files found in the input directory %s matching includeFileNamePattern: %s,"
+          String.format("No file found in the input directory: %s matching includeFileNamePattern: %s,"
                   + " excludeFileNamePattern: %s", _spec.getInputDirURI(), _spec.getIncludeFileNamePattern(),
               _spec.getExcludeFileNamePattern()));
     }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3.2/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3.2/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunner.java
@@ -191,6 +191,13 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
       }
     }
 
+    if (filteredFiles.isEmpty()) {
+      throw new RuntimeException(
+          String.format("No files found in the input directory %s matching includeFileNamePattern: %s,"
+                  + " excludeFileNamePattern: %s", _spec.getInputDirURI(), _spec.getIncludeFileNamePattern(),
+              _spec.getExcludeFileNamePattern()));
+    }
+
     LOGGER.info("Found {} files to create Pinot segments!", filteredFiles.size());
     try {
       JavaSparkContext sparkContext = JavaSparkContext.fromSparkContext(SparkContext.getOrCreate());


### PR DESCRIPTION
Currently spark application fails silently with `a positive number of partitions is required` error instead of throwing a proper exception when no input files are present. We should throw a runtime exception in this case with root cause.