### PR TITLE
add health check queryParam for servers

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/HealthCheckResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/HealthCheckResource.java
@@ -58,10 +58,10 @@ public class HealthCheckResource {
   })
   public String checkHealth(
       @ApiParam(value = "health check type: liveness or readiness") @QueryParam("checkType") String checkType) {
-    if (checkType == null || checkType.equalsIgnoreCase("readiness")) {
-      return getReadinessStatus(_instanceId);
-    } else {
+    if ("liveness".equalsIgnoreCase(checkType)) {
       return "OK";
+    } else {
+      return getReadinessStatus(_instanceId);
     }
   }
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/HealthCheckResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/HealthCheckResource.java
@@ -20,6 +20,7 @@ package org.apache.pinot.server.api.resources;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.ApiResponse;
 import io.swagger.annotations.ApiResponses;
 import javax.inject.Inject;
@@ -27,6 +28,7 @@ import javax.inject.Named;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
@@ -54,8 +56,13 @@ public class HealthCheckResource {
       @ApiResponse(code = 200, message = "Server is healthy"),
       @ApiResponse(code = 503, message = "Server is not healthy")
   })
-  public String checkHealth() {
-    return getReadinessStatus(_instanceId);
+  public String checkHealth(
+      @ApiParam(value = "health check type: liveness or readiness") @QueryParam("checkType") String checkType) {
+    if (checkType == null || checkType.equalsIgnoreCase("readiness")) {
+      return getReadinessStatus(_instanceId);
+    } else {
+      return "OK";
+    }
   }
 
   @GET

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/HealthCheckResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/HealthCheckResourceTest.java
@@ -53,5 +53,9 @@ public class HealthCheckResourceTest extends BaseResourceTest {
     Assert.assertEquals(_webTarget.path(livenessPath).request().get(Response.class).getStatus(), 200);
     Assert.assertEquals(_webTarget.path(healthPath).request().get(Response.class).getStatus(), 503);
     Assert.assertEquals(_webTarget.path(readinessPath).request().get(Response.class).getStatus(), 503);
+    Assert.assertEquals(_webTarget.path(healthPath).queryParam("checkType", "readiness")
+        .request().get(Response.class).getStatus(), 503);
+    Assert.assertEquals(_webTarget.path(healthPath).queryParam("checkType", "liveness")
+        .request().get(Response.class).getStatus(), 200);
   }
 }


### PR DESCRIPTION
follow up on https://github.com/apache/pinot/pull/9031

With the 2 new added APIs. we also want to make `/health` path return either liveness or readiness based on query parameter.
This way we can switch the default return health check from readiness to liveness in the future.