### PR TITLE
Fix transformation to string for BOOLEAN and TIMESTAMP

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.common;
 import java.io.Closeable;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
@@ -32,7 +33,7 @@ import org.apache.pinot.segment.spi.evaluator.TransformEvaluator;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.BytesUtils;
 
@@ -66,10 +67,11 @@ public class DataFetcher {
     for (Map.Entry<String, DataSource> entry : dataSourceMap.entrySet()) {
       String column = entry.getKey();
       DataSource dataSource = entry.getValue();
-      ColumnValueReader columnValueReader =
-          new ColumnValueReader(dataSource.getForwardIndex(), dataSource.getDictionary());
-      _columnValueReaderMap.put(column, columnValueReader);
       DataSourceMetadata dataSourceMetadata = dataSource.getDataSourceMetadata();
+      ColumnValueReader columnValueReader =
+          new ColumnValueReader(dataSource.getForwardIndex(), dataSource.getDictionary(),
+              dataSourceMetadata.getDataType());
+      _columnValueReaderMap.put(column, columnValueReader);
       if (!dataSourceMetadata.isSingleValue()) {
         maxNumValuesPerMVEntry = Math.max(maxNumValuesPerMVEntry, dataSourceMetadata.getMaxNumValuesPerMVEntry());
       }
@@ -427,16 +429,16 @@ public class DataFetcher {
   private class ColumnValueReader implements Closeable {
     final ForwardIndexReader _reader;
     final Dictionary _dictionary;
-    final FieldSpec.DataType _dataType;
+    final DataType _dataType;
     final boolean _singleValue;
 
     boolean _readerContextCreated;
     ForwardIndexReaderContext _readerContext;
 
-    ColumnValueReader(ForwardIndexReader reader, @Nullable Dictionary dictionary) {
+    ColumnValueReader(ForwardIndexReader reader, @Nullable Dictionary dictionary, DataType dataType) {
       _reader = reader;
       _dictionary = dictionary;
-      _dataType = reader.getStoredType();
+      _dataType = dataType;
       _singleValue = reader.isSingleValue();
     }
 
@@ -550,9 +552,19 @@ public class DataFetcher {
       if (_dictionary != null) {
         int[] dictIdBuffer = THREAD_LOCAL_DICT_IDS.get();
         _reader.readDictIds(docIds, length, dictIdBuffer, readerContext);
-        _dictionary.readStringValues(dictIdBuffer, length, valueBuffer);
+        if (_dataType == DataType.BOOLEAN) {
+          for (int i = 0; i < length; i++) {
+            valueBuffer[i] = Boolean.toString(_dictionary.getIntValue(dictIdBuffer[i]) == 1);
+          }
+        } else if (_dataType == DataType.TIMESTAMP) {
+          for (int i = 0; i < length; i++) {
+            valueBuffer[i] = new Timestamp(_dictionary.getLongValue(dictIdBuffer[i])).toString();
+          }
+        } else {
+          _dictionary.readStringValues(dictIdBuffer, length, valueBuffer);
+        }
       } else {
-        switch (_reader.getStoredType()) {
+        switch (_dataType) {
           case INT:
             for (int i = 0; i < length; i++) {
               valueBuffer[i] = Integer.toString(_reader.getInt(docIds[i], readerContext));
@@ -573,7 +585,23 @@ public class DataFetcher {
               valueBuffer[i] = Double.toString(_reader.getDouble(docIds[i], readerContext));
             }
             break;
+          case BIG_DECIMAL:
+            for (int i = 0; i < length; i++) {
+              valueBuffer[i] = _reader.getBigDecimal(docIds[i], readerContext).toPlainString();
+            }
+            break;
+          case BOOLEAN:
+            for (int i = 0; i < length; i++) {
+              valueBuffer[i] = Boolean.toString(_reader.getInt(docIds[i], readerContext) == 1);
+            }
+            break;
+          case TIMESTAMP:
+            for (int i = 0; i < length; i++) {
+              valueBuffer[i] = new Timestamp(_reader.getLong(docIds[i], readerContext)).toString();
+            }
+            break;
           case STRING:
+          case JSON:
             for (int i = 0; i < length; i++) {
               valueBuffer[i] = _reader.getString(docIds[i], readerContext);
             }
@@ -622,23 +650,25 @@ public class DataFetcher {
 
     void readDictIdsMV(int[] docIds, int length, int[][] dictIdsBuffer) {
       Tracing.activeRecording().setInputDataType(_dataType, _singleValue);
+      ForwardIndexReaderContext readerContext = getReaderContext();
       for (int i = 0; i < length; i++) {
-        int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, getReaderContext());
+        int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, readerContext);
         dictIdsBuffer[i] = Arrays.copyOfRange(_reusableMVDictIds, 0, numValues);
       }
     }
 
     void readIntValuesMV(int[] docIds, int length, int[][] valuesBuffer) {
       Tracing.activeRecording().setInputDataType(_dataType, _singleValue);
+      ForwardIndexReaderContext readerContext = getReaderContext();
       if (_dictionary != null) {
         for (int i = 0; i < length; i++) {
-          int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, getReaderContext());
+          int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, readerContext);
           int[] values = new int[numValues];
           _dictionary.readIntValues(_reusableMVDictIds, numValues, values);
           valuesBuffer[i] = values;
         }
       } else {
-        _reader.readValuesMV(docIds, length, _maxNumValuesPerMVEntry, valuesBuffer, getReaderContext());
+        _reader.readValuesMV(docIds, length, _maxNumValuesPerMVEntry, valuesBuffer, readerContext);
       }
     }
 
@@ -650,15 +680,16 @@ public class DataFetcher {
 
     void readLongValuesMV(int[] docIds, int length, long[][] valuesBuffer) {
       Tracing.activeRecording().setInputDataType(_dataType, _singleValue);
+      ForwardIndexReaderContext readerContext = getReaderContext();
       if (_dictionary != null) {
         for (int i = 0; i < length; i++) {
-          int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, getReaderContext());
+          int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, readerContext);
           long[] values = new long[numValues];
           _dictionary.readLongValues(_reusableMVDictIds, numValues, values);
           valuesBuffer[i] = values;
         }
       } else {
-        _reader.readValuesMV(docIds, length, _maxNumValuesPerMVEntry, valuesBuffer, getReaderContext());
+        _reader.readValuesMV(docIds, length, _maxNumValuesPerMVEntry, valuesBuffer, readerContext);
       }
     }
 
@@ -670,15 +701,16 @@ public class DataFetcher {
 
     void readFloatValuesMV(int[] docIds, int length, float[][] valuesBuffer) {
       Tracing.activeRecording().setInputDataType(_dataType, _singleValue);
+      ForwardIndexReaderContext readerContext = getReaderContext();
       if (_dictionary != null) {
         for (int i = 0; i < length; i++) {
-          int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, getReaderContext());
+          int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, readerContext);
           float[] values = new float[numValues];
           _dictionary.readFloatValues(_reusableMVDictIds, numValues, values);
           valuesBuffer[i] = values;
         }
       } else {
-        _reader.readValuesMV(docIds, length, _maxNumValuesPerMVEntry, valuesBuffer, getReaderContext());
+        _reader.readValuesMV(docIds, length, _maxNumValuesPerMVEntry, valuesBuffer, readerContext);
       }
     }
 
@@ -690,15 +722,16 @@ public class DataFetcher {
 
     void readDoubleValuesMV(int[] docIds, int length, double[][] valuesBuffer) {
       Tracing.activeRecording().setInputDataType(_dataType, _singleValue);
+      ForwardIndexReaderContext readerContext = getReaderContext();
       if (_dictionary != null) {
         for (int i = 0; i < length; i++) {
-          int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, getReaderContext());
+          int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, readerContext);
           double[] values = new double[numValues];
           _dictionary.readDoubleValues(_reusableMVDictIds, numValues, values);
           valuesBuffer[i] = values;
         }
       } else {
-        _reader.readValuesMV(docIds, length, _maxNumValuesPerMVEntry, valuesBuffer, getReaderContext());
+        _reader.readValuesMV(docIds, length, _maxNumValuesPerMVEntry, valuesBuffer, readerContext);
       }
     }
 
@@ -710,15 +743,62 @@ public class DataFetcher {
 
     void readStringValuesMV(int[] docIds, int length, String[][] valuesBuffer) {
       Tracing.activeRecording().setInputDataType(_dataType, _singleValue);
+      ForwardIndexReaderContext readerContext = getReaderContext();
       if (_dictionary != null) {
-        for (int i = 0; i < length; i++) {
-          int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, getReaderContext());
-          String[] values = new String[numValues];
-          _dictionary.readStringValues(_reusableMVDictIds, numValues, values);
-          valuesBuffer[i] = values;
+        if (_dataType == DataType.BOOLEAN) {
+          for (int i = 0; i < length; i++) {
+            int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, readerContext);
+            int[] intValues = new int[numValues];
+            _dictionary.readIntValues(_reusableMVDictIds, numValues, intValues);
+            String[] values = new String[numValues];
+            for (int j = 0; j < numValues; j++) {
+              values[i] = Boolean.toString(intValues[i] == 1);
+            }
+            valuesBuffer[i] = values;
+          }
+        } else if (_dataType == DataType.TIMESTAMP) {
+          for (int i = 0; i < length; i++) {
+            int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, readerContext);
+            long[] longValues = new long[numValues];
+            _dictionary.readLongValues(_reusableMVDictIds, numValues, longValues);
+            String[] values = new String[numValues];
+            for (int j = 0; j < numValues; j++) {
+              values[i] = new Timestamp(longValues[i]).toString();
+            }
+            valuesBuffer[i] = values;
+          }
+        } else {
+          for (int i = 0; i < length; i++) {
+            int numValues = _reader.getDictIdMV(docIds[i], _reusableMVDictIds, readerContext);
+            String[] values = new String[numValues];
+            _dictionary.readStringValues(_reusableMVDictIds, numValues, values);
+            valuesBuffer[i] = values;
+          }
         }
       } else {
-        _reader.readValuesMV(docIds, length, _maxNumValuesPerMVEntry, valuesBuffer, getReaderContext());
+        if (_dataType == DataType.BOOLEAN) {
+          int[] intValueBuffer = new int[_maxNumValuesPerMVEntry];
+          for (int i = 0; i < length; i++) {
+            int numValues = _reader.getIntMV(docIds[i], intValueBuffer, readerContext);
+            String[] values = new String[numValues];
+            for (int j = 0; j < numValues; j++) {
+              values[i] = Boolean.toString(intValueBuffer[i] == 1);
+            }
+            valuesBuffer[i] = values;
+          }
+        } else if (_dataType == DataType.TIMESTAMP) {
+          long[] longValueBuffer = new long[_maxNumValuesPerMVEntry];
+          for (int i = 0; i < length; i++) {
+            int numValues = _reader.getLongMV(docIds[i], longValueBuffer, readerContext);
+            String[] values = new String[numValues];
+            for (int j = 0; j < numValues; j++) {
+              values[i] = new Timestamp(longValueBuffer[i]).toString();
+            }
+            valuesBuffer[i] = values;
+          }
+        } else {
+          _reader.readValuesMV(docIds, length, _maxNumValuesPerMVEntry, valuesBuffer, readerContext);
+        }
       }
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
@@ -19,14 +19,12 @@
 package org.apache.pinot.core.operator.transform.function;
 
 import java.math.BigDecimal;
-import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
-import org.apache.pinot.spi.utils.ArrayCopyUtils;
 
 
 public class CastTransformFunction extends BaseTransformFunction {
@@ -71,6 +69,7 @@ public class CastTransformFunction extends BaseTransformFunction {
         case "BIG_DECIMAL":
           _resultMetadata = BIG_DECIMAL_SV_NO_DICTIONARY_METADATA;
           break;
+        case "BOOL":
         case "BOOLEAN":
           _resultMetadata = BOOLEAN_SV_NO_DICTIONARY_METADATA;
           break;
@@ -99,275 +98,55 @@ public class CastTransformFunction extends BaseTransformFunction {
 
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
-    // When casting to types other than INT, need to first read as the result type then convert to int values
-    DataType resultStoredType = _resultMetadata.getDataType().getStoredType();
-    if (resultStoredType == DataType.INT) {
+    if (_resultMetadata.getDataType().getStoredType() == DataType.INT) {
       return _transformFunction.transformToIntValuesSV(projectionBlock);
     } else {
-      int length = projectionBlock.getNumDocs();
-      if (_intValuesSV == null || _intValuesSV.length < length) {
-        _intValuesSV = new int[length];
-      }
-      switch (resultStoredType) {
-        case LONG:
-          long[] longValues = _transformFunction.transformToLongValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(longValues, _intValuesSV, length);
-          break;
-        case FLOAT:
-          float[] floatValues = _transformFunction.transformToFloatValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(floatValues, _intValuesSV, length);
-          break;
-        case DOUBLE:
-          double[] doubleValues = _transformFunction.transformToDoubleValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(doubleValues, _intValuesSV, length);
-          break;
-        case BIG_DECIMAL:
-          BigDecimal[] bigDecimalValues = _transformFunction.transformToBigDecimalValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(bigDecimalValues, _intValuesSV, length);
-          break;
-        case STRING:
-          String[] stringValues = _transformFunction.transformToStringValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(stringValues, _intValuesSV, length);
-          break;
-        default:
-          throw new IllegalStateException();
-      }
-      return _intValuesSV;
+      return super.transformToIntValuesSV(projectionBlock);
     }
   }
 
   @Override
   public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
-    // When casting to types other than LONG, need to first read as the result type then convert to long values
-    DataType resultStoredType = _resultMetadata.getDataType().getStoredType();
-    if (resultStoredType == DataType.LONG) {
+    if (_resultMetadata.getDataType().getStoredType() == DataType.LONG) {
       return _transformFunction.transformToLongValuesSV(projectionBlock);
     } else {
-      int length = projectionBlock.getNumDocs();
-
-      if (_longValuesSV == null || _longValuesSV.length < length) {
-        _longValuesSV = new long[length];
-      }
-      switch (resultStoredType) {
-        case INT:
-          int[] intValues = _transformFunction.transformToIntValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(intValues, _longValuesSV, length);
-          break;
-        case FLOAT:
-          float[] floatValues = _transformFunction.transformToFloatValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(floatValues, _longValuesSV, length);
-          break;
-        case DOUBLE:
-          double[] doubleValues = _transformFunction.transformToDoubleValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(doubleValues, _longValuesSV, length);
-          break;
-        case BIG_DECIMAL:
-          BigDecimal[] bigDecimalValues = _transformFunction.transformToBigDecimalValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(bigDecimalValues, _longValuesSV, length);
-          break;
-        case STRING:
-          String[] stringValues = _transformFunction.transformToStringValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(stringValues, _longValuesSV, length);
-          break;
-        default:
-          throw new IllegalStateException();
-      }
-      return _longValuesSV;
+      return super.transformToLongValuesSV(projectionBlock);
     }
   }
 
   @Override
   public float[] transformToFloatValuesSV(ProjectionBlock projectionBlock) {
-    // When casting to types other than FLOAT, need to first read as the result type then convert to float values
-    DataType resultStoredType = _resultMetadata.getDataType().getStoredType();
-    if (resultStoredType == DataType.FLOAT) {
+    if (_resultMetadata.getDataType().getStoredType() == DataType.FLOAT) {
       return _transformFunction.transformToFloatValuesSV(projectionBlock);
     } else {
-      int length = projectionBlock.getNumDocs();
-
-      if (_floatValuesSV == null || _floatValuesSV.length < length) {
-        _floatValuesSV = new float[length];
-      }
-      switch (resultStoredType) {
-        case INT:
-          int[] intValues = _transformFunction.transformToIntValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(intValues, _floatValuesSV, length);
-          break;
-        case LONG:
-          long[] longValues = _transformFunction.transformToLongValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(longValues, _floatValuesSV, length);
-          break;
-        case DOUBLE:
-          double[] doubleValues = _transformFunction.transformToDoubleValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(doubleValues, _floatValuesSV, length);
-          break;
-        case BIG_DECIMAL:
-          BigDecimal[] bigDecimalValues = _transformFunction.transformToBigDecimalValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(bigDecimalValues, _floatValuesSV, length);
-          break;
-        case STRING:
-          String[] stringValues = _transformFunction.transformToStringValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(stringValues, _floatValuesSV, length);
-          break;
-        default:
-          throw new IllegalStateException();
-      }
-      return _floatValuesSV;
+      return super.transformToFloatValuesSV(projectionBlock);
     }
   }
 
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
-    // When casting to types other than DOUBLE, need to first read as the result type then convert to double values
-    DataType resultStoredType = _resultMetadata.getDataType().getStoredType();
-    if (resultStoredType == DataType.DOUBLE) {
+    if (_resultMetadata.getDataType().getStoredType() == DataType.DOUBLE) {
       return _transformFunction.transformToDoubleValuesSV(projectionBlock);
     } else {
-      int length = projectionBlock.getNumDocs();
-
-      if (_doubleValuesSV == null || _doubleValuesSV.length < length) {
-        _doubleValuesSV = new double[length];
-      }
-      switch (resultStoredType) {
-        case INT:
-          int[] intValues = _transformFunction.transformToIntValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(intValues, _doubleValuesSV, length);
-          break;
-        case LONG:
-          long[] longValues = _transformFunction.transformToLongValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(longValues, _doubleValuesSV, length);
-          break;
-        case FLOAT:
-          float[] floatValues = _transformFunction.transformToFloatValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(floatValues, _doubleValuesSV, length);
-          break;
-        case BIG_DECIMAL:
-          BigDecimal[] bigDecimalValues = _transformFunction.transformToBigDecimalValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(bigDecimalValues, _doubleValuesSV, length);
-          break;
-        case STRING:
-          String[] stringValues = _transformFunction.transformToStringValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(stringValues, _doubleValuesSV, length);
-          break;
-        default:
-          throw new IllegalStateException();
-      }
-      return _doubleValuesSV;
+      return super.transformToDoubleValuesSV(projectionBlock);
     }
   }
 
   @Override
   public BigDecimal[] transformToBigDecimalValuesSV(ProjectionBlock projectionBlock) {
-    // When casting to types other than BIG_DECIMAL, need to first read as the result type then convert to
-    // BigDecimal values
-    DataType dataType = _resultMetadata.getDataType();
-    DataType resultStoredType = dataType.getStoredType();
-    if (dataType == DataType.BIG_DECIMAL) {
+    if (_resultMetadata.getDataType().getStoredType() == DataType.BIG_DECIMAL) {
       return _transformFunction.transformToBigDecimalValuesSV(projectionBlock);
     } else {
-      int length = projectionBlock.getNumDocs();
-      if (_bigDecimalValuesSV == null || _bigDecimalValuesSV.length < length) {
-        _bigDecimalValuesSV = new BigDecimal[length];
-      }
-      int numDocs = projectionBlock.getNumDocs();
-      switch (resultStoredType) {
-        case INT:
-          int[] intValues = _transformFunction.transformToIntValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(intValues, _bigDecimalValuesSV, numDocs);
-          break;
-        case LONG:
-          long[] longValues = _transformFunction.transformToLongValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(longValues, _bigDecimalValuesSV, numDocs);
-          break;
-        case FLOAT:
-          float[] floatValues = _transformFunction.transformToFloatValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(floatValues, _bigDecimalValuesSV, numDocs);
-          break;
-        case DOUBLE:
-          double[] doubleValues = _transformFunction.transformToDoubleValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(doubleValues, _bigDecimalValuesSV, numDocs);
-          break;
-        case STRING:
-          String[] stringValues = _transformFunction.transformToStringValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(stringValues, _bigDecimalValuesSV, numDocs);
-          break;
-        default:
-          throw new IllegalStateException();
-      }
-      return _bigDecimalValuesSV;
+      return super.transformToBigDecimalValuesSV(projectionBlock);
     }
   }
 
   @Override
   public String[] transformToStringValuesSV(ProjectionBlock projectionBlock) {
-    // When casting to types other than STRING, need to first read as the result type then convert to string values
-    DataType resultDataType = _resultMetadata.getDataType();
-    DataType resultStoredType = resultDataType.getStoredType();
-    int length = projectionBlock.getNumDocs();
-    if (resultStoredType == DataType.STRING) {
-      // Specialize BOOlEAN and TIMESTAMP when casting to STRING
-      DataType inputDataType = _transformFunction.getResultMetadata().getDataType();
-      if (inputDataType.getStoredType() != inputDataType) {
-        if (_stringValuesSV == null || _stringValuesSV.length < length) {
-          _stringValuesSV = new String[length];
-        }
-        if (inputDataType == DataType.BOOLEAN) {
-          int[] intValues = _transformFunction.transformToIntValuesSV(projectionBlock);
-          for (int i = 0; i < length; i++) {
-            _stringValuesSV[i] = Boolean.toString(intValues[i] == 1);
-          }
-        } else {
-          assert inputDataType == DataType.TIMESTAMP;
-          long[] longValues = _transformFunction.transformToLongValuesSV(projectionBlock);
-          for (int i = 0; i < length; i++) {
-            _stringValuesSV[i] = new Timestamp(longValues[i]).toString();
-          }
-        }
-        return _stringValuesSV;
-      } else {
-        return _transformFunction.transformToStringValuesSV(projectionBlock);
-      }
+    if (_resultMetadata.getDataType().getStoredType() == DataType.STRING) {
+      return _transformFunction.transformToStringValuesSV(projectionBlock);
     } else {
-      if (_stringValuesSV == null || _stringValuesSV.length < length) {
-        _stringValuesSV = new String[length];
-      }
-      switch (resultDataType) {
-        case INT:
-          int[] intValues = _transformFunction.transformToIntValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(intValues, _stringValuesSV, length);
-          break;
-        case LONG:
-          long[] longValues = _transformFunction.transformToLongValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(longValues, _stringValuesSV, length);
-          break;
-        case FLOAT:
-          float[] floatValues = _transformFunction.transformToFloatValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(floatValues, _stringValuesSV, length);
-          break;
-        case DOUBLE:
-          double[] doubleValues = _transformFunction.transformToDoubleValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(doubleValues, _stringValuesSV, length);
-          break;
-        case BIG_DECIMAL:
-          BigDecimal[] bigDecimalValues = _transformFunction.transformToBigDecimalValuesSV(projectionBlock);
-          ArrayCopyUtils.copy(bigDecimalValues, _stringValuesSV, length);
-          break;
-        case BOOLEAN:
-          intValues = _transformFunction.transformToIntValuesSV(projectionBlock);
-          for (int i = 0; i < length; i++) {
-            _stringValuesSV[i] = Boolean.toString(intValues[i] == 1);
-          }
-          break;
-        case TIMESTAMP:
-          longValues = _transformFunction.transformToLongValuesSV(projectionBlock);
-          for (int i = 0; i < length; i++) {
-            _stringValuesSV[i] = new Timestamp(longValues[i]).toString();
-          }
-          break;
-        default:
-          throw new IllegalStateException();
-      }
-      return _stringValuesSV;
+      return super.transformToStringValuesSV(projectionBlock);
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.operator.transform.function;
 
 import java.io.File;
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.util.ArrayList;
@@ -219,7 +220,11 @@ public abstract class BaseTransformFunctionTest {
       Assert.assertEquals(floatValues[i], (float) expectedValues[i]);
       Assert.assertEquals(doubleValues[i], (double) expectedValues[i]);
       Assert.assertEquals(bigDecimalValues[i].intValue(), expectedValues[i]);
-      Assert.assertEquals(stringValues[i], Integer.toString(expectedValues[i]));
+      if (transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.BOOLEAN) {
+        Assert.assertEquals(stringValues[i], Boolean.toString(expectedValues[i] == 1));
+      } else {
+        Assert.assertEquals(stringValues[i], Integer.toString(expectedValues[i]));
+      }
     }
   }
 
@@ -236,7 +241,11 @@ public abstract class BaseTransformFunctionTest {
       Assert.assertEquals(floatValues[i], (float) expectedValues[i]);
       Assert.assertEquals(doubleValues[i], (double) expectedValues[i]);
       Assert.assertEquals(bigDecimalValues[i].longValue(), expectedValues[i]);
-      Assert.assertEquals(stringValues[i], Long.toString(expectedValues[i]));
+      if (transformFunction.getResultMetadata().getDataType() == FieldSpec.DataType.TIMESTAMP) {
+        Assert.assertEquals(stringValues[i], new Timestamp(expectedValues[i]).toString());
+      } else {
+        Assert.assertEquals(stringValues[i], Long.toString(expectedValues[i]));
+      }
     }
   }
 


### PR DESCRIPTION
For `BOOLEAN` and `TIMESTAMP` (logical types), when reading them as string, we should use the logical type to return `true`, `2022-02-02 00:00:00.000` instead of the int/long value.
With the fix in `BaseTransformFunction`, the `CAST` transform function can be greatly simplified.