### PR TITLE
Remove currentDataTableVersion from helm value

### DIFF
--- a/kubernetes/helm/pinot/values.yaml
+++ b/kubernetes/helm/pinot/values.yaml
@@ -350,7 +350,6 @@ server:
     configs: |-
       pinot.set.instance.id.to.hostname=true
       pinot.server.instance.realtime.alloc.offheap=true
-      pinot.server.instance.currentDataTableVersion=2
 
 # ------------------------------------------------------------------------------
 # Pinot Minion:


### PR DESCRIPTION
This is no longer needed as presto/trino side has upgraded the DataTable version