### PR TITLE
use default authorization behavior for zk user config

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotAccessControlUserRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotAccessControlUserRestletResource.java
@@ -44,8 +44,6 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.utils.BcryptUtils;
-import org.apache.pinot.controller.api.access.AccessControlFactory;
-import org.apache.pinot.controller.api.access.AccessControlUtils;
 import org.apache.pinot.controller.api.access.AccessType;
 import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
@@ -54,7 +52,6 @@ import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.spi.config.user.ComponentType;
 import org.apache.pinot.spi.config.user.UserConfig;
 import org.apache.pinot.spi.utils.JsonUtils;
-import org.glassfish.grizzly.http.server.Request;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,17 +90,12 @@ public class PinotAccessControlUserRestletResource {
     @Inject
     PinotHelixResourceManager _pinotHelixResourceManager;
 
-    @Inject
-    AccessControlFactory _accessControlFactory;
-
     @GET
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/users")
     @ApiOperation(value = "List all uses in cluster", notes = "List all users in cluster")
-    public String listUers(@Context HttpHeaders httpHeaders, @Context Request request) {
+    public String listUsers() {
         try {
-            String endpointUrl = request.getRequestURL().toString();
-            AccessControlUtils.validatePermission(httpHeaders, endpointUrl, _accessControlFactory.create());
             ZkHelixPropertyStore<ZNRecord> propertyStore = _pinotHelixResourceManager.getPropertyStore();
             Map<String, UserConfig> allUserInfo = ZKMetadataProvider.getAllUserInfo(propertyStore);
             return JsonUtils.newObjectNode().set("users", JsonUtils.objectToJsonNode(allUserInfo)).toString();
@@ -117,10 +109,8 @@ public class PinotAccessControlUserRestletResource {
     @Path("/users/{username}")
     @ApiOperation(value = "Get an user in cluster", notes = "Get an user in cluster")
     public String getUser(@PathParam("username") String username, @QueryParam("component") String componentTypeStr,
-        @Context HttpHeaders httpHeaders, @Context Request request) {
+        @Context HttpHeaders httpHeaders) {
         try {
-            String endpointUrl = request.getRequestURL().toString();
-            AccessControlUtils.validatePermission(httpHeaders, endpointUrl, _accessControlFactory.create());
             ZkHelixPropertyStore<ZNRecord> propertyStore = _pinotHelixResourceManager.getPropertyStore();
             ComponentType componentType = Constants.validateComponentType(componentTypeStr);
             String usernameWithType = username + "_" + componentType.name();
@@ -136,7 +126,7 @@ public class PinotAccessControlUserRestletResource {
     @Produces(MediaType.APPLICATION_JSON)
     @Path("/users")
     @ApiOperation(value = "Add a user", notes = "Add a user")
-    public SuccessResponse addUser(String userConfigStr, @Context HttpHeaders httpHeaders, @Context Request request) {
+    public SuccessResponse addUser(String userConfigStr) {
         // TODO introduce a table config ctor with json string.
 
         UserConfig userConfig;
@@ -144,8 +134,6 @@ public class PinotAccessControlUserRestletResource {
         try {
             userConfig = JsonUtils.stringToObject(userConfigStr, UserConfig.class);
             username = userConfig.getUserName();
-            String endpointUrl = request.getRequestURL().toString();
-            AccessControlUtils.validatePermission(httpHeaders, endpointUrl, _accessControlFactory.create());
             if (username.contains(".") || username.contains(" ")) {
                 throw new IllegalStateException("Username: " + username + " containing '.' or space is not allowed");
             }
@@ -171,8 +159,7 @@ public class PinotAccessControlUserRestletResource {
     @Produces(MediaType.APPLICATION_JSON)
     @ApiOperation(value = "Delete a user", notes = "Delete a user")
     public SuccessResponse deleteUser(@PathParam("username") String username,
-        @QueryParam("component") String componentTypeStr,
-        @Context HttpHeaders httpHeaders, @Context Request request) {
+        @QueryParam("component") String componentTypeStr) {
 
         List<String> usersDeleted = new LinkedList<>();
         String usernameWithComponentType = username + "_" + componentTypeStr;
@@ -181,9 +168,6 @@ public class PinotAccessControlUserRestletResource {
 
             boolean userExist = false;
             userExist = _pinotHelixResourceManager.hasUser(username, componentTypeStr);
-
-            String endpointUrl = request.getRequestURL().toString();
-            AccessControlUtils.validatePermission(httpHeaders, endpointUrl, _accessControlFactory.create());
 
             _pinotHelixResourceManager.deleteUser(usernameWithComponentType);
             if (userExist) {
@@ -210,16 +194,11 @@ public class PinotAccessControlUserRestletResource {
         @PathParam("username") String username,
         @QueryParam("component") String componentTypeStr,
         @QueryParam("passwordChanged") boolean passwordChanged,
-        String userConfigString,
-        @Context HttpHeaders httpHeaders,
-        @Context Request request) {
+        String userConfigString) {
 
         UserConfig userConfig;
         String usernameWithComponentType = username + "_" + componentTypeStr;
         try {
-            String endpointUrl = request.getRequestURL().toString();
-            AccessControlUtils.validatePermission(httpHeaders, endpointUrl, _accessControlFactory.create());
-
             userConfig = JsonUtils.stringToObject(userConfigString, UserConfig.class);
             if (passwordChanged) {
                 userConfig.setPassword(BcryptUtils.encrypt(userConfig.getPassword()));


### PR DESCRIPTION
Minor refactor of `PinotAccessControlUserRestletResource` to rely on the AuthFilter's default behavior rather than performing authorization manually.

CC: original author @INNOCENT-BOY, any subtle issues you see with this?