### PR TITLE
Add support for Base64 Encode/Decode Scalar Functions

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
@@ -107,12 +107,6 @@ public class LiteralOnlyBrokerRequestTest {
     Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser
         .compileToPinotQuery("SELECT toBase64('hello!'),"
             + " fromBase64('aGVsbG8h') FROM myTable")));
-    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser
-        .compileToPinotQuery("SELECT toBase64('hello!'),"
-            + " fromDateTime('2020-01-01 UTC', 'yyyy-MM-dd z') FROM myTable")));
-    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser
-        .compileToPinotQuery("SELECT fromBase64('aGVsbG8h'),"
-            + " fromDateTime('2020-01-01 UTC', 'yyyy-MM-dd z') FROM myTable")));
     Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser
         .compileToPinotQuery("SELECT count(*) from foo "
             + "where bar = toBase64('hello!')")));

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
@@ -108,10 +108,10 @@ public class LiteralOnlyBrokerRequestTest {
             + "where bar = decodeUrl('key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253')")));
     Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(
         CalciteSqlParser.compileToPinotQuery("SELECT toBase64('hello!')," + " fromBase64('aGVsbG8h') FROM myTable")));
-    Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(
-        CalciteSqlParser.compileToPinotQuery("SELECT reverse(fromBase64(foo))," + " toBase64(fromBase64('aGVsbG8h')) FROM myTable")));
-    Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(
-        CalciteSqlParser.compileToPinotQuery("SELECT toBase64(max(foo))," + " fromBase64(toBase64(max(foo))) FROM myTable")));
+    Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery(
+        "SELECT reverse(fromBase64(foo))," + " toBase64(fromBase64('aGVsbG8h')) FROM myTable")));
+    Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery(
+        "SELECT toBase64(max(foo))," + " fromBase64(toBase64(max(foo))) FROM myTable")));
     Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(
         CalciteSqlParser.compileToPinotQuery("SELECT count(*) from foo " + "where bar = toBase64('hello!')")));
     Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
@@ -120,8 +120,8 @@ public class LiteralOnlyBrokerRequestTest {
         CalciteSqlParser.compileToPinotQuery("SELECT count(*) from foo " + "where bar = toBase64(toASCII('hello!'))")));
     Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(
         CalciteSqlParser.compileToPinotQuery("SELECT count(*) from foo " + "where bar = fromBase64('aGVsbG8h')")));
-    Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(
-        CalciteSqlParser.compileToPinotQuery("SELECT count(*) from foo " + "where bar = fromUtf8(fromBase64('aGVsbG8h'))")));
+    Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery(
+        "SELECT count(*) from foo " + "where bar = fromUtf8(fromBase64('aGVsbG8h'))")));
   }
 
   @Test

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -396,6 +396,15 @@ public class StringFunctions {
   }
 
   /**
+   * @param input
+   * @return string
+   */
+  @ScalarFunction
+  public static String fromUtf8(byte[] input) {
+    return new String(input, StandardCharsets.UTF_8);
+  }
+
+  /**
    * @see StandardCharsets#US_ASCII#encode(String)
    * @param input
    * @return bytes
@@ -568,36 +577,16 @@ public class StringFunctions {
    * @return Base64 encoded String
    */
   @ScalarFunction
