### PR TITLE
Max number of multi values should be set in DefaultNullValueProvider

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -636,6 +636,11 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     assertEquals(resultTable.get("dataSchema").get("columnNames").size(), schema.size());
     assertEquals(resultTable.get("rows").size(), 10);
 
+    // Test aggregation query to include querying all segemnts (including realtime)
+    String aggregationQuery = "SELECT SUMMV(NewIntMVDimension) FROM " + rawTableName;
+    queryResponse = postQuery(aggregationQuery);
+    assertEquals(queryResponse.get("exceptions").size(), 0);
+
     // Test filter on all new added columns
     String countStarQuery = "SELECT COUNT(*) FROM " + rawTableName
         + " WHERE NewIntSVDimension < 0 AND NewLongSVDimension < 0 AND NewFloatSVDimension < 0 AND "

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -966,7 +966,6 @@ public class MutableSegmentImpl implements MutableSegment {
   public DataSource getDataSource(String column) {
     FieldSpec fieldSpec = _schema.getFieldSpecFor(column);
     if (fieldSpec == null || fieldSpec.isVirtualColumn()) {
-      VirtualColumnContext virtualColumnContext = null;
       // Column is either added during ingestion, or was initiated with a virtual column provider
       if (fieldSpec == null) {
         // If the column was added during ingestion, we will construct the column provider based on its fieldSpec to
@@ -974,13 +973,9 @@ public class MutableSegmentImpl implements MutableSegment {
         fieldSpec = _newlyAddedColumnsFieldMap.get(column);
         Preconditions.checkNotNull(fieldSpec,
             "FieldSpec for " + column + " should not be null. " + "Potentially invalid column name specified.");
-        // newly added column shouldn't have any doc count?
-        virtualColumnContext = new VirtualColumnContext(fieldSpec, 0);
       }
       // TODO: Refactor virtual column provider to directly generate data source
-      if (virtualColumnContext == null) {
-        virtualColumnContext = new VirtualColumnContext(fieldSpec, _numDocsIndexed);
-      }
+      VirtualColumnContext virtualColumnContext = new VirtualColumnContext(fieldSpec, _numDocsIndexed);
       VirtualColumnProvider virtualColumnProvider = VirtualColumnProviderFactory.buildProvider(virtualColumnContext);
       return new ImmutableDataSource(virtualColumnProvider.buildMetadata(virtualColumnContext),
           virtualColumnProvider.buildColumnIndexContainer(virtualColumnContext));

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProvider.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProvider.java
@@ -87,9 +87,11 @@ public class DefaultNullValueVirtualColumnProvider extends BaseVirtualColumnProv
   public ColumnMetadataImpl buildMetadata(VirtualColumnContext context) {
     if (context.getFieldSpec().isSingleValueField()) {
       return getColumnMetadataBuilder(context).setCardinality(1).setSorted(true)
+          .setTotalDocs(context.getTotalDocCount())
           .setHasDictionary(true).build();
     }
-    return getColumnMetadataBuilder(context).setSorted(false).setHasDictionary(true).setMaxNumberOfMultiValues(0)
+    return getColumnMetadataBuilder(context).setSorted(false).setTotalDocs(context.getTotalDocCount())
+        .setHasDictionary(true).setMaxNumberOfMultiValues(0)
         .build();
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProvider.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProvider.java
@@ -85,12 +85,11 @@ public class DefaultNullValueVirtualColumnProvider extends BaseVirtualColumnProv
 
   @Override
   public ColumnMetadataImpl buildMetadata(VirtualColumnContext context) {
-
     ColumnMetadataImpl.Builder builder = getColumnMetadataBuilder(context).setCardinality(1).setHasDictionary(true);
     if (context.getFieldSpec().isSingleValueField()) {
       builder.setSorted(true);
     } else {
-      builder.setMaxNumberOfMultiValues(1);
+      builder.setMaxNumberOfMultiValues(0);
     }
     return builder.build();
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProvider.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProvider.java
@@ -85,7 +85,11 @@ public class DefaultNullValueVirtualColumnProvider extends BaseVirtualColumnProv
 
   @Override
   public ColumnMetadataImpl buildMetadata(VirtualColumnContext context) {
-    return getColumnMetadataBuilder(context).setCardinality(1).setSorted(context.getFieldSpec().isSingleValueField())
-        .setHasDictionary(true).build();
+    if (context.getFieldSpec().isSingleValueField()) {
+      return getColumnMetadataBuilder(context).setCardinality(1).setSorted(true)
+          .setHasDictionary(true).build();
+    }
+    return getColumnMetadataBuilder(context).setSorted(false).setHasDictionary(true).setMaxNumberOfMultiValues(0)
+        .build();
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProvider.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProvider.java
@@ -85,13 +85,13 @@ public class DefaultNullValueVirtualColumnProvider extends BaseVirtualColumnProv
 
   @Override
   public ColumnMetadataImpl buildMetadata(VirtualColumnContext context) {
+
+    ColumnMetadataImpl.Builder builder = getColumnMetadataBuilder(context).setCardinality(1).setHasDictionary(true);
     if (context.getFieldSpec().isSingleValueField()) {
-      return getColumnMetadataBuilder(context).setCardinality(1).setSorted(true)
-          .setTotalDocs(context.getTotalDocCount())
-          .setHasDictionary(true).build();
+      builder.setSorted(true);
+    } else {
+      builder.setMaxNumberOfMultiValues(1);
     }
-    return getColumnMetadataBuilder(context).setSorted(false).setTotalDocs(context.getTotalDocCount())
-        .setHasDictionary(true).setMaxNumberOfMultiValues(0)
-        .build();
+    return builder.build();
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProvider.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProvider.java
@@ -89,7 +89,10 @@ public class DefaultNullValueVirtualColumnProvider extends BaseVirtualColumnProv
     if (context.getFieldSpec().isSingleValueField()) {
       builder.setSorted(true);
     } else {
-      builder.setMaxNumberOfMultiValues(0);
+      // When there is no value for a multi-value column, the maxNumberOfMultiValues and cardinality should be
+      // set as 1 because the MV column bitmap uses 1 to delimit the rows for a MV column. Each MV column will have a
+      // default null value based on column's data type
+      builder.setMaxNumberOfMultiValues(1);
     }
     return builder.build();
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/constant/ConstantMVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/constant/ConstantMVForwardIndexReader.java
@@ -45,6 +45,9 @@ public final class ConstantMVForwardIndexReader implements ForwardIndexReader<Fo
 
   @Override
   public int getDictIdMV(int docId, int[] dictIdBuffer, ForwardIndexReaderContext context) {
+    if (dictIdBuffer.length == 0) {
+      return 0;
+    }
     dictIdBuffer[0] = 0;
     return 1;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/constant/ConstantMVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/constant/ConstantMVForwardIndexReader.java
@@ -43,11 +43,13 @@ public final class ConstantMVForwardIndexReader implements ForwardIndexReader<Fo
     return DataType.INT;
   }
 
+  /*
+   * Asserting on dictIdBuffer being non-empty is done on purpose here as this reader is used in the query hot path and
+   * it would be prohibitively expensive.
+   * It is always assumed that the dictIdBuffer is set correctly based on the maxNumberOfMultiValues column metadata.
+   */
   @Override
   public int getDictIdMV(int docId, int[] dictIdBuffer, ForwardIndexReaderContext context) {
-    if (dictIdBuffer.length == 0) {
-      return 0;
-    }
     dictIdBuffer[0] = 0;
     return 1;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/virtualcolumn/VirtualColumnContext.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/virtualcolumn/VirtualColumnContext.java
@@ -26,8 +26,8 @@ import org.apache.pinot.spi.data.FieldSpec;
  * It will be used to build various components (dictionary, reader, etc) in the virtual column provider.
  */
 public class VirtualColumnContext {
-  private FieldSpec _fieldSpec;
-  private int _totalDocCount;
+  private final FieldSpec _fieldSpec;
+  private final int _totalDocCount;
 
   public VirtualColumnContext(FieldSpec fieldSpec, int totalDocCount) {
     _fieldSpec = fieldSpec;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProviderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProviderTest.java
@@ -74,25 +74,25 @@ public class DefaultNullValueVirtualColumnProviderTest {
         new ColumnMetadataImpl.Builder().setFieldSpec(SV_BYTES).setTotalDocs(1).setCardinality(1).setSorted(true)
             .setHasDictionary(true).build());
 
-    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_INT, 1)),
-        new ColumnMetadataImpl.Builder().setFieldSpec(MV_INT).setTotalDocs(1).setCardinality(1).setSorted(false)
-            .setHasDictionary(true).build());
+    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_INT, 0)),
+        new ColumnMetadataImpl.Builder().setFieldSpec(MV_INT).setTotalDocs(0).setCardinality(0).setSorted(false)
+            .setHasDictionary(true).setMaxNumberOfMultiValues(0).build());
 
-    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_LONG, 1)),
-        new ColumnMetadataImpl.Builder().setFieldSpec(MV_LONG).setTotalDocs(1).setCardinality(1).setSorted(false)
-            .setHasDictionary(true).build());
+    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_LONG, 0)),
+        new ColumnMetadataImpl.Builder().setFieldSpec(MV_LONG).setTotalDocs(0).setCardinality(0).setSorted(false)
+            .setHasDictionary(true).setMaxNumberOfMultiValues(0).build());
 
