### PR TITLE
Allow explicit partition for real-time segment assignment

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
@@ -109,15 +109,14 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
         instancePartitionsMap.entrySet().iterator().next();
     InstancePartitionsType instancePartitionsType = typeToInstancePartitions.getKey();
     InstancePartitions instancePartitions = typeToInstancePartitions.getValue();
-    Preconditions
-        .checkState(instancePartitions.getNumPartitions() == 1, "Instance partitions: %s should contain 1 partition",
-            instancePartitions.getInstancePartitionsName());
+    Preconditions.checkState(instancePartitions.getNumPartitions() == 1,
+        "Instance partitions: %s should contain 1 partition", instancePartitions.getInstancePartitionsName());
     LOGGER.info("Assigning segment: {} with instance partitions: {} for table: {}", segmentName, instancePartitions,
         _realtimeTableName);
     checkReplication(instancePartitions);
-    List<String> instancesAssigned = instancePartitionsType == InstancePartitionsType.CONSUMING
-        ? assignConsumingSegment(segmentName, instancePartitions)
-        : assignCompletedSegment(segmentName, currentAssignment, instancePartitions);
+    List<String> instancesAssigned =
+        instancePartitionsType == InstancePartitionsType.CONSUMING ? assignConsumingSegment(segmentName,
+            instancePartitions) : assignCompletedSegment(segmentName, currentAssignment, instancePartitions);
     LOGGER.info("Assigned segment: {} to instances: {} for table: {}", segmentName, instancesAssigned,
         _realtimeTableName);
     return instancesAssigned;
@@ -186,13 +185,12 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
 
     InstancePartitions completedInstancePartitions = instancePartitionsMap.get(InstancePartitionsType.COMPLETED);
     InstancePartitions consumingInstancePartitions = instancePartitionsMap.get(InstancePartitionsType.CONSUMING);
-    Preconditions
-        .checkState(consumingInstancePartitions != null, "Failed to find CONSUMING instance partitions for table: %s",
-            _realtimeTableName);
+    Preconditions.checkState(consumingInstancePartitions != null,
+        "Failed to find CONSUMING instance partitions for table: %s", _realtimeTableName);
     Preconditions.checkState(consumingInstancePartitions.getNumPartitions() == 1,
         "Instance partitions: %s should contain 1 partition", consumingInstancePartitions.getInstancePartitionsName());
-    boolean includeConsuming = config
-        .getBoolean(RebalanceConfigConstants.INCLUDE_CONSUMING, RebalanceConfigConstants.DEFAULT_INCLUDE_CONSUMING);
+    boolean includeConsuming = config.getBoolean(RebalanceConfigConstants.INCLUDE_CONSUMING,
+        RebalanceConfigConstants.DEFAULT_INCLUDE_CONSUMING);
     boolean bootstrap =
         config.getBoolean(RebalanceConfigConstants.BOOTSTRAP, RebalanceConfigConstants.DEFAULT_BOOTSTRAP);
 
@@ -218,9 +216,8 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
         Map<String, Map<String, String>> tierCurrentAssignment = entry.getValue();
 
         InstancePartitions tierInstancePartitions = tierInstancePartitionsMap.get(tierName);
