### PR TITLE
Add Spark Job Launcher tool

### DIFF
--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -34,6 +34,8 @@
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
     <aws.version>2.14.28</aws.version>
+    <scala.version>2.12</scala.version>
+    <spark.version>3.2.1</spark.version>
   </properties>
   <dependencies>
     <dependency>
@@ -277,8 +279,8 @@
     -->
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-launcher_2.12</artifactId>
-      <version>2.4.8</version>
+      <artifactId>spark-launcher_${scala.version}</artifactId>
+      <version>${spark.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.scala-lang</groupId>

--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -268,11 +268,61 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+<!--    <dependency>-->
+<!--      <groupId>org.apache.pinot</groupId>-->
+<!--      <artifactId>pinot-batch-ingestion-spark-2.4</artifactId>-->
+<!--      <version>${project.version}</version>-->
+<!--    </dependency>-->
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_2.11</artifactId>
       <version>2.4.0</version>
-      <scope>provided</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.scala-lang</groupId>
+          <artifactId>scala-library</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.twitter</groupId>
+          <artifactId>chill_2.11</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.twitter</groupId>
+          <artifactId>chill-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.apache.curator</groupId>
+          <artifactId>curator-recipes</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-log4j12</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.zaxxer</groupId>
+          <artifactId>HikariCP-java7</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.glassfish.hk2.external</groupId>
+          <artifactId>jakarta.inject</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>jakarta.ws.rs</groupId>
+          <artifactId>jakarta.ws.rs-api</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
   <build>

--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -268,59 +268,21 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
-<!--    <dependency>-->
-<!--      <groupId>org.apache.pinot</groupId>-->
-<!--      <artifactId>pinot-batch-ingestion-spark-2.4</artifactId>-->
-<!--      <version>${project.version}</version>-->
-<!--    </dependency>-->
+
+    <!--
+      This dependency is needed for LaunchSparkDataIngestionJobCommand.
+      The dependency only contains a few classes and scala library which has been excluded.
+      Hence, it will not interfere with spark-core classes present in runtime env
+      and will use the env spark version to actually execute the spark job
+    -->
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_2.11</artifactId>
-      <version>2.4.0</version>
+      <artifactId>spark-launcher_2.12</artifactId>
+      <version>2.4.8</version>
       <exclusions>
         <exclusion>
           <groupId>org.scala-lang</groupId>
           <artifactId>scala-library</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.twitter</groupId>
-          <artifactId>chill_2.11</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.twitter</groupId>
-          <artifactId>chill-java</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.curator</groupId>
-          <artifactId>curator-recipes</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-log4j12</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.protobuf</groupId>
-          <artifactId>protobuf-java</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.zaxxer</groupId>
-          <artifactId>HikariCP-java7</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.glassfish.hk2.external</groupId>
-          <artifactId>jakarta.inject</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>jakarta.ws.rs</groupId>
-          <artifactId>jakarta.ws.rs-api</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -268,6 +268,12 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_2.11</artifactId>
+      <version>2.4.0</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
@@ -40,6 +40,7 @@ import org.apache.pinot.tools.admin.command.GitHubEventsQuickStartCommand;
 import org.apache.pinot.tools.admin.command.ImportDataCommand;
 import org.apache.pinot.tools.admin.command.JsonToPinotSchema;
 import org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand;
+import org.apache.pinot.tools.admin.command.LaunchSparkDataIngestionJobCommand;
 import org.apache.pinot.tools.admin.command.MoveReplicaGroup;
 import org.apache.pinot.tools.admin.command.OfflineSegmentIntervalCheckerCommand;
 import org.apache.pinot.tools.admin.command.OperateClusterConfigCommand;
@@ -94,6 +95,7 @@ public class PinotAdministrator {
     SUBCOMMAND_MAP.put("OperateClusterConfig", new OperateClusterConfigCommand());
     SUBCOMMAND_MAP.put("GenerateData", new GenerateDataCommand());
     SUBCOMMAND_MAP.put("LaunchDataIngestionJob", new LaunchDataIngestionJobCommand());
+    SUBCOMMAND_MAP.put("LaunchSparkDataIngestionJob", new LaunchSparkDataIngestionJobCommand());
     SUBCOMMAND_MAP.put("CreateSegment", new CreateSegmentCommand());
     SUBCOMMAND_MAP.put("ImportData", new ImportDataCommand());
     SUBCOMMAND_MAP.put("StartZookeeper", new StartZookeeperCommand());

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommand.java
@@ -23,13 +23,10 @@ import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import org.apache.calcite.rel.core.Join;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.JavaVersion;
 import org.apache.commons.lang3.SystemUtils;
@@ -43,7 +40,6 @@ import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.utils.GroovyTemplateUtils;
 import org.apache.pinot.tools.Command;
-import org.apache.spark.launcher.SparkAppHandle;
 import org.apache.spark.launcher.SparkLauncher;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -287,7 +283,8 @@ public class LaunchSparkDataIngestionJobCommand extends AbstractBaseAdminCommand
   }
 
   private boolean shouldLoadPlugin(String parentDir) {
-    boolean shouldLoadPlugin = _pluginsToLoad == null && !_pluginsToExclude.contains(parentDir);
+    boolean shouldLoadPlugin = _pluginsToLoad == null && !_pluginsToExclude.contains(parentDir)
+        && !parentDir.contains("spark");
     shouldLoadPlugin = shouldLoadPlugin || (_pluginsToLoad != null && _pluginsToLoad.contains(parentDir));
     shouldLoadPlugin = shouldLoadPlugin || _sparkVersion.getPluginName().contentEquals(parentDir);
     return shouldLoadPlugin;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommand.java
@@ -1,0 +1,229 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.admin.command;
+
+import com.google.common.base.Joiner;
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.utils.TlsUtils;
+import org.apache.pinot.spi.auth.AuthProvider;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.ingestion.batch.IngestionJobLauncher;
+import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.TlsSpec;
+import org.apache.pinot.spi.plugin.PluginManager;
+import org.apache.pinot.spi.utils.GroovyTemplateUtils;
+import org.apache.pinot.tools.Command;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.launcher.SparkAppHandle;
+import org.apache.spark.launcher.SparkLauncher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+
+/**
+ * Class to implement LaunchDataIngestionJob command.
+ *
+ */
+@CommandLine.Command(name = "LaunchSparkDataIngestionJob")
+public class LaunchSparkDataIngestionJobCommand extends AbstractBaseAdminCommand implements Command {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LaunchSparkDataIngestionJobCommand.class);
+  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
+      description = "Print this message.")
+  private boolean _help = false;
+  @CommandLine.Option(names = {"-jobSpecFile", "-jobSpec"}, required = true,
+      description = "Ingestion job spec file")
+  private String _jobSpecFile;
+  @CommandLine.Option(names = {"-values"}, required = false, arity = "1..*",
+      description = "Context values set to the job spec template")
+  private List<String> _values;
+  @CommandLine.Option(names = {"-propertyFile"}, required = false,
+      description = "A property file contains context values to set the job spec template")
+  private String _propertyFile;
+  @CommandLine.Option(names = {"-user"}, required = false, description = "Username for basic auth.")
+  private String _user;
+  @CommandLine.Option(names = {"-password"}, required = false, description = "Password for basic auth.")
+  private String _password;
+  @CommandLine.Option(names = {"-authToken"}, required = false, description = "Http auth token.")
+  private String _authToken;
+  @CommandLine.Option(names = {"-authTokenUrl"}, required = false, description = "Http auth token url.")
+  private String _authTokenUrl;
+  @CommandLine.Option(names = {"-pluginsToLoad"}, required = false, arity = "1..*", description = "Plugins to Load")
+  private List<String> _pluginsToLoad;
+  @CommandLine.Option(names = {"-pinotJarsDir"}, required = true, description = "Pinot binary installation directory")
+  private String _pinotJarDir;
+
+  private AuthProvider _authProvider;
+
+  public String getJobSpecFile() {
+    return _jobSpecFile;
+  }
+
+  public void setJobSpecFile(String jobSpecFile) {
+    _jobSpecFile = jobSpecFile;
+  }
+
+  public List<String> getValues() {
+    return _values;
+  }
+
+  public void setValues(List<String> values) {
+    _values = values;
+  }
+
+  public String getPropertyFile() {
+    return _propertyFile;
+  }
+
+  public void setPropertyFile(String propertyFile) {
+    _propertyFile = propertyFile;
+  }
+
+  public void setAuthProvider(AuthProvider authProvider) {
+    _authProvider = authProvider;
+  }
+
+  @Override
+  public boolean getHelp() {
+    return _help;
+  }
+
+  public void setHelp(boolean help) {
+    _help = help;
+  }
+
+
+  @Override
+  public boolean execute()
+      throws Exception {
+    SparkLauncher sparkLauncher = new SparkLauncher();
+    sparkLauncher.setMaster("yarn");
+    sparkLauncher.setDeployMode("cluster");
+    sparkLauncher.setMainClass("org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand");
+    SegmentGenerationJobSpec spec;
+    try {
+      spec = IngestionJobLauncher.getSegmentGenerationJobSpec(_jobSpecFile, _propertyFile,
+          GroovyTemplateUtils.getTemplateContext(_values), System.getenv());
+    } catch (Exception e) {
+      LOGGER.error("Got exception to generate IngestionJobSpec for data ingestion job - ", e);
+      throw e;
+    }
+
+    List<PinotFSSpec> pinotFSSpecs = spec.getPinotFSSpecs();
+    for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
+      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
+    }
+
+    addDepsJarToDistributedCache(sparkLauncher, _pinotJarDir);
+    //TODO: Add rest of the args
+    sparkLauncher.addAppArgs("-jobSpecFile", _jobSpecFile);
+
+    sparkLauncher.setAppName("Pinot Spark Ingestion Job");
+    SparkAppHandle sparkAppHandle = sparkLauncher.startApplication(new SparkAppListener());
+    return true;
+  }
+
+  class SparkAppListener implements SparkAppHandle.Listener {
+    @Override
+    public void stateChanged(SparkAppHandle sparkAppHandle) {
+      LOGGER.info("Current app State: {} for appId: {}", sparkAppHandle.getState(), sparkAppHandle.getAppId());
+    }
+
+    @Override
+    public void infoChanged(SparkAppHandle sparkAppHandle) {
+      LOGGER.info("Current app info State: {} for appId: {}", sparkAppHandle.getState(), sparkAppHandle.getAppId());
+    }
+  }
+
+  private void addDepsJarToDistributedCache(SparkLauncher sparkLauncher, String depsJarDir)
+      throws IOException {
+    if (depsJarDir != null) {
+      URI depsJarDirURI = URI.create(depsJarDir);
+      if (depsJarDirURI.getScheme() == null) {
+        depsJarDirURI = new File(depsJarDir).toURI();
+      }
+      PinotFS pinotFS = PinotFSFactory.create(depsJarDirURI.getScheme());
+      String[] files = pinotFS.listFiles(depsJarDirURI, true);
+      List<String> jarFiles = new ArrayList<>();
+      for (String file : files) {
+        if (!pinotFS.isDirectory(URI.create(file))) {
+          if (file.endsWith(".jar")) {
+            LOGGER.info("Adding deps jar: {} to distributed cache", file);
+            if(_pluginsToLoad.isEmpty()) {
+              sparkLauncher.addJar(file);
+              Path path = Paths.get(URI.create(file));
+              jarFiles.add(path.getFileName().toString());
+            } else {
+              Path path = Paths.get(URI.create(file));
+              String fileName = path.getFileName().toString();
+              String parentDir = path.getParent().getFileName().toString();
+              if(_pluginsToLoad.contains(parentDir)) {
+                sparkLauncher.addJar(file);
+                jarFiles.add(fileName);
+              }
+            }
+          }
+        }
+      }
+
+      String extraClassPaths = Joiner.on(":").join(jarFiles);
+      sparkLauncher.setConf("spark.driver.extraClassPath", extraClassPaths);
+      sparkLauncher.setConf("spark.executor.extraClassPath", extraClassPaths);
+    }
+  }
+
+  @Override
+  public String getName() {
+    return "LaunchDataIngestionJob";
+  }
+
+  @Override
+  public String toString() {
+    String results = "LaunchDataIngestionJob -jobSpecFile " + _jobSpecFile;
+    if (_propertyFile != null) {
+      results += " -propertyFile " + _propertyFile;
+    }
+    if (_values != null) {
+      results += " -values " + Arrays.toString(_values.toArray());
+    }
+    return results;
+  }
+
+
+  @Override
+  public String description() {
+    return "Launch a data ingestion job.";
+  }
+
+  public static void main(String[] args) {
+    PluginManager.get().init();
+    new CommandLine(new LaunchSparkDataIngestionJobCommand()).execute(args);
+  }
+}