-  public static String binaryToBase64(byte[] input) {
+  public static String toBase64(byte[] input) {
     return Base64.getEncoder().encodeToString(input);
   }
 
   /**
-   * @param input string to be encoded
-   * @return Base64 encoded String
-   */
-  @ScalarFunction
-  public static String toBase64(String input) {
-    return toBase64(input, "UTF-8");
-  }
-
-  /**
-   * @param input String encoded with user specified encodeScheme
-   * @return Base64 encoded String
-   */
-  @ScalarFunction
-  public static String toBase64(String input, String encodeScheme) {
-    byte[] inputBytes = input.getBytes(Charset.forName(encodeScheme));
-    return Base64.getEncoder().encodeToString(inputBytes);
-  }
-
-  /**
    * @param input Base64 encoded String
-   * @return decoded string
+   * @return decoded binary data
    */
   @ScalarFunction
-  public static String fromBase64(String input) {
-    byte[] inputBytes = Base64.getDecoder().decode(input);
-    return new String(inputBytes, StandardCharsets.UTF_8);
+  public static byte[] fromBase64(String input) {
+    return Base64.getDecoder().decode(input);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -395,8 +395,8 @@ public class StringFunctions {
   }
 
   /**
-   * @param input
-   * @return string
+   * @param input bytes
+   * @return UTF8 encoded string
    */
   @ScalarFunction
   public static String fromUtf8(byte[] input) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -563,7 +563,6 @@ public class StringFunctions {
   }
 
   /**
-   *
    * @param input utf-8 encoded String
    * @return Base64 encoded String
    */
@@ -574,7 +573,6 @@ public class StringFunctions {
   }
 
   /**
-   *
    * @param input Base64 encoded String
    * @return utf8 encoded String
    */

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -23,6 +23,7 @@ import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
+import java.util.Base64;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
@@ -559,5 +560,27 @@ public class StringFunctions {
   public static String decodeUrl(String input)
       throws UnsupportedEncodingException {
     return URLDecoder.decode(input, StandardCharsets.UTF_8.toString());
+  }
+
+  /**
+   *
+   * @param input utf-8 encoded String
+   * @return Base64 encoded String
+   */
+  @ScalarFunction
+  public static String toBase64(String input) {
+    byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+    return Base64.getEncoder().encodeToString(inputBytes);
+  }
+
+  /**
+   *
+   * @param input Base64 encoded String
+   * @return utf8 encoded String
+   */
+  @ScalarFunction
+  public static String fromBase64(String input) {
+    byte[] inputBytes = Base64.getDecoder().decode(input);
+    return new String(inputBytes, StandardCharsets.UTF_8);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -598,6 +598,6 @@ public class StringFunctions {
   @ScalarFunction
   public static String fromBase64(String input) {
     byte[] inputBytes = Base64.getDecoder().decode(input);
-    return new String(inputBytes);
+    return new String(inputBytes, StandardCharsets.UTF_8);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -21,7 +21,6 @@ package org.apache.pinot.common.function.scalar;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
 import java.util.Base64;

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.function.scalar;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
 import java.util.Base64;
@@ -563,22 +564,40 @@ public class StringFunctions {
   }
 
   /**
-   * @param input utf-8 encoded String
+   * @param input binary data
+   * @return Base64 encoded String
+   */
+  @ScalarFunction
+  public static String binaryToBase64(byte[] input) {
+    return Base64.getEncoder().encodeToString(input);
+  }
+
+  /**
+   * @param input string to be encoded
    * @return Base64 encoded String
    */
   @ScalarFunction
   public static String toBase64(String input) {
-    byte[] inputBytes = input.getBytes(StandardCharsets.UTF_8);
+    return toBase64(input, "UTF-8");
+  }
+
+  /**
+   * @param input String encoded with user specified encodeScheme
+   * @return Base64 encoded String
+   */
+  @ScalarFunction
+  public static String toBase64(String input, String encodeScheme) {
+    byte[] inputBytes = input.getBytes(Charset.forName(encodeScheme));
     return Base64.getEncoder().encodeToString(inputBytes);
   }
 
   /**
    * @param input Base64 encoded String
-   * @return utf8 encoded String
+   * @return decoded string
    */
   @ScalarFunction
   public static String fromBase64(String input) {
     byte[] inputBytes = Base64.getDecoder().decode(input);
-    return new String(inputBytes, StandardCharsets.UTF_8);
+    return new String(inputBytes);
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -41,7 +41,6 @@ import org.apache.pinot.sql.parsers.rewriter.CompileTimeFunctionsInvoker;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.common.function.scalar.StringFunctions.toUtf8;
 
 
 /**

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -1942,6 +1942,16 @@ public class CalciteSqlCompilerTest {
     }
     Assert.assertNotNull(expectedError);
     Assert.assertTrue(expectedError instanceof SqlCompilationException);
+
+    query = "select toBase64('hello!') from mytable";
+    expectedError = null;
+    try {
+      CalciteSqlParser.compileToPinotQuery(query);
+    } catch (Exception e) {
+      expectedError = e;
+    }
+    Assert.assertNotNull(expectedError);
+    Assert.assertTrue(expectedError instanceof SqlCompilationException);
   }
 
   @Test

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -42,7 +42,6 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
-
 /**
  * Some tests for the SQL compiler.
  */

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -1912,10 +1912,13 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(encodedBase64, "SEVMTE8h");
     Assert.assertEquals(decodedBase64, "HELLO!");
 
-    query = "select reverse(fromBase64(toBase64(upper('hello!')))) from mytable where fromBase64(toBase64(upper('hello!'))) = bar";
+    query =
+        "select reverse(fromBase64(toBase64(upper('hello!')))) from mytable where fromBase64(toBase64(upper('hello!')"
+            + ")) = bar";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     String arg1 = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
-    String leftOp = pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getStringValue();
+    String leftOp =
+        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getStringValue();
     Assert.assertEquals(arg1, "!OLLEH");
     Assert.assertEquals(leftOp, "HELLO!");
 

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -1898,6 +1898,27 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(encodedBase64, "aGVsbG8h");
     Assert.assertEquals(decodedBase64, "hello!");
 
+    query = "select toBase64(fromBase64('aGVsbG8h')), fromBase64(toBase64('hello!')) from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    encodedBase64 = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
+    decodedBase64 = pinotQuery.getSelectList().get(1).getLiteral().getStringValue();
+    Assert.assertEquals(encodedBase64, "aGVsbG8h");
+    Assert.assertEquals(decodedBase64, "hello!");
+
+    query = "select toBase64(upper('hello!')), fromBase64(toBase64(upper('hello!'))) from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    encodedBase64 = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
+    decodedBase64 = pinotQuery.getSelectList().get(1).getLiteral().getStringValue();
+    Assert.assertEquals(encodedBase64, "SEVMTE8h");
+    Assert.assertEquals(decodedBase64, "HELLO!");
+
+    query = "select reverse(fromBase64(toBase64(upper('hello!')))) from mytable where fromBase64(toBase64(upper('hello!'))) = bar";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    String arg1 = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
+    String leftOp = pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getStringValue();
+    Assert.assertEquals(arg1, "!OLLEH");
+    Assert.assertEquals(leftOp, "HELLO!");
+
     query = "select a from mytable where foo = toBase64('hello!') and bar = fromBase64('aGVsbG8h')";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     and = pinotQuery.getFilterExpression().getFunctionCall();

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -1906,13 +1906,23 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(encoded, "aGVsbG8h");
     Assert.assertEquals(decoded, "hello!");
 
-    query = "select  from mytable where foo = toBase64('hello!') and bar = fromBase64('aGVsbG8h')";
+    query = "select toBase64('hello!'), fromBase64('aGVsbG8h') from mytable where foo = toBase64('hello!') and bar = fromBase64('aGVsbG8h')";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     and = pinotQuery.getFilterExpression().getFunctionCall();
     encoded = and.getOperands().get(0).getFunctionCall().getOperands().get(1).getLiteral().getStringValue();
     decoded = and.getOperands().get(1).getFunctionCall().getOperands().get(1).getLiteral().getStringValue();
     Assert.assertEquals(encoded, "aGVsbG8h");
     Assert.assertEquals(decoded, "hello!");
+
+    query = "select fromBase64('hello') from mytable";
+    Exception expectedError = null;
+    try {
+      CalciteSqlParser.compileToPinotQuery(query);
+    } catch (Exception e) {
+      expectedError = e;
+    }
+    Assert.assertNotNull(expectedError);
+    Assert.assertTrue(expectedError instanceof SqlCompilationException);
   }
 
   @Test

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -1906,7 +1906,9 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(encoded, "aGVsbG8h");
     Assert.assertEquals(decoded, "hello!");
 
-    query = "select toBase64('hello!'), fromBase64('aGVsbG8h') from mytable where foo = toBase64('hello!') and bar = fromBase64('aGVsbG8h')";
+    query =
+        "select toBase64('hello!'), fromBase64('aGVsbG8h') from mytable where foo = toBase64('hello!') and bar = "
+            + "fromBase64('aGVsbG8h')";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     and = pinotQuery.getFilterExpression().getFunctionCall();
     encoded = and.getOperands().get(0).getFunctionCall().getOperands().get(1).getLiteral().getStringValue();
@@ -2052,11 +2054,9 @@ public class CalciteSqlCompilerTest {
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);
     expression = pinotQuery.getFilterExpression();
     Assert.assertNotNull(expression.getLiteral());
-    Assert.assertEquals(expression.getLiteral().getFieldValue(),
-        "aGVsbG8h");
+    Assert.assertEquals(expression.getLiteral().getFieldValue(), "aGVsbG8h");
 
-    expression =
-        CalciteSqlParser.compileToExpression("fromBase64('aGVsbG8h')");
+    expression = CalciteSqlParser.compileToExpression("fromBase64('aGVsbG8h')");
     Assert.assertNotNull(expression.getFunctionCall());
     pinotQuery.setFilterExpression(expression);
     pinotQuery = compileTimeFunctionsInvoker.rewrite(pinotQuery);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
 import java.util.Arrays;
+import java.util.Base64;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -31,8 +32,6 @@ import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ArrayCopyUtils;
 import org.testng.annotations.Test;
-import static org.apache.pinot.common.function.scalar.StringFunctions.fromBase64;
-import static org.apache.pinot.common.function.scalar.StringFunctions.toBase64;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -829,7 +828,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     assertEquals(transformFunction.getName(), "toBase64");
     String[] expectedValues = new String[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = toBase64(_bytesSVValues[i]);
+      expectedValues[i] = Base64.getEncoder().encodeToString(_bytesSVValues[i]);
     }
     testTransformFunction(transformFunction, expectedValues);
 
@@ -839,7 +838,7 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     assertEquals(transformFunction.getName(), "fromBase64");
     byte[][] expectedBinaryValues = new byte[NUM_ROWS][];
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedBinaryValues[i] = fromBase64(toBase64(_bytesSVValues[i]));
+      expectedBinaryValues[i] = Base64.getDecoder().decode(Base64.getEncoder().encodeToString(_bytesSVValues[i]));
     }
     testTransformFunction(transformFunction, expectedBinaryValues);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
@@ -31,8 +31,6 @@ import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ArrayCopyUtils;
 import org.testng.annotations.Test;
-
-import static org.apache.pinot.common.function.scalar.StringFunctions.binaryToBase64;
 import static org.apache.pinot.common.function.scalar.StringFunctions.fromBase64;
 import static org.apache.pinot.common.function.scalar.StringFunctions.toBase64;
 import static org.testng.Assert.assertEquals;
@@ -824,41 +822,25 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   }
 
   @Test
-  public void testStringBase64TransformFunction() {
-    ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("toBase64(%s)", STRING_ALPHANUM_SV_COLUMN));
+  public void testBase64TransformFunction() {
+    ExpressionContext expression = RequestContextUtils.getExpression(String.format("toBase64(%s)", BYTES_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "toBase64");
     String[] expectedValues = new String[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = toBase64(_stringAlphaNumericSVValues[i]);
+      expectedValues[i] = toBase64(_bytesSVValues[i]);
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    expression =
-        RequestContextUtils.getExpression(String.format("fromBase64(toBase64(%s))", STRING_ALPHANUM_SV_COLUMN));
+    expression = RequestContextUtils.getExpression(String.format("fromBase64(toBase64(%s))", BYTES_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "fromBase64");
-    expectedValues = new String[NUM_ROWS];
+    byte[][] expectedBinaryValues = new byte[NUM_ROWS][];
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = fromBase64(toBase64(_stringAlphaNumericSVValues[i]));
+      expectedBinaryValues[i] = fromBase64(toBase64(_bytesSVValues[i]));
     }
-    testTransformFunction(transformFunction, expectedValues);
-  }
-
-  @Test
-  public void testBytesBase64TransformFunction() {
-    ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("binaryToBase64(%s)", BYTES_SV_COLUMN));
-    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
-    assertEquals(transformFunction.getName(), "binaryToBase64");
-    String[] expectedValues = new String[NUM_ROWS];
-    for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = binaryToBase64(_bytesSVValues[i]);
-    }
-    testTransformFunction(transformFunction, expectedValues);
+    testTransformFunction(transformFunction, expectedBinaryValues);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
@@ -32,6 +32,8 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ArrayCopyUtils;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.common.function.scalar.StringFunctions.fromBase64;
+import static org.apache.pinot.common.function.scalar.StringFunctions.toBase64;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
@@ -818,5 +820,30 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
       ;
     }
     testTransformFunctionMV(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testStringBase64TransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression(String.format("toBase64(%s)", STRING_ALPHANUM_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "toBase64");
+    String[] expectedValues = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = toBase64(_stringAlphaNumericSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression =
+        RequestContextUtils.getExpression(String.format("fromBase64(toBase64(%s))", STRING_ALPHANUM_SV_COLUMN));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "fromBase64");
+    expectedValues = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = fromBase64(toBase64(_stringAlphaNumericSVValues[i]));
+    }
+    testTransformFunction(transformFunction, expectedValues);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
@@ -32,6 +32,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ArrayCopyUtils;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.common.function.scalar.StringFunctions.binaryToBase64;
 import static org.apache.pinot.common.function.scalar.StringFunctions.fromBase64;
 import static org.apache.pinot.common.function.scalar.StringFunctions.toBase64;
 import static org.testng.Assert.assertEquals;
@@ -843,6 +844,20 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     expectedValues = new String[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedValues[i] = fromBase64(toBase64(_stringAlphaNumericSVValues[i]));
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testBytesBase64TransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression(String.format("binaryToBase64(%s)", BYTES_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "binaryToBase64");
+    String[] expectedValues = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = binaryToBase64(_bytesSVValues[i]);
     }
     testTransformFunction(transformFunction, expectedValues);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
@@ -32,6 +32,7 @@ import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ArrayCopyUtils;
 import org.testng.annotations.Test;
+
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -82,7 +82,6 @@ import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import software.amazon.awssdk.services.kinesis.model.InvalidArgumentException;
 
 import static org.apache.pinot.common.function.scalar.StringFunctions.decodeUrl;
 import static org.apache.pinot.common.function.scalar.StringFunctions.encodeUrl;
@@ -671,7 +670,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertTrue(response.get("exceptions").get(0).get("message").toString().contains("IllegalArgumentException"));
 
     // string literal used in a filter
-    sqlQuery = "SELECT * FROM myTable WHERE fromBase64('aGVsbG8h') != Carrier AND toBase64('hello!') != Carrier LIMIT 10";
+    sqlQuery =
+        "SELECT * FROM myTable WHERE fromBase64('aGVsbG8h') != Carrier AND toBase64('hello!') != Carrier LIMIT 10";
     response = postQuery(sqlQuery, _brokerBaseApiUrl);
     resultTable = response.get("resultTable");
     rows = resultTable.get("rows");
@@ -692,7 +692,9 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertEquals(rows.size(), 10);
 
     // non-string identifier used in a filter
-    sqlQuery = "SELECT fromBase64(toBase64(AirlineID)), AirlineID FROM myTable WHERE fromBase64(toBase64(AirlineID)) = AirlineID LIMIT 10";
+    sqlQuery =
+        "SELECT fromBase64(toBase64(AirlineID)), AirlineID FROM myTable WHERE fromBase64(toBase64(AirlineID)) = "
+            + "AirlineID LIMIT 10";
     response = postQuery(sqlQuery, _brokerBaseApiUrl);
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
@@ -702,7 +704,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
     // string identifier used in group by order by
     sqlQuery = "SELECT Carrier as originalCol, toBase64(Carrier) as encoded, fromBase64(toBase64(Carrier)) as decoded "
-        + "FROM myTable GROUP BY Carrier, toBase64(Carrier), fromBase64(toBase64(Carrier)) ORDER BY toBase64(Carrier) LIMIT 10";
+        + "FROM myTable GROUP BY Carrier, toBase64(Carrier), fromBase64(toBase64(Carrier)) ORDER BY toBase64(Carrier)"
+        + " LIMIT 10";
     response = postQuery(sqlQuery, _brokerBaseApiUrl);
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
@@ -719,8 +722,10 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     }
 
     // non-string identifier used in group by order by
-    sqlQuery = "SELECT AirlineID as originalCol, toBase64(AirlineID) as encoded, fromBase64(toBase64(AirlineID)) as decoded "
-        + "FROM myTable GROUP BY AirlineID, toBase64(AirlineID), fromBase64(toBase64(AirlineID)) ORDER BY toBase64(AirlineID) LIMIT 10";
+    sqlQuery =
+        "SELECT AirlineID as originalCol, toBase64(AirlineID) as encoded, fromBase64(toBase64(AirlineID)) as decoded "
+            + "FROM myTable GROUP BY AirlineID, toBase64(AirlineID), fromBase64(toBase64(AirlineID)) ORDER BY "
+            + "toBase64(AirlineID) LIMIT 10";
     response = postQuery(sqlQuery, _brokerBaseApiUrl);
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
@@ -745,7 +750,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     String sqlQuery =
         "SELECT 1, now() as currentTs, ago('PT1H') as oneHourAgoTs, 'abc', toDateTime(now(), 'yyyy-MM-dd z') as "
             + "today, now(), ago('PT1H'), encodeUrl('key1=value 1&key2=value@!$2&key3=value%3') as encodedUrl, "
-            + "decodeUrl('key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253') as decodedUrl, toBase64('hello!') as toBase64, fromBase64('aGVsbG8h') as fromBase64";
+            + "decodeUrl('key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253') as decodedUrl, toBase64"
+            + "('hello!') as toBase64, fromBase64('aGVsbG8h') as fromBase64";
     JsonNode response = postQuery(sqlQuery, _brokerBaseApiUrl);
     long currentTsMax = System.currentTimeMillis();
     long oneHourAgoTsMax = currentTsMax - ONE_HOUR_IN_MS;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -621,6 +621,29 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     String expectedDecodedStr = fromBase64("aGVsbG8h");
     assertEquals(decodedString, expectedDecodedStr);
 
+    // long string literal encode
+    sqlQuery =
+        "SELECT toBase64('this is a long string that will encode to more than 76 characters using base64') FROM "
+            + "myTable";
+    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    resultTable = response.get("resultTable");
+    rows = resultTable.get("rows");
+    encodedString = rows.get(0).get(0).asText();
+    assertEquals(encodedString,
+        toBase64("this is a long string that will encode to more than 76 characters using base64"));
+
+    // long string literal decode
+    sqlQuery =
+        "SELECT fromBase64"
+        + "('dGhpcyBpcyBhIGxvbmcgc3RyaW5nIHRoYXQgd2lsbCBlbmNvZGUgdG8gbW9yZSB0aGFuIDc2IGNoYXJhY3RlcnMgdXNpbmcgYmFzZTY0"
+        + "')FROM myTable";
+    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    resultTable = response.get("resultTable");
+    rows = resultTable.get("rows");
+    decodedString = rows.get(0).get(0).asText();
+    assertEquals(decodedString, fromBase64(
+        "dGhpcyBpcyBhIGxvbmcgc3RyaW5nIHRoYXQgd2lsbCBlbmNvZGUgdG8gbW9yZSB0aGFuIDc2IGNoYXJhY3RlcnMgdXNpbmcgYmFzZTY0"));
+
     // non-string literal
     sqlQuery = "SELECT toBase64(123), fromBase64(toBase64(123)), 123 FROM myTable";
     response = postQuery(sqlQuery, _brokerBaseApiUrl);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -682,6 +682,11 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertTrue(response.get("exceptions").get(0).get("message").toString().startsWith("\"QueryExecutionError"));
 
     // invalid argument
+    sqlQuery = "SELECT toBase64('hello!') FROM myTable";
+    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    assertTrue(response.get("exceptions").get(0).get("message").toString().contains("SqlCompilationException"));
+
+    // invalid argument
     sqlQuery = "SELECT fromBase64('hello!') FROM myTable";
     response = postQuery(sqlQuery, _brokerBaseApiUrl);
     assertTrue(response.get("exceptions").get(0).get("message").toString().contains("IllegalArgumentException"));

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -593,11 +593,6 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     String sqlQuery = "SELECT encodeUrl('key1=value 1&key2=value@!$2&key3=value%3'), "
         + "decodeUrl('key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253') FROM myTable";
     JsonNode response = postQuery(sqlQuery, _brokerBaseApiUrl);
-    JsonNode resultTable = response.get("resultTable");
-    JsonNode dataSchema = resultTable.get("dataSchema");
-    assertEquals(dataSchema.get("columnNames").toString(),
-        "[\"encodeUrl('key1=value 1&key2=value@!$2&key3=value%3')\",\"decodeUrl"
-            + "('key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253')\"]");
     String encodedString = response.get("resultTable").get("rows").get(0).get(0).asText();
     String expectedUrlStr = encodeUrl("key1=value 1&key2=value@!$2&key3=value%3");
     assertEquals(encodedString, expectedUrlStr);
@@ -654,17 +649,17 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       assertEquals(decoded, fromBase64(toBase64(original)));
     }
 
-    // encoding NULL should fail
+    // invalid argument
     sqlQuery = "SELECT toBase64() FROM myTable";
     response = postQuery(sqlQuery, _brokerBaseApiUrl);
     assertTrue(response.get("exceptions").get(0).get("message").toString().startsWith("\"QueryExecutionError"));
 
-    // decoding NULL should fail
+    // invalid argument
     sqlQuery = "SELECT fromBase64() FROM myTable";
     response = postQuery(sqlQuery, _brokerBaseApiUrl);
     assertTrue(response.get("exceptions").get(0).get("message").toString().startsWith("\"QueryExecutionError"));
 
-    // decoding invalid encoded argument should fail
+    // invalid argument
     sqlQuery = "SELECT fromBase64('hello!') FROM myTable";
     response = postQuery(sqlQuery, _brokerBaseApiUrl);
     assertTrue(response.get("exceptions").get(0).get("message").toString().contains("IllegalArgumentException"));

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -85,6 +85,8 @@ import org.testng.annotations.Test;
 
 import static org.apache.pinot.common.function.scalar.StringFunctions.decodeUrl;
 import static org.apache.pinot.common.function.scalar.StringFunctions.encodeUrl;
+import static org.apache.pinot.common.function.scalar.StringFunctions.fromBase64;
+import static org.apache.pinot.common.function.scalar.StringFunctions.toBase64;
 import static org.apache.pinot.controller.helix.core.PinotHelixResourceManager.EXTERNAL_VIEW_CHECK_INTERVAL_MS;
 import static org.apache.pinot.controller.helix.core.PinotHelixResourceManager.EXTERNAL_VIEW_ONLINE_SEGMENTS_MAX_WAIT_MS;
 import static org.testng.Assert.*;
@@ -591,6 +593,11 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     String sqlQuery = "SELECT encodeUrl('key1=value 1&key2=value@!$2&key3=value%3'), "
         + "decodeUrl('key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253') FROM myTable";
     JsonNode response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode resultTable = response.get("resultTable");
+    JsonNode dataSchema = resultTable.get("dataSchema");
+    assertEquals(dataSchema.get("columnNames").toString(),
+        "[\"encodeUrl('key1=value 1&key2=value@!$2&key3=value%3')\",\"decodeUrl"
+            + "('key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253')\"]");
     String encodedString = response.get("resultTable").get("rows").get(0).get(0).asText();
     String expectedUrlStr = encodeUrl("key1=value 1&key2=value@!$2&key3=value%3");
     assertEquals(encodedString, expectedUrlStr);
@@ -601,6 +608,84 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   }
 
   @Test
+  public void testBase64Func()
+      throws Exception {
+
+    // literal
+    String sqlQuery = "SELECT toBase64('hello!'), " + "fromBase64('aGVsbG8h') FROM myTable";
+    JsonNode response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode resultTable = response.get("resultTable");
+    JsonNode dataSchema = resultTable.get("dataSchema");
+    assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"STRING\",\"STRING\"]");
+    JsonNode rows = response.get("resultTable").get("rows");
+
+    String encodedString = rows.get(0).get(0).asText();
+    String expectedEncodedStr = toBase64("hello!");
+    assertEquals(encodedString, expectedEncodedStr);
+    String decodedString = rows.get(0).get(1).asText();
+    String expectedDecodedStr = fromBase64("aGVsbG8h");
+    assertEquals(decodedString, expectedDecodedStr);
+
+    // non-string
+    sqlQuery = "SELECT toBase64(123), fromBase64(toBase64(123)), 123 FROM myTable";
+    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    resultTable = response.get("resultTable");
+    rows = resultTable.get("rows");
+    encodedString = rows.get(0).get(0).asText();
+    decodedString = rows.get(0).get(1).asText();
+    String originalCol = rows.get(0).get(2).asText();
+    assertEquals(decodedString, originalCol);
+    assertEquals(encodedString, toBase64("123"));
+
+    // identifier
+    sqlQuery = "SELECT Carrier, toBase64(Carrier), fromBase64(toBase64(Carrier)) FROM myTable LIMIT 100";
+    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    resultTable = response.get("resultTable");
+    dataSchema = resultTable.get("dataSchema");
+    assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"STRING\",\"STRING\",\"STRING\"]");
+    rows = response.get("resultTable").get("rows");
+    assertEquals(rows.size(), 100);
+    for (int i = 0; i < 100; i++) {
+      String original = rows.get(0).asText();
+      String encoded = rows.get(1).asText();
+      String decoded = rows.get(2).asText();
+      assertEquals(original, decoded);
+      assertEquals(encoded, toBase64(original));
+      assertEquals(decoded, fromBase64(toBase64(original)));
+    }
+
+    // string literal used in a filter
+    sqlQuery = "SELECT * FROM myTable WHERE fromBase64('aGVsbG8h') != Carrier AND toBase64('hello!') != Carrier LIMIT 10";
+    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    resultTable = response.get("resultTable");
+    rows = resultTable.get("rows");
+    assertEquals(rows.size(), 10);
+
+    // non-string literal used in a filter
+    sqlQuery = "SELECT * FROM myTable WHERE fromBase64(AirlineID) != Carrier LIMIT 10";
+    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    resultTable = response.get("resultTable");
+    rows = resultTable.get("rows");
+    assertEquals(rows.size(), 10);
+
+    // string identifier used in a filter
+    sqlQuery = "SELECT * FROM myTable WHERE fromBase64(toBase64(Carrier)) = Carrier LIMIT 10";
+    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    resultTable = response.get("resultTable");
+    rows = resultTable.get("rows");
+    assertEquals(rows.size(), 10);
+
+    // non-string identifier used in a filter
+    sqlQuery = "SELECT fromBase64(toBase64(AirlineID)), AirlineID FROM myTable WHERE fromBase64(toBase64(AirlineID)) = AirlineID LIMIT 10";
+    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    resultTable = response.get("resultTable");
+    dataSchema = resultTable.get("dataSchema");
+    assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"STRING\",\"LONG\"]");
+    rows = resultTable.get("rows");
+    assertEquals(rows.size(), 10);
+  }
+
+  @Test
   public void testLiteralOnlyFunc()
       throws Exception {
     long currentTsMin = System.currentTimeMillis();
@@ -608,7 +693,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     String sqlQuery =
         "SELECT 1, now() as currentTs, ago('PT1H') as oneHourAgoTs, 'abc', toDateTime(now(), 'yyyy-MM-dd z') as "
             + "today, now(), ago('PT1H'), encodeUrl('key1=value 1&key2=value@!$2&key3=value%3') as encodedUrl, "
-            + "decodeUrl('key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253') as decodedUrl";
+            + "decodeUrl('key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253') as decodedUrl, toBase64('hello!') as toBase64, fromBase64('aGVsbG8h') as fromBase64";
     JsonNode response = postQuery(sqlQuery, _brokerBaseApiUrl);
     long currentTsMax = System.currentTimeMillis();
     long oneHourAgoTsMax = currentTsMax - ONE_HOUR_IN_MS;
@@ -622,6 +707,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     String oneHourAgoColumnName = response.get("resultTable").get("dataSchema").get("columnNames").get(6).asText();
     assertEquals(response.get("resultTable").get("dataSchema").get("columnNames").get(7).asText(), "encodedUrl");
     assertEquals(response.get("resultTable").get("dataSchema").get("columnNames").get(8).asText(), "decodedUrl");
+    assertEquals(response.get("resultTable").get("dataSchema").get("columnNames").get(9).asText(), "toBase64");
+    assertEquals(response.get("resultTable").get("dataSchema").get("columnNames").get(10).asText(), "fromBase64");
     assertTrue(Long.parseLong(nowColumnName) > currentTsMin);
     assertTrue(Long.parseLong(nowColumnName) < currentTsMax);
     assertTrue(Long.parseLong(oneHourAgoColumnName) > oneHourAgoTsMin);
@@ -636,6 +723,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(6).asText(), "LONG");
     assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(7).asText(), "STRING");
     assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(8).asText(), "STRING");
