### PR TITLE
Adding endpoint to download local log files for each component

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerLogger.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerLogger.java
@@ -25,8 +25,11 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -37,6 +40,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.pinot.common.utils.LoggerFileServer;
 import org.apache.pinot.common.utils.LoggerUtils;
 
 import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
@@ -50,6 +54,9 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
     HttpHeaders.AUTHORIZATION, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER, key = SWAGGER_AUTHORIZATION_KEY)))
 @Path("/")
 public class PinotBrokerLogger {
+
+  @Inject
+  private LoggerFileServer _loggerFileServer;
 
   @GET
   @Path("/loggers")
@@ -79,5 +86,33 @@ public class PinotBrokerLogger {
   public Map<String, String> setLoggerLevel(@ApiParam(value = "Logger name") @PathParam("loggerName") String loggerName,
       @ApiParam(value = "Logger level") @QueryParam("level") String level) {
     return LoggerUtils.setLoggerLevel(loggerName, level);
+  }
+
+  @GET
+  @Path("/loggers/files")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Get all local log files")
+  public Set<String> getLocalLogFiles() {
+    try {
+      if (_loggerFileServer == null) {
+        throw new WebApplicationException("Root log directory doesn't exist", Response.Status.INTERNAL_SERVER_ERROR);
+      }
+      return _loggerFileServer.getAllPaths();
+    } catch (IOException e) {
+      throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @GET
+  @Path("/loggers/download")
+  @Produces(MediaType.APPLICATION_OCTET_STREAM)
+  @ApiOperation(value = "Download a log file")
+  public Response downloadLogFile(
+      @ApiParam(value = "Log file path", required = true) @QueryParam("filePath") String filePath) {
+    if (_loggerFileServer == null) {
+      throw new WebApplicationException("Root log directory is not configured",
+          Response.Status.INTERNAL_SERVER_ERROR);
+    }
+    return _loggerFileServer.downloadLogFile(filePath);
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -32,6 +32,7 @@ import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.apache.pinot.broker.requesthandler.BrokerRequestHandler;
 import org.apache.pinot.broker.routing.BrokerRoutingManager;
 import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.utils.LoggerFileServer;
 import org.apache.pinot.core.api.ServiceAutoDiscoveryFeature;
 import org.apache.pinot.core.query.executor.sql.SqlQueryExecutor;
 import org.apache.pinot.core.transport.ListenerConfig;
@@ -51,6 +52,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
   private static final String RESOURCE_PACKAGE = "org.apache.pinot.broker.api.resources";
   public static final String PINOT_CONFIGURATION = "pinotConfiguration";
   public static final String BROKER_INSTANCE_ID = "brokerInstanceId";
+
   private final boolean _useHttps;
 
   private HttpServer _httpServer;
@@ -78,6 +80,10 @@ public class BrokerAdminApiApplication extends ResourceConfig {
         bind(routingManager).to(BrokerRoutingManager.class);
         bind(brokerRequestHandler).to(BrokerRequestHandler.class);
         bind(brokerMetrics).to(BrokerMetrics.class);
+        String loggerRootDir = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_LOGGER_ROOT_DIR);
+        if (loggerRootDir != null) {
+          bind(new LoggerFileServer(loggerRootDir)).to(LoggerFileServer.class);
+        }
         bind(brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_BROKER_ID)).named(BROKER_INSTANCE_ID);
       }
     });

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/LoggerFileServer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/LoggerFileServer.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils;
+
+import com.google.common.base.Preconditions;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Set;
+import java.util.TreeSet;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.StreamingOutput;
+
+
+/**
+ * Logger file server.
+ */
+public class LoggerFileServer {
+  private final File _loggerRootDir;
+  private final Path _loggerRootDirPath;
+
+  public LoggerFileServer(String loggerRootDir) {
+    Preconditions.checkNotNull(loggerRootDir, "Logger root directory is null");
+    _loggerRootDir = new File(loggerRootDir);
+    Preconditions.checkState(_loggerRootDir.exists(), "Logger directory doesn't exists");
+    _loggerRootDirPath = Paths.get(_loggerRootDir.getAbsolutePath());
+  }
+
+  public Set<String> getAllPaths()
+      throws IOException {
+    Set<String> allFiles = new TreeSet<>();
+    Files.walk(_loggerRootDirPath).filter(Files::isRegularFile).forEach(
+        f -> allFiles.add(f.toAbsolutePath().toString().replace(_loggerRootDirPath.toAbsolutePath() + "/", "")));
+    return allFiles;
+  }
+
+  public Response downloadLogFile(String filePath) {
+    try {
+      if (!getAllPaths().contains(filePath)) {
+        throw new WebApplicationException("Invalid file path: " + filePath, Response.Status.FORBIDDEN);
+      }
+      File logFile = new File(_loggerRootDir, filePath);
+      if (!logFile.exists()) {
+        throw new WebApplicationException("File: " + filePath + " doesn't exists", Response.Status.NOT_FOUND);
+      }
+      Response.ResponseBuilder builder = Response.ok();
+      builder.entity(logFile);
+      builder.entity((StreamingOutput) output -> Files.copy(logFile.toPath(), output));
+      builder.header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=" + logFile.getName());
+      builder.header(HttpHeaders.CONTENT_LENGTH, logFile.length());
+      return builder.build();
+    } catch (IOException e) {
+      throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
@@ -288,7 +288,7 @@ public class HttpClient implements AutoCloseable {
     }
   }
 
-  protected CloseableHttpResponse execute(HttpUriRequest request)
+  public CloseableHttpResponse execute(HttpUriRequest request)
       throws IOException {
     return _httpClient.execute(request);
   }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/LoggerFileServerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/LoggerFileServerTest.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+import org.apache.commons.io.FileUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+
+public class LoggerFileServerTest {
+
+  @Test
+  public void testLoggerFileServer()
+      throws IOException {
+    File logRootDir = new File(FileUtils.getTempDirectory(), "testGetAllLoggers-" + System.currentTimeMillis());
+    try {
+      logRootDir.mkdirs();
+      LoggerFileServer loggerFileServer = new LoggerFileServer(logRootDir.getAbsolutePath());
+
+      // Empty root log directory
+      assertEquals(loggerFileServer.getAllPaths().size(), 0);
+      try {
+        loggerFileServer.downloadLogFile("log1");
+        Assert.fail("Shouldn't reach here");
+      } catch (WebApplicationException e1) {
+        assertEquals(e1.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());
+      }
+
+      // 1 file: [ log1 ] in root log directory
+      FileUtils.writeStringToFile(new File(logRootDir, "log1"), "mylog1", Charset.defaultCharset());
+      assertEquals(loggerFileServer.getAllPaths().size(), 1);
+      assertNotNull(loggerFileServer.downloadLogFile("log1"));
+      try {
+        loggerFileServer.downloadLogFile("log2");
+        Assert.fail("Shouldn't reach here");
+      } catch (WebApplicationException e1) {
+        assertEquals(e1.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());
+      }
+
+      // 2 files: [ log1, log2 ] in root log directory
+      FileUtils.writeStringToFile(new File(logRootDir, "log2"), "mylog2", Charset.defaultCharset());
+      assertEquals(loggerFileServer.getAllPaths().size(), 2);
+      assertNotNull(loggerFileServer.downloadLogFile("log1"));
+      assertNotNull(loggerFileServer.downloadLogFile("log2"));
+      try {
+        loggerFileServer.downloadLogFile("log3");
+        Assert.fail("Shouldn't reach here");
+      } catch (WebApplicationException e1) {
+        assertEquals(e1.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());
+      }
+    } finally {
+      FileUtils.deleteQuietly(logRootDir);
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -59,6 +59,7 @@ import org.apache.pinot.common.metrics.ValidationMetrics;
 import org.apache.pinot.common.minion.InMemoryTaskManagerStatusCache;
 import org.apache.pinot.common.minion.TaskGeneratorMostRecentRunInfo;
 import org.apache.pinot.common.minion.TaskManagerStatusCache;
+import org.apache.pinot.common.utils.LoggerFileServer;
 import org.apache.pinot.common.utils.ServiceStartableUtils;
 import org.apache.pinot.common.utils.ServiceStatus;
 import org.apache.pinot.common.utils.TlsUtils;
@@ -472,6 +473,10 @@ public abstract class BaseControllerStarter implements ServiceStartable {
         bind(_periodicTaskScheduler).to(PeriodicTaskScheduler.class);
         bind(_sqlQueryExecutor).to(SqlQueryExecutor.class);
         bind(_pinotLLCRealtimeSegmentManager).to(PinotLLCRealtimeSegmentManager.class);
+        String loggerRootDir = _config.getProperty(CommonConstants.Controller.CONFIG_OF_LOGGER_ROOT_DIR);
+        if (loggerRootDir != null) {
+          bind(new LoggerFileServer(loggerRootDir)).to(LoggerFileServer.class);
+        }
       }
     });
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerLogger.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerLogger.java
@@ -25,8 +25,16 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -34,10 +42,24 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriBuilder;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpVersion;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.pinot.common.utils.FileUploadDownloadClient;
+import org.apache.pinot.common.utils.LoggerFileServer;
 import org.apache.pinot.common.utils.LoggerUtils;
+import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.apache.pinot.common.utils.config.InstanceUtils;
+import org.apache.pinot.controller.api.access.AccessType;
+import org.apache.pinot.controller.api.access.Authenticate;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 
 import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
 
@@ -50,6 +72,14 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
     HttpHeaders.AUTHORIZATION, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER, key = SWAGGER_AUTHORIZATION_KEY)))
 @Path("/")
 public class PinotControllerLogger {
+
+  private final FileUploadDownloadClient _fileUploadDownloadClient = new FileUploadDownloadClient();
+
+  @Inject
+  private LoggerFileServer _loggerFileServer;
+
+  @Inject
+  PinotHelixResourceManager _pinotHelixResourceManager;
 
   @GET
   @Path("/loggers")
@@ -79,5 +109,113 @@ public class PinotControllerLogger {
   public Map<String, String> setLoggerLevel(@ApiParam(value = "Logger name") @PathParam("loggerName") String loggerName,
       @ApiParam(value = "Logger level") @QueryParam("level") String level) {
     return LoggerUtils.setLoggerLevel(loggerName, level);
+  }
+
+  @GET
+  @Path("/loggers/files")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Get all local log files")
+  public Set<String> getLocalLogFiles() {
+    try {
+      if (_loggerFileServer == null) {
+        throw new WebApplicationException("Root log directory doesn't exist", Response.Status.INTERNAL_SERVER_ERROR);
+      }
+      return _loggerFileServer.getAllPaths();
+    } catch (IOException e) {
+      throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @GET
+  @Path("/loggers/download")
+  @Produces(MediaType.APPLICATION_OCTET_STREAM)
+  @Authenticate(AccessType.DELETE)
+  @ApiOperation(value = "Download a log file")
+  public Response downloadLogFile(
+      @ApiParam(value = "Log file path", required = true) @QueryParam("filePath") String filePath) {
+    if (_loggerFileServer == null) {
+      throw new WebApplicationException("Root log directory is not configured",
+          Response.Status.INTERNAL_SERVER_ERROR);
+    }
+    return _loggerFileServer.downloadLogFile(filePath);
+  }
+
+  @GET
+  @Path("/loggers/instances")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Collect log files from all the instances")
+  public Map<String, Set<String>> getLogFilesFromAllInstances() {
+    if (_loggerFileServer == null) {
+      throw new WebApplicationException("Root directory doesn't exist", Response.Status.INTERNAL_SERVER_ERROR);
+    }
+    Map<String, Set<String>> instancesToLogFilesMap = new HashMap<>();
+    List<String> onlineInstanceList = _pinotHelixResourceManager.getOnlineInstanceList();
+    onlineInstanceList.forEach(
+        instance -> {
+          try {
+            instancesToLogFilesMap.put(instance, getLogFilesFromInstance(instance));
+          } catch (Exception e) {
+            // Skip the instance for any exception.
+          }
+        });
+    return instancesToLogFilesMap;
+  }
+
+  @GET
+  @Path("/loggers/instances/{instanceName}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Collect log files from a given instance")
+  public Set<String> getLogFilesFromInstance(
+      @ApiParam(value = "Instance Name", required = true) @PathParam("instanceName") String instanceName) {
+    try {
+      URI uri = new URI(getInstanceBaseUri(instanceName) + "/loggers/files");
+      SimpleHttpResponse simpleHttpResponse = _fileUploadDownloadClient.getHttpClient().sendGetRequest(uri);
+      if (simpleHttpResponse.getStatusCode() >= 400) {
+        throw new WebApplicationException("Failed to fetch logs from instance name: " + instanceName,
+            Response.Status.fromStatusCode(simpleHttpResponse.getStatusCode()));
+      }
+      String responseString = simpleHttpResponse.getResponse();
+      responseString = responseString.substring(1, responseString.length() - 1).replace("\"", "");
+      return new HashSet<>(Arrays.asList(responseString.split(",")));
+    } catch (IOException | URISyntaxException e) {
+      throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @GET
+  @Path("/loggers/instances/{instanceName}/download")
+  @Produces(MediaType.APPLICATION_OCTET_STREAM)
+  @Authenticate(AccessType.DELETE)
+  @ApiOperation(value = "Download a log file from a given instance")
+  public Response downloadLogFileFromInstance(
+      @ApiParam(value = "Instance Name", required = true) @PathParam("instanceName") String instanceName,
+      @ApiParam(value = "Log file path", required = true) @QueryParam("filePath") String filePath,
+      @Context Map<String, String> headers) {
+    try {
+      URI uri = UriBuilder.fromUri(getInstanceBaseUri(instanceName)).path("/loggers/download")
+          .queryParam("filePath", filePath).build();
+      RequestBuilder requestBuilder = RequestBuilder.get(uri).setVersion(HttpVersion.HTTP_1_1);
+      if (MapUtils.isNotEmpty(headers)) {
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+          requestBuilder.addHeader(header.getKey(), header.getValue());
+        }
+      }
+      CloseableHttpResponse httpResponse = _fileUploadDownloadClient.getHttpClient().execute(requestBuilder.build());
+      if (httpResponse.getStatusLine().getStatusCode() >= 400) {
+        throw new WebApplicationException(IOUtils.toString(httpResponse.getEntity().getContent(), "UTF-8"),
+            Response.Status.fromStatusCode(httpResponse.getStatusLine().getStatusCode()));
+      }
+      Response.ResponseBuilder builder = Response.ok();
+      builder.entity(httpResponse.getEntity().getContent());
+      builder.contentLocation(uri);
+      builder.header(HttpHeaders.CONTENT_LENGTH, httpResponse.getEntity().getContentLength());
+      return builder.build();
+    } catch (IOException e) {
+      throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  private String getInstanceBaseUri(String instanceName) {
+    return InstanceUtils.getInstanceBaseUri(_pinotHelixResourceManager.getHelixInstanceConfig(instanceName));
   }
 }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.List;
+import org.apache.pinot.common.utils.LoggerFileServer;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -59,6 +60,10 @@ public class MinionAdminApiApplication extends ResourceConfig {
       protected void configure() {
         // TODO: Add bindings as needed in future.
         bind(instanceId).named(MINION_INSTANCE_ID);
+        String loggerRootDir = minionConf.getProperty(CommonConstants.Minion.CONFIG_OF_LOGGER_ROOT_DIR);
+        if (loggerRootDir != null) {
+          bind(new LoggerFileServer(loggerRootDir)).to(LoggerFileServer.class);
+        }
       }
     });
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/PinotServerLogger.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/PinotServerLogger.java
@@ -25,8 +25,11 @@ import io.swagger.annotations.ApiParam;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.PUT;
 import javax.ws.rs.Path;
@@ -37,6 +40,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.pinot.common.utils.LoggerFileServer;
 import org.apache.pinot.common.utils.LoggerUtils;
 
 import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
@@ -50,6 +54,9 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
     HttpHeaders.AUTHORIZATION, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER, key = SWAGGER_AUTHORIZATION_KEY)))
 @Path("/")
 public class PinotServerLogger {
+
+  @Inject
+  private LoggerFileServer _loggerFileServer;
 
   @GET
   @Path("/loggers")
@@ -79,5 +86,33 @@ public class PinotServerLogger {
   public Map<String, String> setLoggerLevel(@ApiParam(value = "Logger name") @PathParam("loggerName") String loggerName,
       @ApiParam(value = "Logger level") @QueryParam("level") String level) {
     return LoggerUtils.setLoggerLevel(loggerName, level);
+  }
+
+  @GET
+  @Path("/loggers/files")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Get all local log files")
+  public Set<String> getLocalLogFiles() {
+    try {
+      if (_loggerFileServer == null) {
+        throw new WebApplicationException("Root log directory doesn't exist", Response.Status.INTERNAL_SERVER_ERROR);
+      }
+      return _loggerFileServer.getAllPaths();
+    } catch (IOException e) {
+      throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
+
+  @GET
+  @Path("/loggers/download")
+  @Produces(MediaType.APPLICATION_OCTET_STREAM)
+  @ApiOperation(value = "Download a log file")
+  public Response downloadLogFile(
+      @ApiParam(value = "Log file path", required = true) @QueryParam("filePath") String filePath) {
+    if (_loggerFileServer == null) {
+      throw new WebApplicationException("Root log directory is not configured",
+          Response.Status.INTERNAL_SERVER_ERROR);
+    }
+    return _loggerFileServer.downloadLogFile(filePath);
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/AdminApiApplication.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/AdminApiApplication.java
@@ -29,6 +29,7 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.utils.LoggerFileServer;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
 import org.apache.pinot.server.access.AccessControlFactory;
@@ -70,6 +71,10 @@ public class AdminApiApplication extends ResourceConfig {
         bind(_serverInstance.getServerMetrics()).to(ServerMetrics.class);
         bind(accessControlFactory).to(AccessControlFactory.class);
         bind(serverConf.getProperty(CommonConstants.Server.CONFIG_OF_INSTANCE_ID)).named(SERVER_INSTANCE_ID);
+        String loggerRootDir = serverConf.getProperty(CommonConstants.Server.CONFIG_OF_LOGGER_ROOT_DIR);
+        if (loggerRootDir != null) {
+          bind(new LoggerFileServer(loggerRootDir)).to(LoggerFileServer.class);
+        }
       }
     });
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -262,6 +262,8 @@ public class CommonConstants {
     // TODO: Support populating clientIp for GrpcRequestIdentity.
     public static final boolean DEFAULT_BROKER_REQUEST_CLIENT_IP_LOGGING = false;
 
+    public static final String CONFIG_OF_LOGGER_ROOT_DIR = "pinot.broker.logger.root.dir";
+
     public static class Request {
       public static final String SQL = "sql";
       public static final String TRACE = "trace";
@@ -443,6 +445,7 @@ public class CommonConstants {
 
     // The complete config key is pinot.server.instance.segment.store.uri
     public static final String CONFIG_OF_SEGMENT_STORE_URI = "segment.store.uri";
+    public static final String CONFIG_OF_LOGGER_ROOT_DIR = "pinot.server.logger.root.dir";
 
     public static class SegmentCompletionProtocol {
       public static final String PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER = "pinot.server.segment.uploader";
@@ -522,6 +525,7 @@ public class CommonConstants {
         "pinot.controller.query.rewriter.class.names";
     //Set to true to load all services tagged and compiled with hk2-metadata-generator. Default to False
     public static final String CONTROLLER_SERVICE_AUTO_DISCOVERY = "pinot.controller.service.auto.discovery";
+    public static final String CONFIG_OF_LOGGER_ROOT_DIR = "pinot.controller.logger.root.dir";
   }
 
   public static class Minion {
@@ -563,6 +567,7 @@ public class CommonConstants {
     public static final String CONFIG_TASK_AUTH_NAMESPACE = "task.auth";
     public static final String MINION_TLS_PREFIX = "pinot.minion.tls";
     public static final String CONFIG_OF_MINION_QUERY_REWRITER_CLASS_NAMES = "pinot.minion.query.rewriter.class.names";
+    public static final String CONFIG_OF_LOGGER_ROOT_DIR = "pinot.minion.logger.root.dir";
   }
 
   public static class ControllerJob {


### PR DESCRIPTION
Adding endpoint to download local log files for each component for controller/broker/server/minion.
The purpose here is to simplify users debugging from the remote environment without access to containers.
E.g. users may have access only to controller LoadBalancer without the entire cluster, but want to debug a pinot server logger for why my real-time table is not ingesting, any issue with Kafka consumer or message decoder.

1. Adding configs for logger root directory: `pinot.controller.logger.root.dir`, `pinot.broker.logger.root.dir`, `pinot.server.logger.root.dir`, `pinot.minion.logger.root.dir`
2. Add new endpoints in all controller/broker/server/minion to fetch local logs:
- `/loggers/files`: List all the log files under the logger root directory.
- `/loggers/download?filePath={filePath}`: Download the log file based on the relative path.
3. Add new endpoints in the controller to fetch remote logs:
- `/loggers/instances`: Collect log files from all the instances in the cluster.
- `/loggers/instances/{instanceName}`: List all the log files for a given instance.
- `/loggers/instances/{instanceName}/download?filePath={filePath}`:  Download the log file from a given instance on a given path.