### PR TITLE
Add timestamp index fields to schema for the real-time ingestion path

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -636,7 +636,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
             && timeExpression.getIdentifier() != null) {
           String timeColumn = timeExpression.getIdentifier().getName();
           String timeColumnWithGranularity = TimestampIndexGranularity.getColumnNameWithGranularity(timeColumn,
-              TimestampIndexGranularity.valueOf(granularString));
+              TimestampIndexGranularity.valueOf(granularString.toUpperCase()));
           if (timestampIndexColumns.contains(timeColumnWithGranularity)) {
             pinotQuery.putToExpressionOverrideHints(expression,
                 RequestUtils.getIdentifierExpression(timeColumnWithGranularity));

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -628,7 +628,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     Function function = expression.getFunctionCall();
     switch (function.getOperator()) {
       case "datetrunc":
-        String granularString = function.getOperands().get(0).getLiteral().getStringValue();
+        String granularString = function.getOperands().get(0).getLiteral().getStringValue().toUpperCase();
         Expression timeExpression = function.getOperands().get(1);
         if (((function.getOperandsSize() == 2) || (function.getOperandsSize() == 3 && "MILLISECONDS".equalsIgnoreCase(
             function.getOperands().get(2).getLiteral().getStringValue())))
@@ -636,7 +636,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
             && timeExpression.getIdentifier() != null) {
           String timeColumn = timeExpression.getIdentifier().getName();
           String timeColumnWithGranularity = TimestampIndexGranularity.getColumnNameWithGranularity(timeColumn,
-              TimestampIndexGranularity.valueOf(granularString.toUpperCase()));
+              TimestampIndexGranularity.valueOf(granularString));
           if (timestampIndexColumns.contains(timeColumnWithGranularity)) {
             pinotQuery.putToExpressionOverrideHints(expression,
                 RequestUtils.getIdentifierExpression(timeColumnWithGranularity));

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -64,6 +64,7 @@ import org.apache.pinot.segment.local.utils.SchemaUtils;
 import org.apache.pinot.segment.local.utils.tablestate.TableStateUtils;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.DedupConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -73,8 +74,6 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.Realtime.Status;
 
-import static org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig.extractTimestampIndexConfigsFromTableConfig;
-import static org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig.updateSchemaWithTimestampIndexes;
 import static org.apache.pinot.spi.utils.CommonConstants.Segment.METADATA_URI_FOR_PEER_DOWNLOAD;
 
 
@@ -367,7 +366,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
         }
       }
 
-      schema = updateSchemaWithTimestampIndexes(schema, extractTimestampIndexConfigsFromTableConfig(tableConfig));;
+      schema = SegmentGeneratorConfig.updateSchemaWithTimestampIndexes(schema,
+          SegmentGeneratorConfig.extractTimestampIndexConfigsFromTableConfig(tableConfig));
 
       segmentDataManager =
           new LLRealtimeSegmentDataManager(segmentZKMetadata, tableConfig, this, _indexDir.getAbsolutePath(),

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -73,6 +73,8 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.Realtime.Status;
 
+import static org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig.extractTimestampIndexConfigsFromTableConfig;
+import static org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig.updateSchemaWithTimestampIndexes;
 import static org.apache.pinot.spi.utils.CommonConstants.Segment.METADATA_URI_FOR_PEER_DOWNLOAD;
 
 
@@ -364,6 +366,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
           }
         }
       }
