### PR TITLE
Add flag to allow skipping decoder exceptions in LLRealtimeSegmentDataManager #9045

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -38,6 +38,7 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
+import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.config.TableConfigUtils;
 import org.apache.pinot.core.data.manager.offline.TableDataManagerProvider;
@@ -68,8 +69,10 @@ import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
@@ -118,11 +121,11 @@ public class LLRealtimeSegmentDataManagerTest {
 
   private FakeLLRealtimeSegmentDataManager createFakeSegmentManager()
       throws Exception {
-    return createFakeSegmentManager(false, new TimeSupplier(), null, null);
+    return createFakeSegmentManager(false, new TimeSupplier(), null, null, false);
   }
 
   private FakeLLRealtimeSegmentDataManager createFakeSegmentManager(boolean noUpsert, TimeSupplier timeSupplier,
-      @Nullable String maxRows, @Nullable String maxDuration)
+      @Nullable String maxRows, @Nullable String maxDuration, boolean injectErrors)
       throws Exception {
     SegmentZKMetadata segmentZKMetadata = createZkMetadata();
     TableConfig tableConfig = createTableConfig();
@@ -137,6 +140,8 @@ public class LLRealtimeSegmentDataManagerTest {
       tableConfig.getIndexingConfig().getStreamConfigs()
           .put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME, maxDuration);
     }
+    tableConfig.getIndexingConfig().getStreamConfigs()
+        .put("stream.fakeStream.decoder.prop.throwExceptions", Boolean.toString(injectErrors));
     RealtimeTableDataManager tableDataManager = createTableDataManager(tableConfig);
     LLCSegmentName llcSegmentName = new LLCSegmentName(SEGMENT_NAME_STR);
     _partitionGroupIdToSemaphoreMap.putIfAbsent(PARTITION_GROUP_ID, new Semaphore(1));
@@ -773,7 +778,7 @@ public class LLRealtimeSegmentDataManagerTest {
       }
     };
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager(true, timeSupplier,
-        String.valueOf(FakeStreamConfigUtils.SEGMENT_FLUSH_THRESHOLD_ROWS * 2), segmentTimeThresholdMins + "m");
+        String.valueOf(FakeStreamConfigUtils.SEGMENT_FLUSH_THRESHOLD_ROWS * 2), segmentTimeThresholdMins + "m", false);
     segmentDataManager._stubConsumeLoop = false;
     segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.INITIAL_CONSUMING);
 
@@ -812,7 +817,7 @@ public class LLRealtimeSegmentDataManagerTest {
     TimeSupplier timeSupplier = new TimeSupplier();
     FakeLLRealtimeSegmentDataManager segmentDataManager =
         createFakeSegmentManager(true, timeSupplier, String.valueOf(FakeStreamConfigUtils.SEGMENT_FLUSH_THRESHOLD_ROWS),
-            segmentTimeThresholdMins + "m");
+            segmentTimeThresholdMins + "m", false);
     segmentDataManager._stubConsumeLoop = false;
     segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.INITIAL_CONSUMING);
 
@@ -843,6 +848,38 @@ public class LLRealtimeSegmentDataManagerTest {
     }
   }
 
