### PR TITLE
Update log level to ERROR for HelixZNodeSizeLimitTest

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HelixZNodeSizeLimitTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HelixZNodeSizeLimitTest.java
@@ -22,6 +22,8 @@ package org.apache.pinot.integration.tests;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.apache.helix.zookeeper.constant.ZkSystemPropertyKeys;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
@@ -45,6 +47,13 @@ public class HelixZNodeSizeLimitTest extends BaseClusterIntegrationTest {
     // src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java#L105
     // The below line gets executed before ZkClient.WRITE_SIZE_LIMIT is created
     System.setProperty(ZkSystemPropertyKeys.JUTE_MAXBUFFER, "4000000");
+
+    // Set log level to ERROR, as there are too many warning messages printed if warn level is used like below:
+    //   20:07:11.616 WARN [TopStateHandoffReportStage] [HelixController-pipeline-default-HelixZNodeSizeLimitTest
+    //   -(b90d2ed3_DEFAULT)] Event b90d2ed3_DEFAULT : Cannot confirm top state missing start time.
+    //   Use the current system time as the start time.
+    Configurator.setAllLevels("", Level.ERROR);
+
     TestUtils.ensureDirectoriesExistAndEmpty(_tempDir);
 
     // Start Zookeeper
@@ -63,6 +72,9 @@ public class HelixZNodeSizeLimitTest extends BaseClusterIntegrationTest {
     stopBroker();
     stopController();
     stopZk();
+
+    // Reset log level back to warn.
+    Configurator.setAllLevels("", Level.WARN);
   }
 
   @Test


### PR DESCRIPTION
This PR updates the log level to `ERROR` for HelixZNodeSizeLimitTest, as it printed out too many warning message like below, which is from Helix code:
```
20:07:11.616 WARN [TopStateHandoffReportStage] [HelixController-pipeline-default-HelixZNodeSizeLimitTest-(b90d2ed3_DEFAULT)] Event b90d2ed3_DEFAULT : Cannot confirm top state missing start time.  Use the current system time as the start time.
```

Since the purpose of this test is just to make sure the data size of ideal state can be greater than 1M, we don't need to care about the warning message printed in this test, thus it's okay to set the log level to ERROR.

Issue: https://github.com/apache/pinot/issues/9127

cc: @walterddr 