### PR TITLE
Deprecate instanceId Config For Broker/Minion Specific Configs

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -134,9 +134,10 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
     _tlsPort = ListenerConfigUtil.findLastTlsPort(_listenerConfigs, -1);
 
     _instanceId = _brokerConf.getProperty(Broker.CONFIG_OF_BROKER_ID);
-    if (_instanceId == null && _brokerConf.getProperty(Helix.Instance.INSTANCE_ID_KEY) != null) {
+    if (_instanceId == null) {
       _instanceId = _brokerConf.getProperty(Helix.Instance.INSTANCE_ID_KEY);
-    } else if (_instanceId == null) {
+    }
+    if (_instanceId == null) {
       _instanceId = Helix.PREFIX_OF_BROKER_INSTANCE + _hostname + "_" + _port;
     }
     // NOTE: Force all instances to have the same prefix in order to derive the instance type based on the instance id

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -133,14 +133,15 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
     _port = _listenerConfigs.get(0).getPort();
     _tlsPort = ListenerConfigUtil.findLastTlsPort(_listenerConfigs, -1);
 
-    _instanceId = _brokerConf.getProperty(Helix.Instance.INSTANCE_ID_KEY);
-    if (_instanceId != null) {
-      // NOTE: Force all instances to have the same prefix in order to derive the instance type based on the instance id
-      Preconditions.checkState(InstanceTypeUtils.isBroker(_instanceId), "Instance id must have prefix '%s', got '%s'",
-          Helix.PREFIX_OF_BROKER_INSTANCE, _instanceId);
+    _instanceId = _brokerConf.getProperty(Broker.CONFIG_OF_BROKER_ID);
+    if (_instanceId == null && _brokerConf.getProperty(Helix.Instance.INSTANCE_ID_KEY) != null) {
+      _instanceId = _brokerConf.getProperty(Helix.Instance.INSTANCE_ID_KEY);
     } else {
       _instanceId = Helix.PREFIX_OF_BROKER_INSTANCE + _hostname + "_" + _port;
     }
+    // NOTE: Force all instances to have the same prefix in order to derive the instance type based on the instance id
+    Preconditions.checkState(InstanceTypeUtils.isBroker(_instanceId), "Instance id must have prefix '%s', got '%s'",
+        Helix.PREFIX_OF_BROKER_INSTANCE, _instanceId);
 
     _brokerConf.setProperty(Broker.CONFIG_OF_BROKER_ID, _instanceId);
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -136,7 +136,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
     _instanceId = _brokerConf.getProperty(Broker.CONFIG_OF_BROKER_ID);
     if (_instanceId == null && _brokerConf.getProperty(Helix.Instance.INSTANCE_ID_KEY) != null) {
       _instanceId = _brokerConf.getProperty(Helix.Instance.INSTANCE_ID_KEY);
-    } else {
+    } else if (_instanceId == null) {
       _instanceId = Helix.PREFIX_OF_BROKER_INSTANCE + _hostname + "_" + _port;
     }
     // NOTE: Force all instances to have the same prefix in order to derive the instance type based on the instance id

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterHostnamePortTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterHostnamePortTest.java
@@ -114,7 +114,7 @@ public class HelixBrokerStarterHostnamePortTest extends ControllerTest {
   @Test
   public void testInstanceIdPrecedence()
       throws Exception {
-    // Ensures that pinot.broker.id has higher precedence compared to instanceId
+    // Ensures that pinot.broker.instance.id has higher precedence compared to instanceId
     Map<String, Object> properties = new HashMap<>();
     properties.put(CONFIG_OF_ZOOKEEPR_SERVER, getZkUrl());
     properties.put(CONFIG_OF_CLUSTER_NAME, getHelixClusterName());

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterHostnamePortTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterHostnamePortTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.apache.pinot.spi.utils.CommonConstants.Broker.CONFIG_OF_BROKER_HOSTNAME;
+import static org.apache.pinot.spi.utils.CommonConstants.Broker.CONFIG_OF_BROKER_ID;
 import static org.apache.pinot.spi.utils.CommonConstants.Broker.CONFIG_OF_DELAY_SHUTDOWN_TIME_MS;
 import static org.apache.pinot.spi.utils.CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME;
 import static org.apache.pinot.spi.utils.CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER;
@@ -102,6 +103,33 @@ public class HelixBrokerStarterHostnamePortTest extends ControllerTest {
 
     String instanceId = brokerStarter.getInstanceId();
     assertEquals(instanceId, "Broker_myHost_1234");
+    InstanceConfig instanceConfig = HelixHelper.getInstanceConfig(_helixManager, instanceId);
+    assertEquals(instanceConfig.getInstanceName(), instanceId);
+    assertEquals(instanceConfig.getHostName(), "myHost");
+    assertEquals(instanceConfig.getPort(), "1234");
+
+    brokerStarter.stop();
+  }
+
+  @Test
+  public void testInstanceIdPrecedence()
+      throws Exception {
+    // Ensures that pinot.broker.id has higher precedence compared to instanceId
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CONFIG_OF_ZOOKEEPR_SERVER, getZkUrl());
+    properties.put(CONFIG_OF_CLUSTER_NAME, getHelixClusterName());
+    properties.put(CONFIG_OF_BROKER_ID, "Broker_morePrecedence");
+    properties.put(INSTANCE_ID_KEY, "Broker_lessPrecedence");
+    properties.put(CONFIG_OF_BROKER_HOSTNAME, "myHost");
+    properties.put(KEY_OF_BROKER_QUERY_PORT, 1234);
+    properties.put(CONFIG_OF_DELAY_SHUTDOWN_TIME_MS, 0);
+
+    HelixBrokerStarter brokerStarter = new HelixBrokerStarter();
+    brokerStarter.init(new PinotConfiguration(properties));
+    brokerStarter.start();
+
+    String instanceId = brokerStarter.getInstanceId();
+    assertEquals(instanceId, "Broker_morePrecedence");
     InstanceConfig instanceConfig = HelixHelper.getInstanceConfig(_helixManager, instanceId);
     assertEquals(instanceConfig.getInstanceName(), instanceId);
     assertEquals(instanceConfig.getHostName(), "myHost");

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionConf.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionConf.java
@@ -21,7 +21,6 @@ package org.apache.pinot.minion;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.NetUtils;
@@ -59,10 +58,8 @@ public class MinionConf extends PinotConfiguration {
   }
 
   public String getInstanceId() {
-    if (StringUtils.isNotBlank(getProperty(CommonConstants.Minion.CONFIG_OF_MINION_ID))) {
-      return getProperty(CommonConstants.Minion.CONFIG_OF_MINION_ID);
-    }
-    return getProperty(CommonConstants.Helix.Instance.INSTANCE_ID_KEY);
+    String instanceId = getProperty(CommonConstants.Minion.CONFIG_OF_MINION_ID);
+    return instanceId != null ? instanceId : getProperty(CommonConstants.Helix.Instance.INSTANCE_ID_KEY);
   }
 
   public int getEndReplaceSegmentsTimeoutMs() {

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionConf.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionConf.java
@@ -21,6 +21,7 @@ package org.apache.pinot.minion;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.NetUtils;
@@ -58,6 +59,9 @@ public class MinionConf extends PinotConfiguration {
   }
 
   public String getInstanceId() {
+    if (StringUtils.isNotBlank(getProperty(CommonConstants.Minion.CONFIG_OF_MINION_ID))) {
+      return getProperty(CommonConstants.Minion.CONFIG_OF_MINION_ID);
+    }
     return getProperty(CommonConstants.Helix.Instance.INSTANCE_ID_KEY);
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -211,7 +211,7 @@ public class CommonConstants {
     public static final double DEFAULT_BROKER_QUERY_LOG_MAX_RATE_PER_SECOND = 10_000d;
     public static final String CONFIG_OF_BROKER_TIMEOUT_MS = "pinot.broker.timeoutMs";
     public static final long DEFAULT_BROKER_TIMEOUT_MS = 10_000L;
-    public static final String CONFIG_OF_BROKER_ID = "pinot.broker.id";
+    public static final String CONFIG_OF_BROKER_ID = "pinot.broker.instance.id";
     public static final String CONFIG_OF_BROKER_HOSTNAME = "pinot.broker.hostname";
     public static final String CONFIG_OF_SWAGGER_USE_HTTPS = "pinot.broker.swagger.use.https";
     // Configuration to consider the broker ServiceStatus as being STARTED if the percent of resources (tables) that
@@ -527,7 +527,7 @@ public class CommonConstants {
 
   public static class Minion {
     public static final String CONFIG_OF_METRICS_PREFIX = "pinot.minion.";
-    public static final String CONFIG_OF_MINION_ID = "pinot.minion.id";
+    public static final String CONFIG_OF_MINION_ID = "pinot.minion.instance.id";
     public static final String METADATA_EVENT_OBSERVER_PREFIX = "metadata.event.notifier";
 
     // Config keys

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -136,6 +136,7 @@ public class CommonConstants {
     }
 
     public static class Instance {
+      @Deprecated
       public static final String INSTANCE_ID_KEY = "instanceId";
       public static final String DATA_DIR_KEY = "dataDir";
       public static final String ADMIN_PORT_KEY = "adminPort";
@@ -526,6 +527,7 @@ public class CommonConstants {
 
   public static class Minion {
     public static final String CONFIG_OF_METRICS_PREFIX = "pinot.minion.";
+    public static final String CONFIG_OF_MINION_ID = "pinot.minion.id";
     public static final String METADATA_EVENT_OBSERVER_PREFIX = "metadata.event.notifier";
 
     // Config keys

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
@@ -240,7 +240,7 @@ public class PerfBenchmarkDriver {
     String brokerInstanceName = "Broker_localhost_" + CommonConstants.Helix.DEFAULT_BROKER_QUERY_PORT;
 
     Map<String, Object> properties = new HashMap<>();
-    properties.put(CommonConstants.Helix.Instance.INSTANCE_ID_KEY, brokerInstanceName);
+    properties.put(CommonConstants.Broker.CONFIG_OF_BROKER_ID, brokerInstanceName);
     properties.put(CommonConstants.Broker.CONFIG_OF_BROKER_TIMEOUT_MS, BROKER_TIMEOUT_MS);
     properties.put(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, _clusterName);
     properties.put(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER, _zkAddress);


### PR DESCRIPTION
fixes #9290

I felt it might be best to mark instanceId as deprecated and create a new config for Minion ID. Lmk your thoughts.

cc: @Jackie-Jiang 