+  @Test
+  public void testShouldStopConsumptionWhenNotBeAbleDecodeMessage()
+      throws Exception {
+    final int segmentTimeThresholdMins = 10;
+    TimeSupplier timeSupplier = new TimeSupplier();
+    FakeLLRealtimeSegmentDataManager segmentDataManager =
+        createFakeSegmentManager(true, timeSupplier, String.valueOf(FakeStreamConfigUtils.SEGMENT_FLUSH_THRESHOLD_ROWS),
+            segmentTimeThresholdMins + "m", true);
+    segmentDataManager._stubConsumeLoop = false;
+    segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.INITIAL_CONSUMING);
+
+    LLRealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
+    final LongMsgOffset endOffset =
+        new LongMsgOffset(START_OFFSET_VALUE + FakeStreamConfigUtils.SEGMENT_FLUSH_THRESHOLD_ROWS);
+    segmentDataManager._consumeOffsets.add(endOffset);
+    final SegmentCompletionProtocol.Response response = new SegmentCompletionProtocol.Response(
+        new SegmentCompletionProtocol.Response.Params().withStatus(
+                SegmentCompletionProtocol.ControllerResponseStatus.COMMIT)
+            .withStreamPartitionMsgOffset(endOffset.toString()));
+    segmentDataManager._responses.add(response);
+
+    consumer.run();
+
+    try {
+      Assert.assertEquals(segmentDataManager.getConsumerState(), CommonConstants.ConsumerState.NOT_CONSUMING);
+      verify(segmentDataManager.getRealtimeTableDataManager()).addSegmentError(eq(SEGMENT_NAME_STR),
+          any(SegmentErrorInfo.class));
+    } finally {
+      segmentDataManager.destroy();
+    }
+  }
+
   private static class TimeSupplier implements Supplier<Long> {
     protected final AtomicInteger _timeCheckCounter = new AtomicInteger();
     protected long _timeNow = System.currentTimeMillis();
@@ -868,6 +905,7 @@ public class LLRealtimeSegmentDataManagerTest {
     public Field _shouldStop;
     public Field _stopReason;
     private Field _streamMsgOffsetFactory;
+    private Field _realtimeTableDataManager;
     public LinkedList<LongMsgOffset> _consumeOffsets = new LinkedList<>();
     public LinkedList<SegmentCompletionProtocol.Response> _responses = new LinkedList<>();
     public boolean _commitSegmentCalled = false;
@@ -907,6 +945,8 @@ public class LLRealtimeSegmentDataManagerTest {
       _shouldStop.setAccessible(true);
       _stopReason = LLRealtimeSegmentDataManager.class.getDeclaredField("_stopReason");
       _stopReason.setAccessible(true);
+      _realtimeTableDataManager = LLRealtimeSegmentDataManager.class.getDeclaredField("_realtimeTableDataManager");
+      _realtimeTableDataManager.setAccessible(true);
       _semaphoreMap = semaphoreMap;
       _streamMsgOffsetFactory = LLRealtimeSegmentDataManager.class.getDeclaredField("_streamPartitionMsgOffsetFactory");
       _streamMsgOffsetFactory.setAccessible(true);
@@ -921,6 +961,14 @@ public class LLRealtimeSegmentDataManagerTest {
         Assert.fail();
       }
       return null;
+    }
+
+    private RealtimeTableDataManager getRealtimeTableDataManager() {
+      try {
+        return (RealtimeTableDataManager) _realtimeTableDataManager.get(this);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
     }
 
     public PartitionConsumer createPartitionConsumer() {

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamMessageDecoder.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamMessageDecoder.java
@@ -29,13 +29,21 @@ import org.apache.pinot.spi.stream.StreamMessageDecoder;
  * StreamMessageDecoder implementation for fake stream
  */
 public class FakeStreamMessageDecoder implements StreamMessageDecoder<byte[]> {
+  public static final String THROW_EXCEPTIONS = "throwExceptions";
+  private long _counter = 0;
+  private boolean _throwException = false;
 
   @Override
   public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName) {
+    _throwException = Boolean.valueOf(props.get(THROW_EXCEPTIONS));
   }
 
   @Override
   public GenericRow decode(byte[] payload, GenericRow destination) {
+    _counter++;
+    if (_throwException && _counter % 2 != 0) {
+      throw new RuntimeException("there is a problem");
+    }
     GenericRow row = Fixtures.createSingleRow(System.currentTimeMillis());
     destination.init(row);
     return destination;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -58,6 +58,8 @@ public class StreamConfig {
   public static final int DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS = 5_000;
   public static final int DEFAULT_IDLE_TIMEOUT_MILLIS = 3 * 60 * 1000;
 
+  public static final String DEFAULT_STREAM_DECODER_ERRORS_IGNORE = "false";
+
   private static final String SIMPLE_CONSUMER_TYPE_STRING = "simple";
 
   private static final double CONSUMPTION_RATE_LIMIT_NOT_SPECIFIED = -1;
@@ -68,6 +70,7 @@ public class StreamConfig {
   private final List<ConsumerType> _consumerTypes = new ArrayList<>();
   private final String _consumerFactoryClassName;
   private final String _decoderClass;
+  private final boolean _decoderErrorsIgnore;
   private final Map<String, String> _decoderProperties = new HashMap<>();
 
   private final long _connectionTimeoutMillis;
@@ -136,6 +139,8 @@ public class StreamConfig {
         StreamConfigProperties.constructStreamProperty(_type, StreamConfigProperties.STREAM_DECODER_CLASS);
     _decoderClass = streamConfigMap.get(decoderClassKey);
     Preconditions.checkNotNull(_decoderClass, "Must specify decoder class name " + decoderClassKey);
+
+    _decoderErrorsIgnore = extractDecoderErrorsIgnore(streamConfigMap);
 
     String streamDecoderPropPrefix =
         StreamConfigProperties.constructStreamProperty(_type, StreamConfigProperties.DECODER_PROPS_PREFIX);
@@ -283,6 +288,12 @@ public class StreamConfig {
     }
   }
 
+  protected boolean extractDecoderErrorsIgnore(Map<String, String> streamConfigMap) {
+    String key = StreamConfigProperties.STREAM_DECODER_ERRORS_IGNORE;
+    String decoderErrorsIgnore = streamConfigMap.getOrDefault(key, DEFAULT_STREAM_DECODER_ERRORS_IGNORE);
+    return Boolean.valueOf(decoderErrorsIgnore);
+  }
+
   public String getType() {
     return _type;
   }
@@ -317,6 +328,10 @@ public class StreamConfig {
 
   public String getDecoderClass() {
     return _decoderClass;
+  }
+
+  public boolean getDecoderErrorsIgnore() {
+    return _decoderErrorsIgnore;
   }
 
   public Map<String, String> getDecoderProperties() {
@@ -376,9 +391,10 @@ public class StreamConfig {
         + _fetchTimeoutMillis + ", _idleTimeoutMillis=" + _idleTimeoutMillis + ", _flushThresholdRows="
         + _flushThresholdRows + ", _flushThresholdTimeMillis=" + _flushThresholdTimeMillis
         + ", _flushSegmentDesiredSizeBytes=" + _flushThresholdSegmentSizeBytes + ", _flushAutotuneInitialRows="
-        + _flushAutotuneInitialRows + ", _decoderClass='" + _decoderClass + '\'' + ", _decoderProperties="
-        + _decoderProperties + ", _groupId='" + _groupId + "', _topicConsumptionRateLimit=" + _topicConsumptionRateLimit
-        + ", _tableNameWithType='" + _tableNameWithType + '}';
+        + _flushAutotuneInitialRows + ", _decoderClass='" + _decoderClass + '\'' + ", _decoderErrorsIgnore='"
+        + _decoderErrorsIgnore + '\'' + ", _decoderProperties=" + _decoderProperties + ", _groupId='" + _groupId
+        + "', _topicConsumptionRateLimit=" + _topicConsumptionRateLimit + ", _tableNameWithType='" + _tableNameWithType
+        + '}';
   }
 
   @Override
@@ -402,10 +418,11 @@ public class StreamConfig {
         && EqualityUtils.isEqual(_topicName, that._topicName) && EqualityUtils.isEqual(_consumerTypes,
         that._consumerTypes) && EqualityUtils.isEqual(_consumerFactoryClassName, that._consumerFactoryClassName)
         && EqualityUtils.isEqual(_offsetCriteria, that._offsetCriteria) && EqualityUtils.isEqual(_decoderClass,
-        that._decoderClass) && EqualityUtils.isEqual(_decoderProperties, that._decoderProperties)
-        && EqualityUtils.isEqual(_groupId, that._groupId) && EqualityUtils.isEqual(_tableNameWithType,
-        that._tableNameWithType) && EqualityUtils.isEqual(_topicConsumptionRateLimit, that._topicConsumptionRateLimit)
-        && EqualityUtils.isEqual(_streamConfigMap, that._streamConfigMap);
+        that._decoderClass) && EqualityUtils.isEqual(_decoderErrorsIgnore, that._decoderErrorsIgnore)
+        && EqualityUtils.isEqual(_decoderProperties, that._decoderProperties) && EqualityUtils.isEqual(_groupId,
+        that._groupId) && EqualityUtils.isEqual(_tableNameWithType, that._tableNameWithType) && EqualityUtils.isEqual(
+        _topicConsumptionRateLimit, that._topicConsumptionRateLimit) && EqualityUtils.isEqual(_streamConfigMap,
+        that._streamConfigMap);
   }
 
   @Override
@@ -423,6 +440,7 @@ public class StreamConfig {
     result = EqualityUtils.hashCodeOf(result, _flushThresholdSegmentSizeBytes);
     result = EqualityUtils.hashCodeOf(result, _flushAutotuneInitialRows);
     result = EqualityUtils.hashCodeOf(result, _decoderClass);
+    result = EqualityUtils.hashCodeOf(result, _decoderErrorsIgnore);
     result = EqualityUtils.hashCodeOf(result, _decoderProperties);
     result = EqualityUtils.hashCodeOf(result, _groupId);
     result = EqualityUtils.hashCodeOf(result, _topicConsumptionRateLimit);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
@@ -45,6 +45,7 @@ public class StreamConfigProperties {
   public static final String STREAM_CONNECTION_TIMEOUT_MILLIS = "connection.timeout.millis";
   public static final String STREAM_IDLE_TIMEOUT_MILLIS = "idle.timeout.millis";
   public static final String STREAM_DECODER_CLASS = "decoder.class.name";
+  public static final String STREAM_DECODER_ERRORS_IGNORE = "decoder.errors.ignore";
   public static final String DECODER_PROPS_PREFIX = "decoder.prop";
   public static final String GROUP_ID = "hlc.group.id";
   public static final String PARTITION_MSG_OFFSET_FACTORY_CLASS = "partition.offset.factory.class.name";


### PR DESCRIPTION
Helps fixing #9045

This flag can be used to control whether exceptions thrown by the decoder should be ignore. For example, at the moment the CSV decoder throw an exception if the payload cannot be decoded, this stops consumption. With this flag users may decide to ignore these errors and continue consumption.

Exception will be retied by the consumption loop until the maximum number of retires is reached.

Decoders internally may decide to retry themselves when an exception is thrown and bubble up the exception as a last resort 