--- a/pinot-tools/src/main/resources/appAssemblerScriptTemplate
+++ b/pinot-tools/src/main/resources/appAssemblerScriptTemplate
@@ -155,7 +155,6 @@ if [ -z "$PLUGINS_CLASSPATH" ] ; then
       fi
     fi
   done
-
   unset IFS
 fi
 

--- a/pinot-tools/src/main/resources/appAssemblerScriptTemplate
+++ b/pinot-tools/src/main/resources/appAssemblerScriptTemplate
@@ -123,16 +123,6 @@ if [ -z "$PLUGINS_CLASSPATH" ] ; then
     fi
   fi
 
-    if [ -z "$PLUGINS_EXTERNAL_DIR" ] ; then
-      PLUGINS_EXTERNAL_DIR="$BASEDIR"/plugins-external
-    else
-      if [[ "$PLUGINS_EXTERNAL_DIR" = *,* ]]
-      then
-          echo "\$PLUGINS_DIR should use ; as the delimiter"
-          exit 1
-      fi
-    fi
-
   export IFS=';'
   for DIR in $PLUGINS_DIR; do
     if [ -d "$DIR" ] ; then
@@ -165,37 +155,6 @@ if [ -z "$PLUGINS_CLASSPATH" ] ; then
       fi
     fi
   done
