### PR TITLE
overload divide function to allow a default value when denominator==0

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
@@ -51,6 +51,11 @@ public class ArithmeticFunctions {
   }
 
   @ScalarFunction
+  public static double divide(double a, double b, double defaultValue) {
+    return (b == 0) ? defaultValue : a / b;
+  }
+
+  @ScalarFunction
   public static double mod(double a, double b) {
     return a % b;
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/ArithmeticFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/ArithmeticFunctionsTest.java
@@ -96,6 +96,11 @@ public class ArithmeticFunctionsTest {
     inputs.add(new Object[]{"sign(a)", Lists.newArrayList("a"), row6, 1.0});
     inputs.add(new Object[]{"sign(a)", Lists.newArrayList("a"), row7, -1.0});
 
+    GenericRow row8 = new GenericRow();
+    row8.putValue("a", 9.5);
+    row8.putValue("b", 0);
+    inputs.add(new Object[]{"divide(a, b, 0)", Lists.newArrayList("a", "b"), row8, 0.0});
+
     return inputs.toArray(new Object[0][]);
   }
 }


### PR DESCRIPTION
add scalar function `divide(double a, double b, double defaultValue)` to have divide return specified default value when denominator == 0
