### PR TITLE
Improve server query cancellation and timeout checking during execution

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -142,7 +142,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
     _isStreamSegmentDownloadUntar = tableDataManagerParams.isStreamSegmentDownloadUntar();
     if (_isStreamSegmentDownloadUntar) {
       LOGGER.info("Using streamed download-untar for segment download! "
-              + "The rate limit interval for streamed download-untar is {} ms",
+              + "The rate limit interval for streamed download-untar is {} bytes",
           _streamSegmentDownloadUntarRateLimitBytesPerSec);
     }
     int maxParallelSegmentDownloads = tableDataManagerParams.getMaxParallelSegmentDownloads();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -142,7 +142,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
     _isStreamSegmentDownloadUntar = tableDataManagerParams.isStreamSegmentDownloadUntar();
     if (_isStreamSegmentDownloadUntar) {
       LOGGER.info("Using streamed download-untar for segment download! "
-              + "The rate limit interval for streamed download-untar is {} bytes",
+              + "The rate limit interval for streamed download-untar is {} bytes/s",
           _streamSegmentDownloadUntarRateLimitBytesPerSec);
     }
     int maxParallelSegmentDownloads = tableDataManagerParams.getMaxParallelSegmentDownloads();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -198,7 +198,7 @@ public abstract class BaseCombineOperator extends BaseOperator<IntermediateResul
     while (numBlocksMerged < _numOperators) {
       // Timeout has reached, shouldn't continue to process. `_blockingQueue.poll` will continue to return blocks even
       // if negative timeout is provided; therefore an extra check is needed
-      if (endTimeMs - System.currentTimeMillis() < 0){
+      if (endTimeMs - System.currentTimeMillis() < 0) {
         return generateTimeOutResult(numBlocksMerged);
       }
       IntermediateResultsBlock blockToMerge =

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -196,17 +196,15 @@ public abstract class BaseCombineOperator extends BaseOperator<IntermediateResul
     int numBlocksMerged = 0;
     long endTimeMs = _queryContext.getEndTimeMs();
     while (numBlocksMerged < _numOperators) {
-      IntermediateResultsBlock blockToMerge =
-          _blockingQueue.poll(endTimeMs - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
       // Timeout has reached, shouldn't continue to process. `_blockingQueue.poll` will continue to return blocks even
       // if negative timeout is provided; therefore an extra check is needed
-      boolean timeoutReached = endTimeMs < System.currentTimeMillis();
-      if (blockToMerge == null || timeoutReached) {
-        // Query times out, skip merging the remaining results blocks
-        LOGGER.error("Timed out while polling results block, numBlocksMerged: {} (query: {})", numBlocksMerged,
-            _queryContext);
-        return new IntermediateResultsBlock(QueryException.getException(QueryException.EXECUTION_TIMEOUT_ERROR,
-            new TimeoutException("Timed out while polling results block")));
+      if (endTimeMs - System.currentTimeMillis() < 0){
+        return generateTimeOutResult(numBlocksMerged);
+      }
+      IntermediateResultsBlock blockToMerge =
+          _blockingQueue.poll(endTimeMs - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+      if (blockToMerge == null) {
+        return generateTimeOutResult(numBlocksMerged);
       }
       if (blockToMerge.getProcessingExceptions() != null) {
         // Caught exception while processing segment, skip merging the remaining results blocks and directly return the
@@ -225,6 +223,14 @@ public abstract class BaseCombineOperator extends BaseOperator<IntermediateResul
       }
     }
     return mergedBlock;
+  }
+
+  private IntermediateResultsBlock generateTimeOutResult(int numBlocksMerged) {
+    // Query times out, skip merging the remaining results blocks
+    LOGGER.error("Timed out while polling results block, numBlocksMerged: {} (query: {})", numBlocksMerged,
+        _queryContext);
+    return new IntermediateResultsBlock(QueryException.getException(QueryException.EXECUTION_TIMEOUT_ERROR,
+        new TimeoutException("Timed out while polling results block")));
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -198,7 +198,10 @@ public abstract class BaseCombineOperator extends BaseOperator<IntermediateResul
     while (numBlocksMerged < _numOperators) {
       IntermediateResultsBlock blockToMerge =
           _blockingQueue.poll(endTimeMs - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
-      if (blockToMerge == null) {
+      // Timeout has reached, shouldn't continue to process. `_blockingQueue.poll` will continue to return blocks even
+      // if negative timeout is provided; therefore an extra check is needed
+      boolean timeoutReached = endTimeMs < System.currentTimeMillis();
+      if (blockToMerge == null || timeoutReached) {
         // Query times out, skip merging the remaining results blocks
         LOGGER.error("Timed out while polling results block, numBlocksMerged: {} (query: {})", numBlocksMerged,
             _queryContext);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByOrderByCombineOperator.java
@@ -48,8 +48,7 @@ import org.apache.pinot.core.util.GroupByUtils;
 import org.apache.pinot.spi.exception.EarlyTerminationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.pinot.core.plan.DocIdSetPlanNode.MAX_DOC_PER_CALL;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
 
 
 /**
@@ -208,7 +207,7 @@ public class GroupByOrderByCombineOperator extends BaseCombineOperator {
 
   // Check for thread interruption, every time after merging 10_000 keys
   private void checkMergePhaseInterruption(long mergedKeys) {
-    if (mergedKeys % MAX_DOC_PER_CALL == 0 && Thread.interrupted()) {
+    if (mergedKeys % DocIdSetPlanNode.MAX_DOC_PER_CALL == 0 && Thread.interrupted()) {
       throw new EarlyTerminationException();
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByOrderByCombineOperator.java
@@ -40,6 +40,7 @@ import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.data.table.UnboundedConcurrentIndexedTable;
 import org.apache.pinot.core.operator.AcquireReleaseColumnsSegmentOperator;
 import org.apache.pinot.core.operator.blocks.IntermediateResultsBlock;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
 import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
@@ -48,7 +49,6 @@ import org.apache.pinot.core.util.GroupByUtils;
 import org.apache.pinot.spi.exception.EarlyTerminationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.pinot.core.plan.DocIdSetPlanNode;
 
 
 /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByOrderByCombineOperator.java
@@ -58,7 +58,7 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings("rawtypes")
 public class GroupByOrderByCombineOperator extends BaseCombineOperator {
   public static final int MAX_TRIM_THRESHOLD = 1_000_000_000;
-  public static final int MAX_GROUP_BY_KEYS_PER_MERGE_CALL = 10_000;
+  public static final int MAX_GROUP_BY_KEYS_MERGED_PER_INTERRUPTION_CHECK = 10_000;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GroupByOrderByCombineOperator.class);
 
@@ -208,7 +208,7 @@ public class GroupByOrderByCombineOperator extends BaseCombineOperator {
 
   // Check for thread interruption, every time after merging 10_000 keys
   private void checkMergePhaseInterruption(int mergedKeys) {
-    if (mergedKeys % MAX_GROUP_BY_KEYS_PER_MERGE_CALL == 0 && Thread.interrupted()) {
+    if (mergedKeys % MAX_GROUP_BY_KEYS_MERGED_PER_INTERRUPTION_CHECK == 0 && Thread.interrupted()) {
       throw new EarlyTerminationException();
     }
   }


### PR DESCRIPTION
1. check for interruption during group-by merge, for each 10_000 keys
2. check for timeout during the `mergeResults()`