### PR TITLE
Enforce java compilation version in pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1344,6 +1344,21 @@
               </goals>
               <phase>validate</phase>
             </execution>
+            <execution>
+              <id>default-cli-java-version</id>
+              <phase>validate</phase>
+              <goals>
+                <goal>enforce</goal>
+              </goals>
+              <configuration>
+                <rules>
+                  <requireJavaVersion>
+                    <version>11</version>
+                    <message>Pinot requires Java11 JDK for compilation</message>
+                  </requireJavaVersion>
+                </rules>
+              </configuration>
+            </execution>
           </executions>
           <configuration>
             <rules>


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds Maven Enforcer plugin execution in validate phase to enforce Java 11 before compilation\.

```mermaid
flowchart TD
  N0["Maven validate phase #40;F1#41;"]:::stAdded
  N1["Enforcer plugin execution #40;goal enforce#41; #40;F1#41;"]:::stAdded
  N2["RequireJavaVersion rule #40;version 11#41; #40;F1#41;"]:::stAdded
  N3["Java version check passes #40;F1#41;"]:::stAdded
  N4["Java version check fails #45;#62; error message #40;F1#41;"]:::stAdded
  N0 -->|"triggers"| N1
  N1 -->|"configures"| N2
  N2 -->|"if version #8805; 11"| N3
  N2 -->|"if version #60; 11"| N4
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pom\.xml — [before](https://github.com/apache/pinot/blob/7197461f29e9799e179997828a436076f1b0a130/pom.xml) · [after](https://github.com/apache/pinot/blob/c29b2117adca9acc37da2d107a4c5d0670e172fb/pom.xml)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjcxOTc0NjFmMjllOTc5OWUxNzk5OTc4MjhhNDM2MDc2ZjFiMGExMzAiLCJjb250ZXh0X2hhc2giOiJjMGNlMzg1NWY3MzM4YWVjMjUyZmNhOWMwZTQzMGMzYjg2M2VhMzBkYmEzMWVlNWQ2MTg2ZDFjNTM1NWNiOWIwIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MDM2NjQ2LCJoZWFkX3NoYSI6ImMyOWIyMTE3YWRjYTlhY2MzN2RhMmQxMDdhNGM1ZDA2NzBlMTcyZmIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI3MTk3NDYxZjI5ZTk3OTllMTc5OTk3ODI4YTQzNjA3NmYxYjBhMTMwIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 119c5ce74ef090796338e7c8ed4e809f368c0458554cfd0d7904fc076dfc5ca9 -->
<!-- pinot-pr-flow:end -->

Currently, when folks try to compile pinot with any other version than java11, they get cryptic error messages. The PR adds check in enforcer plugin and triggers before any compilation happens.

e.g.
```
openjdk version "1.8.0_302"
OpenJDK Runtime Environment Corretto-8.302.08.1 (build 1.8.0_302-b08)
OpenJDK 64-Bit Server VM Corretto-8.302.08.1 (build 25.302-b08, mixed mode)

pranay.sankpal@ITIN000509-MAC pinot % mvn -version                              
Apache Maven 3.8.5 (3599d3414f046de2324203b78ddcf9b5e4388aa0)
Maven home: /usr/local/Cellar/maven/3.8.5/libexec
Java version: 18.0.1, vendor: Homebrew, runtime: /usr/local/Cellar/openjdk/18.0.1/libexec/openjdk.jdk/Contents/Home
Default locale: en_IN, platform encoding: UTF-8
OS name: "mac os x", version: "10.15.7", arch: "x86_64", family: "mac"

pranay.sankpal@ITIN000509-MAC pinot % mvn install package -DskipTests -Pbin-dist
[ERROR] Failed to execute goal com.diffplug.spotless:spotless-maven-plugin:2.9.0:check (default) on project pinot-spi: Execution default of goal com.diffplug.spotless:spotless-maven-plugin:2.9.0:check failed: java.lang.reflect.InvocationTargetException: class com.google.googlejavaformat.java.RemoveUnusedImports (in unnamed module @0x687d31a9) cannot access class com.sun.tools.javac.util.Context (in module jdk.compiler) because module jdk.compiler does not export com.sun.tools.javac.util to unnamed module @0x687d31a9 -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal com.diffplug.spotless:spotless-maven-plugin:2.9.0:check (default) on project pinot-spi: Execution default of goal com.diffplug.spotless:spotless-maven-plugin:2.9.0:check failed: java.lang.reflect.InvocationTargetException
    at org.apache.maven.lifecycle.internal.MojoExecutor.doExecute (MojoExecutor.java:306)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:211)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:165)
    at org.apache.maven.lifecycle.internal.MojoExecutor.execute (MojoExecutor.java:157)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:121)
    at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject (LifecycleModuleBuilder.java:81)
    at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build (SingleThreadedBuilder.java:56)
    at org.apache.maven.lifecycle.internal.LifecycleStarter.execute (LifecycleStarter.java:127)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:294)
    at org.apache.maven.DefaultMaven.doExecute (DefaultMaven.java:192)
    at org.apache.maven.DefaultMaven.execute (DefaultMaven.java:105)
    at org.apache.maven.cli.MavenCli.execute (MavenCli.java:960)
    at org.apache.maven.cli.MavenCli.doMain (MavenCli.java:293)
    at org.apache.maven.cli.MavenCli.main (MavenCli.java:196)
    at jdk.internal.reflect.DirectMethodHandleAccessor.invoke (DirectMethodHandleAccessor.java:104)
    at java.lang.reflect.Method.invoke (Method.java:577)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced (Launcher.java:282)
    at org.codehaus.plexus.classworlds.launcher.Launcher.launch (Launcher.java:225)
    at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode (Launcher.java:406)
    at org.codehaus.plexus.classworlds.launcher.Launcher.main (Launcher.java:347)
Caused by: org.apache.maven.plugin.PluginExecutionException: Execution default of goal com.diffplug.spotless:spotless-maven-plugin:2.9.0:check failed: java.lang.reflect.InvocationTargetException
```

