### PR TITLE
refine query cancel resp msg

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
@@ -53,6 +53,7 @@ public class QueryException {
   public static final int ACCESS_DENIED_ERROR_CODE = 180;
   public static final int TABLE_DOES_NOT_EXIST_ERROR_CODE = 190;
   public static final int QUERY_EXECUTION_ERROR_CODE = 200;
+  public static final int QUERY_CANCELLATION_ERROR_CODE = 210;
   // TODO: Handle these errors in broker
   public static final int SERVER_SHUTTING_DOWN_ERROR_CODE = 210;
   public static final int SERVER_OUT_OF_CAPACITY_ERROR_CODE = 211;
@@ -90,6 +91,8 @@ public class QueryException {
   public static final ProcessingException TABLE_DOES_NOT_EXIST_ERROR =
       new ProcessingException(TABLE_DOES_NOT_EXIST_ERROR_CODE);
   public static final ProcessingException QUERY_EXECUTION_ERROR = new ProcessingException(QUERY_EXECUTION_ERROR_CODE);
+  public static final ProcessingException QUERY_CANCELLATION_ERROR =
+      new ProcessingException(QUERY_CANCELLATION_ERROR_CODE);
   public static final ProcessingException SERVER_SCHEDULER_DOWN_ERROR =
       new ProcessingException(SERVER_SHUTTING_DOWN_ERROR_CODE);
   public static final ProcessingException SERVER_OUT_OF_CAPACITY_ERROR =
@@ -132,6 +135,7 @@ public class QueryException {
     COMBINE_SEGMENT_PLAN_TIMEOUT_ERROR.setMessage("CombineSegmentPlanTimeoutError");
     TABLE_DOES_NOT_EXIST_ERROR.setMessage("TableDoesNotExistError");
     QUERY_EXECUTION_ERROR.setMessage("QueryExecutionError");
+    QUERY_CANCELLATION_ERROR.setMessage("QueryCancellationError");
     SERVER_SCHEDULER_DOWN_ERROR.setMessage("ServerShuttingDown");
     SERVER_OUT_OF_CAPACITY_ERROR.setMessage("ServerOutOfCapacity");
     SERVER_TABLE_MISSING_ERROR.setMessage("ServerTableMissing");

--- a/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
@@ -53,7 +53,7 @@ public class QueryException {
   public static final int ACCESS_DENIED_ERROR_CODE = 180;
   public static final int TABLE_DOES_NOT_EXIST_ERROR_CODE = 190;
   public static final int QUERY_EXECUTION_ERROR_CODE = 200;
-  public static final int QUERY_CANCELLATION_ERROR_CODE = 210;
+  public static final int QUERY_CANCELLATION_ERROR_CODE = 205;
   // TODO: Handle these errors in broker
   public static final int SERVER_SHUTTING_DOWN_ERROR_CODE = 210;
   public static final int SERVER_OUT_OF_CAPACITY_ERROR_CODE = 211;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -120,7 +120,6 @@ public abstract class BaseCombineOperator extends BaseOperator<IntermediateResul
     try {
       mergedBlock = mergeResults();
     } catch (InterruptedException ie) {
-      Thread.currentThread().interrupt();
       throw new QueryCancelledException("Cancelled while merging results blocks", ie);
     } catch (Exception e) {
       LOGGER.error("Caught exception while merging results blocks (query: {})", _queryContext, e);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -37,6 +37,7 @@ import org.apache.pinot.core.query.request.context.ThreadTimer;
 import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
 import org.apache.pinot.core.util.trace.TraceRunnable;
 import org.apache.pinot.spi.exception.EarlyTerminationException;
+import org.apache.pinot.spi.exception.QueryCancelledException;
 import org.apache.pinot.spi.trace.Tracing;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -118,6 +119,9 @@ public abstract class BaseCombineOperator extends BaseOperator<IntermediateResul
     IntermediateResultsBlock mergedBlock;
     try {
       mergedBlock = mergeResults();
+    } catch (InterruptedException ie) {
+      Thread.currentThread().interrupt();
+      throw new QueryCancelledException("Cancelled while merging results blocks", ie);
     } catch (Exception e) {
       LOGGER.error("Caught exception while merging results blocks (query: {})", _queryContext, e);
       mergedBlock = new IntermediateResultsBlock(QueryException.getException(QueryException.INTERNAL_ERROR, e));

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -119,8 +119,8 @@ public abstract class BaseCombineOperator extends BaseOperator<IntermediateResul
     IntermediateResultsBlock mergedBlock;
     try {
       mergedBlock = mergeResults();
-    } catch (InterruptedException ie) {
-      throw new QueryCancelledException("Cancelled while merging results blocks", ie);
+    } catch (InterruptedException e) {
+      throw new QueryCancelledException("Cancelled while merging results blocks", e);
     } catch (Exception e) {
       LOGGER.error("Caught exception while merging results blocks (query: {})", _queryContext, e);
       mergedBlock = new IntermediateResultsBlock(QueryException.getException(QueryException.INTERNAL_ERROR, e));

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOrderByCombineOperator.java
@@ -30,6 +30,7 @@ import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
+import org.apache.pinot.spi.exception.QueryCancelledException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -76,8 +77,10 @@ public class SelectionOrderByCombineOperator extends BaseCombineOperator {
     assert orderByExpressions != null;
     if (orderByExpressions.get(0).getExpression().getType() == ExpressionContext.Type.IDENTIFIER) {
       try {
-        return new MinMaxValueBasedSelectionOrderByCombineOperator(_operators, _queryContext,
-            _executorService).getNextBlock();
+        return new MinMaxValueBasedSelectionOrderByCombineOperator(_operators, _queryContext, _executorService)
+            .getNextBlock();
+      } catch (QueryCancelledException e) {
+        throw new QueryCancelledException("Cancelled while running MinMaxValueBasedSelectionOrderByCombineOperator", e);
       } catch (Exception e) {
         LOGGER.warn("Caught exception while using min/max value based combine, using the default combine", e);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOrderByCombineOperator.java
@@ -80,7 +80,7 @@ public class SelectionOrderByCombineOperator extends BaseCombineOperator {
         return new MinMaxValueBasedSelectionOrderByCombineOperator(_operators, _queryContext, _executorService)
             .getNextBlock();
       } catch (QueryCancelledException e) {
-        throw new QueryCancelledException("Cancelled while running MinMaxValueBasedSelectionOrderByCombineOperator", e);
+        throw e;
       } catch (Exception e) {
         LOGGER.warn("Caught exception while using min/max value based combine, using the default combine", e);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
@@ -156,7 +156,6 @@ public class CombinePlanNode implements PlanNode {
         if (cause instanceof BadQueryRequestException) {
           throw (BadQueryRequestException) cause;
         } else if (e instanceof InterruptedException) {
-          Thread.currentThread().interrupt();
           throw new QueryCancelledException("Cancelled while running CombinePlanNode", e);
         } else {
           throw new RuntimeException("Caught exception while running CombinePlanNode.", e);

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
@@ -41,6 +41,7 @@ import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextUtils;
 import org.apache.pinot.core.util.trace.TraceCallable;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
+import org.apache.pinot.spi.exception.QueryCancelledException;
 import org.apache.pinot.spi.trace.InvocationRecording;
 import org.apache.pinot.spi.trace.InvocationScope;
 import org.apache.pinot.spi.trace.Tracing;
@@ -154,6 +155,9 @@ public class CombinePlanNode implements PlanNode {
         Throwable cause = e.getCause();
         if (cause instanceof BadQueryRequestException) {
           throw (BadQueryRequestException) cause;
+        } else if (e instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+          throw new QueryCancelledException("Cancelled while running CombinePlanNode", e);
         } else {
           throw new RuntimeException("Caught exception while running CombinePlanNode.", e);
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -76,6 +76,7 @@ import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
+import org.apache.pinot.spi.exception.QueryCancelledException;
 import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.joda.time.Interval;
@@ -245,16 +246,22 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
           queryRequest.isEnableStreaming());
     } catch (Exception e) {
       _serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.QUERY_EXECUTION_EXCEPTIONS, 1);
-
-      // Do not log error for BadQueryRequestException because it's caused by bad query
+      dataTable = DataTableFactory.getEmptyDataTable();
+      // Do not log verbose error for BadQueryRequestException and QueryCancelledException.
       if (e instanceof BadQueryRequestException) {
         LOGGER.info("Caught BadQueryRequestException while processing requestId: {}, {}", requestId, e.getMessage());
+        dataTable.addException(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
+      } else if (e instanceof QueryCancelledException) {
+        LOGGER.info("Cancelled while processing requestId: {}, {}", requestId, e.getMessage());
+        // NOTE most likely the onFailure() callback registered on query future in InstanceRequestHandler would
+        // return the error table to broker sooner than here. But in case of race condition, we construct the error
+        // table here too.
+        dataTable.addException(QueryException.getException(QueryException.QUERY_CANCELLATION_ERROR,
+            "Query cancelled on: " + _instanceDataManager.getInstanceId()));
       } else {
         LOGGER.error("Exception processing requestId {}", requestId, e);
+        dataTable.addException(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
       }
-
-      dataTable = DataTableFactory.getEmptyDataTable();
-      dataTable.addException(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
     } finally {
       for (SegmentDataManager segmentDataManager : segmentDataManagers) {
         tableDataManager.releaseSegment(segmentDataManager);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -252,7 +252,11 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
         LOGGER.info("Caught BadQueryRequestException while processing requestId: {}, {}", requestId, e.getMessage());
         dataTable.addException(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
       } else if (e instanceof QueryCancelledException) {
-        LOGGER.info("Cancelled while processing requestId: {}, {}", requestId, e.getMessage());
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug("Cancelled while processing requestId: {}", requestId, e);
+        } else {
+          LOGGER.info("Cancelled while processing requestId: {}, {}", requestId, e.getMessage());
+        }
         // NOTE most likely the onFailure() callback registered on query future in InstanceRequestHandler would
         // return the error table to broker sooner than here. But in case of race condition, we construct the error
         // table here too.

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ChannelHandlerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ChannelHandlerFactory.java
@@ -28,6 +28,7 @@ import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.TlsUtils;
 import org.apache.pinot.core.query.scheduler.QueryScheduler;
 import org.apache.pinot.server.access.AccessControl;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 /**
@@ -82,8 +83,8 @@ public class ChannelHandlerFactory {
    * The {@code getInstanceRequestHandler} return a {@code InstanceRequestHandler} Netty inbound handler on Pinot
    * Server side to handle the serialized instance requests sent from Pinot Broker.
    */
-  public static ChannelHandler getInstanceRequestHandler(QueryScheduler queryScheduler, ServerMetrics serverMetrics,
-      AccessControl accessControl) {
-    return new InstanceRequestHandler(queryScheduler, serverMetrics, accessControl);
+  public static ChannelHandler getInstanceRequestHandler(String instanceName, PinotConfiguration config,
+      QueryScheduler queryScheduler, ServerMetrics serverMetrics, AccessControl accessControl) {
+    return new InstanceRequestHandler(instanceName, config, queryScheduler, serverMetrics, accessControl);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/InstanceRequestHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/InstanceRequestHandler.java
@@ -18,15 +18,24 @@
  */
 package org.apache.pinot.core.transport;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.SimpleChannelInboundHandler;
 import io.netty.handler.ssl.SslHandshakeCompletionEvent;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.exception.QueryException;
@@ -41,7 +50,9 @@ import org.apache.pinot.core.common.datatable.DataTableFactory;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.scheduler.QueryScheduler;
 import org.apache.pinot.server.access.AccessControl;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.thrift.TDeserializer;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TCompactProtocol;
@@ -54,19 +65,24 @@ import org.slf4j.LoggerFactory;
  * The {@code InstanceRequestHandler} is the Netty inbound handler on Pinot Server side to handle the serialized
  * instance requests sent from Pinot Broker.
  */
+@ChannelHandler.Sharable
 public class InstanceRequestHandler extends SimpleChannelInboundHandler<ByteBuf> {
   private static final Logger LOGGER = LoggerFactory.getLogger(InstanceRequestHandler.class);
 
   // TODO: make it configurable
   private static final int SLOW_QUERY_LATENCY_THRESHOLD_MS = 100;
 
+  private final String _instanceName;
   private final TDeserializer _deserializer;
   private final QueryScheduler _queryScheduler;
   private final ServerMetrics _serverMetrics;
   private final AccessControl _accessControl;
+  private final boolean _enableQueryCancellation;
+  private final Map<String, Future<byte[]>> _queryFuturesById = new ConcurrentHashMap<>();
 
-  public InstanceRequestHandler(QueryScheduler queryScheduler, ServerMetrics serverMetrics,
-      AccessControl accessControl) {
+  public InstanceRequestHandler(String instanceName, PinotConfiguration config, QueryScheduler queryScheduler,
+      ServerMetrics serverMetrics, AccessControl accessControl) {
+    _instanceName = instanceName;
     _queryScheduler = queryScheduler;
     _serverMetrics = serverMetrics;
     _accessControl = accessControl;
@@ -75,10 +91,16 @@ public class InstanceRequestHandler extends SimpleChannelInboundHandler<ByteBuf>
     } catch (TTransportException e) {
       throw new RuntimeException("Failed to initialize Thrift Deserializer", e);
     }
+    _enableQueryCancellation =
+        Boolean.parseBoolean(config.getProperty(CommonConstants.Server.CONFIG_OF_ENABLE_QUERY_CANCELLATION));
+    if (_enableQueryCancellation) {
+      LOGGER.info("Enable query cancellation");
+    }
   }
 
   @Override
-  public void userEventTriggered(ChannelHandlerContext ctx, Object evt) throws Exception {
+  public void userEventTriggered(ChannelHandlerContext ctx, Object evt)
+      throws Exception {
     super.userEventTriggered(ctx, evt);
     if (evt instanceof SslHandshakeCompletionEvent) {
       if (!_accessControl.isAuthorizedChannel(ctx)) {
@@ -118,11 +140,7 @@ public class InstanceRequestHandler extends SimpleChannelInboundHandler<ByteBuf>
       queryRequest.getTimerContext().startNewPhaseTimer(ServerQueryPhase.REQUEST_DESERIALIZATION, queryArrivalTimeMs)
           .stopAndRecord();
       tableNameWithType = queryRequest.getTableNameWithType();
-
-      // Submit query for execution and register callback for execution results.
-      Futures.addCallback(_queryScheduler.submitQuery(queryRequest),
-          createCallback(ctx, tableNameWithType, queryArrivalTimeMs, instanceRequest, queryRequest),
-          MoreExecutors.directExecutor());
+      submitQuery(queryRequest, ctx, tableNameWithType, queryArrivalTimeMs, instanceRequest);
     } catch (Exception e) {
       if (e instanceof TException) {
         // Deserialization exception
@@ -137,11 +155,39 @@ public class InstanceRequestHandler extends SimpleChannelInboundHandler<ByteBuf>
     }
   }
 
+  /**
+   * Submit query for execution and register callback for execution results.
+   * If query cancellation is enabled, the query future is tracked as well.
+   */
+  @VisibleForTesting
+  void submitQuery(ServerQueryRequest queryRequest, ChannelHandlerContext ctx, String tableNameWithType,
+      long queryArrivalTimeMs, InstanceRequest instanceRequest) {
+    ListenableFuture<byte[]> future = _queryScheduler.submit(queryRequest);
+    if (_enableQueryCancellation) {
+      String queryId = queryRequest.getQueryId();
+      // Track the running query for cancellation.
+      if (LOGGER.isDebugEnabled()) {
+        LOGGER.debug("Keep track of running query: {}", queryId);
+      }
+      _queryFuturesById.put(queryId, future);
+    }
+    Futures
+        .addCallback(future, createCallback(ctx, tableNameWithType, queryArrivalTimeMs, instanceRequest, queryRequest),
+            MoreExecutors.directExecutor());
+  }
+
   private FutureCallback<byte[]> createCallback(ChannelHandlerContext ctx, String tableNameWithType,
       long queryArrivalTimeMs, InstanceRequest instanceRequest, ServerQueryRequest queryRequest) {
     return new FutureCallback<byte[]>() {
       @Override
       public void onSuccess(@Nullable byte[] responseBytes) {
+        if (_enableQueryCancellation) {
+          String queryId = queryRequest.getQueryId();
+          if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Remove track of running query: {} on success", queryId);
+          }
+          _queryFuturesById.remove(queryId);
+        }
         if (responseBytes != null) {
           // responseBytes contains either query results or exception.
           sendResponse(ctx, queryRequest.getTableNameWithType(), queryArrivalTimeMs, responseBytes);
@@ -154,10 +200,23 @@ public class InstanceRequestHandler extends SimpleChannelInboundHandler<ByteBuf>
 
       @Override
       public void onFailure(Throwable t) {
+        if (_enableQueryCancellation) {
+          String queryId = queryRequest.getQueryId();
+          if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Remove track of running query: {} on failure", queryId);
+          }
+          _queryFuturesById.remove(queryId);
+        }
         // Send exception response.
-        LOGGER.error("Exception while processing instance request", t);
+        Exception ex = new Exception(t);
+        if (t instanceof CancellationException) {
+          LOGGER.info("Query: {} got cancelled", queryRequest.getQueryId());
+          ex = (Exception) t;
+        } else {
+          LOGGER.error("Exception while processing instance request", t);
+        }
         sendErrorResponse(ctx, instanceRequest.getRequestId(), tableNameWithType, queryArrivalTimeMs,
-            DataTableFactory.getEmptyDataTable(), new Exception(t));
+            DataTableFactory.getEmptyDataTable(), ex);
       }
     };
   }
@@ -173,21 +232,61 @@ public class InstanceRequestHandler extends SimpleChannelInboundHandler<ByteBuf>
   }
 
   /**
+   * Cancel a query as identified by the queryId. This method is non-blocking and the query may still run for a while
+   * after calling this method. This method can be called multiple times.
+   *
+   * @param queryId a unique Id to find the query
+   * @return true if a running query exists for the given queryId.
+   */
+  public boolean cancelQuery(String queryId) {
+    Preconditions.checkArgument(_enableQueryCancellation, "Query cancellation is not enabled on server");
+    // Keep the future as it'll be cleaned up by the thread executing the query.
+    Future<byte[]> future = _queryFuturesById.get(queryId);
+    if (future == null) {
+      return false;
+    }
+    boolean done = future.isDone();
+    if (!done) {
+      future.cancel(true);
+    }
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Cancelled query: {} that's done: {}", queryId, done);
+    }
+    return true;
+  }
+
+  /**
+   * @return list of ids of the queries currently running on the server.
+   */
+  public Set<String> getRunningQueryIds() {
+    Preconditions.checkArgument(_enableQueryCancellation, "Query cancellation is not enabled on server");
+    return new HashSet<>(_queryFuturesById.keySet());
+  }
+
+  /**
    * Send an exception back to broker as response to the query request.
    */
   private void sendErrorResponse(ChannelHandlerContext ctx, long requestId, String tableNameWithType,
       long queryArrivalTimeMs, DataTable dataTable, Exception e) {
+    boolean cancelled = (e instanceof CancellationException);
     try {
       Map<String, String> dataTableMetadata = dataTable.getMetadata();
       dataTableMetadata.put(MetadataKey.REQUEST_ID.getName(), Long.toString(requestId));
-      dataTable.addException(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
+      if (cancelled) {
+        dataTable.addException(QueryException
+            .getException(QueryException.QUERY_CANCELLATION_ERROR, "Query cancelled on: " + _instanceName));
+      } else {
+        dataTable.addException(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
+      }
       byte[] serializedDataTable = dataTable.toBytes();
       sendResponse(ctx, tableNameWithType, queryArrivalTimeMs, serializedDataTable);
     } catch (Exception exception) {
       LOGGER.error("Exception while sending query processing error to Broker.", exception);
     } finally {
-      // Log query processing exception
-      LOGGER.error("Query processing error: ", e);
+      // Log query processing exception if not due to cancellation
+      if (!cancelled) {
+        LOGGER.error("Query processing error: ", e);
+      }
       _serverMetrics.addMeteredGlobalValue(ServerMeter.QUERY_EXECUTION_EXCEPTIONS, 1);
     }
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineSlowOperatorsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineSlowOperatorsTest.java
@@ -21,10 +21,14 @@ package org.apache.pinot.core.operator.combine;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.core.common.Block;
 import org.apache.pinot.core.common.Operator;
@@ -33,11 +37,20 @@ import org.apache.pinot.core.operator.ExecutionStatistics;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
 import org.apache.pinot.spi.exception.EarlyTerminationException;
+import org.apache.pinot.spi.exception.QueryCancelledException;
+import org.apache.pinot.util.TestUtils;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
@@ -96,6 +109,99 @@ public class CombineSlowOperatorsTest {
     testCombineOperator(operators, combineOperator);
   }
 
+  @Test
+  public void testCancelSelectionOnlyCombineOperator() {
+    // Just need to wait for one operator to start running.
+    CountDownLatch ready = new CountDownLatch(1);
+    List<Operator> operators = getOperators(ready, null);
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable");
+    queryContext.setEndTimeMs(System.currentTimeMillis() + 10000);
+    SelectionOnlyCombineOperator combineOperator =
+        new SelectionOnlyCombineOperator(operators, queryContext, _executorService);
+    testCancelCombineOperator(combineOperator, ready, "Cancelled while merging results blocks");
+  }
+
+  @Test
+  public void testCancelSelectionOrderByCombineOperator() {
+    CountDownLatch ready = new CountDownLatch(1);
+    List<Operator> operators = getOperators(ready, null);
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable ORDER BY column");
+    queryContext.setEndTimeMs(System.currentTimeMillis() + 10000);
+    SelectionOrderByCombineOperator combineOperator =
+        new SelectionOrderByCombineOperator(operators, queryContext, _executorService);
+    testCancelCombineOperator(combineOperator, ready, "Cancelled while merging results blocks");
+  }
+
+  @Test
+  public void testCancelMinMaxValueBasedSelectionOrderByCombineOperator() {
+    CountDownLatch ready = new CountDownLatch(1);
+    List<Operator> operators = getOperators(ready, () -> {
+      IndexSegment seg = mock(IndexSegment.class);
+      DataSource ds = mock(DataSource.class);
+      DataSourceMetadata dsmd = mock(DataSourceMetadata.class);
+      when(dsmd.getMinValue()).thenReturn(100L);
+      when(dsmd.getMaxValue()).thenReturn(200L);
+      when(seg.getDataSource(anyString())).thenReturn(ds);
+      when(ds.getDataSourceMetadata()).thenReturn(dsmd);
+      return seg;
+    });
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable ORDER BY column");
+    queryContext.setEndTimeMs(System.currentTimeMillis() + 10000);
+    SelectionOrderByCombineOperator combineOperator =
+        new SelectionOrderByCombineOperator(operators, queryContext, _executorService);
+    testCancelCombineOperator(combineOperator, ready,
+        "Cancelled while running MinMaxValueBasedSelectionOrderByCombineOperator");
+  }
+
+  @Test
+  public void testCancelAggregationOnlyCombineOperator() {
+    CountDownLatch ready = new CountDownLatch(1);
+    List<Operator> operators = getOperators(ready, null);
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT COUNT(*) FROM testTable");
+    queryContext.setEndTimeMs(System.currentTimeMillis() + 10000);
+    AggregationOnlyCombineOperator combineOperator =
+        new AggregationOnlyCombineOperator(operators, queryContext, _executorService);
+    testCancelCombineOperator(combineOperator, ready, "Cancelled while merging results blocks");
+  }
+
+  @Test
+  public void testCancelGroupByOrderByCombineOperator() {
+    CountDownLatch ready = new CountDownLatch(1);
+    List<Operator> operators = getOperators(ready, null);
+    QueryContext queryContext =
+        QueryContextConverterUtils.getQueryContext("SELECT COUNT(*) FROM testTable GROUP BY column");
+    queryContext.setEndTimeMs(System.currentTimeMillis() + 10000);
+    GroupByOrderByCombineOperator combineOperator =
+        new GroupByOrderByCombineOperator(operators, queryContext, _executorService);
+    testCancelCombineOperator(combineOperator, ready, "Cancelled while merging results blocks");
+  }
+
+  private void testCancelCombineOperator(BaseCombineOperator combineOperator, CountDownLatch ready, String errMsg) {
+    AtomicReference<Exception> exp = new AtomicReference<>();
+    ExecutorService combineExecutor = Executors.newSingleThreadExecutor();
+    try {
+      Future<?> future = combineExecutor.submit(() -> {
+        try {
+          return combineOperator.nextBlock();
+        } catch (Exception e) {
+          exp.set(e);
+          throw e;
+        }
+      });
+      ready.await();
+      // At this point, the combineOperator is or will be waiting on future.get() for all sub operators, and the
+      // waiting can be cancelled as below.
+      future.cancel(true);
+    } catch (Exception e) {
+      Assert.fail();
+    } finally {
+      combineExecutor.shutdownNow();
+    }
+    TestUtils.waitForCondition((aVoid) -> exp.get() instanceof QueryCancelledException, 10_000,
+        "Should have been cancelled");
+    assertEquals(exp.get().getMessage(), errMsg);
+  }
+
   /**
    * NOTE: It is hard to test the logger behavior, but only one error message about the query timeout should be logged
    *       for each query.
@@ -122,9 +228,13 @@ public class CombineSlowOperatorsTest {
   }
 
   private List<Operator> getOperators() {
+    return getOperators(null, null);
+  }
+
+  private List<Operator> getOperators(CountDownLatch ready, Supplier<IndexSegment> segmentSupplier) {
     List<Operator> operators = new ArrayList<>(NUM_OPERATORS);
     for (int i = 0; i < NUM_OPERATORS; i++) {
-      operators.add(new SlowOperator());
+      operators.add(new SlowOperator(ready, segmentSupplier));
     }
     return operators;
   }
@@ -134,10 +244,20 @@ public class CombineSlowOperatorsTest {
 
     final AtomicBoolean _operationInProgress = new AtomicBoolean();
     final AtomicBoolean _notInterrupted = new AtomicBoolean();
+    private final CountDownLatch _ready;
+    private final Supplier<IndexSegment> _segmentSupplier;
+
+    public SlowOperator(CountDownLatch ready, Supplier<IndexSegment> segmentSupplier) {
+      _ready = ready;
+      _segmentSupplier = segmentSupplier;
+    }
 
     @Override
     protected Block getNextBlock() {
       _operationInProgress.set(true);
+      if (_ready != null) {
+        _ready.countDown();
+      }
       try {
         Thread.sleep(3_600_000L);
       } catch (InterruptedException e) {
@@ -169,6 +289,14 @@ public class CombineSlowOperatorsTest {
     @Override
     public ExecutionStatistics getExecutionStatistics() {
       return new ExecutionStatistics(0, 0, 0, 0);
+    }
+
+    @Override
+    public IndexSegment getIndexSegment() {
+      if (_segmentSupplier != null) {
+        return _segmentSupplier.get();
+      }
+      return super.getIndexSegment();
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineSlowOperatorsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineSlowOperatorsTest.java
@@ -149,8 +149,7 @@ public class CombineSlowOperatorsTest {
     queryContext.setEndTimeMs(System.currentTimeMillis() + 10000);
     SelectionOrderByCombineOperator combineOperator =
         new SelectionOrderByCombineOperator(operators, queryContext, _executorService);
-    testCancelCombineOperator(combineOperator, ready,
-        "Cancelled while running MinMaxValueBasedSelectionOrderByCombineOperator");
+    testCancelCombineOperator(combineOperator, ready, "Cancelled while merging results blocks");
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
@@ -29,7 +29,9 @@ import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.common.utils.DataTable.MetadataKey;
 import org.apache.pinot.core.common.datatable.DataTableFactory;
 import org.apache.pinot.core.query.scheduler.QueryScheduler;
+import org.apache.pinot.server.access.AccessControl;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -64,13 +66,14 @@ public class QueryRoutingTest {
   }
 
   private QueryServer getQueryServer(int responseDelayMs, byte[] responseBytes) {
-    return new QueryServer(TEST_PORT, mockQueryScheduler(responseDelayMs, responseBytes), mock(ServerMetrics.class),
-        null);
+    InstanceRequestHandler handler = new InstanceRequestHandler("server01", new PinotConfiguration(),
+        mockQueryScheduler(responseDelayMs, responseBytes), mock(ServerMetrics.class), mock(AccessControl.class));
+    return new QueryServer(TEST_PORT, null, handler);
   }
 
   private QueryScheduler mockQueryScheduler(int responseDelayMs, byte[] responseBytes) {
     QueryScheduler queryScheduler = mock(QueryScheduler.class);
-    when(queryScheduler.submitQuery(any())).thenAnswer(invocation -> {
+    when(queryScheduler.submit(any())).thenAnswer(invocation -> {
       Thread.sleep(responseDelayMs);
       return Futures.immediateFuture(responseBytes);
     });

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/QueryResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/QueryResource.java
@@ -68,7 +68,7 @@ public class QueryResource {
       @ApiParam(value = "QueryId as in the format of <brokerId>_<requestId>", required = true) @PathParam("queryId")
           String queryId) {
     try {
-      if (_serverInstance.getQueryScheduler().cancelQuery(queryId)) {
+      if (_serverInstance.getInstanceRequestHandler().cancelQuery(queryId)) {
         return "Cancelled query: " + queryId;
       }
     } catch (Exception e) {
@@ -91,7 +91,7 @@ public class QueryResource {
   })
   public Set<String> getRunningQueryIds() {
     try {
-      return _serverInstance.getQueryScheduler().getRunningQueryIds();
+      return _serverInstance.getInstanceRequestHandler().getRunningQueryIds();
     } catch (Exception e) {
       throw new WebApplicationException(Response.status(Response.Status.INTERNAL_SERVER_ERROR)
           .entity("Failed to get queryIds of running queries on the server due to error: " + e.getMessage()).build());

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.server.starter;
 
+import com.google.common.base.Preconditions;
+import io.netty.channel.ChannelHandler;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.atomic.LongAccumulator;
@@ -34,10 +36,13 @@ import org.apache.pinot.core.operator.transform.function.TransformFunctionFactor
 import org.apache.pinot.core.query.executor.QueryExecutor;
 import org.apache.pinot.core.query.scheduler.QueryScheduler;
 import org.apache.pinot.core.query.scheduler.QuerySchedulerFactory;
+import org.apache.pinot.core.transport.ChannelHandlerFactory;
+import org.apache.pinot.core.transport.InstanceRequestHandler;
 import org.apache.pinot.core.transport.QueryServer;
 import org.apache.pinot.core.transport.grpc.GrpcQueryServer;
 import org.apache.pinot.server.access.AccessControl;
 import org.apache.pinot.server.access.AccessControlFactory;
+import org.apache.pinot.server.access.AllowAllAccessFactory;
 import org.apache.pinot.server.conf.ServerConf;
 import org.apache.pinot.server.worker.WorkerQueryServer;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -66,6 +71,7 @@ public class ServerInstance {
   private final AccessControl _accessControl;
 
   private final WorkerQueryServer _workerQueryServer;
+  private ChannelHandler _instanceRequestHandler;
 
   private boolean _dataManagerStarted = false;
   private boolean _queryServerStarted = false;
@@ -103,8 +109,9 @@ public class ServerInstance {
         TlsUtils.extractTlsConfig(serverConf.getPinotConfig(), CommonConstants.Server.SERVER_TLS_PREFIX);
     NettyConfig nettyConfig =
         NettyConfig.extractNettyConfig(serverConf.getPinotConfig(), CommonConstants.Server.SERVER_NETTY_PREFIX);
-    accessControlFactory.init(
-        serverConf.getPinotConfig().subset(CommonConstants.Server.PREFIX_OF_CONFIG_OF_ACCESS_CONTROL), helixManager);
+    accessControlFactory
+        .init(serverConf.getPinotConfig().subset(CommonConstants.Server.PREFIX_OF_CONFIG_OF_ACCESS_CONTROL),
+            helixManager);
     _accessControl = accessControlFactory.create();
 
     if (serverConf.isMultiStageServerEnabled()) {
@@ -117,7 +124,10 @@ public class ServerInstance {
     if (serverConf.isNettyServerEnabled()) {
       int nettyPort = serverConf.getNettyPort();
       LOGGER.info("Initializing Netty query server on port: {}", nettyPort);
-      _nettyQueryServer = new QueryServer(nettyPort, _queryScheduler, _serverMetrics, nettyConfig);
+      _instanceRequestHandler = ChannelHandlerFactory
+          .getInstanceRequestHandler(helixManager.getInstanceName(), serverConf.getPinotConfig(), _queryScheduler,
+              _serverMetrics, new AllowAllAccessFactory().create());
+      _nettyQueryServer = new QueryServer(nettyPort, nettyConfig, _instanceRequestHandler);
     } else {
       _nettyQueryServer = null;
     }
@@ -125,8 +135,10 @@ public class ServerInstance {
     if (serverConf.isNettyTlsServerEnabled()) {
       int nettySecPort = serverConf.getNettyTlsPort();
       LOGGER.info("Initializing TLS-secured Netty query server on port: {}", nettySecPort);
-      _nettyTlsQueryServer =
-          new QueryServer(nettySecPort, _queryScheduler, _serverMetrics, nettyConfig, tlsConfig, _accessControl);
+      _instanceRequestHandler = ChannelHandlerFactory
+          .getInstanceRequestHandler(helixManager.getInstanceName(), serverConf.getPinotConfig(), _queryScheduler,
+              _serverMetrics, _accessControl);
+      _nettyTlsQueryServer = new QueryServer(nettySecPort, nettyConfig, tlsConfig, _instanceRequestHandler);
     } else {
       _nettyTlsQueryServer = null;
     }
@@ -134,8 +146,9 @@ public class ServerInstance {
       int grpcPort = serverConf.getGrpcPort();
       LOGGER.info("Initializing gRPC query server on port: {}", grpcPort);
       _grpcQueryServer = new GrpcQueryServer(grpcPort, GrpcConfig.buildGrpcQueryConfig(serverConf.getPinotConfig()),
-          serverConf.isGrpcTlsServerEnabled() ? TlsUtils.extractTlsConfig(serverConf.getPinotConfig(),
-              CommonConstants.Server.SERVER_GRPCTLS_PREFIX) : null, _queryExecutor, _serverMetrics, _accessControl);
+          serverConf.isGrpcTlsServerEnabled() ? TlsUtils
+              .extractTlsConfig(serverConf.getPinotConfig(), CommonConstants.Server.SERVER_GRPCTLS_PREFIX) : null,
+          _queryExecutor, _serverMetrics, _accessControl);
     } else {
       _grpcQueryServer = null;
     }
@@ -259,7 +272,9 @@ public class ServerInstance {
     return _latestQueryTime.get();
   }
 
-  public QueryScheduler getQueryScheduler() {
-    return _queryScheduler;
+  public InstanceRequestHandler getInstanceRequestHandler() {
+    Preconditions.checkState(_instanceRequestHandler instanceof InstanceRequestHandler,
+        "Unexpected type of instance request handler");
+    return (InstanceRequestHandler) _instanceRequestHandler;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/exception/QueryCancelledException.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/exception/QueryCancelledException.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.exception;
+
+public class QueryCancelledException extends RuntimeException {
+  public QueryCancelledException(String message) {
+    super(message);
+  }
+
+  public QueryCancelledException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public QueryCancelledException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -336,6 +336,7 @@ public class CommonConstants {
     public static final String CONFIG_OF_QUERY_EXECUTOR_TIMEOUT = "pinot.server.query.executor.timeout";
     public static final String CONFIG_OF_QUERY_EXECUTOR_CLASS = "pinot.server.query.executor.class";
     public static final String CONFIG_OF_SERVER_QUERY_REWRITER_CLASS_NAMES = "pinot.server.query.rewriter.class.names";
+    public static final String CONFIG_OF_ENABLE_QUERY_CANCELLATION = "pinot.server.enable.query.cancellation";
     public static final String CONFIG_OF_REQUEST_HANDLER_FACTORY_CLASS = "pinot.server.requestHandlerFactory.class";
     public static final String CONFIG_OF_NETTY_SERVER_ENABLED = "pinot.server.netty.enabled";
     public static final boolean DEFAULT_NETTY_SERVER_ENABLED = true;


### PR DESCRIPTION
This PR mainly refines the query cancel resp msg, by defining some explicit query cancel error code and msg, instead of bubbling up the Executor's CancellationException. 

Also moves the query tracking mechanism for query cancellation from QueryScheduler to InstanceRequestHandler to be less likely to be overwritten by subclasses, and be more consistent with the logic in BaseBrokerRequestHandler. 
