### PR TITLE
Emit metrics for ratio of actual consumption rate to rate limit in realtime tables

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -43,7 +43,7 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   UPSERT_PRIMARY_KEYS_COUNT("upsertPrimaryKeysCount", false),
   // Dedup metrics
   DEDUP_PRIMARY_KEYS_COUNT("dedupPrimaryKeysCount", false),
-  CONSUMPTION_RATE_TO_LIMIT_RATIO_PERCENT("ratio", false);
+  CONSUMPTION_QUOTA_UTILIZATION("ratio", false);
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -42,7 +42,8 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   // Upsert metrics
   UPSERT_PRIMARY_KEYS_COUNT("upsertPrimaryKeysCount", false),
   // Dedup metrics
-  DEDUP_PRIMARY_KEYS_COUNT("dedupPrimaryKeysCount", false);
+  DEDUP_PRIMARY_KEYS_COUNT("dedupPrimaryKeysCount", false),
+  CONSUMPTION_RATE_TO_LIMIT_RATIO_PERCENT("ratio", false);
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -499,7 +499,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
    */
   private boolean processStreamEvents(MessageBatch messagesAndOffsets, long idlePipeSleepTimeMillis) {
 
-    int messageCount = messagesAndOffsets.getMessageCount();
+    int messageCount = messagesAndOffsets.getUnfilteredMessageCount();
     _rateLimiter.throttle(messageCount);
 
     PinotMeter realtimeRowsConsumedMeter = null;
@@ -1288,7 +1288,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
         serverMetrics);
 
     _rateLimiter = RealtimeConsumptionRateManager.getInstance()
