### PR TITLE
Support using query options to choose v2 engine

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -58,12 +58,12 @@ import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.response.BrokerResponse;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.core.query.executor.sql.SqlQueryExecutor;
 import org.apache.pinot.spi.trace.RequestScope;
 import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request;
 import org.apache.pinot.spi.utils.JsonUtils;
-import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.pinot.sql.parsers.PinotSqlType;
 import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
 import org.glassfish.jersey.server.ManagedAsync;
@@ -209,7 +209,7 @@ public class PinotClientRequest {
       throws Exception {
     SqlNodeAndOptions sqlNodeAndOptions;
     try {
-      sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sqlRequestJson.get(Request.SQL).asText());
+      sqlNodeAndOptions = RequestUtils.parseQuery(-1, sqlRequestJson.get(Request.SQL).asText(), sqlRequestJson);
     } catch (Exception e) {
       return new BrokerResponseNative(QueryException.getException(QueryException.SQL_PARSING_ERROR, e));
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -273,7 +273,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       }
     }
 
-    MultiStageBrokerRequestHandler multiStageBrokerRequestHandler = null;
+    BrokerRequestHandler multiStageBrokerRequestHandler = null;
     if (_brokerConf.getProperty(Helix.CONFIG_OF_MULTI_STAGE_ENGINE_ENABLED, Helix.DEFAULT_MULTI_STAGE_ENGINE_ENABLED)) {
       // multi-stage request handler uses both Netty and GRPC ports.
       // worker requires both the "Netty port" for protocol transport; and "GRPC port" for mailbox transport.

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -21,7 +21,6 @@ package org.apache.pinot.broker.requesthandler;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Splitter;
 import com.google.common.util.concurrent.RateLimiter;
 import java.net.InetAddress;
 import java.util.ArrayList;
@@ -252,7 +251,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   }
 
   @Override
