### PR TITLE
isArray should return false for byte[] in ComplexTypeTransformer

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -203,7 +203,7 @@ public class ComplexTypeTransformer implements RecordTransformer {
           list.add(copy);
         }
       }
-    } else if (isArray(value)) {
+    } else if (isNonPrimitiveArray(value)) {
       if (((Object[]) value).length == 0) {
         // use the record itself
         list.add(record);
@@ -245,7 +245,7 @@ public class ComplexTypeTransformer implements RecordTransformer {
           String flattenName = concat(column, entry.getKey());
           Object nestedValue = entry.getValue();
           record.putValue(flattenName, nestedValue);
-          if (nestedValue instanceof Map || nestedValue instanceof Collection || isArray(nestedValue)) {
+          if (nestedValue instanceof Map || nestedValue instanceof Collection || isNonPrimitiveArray(nestedValue)) {
             mapColumns.add(flattenName);
           }
         }
@@ -269,7 +269,7 @@ public class ComplexTypeTransformer implements RecordTransformer {
                 String.format("Caught exception while converting value to JSON string %s", value), e);
           }
         }
-      } else if (isArray(value)) {
+      } else if (isNonPrimitiveArray(value)) {
         Object[] array = (Object[]) value;
         if (_fieldsToUnnest.contains(column)) {
           for (Object inner : array) {
@@ -324,7 +324,7 @@ public class ComplexTypeTransformer implements RecordTransformer {
       return true;
     }
     Object element = value[0];
-    return !(element instanceof Map || element instanceof Collection || isArray(element));
+    return !(element instanceof Map || element instanceof Collection || isNonPrimitiveArray(element));
   }
 
   /**
@@ -336,14 +336,11 @@ public class ComplexTypeTransformer implements RecordTransformer {
       return true;
     }
     Object element = value.iterator().next();
-    return !(element instanceof Map || element instanceof Collection || isArray(element));
+    return !(element instanceof Map || element instanceof Collection || isNonPrimitiveArray(element));
   }
 
-  protected static boolean isArray(Object obj) {
-    if (obj == null) {
-      return false;
-    }
-    return obj.getClass().isArray();
+  protected static boolean isNonPrimitiveArray(Object obj) {
+    return obj instanceof Object[];
   }
 
   private void flattenMap(String path, Map<String, Object> map, Collection<String> fields) {
@@ -357,7 +354,7 @@ public class ComplexTypeTransformer implements RecordTransformer {
           Object innerValue = innerEntry.getValue();
           String innerCancatName = concat(field, innerEntry.getKey());
           map.put(innerCancatName, innerEntry.getValue());
-          if (innerValue instanceof Map || innerValue instanceof Collection || isArray(innerValue)) {
+          if (innerValue instanceof Map || innerValue instanceof Collection || isNonPrimitiveArray(innerValue)) {
             innerMapFields.add(innerCancatName);
           }
         }
@@ -383,7 +380,7 @@ public class ComplexTypeTransformer implements RecordTransformer {
                 String.format("Caught exception while converting value to JSON string %s", value), e);
           }
         }
-      } else if (isArray(value)) {
+      } else if (isNonPrimitiveArray(value)) {
         Object[] array = (Object[]) value;
         if (_fieldsToUnnest.contains(concatName)) {
           for (Object inner : (Object[]) value) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
@@ -48,6 +48,8 @@ public class ComplexTypeTransformerTest {
     Map<String, Object> innerMap1 = new HashMap<>();
     innerMap1.put("aa", 2);
     innerMap1.put("bb", "u");
+    innerMap1.put("cc", new byte[]{1, 1});
+
     map1.put("im1", innerMap1);
     Map<String, Object> map2 = new HashMap<>();
     map2.put("c", 3);
@@ -58,6 +60,8 @@ public class ComplexTypeTransformerTest {
     Assert.assertEquals(genericRow.getValue("map1.b"), "v");
     Assert.assertEquals(genericRow.getValue("map1.im1.aa"), 2);
     Assert.assertEquals(genericRow.getValue("map1.im1.bb"), "u");
+    Assert.assertEquals(genericRow.getValue("map1.im1.cc"), new byte[]{1, 1});
+
     Assert.assertEquals(genericRow.getValue("map2.c"), 3);
 
     // test flattening the tuple inside the collection
@@ -347,7 +351,7 @@ public class ComplexTypeTransformerTest {
     transformer = new ComplexTypeTransformer(Arrays.asList(), ".",
             ComplexTypeConfig.CollectionNotUnnestedToJson.NONE, new HashMap<>());
     transformer.transform(genericRow);
-    Assert.assertTrue(ComplexTypeTransformer.isArray(genericRow.getValue("t.array1")));
+    Assert.assertTrue(ComplexTypeTransformer.isNonPrimitiveArray(genericRow.getValue("t.array1")));
   }
 
   @Test


### PR DESCRIPTION
Fixes #9146. Currently this causes `ClassCastException` issue when you have nested types with byte array values.