### PR TITLE
show segment and instance count; use pagination for segments

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
@@ -497,10 +497,9 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
             </SimpleAccordion>
           </div>
           <CustomizedTables
-            title="Segments"
+            title={"Segments - " + segmentList.records.length}
             data={segmentList}
-            isPagination={false}
-            noOfRows={segmentList.records.length}
+            isPagination={true}
             baseURL={
               tenantName && `/tenants/${tenantName}/table/${tableName}/` ||
               instanceName && `/instance/${instanceName}/table/${tableName}/` ||
@@ -547,7 +546,7 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
           </div>
           }
           <CustomizedTables
-            title="Instance Count"
+            title={"Instance Count - " + instanceCountData.records.length}
             data={instanceCountData}
             isPagination={false}
             noOfRows={instanceCountData.records.length}


### PR DESCRIPTION
This is a `ui` `bugfix`

- shows instance and segment count in the UI on the table page. this must makes it easier to see how many you have at a glance
- paginates the segments table
  - this table can grow quite large (10s to 100s thousands)
  - trying to render that all at once breaks browsers, and isn't useful visually
  - we could use virtualized tables, but that's a lot harder to setup

Here's a screenshot. Ignore the segment count mismatch. This was just local tinkering to make it render 10,000 segments to test pagination is working correctly.
![image](https://user-images.githubusercontent.com/4760722/183318325-0aa74c47-1733-47d7-aef3-b1d2629f9f0d.png)