-    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_FLOAT, 1)),
-        new ColumnMetadataImpl.Builder().setFieldSpec(MV_FLOAT).setTotalDocs(1).setCardinality(1).setSorted(false)
-            .setHasDictionary(true).build());
+    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_FLOAT, 0)),
+        new ColumnMetadataImpl.Builder().setFieldSpec(MV_FLOAT).setTotalDocs(0).setCardinality(0).setSorted(false)
+            .setHasDictionary(true).setMaxNumberOfMultiValues(0).build());
 
-    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_DOUBLE, 1)),
-        new ColumnMetadataImpl.Builder().setFieldSpec(MV_DOUBLE).setTotalDocs(1).setCardinality(1).setSorted(false)
-            .setHasDictionary(true).build());
+    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_DOUBLE, 0)),
+        new ColumnMetadataImpl.Builder().setFieldSpec(MV_DOUBLE).setTotalDocs(0).setCardinality(0).setSorted(false)
+            .setHasDictionary(true).setMaxNumberOfMultiValues(0).build());
 
-    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_STRING, 1)),
-        new ColumnMetadataImpl.Builder().setFieldSpec(MV_STRING).setTotalDocs(1).setCardinality(1).setSorted(false)
-            .setHasDictionary(true).build());
+    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_STRING, 0)),
+        new ColumnMetadataImpl.Builder().setFieldSpec(MV_STRING).setTotalDocs(0).setCardinality(0).setSorted(false)
+            .setHasDictionary(true).setMaxNumberOfMultiValues(0).build());
   }
 
   @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProviderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProviderTest.java
