### PR TITLE
[UI]: hide query console tab based on cluster config

### DIFF
--- a/pinot-controller/src/main/resources/app/App.tsx
+++ b/pinot-controller/src/main/resources/app/App.tsx
@@ -85,12 +85,17 @@ const App = () => {
   const fetchClusterConfig = async () => {
     const clusterConfig = await PinotMethodUtils.getClusterConfigJSON();
     app_state.queryConsoleOnlyView = clusterConfig?.queryConsoleOnlyView === 'true';
+    app_state.hideQueryConsoleTab = clusterConfig?.hideQueryConsoleTab === 'true';
+
     setLoading(false);
   };
 
   const getRouterData = () => {
     if(app_state.queryConsoleOnlyView){
       return RouterData.filter((routeObj)=>{return routeObj.path === '/query'});
+    }
+    if (app_state.hideQueryConsoleTab) {
+      return RouterData.filter((routeObj) => routeObj.path !== '/query');
     }
     return RouterData;
   };

--- a/pinot-controller/src/main/resources/app/app_state.ts
+++ b/pinot-controller/src/main/resources/app/app_state.ts
@@ -23,6 +23,7 @@ class app_state {
   authWorkflow: AuthWorkflow;
   authToken: string | null;
   columnNameSeparator: string = '#$%';
+  hideQueryConsoleTab: boolean;
   username: string;
   role: string;
 }

--- a/pinot-controller/src/main/resources/app/components/Layout.tsx
+++ b/pinot-controller/src/main/resources/app/components/Layout.tsx
@@ -52,6 +52,17 @@ const Layout = (props) => {
   const sidebarOpenState = !(localStorage.getItem('pinot_ui:sidebarState') === 'false');
   const [openSidebar, setOpenSidebar] = React.useState(sidebarOpenState);
 
+  const appNavigationItems = React.useMemo(() => {
+    if (app_state.queryConsoleOnlyView) {
+      return navigationItems.filter((navItem) => navItem.link === '/query');
+    }
+    if (app_state.hideQueryConsoleTab) {
+      return navigationItems.filter((navItem) => navItem.link !== '/query');
+  }
+
+    return navigationItems;
+  }, [navigationItems, app_state.queryConsoleOnlyView, app_state.hideQueryConsoleTab]);
+
   const highlightSidebarLink = (id: number) => {
     setSelectedId(id);
   };
@@ -62,16 +73,7 @@ const Layout = (props) => {
     setOpenSidebar(newSidebarState);
   };
 
-  const getAppNavigationItems = () => {
-    if (app_state.queryConsoleOnlyView) {
-      return navigationItems.filter((navItem) => navItem.link === '/query');
-    }
-    if (app_state.hideQueryConsoleTab) {
-      return navigationItems.filter((navItem) => navItem.link !== '/query');
-  }
-
-    return navigationItems;
-  };
+  
 
   return (
     <Grid container direction="column">
@@ -85,7 +87,7 @@ const Layout = (props) => {
         <Grid container>
           <Grid item>
             <Sidebar
-              list={getAppNavigationItems()}
+              list={appNavigationItems}
               showMenu={openSidebar}
               selectedId={selectedId}
               highlightSidebarLink={highlightSidebarLink}

--- a/pinot-controller/src/main/resources/app/components/Layout.tsx
+++ b/pinot-controller/src/main/resources/app/components/Layout.tsx
@@ -62,9 +62,16 @@ const Layout = (props) => {
     setOpenSidebar(newSidebarState);
   };
 
-  const filterNavigationItems = () => {
-    return navigationItems.filter((item)=>{return item.name.toLowerCase() === 'query console'});
+  const getAppNavigationItems = () => {
+    if (app_state.queryConsoleOnlyView) {
+      return navigationItems.filter((navItem) => navItem.link === '/query');
+    }
+    if (app_state.hideQueryConsoleTab) {
+      return navigationItems.filter((navItem) => navItem.link !== '/query');
   }
+
+    return navigationItems;
+  };
 
   return (
     <Grid container direction="column">
@@ -78,7 +85,7 @@ const Layout = (props) => {
         <Grid container>
           <Grid item>
             <Sidebar
-              list={app_state.queryConsoleOnlyView ? filterNavigationItems() : navigationItems}
+              list={getAppNavigationItems()}
               showMenu={openSidebar}
               selectedId={selectedId}
               highlightSidebarLink={highlightSidebarLink}


### PR DESCRIPTION
What does this PR do?
- Based on cluster config hide Query Console tab from UI 
- by default show Query Console tab but hide if the API cluster/configs returns `hideQueryConsoleTab`: "true"

**Note**: If we decide to go ahead with config key `hideQueryConsoleTab` then it should also be included in the [docs](https://docs.pinot.apache.org/configuration-reference/cluster#cluster-configs-definition) 

Screenshot: 
- Hidden query console tab
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/41536903/185811487-2ed47aa9-f7f2-4408-94e4-0a71cf6932d8.png">

reviewers - @joshigaurava @npawar 
