### PR TITLE
Allow server to directly return the final aggregation result

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/Table.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/Table.java
@@ -55,11 +55,16 @@ public interface Table {
    */
   Iterator<Record> iterator();
 
+  default void finish(boolean sort) {
+    finish(sort, false);
+  }
+
   /**
    * Finish any pre exit processing
    * @param sort sort the final results if true
+   * @param storeFinalResult whether to store final aggregation result
    */
-  void finish(boolean sort);
+  void finish(boolean sort, boolean storeFinalResult);
 
   /**
    * Returns the data schema of the table

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/AggregationResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/AggregationResultsBlock.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pinot.core.operator.blocks.results;
 
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.List;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -27,6 +29,7 @@ import org.apache.pinot.core.common.datatable.DataTableBuilder;
 import org.apache.pinot.core.common.datatable.DataTableFactory;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.NullValueUtils;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -34,7 +37,7 @@ import org.roaringbitmap.RoaringBitmap;
 /**
  * Results block for aggregation queries.
  */
-@SuppressWarnings("rawtypes")
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class AggregationResultsBlock extends BaseResultsBlock {
   private final AggregationFunction[] _aggregationFunctions;
   private final List<Object> _results;
@@ -55,6 +58,8 @@ public class AggregationResultsBlock extends BaseResultsBlock {
   @Override
   public DataTable getDataTable(QueryContext queryContext)
       throws Exception {
+    boolean returnFinalResult = queryContext.isServerReturnFinalResult();
+
     // Extract result column name and type from each aggregation function
     int numColumns = _aggregationFunctions.length;
     String[] columnNames = new String[numColumns];
@@ -62,7 +67,8 @@ public class AggregationResultsBlock extends BaseResultsBlock {
     for (int i = 0; i < numColumns; i++) {
       AggregationFunction aggregationFunction = _aggregationFunctions[i];
       columnNames[i] = aggregationFunction.getColumnName();
-      columnDataTypes[i] = aggregationFunction.getIntermediateResultColumnType();
+      columnDataTypes[i] = returnFinalResult ? aggregationFunction.getFinalResultColumnType()
+          : aggregationFunction.getIntermediateResultColumnType();
     }
 
     // Build the data table.
@@ -76,11 +82,20 @@ public class AggregationResultsBlock extends BaseResultsBlock {
       dataTableBuilder.startRow();
       for (int i = 0; i < numColumns; i++) {
         Object result = _results.get(i);
-        if (result == null && columnDataTypes[i] != ColumnDataType.OBJECT) {
-          result = NullValueUtils.getDefaultNullValue(columnDataTypes[i].toDataType());
-          nullBitmaps[i].add(0);
+        if (!returnFinalResult) {
+          if (result == null && columnDataTypes[i] != ColumnDataType.OBJECT) {
+            result = NullValueUtils.getDefaultNullValue(columnDataTypes[i].toDataType());
+            nullBitmaps[i].add(0);
+          }
+          setIntermediateResult(dataTableBuilder, columnDataTypes, i, result);
+        } else {
+          result = _aggregationFunctions[i].extractFinalResult(result);
+          if (result == null) {
+            result = NullValueUtils.getDefaultNullValue(columnDataTypes[i].toDataType());
+            nullBitmaps[i].add(0);
+          }
+          setFinalResult(dataTableBuilder, columnDataTypes, i, result);
         }
-        setResult(dataTableBuilder, columnNames, columnDataTypes, i, result);
       }
       dataTableBuilder.finishRow();
       for (RoaringBitmap nullBitmap : nullBitmaps) {
@@ -89,7 +104,13 @@ public class AggregationResultsBlock extends BaseResultsBlock {
     } else {
       dataTableBuilder.startRow();
       for (int i = 0; i < numColumns; i++) {
-        setResult(dataTableBuilder, columnNames, columnDataTypes, i, _results.get(i));
+        Object result = _results.get(i);
+        if (!returnFinalResult) {
+          setIntermediateResult(dataTableBuilder, columnDataTypes, i, result);
+        } else {
+          result = _aggregationFunctions[i].extractFinalResult(result);
+          setFinalResult(dataTableBuilder, columnDataTypes, i, result);
+        }
       }
       dataTableBuilder.finishRow();
     }
@@ -99,23 +120,56 @@ public class AggregationResultsBlock extends BaseResultsBlock {
     return dataTable;
   }
 
-  private void setResult(DataTableBuilder dataTableBuilder, String[] columnNames, ColumnDataType[] columnDataTypes,
-      int index, Object result)
+  private void setIntermediateResult(DataTableBuilder dataTableBuilder, ColumnDataType[] columnDataTypes, int index,
+      Object result)
       throws IOException {
     ColumnDataType columnDataType = columnDataTypes[index];
     switch (columnDataType) {
       case LONG:
-        dataTableBuilder.setColumn(index, ((Number) result).longValue());
+        dataTableBuilder.setColumn(index, (long) result);
         break;
       case DOUBLE:
-        dataTableBuilder.setColumn(index, ((Double) result).doubleValue());
+        dataTableBuilder.setColumn(index, (double) result);
         break;
       case OBJECT:
         dataTableBuilder.setColumn(index, result);
         break;
       default:
-        throw new UnsupportedOperationException(
-            "Unsupported aggregation column data type: " + columnDataType + " for column: " + columnNames[index]);
+        throw new IllegalStateException("Illegal column data type in intermediate result: " + columnDataType);
+    }
+  }
+
+  private void setFinalResult(DataTableBuilder dataTableBuilder, ColumnDataType[] columnDataTypes, int index,
+      Object result)
+      throws IOException {
+    ColumnDataType columnDataType = columnDataTypes[index];
+    switch (columnDataType) {
+      case INT:
+        dataTableBuilder.setColumn(index, (int) result);
+        break;
+      case LONG:
+        dataTableBuilder.setColumn(index, (long) result);
+        break;
+      case FLOAT:
+        dataTableBuilder.setColumn(index, (float) result);
+        break;
+      case DOUBLE:
+        dataTableBuilder.setColumn(index, (double) result);
+        break;
+      case BIG_DECIMAL:
+        dataTableBuilder.setColumn(index, (BigDecimal) result);
+        break;
+      case STRING:
+        dataTableBuilder.setColumn(index, result.toString());
+        break;
+      case BYTES:
+        dataTableBuilder.setColumn(index, (ByteArray) result);
+        break;
+      case DOUBLE_ARRAY:
+        dataTableBuilder.setColumn(index, ((DoubleArrayList) result).elements());
+        break;
+      default:
+        throw new IllegalStateException("Illegal column data type in final result: " + columnDataType);
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/GroupByResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/GroupByResultsBlock.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.operator.blocks.results;
 
 import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -193,13 +194,10 @@ public class GroupByResultsBlock extends BaseResultsBlock {
         dataTableBuilder.setColumn(columnIndex, (BigDecimal) value);
         break;
       case STRING:
-        dataTableBuilder.setColumn(columnIndex, (String) value);
+        dataTableBuilder.setColumn(columnIndex, value.toString());
         break;
       case BYTES:
         dataTableBuilder.setColumn(columnIndex, (ByteArray) value);
-        break;
-      case OBJECT:
-        dataTableBuilder.setColumn(columnIndex, value);
         break;
       case INT_ARRAY:
         dataTableBuilder.setColumn(columnIndex, (int[]) value);
@@ -211,10 +209,17 @@ public class GroupByResultsBlock extends BaseResultsBlock {
         dataTableBuilder.setColumn(columnIndex, (float[]) value);
         break;
       case DOUBLE_ARRAY:
-        dataTableBuilder.setColumn(columnIndex, (double[]) value);
+        if (value instanceof DoubleArrayList) {
+          dataTableBuilder.setColumn(columnIndex, ((DoubleArrayList) value).elements());
+        } else {
+          dataTableBuilder.setColumn(columnIndex, (double[]) value);
+        }
         break;
       case STRING_ARRAY:
         dataTableBuilder.setColumn(columnIndex, (String[]) value);
+        break;
+      case OBJECT:
+        dataTableBuilder.setColumn(columnIndex, value);
         break;
       default:
         throw new IllegalStateException("Unsupported stored type: " + storedColumnDataType);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByOrderByCombineOperator.java
@@ -85,7 +85,8 @@ public class GroupByOrderByCombineOperator extends BaseCombineOperator<GroupByRe
     int minTrimSize = queryContext.getMinServerGroupTrimSize();
     if (minTrimSize > 0) {
       int limit = queryContext.getLimit();
-      if (queryContext.getOrderByExpressions() != null || queryContext.getHavingFilter() != null) {
+      if ((!queryContext.isServerReturnFinalResult() && queryContext.getOrderByExpressions() != null)
+          || queryContext.getHavingFilter() != null) {
         _trimSize = GroupByUtils.getTableCapacity(limit, minTrimSize);
       } else {
         // TODO: Keeping only 'LIMIT' groups can cause inaccurate result because the groups are randomly selected
@@ -252,7 +253,11 @@ public class GroupByOrderByCombineOperator extends BaseCombineOperator<GroupByRe
     }
 
     IndexedTable indexedTable = _indexedTable;
-    indexedTable.finish(false);
+    if (!_queryContext.isServerReturnFinalResult()) {
+      indexedTable.finish(false);
+    } else {
+      indexedTable.finish(true, true);
+    }
     GroupByResultsBlock mergedBlock = new GroupByResultsBlock(indexedTable);
     mergedBlock.setNumGroupsLimitReached(_numGroupsLimitReached);
     mergedBlock.setNumResizes(indexedTable.getNumResizes());

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -27,6 +27,8 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.operator.blocks.TransformBlock;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
@@ -114,5 +116,49 @@ public class AggregationFunctionUtils {
     ExpressionContext expression = ExpressionContext.forIdentifier(aggregationFunctionColumnPair.getColumn());
     BlockValSet blockValSet = transformBlock.getBlockValueSet(aggregationFunctionColumnPair.toColumnName());
     return Collections.singletonMap(expression, blockValSet);
+  }
+
+  /**
+   * Reads the intermediate result from the {@link DataTable}.
+   */
+  public static Object getIntermediateResult(DataTable dataTable, ColumnDataType columnDataType, int rowId, int colId) {
+    switch (columnDataType) {
+      case LONG:
+        return dataTable.getLong(rowId, colId);
+      case DOUBLE:
+        return dataTable.getDouble(rowId, colId);
+      case OBJECT:
+        return dataTable.getObject(rowId, colId);
+      default:
+        throw new IllegalStateException("Illegal column data type in intermediate result: " + columnDataType);
+    }
+  }
+
+  /**
+   * Reads the converted final result from the {@link DataTable}. It should be equivalent to running
+   * {@link AggregationFunction#extractFinalResult(Object)} and {@link ColumnDataType#convert(Object)}.
+   */
+  public static Object getConvertedFinalResult(DataTable dataTable, ColumnDataType columnDataType, int rowId,
+      int colId) {
+    switch (columnDataType) {
+      case INT:
+        return dataTable.getInt(rowId, colId);
+      case LONG:
+        return dataTable.getLong(rowId, colId);
+      case FLOAT:
+        return dataTable.getFloat(rowId, colId);
+      case DOUBLE:
+        return dataTable.getDouble(rowId, colId);
+      case BIG_DECIMAL:
+        return dataTable.getBigDecimal(rowId, colId);
+      case STRING:
+        return dataTable.getString(rowId, colId);
+      case BYTES:
+        return dataTable.getBytes(rowId, colId).getBytes();
+      case DOUBLE_ARRAY:
+        return dataTable.getDoubleArray(rowId, colId);
+      default:
+        throw new IllegalStateException("Illegal column data type in final result: " + columnDataType);
+    }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/AggregationDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/AggregationDataTableReducer.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.core.query.reduce;
 
+import com.google.common.base.Preconditions;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import org.apache.pinot.common.metrics.BrokerMetrics;
@@ -27,6 +29,7 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
 import org.roaringbitmap.RoaringBitmap;
@@ -52,6 +55,8 @@ public class AggregationDataTableReducer implements DataTableReducer {
   public void reduceAndSetResults(String tableName, DataSchema dataSchema,
       Map<ServerRoutingInstance, DataTable> dataTableMap, BrokerResponseNative brokerResponseNative,
       DataTableReducerContext reducerContext, BrokerMetrics brokerMetrics) {
+    assert dataSchema != null;
+
     if (dataTableMap.isEmpty()) {
       DataSchema resultTableSchema =
           new PostAggregationHandler(_queryContext, getPrePostAggregationDataSchema()).getResultDataSchema();
@@ -59,43 +64,31 @@ public class AggregationDataTableReducer implements DataTableReducer {
       return;
     }
 
-    // Merge results from all data tables
+    if (!_queryContext.isServerReturnFinalResult()) {
+      reduceWithIntermediateResult(dataSchema, dataTableMap.values(), brokerResponseNative);
+    } else {
+      Preconditions.checkState(dataTableMap.size() == 1, "Cannot merge final results from multiple servers");
+      reduceWithFinalResult(dataSchema, dataTableMap.values().iterator().next(), brokerResponseNative);
+    }
+  }
+
+  private void reduceWithIntermediateResult(DataSchema dataSchema, Collection<DataTable> dataTables,
+      BrokerResponseNative brokerResponseNative) {
     int numAggregationFunctions = _aggregationFunctions.length;
     Object[] intermediateResults = new Object[numAggregationFunctions];
-    for (DataTable dataTable : dataTableMap.values()) {
+    for (DataTable dataTable : dataTables) {
       for (int i = 0; i < numAggregationFunctions; i++) {
         Object intermediateResultToMerge;
         ColumnDataType columnDataType = dataSchema.getColumnDataType(i);
         if (_queryContext.isNullHandlingEnabled()) {
           RoaringBitmap nullBitmap = dataTable.getNullRowIds(i);
-          boolean isNull = nullBitmap != null && nullBitmap.contains(0);
-          switch (columnDataType) {
-            case LONG:
-              intermediateResultToMerge = isNull ? null : dataTable.getLong(0, i);
-              break;
-            case DOUBLE:
-              intermediateResultToMerge = isNull ? null : dataTable.getDouble(0, i);
-              break;
-            case OBJECT:
-              intermediateResultToMerge = isNull ? null : dataTable.getObject(0, i);
-              break;
-            default:
-              throw new IllegalStateException("Illegal column data type in aggregation results: " + columnDataType);
+          if (nullBitmap != null && nullBitmap.contains(0)) {
+            intermediateResultToMerge = null;
+          } else {
+            intermediateResultToMerge = AggregationFunctionUtils.getIntermediateResult(dataTable, columnDataType, 0, i);
           }
         } else {
-          switch (columnDataType) {
-            case LONG:
-              intermediateResultToMerge = dataTable.getLong(0, i);
-              break;
-            case DOUBLE:
-              intermediateResultToMerge = dataTable.getDouble(0, i);
-              break;
-            case OBJECT:
-              intermediateResultToMerge = dataTable.getObject(0, i);
-              break;
-            default:
-              throw new IllegalStateException("Illegal column data type in aggregation results: " + columnDataType);
-          }
+          intermediateResultToMerge = AggregationFunctionUtils.getIntermediateResult(dataTable, columnDataType, 0, i);
         }
         Object mergedIntermediateResult = intermediateResults[i];
         if (mergedIntermediateResult == null) {
@@ -110,6 +103,26 @@ public class AggregationDataTableReducer implements DataTableReducer {
       AggregationFunction aggregationFunction = _aggregationFunctions[i];
       Comparable result = aggregationFunction.extractFinalResult(intermediateResults[i]);
       finalResults[i] = result == null ? null : aggregationFunction.getFinalResultColumnType().convert(result);
+    }
+    brokerResponseNative.setResultTable(reduceToResultTable(finalResults));
+  }
+
+  private void reduceWithFinalResult(DataSchema dataSchema, DataTable dataTable,
+      BrokerResponseNative brokerResponseNative) {
+    int numAggregationFunctions = _aggregationFunctions.length;
+    Object[] finalResults = new Object[numAggregationFunctions];
+    for (int i = 0; i < numAggregationFunctions; i++) {
+      ColumnDataType columnDataType = dataSchema.getColumnDataType(i);
+      if (_queryContext.isNullHandlingEnabled()) {
+        RoaringBitmap nullBitmap = dataTable.getNullRowIds(i);
+        if (nullBitmap != null && nullBitmap.contains(0)) {
+          finalResults[i] = null;
+        } else {
+          finalResults[i] = AggregationFunctionUtils.getConvertedFinalResult(dataTable, columnDataType, 0, i);
+        }
+      } else {
+        finalResults[i] = AggregationFunctionUtils.getConvertedFinalResult(dataTable, columnDataType, 0, i);
+      }
     }
     brokerResponseNative.setResultTable(reduceToResultTable(finalResults));
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -120,6 +120,8 @@ public class QueryContext {
   private int _groupTrimThreshold = InstancePlanMakerImplV2.DEFAULT_GROUPBY_TRIM_THRESHOLD;
   // Whether null handling is enabled
   private boolean _nullHandlingEnabled;
+  // Whether server returns the final result
+  private boolean _serverReturnFinalResult;
 
   private QueryContext(@Nullable String tableName, @Nullable QueryContext subquery,
       List<ExpressionContext> selectExpressions, List<String> aliasList, @Nullable FilterContext filter,
@@ -383,6 +385,14 @@ public class QueryContext {
     _nullHandlingEnabled = nullHandlingEnabled;
   }
 
+  public boolean isServerReturnFinalResult() {
+    return _serverReturnFinalResult;
+  }
+
+  public void setServerReturnFinalResult(boolean serverReturnFinalResult) {
+    _serverReturnFinalResult = serverReturnFinalResult;
+  }
+
   /**
    * Gets or computes a value of type {@code V} associated with a key of type {@code K} so that it can be shared
    * within the scope of a query.
@@ -500,6 +510,7 @@ public class QueryContext {
           new QueryContext(_tableName, _subquery, _selectExpressions, _aliasList, _filter, _groupByExpressions,
               _havingFilter, _orderByExpressions, _limit, _offset, _queryOptions, _expressionOverrideHints, _explain);
       queryContext.setNullHandlingEnabled(QueryOptionsUtils.isNullHandlingEnabled(_queryOptions));
+      queryContext.setServerReturnFinalResult(QueryOptionsUtils.isServerReturnFinalResult(_queryOptions));
 
       // Pre-calculate the aggregation functions and columns for the query
       generateAggregationFunctions(queryContext);

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
@@ -22,7 +22,8 @@ import com.google.common.base.Preconditions;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.common.datatable.DataTableFactory;
-import org.apache.pinot.spi.utils.CommonConstants.Broker.Request;
+import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
+import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionValue;
 
 
 /**
@@ -34,7 +35,7 @@ public class QueryOptionsUtils {
 
   @Nullable
   public static Long getTimeoutMs(Map<String, String> queryOptions) {
-    String timeoutMsString = queryOptions.get(Request.QueryOptionKey.TIMEOUT_MS);
+    String timeoutMsString = queryOptions.get(QueryOptionKey.TIMEOUT_MS);
     if (timeoutMsString != null) {
       long timeoutMs = Long.parseLong(timeoutMsString);
       Preconditions.checkState(timeoutMs > 0, "Query timeout must be positive, got: %s", timeoutMs);
@@ -45,56 +46,60 @@ public class QueryOptionsUtils {
   }
 
   public static boolean isSkipUpsert(Map<String, String> queryOptions) {
-    return Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.SKIP_UPSERT));
+    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.SKIP_UPSERT));
   }
 
   public static boolean isSkipStarTree(Map<String, String> queryOptions) {
-    return "false".equalsIgnoreCase(queryOptions.get(Request.QueryOptionKey.USE_STAR_TREE));
+    return "false".equalsIgnoreCase(queryOptions.get(QueryOptionKey.USE_STAR_TREE));
   }
 
   public static boolean isRoutingForceHLC(Map<String, String> queryOptions) {
-    String routingOptions = queryOptions.get(Request.QueryOptionKey.ROUTING_OPTIONS);
-    return routingOptions != null && routingOptions.toUpperCase().contains(Request.QueryOptionValue.ROUTING_FORCE_HLC);
+    String routingOptions = queryOptions.get(QueryOptionKey.ROUTING_OPTIONS);
+    return routingOptions != null && routingOptions.toUpperCase().contains(QueryOptionValue.ROUTING_FORCE_HLC);
   }
 
   public static boolean isSkipScanFilterReorder(Map<String, String> queryOptions) {
-    return "false".equalsIgnoreCase(queryOptions.get(Request.QueryOptionKey.USE_SCAN_REORDER_OPTIMIZATION));
+    return "false".equalsIgnoreCase(queryOptions.get(QueryOptionKey.USE_SCAN_REORDER_OPTIMIZATION));
   }
 
   @Nullable
   public static Integer getNumReplicaGroupsToQuery(Map<String, String> queryOptions) {
-    String numReplicaGroupsToQuery = queryOptions.get(Request.QueryOptionKey.NUM_REPLICA_GROUPS_TO_QUERY);
+    String numReplicaGroupsToQuery = queryOptions.get(QueryOptionKey.NUM_REPLICA_GROUPS_TO_QUERY);
     return numReplicaGroupsToQuery != null ? Integer.parseInt(numReplicaGroupsToQuery) : null;
   }
 
   public static boolean isExplainPlanVerbose(Map<String, String> queryOptions) {
-    return Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.EXPLAIN_PLAN_VERBOSE));
+    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.EXPLAIN_PLAN_VERBOSE));
   }
 
   @Nullable
   public static Integer getMaxExecutionThreads(Map<String, String> queryOptions) {
-    String maxExecutionThreadsString = queryOptions.get(Request.QueryOptionKey.MAX_EXECUTION_THREADS);
+    String maxExecutionThreadsString = queryOptions.get(QueryOptionKey.MAX_EXECUTION_THREADS);
     return maxExecutionThreadsString != null ? Integer.parseInt(maxExecutionThreadsString) : null;
   }
 
   @Nullable
   public static Integer getMinSegmentGroupTrimSize(Map<String, String> queryOptions) {
-    String minSegmentGroupTrimSizeString = queryOptions.get(Request.QueryOptionKey.MIN_SEGMENT_GROUP_TRIM_SIZE);
+    String minSegmentGroupTrimSizeString = queryOptions.get(QueryOptionKey.MIN_SEGMENT_GROUP_TRIM_SIZE);
     return minSegmentGroupTrimSizeString != null ? Integer.parseInt(minSegmentGroupTrimSizeString) : null;
   }
 
   @Nullable
   public static Integer getMinServerGroupTrimSize(Map<String, String> queryOptions) {
-    String minServerGroupTrimSizeString = queryOptions.get(Request.QueryOptionKey.MIN_SERVER_GROUP_TRIM_SIZE);
+    String minServerGroupTrimSizeString = queryOptions.get(QueryOptionKey.MIN_SERVER_GROUP_TRIM_SIZE);
     return minServerGroupTrimSizeString != null ? Integer.parseInt(minServerGroupTrimSizeString) : null;
   }
 
   public static boolean isNullHandlingEnabled(Map<String, String> queryOptions) {
-    boolean nullHandlingEnabled = Boolean.parseBoolean(queryOptions.get(Request.QueryOptionKey.ENABLE_NULL_HANDLING));
+    boolean nullHandlingEnabled = Boolean.parseBoolean(queryOptions.get(QueryOptionKey.ENABLE_NULL_HANDLING));
     if (nullHandlingEnabled) {
       Preconditions.checkState(DataTableFactory.getDataTableVersion() >= DataTableFactory.VERSION_4,
           "Null handling cannot be enabled for data table version smaller than 4");
     }
     return nullHandlingEnabled;
+  }
+
+  public static boolean isServerReturnFinalResult(Map<String, String> queryOptions) {
+    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.SERVER_RETURN_FINAL_RESULT));
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -88,7 +88,6 @@ import static org.apache.pinot.common.function.scalar.StringFunctions.*;
 import static org.apache.pinot.controller.helix.core.PinotHelixResourceManager.EXTERNAL_VIEW_CHECK_INTERVAL_MS;
 import static org.apache.pinot.controller.helix.core.PinotHelixResourceManager.EXTERNAL_VIEW_ONLINE_SEGMENTS_MAX_WAIT_MS;
 import static org.testng.Assert.*;
-import static org.testng.Assert.assertEquals;
 
 
 /**
@@ -258,6 +257,15 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
           new ServiceStatus.IdealStateAndExternalViewMatchServiceStatusCallback(_helixManager, getHelixClusterName(),
               instance, resourcesToMonitor, 100.0))));
     }
+  }
+
+  @Override
+  protected void testQuery(String pinotQuery, String h2Query)
+      throws Exception {
+    if (getNumServers() == 1) {
+      pinotQuery = "SET serverReturnFinalResult = true;" + pinotQuery;
+    }
+    super.testQuery(pinotQuery, h2Query);
   }
 
   @Test
@@ -554,8 +562,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     TableConfig tableConfig = getOfflineTableConfig();
     tableConfig.getIndexingConfig().setInvertedIndexColumns(UPDATED_INVERTED_INDEX_COLUMNS);
     updateTableConfig(tableConfig);
-    String reloadJobId = reloadOfflineTableAndValidateResponse(
-        TableNameBuilder.OFFLINE.tableNameWithType(getTableName()), false);
+    String reloadJobId =
+        reloadOfflineTableAndValidateResponse(TableNameBuilder.OFFLINE.tableNameWithType(getTableName()), false);
 
     // It takes a while to reload multiple segments, thus we retry the query for some time.
     // After all segments are reloaded, the inverted index is added on DivActualElapsedTime.
@@ -592,7 +600,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   }
 
   @Test
-  public void testRegexpReplace() throws Exception {
+  public void testRegexpReplace()
+      throws Exception {
     // Correctness tests of regexpReplace.
 
     // Test replace all.
@@ -643,7 +652,6 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     result = response.get("resultTable").get("rows").get(0).get(0).asText();
     assertEquals(result, "hsomething, something, something and wise");
 
-
     // Test occurence
     sqlQuery = "SELECT regexpReplace('healthy, wealthy, stealthy and wise','\\w+thy', 'something', 0, 2)";
     response = postQuery(sqlQuery, _brokerBaseApiUrl);
@@ -685,8 +693,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     JsonNode rows = response.get("resultTable").get("rows");
     for (int i = 0; i < rows.size(); i++) {
       JsonNode row = rows.get(i);
-      boolean containsSpace = row.get(0).asText().contains(" ");
-      assertEquals(containsSpace, false);
+      assertFalse(row.get(0).asText().contains(" "));
     }
 
     // Test in where clause
@@ -699,8 +706,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertEquals(count1, count2);
 
     // Test nested transform
-    sqlQuery = "SELECT count(*) from myTable where contains(regexpReplace(originState, '(C)(A)', '$1TEST$2'), "
-        + "'CTESTA')";
+    sqlQuery =
+        "SELECT count(*) from myTable where contains(regexpReplace(originState, '(C)(A)', '$1TEST$2'), 'CTESTA')";
     response = postQuery(sqlQuery, _brokerBaseApiUrl);
     count1 = response.get("resultTable").get("rows").get(0).get(0).asInt();
     sqlQuery = "SELECT count(*) from myTable where originState='CA'";
@@ -746,8 +753,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     // long string literal encode
     sqlQuery =
         "SELECT toBase64(toUtf8('this is a long string that will encode to more than 76 characters using base64')) "
-            + "FROM "
-            + "myTable";
+            + "FROM myTable";
     response = postQuery(sqlQuery, _brokerBaseApiUrl);
     resultTable = response.get("resultTable");
     rows = resultTable.get("rows");
@@ -778,9 +784,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertEquals(encodedString, toBase64(toUtf8("123")));
 
     // identifier
-    sqlQuery =
-        "SELECT Carrier, toBase64(toUtf8(Carrier)), fromUtf8(fromBase64(toBase64(toUtf8(Carrier)))), fromBase64"
-            + "(toBase64(toUtf8(Carrier))) FROM myTable LIMIT 100";
+    sqlQuery = "SELECT Carrier, toBase64(toUtf8(Carrier)), fromUtf8(fromBase64(toBase64(toUtf8(Carrier)))), "
+        + "fromBase64(toBase64(toUtf8(Carrier))) FROM myTable LIMIT 100";
     response = postQuery(sqlQuery, _brokerBaseApiUrl);
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
@@ -817,9 +822,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertTrue(response.get("exceptions").get(0).get("message").toString().contains("IllegalArgumentException"));
 
     // string literal used in a filter
-    sqlQuery =
-        "SELECT * FROM myTable WHERE fromUtf8(fromBase64('aGVsbG8h')) != Carrier AND toBase64(toUtf8('hello!')) != "
-        + "Carrier LIMIT 10";
+    sqlQuery = "SELECT * FROM myTable WHERE fromUtf8(fromBase64('aGVsbG8h')) != Carrier AND "
+        + "toBase64(toUtf8('hello!')) != Carrier LIMIT 10";
     response = postQuery(sqlQuery, _brokerBaseApiUrl);
     resultTable = response.get("resultTable");
     rows = resultTable.get("rows");
@@ -840,10 +844,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertEquals(rows.size(), 10);
 
     // non-string identifier used in a filter
-    sqlQuery =
-        "SELECT fromUtf8(fromBase64(toBase64(toUtf8(AirlineID)))), AirlineID FROM myTable WHERE fromUtf8(fromBase64"
-        + "(toBase64(toUtf8(AirlineID)))) = "
-            + "AirlineID LIMIT 10";
+    sqlQuery = "SELECT fromUtf8(fromBase64(toBase64(toUtf8(AirlineID)))), AirlineID FROM myTable WHERE "
+        + "fromUtf8(fromBase64(toBase64(toUtf8(AirlineID)))) = AirlineID LIMIT 10";
     response = postQuery(sqlQuery, _brokerBaseApiUrl);
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
@@ -852,12 +854,10 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertEquals(rows.size(), 10);
 
     // string identifier used in group by order by
-    sqlQuery =
-        "SELECT Carrier as originalCol, toBase64(toUtf8(Carrier)) as encoded, fromUtf8(fromBase64(toBase64(toUtf8"
-        + "(Carrier)))) as decoded "
-            + "FROM myTable GROUP BY Carrier, toBase64(toUtf8(Carrier)), fromUtf8(fromBase64(toBase64(toUtf8(Carrier)"
-            + "))) ORDER BY toBase64(toUtf8(Carrier))"
-            + " LIMIT 10";
+    sqlQuery = "SELECT Carrier as originalCol, toBase64(toUtf8(Carrier)) as encoded, "
+        + "fromUtf8(fromBase64(toBase64(toUtf8(Carrier)))) as decoded FROM myTable "
+        + "GROUP BY Carrier, toBase64(toUtf8(Carrier)), fromUtf8(fromBase64(toBase64(toUtf8(Carrier)))) "
+        + "ORDER BY toBase64(toUtf8(Carrier)) LIMIT 10";
     response = postQuery(sqlQuery, _brokerBaseApiUrl);
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
@@ -874,12 +874,10 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     }
 
     // non-string identifier used in group by order by
-    sqlQuery =
-        "SELECT AirlineID as originalCol, toBase64(toUtf8(AirlineID)) as encoded, fromUtf8(fromBase64(toBase64(toUtf8"
-        + "(AirlineID)))) as decoded "
-            + "FROM myTable GROUP BY AirlineID, toBase64(toUtf8(AirlineID)), fromUtf8(fromBase64(toBase64(toUtf8"
-            + "(AirlineID)))) ORDER BY "
-            + "fromUtf8(fromBase64(toBase64(toUtf8(AirlineID)))) LIMIT 10";
+    sqlQuery = "SELECT AirlineID as originalCol, toBase64(toUtf8(AirlineID)) as encoded, "
+        + "fromUtf8(fromBase64(toBase64(toUtf8(AirlineID)))) as decoded FROM myTable "
+        + "GROUP BY AirlineID, toBase64(toUtf8(AirlineID)), fromUtf8(fromBase64(toBase64(toUtf8(AirlineID)))) "
+        + "ORDER BY fromUtf8(fromBase64(toBase64(toUtf8(AirlineID)))) LIMIT 10";
     response = postQuery(sqlQuery, _brokerBaseApiUrl);
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
@@ -960,10 +958,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         "key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253");
     assertEquals(response.get("resultTable").get("rows").get(0).get(8).asText(),
         "key1=value 1&key2=value@!$2&key3=value%3");
-    assertEquals(response.get("resultTable").get("rows").get(0).get(9).asText(),
-        "aGVsbG8h");
-    assertEquals(response.get("resultTable").get("rows").get(0).get(10).asText(),
-        "hello!");
+    assertEquals(response.get("resultTable").get("rows").get(0).get(9).asText(), "aGVsbG8h");
+    assertEquals(response.get("resultTable").get("rows").get(0).get(10).asText(), "hello!");
   }
 
   @Test(dependsOnMethods = "testBloomFilterTriggering")
@@ -2705,8 +2701,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       throws IOException {
     String jobId = null;
     String response =
-        sendPostRequest(_controllerRequestURLBuilder.forTableReload(tableName, TableType.OFFLINE, forceDownload),
-            null);
+        sendPostRequest(_controllerRequestURLBuilder.forTableReload(tableName, TableType.OFFLINE, forceDownload), null);
     String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
     JsonNode tableLevelDetails =
         JsonUtils.stringToJsonNode(StringEscapeUtils.unescapeJava(response.split(": ")[1])).get(tableNameWithType);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -283,6 +283,7 @@ public class CommonConstants {
         public static final String EXPLAIN_PLAN_VERBOSE = "explainPlanVerbose";
         public static final String USE_MULTISTAGE_ENGINE = "useMultistageEngine";
         public static final String ENABLE_NULL_HANDLING = "enableNullHandling";
+        public static final String SERVER_RETURN_FINAL_RESULT = "serverReturnFinalResult";
 
         // TODO: Remove these keys (only apply to PQL) after releasing 0.11.0
         @Deprecated


### PR DESCRIPTION
When there is only one server queried, we can calculate the final aggregation result on the server side, instead of serializing back the intermediate result (which can be huge for distinct_count, percentile etc.).

This PR adds a new query option `serverReturnFinalResult` to let the server directly return the final aggregation result. As a follow up, we may add a flag to the broker config to let the broker automatically add this query option when it is querying only one server.