### PR TITLE
Fix authentication issue when auth annotation is not required

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
@@ -95,7 +95,6 @@ public class AuthenticationFilter implements ContainerRequestFilter {
   AccessType extractAccessType(Method endpointMethod) {
     // default access type
     AccessType accessType = AccessType.READ;
-
     if (endpointMethod.isAnnotationPresent(Authenticate.class)) {
       accessType = endpointMethod.getAnnotation(Authenticate.class).value();
     } else {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/AuthenticationFilter.java
@@ -87,13 +87,18 @@ public class AuthenticationFilter implements ContainerRequestFilter {
     //     - "schemaName"
     // If table name is not available, it means the endpoint is not a table-level endpoint.
     Optional<String> tableName = extractTableName(uriInfo.getPathParameters(), uriInfo.getQueryParameters());
+    AccessType accessType = extractAccessType(endpointMethod);
+    new AccessControlUtils().validatePermission(tableName, accessType, _httpHeaders, endpointUrl, accessControl);
+  }
 
+  @VisibleForTesting
+  AccessType extractAccessType(Method endpointMethod) {
     // default access type
     AccessType accessType = AccessType.READ;
 
     if (endpointMethod.isAnnotationPresent(Authenticate.class)) {
       accessType = endpointMethod.getAnnotation(Authenticate.class).value();
-    } else if (accessControl.protectAnnotatedOnly()) {
+    } else {
       // heuristically infer access type via javax.ws.rs annotations
       if (endpointMethod.getAnnotation(POST.class) != null) {
         accessType = AccessType.CREATE;
@@ -103,8 +108,7 @@ public class AuthenticationFilter implements ContainerRequestFilter {
         accessType = AccessType.DELETE;
       }
     }
-
-    new AccessControlUtils().validatePermission(tableName, accessType, _httpHeaders, endpointUrl, accessControl);
+    return accessType;
   }
 
   @VisibleForTesting

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AuthenticationFilterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/access/AuthenticationFilterTest.java
@@ -19,7 +19,12 @@
 
 package org.apache.pinot.controller.api.access;
 
+import java.lang.reflect.Method;
 import java.util.Optional;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
 import org.testng.annotations.Test;
@@ -105,5 +110,43 @@ public class AuthenticationFilterTest {
     MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
     Optional<String> actual = _authFilter.extractTableName(pathParams, queryParams);
     assertEquals(actual, Optional.empty());
+  }
+
+  @Test
+  public void testExtractAccessTypeWithAuthAnnotation() throws Exception {
+    Method method = AuthenticationFilterTest.class.getMethod("methodWithAuthAnnotation");
+    assertEquals(AccessType.UPDATE, _authFilter.extractAccessType(method));
+  }
+
+  @Test
+  public void testExtractAccessTypeWithMissingAuthAnnotation() throws Exception {
+    Method method = AuthenticationFilterTest.class.getMethod("methodWithGet");
+    assertEquals(AccessType.READ, _authFilter.extractAccessType(method));
+    method = AuthenticationFilterTest.class.getMethod("methodWithPost");
+    assertEquals(AccessType.CREATE, _authFilter.extractAccessType(method));
+    method = AuthenticationFilterTest.class.getMethod("methodWithPut");
+    assertEquals(AccessType.UPDATE, _authFilter.extractAccessType(method));
+    method = AuthenticationFilterTest.class.getMethod("methodWithDelete");
+    assertEquals(AccessType.DELETE, _authFilter.extractAccessType(method));
+  }
+
+  @Authenticate(AccessType.UPDATE)
+  public void methodWithAuthAnnotation() {
+  }
+
+  @GET
+  public void methodWithGet() {
+  }
+
+  @PUT
+  public void methodWithPut() {
+  }
+
+  @POST
+  public void methodWithPost() {
+  }
+
+  @DELETE
+  public void methodWithDelete() {
   }
 }


### PR DESCRIPTION
AccessControl on pinot controller can enable authentication on the endpoints that don't even have `@Authentication` annotation (the access type is inferred based `@PUT`, `@GET`, `@POST`, and `@DELETE` annotation of the endpoint). The wiring is not properly set though. If the implementation of AccessControl return false for `protectAnnotatedOnly` method, access type is always set to READ.
This PR fixes the issue.