-  public BrokerResponseNative handleRequest(JsonNode request, @Nullable SqlNodeAndOptions sqlNodeAndOptions,
+  public BrokerResponse handleRequest(JsonNode request, @Nullable SqlNodeAndOptions sqlNodeAndOptions,
       @Nullable RequesterIdentity requesterIdentity, RequestContext requestContext)
       throws Exception {
     long requestId = _requestIdGenerator.incrementAndGet();
@@ -292,16 +291,14 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       throws Exception {
     LOGGER.debug("SQL query for request {}: {}", requestId, query);
 
-    // Compile the request
-    long compilationStartTimeNs = System.nanoTime();
+    long compilationStartTimeNs;
     PinotQuery pinotQuery;
     try {
-      if (sqlNodeAndOptions != null) {
-        // Include parse time when the query is already parsed
-        compilationStartTimeNs -= sqlNodeAndOptions.getParseTimeNs();
-      } else {
-        sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(query);
-      }
+      // Parse the request
+      sqlNodeAndOptions = sqlNodeAndOptions != null ? sqlNodeAndOptions
+          : RequestUtils.parseQuery(query, request);
+      // Compile the request into PinotQuery
+      compilationStartTimeNs = System.nanoTime();
       pinotQuery = CalciteSqlParser.compileToPinotQuery(sqlNodeAndOptions);
     } catch (Exception e) {
       LOGGER.info("Caught exception while compiling SQL request {}: {}, {}", requestId, query, e.getMessage());
@@ -309,7 +306,6 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       requestContext.setErrorCode(QueryException.SQL_PARSING_ERROR_CODE);
       return new BrokerResponseNative(QueryException.getException(QueryException.SQL_PARSING_ERROR, e));
     }
-    setOptions(pinotQuery, requestId, query, request);
 
     if (isLiteralOnlyQuery(pinotQuery)) {
       LOGGER.debug("Request {} contains only Literal, skipping server query: {}", requestId, query);
@@ -379,8 +375,9 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     }
 
     long compilationEndTimeNs = System.nanoTime();
+    // full request compile time = compilationTimeNs + parserTimeNs
     _brokerMetrics.addPhaseTiming(rawTableName, BrokerQueryPhase.REQUEST_COMPILATION,
-        compilationEndTimeNs - compilationStartTimeNs);
+        (compilationEndTimeNs - compilationStartTimeNs) + sqlNodeAndOptions.getParseTimeNs());
 
     // Second-stage table-level access control
     // TODO: Modify AccessControl interface to directly take PinotQuery
@@ -1561,11 +1558,6 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     throw new BadQueryRequestException("Unknown columnName '" + columnName + "' found in the query");
   }
 
-  public static Map<String, String> getOptionsFromJson(JsonNode request, String optionsKey) {
-    return Splitter.on(';').omitEmptyStrings().trimResults().withKeyValueSeparator('=')
-        .split(request.get(optionsKey).asText());
-  }
-
   /**
    * Helper function to decide whether to force the log
    *
@@ -1582,46 +1574,6 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
     // If response time is more than 1 sec, force the log
     return totalTimeMs > 1000L;
-  }
-
-  /**
-   * Sets extra options for the given query.
-   */
-  @VisibleForTesting
-  static void setOptions(PinotQuery pinotQuery, long requestId, String query, JsonNode jsonRequest) {
-    Map<String, String> queryOptions = new HashMap<>();
-    if (jsonRequest.has(Broker.Request.DEBUG_OPTIONS)) {
-      Map<String, String> debugOptions = getOptionsFromJson(jsonRequest, Broker.Request.DEBUG_OPTIONS);
-      if (!debugOptions.isEmpty()) {
-        // TODO: Do not set debug options after releasing 0.11.0. Currently we kept it for backward compatibility.
-        LOGGER.debug("Debug options are set to: {} for request {}: {}", debugOptions, requestId, query);
-        pinotQuery.setDebugOptions(debugOptions);
-
-        // NOTE: Debug options are deprecated. Put all debug options into query options for backward compatibility.
-        queryOptions.putAll(debugOptions);
-      }
-    }
-    if (jsonRequest.has(Broker.Request.QUERY_OPTIONS)) {
-      Map<String, String> queryOptionsFromJson = getOptionsFromJson(jsonRequest, Broker.Request.QUERY_OPTIONS);
-      queryOptions.putAll(queryOptionsFromJson);
-    }
-    Map<String, String> queryOptionsFromQuery = pinotQuery.getQueryOptions();
-    if (queryOptionsFromQuery != null) {
-      queryOptions.putAll(queryOptionsFromQuery);
-    }
-    boolean enableTrace = jsonRequest.has(Broker.Request.TRACE) && jsonRequest.get(Broker.Request.TRACE).asBoolean();
-    if (enableTrace) {
-      queryOptions.put(Broker.Request.TRACE, "true");
-    }
-    // NOTE: Always set query options because we will put 'timeoutMs' later
-    pinotQuery.setQueryOptions(queryOptions);
-    if (!queryOptions.isEmpty()) {
-      LOGGER.debug("Query options are set to: {} for request {}: {}", queryOptions, requestId, query);
-    }
-    // TODO: Remove the SQL query options after releasing 0.11.0
-    // The query engine will break if these 2 options are missing during version upgrade.
-    queryOptions.put(Broker.Request.QueryOptionKey.GROUP_BY_MODE, Broker.Request.SQL);
-    queryOptions.put(Broker.Request.QueryOptionKey.RESPONSE_FORMAT, Broker.Request.SQL);
   }
 
   /**

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandler.java
@@ -25,7 +25,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.pinot.broker.api.RequesterIdentity;
-import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.BrokerResponse;
 import org.apache.pinot.spi.trace.RequestContext;
 import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
 
@@ -37,11 +37,11 @@ public interface BrokerRequestHandler {
 
   void shutDown();
 
-  BrokerResponseNative handleRequest(JsonNode request, @Nullable SqlNodeAndOptions sqlNodeAndOptions,
+  BrokerResponse handleRequest(JsonNode request, @Nullable SqlNodeAndOptions sqlNodeAndOptions,
       @Nullable RequesterIdentity requesterIdentity, RequestContext requestContext)
       throws Exception;
 
-  default BrokerResponseNative handleRequest(JsonNode request, @Nullable RequesterIdentity requesterIdentity,
+  default BrokerResponse handleRequest(JsonNode request, @Nullable RequesterIdentity requesterIdentity,
       RequestContext requestContext)
       throws Exception {
     return handleRequest(request, null, requesterIdentity, requestContext);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -135,7 +135,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
 
     // Parse the request
     sqlNodeAndOptions = sqlNodeAndOptions != null ? sqlNodeAndOptions
-        : RequestUtils.parseQuery(requestId, query, request);
+        : RequestUtils.parseQuery(query, request);
     // Compile the request
     long compilationStartTimeNs = System.nanoTime();
     QueryPlan queryPlan;

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BrokerRequestOptionsTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BrokerRequestOptionsTest.java
@@ -21,10 +21,11 @@ package org.apache.pinot.broker.requesthandler;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -43,49 +44,49 @@ public class BrokerRequestOptionsTest {
 
     // None of the options
     ObjectNode jsonRequest = JsonUtils.newObjectNode();
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
-    Assert.assertNull(pinotQuery.getDebugOptions());
-    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 0 + LEGACY_PQL_QUERY_OPTION_SIZE);
+    SqlNodeAndOptions sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(query);;
+    RequestUtils.setOptions(sqlNodeAndOptions, jsonRequest);
+    Assert.assertEquals(sqlNodeAndOptions.getDebugOptions().size(), 0);
+    Assert.assertEquals(sqlNodeAndOptions.getQueryOptions().size(), 0 + LEGACY_PQL_QUERY_OPTION_SIZE);
 
     // TRACE
     // Has trace false
     jsonRequest.put(Request.TRACE, false);
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
-    Assert.assertNull(pinotQuery.getDebugOptions());
-    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 0 + LEGACY_PQL_QUERY_OPTION_SIZE);
+    sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(query);
+    RequestUtils.setOptions(sqlNodeAndOptions, jsonRequest);
+    Assert.assertEquals(sqlNodeAndOptions.getDebugOptions().size(), 0);
+    Assert.assertEquals(sqlNodeAndOptions.getQueryOptions().size(), 0 + LEGACY_PQL_QUERY_OPTION_SIZE);
 
     // Has trace true
     jsonRequest.put(Request.TRACE, true);
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
-    Assert.assertNull(pinotQuery.getDebugOptions());
-    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1 + LEGACY_PQL_QUERY_OPTION_SIZE);
-    Assert.assertEquals(pinotQuery.getQueryOptions().get(Request.TRACE), "true");
+    sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(query);
+    RequestUtils.setOptions(sqlNodeAndOptions, jsonRequest);
+    Assert.assertEquals(sqlNodeAndOptions.getDebugOptions().size(), 0);
+    Assert.assertEquals(sqlNodeAndOptions.getQueryOptions().size(), 1 + LEGACY_PQL_QUERY_OPTION_SIZE);
+    Assert.assertEquals(sqlNodeAndOptions.getQueryOptions().get(Request.TRACE), "true");
 
     // DEBUG_OPTIONS (debug options will also be included as query options)
     // Has debugOptions
     jsonRequest = JsonUtils.newObjectNode();
     jsonRequest.put(Request.DEBUG_OPTIONS, "debugOption1=foo");
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
-    Assert.assertEquals(pinotQuery.getDebugOptionsSize(), 1);
-    Assert.assertEquals(pinotQuery.getDebugOptions().get("debugOption1"), "foo");
+    sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(query);
+    RequestUtils.setOptions(sqlNodeAndOptions, jsonRequest);
+    Assert.assertEquals(sqlNodeAndOptions.getDebugOptions().size(), 1);
+    Assert.assertEquals(sqlNodeAndOptions.getDebugOptions().get("debugOption1"), "foo");
 
     // Has multiple debugOptions
     jsonRequest.put(Request.DEBUG_OPTIONS, "debugOption1=foo;debugOption2=bar");
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
-    Assert.assertEquals(pinotQuery.getDebugOptionsSize(), 2);
-    Assert.assertEquals(pinotQuery.getDebugOptions().get("debugOption1"), "foo");
-    Assert.assertEquals(pinotQuery.getDebugOptions().get("debugOption2"), "bar");
+    sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(query);
+    RequestUtils.setOptions(sqlNodeAndOptions, jsonRequest);
+    Assert.assertEquals(sqlNodeAndOptions.getDebugOptions().size(), 2);
+    Assert.assertEquals(sqlNodeAndOptions.getDebugOptions().get("debugOption1"), "foo");
+    Assert.assertEquals(sqlNodeAndOptions.getDebugOptions().get("debugOption2"), "bar");
 
     // Invalid debug options
     jsonRequest.put(Request.DEBUG_OPTIONS, "debugOption1");
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(query);
     try {
-      BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
+      RequestUtils.setOptions(sqlNodeAndOptions, jsonRequest);
       Assert.fail();
     } catch (Exception e) {
       // Expected
@@ -93,53 +94,53 @@ public class BrokerRequestOptionsTest {
 
     // QUERY_OPTIONS
     jsonRequest = JsonUtils.newObjectNode();
-    // Has queryOptions in pinotQuery already
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    // Has queryOptions in sqlNodeAndOptions already
+    sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(query);
     Map<String, String> queryOptions = new HashMap<>();
     queryOptions.put("queryOption1", "foo");
-    pinotQuery.setQueryOptions(queryOptions);
-    BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
-    Assert.assertNull(pinotQuery.getDebugOptions());
-    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1 + LEGACY_PQL_QUERY_OPTION_SIZE);
-    Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption1"), "foo");
+    sqlNodeAndOptions.getQueryOptions().putAll(queryOptions);
+    RequestUtils.setOptions(sqlNodeAndOptions, jsonRequest);
+    Assert.assertEquals(sqlNodeAndOptions.getDebugOptions().size(), 0);
+    Assert.assertEquals(sqlNodeAndOptions.getQueryOptions().size(), 1 + LEGACY_PQL_QUERY_OPTION_SIZE);
+    Assert.assertEquals(sqlNodeAndOptions.getQueryOptions().get("queryOption1"), "foo");
 
     // Has queryOptions in query
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("SET queryOption1='foo'; select * from testTable");
-    BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
-    Assert.assertNull(pinotQuery.getDebugOptions());
-    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1 + LEGACY_PQL_QUERY_OPTION_SIZE);
-    Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption1"), "foo");
+    sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions("SET queryOption1='foo'; select * from testTable");
+    RequestUtils.setOptions(sqlNodeAndOptions, jsonRequest);
+    Assert.assertEquals(sqlNodeAndOptions.getDebugOptions().size(), 0);
+    Assert.assertEquals(sqlNodeAndOptions.getQueryOptions().size(), 1 + LEGACY_PQL_QUERY_OPTION_SIZE);
+    Assert.assertEquals(sqlNodeAndOptions.getQueryOptions().get("queryOption1"), "foo");
 
     // Has query options in json payload
     jsonRequest.put(Request.QUERY_OPTIONS, "queryOption1=foo");
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
-    Assert.assertNull(pinotQuery.getDebugOptions());
-    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 1 + LEGACY_PQL_QUERY_OPTION_SIZE);
-    Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption1"), "foo");
+    sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(query);
+    RequestUtils.setOptions(sqlNodeAndOptions, jsonRequest);
+    Assert.assertEquals(sqlNodeAndOptions.getDebugOptions().size(), 0);
+    Assert.assertEquals(sqlNodeAndOptions.getQueryOptions().size(), 1 + LEGACY_PQL_QUERY_OPTION_SIZE);
+    Assert.assertEquals(sqlNodeAndOptions.getQueryOptions().get("queryOption1"), "foo");
 
-    // Has query options in both json payload and pinotQuery, pinotQuery takes priority
+    // Has query options in both json payload and sqlNodeAndOptions, sqlNodeAndOptions takes priority
     jsonRequest.put(Request.QUERY_OPTIONS, "queryOption1=bar;queryOption2=moo");
-    pinotQuery = CalciteSqlParser.compileToPinotQuery("SET queryOption1='foo'; select * from testTable;");
-    BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
-    Assert.assertNull(pinotQuery.getDebugOptions());
-    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 2 + LEGACY_PQL_QUERY_OPTION_SIZE);
-    Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption1"), "foo");
-    Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption2"), "moo");
+    sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions("SET queryOption1='foo'; select * from testTable;");
+    RequestUtils.setOptions(sqlNodeAndOptions, jsonRequest);
+    Assert.assertEquals(sqlNodeAndOptions.getDebugOptions().size(), 0);
+    Assert.assertEquals(sqlNodeAndOptions.getQueryOptions().size(), 2 + LEGACY_PQL_QUERY_OPTION_SIZE);
+    Assert.assertEquals(sqlNodeAndOptions.getQueryOptions().get("queryOption1"), "foo");
+    Assert.assertEquals(sqlNodeAndOptions.getQueryOptions().get("queryOption2"), "moo");
 
     // Has all 3
     jsonRequest = JsonUtils.newObjectNode();
     jsonRequest.put(Request.TRACE, true);
     jsonRequest.put(Request.DEBUG_OPTIONS, "debugOption1=foo");
     jsonRequest.put(Request.QUERY_OPTIONS, "queryOption1=bar;queryOption2=moo");
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    BaseBrokerRequestHandler.setOptions(pinotQuery, requestId, query, jsonRequest);
-    Assert.assertEquals(pinotQuery.getDebugOptionsSize(), 1);
-    Assert.assertEquals(pinotQuery.getDebugOptions().get("debugOption1"), "foo");
-    Assert.assertEquals(pinotQuery.getQueryOptionsSize(), 4 + LEGACY_PQL_QUERY_OPTION_SIZE);
-    Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption1"), "bar");
-    Assert.assertEquals(pinotQuery.getQueryOptions().get("queryOption2"), "moo");
-    Assert.assertEquals(pinotQuery.getQueryOptions().get(Request.TRACE), "true");
-    Assert.assertEquals(pinotQuery.getDebugOptions().get("debugOption1"), "foo");
+    sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(query);
+    RequestUtils.setOptions(sqlNodeAndOptions, jsonRequest);
+    Assert.assertEquals(sqlNodeAndOptions.getDebugOptions().size(), 1);
+    Assert.assertEquals(sqlNodeAndOptions.getDebugOptions().get("debugOption1"), "foo");
+    Assert.assertEquals(sqlNodeAndOptions.getQueryOptions().size(), 4 + LEGACY_PQL_QUERY_OPTION_SIZE);
+    Assert.assertEquals(sqlNodeAndOptions.getQueryOptions().get("queryOption1"), "bar");
+    Assert.assertEquals(sqlNodeAndOptions.getQueryOptions().get("queryOption2"), "moo");
+    Assert.assertEquals(sqlNodeAndOptions.getQueryOptions().get(Request.TRACE), "true");
+    Assert.assertEquals(sqlNodeAndOptions.getDebugOptions().get("debugOption1"), "foo");
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.pinot.broker.broker.AccessControlFactory;
 import org.apache.pinot.broker.broker.AllowAllAccessControlFactory;
 import org.apache.pinot.common.metrics.BrokerMetrics;
-import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.BrokerResponse;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -169,7 +169,7 @@ public class LiteralOnlyBrokerRequestTest {
     String ranStr = BytesUtils.toHexString(randBytes);
     JsonNode request = JsonUtils.stringToJsonNode(String.format("{\"sql\":\"SELECT %d, '%s'\"}", randNum, ranStr));
     RequestContext requestStats = Tracing.getTracer().createRequestScope();
-    BrokerResponseNative brokerResponse = requestHandler.handleRequest(request, null, requestStats);
+    BrokerResponse brokerResponse = requestHandler.handleRequest(request, null, requestStats);
     Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnName(0), String.format("%d", randNum));
     Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnDataType(0),
         DataSchema.ColumnDataType.LONG);
@@ -194,7 +194,7 @@ public class LiteralOnlyBrokerRequestTest {
     JsonNode request = JsonUtils.stringToJsonNode(
         "{\"sql\":\"SELECT now() as currentTs, fromDateTime('2020-01-01 UTC', 'yyyy-MM-dd z') as firstDayOf2020\"}");
     RequestContext requestStats = Tracing.getTracer().createRequestScope();
-    BrokerResponseNative brokerResponse = requestHandler.handleRequest(request, null, requestStats);
+    BrokerResponse brokerResponse = requestHandler.handleRequest(request, null, requestStats);
     long currentTsMax = System.currentTimeMillis();
     Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnName(0), "currentTs");
     Assert.assertEquals(brokerResponse.getResultTable().getDataSchema().getColumnDataType(0),
@@ -334,7 +334,7 @@ public class LiteralOnlyBrokerRequestTest {
     // Test 1: select constant
     JsonNode request = JsonUtils.stringToJsonNode("{\"sql\":\"EXPLAIN PLAN FOR SELECT 1.5, 'test'\"}");
     RequestContext requestStats = Tracing.getTracer().createRequestScope();
-    BrokerResponseNative brokerResponse = requestHandler.handleRequest(request, null, requestStats);
+    BrokerResponse brokerResponse = requestHandler.handleRequest(request, null, requestStats);
 
     checkExplainResultSchema(brokerResponse.getResultTable().getDataSchema(),
         new String[]{"Operator", "Operator_Id", "Parent_Id"},

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
@@ -20,6 +20,7 @@ package org.apache.pinot.common.response;
 
 import java.util.List;
 import org.apache.pinot.common.response.broker.QueryProcessingException;
+import org.apache.pinot.common.response.broker.ResultTable;
 
 
 /**
@@ -136,6 +137,18 @@ public interface BrokerResponse {
    * Get number of exceptions recorded in the response.
    */
   int getExceptionsSize();
+
+  /**
+   * set the result table.
+   * @param resultTable result table to be set.
+   */
+  void setResultTable(ResultTable resultTable);
+
+  /**
+   * Get the result table.
+   * @return result table.
+   */
+  ResultTable getResultTable();
 
   /**
    * Get the list of exceptions

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
@@ -312,11 +312,13 @@ public class BrokerResponseNative implements BrokerResponse {
 
   @JsonProperty("resultTable")
   @JsonInclude(JsonInclude.Include.NON_NULL)
+  @Override
   public ResultTable getResultTable() {
     return _resultTable;
   }
 
   @JsonProperty("resultTable")
+  @Override
   public void setResultTable(ResultTable resultTable) {
     _resultTable = resultTable;
     _numRowsResultSet = resultTable.getRows().size();

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -125,10 +125,10 @@ public class CalciteSqlParser {
       SqlParserImpl sqlParser = newSqlParser(inStream);
       SqlNodeList sqlNodeList = sqlParser.SqlStmtsEof();
       // Extract OPTION statements from sql.
-      SqlNodeAndOptions sqlNodeAndOptions = extractSqlNodeAndOptions(sqlNodeList);
+      SqlNodeAndOptions sqlNodeAndOptions = extractSqlNodeAndOptions(sql, sqlNodeList);
       // add legacy OPTIONS keyword-based options
       if (options.size() > 0) {
-        sqlNodeAndOptions.setExtraOptions(extractOptionsMap(options));
+        sqlNodeAndOptions.putExtraQueryOptions(extractOptionsMap(options));
       }
       sqlNodeAndOptions.setParseTimeNs(System.nanoTime() - parseStartTimeNs);
       return sqlNodeAndOptions;
@@ -137,7 +137,8 @@ public class CalciteSqlParser {
     }
   }
 
-  public static SqlNodeAndOptions extractSqlNodeAndOptions(SqlNodeList sqlNodeList) {
+  @VisibleForTesting
+  static SqlNodeAndOptions extractSqlNodeAndOptions(String sql, SqlNodeList sqlNodeList) {
     PinotSqlType sqlType = null;
     SqlNode statementNode = null;
     Map<String, String> options = new HashMap<>();
@@ -169,7 +170,8 @@ public class CalciteSqlParser {
     if (sqlType == null) {
       throw new SqlCompilationException("SqlNode with executable statement not found!");
     }
-    return new SqlNodeAndOptions(statementNode, sqlType, options);
+    // Debug Options are attached from query request JSON. setting it to empty for now.
+    return new SqlNodeAndOptions(sql, statementNode, sqlType, options, new HashMap<>());
   }
 
   public static PinotQuery compileToPinotQuery(String sql)
@@ -182,9 +184,14 @@ public class CalciteSqlParser {
     PinotQuery pinotQuery = compileSqlNodeToPinotQuery(sqlNodeAndOptions.getSqlNode());
 
     // Set Option statements to PinotQuery.
-    Map<String, String> options = sqlNodeAndOptions.getOptions();
-    if (!options.isEmpty()) {
-      pinotQuery.setQueryOptions(options);
+    Map<String, String> queryOptions = sqlNodeAndOptions.getQueryOptions();
+    if (!queryOptions.isEmpty()) {
+      pinotQuery.setQueryOptions(queryOptions);
+    }
+    // DebugOptions has been deprecated. keeping this for backward compatibility purpose.
+    Map<String, String> debugOptions = sqlNodeAndOptions.getDebugOptions();
+    if (!debugOptions.isEmpty()) {
+      pinotQuery.setDebugOptions(debugOptions);
     }
     return pinotQuery;
   }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/SqlNodeAndOptions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/SqlNodeAndOptions.java
@@ -23,17 +23,25 @@ import org.apache.calcite.sql.SqlNode;
 
 
 public class SqlNodeAndOptions {
+  private String _sql;
   private final SqlNode _sqlNode;
   private final PinotSqlType _sqlType;
   // TODO: support option literals other than STRING
-  private final Map<String, String> _options;
-
+  private final Map<String, String> _queryOptions;
+  private final Map<String, String> _debugOptions;
   private long _parseTimeNs;
 
-  public SqlNodeAndOptions(SqlNode sqlNode, PinotSqlType sqlType, Map<String, String> options) {
+  public SqlNodeAndOptions(String sql, SqlNode sqlNode, PinotSqlType sqlType, Map<String, String> queryOptions,
+      Map<String, String> debugOptions) {
+    _sql = sql;
     _sqlNode = sqlNode;
     _sqlType = sqlType;
-    _options = options;
+    _queryOptions = queryOptions;
+    _debugOptions = debugOptions;
+  }
+
+  public String getSql() {
+    return _sql;
   }
 
   public SqlNode getSqlNode() {
@@ -44,8 +52,12 @@ public class SqlNodeAndOptions {
     return _sqlType;
   }
 
-  public Map<String, String> getOptions() {
-    return _options;
+  public Map<String, String> getQueryOptions() {
+    return _queryOptions;
+  }
+
+  public Map<String, String> getDebugOptions() {
+    return _debugOptions;
   }
 
   public long getParseTimeNs() {
@@ -56,7 +68,17 @@ public class SqlNodeAndOptions {
     _parseTimeNs = parseTimeNs;
   }
 
-  public void setExtraOptions(Map<String, String> extractOptionsMap) {
-    _options.putAll(extractOptionsMap);
+  public void putExtraQueryOptions(Map<String, String> extractOptionsMap) {
+    putOptionsIfNotPresent(_queryOptions, extractOptionsMap);
+  }
+
+  public void putExtraDebugOptions(Map<String, String> extraDebugOptions) {
+    putOptionsIfNotPresent(_debugOptions, extraDebugOptions);
+  }
+
+  static void putOptionsIfNotPresent(Map<String, String> destination, Map<String, String> source) {
+    for (Map.Entry<String, String> e : source.entrySet()) {
+      destination.putIfAbsent(e.getKey(), e.getValue());
+    }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/dml/InsertIntoFile.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/dml/InsertIntoFile.java
@@ -68,7 +68,7 @@ public class InsertIntoFile implements DataManipulationStatement {
     String tableName = operandList.get(0) != null ? StringUtils.joinWith(",", operandList.get(0), operandList.get(1))
         : operandList.get(1).toString();
     // Set Options
-    Map<String, String> optionsMap = sqlNodeAndOptions.getOptions();
+    Map<String, String> optionsMap = sqlNodeAndOptions.getQueryOptions();
     List<String> inputDirList = new ArrayList<>();
     ((SqlNodeList) operandList.get(2)).getList()
         .forEach(sqlNode1 -> inputDirList.add(sqlNode1.toString().replace("'", "")));

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -2654,7 +2654,7 @@ public class CalciteSqlCompilerTest {
       SqlParserImpl sqlParser = CalciteSqlParser.newSqlParser(inStream);
       SqlNodeList sqlNodeList = sqlParser.SqlStmtsEof();
       // Extract OPTION statements from sql.
-      return CalciteSqlParser.extractSqlNodeAndOptions(sqlNodeList);
+      return CalciteSqlParser.extractSqlNodeAndOptions(sqlString, sqlNodeList);
     } catch (Exception e) {
       Assert.fail("test custom sql parser failed", e);
       return null;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -127,7 +127,7 @@ public class QueryEnvironment {
   public QueryPlan planQuery(String sqlQuery, SqlNodeAndOptions sqlNodeAndOptions) {
     PlannerContext plannerContext = new PlannerContext();
     try {
-      plannerContext.setOptions(sqlNodeAndOptions.getOptions());
+      plannerContext.setOptions(sqlNodeAndOptions.getQueryOptions());
       SqlNode validated = validate(sqlNodeAndOptions.getSqlNode());
       RelRoot relation = toRelation(validated, plannerContext);
       RelNode optimized = optimize(relation, plannerContext);
@@ -154,7 +154,7 @@ public class QueryEnvironment {
       throws Exception {
     // 1. invoke CalciteSqlParser to parse out SqlNode;
     SqlNodeAndOptions sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(query);
-    plannerContext.setOptions(sqlNodeAndOptions.getOptions());
+    plannerContext.setOptions(sqlNodeAndOptions.getQueryOptions());
     return sqlNodeAndOptions.getSqlNode();
   }
 


### PR DESCRIPTION
- [x] add handleRequest API that also take a parsed sqlNodeAndOption object (done in #9202)
- [x] allow option parsing to be in commonly used by controller and broker

with this change the `CalciteSqlParser.#SqlParserImpl` usage is once in broker and once in controller. 