### PR TITLE
Optimize ser/de to avoid using output stream

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
@@ -538,6 +538,7 @@ public class ObjectSerDeUtils {
         return new byte[Integer.BYTES];
       }
 
+      // Besides the value bytes, we store: size, key type, value type, length for each key, length for each value
       long bufferSize = (3 + 2 * (long) size) * Integer.BYTES;
       byte[][] keyBytesArray = new byte[size][];
       byte[][] valueBytesArray = new byte[size][];
@@ -733,6 +734,7 @@ public class ObjectSerDeUtils {
     @Override
     public byte[] serialize(Set<String> stringSet) {
       int size = stringSet.size();
+      // Besides the value bytes, we store: size, length for each value
       long bufferSize = (1 + (long) size) * Integer.BYTES;
       byte[][] valueBytesArray = new byte[size][];
       int index = 0;
@@ -776,6 +778,7 @@ public class ObjectSerDeUtils {
     @Override
     public byte[] serialize(Set<ByteArray> bytesSet) {
       int size = bytesSet.size();
+      // Besides the value bytes, we store: size, length for each value
       long bufferSize = (1 + (long) size) * Integer.BYTES;
       for (ByteArray value : bytesSet) {
         bufferSize += value.length();
@@ -941,6 +944,7 @@ public class ObjectSerDeUtils {
         return new byte[Integer.BYTES];
       }
 
+      // Besides the value bytes, we store: size, value type, length for each value
       long bufferSize = (2 + (long) size) * Integer.BYTES;
       byte[][] valueBytesArray = new byte[size][];
       int valueType = ObjectType.getObjectType(list.get(0)).getValue();

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkObjectSerDe.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkObjectSerDe.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.pinot.common.utils.HashUtil;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 10)
+@Measurement(iterations = 5, time = 10)
+@State(Scope.Benchmark)
+public class BenchmarkObjectSerDe {
+  private static final int NUM_VALUES = 5_000_000;
+
+  List<String> _stringList = new ArrayList<>(NUM_VALUES);
+  Set<String> _stringSet = new ObjectOpenHashSet<>(NUM_VALUES);
+  Map<String, String> _stringToStringMap = new HashMap<>(HashUtil.getHashMapCapacity(NUM_VALUES));
+  Set<ByteArray> _bytesSet = new ObjectOpenHashSet<>(NUM_VALUES);
+
+  @Setup
+  public void setUp()
+      throws IOException {
+    for (int i = 0; i < NUM_VALUES; i++) {
+      String stringValue = RandomStringUtils.randomAlphanumeric(10, 201);
+      _stringList.add(stringValue);
+      _stringSet.add(stringValue);
+      _stringToStringMap.put(stringValue, stringValue);
+      _bytesSet.add(new ByteArray(stringValue.getBytes(UTF_8)));
+    }
+  }
+
+  @Benchmark
+  public int stringList() {
+    return ObjectSerDeUtils.serialize(_stringList).length;
+  }
+
+  @Benchmark
+  public int stringSet() {
+    return ObjectSerDeUtils.serialize(_stringSet).length;
+  }
+
+  @Benchmark
+  public int stringToStringMap() {
+    return ObjectSerDeUtils.serialize(_stringToStringMap).length;
+  }
+
+  @Benchmark
+  public int bytesSet() {
+    return ObjectSerDeUtils.serialize(_bytesSet).length;
+  }
+
+  public static void main(String[] args)
+      throws Exception {
+    new Runner(new OptionsBuilder().include(BenchmarkObjectSerDe.class.getSimpleName()).build()).run();
+  }
+}


### PR DESCRIPTION
Avoid using `ByteArrayOutputStream` which will potentially copy bytes multiple times (during expand and final `toByteArray()`). Pre-calculate the buffer size required, and then create the buffer only once.

## Before optimization

BenchmarkObjectSerDe.bytesSet           avgt    5   557.718 ± 31.501  ms/op
BenchmarkObjectSerDe.stringList         avgt    5  1089.643 ± 30.302  ms/op
BenchmarkObjectSerDe.stringSet          avgt    5  1061.030 ± 98.827  ms/op
BenchmarkObjectSerDe.stringToStringMap  avgt    5  1947.736 ± 29.011  ms/op

## After optimization

BenchmarkObjectSerDe.bytesSet           avgt    5   360.085 ±  10.518  ms/op
BenchmarkObjectSerDe.stringList         avgt    5   911.377 ±  35.301  ms/op
BenchmarkObjectSerDe.stringSet          avgt    5   920.723 ±  29.300  ms/op
BenchmarkObjectSerDe.stringToStringMap  avgt    5  1699.881 ± 165.362  ms/op