### PR TITLE
Support partitioned assignment with single replica

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineSegmentAssignment.java
@@ -106,8 +106,8 @@ public class OfflineSegmentAssignment implements SegmentAssignment {
 
     List<String> instancesAssigned = assignSegment(segmentName, currentAssignment, instancePartitions);
 
-    LOGGER
-        .info("Assigned segment: {} to instances: {} for table: {}", segmentName, instancesAssigned, _offlineTableName);
+    LOGGER.info("Assigned segment: {} to instances: {} for table: {}", segmentName, instancesAssigned,
+        _offlineTableName);
     return instancesAssigned;
   }
 
@@ -136,8 +136,8 @@ public class OfflineSegmentAssignment implements SegmentAssignment {
     if (numReplicaGroups == 1) {
       // Non-replica-group based assignment
 
-      return SegmentAssignmentUtils
-          .assignSegmentWithoutReplicaGroup(currentAssignment, instancePartitions, _replication);
+      return SegmentAssignmentUtils.assignSegmentWithoutReplicaGroup(currentAssignment, instancePartitions,
+          _replication);
     } else {
       // Replica-group based assignment
 
@@ -146,11 +146,11 @@ public class OfflineSegmentAssignment implements SegmentAssignment {
       if (_partitionColumn == null) {
         partitionId = 0;
       } else {
-        SegmentZKMetadata segmentZKMetadata = ZKMetadataProvider
-            .getSegmentZKMetadata(_helixManager.getHelixPropertyStore(), _offlineTableName, segmentName);
-        Preconditions
-            .checkState(segmentZKMetadata != null, "Failed to find segment ZK metadata for segment: %s of table: %s",
-                segmentName, _offlineTableName);
+        SegmentZKMetadata segmentZKMetadata =
+            ZKMetadataProvider.getSegmentZKMetadata(_helixManager.getHelixPropertyStore(), _offlineTableName,
+                segmentName);
+        Preconditions.checkState(segmentZKMetadata != null,
+            "Failed to find segment ZK metadata for segment: %s of table: %s", segmentName, _offlineTableName);
         int segmentPartitionId = getPartitionId(segmentZKMetadata);
 
         // Uniformly spray the segment partitions over the instance partitions
@@ -167,9 +167,8 @@ public class OfflineSegmentAssignment implements SegmentAssignment {
       Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap, @Nullable List<Tier> sortedTiers,
       @Nullable Map<String, InstancePartitions> tierInstancePartitionsMap, Configuration config) {
     InstancePartitions offlineInstancePartitions = instancePartitionsMap.get(InstancePartitionsType.OFFLINE);
-    Preconditions
-        .checkState(offlineInstancePartitions != null, "Failed to find OFFLINE instance partitions for table: %s",
-            _offlineTableName);
+    Preconditions.checkState(offlineInstancePartitions != null,
+        "Failed to find OFFLINE instance partitions for table: %s", _offlineTableName);
     boolean bootstrap =
         config.getBoolean(RebalanceConfigConstants.BOOTSTRAP, RebalanceConfigConstants.DEFAULT_BOOTSTRAP);
 
@@ -194,9 +193,8 @@ public class OfflineSegmentAssignment implements SegmentAssignment {
         Map<String, Map<String, String>> tierCurrentAssignment = entry.getValue();
 
         InstancePartitions tierInstancePartitions = tierInstancePartitionsMap.get(tierName);
-        Preconditions
-            .checkNotNull(tierInstancePartitions, "Failed to find instance partitions for tier: %s of table: %s",
-                tierName, _offlineTableName);
+        Preconditions.checkNotNull(tierInstancePartitions,
+            "Failed to find instance partitions for tier: %s of table: %s", tierName, _offlineTableName);
         checkReplication(tierInstancePartitions);
 
         LOGGER.info("Rebalancing tier: {} for table: {} with bootstrap: {}, instance partitions: {}", tierName,
@@ -239,8 +237,8 @@ public class OfflineSegmentAssignment implements SegmentAssignment {
       newAssignment = new TreeMap<>();
       for (String segment : currentAssignment.keySet()) {
         List<String> assignedInstances = assignSegment(segment, newAssignment, instancePartitions);
-        newAssignment
-            .put(segment, SegmentAssignmentUtils.getInstanceStateMap(assignedInstances, SegmentStateModel.ONLINE));
+        newAssignment.put(segment,
+            SegmentAssignmentUtils.getInstanceStateMap(assignedInstances, SegmentStateModel.ONLINE));
       }
     } else {
       int numReplicaGroups = instancePartitions.getNumReplicaGroups();
@@ -249,8 +247,9 @@ public class OfflineSegmentAssignment implements SegmentAssignment {
 
         List<String> instances =
             SegmentAssignmentUtils.getInstancesForNonReplicaGroupBasedAssignment(instancePartitions, _replication);
-        newAssignment = SegmentAssignmentUtils
-            .rebalanceTableWithHelixAutoRebalanceStrategy(currentAssignment, instances, _replication);
+        newAssignment =
+            SegmentAssignmentUtils.rebalanceTableWithHelixAutoRebalanceStrategy(currentAssignment, instances,
+                _replication);
       } else {
         // Replica-group based assignment
 
@@ -262,8 +261,8 @@ public class OfflineSegmentAssignment implements SegmentAssignment {
           Collections.shuffle(segments, new Random(_offlineTableName.hashCode()));
 
           newAssignment = new TreeMap<>();
-          SegmentAssignmentUtils
-              .rebalanceReplicaGroupBasedPartition(currentAssignment, instancePartitions, 0, segments, newAssignment);
+          SegmentAssignmentUtils.rebalanceReplicaGroupBasedPartition(currentAssignment, instancePartitions, 0, segments,
+              newAssignment);
         } else {
           newAssignment = rebalanceTableWithPartition(currentAssignment, instancePartitions);
         }
@@ -297,8 +296,8 @@ public class OfflineSegmentAssignment implements SegmentAssignment {
       Collections.shuffle(segments, random);
     }
 
-    return SegmentAssignmentUtils
-        .rebalanceReplicaGroupBasedTable(currentAssignment, instancePartitions, instancePartitionIdToSegmentsMap);
+    return SegmentAssignmentUtils.rebalanceReplicaGroupBasedTable(currentAssignment, instancePartitions,
+        instancePartitionIdToSegmentsMap);
   }
 
   private int getPartitionId(SegmentZKMetadata segmentZKMetadata) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtils.java
@@ -74,10 +74,10 @@ public class SegmentAssignmentUtils {
    */
   public static List<String> getInstancesForNonReplicaGroupBasedAssignment(InstancePartitions instancePartitions,
       int replication) {
-    Preconditions
-        .checkState(instancePartitions.getNumReplicaGroups() == 1 && instancePartitions.getNumPartitions() == 1,
-            "Instance partitions: %s should contain 1 replica and 1 partition for non-replica-group based assignment",
-            instancePartitions.getInstancePartitionsName());
+    Preconditions.checkState(
+        instancePartitions.getNumReplicaGroups() == 1 && instancePartitions.getNumPartitions() == 1,
+        "Instance partitions: %s should contain 1 replica and 1 partition for non-replica-group based assignment",
+        instancePartitions.getInstancePartitionsName());
     List<String> instances = instancePartitions.getInstances(0, 0);
     int numInstances = instances.size();
     Preconditions.checkState(numInstances >= replication,
@@ -129,8 +129,8 @@ public class SegmentAssignmentUtils {
     int numReplicaGroups = instancePartitions.getNumReplicaGroups();
     List<String> instancesAssigned = new ArrayList<>(numReplicaGroups);
     for (int replicaGroupId = 0; replicaGroupId < numReplicaGroups; replicaGroupId++) {
-      instancesAssigned
-          .add(instancePartitions.getInstances(partitionId, replicaGroupId).get(instanceIdWithLeastSegmentsAssigned));
+      instancesAssigned.add(
+          instancePartitions.getInstances(partitionId, replicaGroupId).get(instanceIdWithLeastSegmentsAssigned));
     }
     return instancesAssigned;
   }
@@ -168,9 +168,8 @@ public class SegmentAssignmentUtils {
       // Uniformly spray the segment partitions over the instance partitions
       int instancePartitionId = entry.getKey();
       List<String> segments = entry.getValue();
-      SegmentAssignmentUtils
-          .rebalanceReplicaGroupBasedPartition(currentAssignment, instancePartitions, instancePartitionId, segments,
-              newAssignment);
+      SegmentAssignmentUtils.rebalanceReplicaGroupBasedPartition(currentAssignment, instancePartitions,
+          instancePartitionId, segments, newAssignment);
     }
     return newAssignment;
   }
@@ -215,8 +214,8 @@ public class SegmentAssignmentUtils {
       for (String instanceName : currentAssignment.get(segmentName).keySet()) {
         Integer instanceId = instanceNameToIdMap.get(instanceName);
         if (instanceId != null && numSegmentsAssignedPerInstance[instanceId] < targetNumSegmentsPerInstance) {
-          newAssignment
-              .put(segmentName, getReplicaGroupBasedInstanceStateMap(instancePartitions, partitionId, instanceId));
+          newAssignment.put(segmentName,
+              getReplicaGroupBasedInstanceStateMap(instancePartitions, partitionId, instanceId));
           numSegmentsAssignedPerInstance[instanceId]++;
           segmentAssigned = true;
           break;
@@ -251,8 +250,8 @@ public class SegmentAssignmentUtils {
     Map<String, String> instanceStateMap = new TreeMap<>();
     int numReplicaGroups = instancePartitions.getNumReplicaGroups();
     for (int replicaGroupId = 0; replicaGroupId < numReplicaGroups; replicaGroupId++) {
-      instanceStateMap
-          .put(instancePartitions.getInstances(partitionId, replicaGroupId).get(instanceId), SegmentStateModel.ONLINE);
+      instanceStateMap.put(instancePartitions.getInstances(partitionId, replicaGroupId).get(instanceId),
+          SegmentStateModel.ONLINE);
     }
     return instanceStateMap;
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineNonReplicaGroupTieredSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineNonReplicaGroupTieredSegmentAssignmentTest.java
@@ -132,11 +132,10 @@ public class OfflineNonReplicaGroupTieredSegmentAssignmentTest {
     _tierInstancePartitionsMap.put(TIER_B_NAME, instancePartitionsTierB);
     _tierInstancePartitionsMap.put(TIER_C_NAME, instancePartitionsTierC);
 
-    _sortedTiers = Lists
-        .newArrayList(
-            new Tier(TIER_C_NAME, new TestSegmentSelectorC(), new PinotServerTierStorage(TAG_C_NAME, null, null)),
-            new Tier(TIER_B_NAME, new TestSegmentSelectorB(), new PinotServerTierStorage(TAG_B_NAME, null, null)),
-            new Tier(TIER_A_NAME, new TestSegmentSelectorA(), new PinotServerTierStorage(TAG_A_NAME, null, null)));
+    _sortedTiers = Lists.newArrayList(
+        new Tier(TIER_C_NAME, new TestSegmentSelectorC(), new PinotServerTierStorage(TAG_C_NAME, null, null)),
+        new Tier(TIER_B_NAME, new TestSegmentSelectorB(), new PinotServerTierStorage(TAG_B_NAME, null, null)),
+        new Tier(TIER_A_NAME, new TestSegmentSelectorA(), new PinotServerTierStorage(TAG_A_NAME, null, null)));
   }
 
   @Test
@@ -145,8 +144,8 @@ public class OfflineNonReplicaGroupTieredSegmentAssignmentTest {
     for (String segmentName : SEGMENTS) {
       List<String> instancesAssigned =
           _segmentAssignment.assignSegment(segmentName, currentAssignment, _instancePartitionsMap);
-      currentAssignment
-          .put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
+      currentAssignment.put(segmentName,
+          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
     }
 
     // There should be 100 segments assigned
@@ -164,9 +163,9 @@ public class OfflineNonReplicaGroupTieredSegmentAssignmentTest {
     assertEquals(numSegmentsAssignedPerInstance, expectedNumSegmentsAssignedPerInstance);
 
     // On rebalancing, segments move to tiers
-    Map<String, Map<String, String>> newAssignment = _segmentAssignment
-        .rebalanceTable(currentAssignment, _instancePartitionsMap, _sortedTiers, _tierInstancePartitionsMap,
-            new BaseConfiguration());
+    Map<String, Map<String, String>> newAssignment =
+        _segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, _sortedTiers,
+            _tierInstancePartitionsMap, new BaseConfiguration());
     assertEquals(newAssignment.size(), NUM_SEGMENTS);
 
     // segments 0-49 remain unchanged
@@ -218,16 +217,16 @@ public class OfflineNonReplicaGroupTieredSegmentAssignmentTest {
     for (String segmentName : SEGMENTS) {
       List<String> instancesAssigned =
           _segmentAssignment.assignSegment(segmentName, currentAssignment, _instancePartitionsMap);
-      currentAssignment
-          .put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
+      currentAssignment.put(segmentName,
+          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
     }
 
     // Bootstrap table should reassign all segments
     Configuration rebalanceConfig = new BaseConfiguration();
     rebalanceConfig.setProperty(RebalanceConfigConstants.BOOTSTRAP, true);
-    Map<String, Map<String, String>> newAssignment = _segmentAssignment
-        .rebalanceTable(currentAssignment, _instancePartitionsMap, _sortedTiers, _tierInstancePartitionsMap,
-            new BaseConfiguration());
+    Map<String, Map<String, String>> newAssignment =
+        _segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, _sortedTiers,
+            _tierInstancePartitionsMap, new BaseConfiguration());
     assertEquals(newAssignment.size(), NUM_SEGMENTS);
 
     // segments 0-49 remain unchanged

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineReplicaGroupSegmentAssignmentTest.java
@@ -126,9 +126,9 @@ public class OfflineReplicaGroupSegmentAssignmentTest {
           any(), anyInt())).thenReturn(segmentZKMetadataZNRecord);
       segmentZKMetadataZNRecords.add(segmentZKMetadataZNRecord);
     }
-    when(propertyStoreWithPartitions
-        .getChildren(eq(ZKMetadataProvider.constructPropertyStorePathForResource(OFFLINE_TABLE_NAME_WITH_PARTITION)),
-            any(), anyInt(), anyInt(), anyInt())).thenReturn(segmentZKMetadataZNRecords);
+    when(propertyStoreWithPartitions.getChildren(
+        eq(ZKMetadataProvider.constructPropertyStorePathForResource(OFFLINE_TABLE_NAME_WITH_PARTITION)), any(),
+        anyInt(), anyInt(), anyInt())).thenReturn(segmentZKMetadataZNRecords);
     HelixManager helixManagerWithPartitions = mock(HelixManager.class);
     when(helixManagerWithPartitions.getHelixPropertyStore()).thenReturn(propertyStoreWithPartitions);
 
@@ -182,8 +182,8 @@ public class OfflineReplicaGroupSegmentAssignmentTest {
     Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
     for (int segmentId = 0; segmentId < NUM_SEGMENTS; segmentId++) {
       String segmentName = SEGMENTS.get(segmentId);
-      List<String> instancesAssigned = _segmentAssignmentWithoutPartition
-          .assignSegment(segmentName, currentAssignment, _instancePartitionsMapWithoutPartition);
+      List<String> instancesAssigned = _segmentAssignmentWithoutPartition.assignSegment(segmentName, currentAssignment,
+          _instancePartitionsMapWithoutPartition);
       assertEquals(instancesAssigned.size(), NUM_REPLICAS);
 
       // Segment 0 should be assigned to instance 0, 6, 12
@@ -201,8 +201,8 @@ public class OfflineReplicaGroupSegmentAssignmentTest {
         assertEquals(instancesAssigned.get(replicaGroupId), INSTANCES.get(expectedAssignedInstanceId));
       }
 
-      currentAssignment
-          .put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
+      currentAssignment.put(segmentName,
+          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
     }
   }
 
@@ -213,8 +213,8 @@ public class OfflineReplicaGroupSegmentAssignmentTest {
     int numInstancesPerPartition = numInstancesPerReplicaGroup / NUM_PARTITIONS;
     for (int segmentId = 0; segmentId < NUM_SEGMENTS; segmentId++) {
       String segmentName = SEGMENTS.get(segmentId);
-      List<String> instancesAssigned = _segmentAssignmentWithPartition
-          .assignSegment(segmentName, currentAssignment, _instancePartitionsMapWithPartition);
+      List<String> instancesAssigned = _segmentAssignmentWithPartition.assignSegment(segmentName, currentAssignment,
+          _instancePartitionsMapWithPartition);
       assertEquals(instancesAssigned.size(), NUM_REPLICAS);
 
       // Segment 0 (partition 0) should be assigned to instance 0, 6, 12
@@ -234,8 +234,8 @@ public class OfflineReplicaGroupSegmentAssignmentTest {
         assertEquals(instancesAssigned.get(replicaGroupId), INSTANCES.get(expectedAssignedInstanceId));
       }
 
-      currentAssignment
-          .put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
+      currentAssignment.put(segmentName,
+          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
     }
   }
 
@@ -243,10 +243,10 @@ public class OfflineReplicaGroupSegmentAssignmentTest {
   public void testTableBalancedWithoutPartition() {
     Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
     for (String segmentName : SEGMENTS) {
-      List<String> instancesAssigned = _segmentAssignmentWithoutPartition
-          .assignSegment(segmentName, currentAssignment, _instancePartitionsMapWithoutPartition);
-      currentAssignment
-          .put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
+      List<String> instancesAssigned = _segmentAssignmentWithoutPartition.assignSegment(segmentName, currentAssignment,
+          _instancePartitionsMapWithoutPartition);
+      currentAssignment.put(segmentName,
+          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
     }
 
     assertEquals(currentAssignment.size(), NUM_SEGMENTS);
@@ -261,20 +261,19 @@ public class OfflineReplicaGroupSegmentAssignmentTest {
     Arrays.fill(expectedNumSegmentsAssignedPerInstance, numSegmentsPerInstance);
     assertEquals(numSegmentsAssignedPerInstance, expectedNumSegmentsAssignedPerInstance);
     // Current assignment should already be balanced
-    assertEquals(_segmentAssignmentWithoutPartition
-            .rebalanceTable(currentAssignment, _instancePartitionsMapWithoutPartition, null, null,
-                new BaseConfiguration()),
-        currentAssignment);
+    assertEquals(
+        _segmentAssignmentWithoutPartition.rebalanceTable(currentAssignment, _instancePartitionsMapWithoutPartition,
+            null, null, new BaseConfiguration()), currentAssignment);
   }
 
   @Test
   public void testTableBalancedWithPartition() {
     Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
     for (String segmentName : SEGMENTS) {
-      List<String> instancesAssigned = _segmentAssignmentWithPartition
-          .assignSegment(segmentName, currentAssignment, _instancePartitionsMapWithPartition);
-      currentAssignment
-          .put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
+      List<String> instancesAssigned = _segmentAssignmentWithPartition.assignSegment(segmentName, currentAssignment,
+          _instancePartitionsMapWithPartition);
+      currentAssignment.put(segmentName,
+          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
     }
 
     assertEquals(currentAssignment.size(), NUM_SEGMENTS);
@@ -289,27 +288,27 @@ public class OfflineReplicaGroupSegmentAssignmentTest {
     Arrays.fill(expectedNumSegmentsAssignedPerInstance, numSegmentsPerInstance);
     assertEquals(numSegmentsAssignedPerInstance, expectedNumSegmentsAssignedPerInstance);
     // Current assignment should already be balanced
-    assertEquals(_segmentAssignmentWithPartition
-            .rebalanceTable(currentAssignment, _instancePartitionsMapWithPartition, null, null,
-                new BaseConfiguration()),
-        currentAssignment);
+    assertEquals(
+        _segmentAssignmentWithPartition.rebalanceTable(currentAssignment, _instancePartitionsMapWithPartition, null,
+            null, new BaseConfiguration()), currentAssignment);
   }
 
   @Test
   public void testBootstrapTableWithoutPartition() {
     Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
     for (String segmentName : SEGMENTS) {
-      List<String> instancesAssigned = _segmentAssignmentWithoutPartition
-          .assignSegment(segmentName, currentAssignment, _instancePartitionsMapWithoutPartition);
-      currentAssignment
-          .put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
+      List<String> instancesAssigned = _segmentAssignmentWithoutPartition.assignSegment(segmentName, currentAssignment,
+          _instancePartitionsMapWithoutPartition);
+      currentAssignment.put(segmentName,
+          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
     }
 
     // Bootstrap table should reassign all segments based on their alphabetical order
     Configuration rebalanceConfig = new BaseConfiguration();
     rebalanceConfig.setProperty(RebalanceConfigConstants.BOOTSTRAP, true);
-    Map<String, Map<String, String>> newAssignment = _segmentAssignmentWithoutPartition
-        .rebalanceTable(currentAssignment, _instancePartitionsMapWithoutPartition, null, null, rebalanceConfig);
+    Map<String, Map<String, String>> newAssignment =
+        _segmentAssignmentWithoutPartition.rebalanceTable(currentAssignment, _instancePartitionsMapWithoutPartition,
+            null, null, rebalanceConfig);
     assertEquals(newAssignment.size(), NUM_SEGMENTS);
     List<String> sortedSegments = new ArrayList<>(SEGMENTS);
     sortedSegments.sort(null);
@@ -322,17 +321,18 @@ public class OfflineReplicaGroupSegmentAssignmentTest {
   public void testBootstrapTableWithPartition() {
     Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
     for (String segmentName : SEGMENTS) {
-      List<String> instancesAssigned = _segmentAssignmentWithPartition
-          .assignSegment(segmentName, currentAssignment, _instancePartitionsMapWithPartition);
-      currentAssignment
-          .put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
+      List<String> instancesAssigned = _segmentAssignmentWithPartition.assignSegment(segmentName, currentAssignment,
+          _instancePartitionsMapWithPartition);
+      currentAssignment.put(segmentName,
+          SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.ONLINE));
     }
 
     // Bootstrap table should reassign all segments based on their alphabetical order within the partition
     Configuration rebalanceConfig = new BaseConfiguration();
     rebalanceConfig.setProperty(RebalanceConfigConstants.BOOTSTRAP, true);
-    Map<String, Map<String, String>> newAssignment = _segmentAssignmentWithPartition
-        .rebalanceTable(currentAssignment, _instancePartitionsMapWithPartition, null, null, rebalanceConfig);
+    Map<String, Map<String, String>> newAssignment =
+        _segmentAssignmentWithPartition.rebalanceTable(currentAssignment, _instancePartitionsMapWithPartition, null,
+            null, rebalanceConfig);
     assertEquals(newAssignment.size(), NUM_SEGMENTS);
     int numSegmentsPerPartition = NUM_SEGMENTS / NUM_PARTITIONS;
     String[][] partitionIdToSegmentsMap = new String[NUM_PARTITIONS][numSegmentsPerPartition];
@@ -361,16 +361,12 @@ public class OfflineReplicaGroupSegmentAssignmentTest {
     String instance1 = INSTANCE_NAME_PREFIX + "1";
     String instance2 = INSTANCE_NAME_PREFIX + "2";
     Map<String, Map<String, String>> unbalancedAssignment = new TreeMap<>();
-    SEGMENTS.forEach(segName ->
-        unbalancedAssignment.put(segName, ImmutableMap.of(
-            instance0, SegmentStateModel.ONLINE,
-            instance1, SegmentStateModel.ONLINE,
-            instance2, SegmentStateModel.ONLINE
-        ))
-    );
-    Map<String, Map<String, String>> balancedAssignment = _segmentAssignmentWithPartition
-        .rebalanceTable(unbalancedAssignment, _instancePartitionsMapWithoutPartition, null, null,
-            new BaseConfiguration());
+    SEGMENTS.forEach(segName -> unbalancedAssignment.put(segName,
+        ImmutableMap.of(instance0, SegmentStateModel.ONLINE, instance1, SegmentStateModel.ONLINE, instance2,
+            SegmentStateModel.ONLINE)));
+    Map<String, Map<String, String>> balancedAssignment =
+        _segmentAssignmentWithPartition.rebalanceTable(unbalancedAssignment, _instancePartitionsMapWithoutPartition,
+            null, null, new BaseConfiguration());
     int[] actualNumSegmentsAssignedPerInstance =
         SegmentAssignmentUtils.getNumSegmentsAssignedPerInstance(balancedAssignment, INSTANCES);
     int[] expectedNumSegmentsAssignedPerInstance = new int[NUM_INSTANCES];

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineReplicaGroupSegmentAssignmentTest.java
@@ -111,7 +111,7 @@ public class OfflineReplicaGroupSegmentAssignmentTest {
     _instancePartitionsMapWithoutPartition =
         Collections.singletonMap(InstancePartitionsType.OFFLINE, instancePartitionsWithoutPartition);
 
-    // Mock HelixManager]
+    // Mock HelixManager
     ZkHelixPropertyStore<ZNRecord> propertyStoreWithPartitions = mock(ZkHelixPropertyStore.class);
     List<ZNRecord> segmentZKMetadataZNRecords = new ArrayList<>(NUM_SEGMENTS);
     for (int segmentId = 0; segmentId < NUM_SEGMENTS; segmentId++) {


### PR DESCRIPTION
Fix #8090

The first commit auto-reformats the related classes. Please review the second commit for the actual change.