### PR TITLE
Improve the retry policy so that the thread doesn't sleep after the last failure

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/BaseRetryPolicy.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/BaseRetryPolicy.java
@@ -55,7 +55,7 @@ public abstract class BaseRetryPolicy implements RetryPolicy {
           Thread.sleep(getDelayMs(attempt++));
         }
       }
-      if (_maxNumAttempts>0 && Boolean.TRUE.equals(operation.call())) {
+      if (_maxNumAttempts > 0 && Boolean.TRUE.equals(operation.call())) {
         // Succeeded
         return;
       }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/BaseRetryPolicy.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/BaseRetryPolicy.java
@@ -45,8 +45,8 @@ public abstract class BaseRetryPolicy implements RetryPolicy {
   public void attempt(Callable<Boolean> operation)
       throws AttemptsExceededException, RetriableOperationException {
     int attempt = 0;
-    while (attempt < _maxNumAttempts) {
-      try {
+    try {
+      while (attempt < _maxNumAttempts - 1) {
         if (Boolean.TRUE.equals(operation.call())) {
           // Succeeded
           return;
@@ -54,9 +54,13 @@ public abstract class BaseRetryPolicy implements RetryPolicy {
           // Failed
           Thread.sleep(getDelayMs(attempt++));
         }
-      } catch (Exception e) {
-        throw new RetriableOperationException(e);
       }
+      if (Boolean.TRUE.equals(operation.call())) {
+        // Succeeded
+        return;
+      }
+    } catch (Exception e) {
+      throw new RetriableOperationException(e);
     }
     throw new AttemptsExceededException("Operation failed after " + _maxNumAttempts + " attempts");
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/BaseRetryPolicy.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/BaseRetryPolicy.java
@@ -55,7 +55,7 @@ public abstract class BaseRetryPolicy implements RetryPolicy {
           Thread.sleep(getDelayMs(attempt++));
         }
       }
-      if (Boolean.TRUE.equals(operation.call())) {
+      if (_maxNumAttempts>0 && Boolean.TRUE.equals(operation.call())) {
         // Succeeded
         return;
       }


### PR DESCRIPTION
in the previous code, if I set `_maxNumAttempts = 3` the program will do 

|action | attempt|
|-------|--------|
| try      | 0    |
| sleep      | 1    |
| try      | 1    |
| sleep      | 2    |
| try      | 2    |
| sleep      | 3    |
|break|

For failed attempts, where the last sleep is causing unnecessary hanging especially for exponential back off case. The new code will be

|action | attempt|
|-------|--------|
| try      | 0    |
| sleep      | 1    |
| try      | 1    |
| sleep      | 2    |
| break      |
|try |