### PR TITLE
Upgrade netty version (4.1.74.Final -> 4.1.79.Final)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <zstd-jni.version>1.4.9-5</zstd-jni.version>
     <lz4-java.version>1.8.0</lz4-java.version>
     <log4j.version>2.17.1</log4j.version>
-    <netty.version>4.1.74.Final</netty.version>
+    <netty.version>4.1.79.Final</netty.version>
     <reactivestreams.version>1.0.3</reactivestreams.version>
     <jts.version>1.16.1</jts.version>
     <h3.version>3.7.2</h3.version>


### PR DESCRIPTION
This upgrade should remove [CVE-2022-24823](https://nvd.nist.gov/vuln/detail/CVE-2022-24823)