### PR TITLE
Extract record keys, headers and metadata from Stream sources

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -385,6 +385,36 @@ public class StringFunctions {
   }
 
   /**
+   * @param bytes
+   * @param charsetName encoding
+   * @return bytearray to string
+   * returns null on exception
+   */
+  @ScalarFunction
+  public static String fromBytes(byte[] bytes, String charsetName) {
+    try {
+      return new String(bytes, charsetName);
+    } catch (UnsupportedEncodingException e) {
+      return null;
+    }
+  }
+
+  /**
+   * @param input
+   * @param charsetName encoding
+   * @return bytearray to string
+   * returns null on exception
+   */
+  @ScalarFunction
+  public static byte[] toBytes(String input, String charsetName) {
+    try {
+      return input.getBytes(charsetName);
+    } catch (UnsupportedEncodingException e) {
+      return null;
+    }
+  }
+
+  /**
    * @see StandardCharsets#UTF_8#encode(String)
    * @param input
    * @return bytes
@@ -556,7 +586,7 @@ public class StringFunctions {
   @ScalarFunction
   public static String encodeUrl(String input)
       throws UnsupportedEncodingException {
-      return URLEncoder.encode(input, StandardCharsets.UTF_8.toString());
+    return URLEncoder.encode(input, StandardCharsets.UTF_8.toString());
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -547,7 +547,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       StreamDataDecoderResult decodedRow = _streamDataDecoder.decode(messagesAndOffsets.getStreamMessage(index));
       RowMetadata msgMetadata = messagesAndOffsets.getStreamMessage(index).getMetadata();
       if (decodedRow.getException() != null) {
-        // TODO: handle exception as we do today - do we silently drop the record or throw exception?
+        // TODO: based on a config, decide whether the record should be silently dropped or stop further consumption on
+        // decode error
         realtimeRowsDroppedMeter =
             _serverMetrics.addMeteredTableValue(_metricKeyName, ServerMeter.INVALID_REALTIME_ROWS_DROPPED, 1,
                 realtimeRowsDroppedMeter);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -82,6 +82,9 @@ import org.apache.pinot.spi.stream.PermanentConsumerException;
 import org.apache.pinot.spi.stream.RowMetadata;
 import org.apache.pinot.spi.stream.StreamConsumerFactory;
 import org.apache.pinot.spi.stream.StreamConsumerFactoryProvider;
+import org.apache.pinot.spi.stream.StreamDataDecoder;
+import org.apache.pinot.spi.stream.StreamDataDecoderImpl;
+import org.apache.pinot.spi.stream.StreamDataDecoderResult;
 import org.apache.pinot.spi.stream.StreamDecoderProvider;
 import org.apache.pinot.spi.stream.StreamMessageDecoder;
 import org.apache.pinot.spi.stream.StreamMetadataProvider;
@@ -212,7 +215,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   private final SegmentZKMetadata _segmentZKMetadata;
   private final TableConfig _tableConfig;
   private final RealtimeTableDataManager _realtimeTableDataManager;
-  private final StreamMessageDecoder _messageDecoder;
+  private final StreamDataDecoder _streamDataDecoder;
   private final int _segmentMaxRowCount;
   private final String _resourceDataDir;
   private final IndexLoadingConfig _indexLoadingConfig;
@@ -541,16 +544,16 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
       // Index each message
       reuse.clear();
-      // retrieve metadata from the message batch if available
-      // this can be overridden by the decoder if there is a better indicator in the message payload
-      RowMetadata msgMetadata = messagesAndOffsets.getMetadataAtIndex(index);
-
-      GenericRow decodedRow = _messageDecoder
-          .decode(messagesAndOffsets.getMessageAtIndex(index), messagesAndOffsets.getMessageOffsetAtIndex(index),
-              messagesAndOffsets.getMessageLengthAtIndex(index), reuse);
-      if (decodedRow != null) {
+      StreamDataDecoderResult decodedRow = _streamDataDecoder.decode(messagesAndOffsets.getStreamMessage(index));
+      RowMetadata msgMetadata = messagesAndOffsets.getStreamMessage(index).getMetadata();
+      if (decodedRow.getException() != null) {
+        // TODO: handle exception as we do today - do we silently drop the record or throw exception?
+        realtimeRowsDroppedMeter =
+            _serverMetrics.addMeteredTableValue(_metricKeyName, ServerMeter.INVALID_REALTIME_ROWS_DROPPED, 1,
+                realtimeRowsDroppedMeter);
+      } else {
         try {
-          _transformPipeline.processRow(decodedRow, reusedResult);
+          _transformPipeline.processRow(decodedRow.getResult(), reusedResult);
         } catch (Exception e) {
           _numRowsErrored++;
           // when exception happens we prefer abandoning the whole batch and not partially indexing some rows
@@ -585,10 +588,6 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
                 new SegmentErrorInfo(now(), errorMessage, e));
           }
         }
-      } else {
-        realtimeRowsDroppedMeter =
-            _serverMetrics.addMeteredTableValue(_metricKeyName, ServerMeter.INVALID_REALTIME_ROWS_DROPPED, 1,
-                realtimeRowsDroppedMeter);
       }
 
       _currentOffset = messagesAndOffsets.getNextStreamPartitionMsgOffsetAtIndex(index);
@@ -1364,7 +1363,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
     // Create message decoder
     Set<String> fieldsToRead = IngestionUtils.getFieldsForRecordExtractor(_tableConfig.getIngestionConfig(), _schema);
-    _messageDecoder = StreamDecoderProvider.create(_partitionLevelStreamConfig, fieldsToRead);
+    StreamMessageDecoder streamMessageDecoder = StreamDecoderProvider.create(_partitionLevelStreamConfig, fieldsToRead);
+    _streamDataDecoder = new StreamDataDecoderImpl(streamMessageDecoder);
     _clientId = streamTopic + "-" + _partitionGroupId;
 
     _transformPipeline = new TransformPipeline(tableConfig, schema);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -509,7 +509,6 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     int streamMessageCount = 0;
     boolean canTakeMore = true;
 
-    GenericRow reuse = new GenericRow();
     TransformPipeline.Result reusedResult = new TransformPipeline.Result();
     boolean prematureExit = false;
     for (int index = 0; index < messageCount; index++) {
@@ -542,8 +541,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
         throw new RuntimeException("Realtime segment full");
       }
 
-      // Index each message
-      reuse.clear();
+      // Decode message
       StreamDataDecoderResult decodedRow = _streamDataDecoder.decode(messagesAndOffsets.getStreamMessage(index));
       RowMetadata msgMetadata = messagesAndOffsets.getStreamMessage(index).getMetadata();
       if (decodedRow.getException() != null) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -135,6 +135,7 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
         segmentMetadataFromDirectEndpoint.get("segment.total.docs"));
   }
 
+  // TODO: This test fails when using `llc` consumer mode. Needs investigation
   @Test
   public void testSegmentListApi()
       throws Exception {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeClusterIntegrationTest.java
@@ -76,8 +76,6 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTestSe
 
     // Wait for all documents loaded
     waitForAllDocsLoaded(600_000L);
-
-    Thread.currentThread().join();
   }
 
   protected void createSegmentsAndUpload(List<File> avroFile, Schema schema, TableConfig tableConfig)

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeClusterIntegrationTest.java
@@ -76,6 +76,8 @@ public class RealtimeClusterIntegrationTest extends BaseClusterIntegrationTestSe
 
     // Wait for all documents loaded
     waitForAllDocsLoaded(600_000L);
+
+    Thread.currentThread().join();
   }
 
   protected void createSegmentsAndUpload(List<File> avroFile, Schema schema, TableConfig tableConfig)

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMessageBatch.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMessageBatch.java
@@ -18,16 +18,18 @@
  */
 package org.apache.pinot.plugin.stream.kafka20;
 
+import java.nio.ByteBuffer;
 import java.util.List;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.MessageBatch;
 import org.apache.pinot.spi.stream.RowMetadata;
+import org.apache.pinot.spi.stream.StreamMessage;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 
 