@@ -74,24 +74,24 @@ public class DefaultNullValueVirtualColumnProviderTest {
         new ColumnMetadataImpl.Builder().setFieldSpec(SV_BYTES).setTotalDocs(1).setCardinality(1).setSorted(true)
             .setHasDictionary(true).build());
 
-    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_INT, 0)),
-        new ColumnMetadataImpl.Builder().setFieldSpec(MV_INT).setTotalDocs(0).setCardinality(0).setSorted(false)
-            .setHasDictionary(true).setMaxNumberOfMultiValues(0).build());
+    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_INT, 1)),
+        new ColumnMetadataImpl.Builder().setFieldSpec(MV_INT).setTotalDocs(1).setSorted(false)
+            .setHasDictionary(true).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_LONG, 0)),
-        new ColumnMetadataImpl.Builder().setFieldSpec(MV_LONG).setTotalDocs(0).setCardinality(0).setSorted(false)
+        new ColumnMetadataImpl.Builder().setFieldSpec(MV_LONG).setTotalDocs(0).setSorted(false)
             .setHasDictionary(true).setMaxNumberOfMultiValues(0).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_FLOAT, 0)),
-        new ColumnMetadataImpl.Builder().setFieldSpec(MV_FLOAT).setTotalDocs(0).setCardinality(0).setSorted(false)
+        new ColumnMetadataImpl.Builder().setFieldSpec(MV_FLOAT).setTotalDocs(0).setSorted(false)
             .setHasDictionary(true).setMaxNumberOfMultiValues(0).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_DOUBLE, 0)),
-        new ColumnMetadataImpl.Builder().setFieldSpec(MV_DOUBLE).setTotalDocs(0).setCardinality(0).setSorted(false)
+        new ColumnMetadataImpl.Builder().setFieldSpec(MV_DOUBLE).setTotalDocs(0).setSorted(false)
             .setHasDictionary(true).setMaxNumberOfMultiValues(0).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_STRING, 0)),