-  for DIR in $PLUGINS_EXTERNAL_DIR; do
-      if [ -d "$DIR" ] ; then
-        unset IFS
-        if [ -n "$PLUGINS_INCLUDE" ] ; then
-          if [[ "$PLUGINS_INCLUDE" = *,* ]]
-          then
-              echo "\$PLUGINS_INCLUDE should use ; as the delimiter"
-              exit 1
-          fi
-          export IFS=';'
-          for PLUGIN_JAR in $PLUGINS_INCLUDE; do
-              PLUGIN_JAR_PATH=$(find "$DIR" -path \*/"$PLUGIN_JAR"/"$PLUGIN_JAR"-\*.jar)
-              if [ -n "$PLUGINS_CLASSPATH" ] ; then
-                PLUGINS_CLASSPATH=$PLUGINS_CLASSPATH:$PLUGIN_JAR_PATH
-              else
-                PLUGINS_CLASSPATH=$PLUGIN_JAR_PATH
-              fi
-          done
-          unset IFS
-        else
-          PLUGIN_JARS=$(find "$DIR" -name \*.jar)
-          for PLUGIN_JAR in $PLUGIN_JARS ; do
-            if [ -n "$PLUGINS_CLASSPATH" ] ; then
-              PLUGINS_CLASSPATH=$PLUGINS_CLASSPATH:$PLUGIN_JAR
-            else
-              PLUGINS_CLASSPATH=$PLUGIN_JAR
-            fi
-          done
-        fi
-      fi
-    done
 
   unset IFS
 fi