-        Preconditions
-            .checkNotNull(tierInstancePartitions, "Failed to find instance partitions for tier: %s of table: %s",
-                tierName, _realtimeTableName);
+        Preconditions.checkNotNull(tierInstancePartitions,
+            "Failed to find instance partitions for tier: %s of table: %s", tierName, _realtimeTableName);
         checkReplication(tierInstancePartitions);
 
         LOGGER.info("Rebalancing tier: {} for table: {} with bootstrap: {}, instance partitions: {}", tierName,
@@ -250,8 +247,8 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
     if (completedInstancePartitions != null) {
       // When COMPLETED instance partitions are provided, reassign COMPLETED segments in a balanced way (relocate
       // COMPLETED segments to offload them from CONSUMING instances to COMPLETED instances)
-      LOGGER
-          .info("Reassigning COMPLETED segments with COMPLETED instance partitions for table: {}", _realtimeTableName);
+      LOGGER.info("Reassigning COMPLETED segments with COMPLETED instance partitions for table: {}",
+          _realtimeTableName);
       newAssignment = reassignSegments(InstancePartitionsType.COMPLETED.toString(), completedSegmentAssignment,
           completedInstancePartitions, bootstrap);
     } else {
@@ -275,8 +272,8 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
     Map<String, Map<String, String>> consumingSegmentAssignment =
         completedConsumingOfflineSegmentAssignment.getConsumingSegmentAssignment();
     if (includeConsuming) {
-      LOGGER
-          .info("Reassigning CONSUMING segments with CONSUMING instance partitions for table: {}", _realtimeTableName);
+      LOGGER.info("Reassigning CONSUMING segments with CONSUMING instance partitions for table: {}",
+          _realtimeTableName);
 
       for (String segmentName : consumingSegmentAssignment.keySet()) {
         List<String> instancesAssigned = assignConsumingSegment(segmentName, consumingInstancePartitions);
@@ -316,8 +313,8 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
       newAssignment = new TreeMap<>();
       for (String segment : currentAssignment.keySet()) {
         List<String> assignedInstances = assignCompletedSegment(segment, newAssignment, instancePartitions);
-        newAssignment
-            .put(segment, SegmentAssignmentUtils.getInstanceStateMap(assignedInstances, SegmentStateModel.ONLINE));
+        newAssignment.put(segment,
+            SegmentAssignmentUtils.getInstanceStateMap(assignedInstances, SegmentStateModel.ONLINE));
       }
     } else {
       if (instancePartitions.getNumReplicaGroups() == 1) {
@@ -325,8 +322,9 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
 
         List<String> instances =
             SegmentAssignmentUtils.getInstancesForNonReplicaGroupBasedAssignment(instancePartitions, _replication);
-        newAssignment = SegmentAssignmentUtils
-            .rebalanceTableWithHelixAutoRebalanceStrategy(currentAssignment, instances, _replication);
+        newAssignment =
+            SegmentAssignmentUtils.rebalanceTableWithHelixAutoRebalanceStrategy(currentAssignment, instances,
+                _replication);
       } else {
         // Replica-group based assignment
 
@@ -347,8 +345,8 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
           Collections.shuffle(segments, random);
         }
 
-        newAssignment = SegmentAssignmentUtils
-            .rebalanceReplicaGroupBasedTable(currentAssignment, instancePartitions, instancePartitionIdToSegmentsMap);
+        newAssignment = SegmentAssignmentUtils.rebalanceReplicaGroupBasedTable(currentAssignment, instancePartitions,
+            instancePartitionIdToSegmentsMap);
       }
     }
     return newAssignment;
@@ -363,8 +361,8 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
     if (numReplicaGroups == 1) {
       // Non-replica-group based assignment
 
-      return SegmentAssignmentUtils
-          .assignSegmentWithoutReplicaGroup(currentAssignment, instancePartitions, _replication);
+      return SegmentAssignmentUtils.assignSegmentWithoutReplicaGroup(currentAssignment, instancePartitions,
+          _replication);
     } else {
       // Replica-group based assignment
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
@@ -79,6 +79,8 @@ import org.slf4j.LoggerFactory;
  *     </ul>
  *   </li>
  * </ul>
+ *
+ * TODO: This class shares a lot of common code with {@link OfflineSegmentAssignment}, extracts a base class from them.
  */
 public class RealtimeSegmentAssignment implements SegmentAssignment {
   private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeSegmentAssignment.class);
@@ -97,8 +99,13 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
         tableConfig.getValidationConfig().getReplicaGroupStrategyConfig();
     _partitionColumn = replicaGroupStrategyConfig != null ? replicaGroupStrategyConfig.getPartitionColumn() : null;
 
-    LOGGER.info("Initialized RealtimeSegmentAssignment with replication: {}, partitionColumn: {} for table: {}",
-        _replication, _partitionColumn, _realtimeTableName);
+    if (_partitionColumn == null) {
+      LOGGER.info("Initialized RealtimeSegmentAssignment with replication: {} without partition column for table: {} ",
+          _replication, _realtimeTableName);
+    } else {
+      LOGGER.info("Initialized RealtimeSegmentAssignment with replication: {} and partition column: {} for table: {}",
+          _replication, _partitionColumn, _realtimeTableName);
+    }
   }
 
   @Override
@@ -109,11 +116,8 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
         instancePartitionsMap.entrySet().iterator().next();
     InstancePartitionsType instancePartitionsType = typeToInstancePartitions.getKey();
     InstancePartitions instancePartitions = typeToInstancePartitions.getValue();
-    Preconditions.checkState(instancePartitions.getNumPartitions() == 1,
-        "Instance partitions: %s should contain 1 partition", instancePartitions.getInstancePartitionsName());
     LOGGER.info("Assigning segment: {} with instance partitions: {} for table: {}", segmentName, instancePartitions,
         _realtimeTableName);
-    checkReplication(instancePartitions);
     List<String> instancesAssigned =
         instancePartitionsType == InstancePartitionsType.CONSUMING ? assignConsumingSegment(segmentName,
             instancePartitions) : assignCompletedSegment(segmentName, currentAssignment, instancePartitions);
@@ -130,7 +134,7 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
    */
   private void checkReplication(InstancePartitions instancePartitions) {
     int numReplicaGroups = instancePartitions.getNumReplicaGroups();
-    if (numReplicaGroups != 1 && numReplicaGroups != _replication) {
+    if (numReplicaGroups != _replication) {
       LOGGER.warn(
           "Number of replica-groups in instance partitions {}: {} does not match replication in table config: {} for "
               + "table: {}, use: {}", instancePartitions.getInstancePartitionsName(), numReplicaGroups, _replication,
@@ -142,9 +146,11 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
    * Helper method to assign instances for CONSUMING segment based on the segment partition id and instance partitions.
    */
   private List<String> assignConsumingSegment(String segmentName, InstancePartitions instancePartitions) {
-    int partitionGroupId = getPartitionGroupId(segmentName);
+    int segmentPartitionId = getSegmentPartitionId(segmentName);
     int numReplicaGroups = instancePartitions.getNumReplicaGroups();
-    if (numReplicaGroups == 1) {
+    int numPartitions = instancePartitions.getNumPartitions();
+
+    if (numReplicaGroups == 1 && numPartitions == 1) {
       // Non-replica-group based assignment:
       // Uniformly spray the partitions and replicas across the instances.
       // E.g. (6 instances, 3 partitions, 4 replicas)
@@ -157,23 +163,38 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
       int numInstances = instances.size();
       List<String> instancesAssigned = new ArrayList<>(_replication);
       for (int replicaId = 0; replicaId < _replication; replicaId++) {
-        int instanceIndex = (partitionGroupId * _replication + replicaId) % numInstances;
+        int instanceIndex = (segmentPartitionId * _replication + replicaId) % numInstances;
         instancesAssigned.add(instances.get(instanceIndex));
       }
       return instancesAssigned;
     } else {
-      // Replica-group based assignment:
-      // Within a replica-group, uniformly spray the partitions across the instances.
-      // E.g. (within a replica-group, 3 instances, 6 partitions)
-      // "0_0": [i0, i1, i2]
-      //         p0  p1  p2
-      //         p3  p4  p5
+      // Replica-group based assignment
 
+      checkReplication(instancePartitions);
       List<String> instancesAssigned = new ArrayList<>(numReplicaGroups);
-      for (int replicaGroupId = 0; replicaGroupId < numReplicaGroups; replicaGroupId++) {
-        List<String> instances = instancePartitions.getInstances(0, replicaGroupId);
-        instancesAssigned.add(instances.get(partitionGroupId % instances.size()));
+
+      if (numPartitions == 1) {
+        // Implicit partition:
+        // Within a replica-group, uniformly spray the partitions across the instances.
+        // E.g. (within a replica-group, 3 instances, 6 partitions)
+        // "0_0": [i0, i1, i2]
+        //         p0  p1  p2
+        //         p3  p4  p5
+
+        for (int replicaGroupId = 0; replicaGroupId < numReplicaGroups; replicaGroupId++) {
+          List<String> instances = instancePartitions.getInstances(0, replicaGroupId);
+          instancesAssigned.add(instances.get(segmentPartitionId % instances.size()));
+        }
+      } else {
+        // Explicit partition:
+        // Assign segment to the first instance within the partition.
+
+        for (int replicaGroupId = 0; replicaGroupId < numReplicaGroups; replicaGroupId++) {
+          int partitionId = segmentPartitionId % numPartitions;
+          instancesAssigned.add(instancePartitions.getInstances(partitionId, replicaGroupId).get(0));
+        }
       }
+
       return instancesAssigned;
     }
   }
@@ -182,13 +203,10 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
   public Map<String, Map<String, String>> rebalanceTable(Map<String, Map<String, String>> currentAssignment,
       Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap, @Nullable List<Tier> sortedTiers,
       @Nullable Map<String, InstancePartitions> tierInstancePartitionsMap, Configuration config) {
-
     InstancePartitions completedInstancePartitions = instancePartitionsMap.get(InstancePartitionsType.COMPLETED);
     InstancePartitions consumingInstancePartitions = instancePartitionsMap.get(InstancePartitionsType.CONSUMING);
     Preconditions.checkState(consumingInstancePartitions != null,
         "Failed to find CONSUMING instance partitions for table: %s", _realtimeTableName);
-    Preconditions.checkState(consumingInstancePartitions.getNumPartitions() == 1,
-        "Instance partitions: %s should contain 1 partition", consumingInstancePartitions.getInstancePartitionsName());
     boolean includeConsuming = config.getBoolean(RebalanceConfigConstants.INCLUDE_CONSUMING,
         RebalanceConfigConstants.DEFAULT_INCLUDE_CONSUMING);
     boolean bootstrap =
@@ -218,7 +236,6 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
         InstancePartitions tierInstancePartitions = tierInstancePartitionsMap.get(tierName);
         Preconditions.checkNotNull(tierInstancePartitions,
             "Failed to find instance partitions for tier: %s of table: %s", tierName, _realtimeTableName);
-        checkReplication(tierInstancePartitions);
 
         LOGGER.info("Rebalancing tier: {} for table: {} with bootstrap: {}, instance partitions: {}", tierName,
             _realtimeTableName, bootstrap, tierInstancePartitions);
@@ -232,10 +249,6 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
     LOGGER.info("Rebalancing table: {} with COMPLETED instance partitions: {}, CONSUMING instance partitions: {}, "
             + "includeConsuming: {}, bootstrap: {}", _realtimeTableName, completedInstancePartitions,
         consumingInstancePartitions, includeConsuming, bootstrap);
-    if (completedInstancePartitions != null) {
-      checkReplication(completedInstancePartitions);
-    }
-    checkReplication(consumingInstancePartitions);
 
     SegmentAssignmentUtils.CompletedConsumingOfflineSegmentAssignment completedConsumingOfflineSegmentAssignment =
         new SegmentAssignmentUtils.CompletedConsumingOfflineSegmentAssignment(nonTierAssignment);
@@ -317,7 +330,10 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
             SegmentAssignmentUtils.getInstanceStateMap(assignedInstances, SegmentStateModel.ONLINE));
       }
     } else {
-      if (instancePartitions.getNumReplicaGroups() == 1) {
+      int numReplicaGroups = instancePartitions.getNumReplicaGroups();
+      int numPartitions = instancePartitions.getNumPartitions();
+
+      if (numReplicaGroups == 1 && numPartitions == 1) {
         // Non-replica-group based assignment
 
         List<String> instances =
@@ -328,28 +344,45 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
       } else {
         // Replica-group based assignment
 
-        int numPartitions = instancePartitions.getNumPartitions();
-        Map<Integer, List<String>> instancePartitionIdToSegmentsMap = new HashMap<>();
-        for (String segmentName : currentAssignment.keySet()) {
-          int partitionGroupId = getPartitionGroupId(segmentName);
-          int instancePartitionId = partitionGroupId % numPartitions;
-          instancePartitionIdToSegmentsMap.computeIfAbsent(instancePartitionId, k -> new ArrayList<>())
-              .add(segmentName);
-        }
+        checkReplication(instancePartitions);
 
-        // NOTE: Shuffle the segments within the current assignment to avoid moving only new segments to the new added
-        //       servers, which might cause hotspot servers because queries tend to hit the new segments. Use the table
-        //       name hash as the random seed for the shuffle so that the result is deterministic.
-        Random random = new Random(_realtimeTableName.hashCode());
-        for (List<String> segments : instancePartitionIdToSegmentsMap.values()) {
-          Collections.shuffle(segments, random);
-        }
+        if (_partitionColumn == null || numPartitions == 1) {
+          // NOTE: Shuffle the segments within the current assignment to avoid moving only new segments to the new added
+          //       servers, which might cause hotspot servers because queries tend to hit the new segments. Use the
+          //       table name hash as the random seed for the shuffle so that the result is deterministic.
+          List<String> segments = new ArrayList<>(currentAssignment.keySet());
+          Collections.shuffle(segments, new Random(_realtimeTableName.hashCode()));
 
-        newAssignment = SegmentAssignmentUtils.rebalanceReplicaGroupBasedTable(currentAssignment, instancePartitions,
-            instancePartitionIdToSegmentsMap);
+          newAssignment = new TreeMap<>();
+          SegmentAssignmentUtils.rebalanceReplicaGroupBasedPartition(currentAssignment, instancePartitions, 0, segments,
+              newAssignment);
+        } else {
+          newAssignment = rebalanceTableWithPartition(currentAssignment, instancePartitions);
+        }
       }
     }
     return newAssignment;
+  }
+
+  private Map<String, Map<String, String>> rebalanceTableWithPartition(
+      Map<String, Map<String, String>> currentAssignment, InstancePartitions instancePartitions) {
+    int numPartitions = instancePartitions.getNumPartitions();
+    Map<Integer, List<String>> instancePartitionIdToSegmentsMap = new HashMap<>();
+    for (String segmentName : currentAssignment.keySet()) {
+      int instancePartitionId = getSegmentPartitionId(segmentName) % numPartitions;
+      instancePartitionIdToSegmentsMap.computeIfAbsent(instancePartitionId, k -> new ArrayList<>()).add(segmentName);
+    }
+
+    // NOTE: Shuffle the segments within the current assignment to avoid moving only new segments to the new added
+    //       servers, which might cause hotspot servers because queries tend to hit the new segments. Use the table
+    //       name hash as the random seed for the shuffle so that the result is deterministic.
+    Random random = new Random(_realtimeTableName.hashCode());
+    for (List<String> segments : instancePartitionIdToSegmentsMap.values()) {
+      Collections.shuffle(segments, random);
+    }
+
+    return SegmentAssignmentUtils.rebalanceReplicaGroupBasedTable(currentAssignment, instancePartitions,
+        instancePartitionIdToSegmentsMap);
   }
 
   /**
@@ -358,7 +391,9 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
   private List<String> assignCompletedSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,
       InstancePartitions instancePartitions) {
     int numReplicaGroups = instancePartitions.getNumReplicaGroups();
-    if (numReplicaGroups == 1) {
+    int numPartitions = instancePartitions.getNumPartitions();
+
+    if (numReplicaGroups == 1 && numPartitions == 1) {
       // Non-replica-group based assignment
 
       return SegmentAssignmentUtils.assignSegmentWithoutReplicaGroup(currentAssignment, instancePartitions,
@@ -366,13 +401,21 @@ public class RealtimeSegmentAssignment implements SegmentAssignment {
     } else {
       // Replica-group based assignment
 
-      // Uniformly spray the segment partitions over the instance partitions
-      int partitionId = getPartitionGroupId(segmentName) % instancePartitions.getNumPartitions();
+      checkReplication(instancePartitions);
+
+      int partitionId;
+      if (_partitionColumn == null || numPartitions == 1) {
+        partitionId = 0;
+      } else {
+        // Uniformly spray the segment partitions over the instance partitions
+        partitionId = getSegmentPartitionId(segmentName) % numPartitions;
+      }
+
       return SegmentAssignmentUtils.assignSegmentWithReplicaGroup(currentAssignment, instancePartitions, partitionId);
     }
   }
 
-  private int getPartitionGroupId(String segmentName) {
+  private int getSegmentPartitionId(String segmentName) {
     Integer segmentPartitionId =
         SegmentUtils.getRealtimeSegmentPartitionId(segmentName, _realtimeTableName, _helixManager, _partitionColumn);
     if (segmentPartitionId == null) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtils.java
@@ -91,8 +91,7 @@ public class SegmentAssignmentUtils {
    */
   public static List<String> assignSegmentWithoutReplicaGroup(Map<String, Map<String, String>> currentAssignment,
       InstancePartitions instancePartitions, int replication) {
-    List<String> instances =
-        SegmentAssignmentUtils.getInstancesForNonReplicaGroupBasedAssignment(instancePartitions, replication);
+    List<String> instances = getInstancesForNonReplicaGroupBasedAssignment(instancePartitions, replication);
     int[] numSegmentsAssignedPerInstance = getNumSegmentsAssignedPerInstance(currentAssignment, instances);
     int numInstances = numSegmentsAssignedPerInstance.length;
     PriorityQueue<Pairs.IntPair> heap = new PriorityQueue<>(numInstances, Pairs.intPairComparator());
@@ -113,8 +112,7 @@ public class SegmentAssignmentUtils {
       InstancePartitions instancePartitions, int partitionId) {
     // First assign the segment to replica-group 0
     List<String> instances = instancePartitions.getInstances(partitionId, 0);
-    int[] numSegmentsAssignedPerInstance =
-        SegmentAssignmentUtils.getNumSegmentsAssignedPerInstance(currentAssignment, instances);
+    int[] numSegmentsAssignedPerInstance = getNumSegmentsAssignedPerInstance(currentAssignment, instances);
     int minNumSegmentsAssigned = numSegmentsAssignedPerInstance[0];
     int instanceIdWithLeastSegmentsAssigned = 0;
     int numInstances = numSegmentsAssignedPerInstance.length;
@@ -168,8 +166,8 @@ public class SegmentAssignmentUtils {
       // Uniformly spray the segment partitions over the instance partitions
       int instancePartitionId = entry.getKey();
       List<String> segments = entry.getValue();
-      SegmentAssignmentUtils.rebalanceReplicaGroupBasedPartition(currentAssignment, instancePartitions,
-          instancePartitionId, segments, newAssignment);
+      rebalanceReplicaGroupBasedPartition(currentAssignment, instancePartitions, instancePartitionId, segments,
+          newAssignment);
     }
     return newAssignment;
   }
@@ -198,7 +196,7 @@ public class SegmentAssignmentUtils {
       Map<String, Map<String, String>> newAssignment) {
     // Fetch instances in replica-group 0
     List<String> instances = instancePartitions.getInstances(partitionId, 0);
-    Map<String, Integer> instanceNameToIdMap = SegmentAssignmentUtils.getInstanceNameToIdMap(instances);
+    Map<String, Integer> instanceNameToIdMap = getInstanceNameToIdMap(instances);
 
     // Calculate target number of segments per instance
     // NOTE: in order to minimize the segment movements, use the ceiling of the quotient

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineReplicaGroupSegmentAssignmentTest.java
@@ -138,21 +138,15 @@ public class OfflineReplicaGroupSegmentAssignmentTest {
     TableConfig tableConfigWithPartitions =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME_WITH_PARTITION)
             .setNumReplicas(NUM_REPLICAS)
-            .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY).build();
-    tableConfigWithPartitions.getValidationConfig().setReplicaGroupStrategyConfig(replicaGroupStrategyConfig);
+            .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
+            .setReplicaGroupStrategyConfig(replicaGroupStrategyConfig).build();
     _segmentAssignmentWithPartition =
         SegmentAssignmentFactory.getSegmentAssignment(helixManagerWithPartitions, tableConfigWithPartitions);
 
     // {
-    //   0_0=[instance_0, instance_1],
-    //   0_1=[instance_6, instance_7],
-    //   0_2=[instance_12, instance_13],
-    //   1_0=[instance_2, instance_3],
-    //   1_1=[instance_8, instance_9],
-    //   1_2=[instance_14, instance_15],
-    //   2_0=[instance_4, instance_5],
-    //   2_1=[instance_10, instance_11],
-    //   2_2=[instance_16, instance_17]
+    //   0_0=[instance_0, instance_1], 1_0=[instance_2, instance_3], 2_0=[instance_4, instance_5],
+    //   0_1=[instance_6, instance_7], 1_1=[instance_8, instance_9], 2_1=[instance_10, instance_11],
+    //   0_2=[instance_12, instance_13], 1_2=[instance_14, instance_15], 2_2=[instance_16, instance_17]
     // }
     InstancePartitions instancePartitionsWithPartition =
         new InstancePartitions(INSTANCE_PARTITIONS_NAME_WITH_PARTITION);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupSegmentAssignmentTest.java
@@ -159,8 +159,8 @@ public class RealtimeNonReplicaGroupSegmentAssignmentTest {
 
     // Add an OFFLINE segment on some bad instances
     String offlineSegmentName = "offlineSegment";
-    Map<String, String> offlineSegmentInstanceStateMap = SegmentAssignmentUtils
-        .getInstanceStateMap(SegmentAssignmentTestUtils.getNameList("badInstance_", NUM_REPLICAS),
+    Map<String, String> offlineSegmentInstanceStateMap =
+        SegmentAssignmentUtils.getInstanceStateMap(SegmentAssignmentTestUtils.getNameList("badInstance_", NUM_REPLICAS),
             SegmentStateModel.OFFLINE);
     currentAssignment.put(offlineSegmentName, offlineSegmentInstanceStateMap);
 
@@ -189,14 +189,14 @@ public class RealtimeNonReplicaGroupSegmentAssignmentTest {
     // Rebalance without COMPLETED instance partitions should not change the segment assignment
     Map<InstancePartitionsType, InstancePartitions> noRelocationInstancePartitionsMap =
         ImmutableMap.of(InstancePartitionsType.CONSUMING, _instancePartitionsMap.get(InstancePartitionsType.CONSUMING));
-    assertEquals(_segmentAssignment
-            .rebalanceTable(currentAssignment, noRelocationInstancePartitionsMap, null, null, new BaseConfiguration()),
-        currentAssignment);
+    assertEquals(_segmentAssignment.rebalanceTable(currentAssignment, noRelocationInstancePartitionsMap, null, null,
+        new BaseConfiguration()), currentAssignment);
 
     // Rebalance with COMPLETED instance partitions should relocate all COMPLETED (ONLINE) segments to the COMPLETED
     // instances
-    Map<String, Map<String, String>> newAssignment = _segmentAssignment
-        .rebalanceTable(currentAssignment, _instancePartitionsMap, null, null, new BaseConfiguration());
+    Map<String, Map<String, String>> newAssignment =
+        _segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, null, null,
+            new BaseConfiguration());
     assertEquals(newAssignment.size(), NUM_SEGMENTS + uploadedSegmentNames.size() + 1);
     for (int segmentId = 0; segmentId < NUM_SEGMENTS; segmentId++) {
       if (segmentId < NUM_SEGMENTS - NUM_PARTITIONS) {
@@ -240,19 +240,16 @@ public class RealtimeNonReplicaGroupSegmentAssignmentTest {
 
     // Rebalance without COMPLETED instance partitions again should change the segment assignment back
     currentAssignment.put(offlineSegmentName, offlineSegmentInstanceStateMap);
-    assertEquals(_segmentAssignment
-            .rebalanceTable(newAssignment, noRelocationInstancePartitionsMap, null, null, new BaseConfiguration()),
-        currentAssignment);
+    assertEquals(_segmentAssignment.rebalanceTable(newAssignment, noRelocationInstancePartitionsMap, null, null,
+        new BaseConfiguration()), currentAssignment);
 
     // Bootstrap table without COMPLETED instance partitions should be the same as regular rebalance
     rebalanceConfig = new BaseConfiguration();
     rebalanceConfig.setProperty(RebalanceConfigConstants.BOOTSTRAP, true);
-    assertEquals(_segmentAssignment
-            .rebalanceTable(currentAssignment, noRelocationInstancePartitionsMap, null, null, rebalanceConfig),
-        currentAssignment);
-    assertEquals(_segmentAssignment
-            .rebalanceTable(newAssignment, noRelocationInstancePartitionsMap, null, null, rebalanceConfig),
-        currentAssignment);
+    assertEquals(_segmentAssignment.rebalanceTable(currentAssignment, noRelocationInstancePartitionsMap, null, null,
+        rebalanceConfig), currentAssignment);
+    assertEquals(_segmentAssignment.rebalanceTable(newAssignment, noRelocationInstancePartitionsMap, null, null,
+        rebalanceConfig), currentAssignment);
 
     // Bootstrap table with COMPLETED instance partitions should reassign all COMPLETED segments based on their
     // alphabetical order
@@ -291,8 +288,8 @@ public class RealtimeNonReplicaGroupSegmentAssignmentTest {
       List<String> actualInstances =
           _segmentAssignment.assignSegment(segmentName, currentAssignment, onlyCompletedInstancePartitionMap);
       assertEquals(actualInstances, expectedInstances);
-      currentAssignment
-          .put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(actualInstances, SegmentStateModel.ONLINE));
+      currentAssignment.put(segmentName,
+          SegmentAssignmentUtils.getInstanceStateMap(actualInstances, SegmentStateModel.ONLINE));
     });
   }
 
@@ -302,8 +299,9 @@ public class RealtimeNonReplicaGroupSegmentAssignmentTest {
     if (segmentId >= NUM_PARTITIONS) {
       String lastSegmentInPartition = _segments.get(segmentId - NUM_PARTITIONS);
       Map<String, String> instanceStateMap = currentAssignment.get(lastSegmentInPartition);
-      currentAssignment.put(lastSegmentInPartition, SegmentAssignmentUtils
-          .getInstanceStateMap(new ArrayList<>(instanceStateMap.keySet()), SegmentStateModel.ONLINE));
+      currentAssignment.put(lastSegmentInPartition,
+          SegmentAssignmentUtils.getInstanceStateMap(new ArrayList<>(instanceStateMap.keySet()),
+              SegmentStateModel.ONLINE));
     }
 
     // Add the new segment into the assignment as CONSUMING

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupTieredSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupTieredSegmentAssignmentTest.java
@@ -154,11 +154,10 @@ public class RealtimeNonReplicaGroupTieredSegmentAssignmentTest {
     _tierInstancePartitionsMap.put(TIER_B_NAME, instancePartitionsTierB);
     _tierInstancePartitionsMap.put(TIER_C_NAME, instancePartitionsTierC);
 
-    _sortedTiers = Lists
-        .newArrayList(
-            new Tier(TIER_C_NAME, new TestSegmentSelectorC(), new PinotServerTierStorage(TAG_C_NAME, null, null)),
-            new Tier(TIER_B_NAME, new TestSegmentSelectorB(), new PinotServerTierStorage(TAG_B_NAME, null, null)),
-            new Tier(TIER_A_NAME, new TestSegmentSelectorA(), new PinotServerTierStorage(TAG_A_NAME, null, null)));
+    _sortedTiers = Lists.newArrayList(
+        new Tier(TIER_C_NAME, new TestSegmentSelectorC(), new PinotServerTierStorage(TAG_C_NAME, null, null)),
+        new Tier(TIER_B_NAME, new TestSegmentSelectorB(), new PinotServerTierStorage(TAG_B_NAME, null, null)),
+        new Tier(TIER_A_NAME, new TestSegmentSelectorA(), new PinotServerTierStorage(TAG_A_NAME, null, null)));
   }
 
   @Test
@@ -181,8 +180,9 @@ public class RealtimeNonReplicaGroupTieredSegmentAssignmentTest {
     }
 
     // Rebalance without tier instancePartitions moves all instances to COMPLETED
-    Map<String, Map<String, String>> newAssignment = _segmentAssignment
-        .rebalanceTable(currentAssignment, _instancePartitionsMap, null, null, new BaseConfiguration());
+    Map<String, Map<String, String>> newAssignment =
+        _segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, null, null,
+            new BaseConfiguration());
     assertEquals(newAssignment.size(), NUM_SEGMENTS);
     for (int segmentId = 0; segmentId < NUM_SEGMENTS; segmentId++) {
       if (segmentId < NUM_SEGMENTS - NUM_PARTITIONS) { // ONLINE segments
@@ -204,9 +204,8 @@ public class RealtimeNonReplicaGroupTieredSegmentAssignmentTest {
     int expectedOnTierA = 40;
     int expectedOnTierB = 20;
     int expectedOnCompleted = NUM_SEGMENTS - NUM_PARTITIONS - expectedOnTierA - expectedOnTierB;
-    newAssignment = _segmentAssignment
-        .rebalanceTable(currentAssignment, _instancePartitionsMap, _sortedTiers, _tierInstancePartitionsMap,
-            new BaseConfiguration());
+    newAssignment = _segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, _sortedTiers,
+        _tierInstancePartitionsMap, new BaseConfiguration());
     assertEquals(newAssignment.size(), NUM_SEGMENTS);
     for (int segmentId = 0; segmentId < NUM_SEGMENTS; segmentId++) {
       if (segmentId < NUM_SEGMENTS - NUM_PARTITIONS) {
@@ -259,25 +258,22 @@ public class RealtimeNonReplicaGroupTieredSegmentAssignmentTest {
     // Rebalance with including CONSUMING should give the same assignment
     BaseConfiguration rebalanceConfig = new BaseConfiguration();
     rebalanceConfig.setProperty(RebalanceConfigConstants.INCLUDE_CONSUMING, true);
-    assertEquals(_segmentAssignment
-        .rebalanceTable(currentAssignment, _instancePartitionsMap, _sortedTiers, _tierInstancePartitionsMap,
-            rebalanceConfig), newAssignment);
+    assertEquals(_segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, _sortedTiers,
+        _tierInstancePartitionsMap, rebalanceConfig), newAssignment);
 
     // Rebalance without COMPLETED instance partitions and without tierInstancePartitions again should change the
     // segment assignment back
     Map<InstancePartitionsType, InstancePartitions> noRelocationInstancePartitionsMap = new TreeMap<>();
-    noRelocationInstancePartitionsMap
-        .put(InstancePartitionsType.CONSUMING, _instancePartitionsMap.get(InstancePartitionsType.CONSUMING));
-    assertEquals(_segmentAssignment
-            .rebalanceTable(newAssignment, noRelocationInstancePartitionsMap, null, null, new BaseConfiguration()),
-        currentAssignment);
+    noRelocationInstancePartitionsMap.put(InstancePartitionsType.CONSUMING,
+        _instancePartitionsMap.get(InstancePartitionsType.CONSUMING));
+    assertEquals(_segmentAssignment.rebalanceTable(newAssignment, noRelocationInstancePartitionsMap, null, null,
+        new BaseConfiguration()), currentAssignment);
 
     // Bootstrap
     rebalanceConfig = new BaseConfiguration();
     rebalanceConfig.setProperty(RebalanceConfigConstants.BOOTSTRAP, true);
-    newAssignment = _segmentAssignment
-        .rebalanceTable(currentAssignment, _instancePartitionsMap, _sortedTiers, _tierInstancePartitionsMap,
-            rebalanceConfig);
+    newAssignment = _segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, _sortedTiers,
+        _tierInstancePartitionsMap, rebalanceConfig);
     int index = 0;
     int indexA = 0;
     int indexB = 0;
@@ -315,8 +311,9 @@ public class RealtimeNonReplicaGroupTieredSegmentAssignmentTest {
     if (segmentId >= NUM_PARTITIONS) {
       String lastSegmentInPartition = _segments.get(segmentId - NUM_PARTITIONS);
       Map<String, String> instanceStateMap = currentAssignment.get(lastSegmentInPartition);
-      currentAssignment.put(lastSegmentInPartition, SegmentAssignmentUtils
-          .getInstanceStateMap(new ArrayList<>(instanceStateMap.keySet()), SegmentStateModel.ONLINE));
+      currentAssignment.put(lastSegmentInPartition,
+          SegmentAssignmentUtils.getInstanceStateMap(new ArrayList<>(instanceStateMap.keySet()),
+              SegmentStateModel.ONLINE));
     }
 
     // Add the new segment into the assignment as CONSUMING

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeReplicaGroupSegmentAssignmentTest.java
@@ -176,8 +176,8 @@ public class RealtimeReplicaGroupSegmentAssignmentTest {
 
     // Add an OFFLINE segment on some bad instances
     String offlineSegmentName = "offlineSegment";
-    Map<String, String> offlineSegmentInstanceStateMap = SegmentAssignmentUtils
-        .getInstanceStateMap(SegmentAssignmentTestUtils.getNameList("badInstance_", NUM_REPLICAS),
+    Map<String, String> offlineSegmentInstanceStateMap =
+        SegmentAssignmentUtils.getInstanceStateMap(SegmentAssignmentTestUtils.getNameList("badInstance_", NUM_REPLICAS),
             SegmentStateModel.OFFLINE);
     currentAssignment.put(offlineSegmentName, offlineSegmentInstanceStateMap);
 
@@ -206,14 +206,14 @@ public class RealtimeReplicaGroupSegmentAssignmentTest {
     // Rebalance without COMPLETED instance partitions should not change the segment assignment
     Map<InstancePartitionsType, InstancePartitions> noRelocationInstancePartitionsMap =
         ImmutableMap.of(InstancePartitionsType.CONSUMING, _instancePartitionsMap.get(InstancePartitionsType.CONSUMING));
-    assertEquals(_segmentAssignment
-            .rebalanceTable(currentAssignment, noRelocationInstancePartitionsMap, null, null, new BaseConfiguration()),
-        currentAssignment);
+    assertEquals(_segmentAssignment.rebalanceTable(currentAssignment, noRelocationInstancePartitionsMap, null, null,
+        new BaseConfiguration()), currentAssignment);
 
     // Rebalance with COMPLETED instance partitions should relocate all COMPLETED (ONLINE) segments to the COMPLETED
     // instances
-    Map<String, Map<String, String>> newAssignment = _segmentAssignment
-        .rebalanceTable(currentAssignment, _instancePartitionsMap, null, null, new BaseConfiguration());
+    Map<String, Map<String, String>> newAssignment =
+        _segmentAssignment.rebalanceTable(currentAssignment, _instancePartitionsMap, null, null,
+            new BaseConfiguration());
     assertEquals(newAssignment.size(), NUM_SEGMENTS + uploadedSegmentNames.size() + 1);
     for (int segmentId = 0; segmentId < NUM_SEGMENTS; segmentId++) {
       if (segmentId < NUM_SEGMENTS - NUM_PARTITIONS) {
@@ -255,19 +255,16 @@ public class RealtimeReplicaGroupSegmentAssignmentTest {
         newAssignment);
 
     // Rebalance without COMPLETED instance partitions again should change the segment assignment back
-    assertEquals(_segmentAssignment
-            .rebalanceTable(newAssignment, noRelocationInstancePartitionsMap, null, null, new BaseConfiguration()),
-        currentAssignment);
+    assertEquals(_segmentAssignment.rebalanceTable(newAssignment, noRelocationInstancePartitionsMap, null, null,
+        new BaseConfiguration()), currentAssignment);
 
     // Bootstrap table without COMPLETED instance partitions should be the same as regular rebalance
     rebalanceConfig = new BaseConfiguration();
     rebalanceConfig.setProperty(RebalanceConfigConstants.BOOTSTRAP, true);
-    assertEquals(_segmentAssignment
-            .rebalanceTable(currentAssignment, noRelocationInstancePartitionsMap, null, null, rebalanceConfig),
-        currentAssignment);
-    assertEquals(_segmentAssignment
-            .rebalanceTable(newAssignment, noRelocationInstancePartitionsMap, null, null, rebalanceConfig),
-        currentAssignment);
+    assertEquals(_segmentAssignment.rebalanceTable(currentAssignment, noRelocationInstancePartitionsMap, null, null,
+        rebalanceConfig), currentAssignment);
+    assertEquals(_segmentAssignment.rebalanceTable(newAssignment, noRelocationInstancePartitionsMap, null, null,
+        rebalanceConfig), currentAssignment);
 
     // Bootstrap table with COMPLETED instance partitions should reassign all COMPLETED segments based on their
     // alphabetical order
@@ -315,8 +312,8 @@ public class RealtimeReplicaGroupSegmentAssignmentTest {
       List<String> actualInstances =
           _segmentAssignment.assignSegment(segmentName, currentAssignment, onlyCompletedInstancePartitionMap);
       assertEquals(actualInstances, expectedInstances);
-      currentAssignment
-          .put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(actualInstances, SegmentStateModel.ONLINE));
+      currentAssignment.put(segmentName,
+          SegmentAssignmentUtils.getInstanceStateMap(actualInstances, SegmentStateModel.ONLINE));
     });
   }
 
@@ -326,8 +323,9 @@ public class RealtimeReplicaGroupSegmentAssignmentTest {
     if (segmentId >= NUM_PARTITIONS) {
       String lastSegmentInPartition = _segments.get(segmentId - NUM_PARTITIONS);
       Map<String, String> instanceStateMap = currentAssignment.get(lastSegmentInPartition);
-      currentAssignment.put(lastSegmentInPartition, SegmentAssignmentUtils
-          .getInstanceStateMap(new ArrayList<>(instanceStateMap.keySet()), SegmentStateModel.ONLINE));
+      currentAssignment.put(lastSegmentInPartition,
+          SegmentAssignmentUtils.getInstanceStateMap(new ArrayList<>(instanceStateMap.keySet()),
+              SegmentStateModel.ONLINE));
     }
 
     // Add the new segment into the assignment as CONSUMING


### PR DESCRIPTION
Currently we don't support explicit partition in real-time segment assignment, which makes it unaligned with the offline segment behavior. This PR adds support for that, and make the COMPLETED/UPLOADED segment behavior the same as offline segment assignment for consistency.
Right now real-time and offline segment assignment shares a lot of common code. Will make a separate PR to extract a common class to reduce the duplicate code.

The first commit auto-reformats the related classes. Please review the second commit for the actual change.