### PR TITLE
Enable Consistent Data Push for Standalone Segment Push Job Runners

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -775,7 +775,7 @@ public class FileUploadDownloadClient implements AutoCloseable {
           tableTypeToFilter, excludeReplacedSegments);
       RequestBuilder requestBuilder = RequestBuilder.get(uri).setVersion(HttpVersion.HTTP_1_1);
       HttpClient.setTimeout(requestBuilder, HttpClient.DEFAULT_SOCKET_TIMEOUT_MS);
-      RetryPolicies.fixedDelayRetryPolicy(5, 10_000L).attempt(() -> {
+      RetryPolicies.exponentialBackoffRetryPolicy(5, 10_000L, 2.0).attempt(() -> {
         try {
           SimpleHttpResponse response =
               HttpClient.wrapAndThrowHttpException(_httpClient.sendRequest(requestBuilder.build()));

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -800,7 +800,7 @@ public class FileUploadDownloadClient implements AutoCloseable {
     return tableTypeToSegments;
   }
 
-  public List<String> getSegmentNamesFromResponse(String tableType, String responseString)
+  private List<String> getSegmentNamesFromResponse(String tableType, String responseString)
       throws IOException {
     List<String> segments = new ArrayList<>();
     JsonNode responseJsonNode = JsonUtils.stringToJsonNode(responseString);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -771,7 +771,7 @@ public class FileUploadDownloadClient implements AutoCloseable {
     Map<String, List<String>> tableTypeToSegments = new HashMap<>();
     for (String tableTypeToFilter : tableTypes) {
       tableTypeToSegments.put(tableTypeToFilter, new ArrayList<>());
-      String uri = controllerRequestURLBuilder.forSegmentListAPIWithTableTypeAndExcludeReplacedSegments(rawTableName,
+      String uri = controllerRequestURLBuilder.forSegmentListAPI(rawTableName,
           tableTypeToFilter, excludeReplacedSegments);
       RequestBuilder requestBuilder = RequestBuilder.get(uri).setVersion(HttpVersion.HTTP_1_1);
       HttpClient.setTimeout(requestBuilder, HttpClient.DEFAULT_SOCKET_TIMEOUT_MS);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -755,14 +755,14 @@ public class FileUploadDownloadClient implements AutoCloseable {
    * Returns a map from a given tableType to a list of segments for that given tableType (OFFLINE or REALTIME)
    * If tableType is left unspecified, both OFFLINE and REALTIME segments will be returned in the map.
    */
-  public Map<String, List<String>> getSegments(URI uri, String rawTableName, @Nullable String tableType,
+  public Map<String, List<String>> getSegments(URI uri, String rawTableName, @Nullable TableType tableType,
       boolean excludeReplacedSegments)
       throws URISyntaxException, IOException {
     List<String> tableTypes;
-    if (tableType == null || tableType.isEmpty()) {
+    if (tableType == null) {
       tableTypes = Arrays.asList(TableType.OFFLINE.toString(), TableType.REALTIME.toString());
     } else {
-      tableTypes = Arrays.asList(tableType);
+      tableTypes = Arrays.asList(tableType.toString());
     }
     ControllerRequestURLBuilder controllerRequestURLBuilder = ControllerRequestURLBuilder.baseUrl(uri.toString());
     Map<String, List<String>> tableTypeToSegments = new HashMap<>();
@@ -776,6 +776,8 @@ public class FileUploadDownloadClient implements AutoCloseable {
       try {
         response = HttpClient.wrapAndThrowHttpException(_httpClient.sendRequest(requestBuilder.build()));
       } catch (HttpErrorStatusException e) {
+        LOGGER.info("Caught HttpErrorStatusException while getting segments for table: {} with type: {}", rawTableName,
+            tableTypeToFilter, e);
         tableTypeToSegments.put(tableTypeToFilter, segments);
         continue;
       }

--- a/pinot-connectors/pinot-flink-connector/src/main/java/org/apache/pinot/connector/flink/sink/FlinkSegmentWriter.java
+++ b/pinot-connectors/pinot-flink-connector/src/main/java/org/apache/pinot/connector/flink/sink/FlinkSegmentWriter.java
@@ -219,7 +219,8 @@ public class FlinkSegmentWriter implements SegmentWriter {
       batchConfigMapOverride.put(BatchConfigProperties.OUTPUT_DIR_URI, segmentDir.getAbsolutePath());
       batchConfigMapOverride.put(BatchConfigProperties.INPUT_FORMAT, BUFFER_FILE_FORMAT.toString());
       BatchIngestionConfig batchIngestionConfig = new BatchIngestionConfig(Lists.newArrayList(batchConfigMapOverride),
-          _batchIngestionConfig.getSegmentIngestionType(), _batchIngestionConfig.getSegmentIngestionFrequency());
+          _batchIngestionConfig.getSegmentIngestionType(), _batchIngestionConfig.getSegmentIngestionFrequency(),
+          _batchIngestionConfig.getConsistentDataPush());
 
       // Build segment
       SegmentGeneratorConfig segmentGeneratorConfig =

--- a/pinot-connectors/pinot-flink-connector/src/test/java/org/apache/pinot/connector/flink/sink/PinotSinkIntegrationTest.java
+++ b/pinot-connectors/pinot-flink-connector/src/test/java/org/apache/pinot/connector/flink/sink/PinotSinkIntegrationTest.java
@@ -142,7 +142,7 @@ public class PinotSinkIntegrationTest extends BaseClusterIntegrationTest {
   private int getNumSegments()
       throws IOException {
     String jsonOutputStr = sendGetRequest(
-        _controllerRequestURLBuilder.forSegmentListAPIWithTableType(OFFLINE_TABLE_NAME, TableType.OFFLINE.toString()));
+        _controllerRequestURLBuilder.forSegmentListAPI(OFFLINE_TABLE_NAME, TableType.OFFLINE.toString()));
     JsonNode array = JsonUtils.stringToJsonNode(jsonOutputStr);
     return array.get(0).get("OFFLINE").size();
   }
@@ -150,7 +150,7 @@ public class PinotSinkIntegrationTest extends BaseClusterIntegrationTest {
   private int getTotalNumDocs()
       throws IOException {
     String jsonOutputStr = sendGetRequest(
-        _controllerRequestURLBuilder.forSegmentListAPIWithTableType(OFFLINE_TABLE_NAME, TableType.OFFLINE.toString()));
+        _controllerRequestURLBuilder.forSegmentListAPI(OFFLINE_TABLE_NAME, TableType.OFFLINE.toString()));
     JsonNode array = JsonUtils.stringToJsonNode(jsonOutputStr);
     JsonNode segments = array.get(0).get("OFFLINE");
     int totalDocCount = 0;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -140,7 +140,7 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
       throws Exception {
     {
       String jsonOutputStr = sendGetRequest(
-          _controllerRequestURLBuilder.forSegmentListAPIWithTableType(getTableName(), TableType.OFFLINE.toString()));
+          _controllerRequestURLBuilder.forSegmentListAPI(getTableName(), TableType.OFFLINE.toString()));
       JsonNode array = JsonUtils.stringToJsonNode(jsonOutputStr);
       // There should be one element in the array
       JsonNode element = array.get(0);
@@ -149,7 +149,7 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
     }
     {
       String jsonOutputStr = sendGetRequest(
-          _controllerRequestURLBuilder.forSegmentListAPIWithTableType(getTableName(), TableType.REALTIME.toString()));
+          _controllerRequestURLBuilder.forSegmentListAPI(getTableName(), TableType.REALTIME.toString()));
       JsonNode array = JsonUtils.stringToJsonNode(jsonOutputStr);
       // There should be one element in the array
       JsonNode element = array.get(0);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
@@ -27,9 +27,14 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.controller.helix.ControllerTest;
+import org.apache.pinot.plugin.ingestion.batch.common.BaseSegmentPushJobRunner;
 import org.apache.pinot.plugin.ingestion.batch.standalone.SegmentMetadataPushJobRunner;
+import org.apache.pinot.plugin.ingestion.batch.standalone.SegmentTarPushJobRunner;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.ingestion.batch.spec.PinotClusterSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
@@ -37,10 +42,13 @@ import org.apache.pinot.spi.ingestion.batch.spec.PushJobSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.TableSpec;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.ControllerRequestURLBuilder;
 import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 
@@ -81,10 +89,15 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     return null;
   }
 
+  @BeforeMethod
+  public void setUpTest()
+      throws IOException {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+  }
+
   @BeforeClass
   public void setUp()
       throws Exception {
-    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
     // Start Zk and Kafka
     startZk();
 
@@ -122,6 +135,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     jobSpec.setOutputDirURI(_tarDir.getAbsolutePath());
     TableSpec tableSpec = new TableSpec();
     tableSpec.setTableName(DEFAULT_TABLE_NAME);
+    tableSpec.setTableConfigURI(_controllerRequestURLBuilder.forUpdateTableConfig(DEFAULT_TABLE_NAME));
     jobSpec.setTableSpec(tableSpec);
     PinotClusterSpec clusterSpec = new PinotClusterSpec();
     clusterSpec.setControllerURI(_controllerBaseApiUrl);
@@ -188,6 +202,133 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     testCountStar(numDocs);
   }
 
+  /**
+   * Runs both SegmentMetadataPushJobRunner and SegmentTarPushJobRunner while enabling consistent data push.
+   * Checks that segments are properly loaded and segment lineage entry were also in expected states.
+   */
+  @Test
+  public void testUploadAndQueryWithConsistentPush()
+      throws Exception {
+    // Create and upload the schema and table config
+    Schema schema = createSchema();
+    addSchema(schema);
+    TableConfig offlineTableConfig = createOfflineTableConfigWithConsistentPush();
+    addTableConfig(offlineTableConfig);
+
+    List<File> avroFiles = getAllAvroFiles();
+
+    ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFiles.get(0), offlineTableConfig, schema, "_with_move",
+        _segmentDir, _tarDir);
+
+    // First test standalone metadata push job runner
+    BaseSegmentPushJobRunner runner = new SegmentMetadataPushJobRunner();
+    SegmentGenerationJobSpec jobSpec = new SegmentGenerationJobSpec();
+    PushJobSpec pushJobSpec = new PushJobSpec();
+    pushJobSpec.setCopyToDeepStoreForMetadataPush(true);
+    jobSpec.setPushJobSpec(pushJobSpec);
+    PinotFSSpec fsSpec = new PinotFSSpec();
+    fsSpec.setScheme("file");
+    fsSpec.setClassName("org.apache.pinot.spi.filesystem.LocalPinotFS");
+    jobSpec.setPinotFSSpecs(Lists.newArrayList(fsSpec));
+    jobSpec.setOutputDirURI(_tarDir.getAbsolutePath());
+    TableSpec tableSpec = new TableSpec();
+    tableSpec.setTableName(DEFAULT_TABLE_NAME);
+    tableSpec.setTableConfigURI(_controllerRequestURLBuilder.forUpdateTableConfig(DEFAULT_TABLE_NAME));
+    jobSpec.setTableSpec(tableSpec);
+    PinotClusterSpec clusterSpec = new PinotClusterSpec();
+    clusterSpec.setControllerURI(_controllerBaseApiUrl);
+    jobSpec.setPinotClusterSpecs(new PinotClusterSpec[]{clusterSpec});
+
+    File dataDir = new File(_controllerConfig.getDataDir());
+    File dataDirSegments = new File(dataDir, DEFAULT_TABLE_NAME);
+
+    Assert.assertEquals(_tarDir.listFiles().length, 1);
+
+    runner.init(jobSpec);
+    runner.run();
+
+    // Segment should be seen in dataDir
+    Assert.assertTrue(dataDirSegments.exists());
+    Assert.assertEquals(dataDirSegments.listFiles().length, 1);
+    Assert.assertEquals(_tarDir.listFiles().length, 1);
+
+    // test segment loaded
+    JsonNode segmentsList = getSegmentsList();
+    Assert.assertEquals(segmentsList.size(), 1);
+    String segmentNameWithMove = segmentsList.get(0).asText();
+    Assert.assertTrue(segmentNameWithMove.endsWith("_with_move"));
+    long numDocs = getNumDocs(segmentNameWithMove);
+    testCountStar(numDocs);
+
+    // Fetch segment lineage entry after running segment metadata push with consistent push enabled.
+    String segmentLineageResponse = ControllerTest.sendGetRequest(
+        ControllerRequestURLBuilder.baseUrl(_controllerBaseApiUrl)
+            .forListAllSegmentLineages(DEFAULT_TABLE_NAME, TableType.OFFLINE.toString()));
+    // Segment lineage should be in completed state.
+    Assert.assertTrue(segmentLineageResponse.contains("\"state\":\"COMPLETED\""));
+    // SegmentsFrom should be empty as we started with a blank table.
+    Assert.assertTrue(segmentLineageResponse.contains("\"segmentsFrom\":[]"));
+    // SegmentsTo should contain uploaded segment.
+    Assert.assertTrue(segmentLineageResponse.contains("\"segmentsTo\":[\"" + segmentNameWithMove + "\"]"));
+
+    // Clear segment and tar dir
+    for (File segment : _segmentDir.listFiles()) {
+      FileUtils.deleteQuietly(segment);
+    }
+    for (File tar : _tarDir.listFiles()) {
+      FileUtils.deleteQuietly(tar);
+    }
+
+    ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFiles.get(1), offlineTableConfig, schema, "_without_move",
+        _segmentDir, _tarDir);
+    jobSpec.setPushJobSpec(new PushJobSpec());
+
+    // Now test standalone tar push job runner
+    runner = new SegmentTarPushJobRunner();
+
+    Assert.assertEquals(dataDirSegments.listFiles().length, 1);
+    Assert.assertEquals(_tarDir.listFiles().length, 1);
+
+    runner.init(jobSpec);
+    runner.run();
+
+    // should not see new segments in dataDir
+    //Assert.assertEquals(dataDirSegments.listFiles().length, 1);
+    Assert.assertEquals(_tarDir.listFiles().length, 1);
+
+    // test segment loaded
+    segmentsList = getSegmentsList();
+    Assert.assertEquals(segmentsList.size(), 2);
+    String segmentNameWithoutMove = null;
+    for (JsonNode segment : segmentsList) {
+      if (segment.asText().endsWith("_without_move")) {
+        segmentNameWithoutMove = segment.asText();
+      }
+    }
+    Assert.assertNotNull(segmentNameWithoutMove);
+    numDocs = getNumDocs(segmentNameWithoutMove);
+    testCountStar(numDocs);
+
+    // Fetch segment lineage entry after running segment tar push with consistent push enabled.
+    segmentLineageResponse = ControllerTest.sendGetRequest(
+        ControllerRequestURLBuilder.baseUrl(_controllerBaseApiUrl)
+            .forListAllSegmentLineages(DEFAULT_TABLE_NAME, TableType.OFFLINE.toString()));
+    // Segment lineage should be in completed state.
+    Assert.assertTrue(segmentLineageResponse.contains("\"state\":\"COMPLETED\""));
+    // SegmentsFrom should contain the previous segment
+    Assert.assertTrue(segmentLineageResponse.contains("\"segmentsFrom\":[\"" + segmentNameWithMove + "\"]"));
+    // SegmentsTo should contain uploaded segment.
+    Assert.assertTrue(segmentLineageResponse.contains("\"segmentsTo\":[\"" + segmentNameWithoutMove + "\"]"));
+  }
+
+  protected TableConfig createOfflineTableConfigWithConsistentPush() {
+    TableConfig offlineTableConfig = createOfflineTableConfig();
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setBatchIngestionConfig(new BatchIngestionConfig(null, "REFRESH", "DAILY", true));
+    offlineTableConfig.setIngestionConfig(ingestionConfig);
+    return offlineTableConfig;
+  }
+
   private long getNumDocs(String segmentName)
       throws IOException {
     return JsonUtils.stringToJsonNode(
@@ -217,10 +358,15 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     }, 100L, 300_000, "Failed to load " + countStarResult + " documents", true);
   }
 
+  @AfterMethod
+  public void tearDownTest()
+      throws IOException {
+    dropOfflineTable(getTableName());
+  }
+
   @AfterClass
   public void tearDown()
       throws Exception {
-    dropOfflineTable(getTableName());
     stopServer();
     stopBroker();
     stopController();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
@@ -341,8 +341,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
   private JsonNode getSegmentsList()
       throws IOException {
     return JsonUtils.stringToJsonNode(sendGetRequest(
-            _controllerRequestURLBuilder.forSegmentListAPIWithTableType(DEFAULT_TABLE_NAME,
-                TableType.OFFLINE.toString())))
+            _controllerRequestURLBuilder.forSegmentListAPI(DEFAULT_TABLE_NAME, TableType.OFFLINE.toString())))
         .get(0).get("OFFLINE");
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentWriterUploaderIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentWriterUploaderIntegrationTest.java
@@ -155,7 +155,7 @@ public class SegmentWriterUploaderIntegrationTest extends BaseClusterIntegration
   private int getNumSegments()
       throws IOException {
     String jsonOutputStr = sendGetRequest(_controllerRequestURLBuilder.
-        forSegmentListAPIWithTableType(_tableNameWithType, TableType.OFFLINE.toString()));
+        forSegmentListAPI(_tableNameWithType, TableType.OFFLINE.toString()));
     JsonNode array = JsonUtils.stringToJsonNode(jsonOutputStr);
     return array.get(0).get("OFFLINE").size();
   }
@@ -169,7 +169,7 @@ public class SegmentWriterUploaderIntegrationTest extends BaseClusterIntegration
   private int getNumDocsInLatestSegment()
       throws IOException {
     String jsonOutputStr = sendGetRequest(_controllerRequestURLBuilder.
-        forSegmentListAPIWithTableType(_tableNameWithType, TableType.OFFLINE.toString()));
+        forSegmentListAPI(_tableNameWithType, TableType.OFFLINE.toString()));
     JsonNode array = JsonUtils.stringToJsonNode(jsonOutputStr);
     JsonNode segments = array.get(0).get("OFFLINE");
     String segmentName = segments.get(segments.size() - 1).asText();

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/BaseSegmentPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/BaseSegmentPushJobRunner.java
@@ -1,0 +1,142 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.ingestion.batch.common;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.segment.local.utils.ConsistentDataPushUtils;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner;
+import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
+
+public abstract class BaseSegmentPushJobRunner implements IngestionJobRunner {
+
+  protected SegmentGenerationJobSpec _spec;
+  protected String[] _files;
+  protected PinotFS _outputDirFS;
+  protected URI _outputDirURI;
+  protected List<String> _segmentsToPush = new ArrayList<>();
+  protected Map<String, String> _segmentUriToTarPathMap;
+  protected boolean _consistentPushEnabled;
+
+  /**
+   * Initialize BaseSegmentPushJobRunner with SegmentGenerationJobSpec
+   * Checks for required parameters in the spec and enablement of consistent data push.
+   */
+  @Override
+  public void init(SegmentGenerationJobSpec spec) {
+    _spec = spec;
+    if (_spec.getPushJobSpec() == null) {
+      throw new RuntimeException("Missing PushJobSpec");
+    }
+
+    // Read Table spec
+    if (_spec.getTableSpec() == null) {
+      throw new RuntimeException("Missing tableSpec");
+    }
+
+    // Read Table config
+    if (_spec.getTableSpec().getTableConfigURI() == null) {
+      throw new RuntimeException("Missing property 'tableConfigURI' in 'tableSpec'");
+    }
+
+    _consistentPushEnabled = ConsistentDataPushUtils.consistentDataPushEnabled(_spec);
+  }
+
+  /**
+   * Initialize filesystems and obtain the raw input files for upload.
+   */
+  public void initFileSys() {
+    // init all file systems
+    List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
+    for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
+      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
+    }
+
+    // Get outputFS for writing output Pinot segments
+    try {
+      _outputDirURI = new URI(_spec.getOutputDirURI());
+      if (_outputDirURI.getScheme() == null) {
+        _outputDirURI = new File(_spec.getOutputDirURI()).toURI();
+      }
+    } catch (URISyntaxException e) {
+      throw new RuntimeException("outputDirURI is not valid - '" + _spec.getOutputDirURI() + "'");
+    }
+    _outputDirFS = PinotFSFactory.create(_outputDirURI.getScheme());
+
+    // Get list of files to process
+    try {
+      _files = _outputDirFS.listFiles(_outputDirURI, true);
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to list all files under outputDirURI - '" + _outputDirURI + "'");
+    }
+  }
+
+  /**
+   * Populates either _segmentsToPush or _segmentUriToTarPathMap based on push type.
+   */
+  public abstract void getSegmentsToPush();
+
+  /**
+   * Returns segmentsTo based on segments obtained from getSegmentsToPush.
+   * The result will to be supplied to the segment replacement protocol when consistent data push is enabled.
+   */
+  public abstract List<String> getSegmentsTo();
+
+  /**
+   * Upload segment obtained by getSegmentsToPush.
+   */
+  public abstract void uploadSegments()
+      throws Exception;
+
+  /**
+   * Runs the main logic of the segment push job runner.
+   * First initialize the filesystem, then upload the segments, while optionally configured to be wrapped around by
+   * the consistent data push protocol.
+   */
+  @Override
+  public void run() {
+    initFileSys();
+    Map<URI, String> uriToLineageEntryIdMap = null;
+    try {
+      getSegmentsToPush();
+      if (_consistentPushEnabled) {
+        List<String> segmentsTo = getSegmentsTo();
+        uriToLineageEntryIdMap = ConsistentDataPushUtils.preUpload(_spec, segmentsTo);
+      }
+      uploadSegments();
+      if (_consistentPushEnabled) {
+        ConsistentDataPushUtils.postUpload(_spec, uriToLineageEntryIdMap);
+      }
+    } catch (Exception e) {
+      if (_consistentPushEnabled) {
+        ConsistentDataPushUtils.handleUploadException(_spec, uriToLineageEntryIdMap, e);
+      }
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/BaseSegmentPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/BaseSegmentPushJobRunner.java
@@ -66,7 +66,6 @@ public abstract class BaseSegmentPushJobRunner implements IngestionJobRunner {
     }
 
     _tableConfig = SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), spec.getAuthToken());
-
     _consistentPushEnabled = ConsistentDataPushUtils.consistentDataPushEnabled(_tableConfig);
   }
 
@@ -105,7 +104,9 @@ public abstract class BaseSegmentPushJobRunner implements IngestionJobRunner {
    * @param segmentsUriToTarPathMap Map from segment URI to corresponding tar path. Either the URIs (keys), the
    *                                tarPaths (values), or both may be used depending on upload mode.
    */
-  public abstract List<String> getSegmentsToReplace(Map<String, String> segmentsUriToTarPathMap);
+  public List<String> getSegmentsToReplace(Map<String, String> segmentsUriToTarPathMap) {
+    return SegmentPushUtils.getSegmentNames(segmentsUriToTarPathMap.values());
+  }
 
   /**
    * Upload segments supplied in segmentsUriToTarPathMap.

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
@@ -39,6 +39,7 @@ import org.apache.pinot.common.segment.generation.SegmentGenerationUtils;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationJobUtils;
 import org.apache.pinot.plugin.ingestion.batch.common.SegmentGenerationTaskRunner;
+import org.apache.pinot.segment.local.utils.ConsistentDataPushUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -172,6 +173,8 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
     // Get list of files to process.
     List<String> filteredFiles = SegmentGenerationUtils.listMatchedFilesWithRecursiveOption(_inputDirFS, _inputDirURI,
         _spec.getIncludeFileNamePattern(), _spec.getExcludeFileNamePattern(), _spec.isSearchRecursively());
+
+    ConsistentDataPushUtils.configureSegmentPostfix(_spec);
 
     File localTempDir = new File(FileUtils.getTempDirectory(), "pinot-" + UUID.randomUUID());
     try {

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentMetadataPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentMetadataPushJobRunner.java
@@ -19,10 +19,12 @@
 package org.apache.pinot.plugin.ingestion.batch.standalone;
 
 import java.util.List;
+import java.util.Map;
 import org.apache.pinot.plugin.ingestion.batch.common.BaseSegmentPushJobRunner;
-import org.apache.pinot.segment.local.utils.ConsistentDataPushUtils;
 import org.apache.pinot.segment.local.utils.SegmentPushUtils;
+import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
+
 
 public class SegmentMetadataPushJobRunner extends BaseSegmentPushJobRunner {
 
@@ -33,15 +35,13 @@ public class SegmentMetadataPushJobRunner extends BaseSegmentPushJobRunner {
     init(spec);
   }
 
-  public void getSegmentsToPush() {
-    _segmentUriToTarPathMap = SegmentPushUtils.getSegmentUriToTarPathMap(_outputDirURI, _spec.getPushJobSpec(), _files);
+  public List<String> getSegmentsToReplace(Map<String, String> segmentsUriToTarPathMap) {
+    return SegmentPushUtils.getSegmentNames(BatchConfigProperties.SegmentPushType.METADATA,
+        segmentsUriToTarPathMap);
   }
 
-  public List<String> getSegmentsTo() {
-    return ConsistentDataPushUtils.getMetadataSegmentsTo(_segmentUriToTarPathMap);
-  }
-
-  public void uploadSegments() throws Exception {
-    SegmentPushUtils.sendSegmentUriAndMetadata(_spec, _outputDirFS, _segmentUriToTarPathMap);
+  public void uploadSegments(Map<String, String> segmentsUriToTarPathMap)
+      throws Exception {
+    SegmentPushUtils.sendSegmentUriAndMetadata(_spec, _outputDirFS, segmentsUriToTarPathMap);
   }
 }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentMetadataPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentMetadataPushJobRunner.java
@@ -18,11 +18,9 @@
  */
 package org.apache.pinot.plugin.ingestion.batch.standalone;
 
-import java.util.List;
 import java.util.Map;
 import org.apache.pinot.plugin.ingestion.batch.common.BaseSegmentPushJobRunner;
 import org.apache.pinot.segment.local.utils.SegmentPushUtils;
-import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 
 
@@ -33,11 +31,6 @@ public class SegmentMetadataPushJobRunner extends BaseSegmentPushJobRunner {
 
   public SegmentMetadataPushJobRunner(SegmentGenerationJobSpec spec) {
     init(spec);
-  }
-
-  public List<String> getSegmentsToReplace(Map<String, String> segmentsUriToTarPathMap) {
-    return SegmentPushUtils.getSegmentNames(BatchConfigProperties.SegmentPushType.METADATA,
-        segmentsUriToTarPathMap);
   }
 
   public void uploadSegments(Map<String, String> segmentsUriToTarPathMap)

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentMetadataPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentMetadataPushJobRunner.java
@@ -18,24 +18,13 @@
  */
 package org.apache.pinot.plugin.ingestion.batch.standalone;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
 import java.util.List;
-import java.util.Map;
+import org.apache.pinot.plugin.ingestion.batch.common.BaseSegmentPushJobRunner;
+import org.apache.pinot.segment.local.utils.ConsistentDataPushUtils;
 import org.apache.pinot.segment.local.utils.SegmentPushUtils;
-import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.filesystem.PinotFS;
-import org.apache.pinot.spi.filesystem.PinotFSFactory;
-import org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner;
-import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 
-
-public class SegmentMetadataPushJobRunner implements IngestionJobRunner {
-
-  private SegmentGenerationJobSpec _spec;
+public class SegmentMetadataPushJobRunner extends BaseSegmentPushJobRunner {
 
   public SegmentMetadataPushJobRunner() {
   }
@@ -44,47 +33,15 @@ public class SegmentMetadataPushJobRunner implements IngestionJobRunner {
     init(spec);
   }
 
-  @Override
-  public void init(SegmentGenerationJobSpec spec) {
-    _spec = spec;
-    if (_spec.getPushJobSpec() == null) {
-      throw new RuntimeException("Missing PushJobSpec");
-    }
+  public void getSegmentsToPush() {
+    _segmentUriToTarPathMap = SegmentPushUtils.getSegmentUriToTarPathMap(_outputDirURI, _spec.getPushJobSpec(), _files);
   }
 
-  @Override
-  public void run() {
-    //init all file systems
-    List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
-    for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
-      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
-    }
+  public List<String> getSegmentsTo() {
+    return ConsistentDataPushUtils.getMetadataSegmentsTo(_segmentUriToTarPathMap);
+  }
 
-    //Get outputFS for list of available Pinot segments
-    URI outputDirURI;
-    try {
-      outputDirURI = new URI(_spec.getOutputDirURI());
-      if (outputDirURI.getScheme() == null) {
-        outputDirURI = new File(_spec.getOutputDirURI()).toURI();
-      }
-    } catch (URISyntaxException e) {
-      throw new RuntimeException("outputDirURI is not valid - '" + _spec.getOutputDirURI() + "'");
-    }
-    PinotFS outputDirFS = PinotFSFactory.create(outputDirURI.getScheme());
-
-    //Get list of files to process
-    String[] files;
-    try {
-      files = outputDirFS.listFiles(outputDirURI, true);
-    } catch (IOException e) {
-      throw new RuntimeException("Unable to list all files under outputDirURI - '" + outputDirURI + "'");
-    }
-    Map<String, String> segmentUriToTarPathMap =
-        SegmentPushUtils.getSegmentUriToTarPathMap(outputDirURI, _spec.getPushJobSpec(), files);
-    try {
-      SegmentPushUtils.sendSegmentUriAndMetadata(_spec, outputDirFS, segmentUriToTarPathMap);
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+  public void uploadSegments() throws Exception {
+    SegmentPushUtils.sendSegmentUriAndMetadata(_spec, _outputDirFS, _segmentUriToTarPathMap);
   }
 }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentTarPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentTarPushJobRunner.java
@@ -19,11 +19,9 @@
 package org.apache.pinot.plugin.ingestion.batch.standalone;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import org.apache.pinot.plugin.ingestion.batch.common.BaseSegmentPushJobRunner;
 import org.apache.pinot.segment.local.utils.SegmentPushUtils;
-import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.utils.retry.AttemptsExceededException;
 import org.apache.pinot.spi.utils.retry.RetriableOperationException;
@@ -35,10 +33,6 @@ public class SegmentTarPushJobRunner extends BaseSegmentPushJobRunner {
 
   public SegmentTarPushJobRunner(SegmentGenerationJobSpec spec) {
     init(spec);
-  }
-
-  public List<String> getSegmentsToReplace(Map<String, String> segmentsUriToTarPathMap) {
-    return SegmentPushUtils.getSegmentNames(BatchConfigProperties.SegmentPushType.TAR, segmentsUriToTarPathMap);
   }
 
   public void uploadSegments(Map<String, String> segmentsUriToTarPathMap)

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentTarPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentTarPushJobRunner.java
@@ -18,26 +18,16 @@
  */
 package org.apache.pinot.plugin.ingestion.batch.standalone;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.List;
+import org.apache.pinot.plugin.ingestion.batch.common.BaseSegmentPushJobRunner;
+import org.apache.pinot.segment.local.utils.ConsistentDataPushUtils;
 import org.apache.pinot.segment.local.utils.SegmentPushUtils;
-import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.filesystem.PinotFS;
-import org.apache.pinot.spi.filesystem.PinotFSFactory;
-import org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner;
 import org.apache.pinot.spi.ingestion.batch.spec.Constants;
-import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.utils.retry.AttemptsExceededException;
 import org.apache.pinot.spi.utils.retry.RetriableOperationException;
 
-
-public class SegmentTarPushJobRunner implements IngestionJobRunner {
-  private SegmentGenerationJobSpec _spec;
+public class SegmentTarPushJobRunner extends BaseSegmentPushJobRunner {
 
   public SegmentTarPushJobRunner() {
   }
@@ -46,48 +36,20 @@ public class SegmentTarPushJobRunner implements IngestionJobRunner {
     init(spec);
   }
 
-  @Override
-  public void init(SegmentGenerationJobSpec spec) {
-    _spec = spec;
+  public void getSegmentsToPush() {
+    for (String file : _files) {
+      if (file.endsWith(Constants.TAR_GZ_FILE_EXT)) {
+        _segmentsToPush.add(file);
+      }
+    }
   }
 
-  @Override
-  public void run() {
-    //init all file systems
-    List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
-    for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
-      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
-    }
+  public List<String> getSegmentsTo() {
+    return ConsistentDataPushUtils.getTarSegmentsTo(_segmentsToPush);
+  }
 
-    //Get outputFS for writing output pinot segments
-    URI outputDirURI;
-    try {
-      outputDirURI = new URI(_spec.getOutputDirURI());
-      if (outputDirURI.getScheme() == null) {
-        outputDirURI = new File(_spec.getOutputDirURI()).toURI();
-      }
-    } catch (URISyntaxException e) {
-      throw new RuntimeException("outputDirURI is not valid - '" + _spec.getOutputDirURI() + "'");
-    }
-    PinotFS outputDirFS = PinotFSFactory.create(outputDirURI.getScheme());
-    //Get list of files to process
-    String[] files;
-    try {
-      files = outputDirFS.listFiles(outputDirURI, true);
-    } catch (IOException e) {
-      throw new RuntimeException("Unable to list all files under outputDirURI - '" + outputDirURI + "'");
-    }
-
-    List<String> segmentsToPush = new ArrayList<>();
-    for (String file : files) {
-      if (file.endsWith(Constants.TAR_GZ_FILE_EXT)) {
-        segmentsToPush.add(file);
-      }
-    }
-    try {
-      SegmentPushUtils.pushSegments(_spec, outputDirFS, segmentsToPush);
-    } catch (RetriableOperationException | AttemptsExceededException e) {
-      throw new RuntimeException(e);
-    }
+  public void uploadSegments()
+      throws AttemptsExceededException, RetriableOperationException {
+    SegmentPushUtils.pushSegments(_spec, _outputDirFS, _segmentsToPush);
   }
 }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentTarPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentTarPushJobRunner.java
@@ -18,11 +18,12 @@
  */
 package org.apache.pinot.plugin.ingestion.batch.standalone;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.apache.pinot.plugin.ingestion.batch.common.BaseSegmentPushJobRunner;
-import org.apache.pinot.segment.local.utils.ConsistentDataPushUtils;
 import org.apache.pinot.segment.local.utils.SegmentPushUtils;
-import org.apache.pinot.spi.ingestion.batch.spec.Constants;
+import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.utils.retry.AttemptsExceededException;
 import org.apache.pinot.spi.utils.retry.RetriableOperationException;
@@ -36,20 +37,12 @@ public class SegmentTarPushJobRunner extends BaseSegmentPushJobRunner {
     init(spec);
   }
 
-  public void getSegmentsToPush() {
-    for (String file : _files) {
-      if (file.endsWith(Constants.TAR_GZ_FILE_EXT)) {
-        _segmentsToPush.add(file);
-      }
-    }
+  public List<String> getSegmentsToReplace(Map<String, String> segmentsUriToTarPathMap) {
+    return SegmentPushUtils.getSegmentNames(BatchConfigProperties.SegmentPushType.TAR, segmentsUriToTarPathMap);
   }
 
-  public List<String> getSegmentsTo() {
-    return ConsistentDataPushUtils.getTarSegmentsTo(_segmentsToPush);
-  }
-
-  public void uploadSegments()
+  public void uploadSegments(Map<String, String> segmentsUriToTarPathMap)
       throws AttemptsExceededException, RetriableOperationException {
-    SegmentPushUtils.pushSegments(_spec, _outputDirFS, _segmentsToPush);
+    SegmentPushUtils.pushSegments(_spec, _outputDirFS, new ArrayList<>(segmentsUriToTarPathMap.values()));
   }
 }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentUriPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentUriPushJobRunner.java
@@ -18,27 +18,18 @@
  */
 package org.apache.pinot.plugin.ingestion.batch.standalone;
 
-import java.io.File;
-import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.List;
+import org.apache.pinot.plugin.ingestion.batch.common.BaseSegmentPushJobRunner;
+import org.apache.pinot.segment.local.utils.ConsistentDataPushUtils;
 import org.apache.pinot.segment.local.utils.SegmentPushUtils;
-import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.filesystem.PinotFS;
-import org.apache.pinot.spi.filesystem.PinotFSFactory;
-import org.apache.pinot.spi.ingestion.batch.runner.IngestionJobRunner;
 import org.apache.pinot.spi.ingestion.batch.spec.Constants;
-import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.utils.retry.AttemptsExceededException;
 import org.apache.pinot.spi.utils.retry.RetriableOperationException;
 
 
-public class SegmentUriPushJobRunner implements IngestionJobRunner {
-
-  private SegmentGenerationJobSpec _spec;
+public class SegmentUriPushJobRunner extends BaseSegmentPushJobRunner {
 
   public SegmentUriPushJobRunner() {
   }
@@ -47,55 +38,24 @@ public class SegmentUriPushJobRunner implements IngestionJobRunner {
     init(spec);
   }
 
-  @Override
-  public void init(SegmentGenerationJobSpec spec) {
-    _spec = spec;
-    if (_spec.getPushJobSpec() == null) {
-      throw new RuntimeException("Missing PushJobSpec");
-    }
-  }
-
-  @Override
-  public void run() {
-    //init all file systems
-    List<PinotFSSpec> pinotFSSpecs = _spec.getPinotFSSpecs();
-    for (PinotFSSpec pinotFSSpec : pinotFSSpecs) {
-      PinotFSFactory.register(pinotFSSpec.getScheme(), pinotFSSpec.getClassName(), new PinotConfiguration(pinotFSSpec));
-    }
-
-    //Get outputFS for writing output Pinot segments
-    URI outputDirURI;
-    try {
-      outputDirURI = new URI(_spec.getOutputDirURI());
-      if (outputDirURI.getScheme() == null) {
-        outputDirURI = new File(_spec.getOutputDirURI()).toURI();
-      }
-    } catch (URISyntaxException e) {
-      throw new RuntimeException("outputDirURI is not valid - '" + _spec.getOutputDirURI() + "'");
-    }
-    PinotFS outputDirFS = PinotFSFactory.create(outputDirURI.getScheme());
-
-    //Get list of files to process
-    String[] files;
-    try {
-      files = outputDirFS.listFiles(outputDirURI, true);
-    } catch (IOException e) {
-      throw new RuntimeException("Unable to list all files under outputDirURI - '" + outputDirURI + "'");
-    }
-    List<String> segmentUris = new ArrayList<>();
-    for (String file : files) {
+  public void getSegmentsToPush() {
+    for (String file : _files) {
       URI uri = URI.create(file);
       if (uri.getPath().endsWith(Constants.TAR_GZ_FILE_EXT)) {
         URI updatedURI = SegmentPushUtils
-            .generateSegmentTarURI(outputDirURI, uri, _spec.getPushJobSpec().getSegmentUriPrefix(),
+            .generateSegmentTarURI(_outputDirURI, uri, _spec.getPushJobSpec().getSegmentUriPrefix(),
                 _spec.getPushJobSpec().getSegmentUriSuffix());
-        segmentUris.add(updatedURI.toString());
+        _segmentsToPush.add(updatedURI.toString());
       }
     }
-    try {
-      SegmentPushUtils.sendSegmentUris(_spec, segmentUris);
-    } catch (RetriableOperationException | AttemptsExceededException e) {
-      throw new RuntimeException(e);
-    }
+  }
+
+  public List<String> getSegmentsTo() {
+    return ConsistentDataPushUtils.getUriSegmentsTo(_segmentsToPush);
+  }
+
+  public void uploadSegments()
+      throws AttemptsExceededException, RetriableOperationException {
+    SegmentPushUtils.sendSegmentUris(_spec, _segmentsToPush);
   }
 }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentUriPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentUriPushJobRunner.java
@@ -19,11 +19,9 @@
 package org.apache.pinot.plugin.ingestion.batch.standalone;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 import org.apache.pinot.plugin.ingestion.batch.common.BaseSegmentPushJobRunner;
 import org.apache.pinot.segment.local.utils.SegmentPushUtils;
-import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.utils.retry.AttemptsExceededException;
 import org.apache.pinot.spi.utils.retry.RetriableOperationException;
@@ -36,10 +34,6 @@ public class SegmentUriPushJobRunner extends BaseSegmentPushJobRunner {
 
   public SegmentUriPushJobRunner(SegmentGenerationJobSpec spec) {
     init(spec);
-  }
-
-  public List<String> getSegmentsToReplace(Map<String, String> segmentsUriToTarPathMap) {
-    return SegmentPushUtils.getSegmentNames(BatchConfigProperties.SegmentPushType.URI, segmentsUriToTarPathMap);
   }
 
   public void uploadSegments(Map<String, String> segmentsUriToTarPathMap)

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/test/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunnerTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/test/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunnerTest.java
@@ -31,6 +31,8 @@ import org.apache.pinot.plugin.inputformat.csv.CSVRecordReader;
 import org.apache.pinot.plugin.inputformat.csv.CSVRecordReaderConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.Schema.SchemaBuilder;
@@ -101,6 +103,35 @@ public class SegmentGenerationJobRunnerTest {
     Assert.assertTrue(newSegmentFile.length() > 0);
 
     // FUTURE - validate contents of file?
+  }
+
+  /**
+   * Enabling consistent data push should generate segment names with timestamps in order to differentiate between
+   * the non-unique raw segment names.
+   */
+  @Test
+  public void testSegmentGenerationWithConsistentPush()
+      throws Exception {
+    File testDir = makeTestDir();
+    File inputDir = new File(testDir, "input");
+    inputDir.mkdirs();
+    File inputFile = new File(inputDir, "input.csv");
+    FileUtils.writeLines(inputFile, Lists.newArrayList("col1,col2", "value1,1", "value2,2"));
+
+    // Create an output directory
+    File outputDir = new File(testDir, "output");
+
+    final String schemaName = "mySchema";
+    File schemaFile = makeSchemaFile(testDir, schemaName);
+    File tableConfigFile = makeTableConfigFileWithConsistentPush(testDir, schemaName);
+    SegmentGenerationJobSpec jobSpec = makeJobSpec(inputDir, outputDir, schemaFile, tableConfigFile);
+    jobSpec.setOverwriteOutput(false);
+    SegmentGenerationJobRunner jobRunner = new SegmentGenerationJobRunner(jobSpec);
+    jobRunner.run();
+
+    // There should be a tar file generated with timestamp (13 digits)
+    String[] list = outputDir.list((dir, name) -> name.matches("myTable_OFFLINE_\\d{13}_0.tar.gz"));
+    assertEquals(list.length, 1);
   }
 
   @Test
@@ -218,10 +249,23 @@ public class SegmentGenerationJobRunnerTest {
   private File makeTableConfigFile(File testDir, String schemaName) throws IOException {
     File tableConfigFile = new File(testDir, "tableConfig");
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
-      .setTableName("myTable")
-      .setSchemaName(schemaName)
-      .setNumReplicas(1)
-      .build();
+        .setTableName("myTable")
+        .setSchemaName(schemaName)
+        .setNumReplicas(1)
+        .build();
+    FileUtils.write(tableConfigFile, tableConfig.toJsonString(), StandardCharsets.UTF_8);
+    return tableConfigFile;
+  }
+
+  private File makeTableConfigFileWithConsistentPush(File testDir, String schemaName) throws IOException {
+    File tableConfigFile = new File(testDir, "tableConfig");
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setBatchIngestionConfig(new BatchIngestionConfig(null, "REFRESH", "DAILY", true));
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("myTable").setSchemaName(schemaName)
+        .setNumReplicas(1)
+        .setIngestionConfig(ingestionConfig)
+        .build();
     FileUtils.write(tableConfigFile, tableConfig.toJsonString(), StandardCharsets.UTF_8);
     return tableConfigFile;
   }

--- a/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/src/main/java/org/apache/pinot/plugin/segmentwriter/filebased/FileBasedSegmentWriter.java
+++ b/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/src/main/java/org/apache/pinot/plugin/segmentwriter/filebased/FileBasedSegmentWriter.java
@@ -184,7 +184,8 @@ public class FileBasedSegmentWriter implements SegmentWriter {
       batchConfigMapOverride.put(BatchConfigProperties.OUTPUT_DIR_URI, segmentDir.getAbsolutePath());
       batchConfigMapOverride.put(BatchConfigProperties.INPUT_FORMAT, BUFFER_FILE_FORMAT.toString());
       BatchIngestionConfig batchIngestionConfig = new BatchIngestionConfig(Lists.newArrayList(batchConfigMapOverride),
-          _batchIngestionConfig.getSegmentIngestionType(), _batchIngestionConfig.getSegmentIngestionFrequency());
+          _batchIngestionConfig.getSegmentIngestionType(), _batchIngestionConfig.getSegmentIngestionFrequency(),
+          _batchIngestionConfig.getConsistentDataPush());
 
       // Build segment
       SegmentGeneratorConfig segmentGeneratorConfig =

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/ConsistentDataPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/ConsistentDataPushUtils.java
@@ -1,0 +1,334 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.utils;
+
+import com.google.common.base.Preconditions;
+import java.io.File;
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.core.Response;
+import org.apache.pinot.common.auth.AuthProviderUtils;
+import org.apache.pinot.common.exception.HttpErrorStatusException;
+import org.apache.pinot.common.restlet.resources.StartReplaceSegmentsRequest;
+import org.apache.pinot.common.segment.generation.SegmentGenerationUtils;
+import org.apache.pinot.common.utils.FileUploadDownloadClient;
+import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.apache.pinot.common.utils.http.HttpClient;
+import org.apache.pinot.spi.auth.AuthProvider;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.ingestion.batch.spec.Constants;
+import org.apache.pinot.spi.ingestion.batch.spec.PinotClusterSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
+import org.apache.pinot.spi.ingestion.batch.spec.SegmentNameGeneratorSpec;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.retry.RetryPolicies;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class ConsistentDataPushUtils {
+  private ConsistentDataPushUtils() {
+  }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentPushUtils.class);
+  private static final FileUploadDownloadClient FILE_UPLOAD_DOWNLOAD_CLIENT = new FileUploadDownloadClient();
+  public static final String SEGMENT_NAME_POSTFIX = "segment.name.postfix";
+
+  /**
+   * Checks for enablement of consistent data push. If enabled, fetch the list of segments to be replaced, then
+   * invoke startReplaceSegments API and returns a map of controller URI to lineage entry IDs.
+   * If not, returns an empty hashmap.
+   */
+  public static Map<URI, String> preUpload(SegmentGenerationJobSpec spec, List<String> segmentsTo)
+      throws Exception {
+    String rawTableName = spec.getTableSpec().getTableName();
+    boolean consistentDataPushEnabled = consistentDataPushEnabled(spec);
+    LOGGER.info("Consistent data push is: {}", consistentDataPushEnabled ? "enabled" : "disabled");
+    Map<URI, String> uriToLineageEntryIdMap = null;
+    if (consistentDataPushEnabled) {
+      LOGGER.info("Start consistent push for table: " + rawTableName);
+      Map<URI, List<String>> uriToExistingOfflineSegments = getSegmentsToReplace(spec, rawTableName);
+      LOGGER.info("Existing segments for table {}: " + uriToExistingOfflineSegments, rawTableName);
+      LOGGER.info("New segments for table: {}: " + segmentsTo, rawTableName);
+      uriToLineageEntryIdMap = startReplaceSegments(spec, uriToExistingOfflineSegments, segmentsTo);
+    }
+    return uriToLineageEntryIdMap;
+  }
+
+  /**
+   * uriToLineageEntryIdMap is non-empty if and only if consistent data push is enabled.
+   * If uriToLineageEntryIdMap is non-empty, end the consistent data push protocol for each controller.
+   */
+  public static void postUpload(SegmentGenerationJobSpec spec, Map<URI, String> uriToLineageEntryIdMap) {
+    String rawTableName = spec.getTableSpec().getTableName();
+    if (uriToLineageEntryIdMap != null && !uriToLineageEntryIdMap.isEmpty()) {
+      LOGGER.info("End consistent push for table: " + rawTableName);
+      endReplaceSegments(spec, uriToLineageEntryIdMap);
+    }
+  }
+
+  /**
+   * Builds a map of controller URI to startReplaceSegments URI for each Pinot cluster in the spec.
+   */
+  public static Map<URI, URI> getStartReplaceSegmentUris(SegmentGenerationJobSpec spec, String rawTableName) {
+    Map<URI, URI> baseUriToStartReplaceSegmentUriMap = new HashMap<>();
+    for (PinotClusterSpec pinotClusterSpec : spec.getPinotClusterSpecs()) {
+      URI controllerURI;
+      try {
+        controllerURI = new URI(pinotClusterSpec.getControllerURI());
+        baseUriToStartReplaceSegmentUriMap.put(controllerURI,
+            FileUploadDownloadClient.getStartReplaceSegmentsURI(controllerURI, rawTableName,
+                TableType.OFFLINE.toString(), true));
+      } catch (URISyntaxException e) {
+        throw new RuntimeException("Got invalid controller uri - '" + pinotClusterSpec.getControllerURI() + "'");
+      }
+    }
+    return baseUriToStartReplaceSegmentUriMap;
+  }
+
+  /**
+   * Starts consistent data push protocol for each Pinot cluster in the spec.
+   * Returns a map of controller URI to segment lineage entry ID.
+   */
+  public static Map<URI, String> startReplaceSegments(SegmentGenerationJobSpec spec,
+      Map<URI, List<String>> uriToSegmentsFrom, List<String> segmentsTo)
+      throws Exception {
+    Map<URI, String> uriToLineageEntryIdMap = new HashMap<>();
+    String rawTableName = spec.getTableSpec().getTableName();
+    Map<URI, URI> segmentsUris = getStartReplaceSegmentUris(spec, rawTableName);
+    AuthProvider authProvider = AuthProviderUtils.makeAuthProvider(spec.getAuthToken());
+    LOGGER.info("Start replace segment URIs: " + segmentsUris);
+
+    int attempts = 1;
+    long retryWaitMs = 1000L;
+
+    for (Map.Entry<URI, URI> entry : segmentsUris.entrySet()) {
+      URI controllerUri = entry.getKey();
+      URI startSegmentUri = entry.getValue();
+      List<String> segmentsFrom = uriToSegmentsFrom.get(controllerUri);
+
+      if (!Collections.disjoint(segmentsFrom, segmentsTo)) {
+        String errorMsg =
+            String.format("Found same segment names when attempting to enable consistent push for table: %s",
+                rawTableName);
+        LOGGER.error("SegmentsFrom: {}", segmentsFrom);
+        LOGGER.error("SegmentsTo: {}", segmentsTo);
+        LOGGER.error(errorMsg);
+        throw new RuntimeException(errorMsg);
+      }
+
+      StartReplaceSegmentsRequest startReplaceSegmentsRequest =
+          new StartReplaceSegmentsRequest(segmentsFrom, segmentsTo);
+      RetryPolicies.exponentialBackoffRetryPolicy(attempts, retryWaitMs, 5).attempt(() -> {
+        try {
+          SimpleHttpResponse response =
+              FILE_UPLOAD_DOWNLOAD_CLIENT.startReplaceSegments(startSegmentUri, startReplaceSegmentsRequest,
+                  authProvider);
+
+          String responseString = response.getResponse();
+          LOGGER.info(
+              "Got response {}: {} while sending start replace segment request for table: {}, uploadURI: {}, request:"
+                  + " {}", response.getStatusCode(), responseString, rawTableName, startSegmentUri,
+              startReplaceSegmentsRequest);
+          String segmentLineageEntryId =
+              JsonUtils.stringToJsonNode(responseString).get("segmentLineageEntryId").asText();
+          uriToLineageEntryIdMap.put(controllerUri, segmentLineageEntryId);
+          return true;
+        } catch (SocketTimeoutException se) {
+          // In case of the timeout, we should re-try.
+          return false;
+        } catch (HttpErrorStatusException e) {
+          if (e.getStatusCode() >= 500) {
+            return false;
+          } else {
+            if (e.getStatusCode() == Response.Status.NOT_FOUND.getStatusCode()) {
+              LOGGER.error("Table: {} not found when sending request: {}", rawTableName, startSegmentUri);
+            }
+            throw e;
+          }
+        }
+      });
+    }
+    return uriToLineageEntryIdMap;
+  }
+
+  /**
+   * Ends consistent data push protocol for each Pinot cluster in the spec.
+   */
+  public static void endReplaceSegments(SegmentGenerationJobSpec spec, Map<URI, String> uriToLineageEntryIdMap) {
+    AuthProvider authProvider = AuthProviderUtils.makeAuthProvider(spec.getAuthToken());
+    String rawTableName = spec.getTableSpec().getTableName();
+    for (URI uri : uriToLineageEntryIdMap.keySet()) {
+      String segmentLineageEntryId = uriToLineageEntryIdMap.get(uri);
+      try {
+        FILE_UPLOAD_DOWNLOAD_CLIENT.endReplaceSegments(
+            FileUploadDownloadClient.getEndReplaceSegmentsURI(uri, rawTableName, TableType.OFFLINE.toString(),
+                segmentLineageEntryId), HttpClient.DEFAULT_SOCKET_TIMEOUT_MS, authProvider);
+      } catch (URISyntaxException e) {
+        throw new RuntimeException("Got invalid controller uri - '" + uri + "'");
+      } catch (HttpErrorStatusException | IOException e) {
+        e.printStackTrace();
+      }
+    }
+  }
+
+  /**
+   * Revert segment lineage entry when exception gets caught. This revert request is called at best effort.
+   * If the revert call fails at this point, the next startReplaceSegment call will do the cleanup
+   * by marking the previous entry to "REVERTED" and cleaning up the leftover segments.
+   */
+  public static void handleUploadException(SegmentGenerationJobSpec spec, Map<URI, String> uriToLineageEntryIdMap,
+      Exception exception) {
+    if (uriToLineageEntryIdMap != null) {
+      LOGGER.error("Exception when pushing segments. Marking segment lineage entry to 'REVERTED'.", exception);
+      String rawTableName = spec.getTableSpec().getTableName();
+      for (Map.Entry<URI, String> entry : uriToLineageEntryIdMap.entrySet()) {
+        String segmentLineageEntryId = entry.getValue();
+        try {
+          URI uri = FileUploadDownloadClient.getRevertReplaceSegmentsURI(entry.getKey(), rawTableName,
+              TableType.OFFLINE.name(), segmentLineageEntryId, true);
+          SimpleHttpResponse response = FILE_UPLOAD_DOWNLOAD_CLIENT.revertReplaceSegments(uri);
+          LOGGER.info("Got response {}: {} while sending revert replace segment request for table: {}, uploadURI: {}",
+              response.getStatusCode(), response.getResponse(), rawTableName, entry.getKey());
+        } catch (URISyntaxException | HttpErrorStatusException | IOException e) {
+          LOGGER.error("Exception when sending revert replace segment request to controller: {} for table: {}",
+              entry.getKey(), rawTableName, e);
+        }
+      }
+    }
+  }
+
+  /**
+   * Ensures that all files in tarFilePaths have the expected tar file extension and obtain segment names given
+   * tarFilePaths.
+   */
+  public static List<String> getTarSegmentsTo(List<String> tarFilePaths) {
+    List<String> segmentsTo = new ArrayList<>();
+    for (String tarFilePath : tarFilePaths) {
+      File tarFile = new File(tarFilePath);
+      String fileName = tarFile.getName();
+      Preconditions.checkArgument(fileName.endsWith(Constants.TAR_GZ_FILE_EXT));
+      String segmentName = getSegmentNameFromFilePath(fileName);
+      segmentsTo.add(segmentName);
+    }
+    return segmentsTo;
+  }
+
+  /**
+   * Ensures that all URIs in segmentUris have the expected tar file extension and obtain segment names given
+   * segmentUris.
+   */
+  public static List<String> getUriSegmentsTo(List<String> segmentUris) {
+    List<String> segmentsTo = new ArrayList<>();
+    for (String segmentUri : segmentUris) {
+      Preconditions.checkArgument(segmentUri.endsWith(Constants.TAR_GZ_FILE_EXT));
+      String segmentName = getSegmentNameFromFilePath(segmentUri);
+      segmentsTo.add(segmentName);
+    }
+    return segmentsTo;
+  }
+
+  /**
+   * Ensures that all tarPaths in segmentUriToTarPathMap have the expected tar file extension and obtain segment names
+   * given tarPaths.
+   */
+  public static List<String> getMetadataSegmentsTo(Map<String, String> segmentUriToTarPathMap) {
+    return getTarSegmentsTo(new ArrayList<>(segmentUriToTarPathMap.values()));
+  }
+
+  /**
+   * Obtain segment name given filePath by reading from after the last slash (if present) up to and before the tar
+   * extension.
+   */
+  public static String getSegmentNameFromFilePath(String filePath) {
+    int startIndex = filePath.contains("/") ? filePath.lastIndexOf("/") + 1 : 0;
+    return filePath.substring(startIndex, filePath.length() - Constants.TAR_GZ_FILE_EXT.length());
+  }
+
+  public static TableConfig getTableConfig(SegmentGenerationJobSpec spec) {
+    String rawTableName = spec.getTableSpec().getTableName();
+    TableConfig tableConfig =
+        SegmentGenerationUtils.getTableConfig(spec.getTableSpec().getTableConfigURI(), spec.getAuthToken());
+    Preconditions.checkState(tableConfig != null, "Failed to find table config for table: %s", rawTableName);
+    return tableConfig;
+  }
+
+  public static boolean consistentDataPushEnabled(SegmentGenerationJobSpec spec) {
+    TableConfig tableConfig = getTableConfig(spec);
+    // Enable consistent data push only if "consistentDataPush" is set to true in batch ingestion config and the
+    // table is REFRESH use case.
+    // TODO: Remove the check for REFRESH when we support consistent push for APPEND table
+    return "REFRESH".equalsIgnoreCase(IngestionConfigUtils.getBatchSegmentIngestionType(tableConfig))
+        && IngestionConfigUtils.getBatchSegmentIngestionConsistentDataPushEnabled(tableConfig);
+  }
+
+  /**
+   * Returns a map of controller URI to a list of existing OFFLINE segments.
+   */
+  public static Map<URI, List<String>> getSegmentsToReplace(SegmentGenerationJobSpec spec, String rawTableName) {
+    Map<URI, List<String>> uriToOfflineSegments = new HashMap<>();
+    for (PinotClusterSpec pinotClusterSpec : spec.getPinotClusterSpecs()) {
+      URI controllerURI;
+      List<String> offlineSegments;
+      try {
+        controllerURI = new URI(pinotClusterSpec.getControllerURI());
+        Map<String, List<String>> segments =
+            FILE_UPLOAD_DOWNLOAD_CLIENT.getSegments(controllerURI, rawTableName, TableType.OFFLINE.toString(), true);
+        offlineSegments = segments.get(TableType.OFFLINE.toString());
+        uriToOfflineSegments.put(controllerURI, offlineSegments);
+      } catch (URISyntaxException e) {
+        throw new RuntimeException("Got invalid controller uri - '" + pinotClusterSpec.getControllerURI() + "'");
+      } catch (IOException e) {
+        e.printStackTrace();
+      }
+    }
+    return uriToOfflineSegments;
+  }
+
+  /**
+   * If consistent data push is enabled, append current timestamp to existing configured segment name postfix, if
+   * configured, to make segment name unique.
+   */
+  public static void configureSegmentPostfix(SegmentGenerationJobSpec spec) {
+    SegmentNameGeneratorSpec segmentNameGeneratorSpec = spec.getSegmentNameGeneratorSpec();
+    if (consistentDataPushEnabled(spec)) {
+      if (segmentNameGeneratorSpec == null) {
+        segmentNameGeneratorSpec = new SegmentNameGeneratorSpec();
+      }
+      String existingPostfix = segmentNameGeneratorSpec.getConfigs().get(SEGMENT_NAME_POSTFIX);
+      String currentTimeStamp = Long.toString(System.currentTimeMillis());
+      String newSegmentPostfix =
+          existingPostfix == null ? currentTimeStamp : String.join("_", existingPostfix, currentTimeStamp);
+      LOGGER.info("Since consistent data push is enabled, appending current timestamp: {} to segment name postfix",
+          currentTimeStamp);
+      LOGGER.info("Segment postfix is now configured as: {}", newSegmentPostfix);
+      segmentNameGeneratorSpec.addConfig(SEGMENT_NAME_POSTFIX, newSegmentPostfix);
+      spec.setSegmentNameGeneratorSpec(segmentNameGeneratorSpec);
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/ConsistentDataPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/ConsistentDataPushUtils.java
@@ -55,7 +55,7 @@ public class ConsistentDataPushUtils {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentPushUtils.class);
   private static final FileUploadDownloadClient FILE_UPLOAD_DOWNLOAD_CLIENT = new FileUploadDownloadClient();
-  private static final RetryPolicy DEFAULT_RETRY_POLICY = RetryPolicies.fixedDelayRetryPolicy(5, 10_000L);
+  private static final RetryPolicy DEFAULT_RETRY_POLICY = RetryPolicies.exponentialBackoffRetryPolicy(5, 10_000L, 2.0);
   public static final String SEGMENT_NAME_POSTFIX = "segment.name.postfix";
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/ConsistentDataPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/ConsistentDataPushUtils.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -128,16 +127,6 @@ public class ConsistentDataPushUtils {
       URI controllerUri = entry.getKey();
       URI startSegmentUri = entry.getValue();
       List<String> segmentsFrom = uriToSegmentsFrom.get(controllerUri);
-
-      if (!Collections.disjoint(segmentsFrom, segmentsTo)) {
-        String errorMsg =
-            String.format("Found same segment names when attempting to enable consistent push for table: %s",
-                rawTableName);
-        LOGGER.error("SegmentsFrom: {}", segmentsFrom);
-        LOGGER.error("SegmentsTo: {}", segmentsTo);
-        LOGGER.error(errorMsg);
-        throw new RuntimeException(errorMsg);
-      }
 
       StartReplaceSegmentsRequest startReplaceSegmentsRequest =
           new StartReplaceSegmentsRequest(segmentsFrom, segmentsTo);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/ConsistentDataPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/ConsistentDataPushUtils.java
@@ -248,7 +248,7 @@ public class ConsistentDataPushUtils {
       try {
         controllerURI = new URI(pinotClusterSpec.getControllerURI());
         Map<String, List<String>> segments =
-            FILE_UPLOAD_DOWNLOAD_CLIENT.getSegments(controllerURI, rawTableName, TableType.OFFLINE.toString(), true);
+            FILE_UPLOAD_DOWNLOAD_CLIENT.getSegments(controllerURI, rawTableName, TableType.OFFLINE, true);
         offlineSegments = segments.get(TableType.OFFLINE.toString());
         uriToOfflineSegments.put(controllerURI, offlineSegments);
       } catch (URISyntaxException e) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/ConsistentDataPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/ConsistentDataPushUtils.java
@@ -19,12 +19,10 @@
 package org.apache.pinot.segment.local.utils;
 
 import com.google.common.base.Preconditions;
-import java.io.File;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -40,7 +38,6 @@ import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.ingestion.batch.spec.Constants;
 import org.apache.pinot.spi.ingestion.batch.spec.PinotClusterSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentGenerationJobSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentNameGeneratorSpec;
@@ -221,53 +218,6 @@ public class ConsistentDataPushUtils {
         }
       }
     }
-  }
-
-  /**
-   * Ensures that all files in tarFilePaths have the expected tar file extension and obtain segment names given
-   * tarFilePaths.
-   */
-  public static List<String> getTarSegmentsTo(List<String> tarFilePaths) {
-    List<String> segmentsTo = new ArrayList<>();
-    for (String tarFilePath : tarFilePaths) {
-      File tarFile = new File(tarFilePath);
-      String fileName = tarFile.getName();
-      Preconditions.checkArgument(fileName.endsWith(Constants.TAR_GZ_FILE_EXT));
-      String segmentName = getSegmentNameFromFilePath(fileName);
-      segmentsTo.add(segmentName);
-    }
-    return segmentsTo;
-  }
-
-  /**
-   * Ensures that all URIs in segmentUris have the expected tar file extension and obtain segment names given
-   * segmentUris.
-   */
-  public static List<String> getUriSegmentsTo(List<String> segmentUris) {
-    List<String> segmentsTo = new ArrayList<>();
-    for (String segmentUri : segmentUris) {
-      Preconditions.checkArgument(segmentUri.endsWith(Constants.TAR_GZ_FILE_EXT));
-      String segmentName = getSegmentNameFromFilePath(segmentUri);
-      segmentsTo.add(segmentName);
-    }
-    return segmentsTo;
-  }
-
-  /**
-   * Ensures that all tarPaths in segmentUriToTarPathMap have the expected tar file extension and obtain segment names
-   * given tarPaths.
-   */
-  public static List<String> getMetadataSegmentsTo(Map<String, String> segmentUriToTarPathMap) {
-    return getTarSegmentsTo(new ArrayList<>(segmentUriToTarPathMap.values()));
-  }
-
-  /**
-   * Obtain segment name given filePath by reading from after the last slash (if present) up to and before the tar
-   * extension.
-   */
-  public static String getSegmentNameFromFilePath(String filePath) {
-    int startIndex = filePath.contains("/") ? filePath.lastIndexOf("/") + 1 : 0;
-    return filePath.substring(startIndex, filePath.length() - Constants.TAR_GZ_FILE_EXT.length());
   }
 
   public static TableConfig getTableConfig(SegmentGenerationJobSpec spec) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
@@ -29,6 +29,7 @@ import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -48,7 +49,6 @@ import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
-import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.ingestion.batch.spec.Constants;
 import org.apache.pinot.spi.ingestion.batch.spec.PinotClusterSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.PushJobSpec;
@@ -373,34 +373,15 @@ public class SegmentPushUtils implements Serializable {
     }
   }
 
-  public static List<String> getSegmentNames(BatchConfigProperties.SegmentPushType pushMode,
-      Map<String, String> segmentsUriToTarPathMap) {
-    List<String> segmentNames = new ArrayList<>(segmentsUriToTarPathMap.size());
-    if (pushMode.equals(BatchConfigProperties.SegmentPushType.TAR) || pushMode.equals(
-        BatchConfigProperties.SegmentPushType.METADATA)) {
-      for (String tarFilePath : segmentsUriToTarPathMap.values()) {
-        File tarFile = new File(tarFilePath);
-        String fileName = tarFile.getName();
-        Preconditions.checkArgument(fileName.endsWith(Constants.TAR_GZ_FILE_EXT));
-        String segmentName = getSegmentNameFromPath(fileName);
-        segmentNames.add(segmentName);
-      }
-    }
-    if (pushMode.equals(BatchConfigProperties.SegmentPushType.URI)) {
-      for (String segmentUri : segmentsUriToTarPathMap.keySet()) {
-        Preconditions.checkArgument(segmentUri.endsWith(Constants.TAR_GZ_FILE_EXT));
-        String segmentName = getSegmentNameFromPath(segmentUri);
-        segmentNames.add(segmentName);
-      }
+  public static List<String> getSegmentNames(Collection<String> tarFilePaths) {
+    List<String> segmentNames = new ArrayList<>(tarFilePaths.size());
+    for (String tarFilePath : tarFilePaths) {
+      File tarFile = new File(tarFilePath);
+      String fileName = tarFile.getName();
+      Preconditions.checkArgument(fileName.endsWith(Constants.TAR_GZ_FILE_EXT));
+      String segmentName = fileName.substring(0, fileName.length() - Constants.TAR_GZ_FILE_EXT.length());
+      segmentNames.add(segmentName);
     }
     return segmentNames;
-  }
-
-  /**
-   * Obtain segment name given filePath by reading from after the last slash (if present) up to and before the tar
-   * extension.
-   */
-  public static String getSegmentNameFromPath(String filePath) {
-    return filePath.substring(filePath.lastIndexOf("/") + 1, filePath.length() - Constants.TAR_GZ_FILE_EXT.length());
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
@@ -375,7 +375,7 @@ public class SegmentPushUtils implements Serializable {
 
   public static List<String> getSegmentNames(BatchConfigProperties.SegmentPushType pushMode,
       Map<String, String> segmentsUriToTarPathMap) {
-    List<String> segmentNames = new ArrayList<>();
+    List<String> segmentNames = new ArrayList<>(segmentsUriToTarPathMap.size());
     if (pushMode.equals(BatchConfigProperties.SegmentPushType.TAR) || pushMode.equals(
         BatchConfigProperties.SegmentPushType.METADATA)) {
       for (String tarFilePath : segmentsUriToTarPathMap.values()) {
@@ -401,7 +401,6 @@ public class SegmentPushUtils implements Serializable {
    * extension.
    */
   public static String getSegmentNameFromPath(String filePath) {
-    int startIndex = filePath.contains("/") ? filePath.lastIndexOf("/") + 1 : 0;
-    return filePath.substring(startIndex, filePath.length() - Constants.TAR_GZ_FILE_EXT.length());
+    return filePath.substring(filePath.lastIndexOf("/") + 1, filePath.length() - Constants.TAR_GZ_FILE_EXT.length());
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
@@ -29,7 +29,6 @@ import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -371,17 +370,5 @@ public class SegmentPushUtils implements Serializable {
       FileUtils.deleteQuietly(tarFile);
       FileUtils.deleteQuietly(segmentMetadataDir);
     }
-  }
-
-  public static List<String> getSegmentNames(Collection<String> tarFilePaths) {
-    List<String> segmentNames = new ArrayList<>(tarFilePaths.size());
-    for (String tarFilePath : tarFilePaths) {
-      File tarFile = new File(tarFilePath);
-      String fileName = tarFile.getName();
-      Preconditions.checkArgument(fileName.endsWith(Constants.TAR_GZ_FILE_EXT));
-      String segmentName = fileName.substring(0, fileName.length() - Constants.TAR_GZ_FILE_EXT.length());
-      segmentNames.add(segmentName);
-    }
-    return segmentNames;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/BatchIngestionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/BatchIngestionConfig.java
@@ -41,13 +41,24 @@ public class BatchIngestionConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Ingestion frequency HOURLY or DAILY")
   private String _segmentIngestionFrequency;
 
+  @JsonPropertyDescription("True to enable consistent data push")
+  private boolean _consistentDataPush;
+
   @JsonCreator
   public BatchIngestionConfig(@JsonProperty("batchConfigMaps") @Nullable List<Map<String, String>> batchConfigMaps,
       @JsonProperty("segmentIngestionType") String segmentIngestionType,
-      @JsonProperty("segmentIngestionFrequency") String segmentIngestionFrequency) {
+      @JsonProperty("segmentIngestionFrequency") String segmentIngestionFrequency,
+      @JsonProperty("consistentDataPush") boolean consistentDataPush) {
     _batchConfigMaps = batchConfigMaps;
     _segmentIngestionType = segmentIngestionType;
     _segmentIngestionFrequency = segmentIngestionFrequency;
+    _consistentDataPush = consistentDataPush;
+  }
+
+  public BatchIngestionConfig(@JsonProperty("batchConfigMaps") @Nullable List<Map<String, String>> batchConfigMaps,
+      @JsonProperty("segmentIngestionType") String segmentIngestionType,
+      @JsonProperty("segmentIngestionFrequency") String segmentIngestionFrequency) {
+    this(batchConfigMaps, segmentIngestionType, segmentIngestionFrequency, false);
   }
 
   @Nullable
@@ -63,6 +74,10 @@ public class BatchIngestionConfig extends BaseJsonConfig {
     return _segmentIngestionFrequency;
   }
 
+  public boolean getConsistentDataPush() {
+    return _consistentDataPush;
+  }
+
   public void setBatchConfigMaps(List<Map<String, String>> batchConfigMaps) {
     _batchConfigMaps = batchConfigMaps;
   }
@@ -73,5 +88,9 @@ public class BatchIngestionConfig extends BaseJsonConfig {
 
   public void setSegmentIngestionFrequency(String segmentIngestionFrequency) {
     _segmentIngestionFrequency = segmentIngestionFrequency;
+  }
+
+  public void setConsistentDataPush(boolean consistentDataPush) {
+    _consistentDataPush = consistentDataPush;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentNameGeneratorSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentNameGeneratorSpec.java
@@ -53,4 +53,10 @@ public class SegmentNameGeneratorSpec implements Serializable {
   public void setConfigs(Map<String, String> configs) {
     _configs = configs;
   }
+
+  public void addConfig(String key, String val) {
+    Map<String, String> configs = getConfigs();
+    configs.put(key, val);
+    setConfigs(configs);
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
@@ -86,6 +86,20 @@ public final class IngestionConfigUtils {
   }
 
   /**
+   * Fetches the configured consistentDataPush boolean from the table config
+   */
+  public static boolean getBatchSegmentIngestionConsistentDataPushEnabled(TableConfig tableConfig) {
+    boolean consistentDataPush = false;
+    if (tableConfig.getIngestionConfig() != null) {
+      BatchIngestionConfig batchIngestionConfig = tableConfig.getIngestionConfig().getBatchIngestionConfig();
+      if (batchIngestionConfig != null) {
+        consistentDataPush = batchIngestionConfig.getConsistentDataPush();
+      }
+    }
+    return consistentDataPush;
+  }
+
+  /**
    * Fetches the configured segmentIngestionType (APPEND/REFRESH) from the table config
    * First checks in the ingestionConfig. If not found, checks in the segmentsConfig (has been deprecated from here
    * in favor of ingestion

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
@@ -370,6 +370,12 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", _baseUrl, "tables", tableName + "?type=" + tableType);
   }
 
+  public String forSegmentListAPIWithTableTypeAndExcludeReplacedSegments(String tableName, String tableType,
+      boolean excludeReplacedSegments) {
+    return StringUtil.join("/", _baseUrl, "segments",
+        tableName + "?type=" + tableType + "&excludeReplacedSegments=" + excludeReplacedSegments);
+  }
+
   public String forSegmentListAPIWithTableType(String tableName, String tableType) {
     return StringUtil.join("/", _baseUrl, "segments", tableName + "?type=" + tableType);
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
@@ -370,18 +370,27 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", _baseUrl, "tables", tableName + "?type=" + tableType);
   }
 
-  public String forSegmentListAPIWithTableTypeAndExcludeReplacedSegments(String tableName, String tableType,
-      boolean excludeReplacedSegments) {
-    return StringUtil.join("/", _baseUrl, "segments",
-        tableName + "?type=" + tableType + "&excludeReplacedSegments=" + excludeReplacedSegments);
-  }
-
-  public String forSegmentListAPIWithTableType(String tableName, String tableType) {
-    return StringUtil.join("/", _baseUrl, "segments", tableName + "?type=" + tableType);
-  }
-
   public String forSegmentListAPI(String tableName) {
-    return StringUtil.join("/", _baseUrl, "segments", tableName);
+    return forSegmentListAPI(tableName, null, false);
+  }
+
+  public String forSegmentListAPI(String tableName, String tableType) {
+    return forSegmentListAPI(tableName, tableType, false);
+  }
+
+  public String forSegmentListAPI(String tableName, @Nullable String tableType, boolean excludeReplacedSegments) {
+    String url = StringUtil.join("/", _baseUrl, "segments", tableName);
+    if (tableType != null) {
+      url += "?type=" + tableType;
+      if (excludeReplacedSegments) {
+        url += "&excludeReplacedSegments=" + excludeReplacedSegments;
+      }
+    } else {
+      if (excludeReplacedSegments) {
+        url += "?excludeReplacedSegments=" + excludeReplacedSegments;
+      }
+    }
+    return url;
   }
 
   public String forInstancePartitions(String tableName, @Nullable InstancePartitionsType instancePartitionsType) {


### PR DESCRIPTION
### Description: 
This PR addresses https://github.com/apache/pinot/issues/9268 for the segment push job runners under the standalone execution framework: `SegmentMetadataPushJobRunner`, `SegmentTarPushJobRunner`, and `SegmentUriPushJobRunner`. 

This is accomplished by introducing a new class `ConsistentDataPushUtils` which contains APIs and helpers for `*PushJobRunner(s)` to call to invoke the consistent push protocol. 

Since there are large overlaps in the code for all of the `*PushJobRunner(s)`, also took this opportunity to refactor and extract the common logic out to `BaseSegmentPushJobRunner` abstract class.

To enable consistent data push, this PR also introduces a new boolean config in table config under 
`TableConfig->IngestionConfig->BatchIngestionConfig->consistentDataPush`.

Users can enable consistent data push by setting the `consistentDataPush` config to true as below before invoking ingestion jobs,
```
...
    "batchIngestionConfig": {
      "segmentIngestionType": "REFRESH",
      "segmentIngestionFrequency": "DAILY",
      "consistentDataPush": true
    },
...
```
which will 
1) _**In the segment generation phase**_: inject timestamps to segment names (via segment postfix) in order to prevent segment name conflicts from overwriting existing segments directly for the REFRESH usecase and 
2) _**In the segment push/upload phase**_: wrap the segments replacement protocol around segments upload which will achieve atomic switching between old and new segments data. In the case of failure, revert and abort the swap, which will ensure broker only routes to the old segments. 


### Testing Done: 
Added new test `testUploadAndQueryWithConsistentPush` in `SegmentUploadIntegrationTest`, which 
1. Runs SegmentMetadataPushJobRunner with consistent push enabled.
[] -> [v1 segments]
2. Checks that the segment lineage entry is in expected and completed state.
3. Checks that count stars return expected outputs. 

4. Runs SegmentTarPushJobRunner with consistent push enabled.
[v1 segments] -> [v2 segments]
5. Checks again that the segment lineage entry is in expected and completed state.
6. Checks again that count stars return expected outputs (that we have successfully bulk replaced the original set of segments). 

