### PR TITLE
Handle nulls in all SELECT paths

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/queries/AllNullQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/AllNullQueriesTest.java
@@ -288,6 +288,19 @@ public class AllNullQueriesTest extends BaseQueriesTest {
     Map<String, String> queryOptions = new HashMap<>();
     queryOptions.put("enableNullHandling", "true");
     DataType dataType = columnDataType.toDataType();
+    {
+      String query = String.format("SELECT %s FROM testTable WHERE %s is null limit 5000", COLUMN_NAME, COLUMN_NAME);
+      BrokerResponseNative brokerResponse = getBrokerResponse(query, queryOptions);
+      ResultTable resultTable = brokerResponse.getResultTable();
+      DataSchema dataSchema = resultTable.getDataSchema();
+      assertEquals(dataSchema,
+          new DataSchema(new String[]{COLUMN_NAME}, new ColumnDataType[]{columnDataType}));
+      List<Object[]> rows = resultTable.getRows();
+      assertEquals(rows.size(), 4000);
+      for (Object[] row : rows) {
+        assertNull(row[0]);
+      }
+    }
     if (columnDataType != ColumnDataType.STRING) {
       {
         String query = String.format(


### PR DESCRIPTION
Found one SELECT path where we don't handle nulls. Updated another path to handle nulls properly:

1. Handle nulls after extracting the row before it is added to rows.
2. We could do it after it is being added by looping through numRows starting from index = previous rows.size(). 1 is cleaner so I went with it.

`bugfix`