### PR TITLE
Cleanup: Modify log message to indicate failure reasons when creating data directory on the server.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -122,7 +122,9 @@ public abstract class BaseTableDataManager implements TableDataManager {
     _indexDir = new File(_tableDataDir);
     if (!_indexDir.exists()) {
       Preconditions.checkState(_indexDir.mkdirs(),
-          "Unable to create index directory at %s. Check that the user has permissions on this directory.", _indexDir);
+          "Unable to create index directory at %s. "
+              + "Please check for available space and write-permissions for this directory.",
+          _indexDir);
     }
     _resourceTmpDir = new File(_indexDir, "tmp");
     // This is meant to cleanup temp resources from TableDataManager. But other code using this same
@@ -130,7 +132,8 @@ public abstract class BaseTableDataManager implements TableDataManager {
     FileUtils.deleteQuietly(_resourceTmpDir);
     if (!_resourceTmpDir.exists()) {
       Preconditions.checkState(_resourceTmpDir.mkdirs(),
-          "Unable to create temp resources directory at %s. Check that the user has permissions on this directory.",
+          "Unable to create temp resources directory at %s."
+              + "Please check for available space and write-permissions for this directory.",
           _resourceTmpDir);
     }
     _errorCache = errorCache;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -132,7 +132,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
     FileUtils.deleteQuietly(_resourceTmpDir);
     if (!_resourceTmpDir.exists()) {
       Preconditions.checkState(_resourceTmpDir.mkdirs(),
-          "Unable to create temp resources directory at %s."
+          "Unable to create temp resources directory at %s. "
               + "Please check for available space and write-permissions for this directory.",
           _resourceTmpDir);
     }


### PR DESCRIPTION
The existing log message seemed to suggest that the only reason for not being able to create data directory was due to permissions issues. Modified the log to indicate that it can also happen in case when there is no space left on device.