+
+      schema = updateSchemaWithTimestampIndexes(schema, extractTimestampIndexConfigsFromTableConfig(tableConfig));;
 
       segmentDataManager =
           new LLRealtimeSegmentDataManager(segmentZKMetadata, tableConfig, this, _indexDir.getAbsolutePath(),

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -71,7 +71,6 @@ import org.apache.pinot.segment.local.utils.TableConfigUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.SegmentMetadata;
-import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.IndexingOverrides;
 import org.apache.pinot.segment.spi.index.creator.H3IndexConfig;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -71,6 +71,7 @@ import org.apache.pinot.segment.local.utils.TableConfigUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.IndexingOverrides;
 import org.apache.pinot.segment.spi.index.creator.H3IndexConfig;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TimestampIndexGranularity.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TimestampIndexGranularity.java
@@ -52,7 +52,7 @@ public enum TimestampIndexGranularity {
   }
 
   public static boolean isValidTimeGranularity(String granularity) {
-    return VALID_VALUES.contains(granularity.toUpperCase());
+    return VALID_VALUES.contains(granularity);
   }
 
   public static Set<String> extractTimestampIndexGranularityColumnNames(TableConfig tableConfig) {

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/TimestampIndexGranularityTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/TimestampIndexGranularityTest.java
@@ -42,7 +42,7 @@ public class TimestampIndexGranularityTest {
     Assert.assertFalse(TimestampIndexGranularity.isValidTimeColumnWithGranularityName(timeColumn));
     Assert.assertFalse(TimestampIndexGranularity.isValidTimeColumnWithGranularityName("$docId"));
     Assert.assertFalse(TimestampIndexGranularity.isValidTimeColumnWithGranularityName("$ts$"));
-    Assert.assertTrue(TimestampIndexGranularity.isValidTimeGranularity("day"));
+    Assert.assertFalse(TimestampIndexGranularity.isValidTimeGranularity("day"));
     Assert.assertTrue(TimestampIndexGranularity.isValidTimeGranularity("DAY"));
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/streams/RsvpSourceGenerator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/streams/RsvpSourceGenerator.java
@@ -29,6 +29,7 @@ import java.util.Properties;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.pinot.spi.stream.StreamDataProducer;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.joda.time.DateTime;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -59,7 +60,7 @@ public class RsvpSourceGenerator implements PinotSourceDataGenerator {
     json.put("group_name", "group_name" + ThreadLocalRandom.current().nextInt());
     json.put("group_lat", ThreadLocalRandom.current().nextDouble(-90.0, 90.0));
     json.put("group_lon", ThreadLocalRandom.current().nextDouble(180.0));
-    json.put("mtime", DATE_TIME_FORMATTER.format(LocalDateTime.now()));
+    json.put("mtime", DateTime.now().getMillis());
     json.put("rsvp_count", 1);
     return new RSVP(eventId, eventId, json);
   }

--- a/pinot-tools/src/main/resources/examples/stream/meetupRsvp/meetupRsvp_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/meetupRsvp/meetupRsvp_realtime_table_config.json
@@ -13,6 +13,20 @@
     "retentionTimeValue": "1"
   },
   "tenants": {},
+  "fieldConfigList": [
+    {
+      "name": "mtime",
+      "encodingType": "DICTIONARY",
+      "indexTypes": ["TIMESTAMP"],
+      "timestampConfig": {
+        "granularities": [
+          "DAY",
+          "WEEK",
+          "MONTH"
+        ]
+      }
+    }
+  ],
   "tableIndexConfig": {
     "loadMode": "MMAP",
     "streamConfigs": {


### PR DESCRIPTION
This is a bug fix for an issue I found when using the timestamp index with streaming data. 

The problem is that the schema passed into the `LLRealTimeDataManager` (and then into `MutableSegmentImpl`) doesn't know about the extra timestamp fields.

This means that when any rows are indexed they ignore the new fields and when Pinot tries to commit the segment we get this type of exception:

```
java.lang.NullPointerException: null
  at org.apache.pinot.segment.spi.creator.ColumnIndexCreationInfo.getDistinctValueCount(ColumnIndexCreationInfo.java:67) ~[pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-0c1037ed90d75bb7cd95315cd6a6bdd00f34a6c2]
  at org.apache.pinot.segment.local.segment.creator.impl.SegmentColumnarIndexCreator.init(SegmentColumnarIndexCreator.java:201) ~[pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-0c1037ed90d75bb7cd95315cd6a6bdd00f34a6c2]
  at org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl.build(SegmentIndexCreationDriverImpl.java:216) ~[pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-0c1037ed90d75bb7cd95315cd6a6bdd00f34a6c2]
  at org.apache.pinot.segment.local.realtime.converter.RealtimeSegmentConverter.build(RealtimeSegmentConverter.java:123) ~[pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-0c1037ed90d75bb7cd95315cd6a6bdd00f34a6c2]
  at org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager.buildSegmentInternal(LLRealtimeSegmentDataManager.java:851) [pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-0c1037ed90d75bb7cd95315cd6a6bdd00f34a6c2]
  at org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager.buildSegmentForCommit(LLRealtimeSegmentDataManager.java:778) [pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-0c1037ed90d75bb7cd95315cd6a6bdd00f34a6c2]
  at org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager$PartitionConsumer.run(LLRealtimeSegmentDataManager.java:677) [pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-0c1037ed90d75bb7cd95315cd6a6bdd00f34a6c2]
  at java.lang.Thread.run(Thread.java:829) [?:?]
```

I have updated the streaming QuickStart to add the timestamp index. While doing that I had to change the value for `mtime` because there is another bug where Pinot runs the following expression when it tries to add the extra date columns:

```
dateTrunc('DAY', '2022-07-29 11:18:23')
```

That doesn't work because the second parameter of this function needs to be a `LONG` value, which isn't yet the case as the `DataTypeTransformer` hasn't coerced the type. I'm not sure what the proper fix for that issue should be, so I'm working around it for the sake of this PR. 

I've also added another fix (https://github.com/apache/pinot/pull/9134/commits/823d8b1011b41ce7fa8062737f694cbac6f9d6e7) for another bug where when you have a timestamp index enabled and write a query with lowercase granularity:

```
select DATETRUNC('year', ts)
from wikievents_timestamp_index 
limit 10
```

You get this error:

```
ProcessingException(errorCode:450, message:InternalError:
java.io.IOException: Failed : HTTP error code : 500
	at org.apache.pinot.controller.api.resources.PinotQueryResource.sendPostRaw(PinotQueryResource.java:270)
	at org.apache.pinot.controller.api.resources.PinotQueryResource.sendRequestRaw(PinotQueryResource.java:308)
	at org.apache.pinot.controller.api.resources.PinotQueryResource.getQueryResponse(PinotQueryResource.java:207)
	at org.apache.pinot.controller.api.resources.PinotQueryResource.executeSqlQuery(PinotQueryResource.java:114))
```

And this stacktrace on the broker:

```
java.lang.IllegalArgumentException: No enum constant org.apache.pinot.spi.config.table.TimestampIndexGranularity.year
	at java.lang.Enum.valueOf(Enum.java:240) ~[?:?]
	at org.apache.pinot.spi.config.table.TimestampIndexGranularity.valueOf(TimestampIndexGranularity.java:33) ~[pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.apache.pinot.broker.requesthandler.BaseBrokerRequestHandler.setTimestampIndexExpressionOverrideHints(BaseBrokerRequestHandler.java:639) ~[pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.apache.pinot.broker.requesthandler.BaseBrokerRequestHandler.handleTimestampIndexOverride(BaseBrokerRequestHandler.java:607) ~[pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.apache.pinot.broker.requesthandler.BaseBrokerRequestHandler.handleRequest(BaseBrokerRequestHandler.java:431) ~[pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.apache.pinot.broker.requesthandler.BaseBrokerRequestHandler.handleRequest(BaseBrokerRequestHandler.java:192) ~[pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.apache.pinot.broker.requesthandler.BaseBrokerRequestHandler.handleRequest(BaseBrokerRequestHandler.java:92) ~[pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.apache.pinot.broker.requesthandler.BrokerRequestHandlerDelegate.handleRequest(BrokerRequestHandlerDelegate.java:82) ~[pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.apache.pinot.broker.api.resources.PinotClientRequest.executeSqlQuery(PinotClientRequest.java:165) ~[pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.apache.pinot.broker.api.resources.PinotClientRequest.processSqlQueryPost(PinotClientRequest.java:139) ~[pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at jdk.internal.reflect.GeneratedMethodAccessor17.invoke(Unknown Source) ~[?:?]
	at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	at org.glassfish.jersey.server.model.internal.ResourceMethodInvocationHandlerFactory.lambda$static$0(ResourceMethodInvocationHandlerFactory.java:52) ~[pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher$1.run(AbstractJavaResourceMethodDispatcher.java:124) ~[pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.invoke(AbstractJavaResourceMethodDispatcher.java:167) ~[pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.glassfish.jersey.server.model.internal.JavaResourceMethodDispatcherProvider$VoidOutInvoker.doDispatch(JavaResourceMethodDispatcherProvider.java:159) ~[pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.glassfish.jersey.server.model.internal.AbstractJavaResourceMethodDispatcher.dispatch(AbstractJavaResourceMethodDispatcher.java:79) ~[pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.invoke(ResourceMethodInvoker.java:475) ~[pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.glassfish.jersey.server.model.ResourceMethodInvoker.lambda$apply$0(ResourceMethodInvoker.java:387) ~[pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.glassfish.jersey.server.ServerRuntime$AsyncResponder$2$1.run(ServerRuntime.java:816) [pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:248) [pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.glassfish.jersey.internal.Errors$1.call(Errors.java:244) [pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.glassfish.jersey.internal.Errors.process(Errors.java:292) [pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.glassfish.jersey.internal.Errors.process(Errors.java:274) [pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.glassfish.jersey.internal.Errors.process(Errors.java:244) [pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:265) [pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at org.glassfish.jersey.server.ServerRuntime$AsyncResponder$2.run(ServerRuntime.java:811) [pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-fdf57632fdf5965356b3e1445bd4e47f406b4311]
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
	at java.lang.Thread.run(Thread.java:829) [?:?]
```