### PR TITLE
Add support for regexpReplace scalar function

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
@@ -122,6 +122,23 @@ public class LiteralOnlyBrokerRequestTest {
         CalciteSqlParser.compileToPinotQuery("SELECT count(*) from foo " + "where bar = fromBase64('aGVsbG8h')")));
     Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery(
         "SELECT count(*) from foo " + "where bar = fromUtf8(fromBase64('aGVsbG8h'))")));
+    Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser
+        .compileToPinotQuery("SELECT count(*) from myTable where regexpReplace(col1, \"b(..)\", \"X$1Y\")  = "
+            + "\"fooXarYXazY\"")));
+    Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser
+        .compileToPinotQuery("SELECT count(*) from myTable where regexpReplace(col1, \"b(..)\", \"X$1Y\", 10)  = "
+            + "\"fooXarYXazY\"")));
+    Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser
+        .compileToPinotQuery("SELECT count(*) from myTable where regexpReplace(col1, \"b(..)\", \"X$1Y\", 10 , 1)  = "
+            + "\"fooXarYXazY\"")));
+    Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser
+        .compileToPinotQuery("SELECT count(*) from myTable where regexpReplace(col1, \"b(..)\", \"X$1Y\", 10 , 1, "
+            + "\"i\")  = "
+            + "\"fooXarYXazY\"")));
+    Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser
+        .compileToPinotQuery("SELECT count(*) from myTable where regexpReplace(col1, \"b(..)\", \"X$1Y\", 10 , 1, "
+            + "\"m\")  = "
+            + "\"fooXarYXazY\"")));
   }
 
   @Test

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -596,30 +596,24 @@ public class StringFunctions {
    * @param inputStr Input string to apply the regexpReplace
    * @param matchStr Regexp or string to match against inputStr
    * @param replaceStr Regexp or string to replace if matchStr is found
-   * @param startPos Index of inputStr from where matching should start. Default is 0.
+   * @param matchStartPos Index of inputStr from where matching should start. Default is 0.
    * @param occurence Controls which occurence of the matched pattern must be replaced. Counting starts at 0. Default
    *                  is -1
    * @param flag Single character flag that controls how the regex finds matches in inputStr. If an incorrect flag is
    *            specified, the function applies default case sensitive match. Only one flag can be specified. Supported
    *             flags:
    *             i -> Case insensitive
-   *             m -> Treats the string to match as multiple lines
-   *             x -> Add comments to the regular expression
    * @return replaced input string
    */
   @ScalarFunction
-  public static String regexpReplace(String inputStr, String matchStr, String replaceStr, int startPos,
+  public static String regexpReplace(String inputStr, String matchStr, String replaceStr, int matchStartPos,
       int occurence, String flag) {
     Integer patternFlag;
+
+    // TODO: Support more flags like MULTILINE, COMMENTS, etc.
     switch (flag) {
       case "i":
         patternFlag = Pattern.CASE_INSENSITIVE;
-        break;
-      case "m":
-        patternFlag = Pattern.MULTILINE;
-        break;
-      case "x":
-        patternFlag = Pattern.COMMENTS;
         break;
       default:
         patternFlag = null;
@@ -633,7 +627,7 @@ public class StringFunctions {
       p = Pattern.compile(matchStr);
     }
 
-    Matcher matcher = p.matcher(inputStr).region(startPos, inputStr.length());
+    Matcher matcher = p.matcher(inputStr).region(matchStartPos, inputStr.length());
     StringBuffer sb;
 
     if (occurence >= 0) {
@@ -677,12 +671,12 @@ public class StringFunctions {
    * @param inputStr Input string to apply the regexpReplace
    * @param matchStr Regexp or string to match against inputStr
    * @param replaceStr Regexp or string to replace if matchStr is found
-   * @param startPos Index of inputStr from where matching should start. Default is 0.
+   * @param matchStartPos Index of inputStr from where matching should start. Default is 0.
    * @return replaced input string
    */
   @ScalarFunction
-  public static String regexpReplace(String inputStr, String matchStr, String replaceStr, int startPos) {
-    return regexpReplace(inputStr, matchStr, replaceStr, startPos, -1, "");
+  public static String regexpReplace(String inputStr, String matchStr, String replaceStr, int matchStartPos) {
+    return regexpReplace(inputStr, matchStr, replaceStr, matchStartPos, -1, "");
   }
 
   /**
@@ -691,13 +685,14 @@ public class StringFunctions {
    * @param inputStr Input string to apply the regexpReplace
    * @param matchStr Regexp or string to match against inputStr
    * @param replaceStr Regexp or string to replace if matchStr is found
-   * @param startPos Index of inputStr from where matching should start. Default is 0.
+   * @param matchStartPos Index of inputStr from where matching should start. Default is 0.
    * @param occurence Controls which occurence of the matched pattern must be replaced. Counting starts
    *                    at 0. Default is -1
    * @return replaced input string
    */
   @ScalarFunction
-  public static String regexpReplace(String inputStr, String matchStr, String replaceStr, int startPos, int occurence) {
-    return regexpReplace(inputStr, matchStr, replaceStr, startPos, occurence, "");
+  public static String regexpReplace(String inputStr, String matchStr, String replaceStr, int matchStartPos,
+      int occurence) {
+    return regexpReplace(inputStr, matchStr, replaceStr, matchStartPos, occurence, "");
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -588,4 +588,116 @@ public class StringFunctions {
   public static byte[] fromBase64(String input) {
     return Base64.getDecoder().decode(input);
   }
+
+  /**
+   * Replace a regular expression pattern. If matchStr is not found, inputStr will be returned. By default, all
+   * occurences of match pattern in the input string will be replaced. Default matching pattern is case sensitive.
+   *
+   * @param inputStr Input string to apply the regexpReplace
+   * @param matchStr Regexp or string to match against inputStr
+   * @param replaceStr Regexp or string to replace if matchStr is found
+   * @param startPos Index of inputStr from where matching should start. Default is 0.
+   * @param occurence Controls which occurence of the matched pattern must be replaced. Counting starts at 0. Default
+   *                  is -1
+   * @param flag Single character flag that controls how the regex finds matches in inputStr. If an incorrect flag is
+   *            specified, the function applies default case sensitive match. Only one flag can be specified. Supported
+   *             flags:
+   *             i -> Case insensitive
+   *             m -> Treats the string to match as multiple lines
+   *             x -> Add comments to the regular expression
+   * @return replaced input string
+   */
+  @ScalarFunction
+  public static String regexpReplace(String inputStr, String matchStr, String replaceStr, int startPos,
+      int occurence, String flag) {
+    Integer patternFlag;
+    switch (flag) {
+      case "i":
+        patternFlag = Pattern.CASE_INSENSITIVE;
+        break;
+      case "m":
+        patternFlag = Pattern.MULTILINE;
+        break;
+      case "x":
+        patternFlag = Pattern.COMMENTS;
+        break;
+      default:
+        patternFlag = null;
+        break;
+    }
+
+    Pattern p;
+    if (patternFlag != null) {
+      p = Pattern.compile(matchStr, patternFlag);
+    } else {
+      p = Pattern.compile(matchStr);
+    }
+
+    Matcher matcher = p.matcher(inputStr).region(startPos, inputStr.length());
+    StringBuffer sb;
+
+    if (occurence >= 0) {
+      sb = new StringBuffer(inputStr);
+      while (occurence >= 0 && matcher.find()) {
+        if (occurence == 0) {
+          sb.replace(matcher.start(), matcher.end(), replaceStr);
+          break;
+        }
+        occurence--;
+      }
+    } else {
+      sb = new StringBuffer();
+      while (matcher.find()) {
+        matcher.appendReplacement(sb, replaceStr);
+      }
+      matcher.appendTail(sb);
+    }
+
+    return sb.toString();
+  }
+
+  /**
+   * See #regexpReplace(String, String, String, int, int, String). Matches against entire inputStr and replaces all
+   * occurences. Match is performed in case-sensitive mode.
+   *
+   * @param inputStr Input string to apply the regexpReplace
+   * @param matchStr Regexp or string to match against inputStr
+   * @param replaceStr Regexp or string to replace if matchStr is found
+   * @return replaced input string
+   */
+  @ScalarFunction
+  public static String regexpReplace(String inputStr, String matchStr, String replaceStr) {
+    return regexpReplace(inputStr, matchStr, replaceStr, 0, -1, "");
+  }
+
+  /**
+   * See #regexpReplace(String, String, String, int, int, String). Matches against entire inputStr and replaces all
+   * occurences. Match is performed in case-sensitive mode.
+   *
+   * @param inputStr Input string to apply the regexpReplace
+   * @param matchStr Regexp or string to match against inputStr
+   * @param replaceStr Regexp or string to replace if matchStr is found
+   * @param startPos Index of inputStr from where matching should start. Default is 0.
+   * @return replaced input string
+   */
+  @ScalarFunction
+  public static String regexpReplace(String inputStr, String matchStr, String replaceStr, int startPos) {
+    return regexpReplace(inputStr, matchStr, replaceStr, startPos, -1, "");
+  }
+
+  /**
+   * See #regexpReplace(String, String, String, int, int, String). Match is performed in case-sensitive mode.
+   *
+   * @param inputStr Input string to apply the regexpReplace
+   * @param matchStr Regexp or string to match against inputStr
+   * @param replaceStr Regexp or string to replace if matchStr is found
+   * @param startPos Index of inputStr from where matching should start. Default is 0.
+   * @param occurence Controls which occurence of the matched pattern must be replaced. Counting starts
+   *                    at 0. Default is -1
+   * @return replaced input string
+   */
+  @ScalarFunction
+  public static String regexpReplace(String inputStr, String matchStr, String replaceStr, int startPos, int occurence) {
+    return regexpReplace(inputStr, matchStr, replaceStr, startPos, occurence, "");
+  }
 }


### PR DESCRIPTION
Fixes issue =  #9079 
Label = `feature`

This PR adds a scalar function to perform REGEXP REPLACE in Pinot. The semantics of using this scalar function is as follows:

* If matches is not found, inputStr is returned as such.
* By default, all occurrences of the matched patterns are replaced unless the `occurence` parameter is not -1.
* Default match flag is case sensitive. Can be overriden with the `flag` parameter

**Parameters:**
1. inputStr (required): Input string against which regexp match and replace should be performed.
2. matchStr (required): String or regexp to match against inputStr
3. replaceStr (required): String or regexp to replace if a pattern is found.
4. startPos (optional): Starting index from where matching should be performed. Default value is 0.
5. occurrence (optional): The occurrence of the matched pattern must be replaced. Default is -1 where all found patterns will be replaced.
6. flag (optional): Single character flag that controls how the regex finds matches in inputStr. Default flag of empty is case sensitive match. If an incorrect flag is specified, the function applies default case sensitive match. Only one flag can be specified. Supported flags are:
  - i -> Case insensitive
  - m -> Treats the string to match as multiple lines
  - x -> Add comments to the regular expression


We can support more flags in the future.
