### PR TITLE
TierBasedSegmentDirectoryLoader to keep segments in multi-datadir

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadata.java
@@ -158,6 +158,14 @@ public class SegmentZKMetadata implements ZKMetadata {
     setNonNegativeValue(Segment.CRC, crc);
   }
 
+  public String getTier() {
+    return _simpleFields.get(Segment.TIER);
+  }
+
+  public void setTier(String tier) {
+    setValue(Segment.TIER, tier);
+  }
+
   public long getCreationTime() {
     return _znRecord.getLongField(Segment.CREATION_TIME, -1);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TierConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TierConfigUtils.java
@@ -51,6 +51,10 @@ public final class TierConfigUtils {
     return CollectionUtils.isNotEmpty(tableConfig.getTierConfigsList());
   }
 
+  public static String normalizeTierName(String tierName) {
+    return tierName == null ? "default" : tierName;
+  }
+
   public static String getDataDirForTier(TableConfig tableConfig, String tierName) {
     String tableNameWithType = tableConfig.getTableName();
     List<TierConfig> tierCfgs = tableConfig.getTierConfigsList();

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TierConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TierConfigUtils.java
@@ -18,10 +18,13 @@
  */
 package org.apache.pinot.common.utils.config;
 
+import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.HelixManager;
 import org.apache.pinot.common.tier.FixedTierSegmentSelector;
 import org.apache.pinot.common.tier.Tier;
@@ -30,6 +33,7 @@ import org.apache.pinot.common.tier.TierSegmentSelector;
 import org.apache.pinot.common.tier.TimeBasedTierSegmentSelector;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TierConfig;
+import org.apache.pinot.spi.utils.CommonConstants;
 
 
 /**
@@ -45,6 +49,28 @@ public final class TierConfigUtils {
    */
   public static boolean shouldRelocateToTiers(TableConfig tableConfig) {
     return CollectionUtils.isNotEmpty(tableConfig.getTierConfigsList());
+  }
+
+  public static String getDataDirFromTierConfig(String tableNameWithType, String tierName, TableConfig tableConfig) {
+    List<TierConfig> tierCfgs = tableConfig.getTierConfigsList();
+    Preconditions
+        .checkState(tierCfgs != null && !tierCfgs.isEmpty(), "No tierConfigs for table: %s", tableNameWithType);
+    TierConfig tierCfg = null;
+    for (TierConfig tc : tierCfgs) {
+      if (tierName.equalsIgnoreCase(tc.getName())) {
+        tierCfg = tc;
+        break;
+      }
+    }
+    Preconditions.checkNotNull(tierCfg, "No configs for tier: %s on table: %s", tierName, tableNameWithType);
+    // TODO: check if the tier configs are predefined in ClusterConfigs.
+    Map<String, String> backendProps = tierCfg.getTierBackendProperties();
+    Preconditions
+        .checkNotNull(backendProps, "No backend properties for tier: %s on table: %s", tierName, tableNameWithType);
+    String dataDir = backendProps.get(CommonConstants.Tier.BACKEND_PROP_DATA_DIR);
+    Preconditions.checkState(StringUtils.isNotEmpty(dataDir), "No dataDir for tier: %s on table: %s", tierName,
+        tableNameWithType);
+    return dataDir;
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TierConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TierConfigUtils.java
@@ -51,12 +51,13 @@ public final class TierConfigUtils {
     return CollectionUtils.isNotEmpty(tableConfig.getTierConfigsList());
   }
 
-  public static String getDataDirFromTierConfig(String tableNameWithType, String tierName, TableConfig tableConfig) {
+  public static String getDataDirForTier(TableConfig tableConfig, String tierName) {
+    String tableNameWithType = tableConfig.getTableName();
     List<TierConfig> tierCfgs = tableConfig.getTierConfigsList();
     Preconditions.checkState(CollectionUtils.isNotEmpty(tierCfgs), "No tierConfigs for table: %s", tableNameWithType);
     TierConfig tierCfg = null;
     for (TierConfig tc : tierCfgs) {
-      if (tierName.equalsIgnoreCase(tc.getName())) {
+      if (tierName.equals(tc.getName())) {
         tierCfg = tc;
         break;
       }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TierConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TierConfigUtils.java
@@ -53,8 +53,7 @@ public final class TierConfigUtils {
 
   public static String getDataDirFromTierConfig(String tableNameWithType, String tierName, TableConfig tableConfig) {
     List<TierConfig> tierCfgs = tableConfig.getTierConfigsList();
-    Preconditions
-        .checkState(tierCfgs != null && !tierCfgs.isEmpty(), "No tierConfigs for table: %s", tableNameWithType);
+    Preconditions.checkState(CollectionUtils.isNotEmpty(tierCfgs), "No tierConfigs for table: %s", tableNameWithType);
     TierConfig tierCfg = null;
     for (TierConfig tc : tierCfgs) {
       if (tierName.equalsIgnoreCase(tc.getName())) {

--- a/pinot-common/src/test/java/org/apache/pinot/common/tier/TierConfigUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/tier/TierConfigUtilsTest.java
@@ -188,31 +188,31 @@ public class TierConfigUtilsTest {
   }
 
   @Test
-  public void testGetDataDirFromTierConfig() {
+  public void testGetDataDirForTier() {
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").build();
     try {
-      TierConfigUtils.getDataDirFromTierConfig("myTable", "tier1", tableConfig);
+      TierConfigUtils.getDataDirForTier(tableConfig, "tier1");
     } catch (Exception e) {
-      Assert.assertEquals(e.getMessage(), "No tierConfigs for table: myTable");
+      Assert.assertEquals(e.getMessage(), "No tierConfigs for table: myTable_OFFLINE");
     }
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").setTierConfigList(Lists
         .newArrayList(new TierConfig("myTier", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "10d", null,
             TierFactory.PINOT_SERVER_STORAGE_TYPE, "tag_OFFLINE", null, null))).build();
     try {
-      TierConfigUtils.getDataDirFromTierConfig("myTable", "tier1", tableConfig);
+      TierConfigUtils.getDataDirForTier(tableConfig, "tier1");
     } catch (Exception e) {
-      Assert.assertEquals(e.getMessage(), "No configs for tier: tier1 on table: myTable");
+      Assert.assertEquals(e.getMessage(), "No configs for tier: tier1 on table: myTable_OFFLINE");
     }
     try {
-      TierConfigUtils.getDataDirFromTierConfig("myTable", "myTier", tableConfig);
+      TierConfigUtils.getDataDirForTier(tableConfig, "myTier");
     } catch (Exception e) {
-      Assert.assertEquals(e.getMessage(), "No backend properties for tier: myTier on table: myTable");
+      Assert.assertEquals(e.getMessage(), "No backend properties for tier: myTier on table: myTable_OFFLINE");
     }
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").setTierConfigList(Lists
         .newArrayList(new TierConfig("myTier", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "10d", null,
             TierFactory.PINOT_SERVER_STORAGE_TYPE, "tag_OFFLINE", null,
             Collections.singletonMap("dataDir", "/foo/bar")))).build();
-    String dataDir = TierConfigUtils.getDataDirFromTierConfig("myTable", "myTier", tableConfig);
+    String dataDir = TierConfigUtils.getDataDirForTier(tableConfig, "myTier");
     Assert.assertEquals(dataDir, "/foo/bar");
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/tier/TierConfigUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/tier/TierConfigUtilsTest.java
@@ -186,4 +186,33 @@ public class TierConfigUtilsTest {
     Assert.assertEquals(tierComparator.compare(tier6, tier5), -1);
     Assert.assertEquals(tierComparator.compare(tier4, tier7), 1);
   }
+
+  @Test
+  public void testGetDataDirFromTierConfig() {
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").build();
+    try {
+      TierConfigUtils.getDataDirFromTierConfig("myTable", "tier1", tableConfig);
+    } catch (Exception e) {
+      Assert.assertEquals(e.getMessage(), "No tierConfigs for table: myTable");
+    }
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").setTierConfigList(Lists
+        .newArrayList(new TierConfig("myTier", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "10d", null,
+            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tag_OFFLINE", null, null))).build();
+    try {
+      TierConfigUtils.getDataDirFromTierConfig("myTable", "tier1", tableConfig);
+    } catch (Exception e) {
+      Assert.assertEquals(e.getMessage(), "No configs for tier: tier1 on table: myTable");
+    }
+    try {
+      TierConfigUtils.getDataDirFromTierConfig("myTable", "myTier", tableConfig);
+    } catch (Exception e) {
+      Assert.assertEquals(e.getMessage(), "No backend properties for tier: myTier on table: myTable");
+    }
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").setTierConfigList(Lists
+        .newArrayList(new TierConfig("myTier", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "10d", null,
+            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tag_OFFLINE", null,
+            Collections.singletonMap("dataDir", "/foo/bar")))).build();
+    String dataDir = TierConfigUtils.getDataDirFromTierConfig("myTable", "myTier", tableConfig);
+    Assert.assertEquals(dataDir, "/foo/bar");
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -224,7 +224,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
   public void addSegment(File indexDir, IndexLoadingConfig indexLoadingConfig)
       throws Exception {
     Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
-    addSegment(ImmutableSegmentLoader.load(indexDir, indexLoadingConfig, schema));
+    addSegment(ImmutableSegmentLoader.load(indexDir, indexLoadingConfig, schema, true, _tableDataDir, null));
   }
 
   @Override
@@ -598,7 +598,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
   }
 
   @VisibleForTesting
-  File getSegmentDataDir(String segmentName, String segmentTier, IndexLoadingConfig indexLoadingConfig) {
+  File getSegmentDataDir(String segmentName, @Nullable String segmentTier, IndexLoadingConfig indexLoadingConfig) {
     if (segmentTier == null) {
       return getSegmentDataDir(segmentName);
     }
@@ -614,6 +614,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
     }
   }
 
+  @Nullable
   private String getSegmentCurrentTier(String segmentName) {
     SegmentDataManager segment = _segmentDataManagerMap.get(segmentName);
     if (segment != null && segment.getSegment() instanceof ImmutableSegment) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -603,8 +603,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
       return getSegmentDataDir(segmentName);
     }
     try {
-      String tierDataDir = TierConfigUtils
-          .getDataDirFromTierConfig(_tableNameWithType, segmentTier, indexLoadingConfig.getTableConfig());
+      String tierDataDir = TierConfigUtils.getDataDirForTier(indexLoadingConfig.getTableConfig(), segmentTier);
       File tierTableDataDir = new File(tierDataDir, _tableNameWithType);
       return new File(tierTableDataDir, segmentName);
     } catch (Exception e) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
@@ -86,15 +86,15 @@ public interface InstanceDataManager {
       throws Exception;
 
   /**
-   * Removes a segment from a table but not dropping its data from server.
+   * Offloads a segment from table but not dropping its data from server.
    */
-  void removeSegment(String tableNameWithType, String segmentName)
+  void offloadSegment(String tableNameWithType, String segmentName)
       throws Exception;
 
   /**
-   * Delete segment data from the server.
+   * Delete segment data from the server physically.
    */
-  void dropSegment(String tableNameWithType, String segmentName)
+  void deleteSegment(String tableNameWithType, String segmentName)
       throws Exception;
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
@@ -86,9 +86,15 @@ public interface InstanceDataManager {
       throws Exception;
 
   /**
-   * Removes a segment from a table.
+   * Removes a segment from a table but not dropping its data from server.
    */
   void removeSegment(String tableNameWithType, String segmentName)
+      throws Exception;
+
+  /**
+   * Delete segment data from the server.
+   */
+  void dropSegment(String tableNameWithType, String segmentName)
       throws Exception;
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -22,10 +22,8 @@ import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -155,13 +153,9 @@ public class BaseTableDataManagerTest {
     tmgr = createTableManager();
     IndexLoadingConfig loadingCfg = createIndexLoadingConfig("tierBased", tableConfig);
     tmgr.reloadSegment(segName, loadingCfg, zkmd, llmd, null, false);
-    File segDirOnTier = tmgr.getSegmentDataDir(segName, tierName, loadingCfg);
+    File segDirOnTier = tmgr.getSegmentDataDir(segName, tierName, loadingCfg.getTableConfig());
     assertTrue(segDirOnTier.exists());
-    // A tier track file is put into the default seg dir, and nothing else.
-    Collection<File> filesInDefaultSegDir = FileUtils.listFiles(defaultSegDir, null, true);
-    assertEquals(filesInDefaultSegDir.size(), 1);
-    File tierTrackFile = filesInDefaultSegDir.iterator().next();
-    assertEquals(FileUtils.readFileToString(tierTrackFile, StandardCharsets.UTF_8), tierName);
+    assertFalse(defaultSegDir.exists());
     llmd = new SegmentMetadataImpl(segDirOnTier);
     assertEquals(llmd.getTotalDocs(), 5);
     assertEquals(llmd.getIndexDir(), segDirOnTier);
@@ -228,13 +222,9 @@ public class BaseTableDataManagerTest {
     tmgr = createTableManager();
     IndexLoadingConfig loadingCfg = createIndexLoadingConfig("tierBased", tableConfig);
     tmgr.reloadSegment(segName, loadingCfg, zkmd, llmd, null, false);
-    File segDirOnTier = tmgr.getSegmentDataDir(segName, tierName, loadingCfg);
+    File segDirOnTier = tmgr.getSegmentDataDir(segName, tierName, loadingCfg.getTableConfig());
     assertTrue(segDirOnTier.exists());
-    // A tier track file is put into the default seg dir, and nothing else.
-    Collection<File> filesInDefaultSegDir = FileUtils.listFiles(localSegDir, null, true);
-    assertEquals(filesInDefaultSegDir.size(), 1);
-    File tierTrackFile = filesInDefaultSegDir.iterator().next();
-    assertEquals(FileUtils.readFileToString(tierTrackFile, StandardCharsets.UTF_8), tierName);
+    assertFalse(localSegDir.exists());
     llmd = new SegmentMetadataImpl(segDirOnTier);
     assertEquals(llmd.getTotalDocs(), 5);
     assertEquals(llmd.getIndexDir(), segDirOnTier);
@@ -377,13 +367,9 @@ public class BaseTableDataManagerTest {
     tmgr = createTableManager();
     IndexLoadingConfig loadingCfg = createIndexLoadingConfig("tierBased", tableConfig);
     tmgr.addOrReplaceSegment(segName, loadingCfg, zkmd, llmd);
-    File segDirOnTier = tmgr.getSegmentDataDir(segName, tierName, loadingCfg);
+    File segDirOnTier = tmgr.getSegmentDataDir(segName, tierName, loadingCfg.getTableConfig());
     assertTrue(segDirOnTier.exists());
-    // A tier track file is put into the default seg dir, and nothing else.
-    Collection<File> filesInDefaultSegDir = FileUtils.listFiles(defaultSegDir, null, true);
-    assertEquals(filesInDefaultSegDir.size(), 1);
-    File tierTrackFile = filesInDefaultSegDir.iterator().next();
-    assertEquals(FileUtils.readFileToString(tierTrackFile, StandardCharsets.UTF_8), tierName);
+    assertFalse(defaultSegDir.exists());
     llmd = new SegmentMetadataImpl(segDirOnTier);
     assertEquals(llmd.getTotalDocs(), 5);
     assertEquals(llmd.getIndexDir(), segDirOnTier);
@@ -461,7 +447,7 @@ public class BaseTableDataManagerTest {
     // Configured dataDir for coolTier, thus move to new dir.
     tableConfig = createTableConfigWithTier(tierName, new File(TEMP_DIR, tierName));
     IndexLoadingConfig loadingCfg = createIndexLoadingConfig("tierBased", tableConfig);
-    File segDirOnTier = tmgr.getSegmentDataDir(segName, tierName, loadingCfg);
+    File segDirOnTier = tmgr.getSegmentDataDir(segName, tierName, loadingCfg.getTableConfig());
     assertFalse(segDirOnTier.exists());
     // Move segDir to new tier to see if addOrReplaceSegment() can load segDir from new tier directly.
     FileUtils.moveDirectory(localSegDir, segDirOnTier);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -22,8 +22,10 @@ import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -155,7 +157,11 @@ public class BaseTableDataManagerTest {
     tmgr.reloadSegment(segName, loadingCfg, zkmd, llmd, null, false);
     File segDirOnTier = tmgr.getSegmentDataDir(segName, tierName, loadingCfg);
     assertTrue(segDirOnTier.exists());
-    assertFalse(defaultSegDir.exists());
+    // A tier track file is put into the default seg dir, and nothing else.
+    Collection<File> filesInDefaultSegDir = FileUtils.listFiles(defaultSegDir, null, true);
+    assertEquals(filesInDefaultSegDir.size(), 1);
+    File tierTrackFile = filesInDefaultSegDir.iterator().next();
+    assertEquals(FileUtils.readFileToString(tierTrackFile, StandardCharsets.UTF_8), tierName);
     llmd = new SegmentMetadataImpl(segDirOnTier);
     assertEquals(llmd.getTotalDocs(), 5);
     assertEquals(llmd.getIndexDir(), segDirOnTier);
@@ -224,7 +230,11 @@ public class BaseTableDataManagerTest {
     tmgr.reloadSegment(segName, loadingCfg, zkmd, llmd, null, false);
     File segDirOnTier = tmgr.getSegmentDataDir(segName, tierName, loadingCfg);
     assertTrue(segDirOnTier.exists());
-    assertFalse(localSegDir.exists());
+    // A tier track file is put into the default seg dir, and nothing else.
+    Collection<File> filesInDefaultSegDir = FileUtils.listFiles(localSegDir, null, true);
+    assertEquals(filesInDefaultSegDir.size(), 1);
+    File tierTrackFile = filesInDefaultSegDir.iterator().next();
+    assertEquals(FileUtils.readFileToString(tierTrackFile, StandardCharsets.UTF_8), tierName);
     llmd = new SegmentMetadataImpl(segDirOnTier);
     assertEquals(llmd.getTotalDocs(), 5);
     assertEquals(llmd.getIndexDir(), segDirOnTier);
@@ -369,7 +379,11 @@ public class BaseTableDataManagerTest {
     tmgr.addOrReplaceSegment(segName, loadingCfg, zkmd, llmd);
     File segDirOnTier = tmgr.getSegmentDataDir(segName, tierName, loadingCfg);
     assertTrue(segDirOnTier.exists());
-    assertFalse(defaultSegDir.exists());
+    // A tier track file is put into the default seg dir, and nothing else.
+    Collection<File> filesInDefaultSegDir = FileUtils.listFiles(defaultSegDir, null, true);
+    assertEquals(filesInDefaultSegDir.size(), 1);
+    File tierTrackFile = filesInDefaultSegDir.iterator().next();
+    assertEquals(FileUtils.readFileToString(tierTrackFile, StandardCharsets.UTF_8), tierName);
     llmd = new SegmentMetadataImpl(segDirOnTier);
     assertEquals(llmd.getTotalDocs(), 5);
     assertEquals(llmd.getIndexDir(), segDirOnTier);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -141,7 +141,7 @@ public class BaseTableDataManagerTest {
     BaseTableDataManager tmgr = createTableManager();
     File defaultSegDir = tmgr.getSegmentDataDir(segName);
     assertFalse(defaultSegDir.exists());
-    tmgr.reloadSegment(segName, createIndexLoadingConfig("multidir", tableConfig), zkmd, llmd, null, false);
+    tmgr.reloadSegment(segName, createIndexLoadingConfig("tierBased", tableConfig), zkmd, llmd, null, false);
     assertTrue(defaultSegDir.exists());
     llmd = new SegmentMetadataImpl(defaultSegDir);
     assertEquals(llmd.getTotalDocs(), 5);
@@ -151,7 +151,7 @@ public class BaseTableDataManagerTest {
     when(llmd.getCrc()).thenReturn("0");
     tableConfig = createTableConfigWithTier(tierName, new File(TEMP_DIR, tierName));
     tmgr = createTableManager();
-    IndexLoadingConfig loadingCfg = createIndexLoadingConfig("multidir", tableConfig);
+    IndexLoadingConfig loadingCfg = createIndexLoadingConfig("tierBased", tableConfig);
     tmgr.reloadSegment(segName, loadingCfg, zkmd, llmd, null, false);
     File segDirOnTier = tmgr.getSegmentDataDir(segName, tierName, loadingCfg);
     assertTrue(segDirOnTier.exists());
@@ -209,7 +209,7 @@ public class BaseTableDataManagerTest {
 
     // No dataDir for coolTier, thus stay on default tier.
     BaseTableDataManager tmgr = createTableManager();
-    tmgr.reloadSegment(segName, createIndexLoadingConfig("multidir", tableConfig), zkmd, llmd, null, false);
+    tmgr.reloadSegment(segName, createIndexLoadingConfig("tierBased", tableConfig), zkmd, llmd, null, false);
     assertTrue(tmgr.getSegmentDataDir(segName).exists());
     llmd = new SegmentMetadataImpl(tmgr.getSegmentDataDir(segName));
     assertEquals(llmd.getTotalDocs(), 5);
@@ -220,7 +220,7 @@ public class BaseTableDataManagerTest {
     when(llmd.getCrc()).thenReturn(segCrc);
     tableConfig = createTableConfigWithTier(tierName, new File(TEMP_DIR, tierName));
     tmgr = createTableManager();
-    IndexLoadingConfig loadingCfg = createIndexLoadingConfig("multidir", tableConfig);
+    IndexLoadingConfig loadingCfg = createIndexLoadingConfig("tierBased", tableConfig);
     tmgr.reloadSegment(segName, loadingCfg, zkmd, llmd, null, false);
     File segDirOnTier = tmgr.getSegmentDataDir(segName, tierName, loadingCfg);
     assertTrue(segDirOnTier.exists());
@@ -355,7 +355,7 @@ public class BaseTableDataManagerTest {
     BaseTableDataManager tmgr = createTableManager();
     File defaultSegDir = tmgr.getSegmentDataDir(segName);
     assertFalse(defaultSegDir.exists());
-    tmgr.addOrReplaceSegment(segName, createIndexLoadingConfig("multidir", tableConfig), zkmd, llmd);
+    tmgr.addOrReplaceSegment(segName, createIndexLoadingConfig("tierBased", tableConfig), zkmd, llmd);
     assertTrue(defaultSegDir.exists());
     llmd = new SegmentMetadataImpl(defaultSegDir);
     assertEquals(llmd.getTotalDocs(), 5);
@@ -365,7 +365,7 @@ public class BaseTableDataManagerTest {
     when(llmd.getCrc()).thenReturn("0");
     tableConfig = createTableConfigWithTier(tierName, new File(TEMP_DIR, tierName));
     tmgr = createTableManager();
-    IndexLoadingConfig loadingCfg = createIndexLoadingConfig("multidir", tableConfig);
+    IndexLoadingConfig loadingCfg = createIndexLoadingConfig("tierBased", tableConfig);
     tmgr.addOrReplaceSegment(segName, loadingCfg, zkmd, llmd);
     File segDirOnTier = tmgr.getSegmentDataDir(segName, tierName, loadingCfg);
     assertTrue(segDirOnTier.exists());
@@ -438,7 +438,7 @@ public class BaseTableDataManagerTest {
 
     // No dataDir for coolTier, thus stay on default tier.
     BaseTableDataManager tmgr = createTableManager();
-    tmgr.addOrReplaceSegment(segName, createIndexLoadingConfig("multidir", tableConfig), zkmd, null);
+    tmgr.addOrReplaceSegment(segName, createIndexLoadingConfig("tierBased", tableConfig), zkmd, null);
     assertTrue(tmgr.getSegmentDataDir(segName).exists());
     SegmentMetadataImpl llmd = new SegmentMetadataImpl(tmgr.getSegmentDataDir(segName));
     assertEquals(llmd.getTotalDocs(), 5);
@@ -446,7 +446,7 @@ public class BaseTableDataManagerTest {
 
     // Configured dataDir for coolTier, thus move to new dir.
     tableConfig = createTableConfigWithTier(tierName, new File(TEMP_DIR, tierName));
-    IndexLoadingConfig loadingCfg = createIndexLoadingConfig("multidir", tableConfig);
+    IndexLoadingConfig loadingCfg = createIndexLoadingConfig("tierBased", tableConfig);
     File segDirOnTier = tmgr.getSegmentDataDir(segName, tierName, loadingCfg);
     assertFalse(segDirOnTier.exists());
     // Move segDir to new tier to see if addOrReplaceSegment() can load segDir from new tier directly.

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -69,7 +69,7 @@ public class ImmutableSegmentLoader {
       throws Exception {
     IndexLoadingConfig defaultIndexLoadingConfig = new IndexLoadingConfig();
     defaultIndexLoadingConfig.setReadMode(readMode);
-    return load(indexDir, defaultIndexLoadingConfig, null, false);
+    return load(indexDir, defaultIndexLoadingConfig, null, false, null, null);
   }
 
   /**
@@ -79,7 +79,7 @@ public class ImmutableSegmentLoader {
    */
   public static ImmutableSegment load(File indexDir, IndexLoadingConfig indexLoadingConfig)
       throws Exception {
-    return load(indexDir, indexLoadingConfig, null, true);
+    return load(indexDir, indexLoadingConfig, null, true, null, null);
   }
 
   /**
@@ -89,7 +89,13 @@ public class ImmutableSegmentLoader {
    */
   public static ImmutableSegment load(File indexDir, IndexLoadingConfig indexLoadingConfig, @Nullable Schema schema)
       throws Exception {
-    return load(indexDir, indexLoadingConfig, schema, true);
+    return load(indexDir, indexLoadingConfig, schema, true, null, null);
+  }
+
+  public static ImmutableSegment load(File indexDir, IndexLoadingConfig indexLoadingConfig, @Nullable Schema schema,
+      boolean needPreprocess)
+      throws Exception {
+    return load(indexDir, indexLoadingConfig, schema, needPreprocess, null, null);
   }
 
   /**
@@ -97,7 +103,7 @@ public class ImmutableSegmentLoader {
    * modify the segment like to convert segment format, add or remove indices.
    */
   public static ImmutableSegment load(File indexDir, IndexLoadingConfig indexLoadingConfig, @Nullable Schema schema,
-      boolean needPreprocess)
+      boolean needPreprocess, @Nullable String tableDataDir, @Nullable String targetTier)
       throws Exception {
     Preconditions.checkArgument(indexDir.isDirectory(), "Index directory: %s does not exist or is not a directory",
         indexDir);
@@ -117,8 +123,8 @@ public class ImmutableSegmentLoader {
     String segmentName = segmentMetadata.getName();
     SegmentDirectoryLoaderContext segmentLoaderContext =
         new SegmentDirectoryLoaderContext.Builder().setTableConfig(indexLoadingConfig.getTableConfig())
-            .setSchema(schema).setInstanceId(indexLoadingConfig.getInstanceId()).setSegmentName(segmentName)
-            .setSegmentCrc(segmentMetadata.getCrc())
+            .setSchema(schema).setInstanceId(indexLoadingConfig.getInstanceId()).setTableDataDir(tableDataDir)
+            .setSegmentName(segmentName).setSegmentCrc(segmentMetadata.getCrc()).setSegmentTier(targetTier)
             .setSegmentDirectoryConfigs(indexLoadingConfig.getSegmentDirectoryConfigs()).build();
     SegmentDirectoryLoader segmentLoader =
         SegmentDirectoryLoaderRegistry.getSegmentDirectoryLoader(indexLoadingConfig.getSegmentDirectoryLoader());

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -69,7 +69,7 @@ public class ImmutableSegmentLoader {
       throws Exception {
     IndexLoadingConfig defaultIndexLoadingConfig = new IndexLoadingConfig();
     defaultIndexLoadingConfig.setReadMode(readMode);
-    return load(indexDir, defaultIndexLoadingConfig, null, false, null, null);
+    return load(indexDir, defaultIndexLoadingConfig, null, false);
   }
 
   /**
@@ -79,7 +79,7 @@ public class ImmutableSegmentLoader {
    */
   public static ImmutableSegment load(File indexDir, IndexLoadingConfig indexLoadingConfig)
       throws Exception {
-    return load(indexDir, indexLoadingConfig, null, true, null, null);
+    return load(indexDir, indexLoadingConfig, null, true);
   }
 
   /**
@@ -89,13 +89,7 @@ public class ImmutableSegmentLoader {
    */
   public static ImmutableSegment load(File indexDir, IndexLoadingConfig indexLoadingConfig, @Nullable Schema schema)
       throws Exception {
-    return load(indexDir, indexLoadingConfig, schema, true, null, null);
-  }
-
-  public static ImmutableSegment load(File indexDir, IndexLoadingConfig indexLoadingConfig, @Nullable Schema schema,
-      boolean needPreprocess)
-      throws Exception {
-    return load(indexDir, indexLoadingConfig, schema, needPreprocess, null, null);
+    return load(indexDir, indexLoadingConfig, schema, true);
   }
 
   /**
@@ -103,10 +97,10 @@ public class ImmutableSegmentLoader {
    * modify the segment like to convert segment format, add or remove indices.
    */
   public static ImmutableSegment load(File indexDir, IndexLoadingConfig indexLoadingConfig, @Nullable Schema schema,
-      boolean needPreprocess, @Nullable String tableDataDir, @Nullable String targetTier)
+      boolean needPreprocess)
       throws Exception {
-    Preconditions.checkArgument(indexDir.isDirectory(), "Index directory: %s does not exist or is not a directory",
-        indexDir);
+    Preconditions
+        .checkArgument(indexDir.isDirectory(), "Index directory: %s does not exist or is not a directory", indexDir);
 
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);
     if (segmentMetadata.getTotalDocs() == 0) {
@@ -123,8 +117,9 @@ public class ImmutableSegmentLoader {
     String segmentName = segmentMetadata.getName();
     SegmentDirectoryLoaderContext segmentLoaderContext =
         new SegmentDirectoryLoaderContext.Builder().setTableConfig(indexLoadingConfig.getTableConfig())
-            .setSchema(schema).setInstanceId(indexLoadingConfig.getInstanceId()).setTableDataDir(tableDataDir)
-            .setSegmentName(segmentName).setSegmentCrc(segmentMetadata.getCrc()).setSegmentTier(targetTier)
+            .setSchema(schema).setInstanceId(indexLoadingConfig.getInstanceId())
+            .setTableDataDir(indexLoadingConfig.getTableDataDir()).setSegmentName(segmentName)
+            .setSegmentCrc(segmentMetadata.getCrc()).setSegmentTier(indexLoadingConfig.getSegmentTier())
             .setSegmentDirectoryConfigs(indexLoadingConfig.getSegmentDirectoryConfigs()).build();
     SegmentDirectoryLoader segmentLoader =
         SegmentDirectoryLoaderRegistry.getSegmentDirectoryLoader(indexLoadingConfig.getSegmentDirectoryLoader());

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/loader/DefaultSegmentDirectoryLoader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/loader/DefaultSegmentDirectoryLoader.java
@@ -60,7 +60,7 @@ public class DefaultSegmentDirectoryLoader implements SegmentDirectoryLoader {
   }
 
   @Override
-  public void drop(SegmentDirectoryLoaderContext segmentLoaderContext)
+  public void delete(SegmentDirectoryLoaderContext segmentLoaderContext)
       throws Exception {
     File indexDir = new File(segmentLoaderContext.getTableDataDir(), segmentLoaderContext.getSegmentName());
     if (indexDir.exists()) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/loader/DefaultSegmentDirectoryLoader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/loader/DefaultSegmentDirectoryLoader.java
@@ -20,6 +20,7 @@ package org.apache.pinot.segment.local.loader;
 
 import java.io.File;
 import java.net.URI;
+import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.store.SegmentLocalFSDirectory;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoader;
@@ -28,6 +29,8 @@ import org.apache.pinot.segment.spi.loader.SegmentLoader;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.ReadMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -35,6 +38,7 @@ import org.apache.pinot.spi.utils.ReadMode;
  */
 @SegmentLoader(name = "default")
 public class DefaultSegmentDirectoryLoader implements SegmentDirectoryLoader {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultSegmentDirectoryLoader.class);
 
   /**
    * Creates and loads the {@link SegmentLocalFSDirectory} which is the default implementation of
@@ -53,5 +57,15 @@ public class DefaultSegmentDirectoryLoader implements SegmentDirectoryLoader {
     }
     return new SegmentLocalFSDirectory(directory,
         ReadMode.valueOf(segmentDirectoryConfigs.getProperty(IndexLoadingConfig.READ_MODE_KEY)));
+  }
+
+  @Override
+  public void drop(SegmentDirectoryLoaderContext segmentLoaderContext)
+      throws Exception {
+    File indexDir = new File(segmentLoaderContext.getTableDataDir(), segmentLoaderContext.getSegmentName());
+    if (indexDir.exists()) {
+      FileUtils.deleteQuietly(indexDir);
+      LOGGER.info("Deleted segment directory {} on default tier", indexDir);
+    }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/loader/MultiDirSegmentDirectoryLoader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/loader/MultiDirSegmentDirectoryLoader.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.loader;
+
+import java.io.File;
+import java.net.URI;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.utils.config.TierConfigUtils;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.segment.local.segment.store.SegmentLocalFSDirectory;
+import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoader;
+import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderContext;
+import org.apache.pinot.segment.spi.loader.SegmentLoader;
+import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Implementation of {@link SegmentDirectoryLoader} that can move segments across data dirs configured as storage tiers.
+ */
+@SegmentLoader(name = "multidir")
+public class MultiDirSegmentDirectoryLoader implements SegmentDirectoryLoader {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MultiDirSegmentDirectoryLoader.class);
+
+  /**
+   * Creates and loads the {@link SegmentLocalFSDirectory} which is the default implementation of
+   * {@link SegmentDirectory}
+   * @param indexDir the current segment index directory
+   * @param segmentLoaderContext context for instantiation of the SegmentDirectory. The target tier set in context is
+   *                            used to decide which data directory to keep the segment data.
+   * @return instance of {@link SegmentLocalFSDirectory}
+   */
+  @Override
+  public SegmentDirectory load(URI indexDir, SegmentDirectoryLoaderContext segmentLoaderContext)
+      throws Exception {
+    File srcDir = new File(indexDir);
+    String segmentName = segmentLoaderContext.getSegmentName();
+    String segmentTier = segmentLoaderContext.getSegmentTier();
+    File destDir = getTargetDataDir(segmentTier, segmentLoaderContext);
+    if (destDir == null) {
+      destDir = getDefaultDataDir(segmentLoaderContext);
+      LOGGER.info("Use destDir: {} on default tier for segment: {} as no dataDir for target tier: {}", destDir,
+          segmentName, segmentTier);
+      segmentTier = null;
+    }
+    if (srcDir.equals(destDir)) {
+      LOGGER.info("Keep segment: {} in current dataDir: {} on current tier: {}", segmentName, destDir, segmentTier);
+    } else {
+      LOGGER.info("Move segment: {} from srcDir: {} to destDir: {} on tier: {}", segmentName, srcDir, destDir,
+          segmentTier);
+      if (destDir.exists()) {
+        LOGGER.warn("The destDir: {} exists on tier: {} and cleans it firstly", destDir, segmentTier);
+        FileUtils.deleteQuietly(destDir);
+      }
+      FileUtils.moveDirectory(srcDir, destDir);
+    }
+    SegmentDirectory segmentDirectory;
+    if (!destDir.exists()) {
+      segmentDirectory = new SegmentLocalFSDirectory(destDir);
+    } else {
+      segmentDirectory = new SegmentLocalFSDirectory(destDir, ReadMode
+          .valueOf(segmentLoaderContext.getSegmentDirectoryConfigs().getProperty(IndexLoadingConfig.READ_MODE_KEY)));
+    }
+    LOGGER.info("Created segmentDirectory object for segment: {} with dataDir: {} on tier: {}", segmentName, destDir,
+        segmentTier);
+    segmentDirectory.setTier(segmentTier);
+    return segmentDirectory;
+  }
+
+  private File getDefaultDataDir(SegmentDirectoryLoaderContext loaderContext) {
+    return new File(loaderContext.getTableDataDir(), loaderContext.getSegmentName());
+  }
+
+  private File getTargetDataDir(String segmentTier, SegmentDirectoryLoaderContext loaderContext) {
+    if (segmentTier == null) {
+      return null;
+    }
+    TableConfig tableConfig = loaderContext.getTableConfig();
+    String tableNameWithType = tableConfig.getTableName();
+    String segmentName = loaderContext.getSegmentName();
+    try {
+      String tierDataDir = TierConfigUtils.getDataDirFromTierConfig(tableNameWithType, segmentTier, tableConfig);
+      File tierTableDataDir = new File(tierDataDir, tableNameWithType);
+      return new File(tierTableDataDir, segmentName);
+    } catch (Exception e) {
+      LOGGER.warn("Failed to get dataDir for segment: {} of table: {} on tier: {} due to error: {}", segmentName,
+          tableNameWithType, segmentTier, e.getMessage());
+      return null;
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/loader/TierBasedSegmentDirectoryLoader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/loader/TierBasedSegmentDirectoryLoader.java
@@ -37,9 +37,9 @@ import org.slf4j.LoggerFactory;
 /**
  * Implementation of {@link SegmentDirectoryLoader} that can move segments across data dirs configured as storage tiers.
  */
-@SegmentLoader(name = "multidir")
-public class MultiDirSegmentDirectoryLoader implements SegmentDirectoryLoader {
-  private static final Logger LOGGER = LoggerFactory.getLogger(MultiDirSegmentDirectoryLoader.class);
+@SegmentLoader(name = "tierBased")
+public class TierBasedSegmentDirectoryLoader implements SegmentDirectoryLoader {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TierBasedSegmentDirectoryLoader.class);
 
   /**
    * Creates and loads the {@link SegmentLocalFSDirectory} which is the default implementation of

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/loader/TierBasedSegmentDirectoryLoader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/loader/TierBasedSegmentDirectoryLoader.java
@@ -98,7 +98,7 @@ public class TierBasedSegmentDirectoryLoader implements SegmentDirectoryLoader {
     String tableNameWithType = tableConfig.getTableName();
     String segmentName = loaderContext.getSegmentName();
     try {
-      String tierDataDir = TierConfigUtils.getDataDirFromTierConfig(tableNameWithType, segmentTier, tableConfig);
+      String tierDataDir = TierConfigUtils.getDataDirForTier(tableConfig, segmentTier);
       File tierTableDataDir = new File(tierDataDir, tableNameWithType);
       return new File(tierTableDataDir, segmentName);
     } catch (Exception e) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -93,7 +93,9 @@ public class IndexLoadingConfig {
   private Map<String, Map<String, String>> _columnProperties = new HashMap<>();
 
   private TableConfig _tableConfig;
+  private String _tableDataDir;
   private String _segmentDirectoryLoader;
+  private String _segmentTier;
 
   private String _instanceId;
 
@@ -645,5 +647,21 @@ public class IndexLoadingConfig {
 
   public String getInstanceId() {
     return _instanceId;
+  }
+
+  public void setTableDataDir(String tableDataDir) {
+    _tableDataDir = tableDataDir;
+  }
+
+  public String getTableDataDir() {
+    return _tableDataDir;
+  }
+
+  public void setSegmentTier(String segmentTier) {
+    _segmentTier = segmentTier;
+  }
+
+  public String getSegmentTier() {
+    return _segmentTier;
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/loader/TierBasedSegmentDirectoryLoaderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/loader/TierBasedSegmentDirectoryLoaderTest.java
@@ -1,0 +1,119 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.loader;
+
+import java.io.File;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.tier.TierFactory;
+import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderContext;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.TierConfig;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.util.TestUtils;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertFalse;
+
+
+public class TierBasedSegmentDirectoryLoaderTest {
+  private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "TierBasedSegmentDirectoryLoaderTest");
+  private static final String TABLE_NAME = "table01";
+  private static final String TABLE_NAME_WITH_TYPE = "table01_OFFLINE";
+
+  @BeforeMethod
+  public void setUp()
+      throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(TEMP_DIR);
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    FileUtils.deleteDirectory(TEMP_DIR);
+  }
+
+  @Test
+  public void testDropSegmentOnDefaultTier()
+      throws Exception {
+    TableConfig tableCfg = mock(TableConfig.class);
+    TierBasedSegmentDirectoryLoader loader = new TierBasedSegmentDirectoryLoader();
+    SegmentDirectoryLoaderContext loaderCtx =
+        new SegmentDirectoryLoaderContext.Builder().setTableConfig(tableCfg).setSegmentName("seg01")
+            .setTableDataDir(TEMP_DIR.getAbsolutePath() + "/" + TABLE_NAME_WITH_TYPE).build();
+    // When segDir is on the default tier.
+    File tableDataDir = new File(TEMP_DIR.getAbsolutePath(), TABLE_NAME_WITH_TYPE);
+    File segDataDir = new File(tableDataDir, "seg01");
+    FileUtils.touch(segDataDir);
+    loader.drop(loaderCtx);
+    assertFalse(segDataDir.exists());
+  }
+
+  @Test
+  public void testDropSegmentOnLastKnownTier()
+      throws Exception {
+    String tierName = "tier01";
+    TableConfig tableCfg = createTableConfigWithTier(tierName, new File(TEMP_DIR, tierName));
+    TierBasedSegmentDirectoryLoader loader = new TierBasedSegmentDirectoryLoader();
+    SegmentDirectoryLoaderContext loaderCtx =
+        new SegmentDirectoryLoaderContext.Builder().setTableConfig(tableCfg).setSegmentName("seg01")
+            .setTableDataDir(TEMP_DIR.getAbsolutePath() + "/" + TABLE_NAME_WITH_TYPE).build();
+
+    // When segDir is on a specific tier.
+    // Put the tier name into the tier track file.
+    File tierTrackFile = new File(TEMP_DIR.getAbsolutePath() + "/" + TABLE_NAME_WITH_TYPE, "seg01.tier");
+    FileUtils.writeStringToFile(tierTrackFile, tierName, StandardCharsets.UTF_8);
+    File tableDataDir = new File(new File(TEMP_DIR, tierName), TABLE_NAME_WITH_TYPE);
+    File segDataDir = new File(tableDataDir, "seg01");
+    FileUtils.touch(segDataDir);
+    loader.drop(loaderCtx);
+    assertFalse(segDataDir.exists());
+    assertFalse(tierTrackFile.exists());
+  }
+
+  @Test
+  public void testDropSegmentOnTargetTier()
+      throws Exception {
+    String tierName = "tier02";
+    TableConfig tableCfg = createTableConfigWithTier(tierName, new File(TEMP_DIR, tierName));
+    TierBasedSegmentDirectoryLoader loader = new TierBasedSegmentDirectoryLoader();
+    SegmentDirectoryLoaderContext loaderCtx =
+        new SegmentDirectoryLoaderContext.Builder().setTableConfig(tableCfg).setSegmentName("seg01")
+            .setSegmentTier(tierName).setTableDataDir(TEMP_DIR.getAbsolutePath() + "/" + TABLE_NAME_WITH_TYPE).build();
+
+    // When segDir is on a specific tier.
+    File tableDataDir = new File(new File(TEMP_DIR, tierName), TABLE_NAME_WITH_TYPE);
+    File segDataDir = new File(tableDataDir, "seg01");
+    FileUtils.touch(segDataDir);
+    loader.drop(loaderCtx);
+    assertFalse(segDataDir.exists());
+  }
+
+  private TableConfig createTableConfigWithTier(String tierName, File dataDir) {
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(Collections
+        .singletonList(new TierConfig(tierName, TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "3d", null,
+            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tag_OFFLINE", null,
+            Collections.singletonMap("dataDir", dataDir.getAbsolutePath())))).build();
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/loader/SegmentDirectoryLoaderRegistryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/loader/SegmentDirectoryLoaderRegistryTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.segment.local.segment.loader;
 
 import java.net.URI;
 import org.apache.pinot.segment.local.loader.DefaultSegmentDirectoryLoader;
+import org.apache.pinot.segment.local.loader.TierBasedSegmentDirectoryLoader;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoader;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderContext;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderRegistry;
@@ -39,6 +40,11 @@ public class SegmentDirectoryLoaderRegistryTest {
     defaultSegmentDirectoryLoader = SegmentDirectoryLoaderRegistry.getSegmentDirectoryLoader("default");
     Assert.assertEquals(defaultSegmentDirectoryLoader.getClass().getSimpleName(),
         DefaultSegmentDirectoryLoader.class.getSimpleName());
+
+    SegmentDirectoryLoader tierBasedSegmentDirectoryLoader =
+        SegmentDirectoryLoaderRegistry.getSegmentDirectoryLoader("tierBased");
+    Assert.assertEquals(tierBasedSegmentDirectoryLoader.getClass().getSimpleName(),
+        TierBasedSegmentDirectoryLoader.class.getSimpleName());
 
     Assert.assertNull(SegmentDirectoryLoaderRegistry.getSegmentDirectoryLoader("custom"));
     SegmentDirectoryLoaderRegistry.setSegmentDirectoryLoader("custom", new CustomSegmentDirectoryLoader());

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/loader/SegmentDirectoryLoader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/loader/SegmentDirectoryLoader.java
@@ -34,4 +34,12 @@ public interface SegmentDirectoryLoader {
    */
   SegmentDirectory load(URI indexDir, SegmentDirectoryLoaderContext segmentDirectoryLoaderContext)
       throws Exception;
+
+  /**
+   * Clean up the segment data from the server.
+   * @param segmentDirectoryLoaderContext context for cleaning up segment data
+   */
+  default void drop(SegmentDirectoryLoaderContext segmentDirectoryLoaderContext)
+      throws Exception {
+  }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/loader/SegmentDirectoryLoader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/loader/SegmentDirectoryLoader.java
@@ -39,7 +39,7 @@ public interface SegmentDirectoryLoader {
    * Clean up the segment data from the server.
    * @param segmentDirectoryLoaderContext context for cleaning up segment data
    */
-  default void drop(SegmentDirectoryLoaderContext segmentDirectoryLoaderContext)
+  default void delete(SegmentDirectoryLoaderContext segmentDirectoryLoaderContext)
       throws Exception {
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/loader/SegmentDirectoryLoaderContext.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/loader/SegmentDirectoryLoaderContext.java
@@ -85,10 +85,10 @@ public class SegmentDirectoryLoaderContext {
     private TableConfig _tableConfig;
     private Schema _schema;
     private String _instanceId;
+    private String _tableDataDir;
     private String _segmentName;
     private String _segmentCrc;
     private String _segmentTier;
-    private String _tableDataDir;
     private PinotConfiguration _segmentDirectoryConfigs;
 
     public Builder setTableConfig(TableConfig tableConfig) {
@@ -106,6 +106,11 @@ public class SegmentDirectoryLoaderContext {
       return this;
     }
 
+    public Builder setTableDataDir(String tableDataDir) {
+      _tableDataDir = tableDataDir;
+      return this;
+    }
+
     public Builder setSegmentName(String segmentName) {
       _segmentName = segmentName;
       return this;
@@ -118,11 +123,6 @@ public class SegmentDirectoryLoaderContext {
 
     public Builder setSegmentTier(String segmentTier) {
       _segmentTier = segmentTier;
-      return this;
-    }
-
-    public Builder setTableDataDir(String tableDataDir) {
-      _tableDataDir = tableDataDir;
       return this;
     }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/loader/SegmentDirectoryLoaderContext.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/loader/SegmentDirectoryLoaderContext.java
@@ -31,17 +31,21 @@ public class SegmentDirectoryLoaderContext {
   private final TableConfig _tableConfig;
   private final Schema _schema;
   private final String _instanceId;
+  private final String _tableDataDir;
   private final String _segmentName;
   private final String _segmentCrc;
+  private final String _segmentTier;
   private final PinotConfiguration _segmentDirectoryConfigs;
 
-  private SegmentDirectoryLoaderContext(TableConfig tableConfig, Schema schema, String instanceId, String segmentName,
-      String segmentCrc, PinotConfiguration segmentDirectoryConfigs) {
+  private SegmentDirectoryLoaderContext(TableConfig tableConfig, Schema schema, String instanceId, String tableDataDir,
+      String segmentName, String segmentCrc, String segmentTier, PinotConfiguration segmentDirectoryConfigs) {
     _tableConfig = tableConfig;
     _schema = schema;
     _instanceId = instanceId;
+    _tableDataDir = tableDataDir;
     _segmentName = segmentName;
     _segmentCrc = segmentCrc;
+    _segmentTier = segmentTier;
     _segmentDirectoryConfigs = segmentDirectoryConfigs;
   }
 
@@ -57,12 +61,20 @@ public class SegmentDirectoryLoaderContext {
     return _instanceId;
   }
 
+  public String getTableDataDir() {
+    return _tableDataDir;
+  }
+
   public String getSegmentName() {
     return _segmentName;
   }
 
   public String getSegmentCrc() {
     return _segmentCrc;
+  }
+
+  public String getSegmentTier() {
+    return _segmentTier;
   }
 
   public PinotConfiguration getSegmentDirectoryConfigs() {
@@ -75,6 +87,8 @@ public class SegmentDirectoryLoaderContext {
     private String _instanceId;
     private String _segmentName;
     private String _segmentCrc;
+    private String _segmentTier;
+    private String _tableDataDir;
     private PinotConfiguration _segmentDirectoryConfigs;
 
     public Builder setTableConfig(TableConfig tableConfig) {
@@ -102,14 +116,24 @@ public class SegmentDirectoryLoaderContext {
       return this;
     }
 
+    public Builder setSegmentTier(String segmentTier) {
+      _segmentTier = segmentTier;
+      return this;
+    }
+
+    public Builder setTableDataDir(String tableDataDir) {
+      _tableDataDir = tableDataDir;
+      return this;
+    }
+
     public Builder setSegmentDirectoryConfigs(PinotConfiguration segmentDirectoryConfigs) {
       _segmentDirectoryConfigs = segmentDirectoryConfigs;
       return this;
     }
 
     public SegmentDirectoryLoaderContext build() {
-      return new SegmentDirectoryLoaderContext(_tableConfig, _schema, _instanceId, _segmentName, _segmentCrc,
-          _segmentDirectoryConfigs);
+      return new SegmentDirectoryLoaderContext(_tableConfig, _schema, _instanceId, _tableDataDir, _segmentName,
+          _segmentCrc, _segmentTier, _segmentDirectoryConfigs);
     }
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
@@ -127,7 +127,7 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
       String realtimeTableName = message.getResourceName();
       String segmentName = message.getPartitionName();
       try {
-        _instanceDataManager.removeSegment(realtimeTableName, segmentName);
+        _instanceDataManager.offloadSegment(realtimeTableName, segmentName);
       } catch (Exception e) {
         _logger.error("Caught exception in state transition from CONSUMING -> OFFLINE for resource: {}, partition: {}",
             realtimeTableName, segmentName, e);
@@ -182,7 +182,7 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
       String tableNameWithType = message.getResourceName();
       String segmentName = message.getPartitionName();
       try {
-        _instanceDataManager.removeSegment(tableNameWithType, segmentName);
+        _instanceDataManager.offloadSegment(tableNameWithType, segmentName);
       } catch (Exception e) {
         _logger.error("Caught exception in state transition from ONLINE -> OFFLINE for resource: {}, partition: {}",
             tableNameWithType, segmentName, e);
@@ -197,7 +197,7 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
       String tableNameWithType = message.getResourceName();
       String segmentName = message.getPartitionName();
       try {
-        _instanceDataManager.dropSegment(tableNameWithType, segmentName);
+        _instanceDataManager.deleteSegment(tableNameWithType, segmentName);
       } catch (final Exception e) {
         _logger.error("Cannot drop the segment : " + segmentName + " from server!\n" + e.getMessage(), e);
         Utils.rethrowException(e);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
@@ -19,9 +19,6 @@
 package org.apache.pinot.server.starter.helix;
 
 import com.google.common.base.Preconditions;
-import java.io.File;
-import java.util.concurrent.locks.Lock;
-import org.apache.commons.io.FileUtils;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.model.Message;
 import org.apache.helix.participant.statemachine.StateModel;
@@ -38,7 +35,6 @@ import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
-import org.apache.pinot.segment.local.utils.SegmentLocks;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
@@ -200,22 +196,11 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
       _logger.info("SegmentOnlineOfflineStateModel.onBecomeDroppedFromOffline() : " + message);
       String tableNameWithType = message.getResourceName();
       String segmentName = message.getPartitionName();
-
-      // This method might modify the file on disk. Use segment lock to prevent race condition
-      Lock segmentLock = SegmentLocks.getSegmentLock(tableNameWithType, segmentName);
       try {
-        segmentLock.lock();
-
-        File segmentDir = _instanceDataManager.getSegmentDataDirectory(tableNameWithType, segmentName);
-        if (segmentDir.exists()) {
-          FileUtils.deleteQuietly(segmentDir);
-          _logger.info("Deleted segment directory {}", segmentDir);
-        }
+        _instanceDataManager.dropSegment(tableNameWithType, segmentName);
       } catch (final Exception e) {
-        _logger.error("Cannot delete the segment : " + segmentName + " from local directory!\n" + e.getMessage(), e);
+        _logger.error("Cannot drop the segment : " + segmentName + " from server!\n" + e.getMessage(), e);
         Utils.rethrowException(e);
-      } finally {
-        segmentLock.unlock();
       }
     }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -745,6 +745,7 @@ public class CommonConstants {
     public static final String INDEX_VERSION = "segment.index.version";
     public static final String TOTAL_DOCS = "segment.total.docs";
     public static final String CRC = "segment.crc";
+    public static final String TIER = "segment.tier";
     public static final String CREATION_TIME = "segment.creation.time";
     public static final String PUSH_TIME = "segment.push.time";
     public static final String REFRESH_TIME = "segment.refresh.time";
@@ -779,6 +780,10 @@ public class CommonConstants {
       public static final String HOSTNAME = "$hostName";
       public static final String SEGMENTNAME = "$segmentName";
     }
+  }
+
+  public static class Tier {
+    public static final String BACKEND_PROP_DATA_DIR = "dataDir";
   }
 
   public static class Query {


### PR DESCRIPTION
This PR is part of the work to support multi-datadir for Pinot server as tracked by [issue](https://github.com/apache/pinot/issues/8843).

TierBasedSegmentDirectoryLoader is added in this PR. It implements SegmentDirectoryLoader interface. It checks the target storage tier for the segment and move it from current tier to the target tier. The tier config is extended to include dataDir, so that one can define multi-tier for a table to use multiple datadirs to store segments. 

TierBasedSegmentDirectoryLoader is not used unless set `pinot.server.instance.segment.directory.loader` to `tierBased`. 

Following PRs will add Controller periodic task to compare segment current/target tiers and trigger segment reloading to move them to target tiers (datadirs) on Pinot servers.