+    assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(9).asText(), "STRING");
+    assertEquals(response.get("resultTable").get("dataSchema").get("columnDataTypes").get(10).asText(), "STRING");
 
     int first = response.get("resultTable").get("rows").get(0).get(0).asInt();
     long second = response.get("resultTable").get("rows").get(0).get(1).asLong();
@@ -659,6 +748,10 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         "key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253");
     assertEquals(response.get("resultTable").get("rows").get(0).get(8).asText(),
         "key1=value 1&key2=value@!$2&key3=value%3");
+    assertEquals(response.get("resultTable").get("rows").get(0).get(9).asText(),
+        "aGVsbG8h");
+    assertEquals(response.get("resultTable").get("rows").get(0).get(10).asText(),
+        "hello!");
   }
 
   @Test(dependsOnMethods = "testBloomFilterTriggering")


### PR DESCRIPTION
Label = `feature`

This PR implements `toBase64(byte[])` and `fromBase64(str)` encoding and decoding functionality.
- Encoding scheme: encodes input using the Base64 encoding scheme as specified in RFC 4648 and RFC 2045
- Decoding will throw an exception if invalid base64 string is passed in.

Use Case Examples
- Encode binary data: `toBase64(binaryCol)` 
- Encode strings in UTF8: `toBase64(toUtf8('hello'))` , `toBase64(toUtf8(stringCol))` 
- Decode base64-encoded strings to binary data: `fromBase64('aGVsbG8h')`, `fromBase64(stringCol)`
- Decode base64-encoded strings to UTF8 charset: `fromUtf8(fromBase64('aGVsbG8h'))`