### PR TITLE
Add close method to upsert interfaces

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -199,6 +199,10 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   @Override
   protected void doShutdown() {
     _segmentAsyncExecutorService.shutdown();
+    if (_tableUpsertMetadataManager != null) {
+      _tableUpsertMetadataManager.close();
+    }
+
     for (SegmentDataManager segmentDataManager : _segmentDataManagerMap.values()) {
       segmentDataManager.destroy();
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -200,9 +200,12 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   protected void doShutdown() {
     _segmentAsyncExecutorService.shutdown();
     if (_tableUpsertMetadataManager != null) {
-      _tableUpsertMetadataManager.close();
+      try {
+        _tableUpsertMetadataManager.close();
+      } catch (IOException e) {
+        _logger.warn("Cannot close upsert metadata manager properly for table: {}", _tableNameWithType, e);
+      }
     }
-
     for (SegmentDataManager segmentDataManager : _segmentDataManagerMap.values()) {
       segmentDataManager.destroy();
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -428,6 +428,13 @@ public class ConcurrentMapPartitionUpsertMetadataManager implements PartitionUps
     }
   }
 
+  @Override
+  public void close() {
+    _logger.info("Closing metadata manager for table {} and partition {}, current primary key count: {}",
+        _tableNameWithType, _partitionId, _primaryKeyToRecordLocationMap.size());
+    _primaryKeyToRecordLocationMap.clear();
+  }
+
   @VisibleForTesting
   static class RecordLocation {
     private final IndexSegment _segment;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -432,7 +432,6 @@ public class ConcurrentMapPartitionUpsertMetadataManager implements PartitionUps
   public void close() {
     _logger.info("Closing metadata manager for table {} and partition {}, current primary key count: {}",
         _tableNameWithType, _partitionId, _primaryKeyToRecordLocationMap.size());
-    _primaryKeyToRecordLocationMap.clear();
   }
 
   @VisibleForTesting

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -37,4 +37,12 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
         k -> new ConcurrentMapPartitionUpsertMetadataManager(_tableNameWithType, k, _primaryKeyColumns,
             _comparisonColumn, _hashFunction, _partialUpsertHandler, _serverMetrics));
   }
+
+  @Override
+  public void close() {
+    for (ConcurrentMapPartitionUpsertMetadataManager partitionUpsertMetadataManager
+        : _partitionMetadataManagerMap.values()) {
+      partitionUpsertMetadataManager.close();
+    }
+  }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
@@ -82,4 +82,9 @@ public interface PartitionUpsertMetadataManager {
    * Returns the merged record when partial-upsert is enabled.
    */
   GenericRow updateRecord(GenericRow record, RecordInfo recordInfo);
+
+  /**
+   * Close the partition upsert data manager
+   */
+  void close();
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.upsert;
 
+import java.io.Closeable;
 import java.util.List;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.segment.spi.ImmutableSegment;
@@ -51,7 +52,7 @@ import org.apache.pinot.spi.data.readers.GenericRow;
  * </ul>
  */
 @ThreadSafe
-public interface PartitionUpsertMetadataManager {
+public interface PartitionUpsertMetadataManager extends Closeable {
 
   /**
    * Returns the primary key columns.
@@ -82,9 +83,4 @@ public interface PartitionUpsertMetadataManager {
    * Returns the merged record when partial-upsert is enabled.
    */
   GenericRow updateRecord(GenericRow record, RecordInfo recordInfo);
-
-  /**
-   * Close the partition upsert data manager
-   */
-  void close();
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.upsert;
 
+import java.io.Closeable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
@@ -30,13 +31,11 @@ import org.apache.pinot.spi.data.Schema;
  * The manager of the upsert metadata of a table.
  */
 @ThreadSafe
-public interface TableUpsertMetadataManager {
+public interface TableUpsertMetadataManager extends Closeable {
 
   void init(TableConfig tableConfig, Schema schema, TableDataManager tableDataManager, ServerMetrics serverMetrics);
 
   ConcurrentMapPartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId);
 
   UpsertConfig.Mode getUpsertMode();
-
-  void close();
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
@@ -37,4 +37,6 @@ public interface TableUpsertMetadataManager {
   ConcurrentMapPartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId);
 
   UpsertConfig.Mode getUpsertMode();
+
+  void close();
 }


### PR DESCRIPTION
In future upsert manager can contain backends that require a clean exit. The `close` method needs to be implemented in such cases to handle the closure of backend.