### PR TITLE
allow mvn build with development webpack; fix instances default value

### DIFF
--- a/pinot-controller/pom.xml
+++ b/pinot-controller/pom.xml
@@ -33,6 +33,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
+    <npm.script>${npm.script}</npm.script>
   </properties>
   <dependencies>
     <dependency>
@@ -244,7 +245,7 @@
             </configuration>
           </execution>
           <execution>
-            <id>npm run-script build</id>
+            <id>npm run-script ${npm.script}</id>
             <goals>
               <goal>npm</goal>
             </goals>
@@ -253,7 +254,7 @@
             <configuration>
               <!-- optional: if not specified, it will run gulp's default task
                   (and you can remove this whole <configuration> section.) -->
-              <arguments>run-script build</arguments>
+              <arguments>run-script ${npm.script}</arguments>
               <!--arguments>build</arguments-->
             </configuration>
           </execution>

--- a/pinot-controller/pom.xml
+++ b/pinot-controller/pom.xml
@@ -33,7 +33,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
-    <npm.script>${npm.script}</npm.script>
+    <npm.script>build</npm.script>
   </properties>
   <dependencies>
     <dependency>

--- a/pinot-controller/src/main/resources/app/components/Homepage/InstanceTable.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/InstanceTable.tsx
@@ -29,7 +29,7 @@ type Props = {
   clusterName: string
 };
 
-const InstaceTable = ({ name, instances, clusterName }: Props) => {
+const InstanceTable = ({ name, instances, clusterName }: Props) => {
 
   const [fetching, setFetching] = useState(true);
   const [tableData, setTableData] = useState<TableData>({
@@ -70,4 +70,4 @@ const InstaceTable = ({ name, instances, clusterName }: Props) => {
   );
 };
 
-export default InstaceTable;
+export default InstanceTable;

--- a/pinot-controller/src/main/resources/app/components/Homepage/InstancesTables.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/InstancesTables.tsx
@@ -28,7 +28,7 @@ const Instances = ({instances, clusterName}) => {
     <>
       {
         map(order, (key) => {
-          const value = get(instances, key, '');
+          const value = get(instances, key, []);
           return <InstanceTable key={key} name={`${key}s`} instances={value} clusterName={clusterName} />;
         })
       }

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -152,7 +152,7 @@ const getAllInstances = () => {
 };
 
 // This method is used to display instance data on cluster manager home page
-// API: /instances/:instaneName
+// API: /instances/:instanceName
 // Expected Output: {columns: [], records: []}
 const getInstanceData = (instances, liveInstanceArr) => {
   const promiseArr = [...instances.map((inst) => getInstance(inst))];

--- a/pinot-controller/src/main/resources/package.json
+++ b/pinot-controller/src/main/resources/package.json
@@ -6,6 +6,7 @@
     "dev": "webpack-dev-server --config ./webpack.config.js --mode development",
     "start": "npm-run-all --parallel lint dev",
     "build": "webpack --mode production",
+    "build-dev": "webpack --mode development",
     "build-analyze": "webpack --mode production --analyze",
     "lint": "eslint 'app/**/*.{js,ts,tsx,jsx}' --quiet --fix",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/pom.xml
+++ b/pom.xml
@@ -175,6 +175,8 @@
 
     <!-- Configuration for Packaging -->
     <shade.prefix>org.apache.pinot.shaded</shade.prefix>
+
+    <npm.script>build</npm.script>
   </properties>
 
   <profiles>

--- a/pom.xml
+++ b/pom.xml
@@ -175,8 +175,6 @@
 
     <!-- Configuration for Packaging -->
     <shade.prefix>org.apache.pinot.shaded</shade.prefix>
-
-    <npm.script>build</npm.script>
   </properties>
 
   <profiles>


### PR DESCRIPTION
This is `ui` and `bugfix`

- fixes a bug from #8978 where instances should default to an array
  - this causes the UI to perpetually have a spinner but wasn't actively breaking
- updates the pom.xml npm build option for the controller
  - the default is still `build`
  - adds a new build-dev to package json where you can build in development mode
  - this lets you do a min command that packages without minifying for an environment like QA so you can actually see the code
- fixes a few typos

This was tested by building pinot-controller in IntelliJ with the new `npm.script` option set to build-dev. The ui ran with non-minified code in main.js. Then I ran realtime Quickstart to ensure the `/instances` worked correctly.