### PR TITLE
Refine error msg when applying TextMatch on column without text index

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -250,6 +250,9 @@ public class FilterPlanNode implements PlanNode {
               return new TextContainsFilterOperator(textIndexReader, (TextContainsPredicate) predicate, numDocs);
             case TEXT_MATCH:
               textIndexReader = dataSource.getTextIndex();
+              Preconditions
+                  .checkState(textIndexReader != null, "Cannot apply TEXT_MATCH on column: %s without text index",
+                      column);
               // We could check for real time and segment Lucene reader, but easier to check the other way round
               if (textIndexReader instanceof NativeTextIndexReader
                   || textIndexReader instanceof NativeMutableTextIndex) {


### PR DESCRIPTION
This PR refines the error msg when using TextMatch on column w/o text index as found in issue https://github.com/apache/pinot/issues/9172. The change is similar with what's done for JSON_MATCH a few lines below in the same method.