### PR TITLE
Avoid swagger loading too much types and showing noisy log

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -91,6 +91,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     beanConfig.setDescription("APIs for accessing Pinot broker information");
     beanConfig.setContact("https://github.com/apache/pinot");
     beanConfig.setVersion("1.0");
+    beanConfig.setExpandSuperTypes(false);
     if (_useHttps) {
       beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL});
     } else {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
@@ -111,6 +111,7 @@ public class ControllerAdminApiApplication extends ResourceConfig {
     beanConfig.setDescription("APIs for accessing Pinot Controller information");
     beanConfig.setContact("https://github.com/apache/pinot");
     beanConfig.setVersion("1.0");
+    beanConfig.setExpandSuperTypes(false);
     if (_useHttps) {
       beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL});
     } else {

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
@@ -85,6 +85,7 @@ public class MinionAdminApiApplication extends ResourceConfig {
     beanConfig.setDescription("APIs for accessing Pinot Minion information");
     beanConfig.setContact("https://github.com/apache/pinot");
     beanConfig.setVersion("1.0");
+    beanConfig.setExpandSuperTypes(false);
     if (_useHttps) {
       beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL});
     } else {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/AdminApiApplication.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/AdminApiApplication.java
@@ -115,6 +115,7 @@ public class AdminApiApplication extends ResourceConfig {
     beanConfig.setDescription("APIs for accessing Pinot server information");
     beanConfig.setContact("https://github.com/apache/pinot");
     beanConfig.setVersion("1.0");
+    beanConfig.setExpandSuperTypes(false);
     if (Boolean.parseBoolean(pinotConfiguration.getProperty(CommonConstants.Server.CONFIG_OF_SWAGGER_USE_HTTPS))) {
       beanConfig.setSchemes(new String[]{CommonConstants.HTTPS_PROTOCOL});
     } else {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
@@ -73,6 +73,7 @@ public class PinotServiceManagerAdminApiApplication extends ResourceConfig {
     beanConfig.setBasePath(_baseUri.getPath());
     beanConfig.setResourcePackage(RESOURCE_PACKAGE);
     beanConfig.setScan(true);
+    beanConfig.setExpandSuperTypes(false);
 
     HttpHandler httpHandler =
         new CLStaticHttpHandler(PinotServiceManagerAdminApiApplication.class.getClassLoader(), "/api/");

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
@@ -74,6 +74,7 @@ public class PinotServiceManagerAdminApiApplication extends ResourceConfig {
     beanConfig.setResourcePackage(RESOURCE_PACKAGE);
     beanConfig.setScan(true);
     beanConfig.setExpandSuperTypes(false);
+
     HttpHandler httpHandler =
         new CLStaticHttpHandler(PinotServiceManagerAdminApiApplication.class.getClassLoader(), "/api/");
     // map both /api and /help to swagger docs. /api because it looks nice. /help for backward compatibility

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManagerAdminApiApplication.java
@@ -74,7 +74,6 @@ public class PinotServiceManagerAdminApiApplication extends ResourceConfig {
     beanConfig.setResourcePackage(RESOURCE_PACKAGE);
     beanConfig.setScan(true);
     beanConfig.setExpandSuperTypes(false);
-
     HttpHandler httpHandler =
         new CLStaticHttpHandler(PinotServiceManagerAdminApiApplication.class.getClassLoader(), "/api/");
     // map both /api and /help to swagger docs. /api because it looks nice. /help for backward compatibility


### PR DESCRIPTION
## Description
Reduce the reflection scan by Swagger and avoid the new noisy logs.

## Problems to fix
With the new Helix 1.0.4 update, somehow if we start Pinot in an large jar files that contains all our packages, we will see **many** of below warnings from Swagger init:

```
2022/08/01 18:31:51.243 WARN [Reflections] [Start a Pinot [SERVER]] could not get type for name org.hibernate.engine.jdbc.connections.spi.ConnectionProvider from any class loader
ai.startree.shaded.org.reflections.ReflectionsException: could not get type for name org.hibernate.engine.jdbc.connections.spi.ConnectionProvider
	at ai.startree.shaded.org.reflections.ReflectionUtils.forName(ReflectionUtils.java:390) ~[startree-pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT]
	at ai.startree.shaded.org.reflections.Reflections.expandSuperTypes(Reflections.java:381) ~[startree-pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT]
	at ai.startree.shaded.org.reflections.Reflections.<init>(Reflections.java:126) ~[startree-pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-6bce1b2023b8253e658324843ba851f469694b9a]
	at io.swagger.jaxrs.config.BeanConfig.classes(BeanConfig.java:288) ~[startree-pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-6bce1b2023b8253e658324843ba851f469694b9a]
	at io.swagger.jaxrs.config.BeanConfig.scanAndRead(BeanConfig.java:250) ~[startree-pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-6bce1b2023b8253e658324843ba851f469694b9a]
	at io.swagger.jaxrs.config.BeanConfig.setScan(BeanConfig.java:231) ~[startree-pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-6bce1b2023b8253e658324843ba851f469694b9a]
	at org.apache.pinot.server.starter.helix.AdminApiApplication.setupSwagger(AdminApiApplication.java:125) ~[startree-pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar:0.11.0-SNAPSHOT-6bce1b2023b8253e658324843ba851f469694b9a]
```
It shows that the Swagger is actually scanning lots of class types and it is not helpful anyways.

## Tests done
This log cannot be reproduced in `quick-start` (not sure why), it only shows up in our pinot-all Docker image run. After this fix the log lines are gone