--- a/pinot-tools/src/main/resources/appAssemblerScriptTemplate
+++ b/pinot-tools/src/main/resources/appAssemblerScriptTemplate
@@ -123,6 +123,16 @@ if [ -z "$PLUGINS_CLASSPATH" ] ; then
     fi
   fi
 
+    if [ -z "$PLUGINS_EXTERNAL_DIR" ] ; then
+      PLUGINS_EXTERNAL_DIR="$BASEDIR"/plugins-external
+    else
+      if [[ "$PLUGINS_EXTERNAL_DIR" = *,* ]]
+      then
+          echo "\$PLUGINS_DIR should use ; as the delimiter"
+          exit 1
+      fi
+    fi
+
   export IFS=';'
   for DIR in $PLUGINS_DIR; do
     if [ -d "$DIR" ] ; then
@@ -155,6 +165,38 @@ if [ -z "$PLUGINS_CLASSPATH" ] ; then
       fi
     fi
   done
+  for DIR in $PLUGINS_EXTERNAL_DIR; do
+      if [ -d "$DIR" ] ; then
+        unset IFS
+        if [ -n "$PLUGINS_INCLUDE" ] ; then
+          if [[ "$PLUGINS_INCLUDE" = *,* ]]
+          then
+              echo "\$PLUGINS_INCLUDE should use ; as the delimiter"
+              exit 1
+          fi
+          export IFS=';'
+          for PLUGIN_JAR in $PLUGINS_INCLUDE; do
+              PLUGIN_JAR_PATH=$(find "$DIR" -path \*/"$PLUGIN_JAR"/"$PLUGIN_JAR"-\*.jar)
+              if [ -n "$PLUGINS_CLASSPATH" ] ; then
+                PLUGINS_CLASSPATH=$PLUGINS_CLASSPATH:$PLUGIN_JAR_PATH
+              else
+                PLUGINS_CLASSPATH=$PLUGIN_JAR_PATH
+              fi
+          done
+          unset IFS
+        else
+          PLUGIN_JARS=$(find "$DIR" -name \*.jar)
+          for PLUGIN_JAR in $PLUGIN_JARS ; do
+            if [ -n "$PLUGINS_CLASSPATH" ] ; then
+              PLUGINS_CLASSPATH=$PLUGINS_CLASSPATH:$PLUGIN_JAR
+            else
+              PLUGINS_CLASSPATH=$PLUGIN_JAR
+            fi
+          done
+        fi
+      fi
+    done
+
   unset IFS
 fi
 


