### PR TITLE
Show most recent scheduling errors

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/TaskDetail.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TaskDetail.tsx
@@ -19,7 +19,6 @@
 
 import React, { useEffect, useState } from 'react';
 import { get, each } from 'lodash';
-import moment from 'moment';
 import { Grid, makeStyles } from '@material-ui/core';
 import PinotMethodUtils from '../utils/PinotMethodUtils';
 import CustomizedTables from '../components/Table';
@@ -104,9 +103,6 @@ const TaskDetail = (props) => {
           <Grid item xs={12}>
             <strong>Start Time:</strong> {get(taskDebugData, 'startTime', '')}
           </Grid>
-          {/* <Grid item xs={12}>
-            <strong>Elapsed Time:</strong> {get(taskDebugData, 'startTime') ? PinotMethodUtils.getElapsedTime(moment(get(taskDebugData, 'startTime'), 'YYYY-MM-DD hh:mm:ss')) : ''}
-          </Grid> */}
           <Grid item xs={12}>
             <strong>Finish Time:</strong> {get(taskDebugData, 'subtaskInfos.0.finishTime', '')}
           </Grid>

--- a/pinot-controller/src/main/resources/app/pages/TaskDetail.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TaskDetail.tsx
@@ -104,9 +104,9 @@ const TaskDetail = (props) => {
           <Grid item xs={12}>
             <strong>Start Time:</strong> {get(taskDebugData, 'startTime', '')}
           </Grid>
-          <Grid item xs={12}>
+          {/* <Grid item xs={12}>
             <strong>Elapsed Time:</strong> {get(taskDebugData, 'startTime') ? PinotMethodUtils.getElapsedTime(moment(get(taskDebugData, 'startTime'), 'YYYY-MM-DD hh:mm:ss')) : ''}
-          </Grid>
+          </Grid> */}
           <Grid item xs={12}>
             <strong>Finish Time:</strong> {get(taskDebugData, 'subtaskInfos.0.finishTime', '')}
           </Grid>

--- a/pinot-controller/src/main/resources/app/pages/TaskQueueTable.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TaskQueueTable.tsx
@@ -18,10 +18,10 @@
  */
 
 import React, { useEffect, useState, useContext } from 'react';
-import { get } from 'lodash';
+import { get, keys, last } from 'lodash';
 import moment from 'moment';
 import { UnControlled as CodeMirror } from 'react-codemirror2';
-import { Grid, makeStyles } from '@material-ui/core';
+import { Grid, makeStyles, Box } from '@material-ui/core';
 import { NotificationContext } from '../components/Notification/NotificationContext';
 import SimpleAccordion from '../components/SimpleAccordion';
 import CustomButton from '../components/CustomButton';
@@ -83,6 +83,7 @@ const TaskQueueTable = (props) => {
   const [fetching, setFetching] = useState(true);
   const [jobDetail, setJobDetail] = useState({});
   const [tableDetail, setTableDetail] = useState({});
+  const [mostRecentErrorRunMessage, setMostRecentErrorRunMessage] = useState('');
   const scheduleAdhocModal = useScheduleAdhocModal();
   const minionMetadata = useMinionMetadata({ taskType, tableName });
   const taskListing = useTaskListing({ taskType, tableName });
@@ -91,6 +92,10 @@ const TaskQueueTable = (props) => {
     setFetching(true);
     const detail = await PinotMethodUtils.getScheduleJobDetail(tableName, taskType);
     const tableDetailRes = await PinotMethodUtils.getTableDetails(tableName);
+    const taskGeneratorDebugData = await PinotMethodUtils.getTaskGeneratorDebugData(tableName, taskType);
+    const mostRecentSuccessRunTS = get(taskGeneratorDebugData, 'data.0.mostRecentErrorRunMessage', {});
+    const mostRecentSuccessRunTSLastTime = last(keys(mostRecentSuccessRunTS).sort());
+    setMostRecentErrorRunMessage(get(mostRecentSuccessRunTS, mostRecentSuccessRunTSLastTime, ''));
     setTableDetail(tableDetailRes);
     setJobDetail(detail);
     setFetching(false);
@@ -197,7 +202,9 @@ const TaskQueueTable = (props) => {
               headerTitle="Scheduling Errors"
               showSearchBox={false}
             >
-              
+              <Box p={3}>
+                {mostRecentErrorRunMessage}
+              </Box>
             </SimpleAccordion>
           </div>
         </Grid>

--- a/pinot-controller/src/main/resources/app/pages/TaskQueueTable.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TaskQueueTable.tsx
@@ -202,7 +202,7 @@ const TaskQueueTable = (props) => {
               headerTitle="Scheduling Errors"
               showSearchBox={false}
             >
-              <Box p={3} style={{ wordBreak: 'break-all' }}>
+              <Box p={3} style={{ overflow: 'auto' }}>
                 {mostRecentErrorRunMessage}
               </Box>
             </SimpleAccordion>

--- a/pinot-controller/src/main/resources/app/pages/TaskQueueTable.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TaskQueueTable.tsx
@@ -202,7 +202,7 @@ const TaskQueueTable = (props) => {
               headerTitle="Scheduling Errors"
               showSearchBox={false}
             >
-              <Box p={3}>
+              <Box p={3} style={{ wordBreak: 'break-all' }}>
                 {mostRecentErrorRunMessage}
               </Box>
             </SimpleAccordion>

--- a/pinot-controller/src/main/resources/app/pages/TaskQueueTable.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TaskQueueTable.tsx
@@ -93,9 +93,9 @@ const TaskQueueTable = (props) => {
     const detail = await PinotMethodUtils.getScheduleJobDetail(tableName, taskType);
     const tableDetailRes = await PinotMethodUtils.getTableDetails(tableName);
     const taskGeneratorDebugData = await PinotMethodUtils.getTaskGeneratorDebugData(tableName, taskType);
-    const mostRecentSuccessRunTS = get(taskGeneratorDebugData, 'data.0.mostRecentErrorRunMessage', {});
-    const mostRecentSuccessRunTSLastTime = last(keys(mostRecentSuccessRunTS).sort());
-    setMostRecentErrorRunMessage(get(mostRecentSuccessRunTS, mostRecentSuccessRunTSLastTime, ''));
+    const mostRecentErrorRunMessagesTS = get(taskGeneratorDebugData, 'data.0.mostRecentErrorRunMessages', {});
+    const mostRecentErrorRunMessagesTSLastTime = last(keys(mostRecentErrorRunMessagesTS).sort());
+    setMostRecentErrorRunMessage(get(mostRecentErrorRunMessagesTS, mostRecentErrorRunMessagesTSLastTime, ''));
     setTableDetail(tableDetailRes);
     setJobDetail(detail);
     setFetching(false);

--- a/pinot-controller/src/main/resources/app/requests/index.ts
+++ b/pinot-controller/src/main/resources/app/requests/index.ts
@@ -129,6 +129,9 @@ export const getTasks = (tableName: string, taskType: string): Promise<AxiosResp
 export const getTaskDebug = (taskName: string): Promise<AxiosResponse<OperationResponse>> =>
   baseApi.get(`/tasks/task/${taskName}/debug?verbosity=1`, { headers: { ...headers, Accept: 'application/json' } });
 
+export const getTaskGeneratorDebug = (taskName: string, taskType: string): Promise<AxiosResponse<OperationResponse>> =>
+  baseApi.get(`/tasks/generator/${taskName}/${taskType}/debug`, { headers: { ...headers, Accept: 'application/json' } });
+
 export const getTaskTypeDebug = (taskType: string): Promise<AxiosResponse<OperationResponse>> =>
   baseApi.get(`/tasks/${taskType}/debug?verbosity=1`, { headers: { ...headers, Accept: 'application/json' } });
 

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -44,6 +44,7 @@ import {
   getMinionMeta,
   getTasks,
   getTaskDebug,
+  getTaskGeneratorDebug,
   updateInstanceTags,
   getClusterConfig,
   getQueryTables,
@@ -797,7 +798,7 @@ const getElapsedTime = (startTime) => {
 
 const getTasksList = async (tableName, taskType) => {
   const finalResponse = {
-    columns: ['Task ID', 'Status', 'Start Time', 'Elapsed Time', 'Finish Time', 'Num of Sub Tasks'],
+    columns: ['Task ID', 'Status', 'Start Time', /*'Elapsed Time',*/ 'Finish Time', 'Num of Sub Tasks'],
     records: []
   }
   await new Promise((resolve, reject) => {
@@ -810,7 +811,7 @@ const getTasksList = async (tableName, taskType) => {
           taskID,
           status,
           get(debugData, 'data.subtaskInfos.0.startTime'),
-          startTime ? getElapsedTime(startTime) : '',
+          // startTime ? getElapsedTime(startTime) : '',
           get(debugData, 'data.subtaskInfos.0.finishTime', ''),
           get(debugData, 'data.subtaskCount.total', 0)
         ]);
@@ -827,6 +828,11 @@ const getTasksList = async (tableName, taskType) => {
 
 const getTaskDebugData = async (taskName) => {
   const debugRes = await getTaskDebug(taskName);
+  return debugRes;
+};
+
+const getTaskGeneratorDebugData = async (taskName, taskType) => {
+  const debugRes = await getTaskGeneratorDebug(taskName, taskType);
   return debugRes;
 };
 
@@ -1102,6 +1108,7 @@ export default {
   getElapsedTime,
   getTasksList,
   getTaskDebugData,
+  getTaskGeneratorDebugData,
   deleteSegmentOp,
   reloadSegmentOp,
   reloadStatusOp,

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -798,7 +798,7 @@ const getElapsedTime = (startTime) => {
 
 const getTasksList = async (tableName, taskType) => {
   const finalResponse = {
-    columns: ['Task ID', 'Status', 'Start Time', /*'Elapsed Time',*/ 'Finish Time', 'Num of Sub Tasks'],
+    columns: ['Task ID', 'Status', 'Start Time', 'Finish Time', 'Num of Sub Tasks'],
     records: []
   }
   await new Promise((resolve, reject) => {
@@ -811,7 +811,6 @@ const getTasksList = async (tableName, taskType) => {
           taskID,
           status,
           get(debugData, 'data.subtaskInfos.0.startTime'),
-          // startTime ? getElapsedTime(startTime) : '',
           get(debugData, 'data.subtaskInfos.0.finishTime', ''),
           get(debugData, 'data.subtaskCount.total', 0)
         ]);


### PR DESCRIPTION
On the TaskName->TableName page, the SCHEDULING ERRORS was previously TBD. Now we have the API for it: GET /tasks/generator/{tableNameWithType}/{taskType}/debug