### PR TITLE
Bug fix: Nested arrays and map not handled correctly for complex types

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -352,14 +352,14 @@ public class ComplexTypeTransformer implements RecordTransformer {
         List<String> innerMapFields = new ArrayList<>();
         for (Map.Entry<String, Object> innerEntry : new ArrayList<>(innerMap.entrySet())) {
           Object innerValue = innerEntry.getValue();
-          String innerCancatName = concat(field, innerEntry.getKey());
-          map.put(innerCancatName, innerEntry.getValue());
+          String innerConcatName = concat(field, innerEntry.getKey());
+          map.put(innerConcatName, innerEntry.getValue());
           if (innerValue instanceof Map || innerValue instanceof Collection || isNonPrimitiveArray(innerValue)) {
-            innerMapFields.add(innerCancatName);
+            innerMapFields.add(innerConcatName);
           }
         }
         if (!innerMapFields.isEmpty()) {
-          flattenMap(concatName, map, innerMapFields);
+          flattenMap(path, map, innerMapFields);
         }
       } else if (value instanceof Collection && _fieldsToUnnest.contains(concatName)) {
         Collection collection = (Collection) value;


### PR DESCRIPTION
When an input is encountered that has the following tree structure [array -> map -> array -> map] , the complex type transformer doesn't unnest the values properly. This is because we append the child node path to both the flattened field name as well as the key being passed.
so instead of getting `array1.map1.array2`, we get `array1.map1.map1.array2`

The PR fixes this bug as well as adds a test case to reproduce this issue.