-        .createRateLimiter(_partitionLevelStreamConfig, _tableNameWithType);
+        .createRateLimiter(_partitionLevelStreamConfig, _tableNameWithType, _serverMetrics, _metricKeyName);
 
     List<String> sortedColumns = indexLoadingConfig.getSortedColumns();
     if (sortedColumns.isEmpty()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
@@ -184,8 +184,8 @@ public class RealtimeConsumptionRateManager {
     private final String _metricKeyName;
 
     // state variables
-    private long previousMinute = -1;
-    private int aggregateNumMessages = 0;
+    private long _previousMinute = -1;
+    private int _aggregateNumMessages = 0;
 
     public MetricEmitter(ServerMetrics serverMetrics, String metricKeyName) {
       _serverMetrics = serverMetrics;
@@ -195,17 +195,17 @@ public class RealtimeConsumptionRateManager {
     int emitMetric(int numMsgsConsumed, double rateLimit, Instant now) {
       int ratioPercentage = 0;
       long nowInMinutes = now.getEpochSecond() / 60;
-      if (nowInMinutes == previousMinute) {
-        aggregateNumMessages += numMsgsConsumed;
+      if (nowInMinutes == _previousMinute) {
+        _aggregateNumMessages += numMsgsConsumed;
       } else {
-        if (previousMinute != -1) { // not first time
-          double actualRate = aggregateNumMessages / ((nowInMinutes - previousMinute) * 60.0); // messages per second
+        if (_previousMinute != -1) { // not first time
+          double actualRate = _aggregateNumMessages / ((nowInMinutes - _previousMinute) * 60.0); // messages per second
           ratioPercentage = (int) Math.round(actualRate / rateLimit * 100);
           _serverMetrics.setValueOfTableGauge(_metricKeyName, ServerGauge.CONSUMPTION_RATE_TO_LIMIT_RATIO_PERCENT,
               ratioPercentage);
         }
-        aggregateNumMessages = numMsgsConsumed;
-        previousMinute = nowInMinutes;
+        _aggregateNumMessages = numMsgsConsumed;
+        _previousMinute = nowInMinutes;
       }
       return ratioPercentage;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
@@ -206,7 +206,7 @@ public class RealtimeConsumptionRateManager {
         if (_previousMinute != -1) { // not first time
           double actualRate = _aggregateNumMessages / ((nowInMinutes - _previousMinute) * 60.0); // messages per second
           ratioPercentage = (int) Math.round(actualRate / rateLimit * 100);
-          _serverMetrics.setValueOfTableGauge(_metricKeyName, ServerGauge.CONSUMPTION_RATE_TO_LIMIT_RATIO_PERCENT,
+          _serverMetrics.setValueOfTableGauge(_metricKeyName, ServerGauge.CONSUMPTION_QUOTA_UTILIZATION,
               ratioPercentage);
         }
         _aggregateNumMessages = numMsgsConsumed;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
@@ -95,6 +95,11 @@ public class RealtimeConsumptionRateManager {
   }
 
   @VisibleForTesting
+  ConsumptionRateLimiter createRateLimiter(StreamConfig streamConfig, String tableName) {
+    return createRateLimiter(streamConfig, tableName, null, null);
+  }
+
+  @VisibleForTesting
   static LoadingCache<StreamConfig, Integer> buildCache(PartitionCountFetcher partitionCountFetcher,
       long duration, TimeUnit unit) {
     return CacheBuilder.newBuilder().refreshAfterWrite(duration, unit)

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
@@ -26,8 +26,12 @@ import com.google.common.cache.LoadingCache;
 import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.RateLimiter;
+import java.time.Clock;
+import java.time.Instant;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+import org.apache.pinot.common.metrics.ServerGauge;
+import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConsumerFactory;
 import org.apache.pinot.spi.stream.StreamConsumerFactoryProvider;
@@ -69,7 +73,8 @@ public class RealtimeConsumptionRateManager {
     _isThrottlingAllowed = true;
   }
 
-  public ConsumptionRateLimiter createRateLimiter(StreamConfig streamConfig, String tableName) {
+  public ConsumptionRateLimiter createRateLimiter(StreamConfig streamConfig, String tableName,
+      ServerMetrics serverMetrics, String metricKeyName) {
     if (!streamConfig.getTopicConsumptionRateLimit().isPresent()) {
       return NOOP_RATE_LIMITER;
     }
@@ -85,7 +90,8 @@ public class RealtimeConsumptionRateManager {
     LOGGER.info("A consumption rate limiter is set up for topic {} in table {} with rate limit: {} "
             + "(topic rate limit: {}, partition count: {})", streamConfig.getTopicName(), tableName, partitionRateLimit,
         topicRateLimit, partitionCount);
-    return new RateLimiterImpl(partitionRateLimit);
+    MetricEmitter metricEmitter = new MetricEmitter(serverMetrics, metricKeyName);
+    return new RateLimiterImpl(partitionRateLimit, metricEmitter);
   }
 
   @VisibleForTesting
@@ -126,14 +132,17 @@ public class RealtimeConsumptionRateManager {
   static class RateLimiterImpl implements ConsumptionRateLimiter {
     private final double _rate;
     private final RateLimiter _rateLimiter;
+    private MetricEmitter _metricEmitter;
 
-    private RateLimiterImpl(double rate) {
+    private RateLimiterImpl(double rate, MetricEmitter metricEmitter) {
       _rate = rate;
       _rateLimiter = RateLimiter.create(rate);
+      _metricEmitter = metricEmitter;
     }
 
     @Override
     public void throttle(int numMsgs) {
+      _metricEmitter.emitMetric(numMsgs, _rate, Clock.systemUTC().instant());
       if (InstanceHolder.INSTANCE._isThrottlingAllowed && numMsgs > 0) {
         _rateLimiter.acquire(numMsgs);
       }
@@ -162,4 +171,43 @@ public class RealtimeConsumptionRateManager {
       return null;
     }
   };
+
+  /**
+   * This class is responsible to emit a gauge metric for the ratio of the actual consumption rate to the rate limit.
+   * Number of messages consumed are aggregated over one minute. Each minute the ratio percentage is calculated and
+   * emitted.
+   */
+  @VisibleForTesting
+  static class MetricEmitter {
+
+    private final ServerMetrics _serverMetrics;
+    private final String _metricKeyName;
+
+    // state variables
+    private long previousMinute = -1;
+    private int aggregateNumMessages = 0;
+
+    public MetricEmitter(ServerMetrics serverMetrics, String metricKeyName) {
+      _serverMetrics = serverMetrics;
+      _metricKeyName = metricKeyName;
+    }
+
+    int emitMetric(int numMsgsConsumed, double rateLimit, Instant now) {
+      int ratioPercentage = 0;
+      long nowInMinutes = now.getEpochSecond() / 60;
+      if (nowInMinutes == previousMinute) {
+        aggregateNumMessages += numMsgsConsumed;
+      } else {
+        if (previousMinute != -1) { // not first time
+          double actualRate = aggregateNumMessages / ((nowInMinutes - previousMinute) * 60.0); // messages per second
+          ratioPercentage = (int) Math.round(actualRate / rateLimit * 100);
+          _serverMetrics.setValueOfTableGauge(_metricKeyName, ServerGauge.CONSUMPTION_RATE_TO_LIMIT_RATIO_PERCENT,
+              ratioPercentage);
+        }
+        aggregateNumMessages = numMsgsConsumed;
+        previousMinute = nowInMinutes;
+      }
+      return ratioPercentage;
+    }
+  }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManagerTest.java
@@ -29,7 +29,14 @@ import java.util.concurrent.TimeUnit;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.testng.annotations.Test;
 
+<<<<<<< HEAD
 import static org.apache.pinot.core.data.manager.realtime.RealtimeConsumptionRateManager.*;
+=======
+import static org.apache.pinot.core.data.manager.realtime.RealtimeConsumptionRateManager.ConsumptionRateLimiter;
+import static org.apache.pinot.core.data.manager.realtime.RealtimeConsumptionRateManager.MetricEmitter;
+import static org.apache.pinot.core.data.manager.realtime.RealtimeConsumptionRateManager.NOOP_RATE_LIMITER;
+import static org.apache.pinot.core.data.manager.realtime.RealtimeConsumptionRateManager.RateLimiterImpl;
+>>>>>>> 845edc0eeb (mvn checkstyle:apply)
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManagerTest.java
@@ -24,19 +24,16 @@ import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.Optional;
 import java.util.concurrent.ExecutionException;
-import org.apache.pinot.common.metrics.ServerMetrics;
 import java.util.concurrent.TimeUnit;
+import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.testng.annotations.Test;
 
-<<<<<<< HEAD
 import static org.apache.pinot.core.data.manager.realtime.RealtimeConsumptionRateManager.*;
-=======
 import static org.apache.pinot.core.data.manager.realtime.RealtimeConsumptionRateManager.ConsumptionRateLimiter;
 import static org.apache.pinot.core.data.manager.realtime.RealtimeConsumptionRateManager.MetricEmitter;
 import static org.apache.pinot.core.data.manager.realtime.RealtimeConsumptionRateManager.NOOP_RATE_LIMITER;
 import static org.apache.pinot.core.data.manager.realtime.RealtimeConsumptionRateManager.RateLimiterImpl;
->>>>>>> 845edc0eeb (mvn checkstyle:apply)
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManagerTest.java
@@ -128,6 +128,7 @@ public class RealtimeConsumptionRateManagerTest {
 
   @Test
   public void testMetricEmitter() {
+
     // setup metric emitter
     double rateLimit = 2; // 2 msgs/sec = 120 msgs/min
     ServerMetrics serverMetrics = mock(ServerMetrics.class);


### PR DESCRIPTION
## Description
This PR adds a gauge metric indicating the ratio (percentage) of the actual consumption rate to the rate limit that's specified in the table config. The number of messages consumed are aggregated over one minute. Each minute the ratio percentage is calculated and emitted.

## Testing Done
Unit tests