### PR TITLE
Add readiness metric to pinot-server

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -75,6 +75,9 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   INDEXING_FAILURES("attributeValues", true),
   QUERY_HAS_MV_SELECTION_ORDER_BY("queryHasMVSelectionOrderBy", false),
 
+  HEALTHCHECK_OK_CALLS("healthcheck", true),
+  HEALTHCHECK_BAD_CALLS("healthcheck", true),
+
   // Netty connection metrics
   NETTY_CONNECTION_BYTES_RECEIVED("nettyConnection", true),
   NETTY_CONNECTION_RESPONSES_SENT("nettyConnection", true),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -75,8 +75,8 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   INDEXING_FAILURES("attributeValues", true),
   QUERY_HAS_MV_SELECTION_ORDER_BY("queryHasMVSelectionOrderBy", false),
 
-  HEALTHCHECK_OK_CALLS("healthcheck", true),
-  HEALTHCHECK_BAD_CALLS("healthcheck", true),
+  READINESS_CHECK_OK_CALLS("readinessCheck", true),
+  READINESS_CHECK_BAD_CALLS("readinessCheck", true),
 
   // Netty connection metrics
   NETTY_CONNECTION_BYTES_RECEIVED("nettyConnection", true),

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/HealthCheckResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/HealthCheckResource.java
@@ -66,7 +66,7 @@ public class HealthCheckResource {
     if ("liveness".equalsIgnoreCase(checkType)) {
       return "OK";
     } else {
-      return getReadinessStatus(_instanceId);
+      return getReadinessStatus();
     }
   }
 
@@ -92,16 +92,16 @@ public class HealthCheckResource {
       @ApiResponse(code = 503, message = "Server is not ready to serve queries")
   })
   public String checkReadiness() {
-    return getReadinessStatus(_instanceId);
+    return getReadinessStatus();
   }
 
-  private String getReadinessStatus(String instanceId) throws WebApplicationException {
-    Status status = ServiceStatus.getServiceStatus(instanceId);
+  private String getReadinessStatus() throws WebApplicationException {
+    Status status = ServiceStatus.getServiceStatus(_instanceId);
     if (status == Status.GOOD) {
-      _serverMetrics.addMeteredGlobalValue(ServerMeter.HEALTHCHECK_OK_CALLS, 1);
+      _serverMetrics.addMeteredGlobalValue(ServerMeter.READINESS_CHECK_OK_CALLS, 1);
       return "OK";
     }
-    _serverMetrics.addMeteredGlobalValue(ServerMeter.HEALTHCHECK_BAD_CALLS, 1);
+    _serverMetrics.addMeteredGlobalValue(ServerMeter.READINESS_CHECK_BAD_CALLS, 1);
     String errMessage = String.format("Pinot server status is %s", status);
     Response response =
         Response.status(Response.Status.SERVICE_UNAVAILABLE).entity(errMessage).build();

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/AdminApiApplication.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/AdminApiApplication.java
@@ -28,6 +28,7 @@ import java.util.List;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
+import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
 import org.apache.pinot.server.access.AccessControlFactory;
@@ -66,6 +67,7 @@ public class AdminApiApplication extends ResourceConfig {
       @Override
       protected void configure() {
         bind(_serverInstance).to(ServerInstance.class);
+        bind(_serverInstance.getServerMetrics()).to(ServerMetrics.class);
         bind(accessControlFactory).to(AccessControlFactory.class);
         bind(serverConf.getProperty(CommonConstants.Server.CONFIG_OF_INSTANCE_ID)).named(SERVER_INSTANCE_ID);
       }

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/AccessControlTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/AccessControlTest.java
@@ -31,6 +31,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.config.TlsConfig;
+import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.auth.BasicAuthUtils;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.server.access.AccessControl;
@@ -53,6 +54,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 public class AccessControlTest {
@@ -71,6 +73,7 @@ public class AccessControlTest {
     // Mock the instance data manager
     // Mock the server instance
     ServerInstance serverInstance = mock(ServerInstance.class);
+    when(serverInstance.getServerMetrics()).thenReturn(mock(ServerMetrics.class));
 
     PinotConfiguration serverConf = DefaultHelixStarterServerConfig.loadDefaultServerConf();
     String hostname = serverConf.getProperty(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST,

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
@@ -107,6 +107,7 @@ public abstract class BaseResourceTest {
 
     // Mock the server instance
     ServerInstance serverInstance = mock(ServerInstance.class);
+    when(serverInstance.getServerMetrics()).thenReturn(mock(ServerMetrics.class));
     when(serverInstance.getInstanceDataManager()).thenReturn(instanceDataManager);
     when(serverInstance.getInstanceDataManager().getSegmentFileDirectory())
         .thenReturn(FileUtils.getTempDirectoryPath());


### PR DESCRIPTION
## What does this PR do?
This code allows pinot-server emit metric based upon readiness check results similar to pinot-controller (see [PinotControllerHealthCheck#L84](https://github.com/apache/pinot/blob/master/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerHealthCheck.java#L84).

Two meters were added in correspondence with pinot-controller meters:
* `readinessCheckOkCalls`
* `readinessCheckBadCalls`

## How was the code tested?
* Unit tests have passed
* Verified cluster restart


I couldn't apply labels due to lack of permissions, would appreciate someone applying "feature" or "enhancement" as necessary. 