### PR DESCRIPTION
The users currently need to create the whole spark-submit command to run a spark job for batch ingestion. With so many plugins available inside pinot leads a lot of classpath errors and you also need to take care of various arguments based on the environment in which you are running. This new command in `pinot-admin` aims to simply this for the users.

### Example
Previously if you had to run

`
export PINOT_VERSION=0.11.0-SNAPSHOT
export PINOT_DISTRIBUTION_DIR=/Users/kharekartik/Documents/Developer/pinot/build/
spark-submit --class org.apache.pinot.tools.admin.command.LaunchDataIngestionJobCommand --master yarn --deploy-mode client --jars ${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar,${PINOT_DISTRIBUTION_DIR}/plugins/pinot-input-format/pinot-parquet/pinot-parquet-0.11.0-SNAPSHOT-shaded.jar,${PINOT_DISTRIBUTION_DIR}/plugins/pinot-file-system/pinot-s3/pinot-s3-0.11.0-SNAPSHOT-shaded.jar,${PINOT_DISTRIBUTION_DIR}/plugins-external/pinot-batch-ingestion/pinot-batch-ingestion-spark-3.2/pinot-batch-ingestion-spark-3.2-0.11.0-SNAPSHOT-shaded.jar local://${PINOT_DISTRIBUTION_DIR}/lib/pinot-all-0.11.0-SNAPSHOT-jar-with-dependencies.jar -jobSpecFile parquet_ingestion_spec_spark3_students.yml
`

but now you can now use

`
export SPARK_HOME=/usr/lib/spark/
bin/pinot-admin.sh LaunchSparkDataIngestionJob  -jobSpecFile parquet_ingestion_spec_spark3_students.yml  -pluginsToLoad pinot-parquet:pinot-s3 -master yarn
`


### Additional Options

- You can also mention any additional spark configurations using the `-sparkConf` option
 `-sparkConf spark.executor.cores=3:num-executors=4`
 
- Users can also specify jars directly from S3/GCS instead of local disk for environments like EMR
 `-pinotBaseDir s3://your-bucket/apache-pinot-0.11.0-SNAPSHOT`

- You can choose whether to run spark 2.x or 3.x with the following option (default is SPARK_3)
 `-sparkVersion SPARK_2`