### PR TITLE
Avoid parsing query multiple times

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -144,7 +144,6 @@ public class PinotClientRequest {
   private BrokerResponse executeSqlQuery(ObjectNode sqlRequestJson, HttpRequesterIdentity httpRequesterIdentity,
       boolean onlyDql)
       throws Exception {
-    long compilationStartTimeNs = System.nanoTime();
     SqlNodeAndOptions sqlNodeAndOptions;
     try {
       sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sqlRequestJson.get(Request.SQL).asText());
@@ -159,8 +158,8 @@ public class PinotClientRequest {
     switch (sqlType) {
       case DQL:
         try (RequestScope requestStatistics = Tracing.getTracer().createRequestScope()) {
-          return _requestHandler.handleRequest(sqlRequestJson, sqlNodeAndOptions, compilationStartTimeNs,
-              httpRequesterIdentity, requestStatistics);
+          return _requestHandler.handleRequest(sqlRequestJson, sqlNodeAndOptions, httpRequesterIdentity,
+              requestStatistics);
         }
       case DML:
         Map<String, String> headers = new HashMap<>();

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -284,7 +284,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
     }
 
     _brokerRequestHandler = new BrokerRequestHandlerDelegate(singleStageBrokerRequestHandler,
-        multiStageBrokerRequestHandler);
+        multiStageBrokerRequestHandler, _brokerMetrics);
     _brokerRequestHandler.start();
     String controllerUrl = _brokerConf.getProperty(Broker.CONTROLLER_URL);
     if (controllerUrl != null) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -86,6 +86,7 @@ import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.sql.FilterKind;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -168,8 +169,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   }
 
   @Override
-  public BrokerResponseNative handleRequest(JsonNode request, @Nullable RequesterIdentity requesterIdentity,
-      RequestContext requestContext)
+  public BrokerResponseNative handleRequest(JsonNode request, @Nullable SqlNodeAndOptions sqlNodeAndOptions,
+      long compilationStartTimeNs, @Nullable RequesterIdentity requesterIdentity, RequestContext requestContext)
       throws Exception {
     long requestId = _requestIdGenerator.incrementAndGet();
     requestContext.setBrokerId(_brokerId);
@@ -190,26 +191,34 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     if (sql == null) {
       throw new BadQueryRequestException("Failed to find 'sql' in the request: " + request);
     }
-    return handleRequest(requestId, sql.asText(), request, requesterIdentity, requestContext);
+    String query = sql.asText();
+    requestContext.setQuery(query);
+    return handleRequest(requestId, query, sqlNodeAndOptions, compilationStartTimeNs, request, requesterIdentity,
+        requestContext);
   }
 
-  private BrokerResponseNative handleRequest(long requestId, String query, JsonNode request,
+  private BrokerResponseNative handleRequest(long requestId, String query,
+      @Nullable SqlNodeAndOptions sqlNodeAndOptions, long compilationStartTimeNs, JsonNode request,
       @Nullable RequesterIdentity requesterIdentity, RequestContext requestContext)
       throws Exception {
     LOGGER.debug("SQL query for request {}: {}", requestId, query);
-    requestContext.setQuery(query);
 
     // Compile the request
-    long compilationStartTimeNs = System.nanoTime();
     PinotQuery pinotQuery;
     try {
-      pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      if (sqlNodeAndOptions != null) {
+        pinotQuery = CalciteSqlParser.compileToPinotQuery(sqlNodeAndOptions);
+      } else {
+        compilationStartTimeNs = System.nanoTime();
+        pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+      }
     } catch (Exception e) {
       LOGGER.info("Caught exception while compiling SQL request {}: {}, {}", requestId, query, e.getMessage());
       _brokerMetrics.addMeteredGlobalValue(BrokerMeter.REQUEST_COMPILATION_EXCEPTIONS, 1);
       requestContext.setErrorCode(QueryException.SQL_PARSING_ERROR_CODE);
       return new BrokerResponseNative(QueryException.getException(QueryException.SQL_PARSING_ERROR, e));
     }
+
     setOptions(pinotQuery, requestId, query, request);
 
     if (isLiteralOnlyQuery(pinotQuery)) {
@@ -244,8 +253,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       return new BrokerResponseNative(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
     }
 
-    String tableName =
-        getActualTableName(serverPinotQuery.getDataSource().getTableName(), _tableCache);
+    String tableName = getActualTableName(serverPinotQuery.getDataSource().getTableName(), _tableCache);
     serverPinotQuery.getDataSource().setTableName(tableName);
     String rawTableName = TableNameBuilder.extractRawTableName(tableName);
     requestContext.setTableName(rawTableName);
@@ -691,7 +699,6 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       }
     }
 
-
     // Please keep the format as name=value comma-separated with no spaces
     // Please keep all the name value pairs together, then followed by the query. To add a new entry, please add it to
     // the end of existing pairs, but before the query.
@@ -702,9 +709,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
               + "{}/{}/{}/{}/{}/{}/{},consumingFreshnessTimeMs={},"
               + "servers={}/{},groupLimitReached={},brokerReduceTimeMs={},exceptions={},serverStats={},"
               + "offlineThreadCpuTimeNs(total/thread/sysActivity/resSer):{}/{}/{}/{},"
-              + "realtimeThreadCpuTimeNs(total/thread/sysActivity/resSer):{}/{}/{}/{},clientIp={}"
-              + ",query={}", requestId, tableName,
-          totalTimeMs, brokerResponse.getNumDocsScanned(), brokerResponse.getTotalDocs(),
+              + "realtimeThreadCpuTimeNs(total/thread/sysActivity/resSer):{}/{}/{}/{},clientIp={},query={}", requestId,
+          tableName, totalTimeMs, brokerResponse.getNumDocsScanned(), brokerResponse.getTotalDocs(),
           brokerResponse.getNumEntriesScannedInFilter(), brokerResponse.getNumEntriesScannedPostFilter(),
           brokerResponse.getNumSegmentsQueried(), brokerResponse.getNumSegmentsProcessed(),
           brokerResponse.getNumSegmentsMatched(), brokerResponse.getNumConsumingSegmentsQueried(),
@@ -779,7 +785,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       Preconditions.checkState(subqueryLiteral != null, "Second argument of IN_SUBQUERY must be a literal (subquery)");
       String subquery = subqueryLiteral.getStringValue();
       BrokerResponseNative response =
-          handleRequest(requestId, subquery, jsonRequest, requesterIdentity, requestContext);
+          handleRequest(requestId, subquery, null, -1, jsonRequest, requesterIdentity, requestContext);
       if (response.getExceptionsSize() != 0) {
         throw new RuntimeException("Caught exception while executing subquery: " + subquery);
       }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandler.java
@@ -34,16 +34,13 @@ public interface BrokerRequestHandler {
 
   void shutDown();
 
-  default BrokerResponseNative handleRequest(JsonNode request, @Nullable SqlNodeAndOptions sqlNodeAndOptions,
-      long compilationStartTimeNs, @Nullable RequesterIdentity requesterIdentity, RequestContext requestContext)
-      throws Exception {
-    return handleRequest(request, requesterIdentity, requestContext);
-  }
+  BrokerResponseNative handleRequest(JsonNode request, @Nullable SqlNodeAndOptions sqlNodeAndOptions,
+      @Nullable RequesterIdentity requesterIdentity, RequestContext requestContext)
+      throws Exception;
 
-  @Deprecated
   default BrokerResponseNative handleRequest(JsonNode request, @Nullable RequesterIdentity requesterIdentity,
       RequestContext requestContext)
       throws Exception {
-    return handleRequest(request, null, -1, requesterIdentity, requestContext);
+    return handleRequest(request, null, requesterIdentity, requestContext);
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandler.java
@@ -22,8 +22,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.broker.api.RequesterIdentity;
-import org.apache.pinot.common.response.BrokerResponse;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.spi.trace.RequestContext;
+import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
 
 
 @ThreadSafe
@@ -33,7 +34,16 @@ public interface BrokerRequestHandler {
 
   void shutDown();
 
-  BrokerResponse handleRequest(JsonNode request, @Nullable RequesterIdentity requesterIdentity,
+  default BrokerResponseNative handleRequest(JsonNode request, @Nullable SqlNodeAndOptions sqlNodeAndOptions,
+      long compilationStartTimeNs, @Nullable RequesterIdentity requesterIdentity, RequestContext requestContext)
+      throws Exception {
+    return handleRequest(request, requesterIdentity, requestContext);
+  }
+
+  @Deprecated
+  default BrokerResponseNative handleRequest(JsonNode request, @Nullable RequesterIdentity requesterIdentity,
       RequestContext requestContext)
-      throws Exception;
+      throws Exception {
+    return handleRequest(request, null, -1, requesterIdentity, requestContext);
+  }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
@@ -78,14 +78,13 @@ public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
 
   @Override
   public BrokerResponseNative handleRequest(JsonNode request, @Nullable SqlNodeAndOptions sqlNodeAndOptions,
-      long compilationStartTimeNs, @Nullable RequesterIdentity requesterIdentity, RequestContext requestContext)
+      @Nullable RequesterIdentity requesterIdentity, RequestContext requestContext)
       throws Exception {
     if (sqlNodeAndOptions == null) {
       JsonNode sql = request.get(Request.SQL);
       if (sql == null) {
         throw new BadQueryRequestException("Failed to find 'sql' in the request: " + request);
       }
-      compilationStartTimeNs = System.nanoTime();
       try {
         sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sql.asText());
       } catch (Exception e) {
@@ -97,11 +96,11 @@ public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
     }
 
     if (_multiStageWorkerRequestHandler != null && useMultiStageEngine(request, sqlNodeAndOptions)) {
-      return _multiStageWorkerRequestHandler.handleRequest(request, sqlNodeAndOptions, compilationStartTimeNs,
-          requesterIdentity, requestContext);
+      return _multiStageWorkerRequestHandler.handleRequest(request, sqlNodeAndOptions, requesterIdentity,
+          requestContext);
     } else {
-      return _singleStageBrokerRequestHandler.handleRequest(request, sqlNodeAndOptions, compilationStartTimeNs,
-          requesterIdentity, requestContext);
+      return _singleStageBrokerRequestHandler.handleRequest(request, sqlNodeAndOptions, requesterIdentity,
+          requestContext);
     }
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
@@ -22,9 +22,18 @@ import com.fasterxml.jackson.databind.JsonNode;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.broker.api.RequesterIdentity;
-import org.apache.pinot.common.response.BrokerResponse;
+import org.apache.pinot.common.exception.QueryException;
+import org.apache.pinot.common.metrics.BrokerMeter;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.apache.pinot.spi.trace.RequestContext;
-import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Broker.Request;
+import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -34,20 +43,17 @@ import org.apache.pinot.spi.utils.CommonConstants;
  * {@see: @CommonConstant
  */
 public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BrokerRequestHandlerDelegate.class);
 
   private final BrokerRequestHandler _singleStageBrokerRequestHandler;
   private final MultiStageBrokerRequestHandler _multiStageWorkerRequestHandler;
+  private final BrokerMetrics _brokerMetrics;
 
-  private final boolean _isMultiStageQueryEngineEnabled;
-
-
-  public BrokerRequestHandlerDelegate(
-      BrokerRequestHandler singleStageBrokerRequestHandler,
-      @Nullable MultiStageBrokerRequestHandler multiStageWorkerRequestHandler
-  ) {
+  public BrokerRequestHandlerDelegate(BrokerRequestHandler singleStageBrokerRequestHandler,
+      @Nullable MultiStageBrokerRequestHandler multiStageWorkerRequestHandler, BrokerMetrics brokerMetrics) {
     _singleStageBrokerRequestHandler = singleStageBrokerRequestHandler;
     _multiStageWorkerRequestHandler = multiStageWorkerRequestHandler;
-    _isMultiStageQueryEngineEnabled = _multiStageWorkerRequestHandler != null;
+    _brokerMetrics = brokerMetrics;
   }
 
   @Override
@@ -71,18 +77,44 @@ public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
   }
 
   @Override
-  public BrokerResponse handleRequest(JsonNode request, @Nullable RequesterIdentity requesterIdentity,
-      RequestContext requestContext)
+  public BrokerResponseNative handleRequest(JsonNode request, @Nullable SqlNodeAndOptions sqlNodeAndOptions,
+      long compilationStartTimeNs, @Nullable RequesterIdentity requesterIdentity, RequestContext requestContext)
       throws Exception {
-    if (_isMultiStageQueryEngineEnabled && _multiStageWorkerRequestHandler != null) {
-      if (request.has("queryOptions")) {
-        Map<String, String> queryOptionMap = BaseBrokerRequestHandler.getOptionsFromJson(request, "queryOptions");
-        if (Boolean.parseBoolean(queryOptionMap.get(
-            CommonConstants.Broker.Request.QueryOptionKey.USE_MULTISTAGE_ENGINE))) {
-          return _multiStageWorkerRequestHandler.handleRequest(request, requesterIdentity, requestContext);
-        }
+    if (sqlNodeAndOptions == null) {
+      JsonNode sql = request.get(Request.SQL);
+      if (sql == null) {
+        throw new BadQueryRequestException("Failed to find 'sql' in the request: " + request);
+      }
+      compilationStartTimeNs = System.nanoTime();
+      try {
+        sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sql.asText());
+      } catch (Exception e) {
+        LOGGER.info("Caught exception while compiling SQL: {}, {}", sql.asText(), e.getMessage());
+        _brokerMetrics.addMeteredGlobalValue(BrokerMeter.REQUEST_COMPILATION_EXCEPTIONS, 1);
+        requestContext.setErrorCode(QueryException.SQL_PARSING_ERROR_CODE);
+        return new BrokerResponseNative(QueryException.getException(QueryException.SQL_PARSING_ERROR, e));
       }
     }
-    return _singleStageBrokerRequestHandler.handleRequest(request, requesterIdentity, requestContext);
+
+    if (_multiStageWorkerRequestHandler != null && useMultiStageEngine(request, sqlNodeAndOptions)) {
+      return _multiStageWorkerRequestHandler.handleRequest(request, sqlNodeAndOptions, compilationStartTimeNs,
+          requesterIdentity, requestContext);
+    } else {
+      return _singleStageBrokerRequestHandler.handleRequest(request, sqlNodeAndOptions, compilationStartTimeNs,
+          requesterIdentity, requestContext);
+    }
+  }
+
+  private boolean useMultiStageEngine(JsonNode request, SqlNodeAndOptions sqlNodeAndOptions) {
+    Map<String, String> optionsFromSql = sqlNodeAndOptions.getOptions();
+    if (Boolean.parseBoolean(optionsFromSql.get(QueryOptionKey.USE_MULTISTAGE_ENGINE))) {
+      return true;
+    }
+    if (request.has(Request.QUERY_OPTIONS)) {
+      Map<String, String> optionsFromRequest =
+          BaseBrokerRequestHandler.getOptionsFromJson(request, Request.QUERY_OPTIONS);
+      return Boolean.parseBoolean(optionsFromRequest.get(QueryOptionKey.USE_MULTISTAGE_ENGINE));
+    }
+    return false;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -107,6 +107,8 @@ public class CalciteSqlParser {
 
   public static SqlNodeAndOptions compileToSqlNodeAndOptions(String sql)
       throws SqlCompilationException {
+    long parseStartTimeNs = System.nanoTime();
+
     // Remove the comments from the query
     sql = removeComments(sql);
 
@@ -128,6 +130,7 @@ public class CalciteSqlParser {
       if (options.size() > 0) {
         sqlNodeAndOptions.setExtraOptions(extractOptionsMap(options));
       }
+      sqlNodeAndOptions.setParseTimeNs(System.nanoTime() - parseStartTimeNs);
       return sqlNodeAndOptions;
     } catch (Throwable e) {
       throw new SqlCompilationException("Caught exception while parsing query: " + sql, e);

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -171,8 +171,10 @@ public class CalciteSqlParser {
 
   public static PinotQuery compileToPinotQuery(String sql)
       throws SqlCompilationException {
-    SqlNodeAndOptions sqlNodeAndOptions = compileToSqlNodeAndOptions(sql);
+    return compileToPinotQuery(compileToSqlNodeAndOptions(sql));
+  }
 
+  public static PinotQuery compileToPinotQuery(SqlNodeAndOptions sqlNodeAndOptions) {
     // Compile Sql without OPTION statements.
     PinotQuery pinotQuery = compileSqlNodeToPinotQuery(sqlNodeAndOptions.getSqlNode());
 

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/SqlNodeAndOptions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/SqlNodeAndOptions.java
@@ -28,6 +28,8 @@ public class SqlNodeAndOptions {
   // TODO: support option literals other than STRING
   private final Map<String, String> _options;
 
+  private long _parseTimeNs;
+
   public SqlNodeAndOptions(SqlNode sqlNode, PinotSqlType sqlType, Map<String, String> options) {
     _sqlNode = sqlNode;
     _sqlType = sqlType;
@@ -38,12 +40,20 @@ public class SqlNodeAndOptions {
     return _sqlNode;
   }
 
+  public PinotSqlType getSqlType() {
+    return _sqlType;
+  }
+
   public Map<String, String> getOptions() {
     return _options;
   }
 
-  public PinotSqlType getSqlType() {
-    return _sqlType;
+  public long getParseTimeNs() {
+    return _parseTimeNs;
+  }
+
+  public void setParseTimeNs(long parseTimeNs) {
+    _parseTimeNs = parseTimeNs;
   }
 
   public void setExtraOptions(Map<String, String> extractOptionsMap) {


### PR DESCRIPTION
Currently we parse the same query multiple times:
1. Figure out whether the query is DQL or DML
2. (not there but needed) Figure out whether to use multi-stage engine
3. When execute the query

This PR changes the `BrokerRequestHandler` to take the parsed `SqlNodeAndOptions` so that we only need to parse the query once. It also adds support to read query options from query in the `BrokerRequestHandlerDelegate`