### PR TITLE
[multistage] support unordered limit

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/rules/PinotLogicalSortFetchEliminationRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/rules/PinotLogicalSortFetchEliminationRule.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.rules;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.core.RelFactories;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rel.logical.LogicalSort;
+import org.apache.calcite.tools.RelBuilderFactory;
+
+
+/**
+ * Special rule for Pinot, Pinot's top level sort fetch doesn't guarantee order without order by clause.
+ */
+public class PinotLogicalSortFetchEliminationRule extends RelOptRule {
+  public static final PinotLogicalSortFetchEliminationRule INSTANCE =
+      new PinotLogicalSortFetchEliminationRule(RelFactories.LOGICAL_BUILDER);
+
+  public PinotLogicalSortFetchEliminationRule(RelBuilderFactory factory) {
+    super(operand(LogicalSort.class, any()), factory, null);
+  }
+
+  @Override
+  public boolean matches(RelOptRuleCall call) {
+    if (call.rels.length < 1) {
+      return false;
+    }
+    if (call.rel(0) instanceof LogicalSort) {
+      Sort sort = call.rel(0);
+      return sort.collation.getFieldCollations().size() == 0;
+    }
+    return false;
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    Sort sort = call.rel(0);
+    call.transformTo(sort.getInputs().get(0));
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/rules/PinotQueryRuleSets.java
@@ -90,5 +90,7 @@ public class PinotQueryRuleSets {
 
           // Pinot specific rules
           PinotJoinExchangeNodeInsertRule.INSTANCE,
-          PinotAggregateExchangeNodeInsertRule.INSTANCE);
+          PinotAggregateExchangeNodeInsertRule.INSTANCE,
+          PinotLogicalSortFetchEliminationRule.INSTANCE
+      );
 }

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
@@ -43,6 +43,7 @@ public class QueryEnvironmentTestBase {
   @DataProvider(name = "testQueryDataProvider")
   protected Object[][] provideQueries() {
     return new Object[][] {
+        new Object[]{"SELECT * FROM a LIMIT 10"},
         new Object[]{"SELECT * FROM a JOIN b ON a.col1 = b.col2"},
         new Object[]{"SELECT * FROM a JOIN b ON a.col1 = b.col2 WHERE a.col3 >= 0"},
         new Object[]{"SELECT * FROM a JOIN b on a.col1 = b.col1 AND a.col2 = b.col2"},


### PR DESCRIPTION
see: https://github.com/apache/pinot/issues/9209

- Adding a customized rule to remove order fetch (thus no LogicalSort needed) for limit queries. 
- ORDER BY is not supported yet at the moment so we will revisit the rule match criteria once LogicalSort is added.
