### PR TITLE
Fix bug with logging request headers

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/HttpRequesterIdentity.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/HttpRequesterIdentity.java
@@ -27,7 +27,6 @@ import org.apache.pinot.spi.utils.CommonConstants;
  * Identity container for HTTP requests with (optional) authorization headers
  */
 public class HttpRequesterIdentity extends RequesterIdentity {
-
   private Multimap<String, String> _httpHeaders;
   private String _endpointUrl;
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/HttpRequesterIdentity.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/HttpRequesterIdentity.java
@@ -46,11 +46,13 @@ public class HttpRequesterIdentity extends RequesterIdentity {
     _endpointUrl = endpointUrl;
   }
 
+  /**
+   * If reverse proxy is used X-Forwarded-For will be populated
+   * If X-Forwarded-For is not present, check if x-real-ip is present
+   * Since X-Forwarded-For can contain comma separated list of values, we convert it to ";" delimiter to avoid
+   * downstream parsing errors for other fields where "," is being used
+   */
   @Override
-  // If reverse proxy is used X-Forwarded-For will be populated
-  // If X-Forwarded-For is not present, check if x-real-ip is present
-  // Since X-Forwarded-For can contain comma separated list of values, we convert it to ";" delimiter to avoid
-  // downstream parsing errors for other fields where "," is being used
   public String getClientIp() {
     if (_httpHeaders != null) {
       StringBuilder clientIp = new StringBuilder();

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequesterIdentity.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequesterIdentity.java
@@ -18,5 +18,11 @@
  */
 package org.apache.pinot.broker.api;
 
+import org.apache.pinot.spi.utils.CommonConstants;
+
+
 public abstract class RequesterIdentity {
+  public String getClientIp() {
+    return CommonConstants.UNKNOWN;
+  }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequesterIdentity.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/RequesterIdentity.java
@@ -20,7 +20,6 @@ package org.apache.pinot.broker.api;
 
 import org.apache.pinot.spi.utils.CommonConstants;
 
-
 public abstract class RequesterIdentity {
   public String getClientIp() {
     return CommonConstants.UNKNOWN;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -39,7 +39,6 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.pinot.broker.api.HttpRequesterIdentity;
 import org.apache.pinot.broker.api.RequesterIdentity;
 import org.apache.pinot.broker.broker.AccessControlFactory;
 import org.apache.pinot.broker.queryquota.QueryQuotaManager;
@@ -670,27 +669,10 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
     boolean enableClientIpLogging = _config.getProperty(Broker.CONFIG_OF_BROKER_REQUEST_CLIENT_IP_LOGGING,
         Broker.DEFAULT_BROKER_REQUEST_CLIENT_IP_LOGGING);
-    String clientIp = "unknown";
-    // If reverse proxy is used X-Forwarded-For will be populated
-    // If X-Forwarded-For is not present, check if x-real-ip is present
-    // Since X-Forwarded-For can contain comma separated list of values, we convert it to ";" delimiter to avoid
-    // downstream parsing errors for other fields where "," is being used
+    String clientIp = CommonConstants.UNKNOWN;
     if (enableClientIpLogging && requesterIdentity != null) {
-      for (Map.Entry<String, String> entry : ((HttpRequesterIdentity) requesterIdentity).getHttpHeaders().entries()) {
-        String key = entry.getKey();
-        String value = entry.getValue();
-        if (key.equalsIgnoreCase("x-forwarded-for")) {
-          if (value.contains(",")) {
-            clientIp = String.join(";", value.split(","));
-          } else {
-            clientIp = value;
-          }
-        } else if (key.equalsIgnoreCase("x-real-ip")) {
-          clientIp = value;
-        }
-      }
+        clientIp = requesterIdentity.getClientIp();
     }
-
 
     // Please keep the format as name=value comma-separated with no spaces
     // Please keep all the name value pairs together, then followed by the query. To add a new entry, please add it to

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -38,7 +38,6 @@ public class CommonConstants {
   public static final String TABLE_NAME = "tableName";
 
   public static final String UNKNOWN = "unknown";
-
   public static final String CONFIG_OF_METRICS_FACTORY_CLASS_NAME = "factory.className";
   public static final String DEFAULT_METRICS_FACTORY_CLASS_NAME =
       "org.apache.pinot.plugin.metrics.yammer.YammerMetricsFactory";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -37,6 +37,8 @@ public class CommonConstants {
 
   public static final String TABLE_NAME = "tableName";
 
+  public static final String UNKNOWN = "unknown";
+
   public static final String CONFIG_OF_METRICS_FACTORY_CLASS_NAME = "factory.className";
   public static final String DEFAULT_METRICS_FACTORY_CLASS_NAME =
       "org.apache.pinot.plugin.metrics.yammer.YammerMetricsFactory";


### PR DESCRIPTION
This PR refactors code to not assume RequestIdentity of type HttpRequestIdentity only. Moving `getClientIp` to `RequestIdentity` forces all subclasses to have its own overridden  implementation or rely on default.

https://github.com/apache/pinot/issues/9194