-public class KafkaMessageBatch implements MessageBatch<byte[]> {
+public class KafkaMessageBatch implements MessageBatch<KafkaStreamMessage> {
 
-  private final List<MessageAndOffsetAndMetadata> _messageList;
+  private final List<KafkaStreamMessage> _messageList;
   private final int _unfilteredMessageCount;
   private final long _lastOffset;
 
@@ -36,7 +38,7 @@ public class KafkaMessageBatch implements MessageBatch<byte[]> {
    * @param lastOffset the offset of the last message in the batch
    * @param batch the messages, which may be smaller than {@see unfilteredMessageCount}
    */
-  public KafkaMessageBatch(int unfilteredMessageCount, long lastOffset, List<MessageAndOffsetAndMetadata> batch) {
+  public KafkaMessageBatch(int unfilteredMessageCount, long lastOffset, List<KafkaStreamMessage> batch) {
     _messageList = batch;
     _lastOffset = lastOffset;
     _unfilteredMessageCount = unfilteredMessageCount;
@@ -53,18 +55,18 @@ public class KafkaMessageBatch implements MessageBatch<byte[]> {
   }
 
   @Override
-  public byte[] getMessageAtIndex(int index) {
-    return _messageList.get(index).getMessage().array();
+  public KafkaStreamMessage getMessageAtIndex(int index) {
+    return _messageList.get(index);
   }
 
   @Override
   public int getMessageOffsetAtIndex(int index) {
-    return _messageList.get(index).getMessage().arrayOffset();
+    return ByteBuffer.wrap(_messageList.get(index).getMessage()).arrayOffset();
   }
 
   @Override
   public int getMessageLengthAtIndex(int index) {
-    return _messageList.get(index).payloadSize();
+    return _messageList.get(index).getMessage().length;
   }
 
   @Override
@@ -84,6 +86,16 @@ public class KafkaMessageBatch implements MessageBatch<byte[]> {
 
   @Override
   public RowMetadata getMetadataAtIndex(int index) {
-    return _messageList.get(index).getRowMetadata();
+    return _messageList.get(index).getMetadata();
+  }
+
+  @Override
+  public byte[] getMessageBytesAtIndex(int index) {
+    return _messageList.get(index).getValue();
+  }
+
+  @Override
+  public StreamMessage getStreamMessage(int index) {
+    return _messageList.get(index);
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMessageBatch.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMessageBatch.java
@@ -27,9 +27,8 @@ import org.apache.pinot.spi.stream.StreamMessage;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 
 
-public class KafkaMessageBatch implements MessageBatch<KafkaStreamMessage> {
-
-  private final List<KafkaStreamMessage> _messageList;
+public class KafkaMessageBatch implements MessageBatch<StreamMessage> {
+  private final List<StreamMessage> _messageList;
   private final int _unfilteredMessageCount;
   private final long _lastOffset;
 
@@ -38,7 +37,7 @@ public class KafkaMessageBatch implements MessageBatch<KafkaStreamMessage> {
    * @param lastOffset the offset of the last message in the batch
    * @param batch the messages, which may be smaller than {@see unfilteredMessageCount}
    */
-  public KafkaMessageBatch(int unfilteredMessageCount, long lastOffset, List<KafkaStreamMessage> batch) {
+  public KafkaMessageBatch(int unfilteredMessageCount, long lastOffset, List<StreamMessage> batch) {
     _messageList = batch;
     _lastOffset = lastOffset;
     _unfilteredMessageCount = unfilteredMessageCount;
@@ -55,18 +54,18 @@ public class KafkaMessageBatch implements MessageBatch<KafkaStreamMessage> {
   }
 
   @Override
-  public KafkaStreamMessage getMessageAtIndex(int index) {
+  public StreamMessage getMessageAtIndex(int index) {
     return _messageList.get(index);
   }
 
   @Override
   public int getMessageOffsetAtIndex(int index) {
-    return ByteBuffer.wrap(_messageList.get(index).getMessage()).arrayOffset();
+    return ByteBuffer.wrap(_messageList.get(index).getValue()).arrayOffset();
   }
 
   @Override
   public int getMessageLengthAtIndex(int index) {
-    return _messageList.get(index).getMessage().length;
+    return _messageList.get(index).getValue().length;
   }
 
   @Override
@@ -76,7 +75,7 @@ public class KafkaMessageBatch implements MessageBatch<KafkaStreamMessage> {
 
   @Override
   public StreamPartitionMsgOffset getNextStreamPartitionMsgOffsetAtIndex(int index) {
-    return new LongMsgOffset(_messageList.get(index).getNextOffset());
+    return new LongMsgOffset(((KafkaStreamMessage) _messageList.get(index)).getNextOffset());
   }
 
   @Override

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMetadataExtractor.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMetadataExtractor.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.plugin.stream.kafka20;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -32,7 +33,8 @@ public interface KafkaMetadataExtractor {
   static KafkaMetadataExtractor build(boolean populateMetadata) {
     return record -> {
       if (!populateMetadata) {
-        return null;
+        return new KafkaStreamMessageMetadata(record.timestamp(), RowMetadata.EMPTY_ROW,
+            Collections.singletonMap(KafkaStreamMessageMetadata.METADATA_OFFSET_KEY, String.valueOf(record.offset())));
       }
       GenericRow headerGenericRow = new GenericRow();
       Headers headers = record.headers();

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMetadataExtractor.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMetadataExtractor.java
@@ -32,9 +32,11 @@ public interface KafkaMetadataExtractor {
   static KafkaMetadataExtractor build(boolean populateMetadata) {
     return record -> {
       if (!populateMetadata) {
-        return new KafkaStreamMessageMetadata(record.timestamp(), RowMetadata.EMPTY_ROW,
-            Map.of(KafkaStreamMessageMetadata.METADATA_OFFSET_KEY, String.valueOf(record.offset()),
-                KafkaStreamMessageMetadata.RECORD_TIMESTAMP_KEY, String.valueOf(record.timestamp())));
+        long recordTimestamp = record.timestamp();
+        Map<String, String> metadataMap = new HashMap<>();
+        metadataMap.put(KafkaStreamMessageMetadata.METADATA_OFFSET_KEY, String.valueOf(record.offset()));
+        metadataMap.put(KafkaStreamMessageMetadata.RECORD_TIMESTAMP_KEY, String.valueOf(recordTimestamp));
+        return new KafkaStreamMessageMetadata(recordTimestamp, RowMetadata.EMPTY_ROW, metadataMap);
       }
       GenericRow headerGenericRow = new GenericRow();
       Headers headers = record.headers();

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMetadataExtractor.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMetadataExtractor.java
@@ -25,12 +25,11 @@ import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.stream.RowMetadata;
-import org.apache.pinot.spi.stream.StreamMessageMetadata;
 
 
 @FunctionalInterface
-public interface RowMetadataExtractor {
-  static RowMetadataExtractor build(boolean populateMetadata) {
+public interface KafkaMetadataExtractor {
+  static KafkaMetadataExtractor build(boolean populateMetadata) {
     return record -> {
       if (!populateMetadata) {
         return null;
@@ -44,8 +43,8 @@ public interface RowMetadataExtractor {
         }
       }
       Map<String, String> metadata = new HashMap<>();
-      metadata.put(KafkaStreamMessageMetadata.OFFSET_KEY, String.valueOf(record.offset()));
-      return new StreamMessageMetadata(record.timestamp(), headerGenericRow, metadata);
+      metadata.put(KafkaStreamMessageMetadata.METADATA_OFFSET_KEY, String.valueOf(record.offset()));
+      return new KafkaStreamMessageMetadata(record.timestamp(), headerGenericRow, metadata);
     };
   }
 

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMetadataExtractor.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMetadataExtractor.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.plugin.stream.kafka20;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -34,7 +33,8 @@ public interface KafkaMetadataExtractor {
     return record -> {
       if (!populateMetadata) {
         return new KafkaStreamMessageMetadata(record.timestamp(), RowMetadata.EMPTY_ROW,
-            Collections.singletonMap(KafkaStreamMessageMetadata.METADATA_OFFSET_KEY, String.valueOf(record.offset())));
+            Map.of(KafkaStreamMessageMetadata.METADATA_OFFSET_KEY, String.valueOf(record.offset()),
+                KafkaStreamMessageMetadata.RECORD_TIMESTAMP_KEY, String.valueOf(record.timestamp())));
       }
       GenericRow headerGenericRow = new GenericRow();
       Headers headers = record.headers();
@@ -46,6 +46,7 @@ public interface KafkaMetadataExtractor {
       }
       Map<String, String> metadata = new HashMap<>();
       metadata.put(KafkaStreamMessageMetadata.METADATA_OFFSET_KEY, String.valueOf(record.offset()));
+      metadata.put(KafkaStreamMessageMetadata.RECORD_TIMESTAMP_KEY, String.valueOf(record.timestamp()));
       return new KafkaStreamMessageMetadata(record.timestamp(), headerGenericRow, metadata);
     };
   }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConnectionHandler.java
@@ -45,7 +45,7 @@ public abstract class KafkaPartitionLevelConnectionHandler {
   protected final String _topic;
   protected final Consumer<String, Bytes> _consumer;
   protected final TopicPartition _topicPartition;
-  protected final RowMetadataExtractor _rowMetadataExtractor;
+  protected final KafkaMetadataExtractor _kafkaMetadataExtractor;
 
   public KafkaPartitionLevelConnectionHandler(String clientId, StreamConfig streamConfig, int partition) {
     _config = new KafkaPartitionLevelStreamConfig(streamConfig);
@@ -64,7 +64,7 @@ public abstract class KafkaPartitionLevelConnectionHandler {
     _consumer = new KafkaConsumer<>(consumerProp);
     _topicPartition = new TopicPartition(_topic, _partition);
     _consumer.assign(Collections.singletonList(_topicPartition));
-    _rowMetadataExtractor = RowMetadataExtractor.build(_config.isPopulateMetadata());
+    _kafkaMetadataExtractor = KafkaMetadataExtractor.build(_config.isPopulateMetadata());
   }
 
   public void close()

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
@@ -58,6 +58,8 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
       LOGGER.debug("poll consumer: {}, startOffset: {}, endOffset:{} timeout: {}ms", _topicPartition, startOffset,
           endOffset, timeoutMillis);
     }
+    LOGGER.warn("poll consumer: {}, startOffset: {}, endOffset:{} timeout: {}ms", _topicPartition, startOffset,
+        endOffset, timeoutMillis);
     _consumer.seek(_topicPartition, startOffset);
     ConsumerRecords<String, Bytes> consumerRecords = _consumer.poll(Duration.ofMillis(timeoutMillis));
     List<ConsumerRecord<String, Bytes>> messageAndOffsets = consumerRecords.records(_topicPartition);
@@ -70,10 +72,7 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
       long offset = messageAndOffset.offset();
       if (offset >= startOffset & (endOffset > offset | endOffset == -1)) {
         if (message != null) {
-          StreamMessageMetadata rowMetadata = null;
-          if (_config.isPopulateMetadata()) {
-            rowMetadata = (StreamMessageMetadata) _kafkaMetadataExtractor.extract(messageAndOffset);
-          }
+          StreamMessageMetadata rowMetadata = (StreamMessageMetadata) _kafkaMetadataExtractor.extract(messageAndOffset);
           filtered.add(
               new KafkaStreamMessage(keyBytes, message.get(), rowMetadata));
         } else if (LOGGER.isDebugEnabled()) {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
@@ -72,7 +72,7 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
         if (message != null) {
           StreamMessageMetadata rowMetadata = null;
           if (_config.isPopulateMetadata()) {
-            rowMetadata = (StreamMessageMetadata) _rowMetadataExtractor.extract(messageAndOffset);
+            rowMetadata = (StreamMessageMetadata) _kafkaMetadataExtractor.extract(messageAndOffset);
           }
           filtered.add(
               new KafkaStreamMessage(keyBytes, message.get(), rowMetadata));

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMessage.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMessage.java
@@ -30,7 +30,7 @@ public class KafkaStreamMessage extends StreamMessage {
 
   public long getNextOffset() {
     if (_metadata != null) {
-      long offset = Long.parseLong(_metadata.getRecordMetadata().get(KafkaStreamMessageMetadata.OFFSET_KEY));
+      long offset = Long.parseLong(_metadata.getRecordMetadata().get(KafkaStreamMessageMetadata.METADATA_OFFSET_KEY));
       return offset < 0 ? -1 : offset + 1;
     }
     return -1;

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMessage.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMessage.java
@@ -27,7 +27,6 @@ import org.apache.pinot.spi.stream.StreamMessageMetadata;
 public class KafkaStreamMessage extends StreamMessage {
   private static final GenericRow EMPTY_ROW_REUSE = new GenericRow();
 
-  // should distinguish stream-specific record metadata in the table??
   private final long _offset;
 
   public KafkaStreamMessage(@Nullable byte[] key, byte[] value, long offset, @Nullable StreamMessageMetadata metadata) {
@@ -37,7 +36,7 @@ public class KafkaStreamMessage extends StreamMessage {
 
   public GenericRow getHeaders() {
     EMPTY_ROW_REUSE.clear();
-    return getMetadata() != null ? getMetadata().getHeaders() : EMPTY_ROW_REUSE;
+    return _metadata != null ? getMetadata().getHeaders() : EMPTY_ROW_REUSE;
   }
 
   // for backward compatibility

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMessageMetadata.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMessageMetadata.java
@@ -26,6 +26,7 @@ import org.apache.pinot.spi.stream.StreamMessageMetadata;
 
 public class KafkaStreamMessageMetadata extends StreamMessageMetadata {
   public static final String METADATA_OFFSET_KEY = "offset";
+  public static final String RECORD_TIMESTAMP_KEY = "recordTimestamp";
 
   public KafkaStreamMessageMetadata(long recordIngestionTimeMs, @Nullable GenericRow headers,
       Map<String, String> metadata) {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMessageMetadata.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMessageMetadata.java
@@ -18,21 +18,17 @@
  */
 package org.apache.pinot.plugin.stream.kafka20;
 
+import java.util.Map;
 import javax.annotation.Nullable;
-import org.apache.pinot.spi.stream.StreamMessage;
+import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.stream.StreamMessageMetadata;
 
 
-public class KafkaStreamMessage extends StreamMessage {
-  public KafkaStreamMessage(@Nullable byte[] key, byte[] value, @Nullable StreamMessageMetadata metadata) {
-    super(key, value, metadata);
-  }
+public class KafkaStreamMessageMetadata extends StreamMessageMetadata {
+  public static final String OFFSET_KEY = "offset";
 
-  public long getNextOffset() {
-    if (_metadata != null) {
-      long offset = Long.parseLong(_metadata.getRecordMetadata().get(KafkaStreamMessageMetadata.OFFSET_KEY));
-      return offset < 0 ? -1 : offset + 1;
-    }
-    return -1;
+  public KafkaStreamMessageMetadata(long recordTimestampMs, @Nullable GenericRow headers,
+      Map<String, String> metadata) {
+    super(recordTimestampMs, headers, metadata);
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMessageMetadata.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMessageMetadata.java
@@ -25,7 +25,7 @@ import org.apache.pinot.spi.stream.StreamMessageMetadata;
 
 
 public class KafkaStreamMessageMetadata extends StreamMessageMetadata {
-  public static final String OFFSET_KEY = "offset";
+  public static final String METADATA_OFFSET_KEY = "offset";
 
   public KafkaStreamMessageMetadata(long recordTimestampMs, @Nullable GenericRow headers,
       Map<String, String> metadata) {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMessageMetadata.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMessageMetadata.java
@@ -27,8 +27,8 @@ import org.apache.pinot.spi.stream.StreamMessageMetadata;
 public class KafkaStreamMessageMetadata extends StreamMessageMetadata {
   public static final String METADATA_OFFSET_KEY = "offset";
 
-  public KafkaStreamMessageMetadata(long recordTimestampMs, @Nullable GenericRow headers,
+  public KafkaStreamMessageMetadata(long recordIngestionTimeMs, @Nullable GenericRow headers,
       Map<String, String> metadata) {
-    super(recordTimestampMs, headers, metadata);
+    super(recordIngestionTimeMs, headers, metadata);
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/RowMetadataExtractor.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/RowMetadataExtractor.java
@@ -44,7 +44,7 @@ public interface RowMetadataExtractor {
         }
       }
       Map<String, String> metadata = new HashMap<>();
-      metadata.put("offset", String.valueOf(record.offset()));
+      metadata.put(KafkaStreamMessageMetadata.OFFSET_KEY, String.valueOf(record.offset()));
       return new StreamMessageMetadata(record.timestamp(), headerGenericRow, metadata);
     };
   }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/RowMetadataExtractor.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/RowMetadataExtractor.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.plugin.stream.kafka20;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.header.Header;
 import org.apache.kafka.common.header.Headers;
@@ -41,7 +43,9 @@ public interface RowMetadataExtractor {
           headerGenericRow.putValue(header.key(), header.value());
         }
       }
-      return new StreamMessageMetadata(record.timestamp(), headerGenericRow);
+      Map<String, String> metadata = new HashMap<>();
+      metadata.put("offset", String.valueOf(record.offset()));
+      return new StreamMessageMetadata(record.timestamp(), headerGenericRow, metadata);
     };
   }
 

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/server/KafkaDataProducer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/server/KafkaDataProducer.java
@@ -18,10 +18,17 @@
  */
 package org.apache.pinot.plugin.stream.kafka20.server;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Properties;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.stream.StreamDataProducer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,6 +73,37 @@ public class KafkaDataProducer implements StreamDataProducer {
   public void produce(String topic, byte[] key, byte[] payload) {
     _producer.send(new ProducerRecord<>(topic, key, payload));
     _producer.flush();
+  }
+
+  @Override
+  public void produce(String topic, byte[] key, byte[] payload, GenericRow headers) {
+    List<Header> headerList = new ArrayList<>();
+    headerList.add(new RecordHeader("producerTimestamp", String.valueOf(System.currentTimeMillis()).getBytes(
+        StandardCharsets.UTF_8)));
+    if (headers != null) {
+      headers.getFieldToValueMap().forEach((k, v) -> {
+        Header header = convertToKafkaHeader(k, v);
+        if (header != null) {
+          headerList.add(header);
+        }
+      });
+    }
+    _producer.send(new ProducerRecord<>(topic, null, key, payload, headerList));
+    _producer.flush();
+  }
+
+  public Header convertToKafkaHeader(String key, Object value) {
+    if (value != null) {
+      if (value instanceof String) {
+        return new RecordHeader(key, ((String) value).getBytes(StandardCharsets.UTF_8));
+      }
+      if (value instanceof Long) {
+        ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+        buffer.putLong(((Long) value));
+        return new RecordHeader(key, buffer.array());
+      }
+    }
+    return null;
   }
 
   @Override

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumerTest.java
@@ -281,7 +281,7 @@ public class KafkaPartitionLevelConsumerTest {
           consumer.fetchMessages(new LongMsgOffset(0), new LongMsgOffset(NUM_MSG_PRODUCED_PER_PARTITION), 10000);
       Assert.assertEquals(batch1.getMessageCount(), 500);
       for (int i = 0; i < batch1.getMessageCount(); i++) {
-        final byte[] msg = (byte[]) batch1.getMessageAtIndex(i);
+        final byte[] msg = batch1.getStreamMessage(i).getValue();
         Assert.assertEquals(new String(msg), "sample_msg_" + i);
         Assert.assertNull(batch1.getMetadataAtIndex(i));
       }
@@ -290,7 +290,7 @@ public class KafkaPartitionLevelConsumerTest {
           consumer.fetchMessages(new LongMsgOffset(500), new LongMsgOffset(NUM_MSG_PRODUCED_PER_PARTITION), 10000);
       Assert.assertEquals(batch2.getMessageCount(), 500);
       for (int i = 0; i < batch2.getMessageCount(); i++) {
-        final byte[] msg = (byte[]) batch2.getMessageAtIndex(i);
+        final byte[] msg = batch2.getStreamMessage(i).getValue();
         Assert.assertEquals(new String(msg), "sample_msg_" + (500 + i));
         Assert.assertNull(batch1.getMetadataAtIndex(i));
       }
@@ -298,7 +298,7 @@ public class KafkaPartitionLevelConsumerTest {
       final MessageBatch batch3 = consumer.fetchMessages(new LongMsgOffset(10), new LongMsgOffset(35), 10000);
       Assert.assertEquals(batch3.getMessageCount(), 25);
       for (int i = 0; i < batch3.getMessageCount(); i++) {
-        final byte[] msg = (byte[]) batch3.getMessageAtIndex(i);
+        final byte[] msg = batch3.getStreamMessage(i).getValue();
         Assert.assertEquals(new String(msg), "sample_msg_" + (10 + i));
         Assert.assertNull(batch1.getMetadataAtIndex(i));
       }
@@ -342,7 +342,7 @@ public class KafkaPartitionLevelConsumerTest {
       for (int i = 0; i < batch1.getMessageCount(); i++) {
         final RowMetadata metadata = batch1.getMetadataAtIndex(i);
         Assert.assertNotNull(metadata);
-        Assert.assertEquals(metadata.getIngestionTimeMs(), TIMESTAMP + i);
+        Assert.assertEquals(metadata.getRecordTimestampMs(), TIMESTAMP + i);
       }
       // Test second half batch
       final MessageBatch batch2 =
@@ -351,7 +351,7 @@ public class KafkaPartitionLevelConsumerTest {
       for (int i = 0; i < batch2.getMessageCount(); i++) {
         final RowMetadata metadata = batch2.getMetadataAtIndex(i);
         Assert.assertNotNull(metadata);
-        Assert.assertEquals(metadata.getIngestionTimeMs(), TIMESTAMP + (500 + i));
+        Assert.assertEquals(metadata.getRecordTimestampMs(), TIMESTAMP + (500 + i));
       }
       // Some random range
       final MessageBatch batch3 = consumer.fetchMessages(new LongMsgOffset(10), new LongMsgOffset(35), 10000);
@@ -359,7 +359,7 @@ public class KafkaPartitionLevelConsumerTest {
       for (int i = 0; i < batch3.getMessageCount(); i++) {
         final RowMetadata metadata = batch3.getMetadataAtIndex(i);
         Assert.assertNotNull(metadata);
-        Assert.assertEquals(metadata.getIngestionTimeMs(), TIMESTAMP + (10 + i));
+        Assert.assertEquals(metadata.getRecordTimestampMs(), TIMESTAMP + (10 + i));
       }
     }
   }
@@ -388,7 +388,7 @@ public class KafkaPartitionLevelConsumerTest {
     MessageBatch batch1 = consumer.fetchMessages(new LongMsgOffset(0), new LongMsgOffset(400), 10000);
     Assert.assertEquals(batch1.getMessageCount(), 200);
     for (int i = 0; i < batch1.getMessageCount(); i++) {
-      byte[] msg = (byte[]) batch1.getMessageAtIndex(i);
+      byte[] msg = batch1.getStreamMessage(i).getValue();
       Assert.assertEquals(new String(msg), "sample_msg_" + (i + 200));
     }
     Assert.assertEquals(batch1.getOffsetOfNextBatch().toString(), "400");
@@ -400,7 +400,7 @@ public class KafkaPartitionLevelConsumerTest {
     MessageBatch batch3 = consumer.fetchMessages(new LongMsgOffset(201), new LongMsgOffset(401), 10000);
     Assert.assertEquals(batch3.getMessageCount(), 200);
     for (int i = 0; i < batch3.getMessageCount(); i++) {
-      byte[] msg = (byte[]) batch3.getMessageAtIndex(i);
+      byte[] msg = batch3.getStreamMessage(i).getValue();
       Assert.assertEquals(new String(msg), "sample_msg_" + (i + 201));
     }
     Assert.assertEquals(batch3.getOffsetOfNextBatch().toString(), "401");
@@ -408,7 +408,7 @@ public class KafkaPartitionLevelConsumerTest {
     MessageBatch batch4 = consumer.fetchMessages(new LongMsgOffset(0), null, 10000);
     Assert.assertEquals(batch4.getMessageCount(), 500);
     for (int i = 0; i < batch4.getMessageCount(); i++) {
-      byte[] msg = (byte[]) batch4.getMessageAtIndex(i);
+      byte[] msg = batch4.getStreamMessage(i).getValue();
       Assert.assertEquals(new String(msg), "sample_msg_" + (i + 200));
     }
     Assert.assertEquals(batch4.getOffsetOfNextBatch().toString(), "700");

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumerTest.java
@@ -283,7 +283,7 @@ public class KafkaPartitionLevelConsumerTest {
       for (int i = 0; i < batch1.getMessageCount(); i++) {
         final byte[] msg = batch1.getStreamMessage(i).getValue();
         Assert.assertEquals(new String(msg), "sample_msg_" + i);
-        Assert.assertNull(batch1.getMetadataAtIndex(i));
+        Assert.assertNotNull(batch1.getMetadataAtIndex(i));
       }
       // Test second half batch
       final MessageBatch batch2 =
@@ -292,7 +292,7 @@ public class KafkaPartitionLevelConsumerTest {
       for (int i = 0; i < batch2.getMessageCount(); i++) {
         final byte[] msg = batch2.getStreamMessage(i).getValue();
         Assert.assertEquals(new String(msg), "sample_msg_" + (500 + i));
-        Assert.assertNull(batch1.getMetadataAtIndex(i));
+        Assert.assertNotNull(batch1.getMetadataAtIndex(i));
       }
       // Some random range
       final MessageBatch batch3 = consumer.fetchMessages(new LongMsgOffset(10), new LongMsgOffset(35), 10000);
@@ -300,7 +300,7 @@ public class KafkaPartitionLevelConsumerTest {
       for (int i = 0; i < batch3.getMessageCount(); i++) {
         final byte[] msg = batch3.getStreamMessage(i).getValue();
         Assert.assertEquals(new String(msg), "sample_msg_" + (10 + i));
-        Assert.assertNull(batch1.getMetadataAtIndex(i));
+        Assert.assertNotNull(batch1.getMetadataAtIndex(i));
       }
     }
   }
@@ -342,7 +342,7 @@ public class KafkaPartitionLevelConsumerTest {
       for (int i = 0; i < batch1.getMessageCount(); i++) {
         final RowMetadata metadata = batch1.getMetadataAtIndex(i);
         Assert.assertNotNull(metadata);
-        Assert.assertEquals(metadata.getRecordTimestampMs(), TIMESTAMP + i);
+        Assert.assertEquals(metadata.getRecordIngestionTimeMs(), TIMESTAMP + i);
       }
       // Test second half batch
       final MessageBatch batch2 =
@@ -351,7 +351,7 @@ public class KafkaPartitionLevelConsumerTest {
       for (int i = 0; i < batch2.getMessageCount(); i++) {
         final RowMetadata metadata = batch2.getMetadataAtIndex(i);
         Assert.assertNotNull(metadata);
-        Assert.assertEquals(metadata.getRecordTimestampMs(), TIMESTAMP + (500 + i));
+        Assert.assertEquals(metadata.getRecordIngestionTimeMs(), TIMESTAMP + (500 + i));
       }
       // Some random range
       final MessageBatch batch3 = consumer.fetchMessages(new LongMsgOffset(10), new LongMsgOffset(35), 10000);
@@ -359,7 +359,7 @@ public class KafkaPartitionLevelConsumerTest {
       for (int i = 0; i < batch3.getMessageCount(); i++) {
         final RowMetadata metadata = batch3.getMetadataAtIndex(i);
         Assert.assertNotNull(metadata);
-        Assert.assertEquals(metadata.getRecordTimestampMs(), TIMESTAMP + (10 + i));
+        Assert.assertEquals(metadata.getRecordIngestionTimeMs(), TIMESTAMP + (10 + i));
       }
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -543,7 +543,7 @@ public class MutableSegmentImpl implements MutableSegment {
     // Update last indexed time and latest ingestion time
     _lastIndexedTimeMs = System.currentTimeMillis();
     if (rowMetadata != null) {
-      _latestIngestionTimeMs = Math.max(_latestIngestionTimeMs, rowMetadata.getIngestionTimeMs());
+      _latestIngestionTimeMs = Math.max(_latestIngestionTimeMs, rowMetadata.getRecordTimestampMs());
     }
 
     return canTakeMore;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -543,7 +543,7 @@ public class MutableSegmentImpl implements MutableSegment {
     // Update last indexed time and latest ingestion time
     _lastIndexedTimeMs = System.currentTimeMillis();
     if (rowMetadata != null) {
-      _latestIngestionTimeMs = Math.max(_latestIngestionTimeMs, rowMetadata.getRecordTimestampMs());
+      _latestIngestionTimeMs = Math.max(_latestIngestionTimeMs, rowMetadata.getRecordIngestionTimeMs());
     }
 
     return canTakeMore;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/IndexingFailureTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/IndexingFailureTest.java
@@ -64,7 +64,7 @@ public class IndexingFailureTest {
   @Test
   public void testIndexingFailures()
       throws IOException {
-    StreamMessageMetadata defaultMetadata = new StreamMessageMetadata(System.currentTimeMillis());
+    StreamMessageMetadata defaultMetadata = new StreamMessageMetadata(System.currentTimeMillis(), new GenericRow());
     GenericRow goodRow = new GenericRow();
     goodRow.putValue(INT_COL, 0);
     goodRow.putValue(STRING_COL, "a");

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplAggregateMetricsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplAggregateMetricsTest.java
@@ -99,7 +99,7 @@ public class MutableSegmentImplAggregateMetricsTest {
 
     Map<String, Long> expectedValues = new HashMap<>();
     Map<String, Float> expectedValuesFloat = new HashMap<>();
-    StreamMessageMetadata defaultMetadata = new StreamMessageMetadata(System.currentTimeMillis());
+    StreamMessageMetadata defaultMetadata = new StreamMessageMetadata(System.currentTimeMillis(), new GenericRow());
     for (int i = 0; i < NUM_ROWS; i++) {
       int hoursSinceEpoch = random.nextInt(10);
       int daysSinceEpoch = random.nextInt(5);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplIngestionAggregationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplIngestionAggregationTest.java
@@ -202,7 +202,7 @@ public class MutableSegmentImplIngestionAggregationTest {
 
 
     Random random = new Random(seed);
-    StreamMessageMetadata defaultMetadata = new StreamMessageMetadata(System.currentTimeMillis());
+    StreamMessageMetadata defaultMetadata = new StreamMessageMetadata(System.currentTimeMillis(), new GenericRow());
 
     for (int i = 0; i < NUM_ROWS; i++) {
       GenericRow row = getRow(random);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplRawMVTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplRawMVTest.java
@@ -103,7 +103,7 @@ public class MutableSegmentImplRawMVTest {
         .createMutableSegmentImpl(_schema, noDictionaryColumns, Collections.emptySet(), Collections.emptySet(),
             false);
     _lastIngestionTimeMs = System.currentTimeMillis();
-    StreamMessageMetadata defaultMetadata = new StreamMessageMetadata(_lastIngestionTimeMs);
+    StreamMessageMetadata defaultMetadata = new StreamMessageMetadata(_lastIngestionTimeMs, new GenericRow());
     _startTimeMs = System.currentTimeMillis();
 
     try (RecordReader recordReader = RecordReaderFactory

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplTest.java
@@ -87,7 +87,7 @@ public class MutableSegmentImplTest {
         .createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(), Collections.emptySet(),
             false);
     _lastIngestionTimeMs = System.currentTimeMillis();
-    StreamMessageMetadata defaultMetadata = new StreamMessageMetadata(_lastIngestionTimeMs);
+    StreamMessageMetadata defaultMetadata = new StreamMessageMetadata(_lastIngestionTimeMs, new GenericRow());
     _startTimeMs = System.currentTimeMillis();
 
     try (RecordReader recordReader = RecordReaderFactory

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/MessageBatch.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/MessageBatch.java
@@ -47,8 +47,23 @@ public interface MessageBatch<T> {
    * @param index
    * @return
    */
+  @Deprecated
   T getMessageAtIndex(int index);
 
+  // for backward-compatibility
+  default byte[] getMessageBytesAtIndex(int index) {
+    return (byte[]) getMessageAtIndex(index);
+  }
+
+  default StreamMessage getStreamMessage(int index) {
+    return new LegacyStreamMessage(getMessageBytesAtIndex(index));
+  }
+
+  class LegacyStreamMessage extends StreamMessage {
+    public LegacyStreamMessage(byte[] value) {
+      super(value);
+    }
+  }
   /**
    * Returns the offset of the message at a particular index inside a set of messages returned from the stream.
    * @param index

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/RowMetadata.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/RowMetadata.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.spi.stream;
 
+import java.util.Collections;
+import java.util.Map;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;
 import org.apache.pinot.spi.data.readers.GenericRow;
@@ -33,7 +35,7 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 @InterfaceStability.Evolving
 public interface RowMetadata {
   GenericRow EMPTY_ROW = new GenericRow();
-
+  Map<String, String> EMPTY_COLLECTION = Collections.emptyMap();
 
   /**
    * Return the timestamp associated with when the row was ingested upstream.
@@ -52,5 +54,17 @@ public interface RowMetadata {
   default GenericRow getHeaders() {
     EMPTY_ROW.clear();
     return EMPTY_ROW;
+  }
+
+  /**
+   * Returns the metadata associated with the stream record
+   *
+   * Kafka's record offset would be an example of a metadata associated with the record. Record metadata is typically
+   * stream specific and hence, it is defined as a Map of strings.
+   *
+   * @return A Map of record metadata entries.
+   */
+  default Map<String, String> getRecordMetadata() {
+    return EMPTY_COLLECTION;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/RowMetadata.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/RowMetadata.java
@@ -20,6 +20,7 @@ package org.apache.pinot.spi.stream;
 
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;
+import org.apache.pinot.spi.data.readers.GenericRow;
 
 
 /**
@@ -31,6 +32,8 @@ import org.apache.pinot.spi.annotations.InterfaceStability;
 @InterfaceAudience.Public
 @InterfaceStability.Evolving
 public interface RowMetadata {
+  GenericRow EMPTY_ROW = new GenericRow();
+
 
   /**
    * Return the timestamp associated with when the row was ingested upstream.
@@ -39,5 +42,15 @@ public interface RowMetadata {
    * @return timestamp (epoch in milliseconds) when the row was ingested upstream
    *         Long.MIN_VALUE if not available
    */
-  long getIngestionTimeMs();
+  long getRecordTimestampMs();
+
+  /**
+   * Returns the stream message headers
+   *
+   * @return A {@link GenericRow} that encapsulates the headers in the ingested row
+   */
+  default GenericRow getHeaders() {
+    EMPTY_ROW.clear();
+    return EMPTY_ROW;
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/RowMetadata.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/RowMetadata.java
@@ -38,13 +38,16 @@ public interface RowMetadata {
   Map<String, String> EMPTY_COLLECTION = Collections.emptyMap();
 
   /**
-   * Return the timestamp associated with when the row was ingested upstream.
-   * Expected to be mainly used for stream-based sources.
+   * Returns the timestamp associated with the record. This typically refers to the time it was ingested into the
+   * upstream source. In some cases, it may be the time at which the record was created, aka event time (eg. in kafka,
+   * a topic may be configured to use record `CreateTime` instead of `LogAppendTime`).
+   *
+   * Expected to be used for stream-based sources.
    *
    * @return timestamp (epoch in milliseconds) when the row was ingested upstream
    *         Long.MIN_VALUE if not available
    */
-  long getRecordTimestampMs();
+  long getRecordIngestionTimeMs();
 
   /**
    * Returns the stream message headers

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataDecoder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataDecoder.java
@@ -16,27 +16,17 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.plugin.stream.kafka20;
+package org.apache.pinot.spi.stream;
 
-import java.nio.ByteBuffer;
-import org.apache.pinot.plugin.stream.kafka.MessageAndOffset;
-import org.apache.pinot.spi.stream.RowMetadata;
-
-
-public class MessageAndOffsetAndMetadata extends MessageAndOffset {
-  private final RowMetadata _rowMetadata;
-
-  public MessageAndOffsetAndMetadata(byte[] message, long offset, RowMetadata rowMetadata) {
-    super(message, offset);
-    _rowMetadata = rowMetadata;
-  }
-
-  public MessageAndOffsetAndMetadata(ByteBuffer message, long offset, RowMetadata rowMetadata) {
-    super(message, offset);
-    _rowMetadata = rowMetadata;
-  }
-
-  public RowMetadata getRowMetadata() {
-    return _rowMetadata;
-  }
+/**
+ * A decoder for {@link StreamMessage}
+ */
+public interface StreamDataDecoder {
+  /**
+   * Decodes a {@link StreamMessage}
+   *
+   * @param message {@link StreamMessage} that contains the data payload and optionally, a key and row metadata
+   * @return {@link StreamDataDecoderResult} that either contains the decoded row or the exception
+   */
+  StreamDataDecoderResult decode(StreamMessage message);
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataDecoderImpl.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataDecoderImpl.java
@@ -43,6 +43,7 @@ public class StreamDataDecoderImpl implements StreamDataDecoder {
     assert message.getValue() != null;
 
     try {
+      _reuse.clear();
       GenericRow row = _valueDecoder.decode(message.getValue(), 0, message.getValue().length, _reuse);
       if (row != null) {
         if (message.getKey() != null) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataDecoderImpl.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataDecoderImpl.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.stream;
+
+import java.util.Map;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class StreamDataDecoderImpl implements StreamDataDecoder {
+  private static final String KEY = "__key";
+  private static final String HEADER_KEY_PREFIX = "header$";
+  private static final Logger LOGGER = LoggerFactory.getLogger(StreamDataDecoderImpl.class);
+
+  private final StreamMessageDecoder _valueDecoder;
+
+  // Maybe simplify by allowing only string keys ?
+  public StreamDataDecoderImpl(StreamMessageDecoder valueDecoder) {
+    _valueDecoder = valueDecoder;
+  }
+
+  @Override
+  public StreamDataDecoderResult decode(StreamMessage message) {
+    assert message.getValue() != null;
+
+    try {
+      GenericRow row = _valueDecoder.decode(message.getValue(), 0, message.getValue().length, new GenericRow());
+      if (row != null) {
+        if (message.getKey() != null) {
+          row.putValue(KEY, message.getKey());
+        }
+        RowMetadata metadata = message.getMetadata();
+        if (metadata != null && metadata.getHeaders() != null) {
+          for (Map.Entry<String, Object> entrySet : metadata.getHeaders().getFieldToValueMap().entrySet()) {
+            row.putValue(HEADER_KEY_PREFIX + entrySet.getKey(), entrySet.getValue());
+          }
+        }
+        return new StreamDataDecoderResult(row, null);
+      } else {
+        return new StreamDataDecoderResult(null,
+            new RuntimeException("Encountered unknown exception when decoding a Stream message"));
+      }
+    } catch (Exception e) {
+      LOGGER.error("Failed to decode message", e);
+      return new StreamDataDecoderResult(null, e);
+    }
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataDecoderImpl.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataDecoderImpl.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.spi.stream;
 
+import java.nio.charset.StandardCharsets;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,14 +27,13 @@ import org.slf4j.LoggerFactory;
 public class StreamDataDecoderImpl implements StreamDataDecoder {
   private static final Logger LOGGER = LoggerFactory.getLogger(StreamDataDecoderImpl.class);
 
-  private static final String KEY = "__key";
-  private static final String HEADER_KEY_PREFIX = "__header$";
-  private static final String METADATA_KEY_PREFIX = "__metadata$";
+  public static final String KEY = "__key";
+  public static final String HEADER_KEY_PREFIX = "__header$";
+  public static final String METADATA_KEY_PREFIX = "__metadata$";
 
   private final StreamMessageDecoder _valueDecoder;
   private final GenericRow _reuse = new GenericRow();
 
-  // Maybe simplify by allowing only string keys ?
   public StreamDataDecoderImpl(StreamMessageDecoder valueDecoder) {
     _valueDecoder = valueDecoder;
   }
@@ -47,7 +47,7 @@ public class StreamDataDecoderImpl implements StreamDataDecoder {
       GenericRow row = _valueDecoder.decode(message.getValue(), 0, message.getValue().length, _reuse);
       if (row != null) {
         if (message.getKey() != null) {
-          row.putValue(KEY, new String(message.getKey()));
+          row.putValue(KEY, new String(message.getKey(), StandardCharsets.UTF_8));
         }
         RowMetadata metadata = message.getMetadata();
         if (metadata != null) {
@@ -63,7 +63,7 @@ public class StreamDataDecoderImpl implements StreamDataDecoder {
             new RuntimeException("Encountered unknown exception when decoding a Stream message"));
       }
     } catch (Exception e) {
-      LOGGER.error("Failed to decode message", e);
+      LOGGER.error("Failed to decode StreamMessage", e);
       return new StreamDataDecoderResult(null, e);
     }
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataDecoderResult.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataDecoderResult.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.spi.stream;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.spi.data.readers.GenericRow;
 
 
@@ -34,10 +35,12 @@ public final class StreamDataDecoderResult {
     _exception = exception;
   }
 
+  @Nullable
   public GenericRow getResult() {
     return _result;
   }
 
+  @Nullable
   public Exception getException() {
     return _exception;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataDecoderResult.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataDecoderResult.java
@@ -16,38 +16,29 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.plugin.stream.kafka;
+package org.apache.pinot.spi.stream;
 
-import java.nio.ByteBuffer;
+import org.apache.pinot.spi.data.readers.GenericRow;
 
 
-public class MessageAndOffset {
+/**
+ * A container class for holding the result of a decoder
+ * At any point in time, only one of Result or exception is set as null.
+ */
+public final class StreamDataDecoderResult {
+  private final GenericRow _result;
+  private final Exception _exception;
 
-  private ByteBuffer _message;
-  private long _offset;
-
-  public MessageAndOffset(byte[] message, long offset) {
-    this(ByteBuffer.wrap(message), offset);
+  public StreamDataDecoderResult(GenericRow result, Exception exception) {
+    _result = result;
+    _exception = exception;
   }
 
-  public MessageAndOffset(ByteBuffer message, long offset) {
-    _message = message;
-    _offset = offset;
+  public GenericRow getResult() {
+    return _result;
   }
 
-  public ByteBuffer getMessage() {
-    return _message;
-  }
-
-  public long getOffset() {
-    return _offset;
-  }
-
-  public long getNextOffset() {
-    return getOffset() + 1;
-  }
-
-  public int payloadSize() {
-    return getMessage().array().length;
+  public Exception getException() {
+    return _exception;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessage.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessage.java
@@ -41,7 +41,7 @@ import javax.annotation.Nullable;
 public abstract class StreamMessage {
   private final byte[] _key;
   private final byte[] _value;
-  private final StreamMessageMetadata _metadata;
+  protected final StreamMessageMetadata _metadata;
 
   public StreamMessage(@Nullable byte[] key, byte[] value, @Nullable StreamMessageMetadata metadata) {
     _key = key;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessage.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessage.java
@@ -38,7 +38,7 @@ import javax.annotation.Nullable;
  * Additionally, the pinot table schema should refer these fields. Otherwise, even though the fields are extracted,
  * they will not materialize in the pinot table.
  */
-public abstract class StreamMessage {
+public class StreamMessage {
   private final byte[] _key;
   private final byte[] _value;
   protected final StreamMessageMetadata _metadata;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessage.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessage.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.stream;
+
+import javax.annotation.Nullable;
+
+
+/**
+ * Represents a Stream message which includes the following components:
+ * 1. record key (optional)
+ * 2. record value (required)
+ * 3. StreamMessageMetadata (optional) - includes all record headers and metadata associated with a stream message
+ *  (such as a message identifier, event timestamp, publish timestamp etc)
+ *
+ * Similar to value decoder, each implementing stream plugin can have a key decoder and header extractor.
+ * If the key and header extractions are enabled for the table, the schema will automatically contain these fields as:
+ * "header$HEADER_KEY" or "metadata$RECORD_TIMESTAMP"
+ *
+ * These columns can be treated similar to any other Pinot table column.
+ *
+ * Usability note: In order to achieve this, table configuration should enable header and metadata extraction.
+ * Additionally, the pinot table schema should refer these fields. Otherwise, even though the fields are extracted,
+ * they will not materialize in the pinot table.
+ */
+public abstract class StreamMessage {
+  private final byte[] _key;
+  private final byte[] _value;
+  private final StreamMessageMetadata _metadata;
+
+  public StreamMessage(@Nullable byte[] key, byte[] value, @Nullable StreamMessageMetadata metadata) {
+    _key = key;
+    _value = value;
+    _metadata = metadata;
+  }
+
+  public StreamMessage(byte[] value) {
+    this(null, value, null);
+  }
+
+  public byte[] getValue() {
+    return _value;
+  }
+
+  @Nullable
+  public StreamMessageMetadata getMetadata() {
+    return _metadata;
+  }
+
+  @Nullable
+  public byte[] getKey() {
+    return _key;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessage.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessage.java
@@ -25,16 +25,16 @@ import javax.annotation.Nullable;
  * Represents a Stream message which includes the following components:
  * 1. record key (optional)
  * 2. record value (required)
- * 3. StreamMessageMetadata (optional) - includes all record headers and metadata associated with a stream message
- *  (such as a message identifier, event timestamp, publish timestamp etc)
+ * 3. StreamMessageMetadata (optional) - encapsulates record headers and metadata associated with a stream message
+ *  (such as a message identifier, publish timestamp, user-provided headers etc)
  *
  * Similar to value decoder, each implementing stream plugin can have a key decoder and header extractor.
  * If the key and header extractions are enabled for the table, the schema will automatically contain these fields as:
- * "header$HEADER_KEY" or "metadata$RECORD_TIMESTAMP"
+ * "__header$HEADER_KEY" or "__metadata$RECORD_TIMESTAMP"
  *
  * These columns can be treated similar to any other Pinot table column.
  *
- * Usability note: In order to achieve this, table configuration should enable header and metadata extraction.
+ * Usability note: In order to achieve this, table configuration should enable "populate metadata" option.
  * Additionally, the pinot table schema should refer these fields. Otherwise, even though the fields are extracted,
  * they will not materialize in the pinot table.
  */

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessageMetadata.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessageMetadata.java
@@ -18,26 +18,38 @@
  */
 package org.apache.pinot.spi.stream;
 
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.data.readers.GenericRow;
+
+
 /**
  * A class that provides metadata associated with the message of a stream, for e.g.,
- * ingestion-timestamp of the message.
+ * timestamp derived from the incoming record (not the ingestion time).
  */
 public class StreamMessageMetadata implements RowMetadata {
 
-  private final long _ingestionTimeMs;
+  private final long _recordTimestampMs;
+
+  private final GenericRow _headers;
 
   /**
    * Construct the stream based message/row message metadata
    *
-   * @param ingestionTimeMs  the time that the message was ingested by the stream provider
+   * @param recordTimestampMs  the time that the message was ingested by the stream provider
    *                         use Long.MIN_VALUE if not applicable
    */
-  public StreamMessageMetadata(long ingestionTimeMs) {
-    _ingestionTimeMs = ingestionTimeMs;
+  public StreamMessageMetadata(long recordTimestampMs, @Nullable GenericRow headers) {
+    _recordTimestampMs = recordTimestampMs;
+    _headers = headers;
   }
 
   @Override
-  public long getIngestionTimeMs() {
-    return _ingestionTimeMs;
+  public long getRecordTimestampMs() {
+    return _recordTimestampMs;
+  }
+
+  @Override
+  public GenericRow getHeaders() {
+    return _headers;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessageMetadata.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessageMetadata.java
@@ -29,16 +29,14 @@ import org.apache.pinot.spi.data.readers.GenericRow;
  * timestamp derived from the incoming record (not the ingestion time).
  */
 public class StreamMessageMetadata implements RowMetadata {
-
   private final long _recordTimestampMs;
-
   private final GenericRow _headers;
-
   private final Map<String, String> _metadata;
 
   public StreamMessageMetadata(long recordTimestampMs, @Nullable GenericRow headers) {
     this(recordTimestampMs, headers, Collections.emptyMap());
   }
+
   /**
    * Construct the stream based message/row message metadata
    *

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessageMetadata.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessageMetadata.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.spi.stream;
 
+import java.util.Collections;
+import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.data.readers.GenericRow;
 
@@ -32,15 +34,23 @@ public class StreamMessageMetadata implements RowMetadata {
 
   private final GenericRow _headers;
 
+  private final Map<String, String> _metadata;
+
+  public StreamMessageMetadata(long recordTimestampMs, @Nullable GenericRow headers) {
+    this(recordTimestampMs, headers, Collections.emptyMap());
+  }
   /**
    * Construct the stream based message/row message metadata
    *
    * @param recordTimestampMs  the time that the message was ingested by the stream provider
    *                         use Long.MIN_VALUE if not applicable
+   * @param metadata
    */
-  public StreamMessageMetadata(long recordTimestampMs, @Nullable GenericRow headers) {
+  public StreamMessageMetadata(long recordTimestampMs, @Nullable GenericRow headers,
+      Map<String, String> metadata) {
     _recordTimestampMs = recordTimestampMs;
     _headers = headers;
+    _metadata = metadata;
   }
 
   @Override
@@ -51,5 +61,10 @@ public class StreamMessageMetadata implements RowMetadata {
   @Override
   public GenericRow getHeaders() {
     return _headers;
+  }
+
+  @Override
+  public Map<String, String> getRecordMetadata() {
+    return _metadata;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessageMetadata.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessageMetadata.java
@@ -29,31 +29,31 @@ import org.apache.pinot.spi.data.readers.GenericRow;
  * timestamp derived from the incoming record (not the ingestion time).
  */
 public class StreamMessageMetadata implements RowMetadata {
-  private final long _recordTimestampMs;
+  private final long _recordIngestionTimeMs;
   private final GenericRow _headers;
   private final Map<String, String> _metadata;
 
-  public StreamMessageMetadata(long recordTimestampMs, @Nullable GenericRow headers) {
-    this(recordTimestampMs, headers, Collections.emptyMap());
+  public StreamMessageMetadata(long recordIngestionTimeMs, @Nullable GenericRow headers) {
+    this(recordIngestionTimeMs, headers, Collections.emptyMap());
   }
 
   /**
    * Construct the stream based message/row message metadata
    *
-   * @param recordTimestampMs  the time that the message was ingested by the stream provider
+   * @param recordIngestionTimeMs  the time that the message was ingested by the stream provider
    *                         use Long.MIN_VALUE if not applicable
    * @param metadata
    */
-  public StreamMessageMetadata(long recordTimestampMs, @Nullable GenericRow headers,
+  public StreamMessageMetadata(long recordIngestionTimeMs, @Nullable GenericRow headers,
       Map<String, String> metadata) {
-    _recordTimestampMs = recordTimestampMs;
+    _recordIngestionTimeMs = recordIngestionTimeMs;
     _headers = headers;
     _metadata = metadata;
   }
 
   @Override
-  public long getRecordTimestampMs() {
-    return _recordTimestampMs;
+  public long getRecordIngestionTimeMs() {
+    return _recordIngestionTimeMs;
   }
 
   @Override

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/stream/StreamDataDecoderImplTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/stream/StreamDataDecoderImplTest.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.stream;
+
+import com.google.common.collect.ImmutableSet;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class StreamDataDecoderImplTest {
+  private static final String NAME_FIELD = "name";
+  private static final String AGE_HEADER_KEY = "age";
+  private static final String SEQNO_RECORD_METADATA = "seqNo";
+
+  @Test
+  public void testDecodeValueOnly()
+      throws Exception {
+    TestDecoder messageDecoder = new TestDecoder();
+    messageDecoder.init(Collections.emptyMap(), ImmutableSet.of(NAME_FIELD), "");
+    String value = "Alice";
+    StreamMessage message = new StreamMessage(value.getBytes(StandardCharsets.UTF_8));
+    StreamDataDecoderResult result = new StreamDataDecoderImpl(messageDecoder).decode(message);
+    Assert.assertNotNull(result);
+    Assert.assertNull(result.getException());
+    Assert.assertNotNull(result.getResult());
+
+    GenericRow row = result.getResult();
+    Assert.assertEquals(row.getFieldToValueMap().size(), 1);
+    Assert.assertEquals(String.valueOf(row.getValue(NAME_FIELD)), value);
+  }
+
+  @Test
+  public void testDecodeKeyAndHeaders()
+      throws Exception {
+    TestDecoder messageDecoder = new TestDecoder();
+    messageDecoder.init(Collections.emptyMap(), ImmutableSet.of(NAME_FIELD), "");
+    String value = "Alice";
+    String key = "id-1";
+    GenericRow headers = new GenericRow();
+    headers.putValue(AGE_HEADER_KEY, 3);
+    Map<String, String> recordMetadata = Collections.singletonMap(SEQNO_RECORD_METADATA, "1");
+    StreamMessageMetadata metadata = new StreamMessageMetadata(1234L, headers, recordMetadata);
+    StreamMessage message = new StreamMessage(key.getBytes(StandardCharsets.UTF_8),
+        value.getBytes(StandardCharsets.UTF_8), metadata);
+
+    StreamDataDecoderResult result = new StreamDataDecoderImpl(messageDecoder).decode(message);
+    Assert.assertNotNull(result);
+    Assert.assertNull(result.getException());
+    Assert.assertNotNull(result.getResult());
+
+    GenericRow row = result.getResult();
+    Assert.assertEquals(row.getFieldToValueMap().size(), 4);
+    Assert.assertEquals(row.getValue(NAME_FIELD), value);
+    Assert.assertEquals(row.getValue(StreamDataDecoderImpl.KEY), key, "Failed to decode record key");
+    Assert.assertEquals(row.getValue(StreamDataDecoderImpl.HEADER_KEY_PREFIX + AGE_HEADER_KEY), 3);
+    Assert.assertEquals(row.getValue(StreamDataDecoderImpl.METADATA_KEY_PREFIX + SEQNO_RECORD_METADATA), "1");
+  }
+
+  @Test
+  public void testNoExceptionIsThrown()
+      throws Exception {
+    ThrowingDecoder messageDecoder = new ThrowingDecoder();
+    messageDecoder.init(Collections.emptyMap(), ImmutableSet.of(NAME_FIELD), "");
+    String value = "Alice";
+    StreamMessage message = new StreamMessage(value.getBytes(StandardCharsets.UTF_8));
+    StreamDataDecoderResult result = new StreamDataDecoderImpl(messageDecoder).decode(message);
+    Assert.assertNotNull(result);
+    Assert.assertNotNull(result.getException());
+    Assert.assertNull(result.getResult());
+  }
+
+  class ThrowingDecoder implements StreamMessageDecoder<byte[]> {
+
+    @Override
+    public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName)
+        throws Exception { }
+
+    @Nullable
+    @Override
+    public GenericRow decode(byte[] payload, GenericRow destination) {
+      throw new RuntimeException("something failed during decoding");
+    }
+
+    @Nullable
+    @Override
+    public GenericRow decode(byte[] payload, int offset, int length, GenericRow destination) {
+      return decode(payload, destination);
+    }
+  }
+
+
+  class TestDecoder implements StreamMessageDecoder<byte[]> {
+    @Override
+    public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName)
+        throws Exception { }
+
+    @Nullable
+    @Override
+    public GenericRow decode(byte[] payload, GenericRow destination) {
+      destination.putValue(NAME_FIELD, new String(payload, StandardCharsets.UTF_8));
+      return destination;
+    }
+
+    @Nullable
+    @Override
+    public GenericRow decode(byte[] payload, int offset, int length, GenericRow destination) {
+      return decode(payload, destination);
+    }
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/stream/StreamMessageTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/stream/StreamMessageTest.java
@@ -18,18 +18,26 @@
  */
 package org.apache.pinot.spi.stream;
 
-/**
- * A decoder for {@link StreamMessage}
- */
-public interface StreamDataDecoder {
-  /**
-   * Decodes a {@link StreamMessage}
-   *
-   * Please note that the expectation is that the implementations of this class should never throw an exception.
-   * Instead, it should encapsulate the exception within the {@link StreamDataDecoderResult} object.
-   *
-   * @param message {@link StreamMessage} that contains the data payload and optionally, a key and row metadata
-   * @return {@link StreamDataDecoderResult} that either contains the decoded row or the exception
-   */
-  StreamDataDecoderResult decode(StreamMessage message);
+import java.nio.charset.StandardCharsets;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class StreamMessageTest {
+
+  @Test
+  public void testAllowNullKeyAndMetadata() {
+    StreamMessage msg = new StreamMessage("hello".getBytes(StandardCharsets.UTF_8));
+    Assert.assertNull(msg.getKey());
+    Assert.assertNull(msg.getMetadata());
+    Assert.assertEquals(new String(msg.getValue()), "hello");
+
+    StreamMessage msg1 = new StreamMessage("key".getBytes(StandardCharsets.UTF_8),
+        "value".getBytes(StandardCharsets.UTF_8), null);
+    Assert.assertNotNull(msg1.getKey());
+    Assert.assertEquals(new String(msg1.getKey()), "key");
+    Assert.assertNotNull(msg1.getValue());
+    Assert.assertEquals(new String(msg1.getValue()), "value");
+    Assert.assertNull(msg1.getMetadata());
+  }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
@@ -399,7 +399,7 @@ public abstract class QuickStartBase {
         case "meetupRsvp":
           kafkaStarter.createTopic("meetupRSVPEvents", KafkaStarterUtils.getTopicCreationProps(10));
           printStatus(Quickstart.Color.CYAN, "***** Starting meetup data stream and publishing to Kafka *****");
-          MeetupRsvpStream meetupRSVPProvider = new MeetupRsvpStream();
+          MeetupRsvpStream meetupRSVPProvider = new MeetupRsvpStream(true);
           meetupRSVPProvider.run();
           Runtime.getRuntime().addShutdownHook(new Thread(() -> {
             try {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/streams/PinotRealtimeSource.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/streams/PinotRealtimeSource.java
@@ -96,7 +96,7 @@ public class PinotRealtimeSource implements AutoCloseable {
         } else {
           _rateLimiter.acquire(rows.size());
           if (!_shutdown) {
-            _producer.produceKeyedBatch(_topicName, rows);
+            _producer.produceKeyedBatch(_topicName, rows, true);
           }
         }
       }

--- a/pinot-tools/src/main/resources/examples/stream/meetupRsvp/meetupRsvp_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/meetupRsvp/meetupRsvp_realtime_table_config.json
@@ -38,7 +38,8 @@
       "stream.kafka.broker.list": "localhost:19092",
       "stream.kafka.consumer.prop.auto.offset.reset": "largest",
       "realtime.segment.flush.threshold.time": "12h",
-      "realtime.segment.flush.threshold.size": "100M"
+      "realtime.segment.flush.threshold.size": "10K",
+      "stream.kafka.metadata.populate": "true"
     }
   },
   "metadata": {

--- a/pinot-tools/src/main/resources/examples/stream/meetupRsvp/meetupRsvp_schema.json
+++ b/pinot-tools/src/main/resources/examples/stream/meetupRsvp/meetupRsvp_schema.json
@@ -8,6 +8,14 @@
   "dimensionFieldSpecs": [
     {
       "dataType": "STRING",
+      "name": "__key"
+    },
+    {
+      "dataType": "STRING",
+      "name": "header$producerTimestamp"
+    },
+    {
+      "dataType": "STRING",
       "name": "venue_name"
     },
     {


### PR DESCRIPTION
Design doc: https://docs.google.com/document/d/1kTUfBud1SBSh_703mvu6ybkbIwiKKH9eXpdcpEmhC2E/edit 

This is an extension of PR #9096 

# Motivation  
Most stream systems provide a message envelope, which encapsulates the record payload, along with record headers, keys and other system-specific metadata  For e.g:
1. Kafka allows keyed records and additionally, provides headers 
2. Kinesis requires keyed records and includes some additional metadata such as sequenceId etc 
3. Pulsar also supports keyed records and allows including arbitrary properties. 
4. Pubsub supports keyed messages, along with user-defined attributes and message metadata. 

Today, Pinot drops everything from the payload, other than the record value itself. Hence, there needs to be a way to extract these values and present them in the Pinot table as regular columns (of course, it has to be defined in the pinot schema). 

This can be very useful for the Pinot user as they don't have to "pre-process" the stream to make the record metadata available in the data payload. It also prevents custom solutions (such as [this](https://github.com/startreedata/startree-pinot/pull/484/files)).

# Context 
Want to clarify the terminology here. Typically, in most streaming systems, a record is composed of the following:
1. Record key - usually, a string, although kafka allows any type (today, `pinot-kafka` connector assumes the key to always be a key)
2. Record value - actual data paylaod. Pinot extract only this value and decodes it.
3. Record headers - these are user-defined record header that can be specific to the publishing application. Typically, headers are meant to be efficient and small. For example, in Kafka , it allows <String, byte[]>. technically, `byte[]` can be anything and we can make a call on whether to support arbitrary header value types or not. 
4. Record Metadata - these may or may not be included in the record payload and it is system-defined. For example, for message identifiers, kinesis has `sequenceId`, kafka has `offset`, pubsub has `messageId` etc. While these may not be useful for the user-facing application, it comes-in handy for debugging. 

# What does this PR do?

This PR attempts to extract key, header and other metadata from any supported streaming connector. This feature is opt-in, meaning it can be enabled by setting `stream.$streamType.metadata.populate` as `true`

please note: Documentation for this feature will follow after this PR is merged.  

For Reviewers, things to discuss:
1. In the current patch, the record key (when available) is extracted as `__key` column , where as headers are extracted as `header$<HEADER_KEY_NAME>` . Does this sound like a good convention to follow for all stream connectors  -> Header columns will always be prefixed with `header$` and any other metadata such as key or offset will be prefixed as `__`
2. In `MessageBatch`, I have marked one of the methods as `@Deprecated` as I am hoping to eventually eliminate the need for typed interface there. The current changes are backwards compatible. Let me know if there is a better way. 