-        new ColumnMetadataImpl.Builder().setFieldSpec(MV_STRING).setTotalDocs(0).setCardinality(0).setSorted(false)
+        new ColumnMetadataImpl.Builder().setFieldSpec(MV_STRING).setTotalDocs(0).setSorted(false)
             .setHasDictionary(true).setMaxNumberOfMultiValues(0).build());
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProviderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProviderTest.java
@@ -75,23 +75,23 @@ public class DefaultNullValueVirtualColumnProviderTest {
             .setHasDictionary(true).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_INT, 1)),
-        new ColumnMetadataImpl.Builder().setFieldSpec(MV_INT).setTotalDocs(1).setSorted(false)
-            .setHasDictionary(true).build());
-
-    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_LONG, 0)),
-        new ColumnMetadataImpl.Builder().setFieldSpec(MV_LONG).setTotalDocs(0).setSorted(false)
+        new ColumnMetadataImpl.Builder().setFieldSpec(MV_INT).setTotalDocs(1).setCardinality(1).setSorted(false)
             .setHasDictionary(true).setMaxNumberOfMultiValues(0).build());
 
-    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_FLOAT, 0)),
-        new ColumnMetadataImpl.Builder().setFieldSpec(MV_FLOAT).setTotalDocs(0).setSorted(false)
+    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_LONG, 1)),
+        new ColumnMetadataImpl.Builder().setFieldSpec(MV_LONG).setTotalDocs(1).setCardinality(1).setSorted(false)
             .setHasDictionary(true).setMaxNumberOfMultiValues(0).build());
 
-    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_DOUBLE, 0)),
-        new ColumnMetadataImpl.Builder().setFieldSpec(MV_DOUBLE).setTotalDocs(0).setSorted(false)
+    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_FLOAT, 1)),
+        new ColumnMetadataImpl.Builder().setFieldSpec(MV_FLOAT).setTotalDocs(1).setCardinality(1).setSorted(false)
             .setHasDictionary(true).setMaxNumberOfMultiValues(0).build());
 
-    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_STRING, 0)),
-        new ColumnMetadataImpl.Builder().setFieldSpec(MV_STRING).setTotalDocs(0).setSorted(false)
+    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_DOUBLE, 1)),
+        new ColumnMetadataImpl.Builder().setFieldSpec(MV_DOUBLE).setTotalDocs(1).setCardinality(1).setSorted(false)
+            .setHasDictionary(true).setMaxNumberOfMultiValues(0).build());
+
+    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_STRING, 1)),
+        new ColumnMetadataImpl.Builder().setFieldSpec(MV_STRING).setTotalDocs(1).setCardinality(1).setSorted(false)
             .setHasDictionary(true).setMaxNumberOfMultiValues(0).build());
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProviderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProviderTest.java
@@ -76,23 +76,23 @@ public class DefaultNullValueVirtualColumnProviderTest {
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_INT, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(MV_INT).setTotalDocs(1).setCardinality(1).setSorted(false)
-            .setHasDictionary(true).setMaxNumberOfMultiValues(0).build());
+            .setHasDictionary(true).setMaxNumberOfMultiValues(1).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_LONG, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(MV_LONG).setTotalDocs(1).setCardinality(1).setSorted(false)
-            .setHasDictionary(true).setMaxNumberOfMultiValues(0).build());
+            .setHasDictionary(true).setMaxNumberOfMultiValues(1).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_FLOAT, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(MV_FLOAT).setTotalDocs(1).setCardinality(1).setSorted(false)
-            .setHasDictionary(true).setMaxNumberOfMultiValues(0).build());
+            .setHasDictionary(true).setMaxNumberOfMultiValues(1).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_DOUBLE, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(MV_DOUBLE).setTotalDocs(1).setCardinality(1).setSorted(false)
-            .setHasDictionary(true).setMaxNumberOfMultiValues(0).build());
+            .setHasDictionary(true).setMaxNumberOfMultiValues(1).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_STRING, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(MV_STRING).setTotalDocs(1).setCardinality(1).setSorted(false)
-            .setHasDictionary(true).setMaxNumberOfMultiValues(0).build());
+            .setHasDictionary(true).setMaxNumberOfMultiValues(1).build());
   }
 
   @Test


### PR DESCRIPTION
Related to #8819 

This issue shows up when we try to add a new Multivalue column and reload the segments of the table. Once the consuming segment commits, it will throw an `ArrayIndexOutOfBoundsException` in the `ConstantMVForwardIndexReader` and stops ingestion. 