### PR TITLE
Disable logging request header by default.

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -256,7 +256,9 @@ public class CommonConstants {
 
     public static final String CONFIG_OF_BROKER_REQUEST_CLIENT_IP_LOGGING =
         "pinot.broker.request.client.ip.logging";
-    public static final boolean DEFAULT_BROKER_REQUEST_CLIENT_IP_LOGGING = true;
+
+    // TODO: Support populating clientIp for GrpcRequestIdentity.
+    public static final boolean DEFAULT_BROKER_REQUEST_CLIENT_IP_LOGGING = false;
 
     public static class Request {
       public static final String SQL = "sql";


### PR DESCRIPTION
label = Bugfix
Changing default to false until the bug is fixed properly. 

I will create an issue to fix this. We should ideally create a function in RequestIdentity to get client IP and have all child classes implement it. 
