### PR TITLE
[Feature]  Support IsDistinctFrom and IsNotDistinctFrom

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -145,7 +145,8 @@ public enum TransformFunctionType {
   COSH("cosh"),
   TANH("tanh"),
   DEGREES("degrees"),
-  RADIANS("radians");
+  RADIANS("radians"),
+  IS_DISTINCT_FROM("is_distinct_from");
 
   private static final Set<String> NAMES = Arrays.stream(values()).flatMap(
       func -> func.getAliases().stream().flatMap(name -> Stream.of(name, StringUtils.remove(name, '_').toUpperCase(),

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -63,6 +63,9 @@ public enum TransformFunctionType {
   IS_NULL("is_null"),
   IS_NOT_NULL("is_not_null"),
 
+  IS_DISTINCT_FROM("is_distinct_from"),
+  IS_NOT_DISTINCT_FROM("is_not_distinct_from"),
+
   AND("and"),
   OR("or"),
   NOT("not"),   // NOT operator doesn't cover the transform for NOT IN and NOT LIKE
@@ -145,8 +148,7 @@ public enum TransformFunctionType {
   COSH("cosh"),
   TANH("tanh"),
   DEGREES("degrees"),
-  RADIANS("radians"),
-  IS_DISTINCT_FROM("is_distinct_from");
+  RADIANS("radians");
 
   private static final Set<String> NAMES = Arrays.stream(values()).flatMap(
       func -> func.getAliases().stream().flatMap(name -> Stream.of(name, StringUtils.remove(name, '_').toUpperCase(),

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
@@ -45,10 +45,10 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
 
   private final int _op;
   private final TransformFunctionType _transformFunctionType;
-  private TransformFunction _leftTransformFunction;
-  private TransformFunction _rightTransformFunction;
-  private DataType _leftStoredType;
-  private DataType _rightStoredType;
+  protected TransformFunction _leftTransformFunction;
+  protected TransformFunction _rightTransformFunction;
+  protected DataType _leftStoredType;
+  protected DataType _rightStoredType;
   private int[] _results;
 
   protected BinaryOperatorTransformFunction(TransformFunctionType transformFunctionType) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
@@ -43,13 +43,13 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
   private static final int LESS_THAN_OR_EQUAL = 4;
   private static final int NOT_EQUAL = 5;
 
-  private final int _op;
-  private final TransformFunctionType _transformFunctionType;
+  protected final int _op;
+  protected final TransformFunctionType _transformFunctionType;
   protected TransformFunction _leftTransformFunction;
   protected TransformFunction _rightTransformFunction;
   protected DataType _leftStoredType;
   protected DataType _rightStoredType;
-  private int[] _results;
+  protected int[] _results;
 
   protected BinaryOperatorTransformFunction(TransformFunctionType transformFunctionType) {
     // translate to integer in [0, 5] for guaranteed tableswitch

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DistinctFromTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DistinctFromTransformFunction.java
@@ -64,7 +64,11 @@ public class DistinctFromTransformFunction extends BinaryOperatorTransformFuncti
   /**
    * @param distinct is set to true for IsDistinctFrom, otherwise it is for IsNotDistinctFrom.
    */
-d
+  protected DistinctFromTransformFunction(boolean distinct) {
+    super(distinct ? TransformFunctionType.NOT_EQUALS : TransformFunctionType.EQUALS);
+    _distinctResult = distinct ? 1 : 0;
+    _notDistinctResult = distinct ? 0 : 1;
+  }
 
   @Override
   public String getName() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DistinctFromTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DistinctFromTransformFunction.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import java.util.Arrays;
+import java.util.BitSet;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.function.TransformFunctionType;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.roaringbitmap.PeekableIntIterator;
+
+
+/**
+ * <code>DistinctFromTransformFunction</code> abstracts the transform needed for IsDistinctFrom and IsNotDistinctFrom.
+ * Null value is considered as distinct from non-null value.
+ * When both values are not null, this function calls equal transform function to determined whether two values are
+ * distinct.
+ * This function only supports two arguments which are both column names.
+ */
+public class DistinctFromTransformFunction extends BinaryOperatorTransformFunction {
+  // getDistinct is set to true for IsDistinctFrom, otherwise it is for IsNotDistinctFrom.
+  protected DistinctFromTransformFunction(boolean getDistinct) {
+    super(getDistinct ? TransformFunctionType.NOT_EQUALS : TransformFunctionType.EQUALS);
+    _getDistinct = getDistinct ? 1 : 0;
+  }
+
+  @Override
+  public String getName() {
+    if (_getDistinct == 1) {
+      return TransformFunctionType.IS_DISTINCT_FROM.getName();
+    }
+    return TransformFunctionType.IS_NOT_DISTINCT_FROM.getName();
+  }
+
+  @Override
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
+    super.init(arguments, dataSourceMap);
+    if (!(_leftTransformFunction instanceof IdentifierTransformFunction)
+        || !(_rightTransformFunction instanceof IdentifierTransformFunction)) {
+      throw new IllegalArgumentException("Only column names are supported in DistinctFrom transformation.");
+    }
+    _leftNullValueVectorIterator =
+        getNullValueIterator(dataSourceMap, _leftTransformFunction, _leftNullValueVectorIterator);
+    _rightNullValueVectorIterator =
+        getNullValueIterator(dataSourceMap, _rightTransformFunction, _rightNullValueVectorIterator);
+  }
+
+  @Override
+  public TransformResultMetadata getResultMetadata() {
+    return BOOLEAN_SV_NO_DICTIONARY_METADATA;
+  }
+
+  @Override
+  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+    if (_results == null || _results.length < length) {
+      _results = new int[length];
+    }
+    _results = super.transformToIntValuesSV(projectionBlock);
+    int[] docIds = projectionBlock.getDocIds();
+    BitSet leftNull = getNullBits(_leftNullValueVectorIterator, length, docIds);
+    BitSet rightNull = getNullBits(_rightNullValueVectorIterator, length, docIds);
+    leftNull.xor(rightNull);
+    // Iterate through docs that are null one side and not null the other side.
+    for (int i = leftNull.nextSetBit(0); i >= 0; i = leftNull.nextSetBit(i + 1)) {
+      _results[i] = _getDistinct;
+    }
+    // Iterate through docs that are null or  not null for both sides.
+    for (int i = leftNull.nextClearBit(0); i >= 0; i = leftNull.nextSetBit(i + 1)) {
+      // if both values are null, mark they are not distinct.
+      if (rightNull.get(i)) {
+        _results[i] = _getDistinct ^ 1;
+      }
+    }
+    return _results;
+  }
+
+  // Returns a bit vector of document length where each bit represents whether the row is null or not.
+  // Set the value as not null by default if null option is disabled.
+  private BitSet getNullBits(@Nullable PeekableIntIterator nullValueVectorIterator, int length, int[] docIds) {
+    BitSet nullBits = new BitSet(length);
+    if (nullValueVectorIterator == null) {
+      return nullBits;
+    }
+    int currentDocIdIndex = 0;
+    while (nullValueVectorIterator.hasNext() & currentDocIdIndex < length) {
+      nullValueVectorIterator.advanceIfNeeded(docIds[currentDocIdIndex]);
+      currentDocIdIndex = Arrays.binarySearch(docIds, currentDocIdIndex, length, nullValueVectorIterator.next());
+      if (currentDocIdIndex >= 0) {
+        nullBits.set(currentDocIdIndex);
+        currentDocIdIndex++;
+      } else {
+        currentDocIdIndex = -currentDocIdIndex - 1;
+      }
+    }
+    return nullBits;
+  }
+
+  static private PeekableIntIterator getNullValueIterator(Map<String, DataSource> dataSourceMap,
+      TransformFunction transformFunction, PeekableIntIterator nullValueVectorIterator) {
+    String columnName = ((IdentifierTransformFunction) transformFunction).getColumnName();
+    NullValueVectorReader nullValueVectorReader = dataSourceMap.get(columnName).getNullValueVector();
+    if (nullValueVectorIterator != null) {
+      return nullValueVectorReader.getNullBitmap().getIntIterator();
+    }
+    return null;
+  }
+  private int[] _results;
+  private PeekableIntIterator _leftNullValueVectorIterator;
+  private PeekableIntIterator _rightNullValueVectorIterator;
+  private int _getDistinct;
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DistinctFromTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DistinctFromTransformFunction.java
@@ -64,11 +64,7 @@ public class DistinctFromTransformFunction extends BinaryOperatorTransformFuncti
   /**
    * @param distinct is set to true for IsDistinctFrom, otherwise it is for IsNotDistinctFrom.
    */
-  protected DistinctFromTransformFunction(boolean distinct) {
-    super(distinct ? TransformFunctionType.NOT_EQUALS : TransformFunctionType.EQUALS);
-    _distinctResult = distinct ? 1 : 0;
-    _notDistinctResult = distinct ? 0 : 1;
-  }
+d
 
   @Override
   public String getName() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DistinctFromTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DistinctFromTransformFunction.java
@@ -45,29 +45,14 @@ public class DistinctFromTransformFunction extends BinaryOperatorTransformFuncti
    * Returns a bit map of corresponding column.
    * Returns null by default if null option is disabled.
    */
-  private static @Nullable RoaringBitmap getNullBitMap(ProjectionBlock projectionBlock,
+  @Nullable
+  private static RoaringBitmap getNullBitMap(ProjectionBlock projectionBlock,
       TransformFunction transformFunction) {
     String columnName = ((IdentifierTransformFunction) transformFunction).getColumnName();
     RoaringBitmap nullBitmap = projectionBlock.getBlockValueSet(columnName).getNullBitmap();
     return nullBitmap;
   }
 
-  /**
-   * Fill in results based on functions
-   * @param isDistinctNull return true if one field is null and the other field is not null
-   * @param isBothNull return true if both fields are null
-   * @param length length of the result
-   */
-  private void fillInDistinctNullValue(Function<Integer, Boolean> isDistinctNull, Function<Integer, Boolean> isBothNull,
-      int length) {
-    for (int i = 0; i < length; i++) {
-      if (isDistinctNull.apply(i)) {
-        _results[i] = _distinctType;
-      } else if (isBothNull.apply(i)) {
-        _results[i] = _distinctType ^ 1;
-      }
-    }
-  }
 
   /**
    * @param distinctType is set to true for IsDistinctFrom, otherwise it is for IsNotDistinctFrom.
@@ -109,6 +94,7 @@ public class DistinctFromTransformFunction extends BinaryOperatorTransformFuncti
       return _results;
     }
     if (leftNull == null) {
+
       fillInDistinctNullValue(rightNull::contains, (Integer i) -> false, length);
       return _results;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DistinctFromTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DistinctFromTransformFunction.java
@@ -18,17 +18,13 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
-import java.util.Arrays;
-import java.util.BitSet;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 import org.apache.pinot.common.function.TransformFunctionType;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.segment.spi.datasource.DataSource;
-import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
-import org.roaringbitmap.PeekableIntIterator;
+import org.roaringbitmap.RoaringBitmap;
 
 
 /**
@@ -39,57 +35,33 @@ import org.roaringbitmap.PeekableIntIterator;
  * This function only supports two arguments which are both column names.
  */
 public class DistinctFromTransformFunction extends BinaryOperatorTransformFunction {
-  private int[] _results;
-  // null iterator for left argument.
-  private PeekableIntIterator _leftNullValueVectorIterator;
-  // null iterator for right argument.
-  private PeekableIntIterator _rightNullValueVectorIterator;
-  // If _getDistinct is 1, act IsDistinctFrom transformation, otherwise act as IsNotDistinctFrom.
-  private int _getDistinct;
+  // If _getDistinct is true, act as IsDistinctFrom transformation, otherwise act as IsNotDistinctFrom.
+  private boolean _getDistinct;
 
-  // getDistinct is set to true for IsDistinctFrom, otherwise it is for IsNotDistinctFrom.
+  /**
+   * @param getDistinct is set to true for IsDistinctFrom, otherwise it is for IsNotDistinctFrom.
+   */
   protected DistinctFromTransformFunction(boolean getDistinct) {
     super(getDistinct ? TransformFunctionType.NOT_EQUALS : TransformFunctionType.EQUALS);
-    _getDistinct = getDistinct ? 1 : 0;
+    _getDistinct = getDistinct;
   }
 
-  // Returns a bit vector of document length where each bit represents whether the row is null or not.
-  // Set the value as not null by default if null option is disabled.
-  static private BitSet getNullBits(@Nullable PeekableIntIterator nullValueVectorIterator, int length, int[] docIds) {
-    BitSet nullBits = new BitSet(length);
-    if (nullValueVectorIterator == null) {
-      return nullBits;
-    }
-    int currentDocIdIndex = 0;
-    while (nullValueVectorIterator.hasNext() & currentDocIdIndex < length) {
-      nullValueVectorIterator.advanceIfNeeded(docIds[currentDocIdIndex]);
-      currentDocIdIndex = Arrays.binarySearch(docIds, currentDocIdIndex, length, nullValueVectorIterator.next());
-      if (currentDocIdIndex >= 0) {
-        nullBits.set(currentDocIdIndex);
-        currentDocIdIndex++;
-      } else {
-        currentDocIdIndex = -currentDocIdIndex - 1;
-      }
-    }
-    return nullBits;
-  }
-
-  // Returns null iterator based on nullValueVectorIterator.
-  // If null value is not enabled, which means nullValueVectorIterator can be null, this function will return a null.
-  @Nullable
-  static private PeekableIntIterator getNullValueIterator(Map<String, DataSource> dataSourceMap,
-      TransformFunction transformFunction, PeekableIntIterator nullValueVectorIterator) {
+  /**
+   * Returns a bit map of corresponding column.
+   * Returns an empty bitmap by default if null option is disabled.
+   */
+  private static RoaringBitmap getNullBitMap(ProjectionBlock projectionBlock, TransformFunction transformFunction) {
     String columnName = ((IdentifierTransformFunction) transformFunction).getColumnName();
-    NullValueVectorReader nullValueVectorReader = dataSourceMap.get(columnName).getNullValueVector();
-    if (nullValueVectorIterator != null) {
-      return nullValueVectorReader.getNullBitmap().getIntIterator();
+    RoaringBitmap nullBitmap = projectionBlock.getBlockValueSet(columnName).getNullBitmap();
+    if (nullBitmap == null) {
+      return new RoaringBitmap();
     }
-    return null;
+    return nullBitmap;
   }
 
   @Override
   public String getName() {
-    if (_getDistinct == 1) {
+    if (_getDistinct) {
       return TransformFunctionType.IS_DISTINCT_FROM.getName();
     }
     return TransformFunctionType.IS_NOT_DISTINCT_FROM.getName();
@@ -102,10 +74,6 @@ public class DistinctFromTransformFunction extends BinaryOperatorTransformFuncti
         || !(_rightTransformFunction instanceof IdentifierTransformFunction)) {
       throw new IllegalArgumentException("Only column names are supported in DistinctFrom transformation.");
     }
-    _leftNullValueVectorIterator =
-        getNullValueIterator(dataSourceMap, _leftTransformFunction, _leftNullValueVectorIterator);
-    _rightNullValueVectorIterator =
-        getNullValueIterator(dataSourceMap, _rightTransformFunction, _rightNullValueVectorIterator);
   }
 
   @Override
@@ -116,23 +84,17 @@ public class DistinctFromTransformFunction extends BinaryOperatorTransformFuncti
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-    if (_results == null || _results.length < length) {
-      _results = new int[length];
-    }
     _results = super.transformToIntValuesSV(projectionBlock);
-    int[] docIds = projectionBlock.getDocIds();
-    BitSet leftNull = getNullBits(_leftNullValueVectorIterator, length, docIds);
-    BitSet rightNull = getNullBits(_rightNullValueVectorIterator, length, docIds);
-    leftNull.xor(rightNull);
-    // Iterate through docs that are null one side and not null the other side.
-    for (int i = leftNull.nextSetBit(0); i >= 0; i = leftNull.nextSetBit(i + 1)) {
-      _results[i] = _getDistinct;
-    }
-    // Iterate through docs that are null or  not null for both sides.
-    for (int i = leftNull.nextClearBit(0); i >= 0; i = leftNull.nextSetBit(i + 1)) {
-      // if both values are null, mark they are not distinct.
-      if (rightNull.get(i)) {
-        _results[i] = _getDistinct ^ 1;
+    RoaringBitmap letNull = getNullBitMap(projectionBlock, _leftTransformFunction);
+    RoaringBitmap rightNull = getNullBitMap(projectionBlock, _rightTransformFunction);
+    RoaringBitmap xorNull = RoaringBitmap.xor(letNull, rightNull);
+    for (int i = 0; i < length; i++) {
+      if (xorNull.contains(i)) {
+        // These are docs that are null one side and not null the other side.
+        _results[i] = _getDistinct ? 1 : 0;
+      } else if (rightNull.contains(i)) {
+        // If both values are null, mark they are not distinct.
+        _results[i] = _getDistinct ? 0 : 1;
       }
     }
     return _results;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsDistinctFromTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsDistinctFromTransformFunction.java
@@ -28,9 +28,9 @@ package org.apache.pinot.core.operator.transform.function;
  * NUll IS_DISTINCT_FROM Null: 0
  * ValueA IS_DISTINCT_FROM ValueB: NotEQUALS(ValueA, ValueB)
  *
- * Not this operator only takes column names for now.
+ * Note this operator only takes column names for now.
  * SQL Syntax:
- *    columnA IS_DISTINCT_FROM columnB
+ *    columnA IS DISTINCT FROM columnB
  *
  * Sample Usage:
  *    IS_DISTINCT_FROM(columnA, columnB)

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsDistinctFromTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsDistinctFromTransformFunction.java
@@ -1,0 +1,558 @@
+package org.apache.pinot.core.operator.transform.function;
+
+import com.google.common.base.Preconditions;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.function.TransformFunctionType;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.utils.ByteArray;
+
+
+/**
+ * <code>BinaryOperatorTransformFunction</code> abstracts common functions for binary operators (=, !=, >=, >, <=, <).
+ * The results are BOOLEAN type.
+ */
+public class DistinctFromTransformFunction extends BaseTransformFunction {
+
+  protected DistinctFromTransformFunction(){
+
+  }
+
+  @Override
+  public String getName() {
+//    return _transformFunctionType.getName();
+  }
+
+  @Override
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
+    // Check that there are exact 2 arguments
+    Preconditions.checkArgument(arguments.size() == 2,
+        "Exact 2 arguments are required for DistinctFrom operator transform function");
+    TransformFunction _leftTransformFunction = arguments.get(0);
+    TransformFunction _rightTransformFunction = arguments.get(1);
+//    if (!(transformFunction instanceof IdentifierTransformFunction)) {
+//      throw new IllegalArgumentException(
+//          "Only column names are supported in IS_NULL. Support for functions is planned for future release");
+//    }
+//    String columnName = ((IdentifierTransformFunction) transformFunction).getColumnName();
+//    NullValueVectorReader nullValueVectorReader = dataSourceMap.get(columnName).getNullValueVector();
+//    if (nullValueVectorReader != null) {
+//      _nullValueVectorIterator = nullValueVectorReader.getNullBitmap().getIntIterator();
+//    } else {
+//      _nullValueVectorIterator = null;
+//    }
+//    _leftTransformFunction = arguments.get(0);
+//    _leftStoredType = _leftTransformFunction.getResultMetadata().getDataType().getStoredType();
+//    _rightStoredType = _rightTransformFunction.getResultMetadata().getDataType().getStoredType();
+//    // Data type check: left and right types should be compatible.
+//    if (_leftStoredType == FieldSpec.DataType.BYTES || _rightStoredType == FieldSpec.DataType.BYTES) {
+//      Preconditions.checkState(_leftStoredType == _rightStoredType, String.format(
+//          "Unsupported data type for comparison: [Left Transform Function [%s] result type is [%s], Right Transform "
+//              + "Function [%s] result type is [%s]]", _leftTransformFunction.getName(), _leftStoredType,
+//          _rightTransformFunction.getName(), _rightStoredType));
+  }
+
+
+  @Override
+  public TransformResultMetadata getResultMetadata() {
+    return BOOLEAN_SV_NO_DICTIONARY_METADATA;
+  }
+
+
+
+  private int[] _results;
+}
+
+//
+//  protected BinaryOperatorTransformFunction(TransformFunctionType transformFunctionType) {
+//    // translate to integer in [0, 5] for guaranteed tableswitch
+//    switch (transformFunctionType) {
+//      case EQUALS:
+//        _op = EQUALS;
+//        break;
+//      case GREATER_THAN_OR_EQUAL:
+//        _op = GREATER_THAN_OR_EQUAL;
+//        break;
+//      case GREATER_THAN:
+//        _op = GREATER_THAN;
+//        break;
+//      case LESS_THAN:
+//        _op = LESS_THAN;
+//        break;
+//      case LESS_THAN_OR_EQUAL:
+//        _op = LESS_THAN_OR_EQUAL;
+//        break;
+//      case NOT_EQUALS:
+//        _op = NOT_EQUAL;
+//        break;
+//      default:
+//        throw new IllegalArgumentException("non-binary transform function provided: " + transformFunctionType);
+//    }
+//    _transformFunctionType = transformFunctionType;
+//  }
+
+
+//
+//
+//  @Override
+//  public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
+//    fillResultArray(projectionBlock);
+//    return _results;
+//  }
+//
+//  private void fillResultArray(ProjectionBlock projectionBlock) {
+//    int length = projectionBlock.getNumDocs();
+//    if (_results == null || _results.length < length) {
+//      _results = new int[length];
+//    }
+//    switch (_leftStoredType) {
+//      case INT:
+//        fillResultInt(projectionBlock, length);
+//        break;
+//      case LONG:
+//        fillResultLong(projectionBlock, length);
+//        break;
+//      case FLOAT:
+//        fillResultFloat(projectionBlock, length);
+//        break;
+//      case DOUBLE:
+//        fillResultDouble(projectionBlock, length);
+//        break;
+//      case BIG_DECIMAL:
+//        fillResultBigDecimal(projectionBlock, length);
+//        break;
+//      case STRING:
+//        fillResultString(projectionBlock, length);
+//        break;
+//      case BYTES:
+//        fillResultBytes(projectionBlock, length);
+//        break;
+//      // NOTE: Multi-value columns are not comparable, so we should not reach here
+//      default:
+//        throw illegalState();
+//    }
+//  }
+//
+//  private void fillResultInt(ProjectionBlock projectionBlock, int length) {
+//    int[] leftIntValues = _leftTransformFunction.transformToIntValuesSV(projectionBlock);
+//    switch (_rightStoredType) {
+//      case INT:
+//        fillIntResultArray(projectionBlock, leftIntValues, length);
+//        break;
+//      case LONG:
+//        fillLongResultArray(projectionBlock, leftIntValues, length);
+//        break;
+//      case FLOAT:
+//        fillFloatResultArray(projectionBlock, leftIntValues, length);
+//        break;
+//      case DOUBLE:
+//        fillDoubleResultArray(projectionBlock, leftIntValues, length);
+//        break;
+//      case BIG_DECIMAL:
+//        fillBigDecimalResultArray(projectionBlock, leftIntValues, length);
+//        break;
+//      case STRING:
+//        fillStringResultArray(projectionBlock, leftIntValues, length);
+//        break;
+//      default:
+//        throw illegalState();
+//    }
+//  }
+//
+//  private void fillResultLong(ProjectionBlock projectionBlock, int length) {
+//    long[] leftLongValues = _leftTransformFunction.transformToLongValuesSV(projectionBlock);
+//    switch (_rightStoredType) {
+//      case INT:
+//        fillIntResultArray(projectionBlock, leftLongValues, length);
+//        break;
+//      case LONG:
+//        fillLongResultArray(projectionBlock, leftLongValues, length);
+//        break;
+//      case FLOAT:
+//        fillFloatResultArray(projectionBlock, leftLongValues, length);
+//        break;
+//      case DOUBLE:
+//        fillDoubleResultArray(projectionBlock, leftLongValues, length);
+//        break;
+//      case BIG_DECIMAL:
+//        fillBigDecimalResultArray(projectionBlock, leftLongValues, length);
+//        break;
+//      case STRING:
+//        fillStringResultArray(projectionBlock, leftLongValues, length);
+//        break;
+//      default:
+//        throw illegalState();
+//    }
+//  }
+//
+//  private void fillResultFloat(ProjectionBlock projectionBlock, int length) {
+//    float[] leftFloatValues = _leftTransformFunction.transformToFloatValuesSV(projectionBlock);
+//    switch (_rightStoredType) {
+//      case INT:
+//        fillIntResultArray(projectionBlock, leftFloatValues, length);
+//        break;
+//      case LONG:
+//        fillLongResultArray(projectionBlock, leftFloatValues, length);
+//        break;
+//      case FLOAT:
+//        fillFloatResultArray(projectionBlock, leftFloatValues, length);
+//        break;
+//      case DOUBLE:
+//        fillDoubleResultArray(projectionBlock, leftFloatValues, length);
+//        break;
+//      case BIG_DECIMAL:
+//        fillBigDecimalResultArray(projectionBlock, leftFloatValues, length);
+//        break;
+//      case STRING:
+//        fillStringResultArray(projectionBlock, leftFloatValues, length);
+//        break;
+//      default:
+//        throw illegalState();
+//    }
+//  }
+//
+//  private void fillResultDouble(ProjectionBlock projectionBlock, int length) {
+//    double[] leftDoubleValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
+//    switch (_rightStoredType) {
+//      case INT:
+//        fillIntResultArray(projectionBlock, leftDoubleValues, length);
+//        break;
+//      case LONG:
+//        fillLongResultArray(projectionBlock, leftDoubleValues, length);
+//        break;
+//      case FLOAT:
+//        fillFloatResultArray(projectionBlock, leftDoubleValues, length);
+//        break;
+//      case DOUBLE:
+//        fillDoubleResultArray(projectionBlock, leftDoubleValues, length);
+//        break;
+//      case BIG_DECIMAL:
+//        fillBigDecimalResultArray(projectionBlock, leftDoubleValues, length);
+//        break;
+//      case STRING:
+//        fillStringResultArray(projectionBlock, leftDoubleValues, length);
+//        break;
+//      default:
+//        throw illegalState();
+//    }
+//  }
+//
+//  private void fillResultBigDecimal(ProjectionBlock projectionBlock, int length) {
+//    BigDecimal[] leftBigDecimalValues = _leftTransformFunction.transformToBigDecimalValuesSV(projectionBlock);
+//    switch (_rightStoredType) {
+//      case INT:
+//        fillIntResultArray(projectionBlock, leftBigDecimalValues, length);
+//        break;
+//      case LONG:
+//        fillLongResultArray(projectionBlock, leftBigDecimalValues, length);
+//        break;
+//      case FLOAT:
+//        fillFloatResultArray(projectionBlock, leftBigDecimalValues, length);
+//        break;
+//      case DOUBLE:
+//        fillDoubleResultArray(projectionBlock, leftBigDecimalValues, length);
+//        break;
+//      case STRING:
+//        fillStringResultArray(projectionBlock, leftBigDecimalValues, length);
+//        break;
+//      case BIG_DECIMAL:
+//        fillBigDecimalResultArray(projectionBlock, leftBigDecimalValues, length);
+//        break;
+//      default:
+//        throw illegalState();
+//    }
+//  }
+//
+//  private IllegalStateException illegalState() {
+//    throw new IllegalStateException(String.format(
+//        "Unsupported data type for comparison: [Left Transform Function [%s] result type is [%s], Right "
+//            + "Transform Function [%s] result type is [%s]]", _leftTransformFunction.getName(), _leftStoredType,
+//        _rightTransformFunction.getName(), _rightStoredType));
+//  }
+//
+//  private void fillResultString(ProjectionBlock projectionBlock, int length) {
+//    String[] leftStringValues = _leftTransformFunction.transformToStringValuesSV(projectionBlock);
+//    String[] rightStringValues = _rightTransformFunction.transformToStringValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(leftStringValues[i].compareTo(rightStringValues[i]));
+//    }
+//  }
+//
+//  private void fillResultBytes(ProjectionBlock projectionBlock, int length) {
+//    byte[][] leftBytesValues = _leftTransformFunction.transformToBytesValuesSV(projectionBlock);
+//    byte[][] rightBytesValues = _rightTransformFunction.transformToBytesValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult((ByteArray.compare(leftBytesValues[i], rightBytesValues[i])));
+//    }
+//  }
+//
+//  private void fillIntResultArray(ProjectionBlock projectionBlock, int[] leftIntValues, int length) {
+//    int[] rightIntValues = _rightTransformFunction.transformToIntValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(Integer.compare(leftIntValues[i], rightIntValues[i]));
+//    }
+//  }
+//
+//  private void fillLongResultArray(ProjectionBlock projectionBlock, int[] leftValues, int length) {
+//    long[] rightValues = _rightTransformFunction.transformToLongValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(Long.compare(leftValues[i], rightValues[i]));
+//    }
+//  }
+//
+//  private void fillFloatResultArray(ProjectionBlock projectionBlock, int[] leftValues, int length) {
+//    float[] rightFloatValues = _rightTransformFunction.transformToFloatValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(Double.compare(leftValues[i], rightFloatValues[i]));
+//    }
+//  }
+//
+//  private void fillDoubleResultArray(ProjectionBlock projectionBlock, int[] leftValues, int length) {
+//    double[] rightDoubleValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(Double.compare(leftValues[i], rightDoubleValues[i]));
+//    }
+//  }
+//
+//  private void fillBigDecimalResultArray(ProjectionBlock projectionBlock, int[] leftValues, int length) {
+//    BigDecimal[] rightBigDecimalValues = _rightTransformFunction.transformToBigDecimalValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(rightBigDecimalValues[i]));
+//    }
+//  }
+//
+//  private void fillStringResultArray(ProjectionBlock projectionBlock, int[] leftValues, int length) {
+//    String[] rightStringValues = _rightTransformFunction.transformToStringValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      try {
+//        _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
+//      } catch (NumberFormatException e) {
+//        _results[i] = 0;
+//      }
+//    }
+//  }
+//
+//  private void fillIntResultArray(ProjectionBlock projectionBlock, long[] leftIntValues, int length) {
+//    int[] rightIntValues = _rightTransformFunction.transformToIntValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(Long.compare(leftIntValues[i], rightIntValues[i]));
+//    }
+//  }
+//
+//  private void fillLongResultArray(ProjectionBlock projectionBlock, long[] leftValues, int length) {
+//    long[] rightValues = _rightTransformFunction.transformToLongValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(Long.compare(leftValues[i], rightValues[i]));
+//    }
+//  }
+//
+//  private void fillFloatResultArray(ProjectionBlock projectionBlock, long[] leftValues, int length) {
+//    float[] rightFloatValues = _rightTransformFunction.transformToFloatValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(compare(leftValues[i], rightFloatValues[i]));
+//    }
+//  }
+//
+//  private void fillDoubleResultArray(ProjectionBlock projectionBlock, long[] leftValues, int length) {
+//    double[] rightDoubleValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(compare(leftValues[i], rightDoubleValues[i]));
+//    }
+//  }
+//
+//  private void fillBigDecimalResultArray(ProjectionBlock projectionBlock, long[] leftValues, int length) {
+//    BigDecimal[] rightBigDecimalValues = _rightTransformFunction.transformToBigDecimalValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(rightBigDecimalValues[i]));
+//    }
+//  }
+//
+//  private void fillStringResultArray(ProjectionBlock projectionBlock, long[] leftValues, int length) {
+//    String[] rightStringValues = _rightTransformFunction.transformToStringValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      try {
+//        _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
+//      } catch (NumberFormatException e) {
+//        _results[i] = 0;
+//      }
+//    }
+//  }
+//
+//  private void fillIntResultArray(ProjectionBlock projectionBlock, float[] leftValues, int length) {
+//    int[] rightIntValues = _rightTransformFunction.transformToIntValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(Double.compare(leftValues[i], rightIntValues[i]));
+//    }
+//  }
+//
+//  private void fillLongResultArray(ProjectionBlock projectionBlock, float[] leftValues, int length) {
+//    long[] rightValues = _rightTransformFunction.transformToLongValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = compare(leftValues[i], rightValues[i]);
+//    }
+//  }
+//
+//  private void fillFloatResultArray(ProjectionBlock projectionBlock, float[] leftValues, int length) {
+//    float[] rightFloatValues = _rightTransformFunction.transformToFloatValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(Float.compare(leftValues[i], rightFloatValues[i]));
+//    }
+//  }
+//
+//  private void fillDoubleResultArray(ProjectionBlock projectionBlock, float[] leftValues, int length) {
+//    double[] rightDoubleValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(Double.compare(leftValues[i], rightDoubleValues[i]));
+//    }
+//  }
+//
+//  private void fillBigDecimalResultArray(ProjectionBlock projectionBlock, float[] leftValues, int length) {
+//    BigDecimal[] rightBigDecimalValues = _rightTransformFunction.transformToBigDecimalValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(rightBigDecimalValues[i]));
+//    }
+//  }
+//
+//  private void fillStringResultArray(ProjectionBlock projectionBlock, float[] leftValues, int length) {
+//    String[] rightStringValues = _rightTransformFunction.transformToStringValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      try {
+//        _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
+//      } catch (NumberFormatException e) {
+//        _results[i] = 0;
+//      }
+//    }
+//  }
+//
+//  private void fillIntResultArray(ProjectionBlock projectionBlock, double[] leftValues, int length) {
+//    int[] rightIntValues = _rightTransformFunction.transformToIntValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(Double.compare(leftValues[i], rightIntValues[i]));
+//    }
+//  }
+//
+//  private void fillLongResultArray(ProjectionBlock projectionBlock, double[] leftValues, int length) {
+//    long[] rightValues = _rightTransformFunction.transformToLongValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = compare(leftValues[i], rightValues[i]);
+//    }
+//  }
+//
+//  private void fillFloatResultArray(ProjectionBlock projectionBlock, double[] leftValues, int length) {
+//    float[] rightFloatValues = _rightTransformFunction.transformToFloatValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(Double.compare(leftValues[i], rightFloatValues[i]));
+//    }
+//  }
+//
+//  private void fillDoubleResultArray(ProjectionBlock projectionBlock, double[] leftValues, int length) {
+//    double[] rightDoubleValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(Double.compare(leftValues[i], rightDoubleValues[i]));
+//    }
+//  }
+//
+//  private void fillBigDecimalResultArray(ProjectionBlock projectionBlock, double[] leftValues, int length) {
+//    BigDecimal[] rightBigDecimalValues = _rightTransformFunction.transformToBigDecimalValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(rightBigDecimalValues[i]));
+//    }
+//  }
+//
+//  private void fillStringResultArray(ProjectionBlock projectionBlock, double[] leftValues, int length) {
+//    String[] rightStringValues = _rightTransformFunction.transformToStringValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      try {
+//        _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
+//      } catch (NumberFormatException e) {
+//        _results[i] = 0;
+//      }
+//    }
+//  }
+//
+//  private void fillIntResultArray(ProjectionBlock projectionBlock, BigDecimal[] leftValues, int length) {
+//    int[] rightIntValues = _rightTransformFunction.transformToIntValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(leftValues[i].compareTo(BigDecimal.valueOf(rightIntValues[i])));
+//    }
+//  }
+//
+//  private void fillLongResultArray(ProjectionBlock projectionBlock, BigDecimal[] leftValues, int length) {
+//    long[] rightLongValues = _rightTransformFunction.transformToLongValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(leftValues[i].compareTo(BigDecimal.valueOf(rightLongValues[i])));
+//    }
+//  }
+//
+//  private void fillFloatResultArray(ProjectionBlock projectionBlock, BigDecimal[] leftValues, int length) {
+//    float[] rightFloatValues = _rightTransformFunction.transformToFloatValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(leftValues[i].compareTo(BigDecimal.valueOf(rightFloatValues[i])));
+//    }
+//  }
+//
+//  private void fillDoubleResultArray(ProjectionBlock projectionBlock, BigDecimal[] leftValues, int length) {
+//    double[] rightDoubleValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(leftValues[i].compareTo(BigDecimal.valueOf(rightDoubleValues[i])));
+//    }
+//  }
+//
+//  private void fillBigDecimalResultArray(ProjectionBlock projectionBlock, BigDecimal[] leftValues, int length) {
+//    BigDecimal[] rightBigDecimalValues = _rightTransformFunction.transformToBigDecimalValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(leftValues[i].compareTo(rightBigDecimalValues[i]));
+//    }
+//  }
+//
+//  private void fillStringResultArray(ProjectionBlock projectionBlock, BigDecimal[] leftValues, int length) {
+//    String[] rightStringValues = _rightTransformFunction.transformToStringValuesSV(projectionBlock);
+//    for (int i = 0; i < length; i++) {
+//      _results[i] = getIntResult(leftValues[i].compareTo(new BigDecimal(rightStringValues[i])));
+//    }
+//  }
+//
+//  private int compare(long left, double right) {
+//    if (Math.abs(left) <= 1L << 53) {
+//      return getIntResult(Double.compare(left, right));
+//    } else {
+//      return getIntResult(BigDecimal.valueOf(left).compareTo(BigDecimal.valueOf(right)));
+//    }
+//  }
+//
+//  private int compare(double left, long right) {
+//    if (Math.abs(right) <= 1L << 53) {
+//      return getIntResult(Double.compare(left, right));
+//    } else {
+//      return getIntResult(BigDecimal.valueOf(left).compareTo(BigDecimal.valueOf(right)));
+//    }
+//  }
+//
+//  private int getIntResult(int comparisonResult) {
+//    return getBinaryFuncResult(comparisonResult) ? 1 : 0;
+//  }
+//
+//  private boolean getBinaryFuncResult(int comparisonResult) {
+//    switch (_op) {
+//      case EQUALS:
+//        return comparisonResult == 0;
+//      case GREATER_THAN_OR_EQUAL:
+//        return comparisonResult >= 0;
+//      case GREATER_THAN:
+//        return comparisonResult > 0;
+//      case LESS_THAN:
+//        return comparisonResult < 0;
+//      case LESS_THAN_OR_EQUAL:
+//        return comparisonResult <= 0;
+//      case NOT_EQUAL:
+//        return comparisonResult != 0;
+//      default:
+//        throw new IllegalStateException();
+//    }
+//  }
+//}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotDistinctFromTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotDistinctFromTransformFunction.java
@@ -28,7 +28,7 @@ package org.apache.pinot.core.operator.transform.function;
  * NUll IS_NOT_DISTINCT_FROM Null: 1
  * ValueA IS_NOT_DISTINCT_FROM ValueB: EQUALS(ValueA, ValueB)
  *
- * Not this operator only takes column names for now.
+ * Note this operator only takes column names for now.
  * SQL Syntax:
  *    columnA IS_NOT_DISTINCT_FROM columnB
  *

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotDistinctFromTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotDistinctFromTransformFunction.java
@@ -19,24 +19,24 @@
 package org.apache.pinot.core.operator.transform.function;
 
 /**
- * The <code>IsDistinctFromTransformFunction</code> extends <code>DistinctFromTransformFunction</code> to implement the
- * IS_DISTINCT_FROM operator.
+ * The <code>IsNotDistinctFromTransformFunction</code> extends <code>DistinctFromTransformFunction</code> to
+ * implement the IS_NOT_DISTINCT_FROM operator.
  *
  * The results are in boolean format and stored as an integer array with 1 represents true and 0 represents false.
  * Expected result:
- * NUll IS_DISTINCT_FROM Value: 1
- * NUll IS_DISTINCT_FROM Null: 0
- * ValueA IS_DISTINCT_FROM ValueB: NotEQUALS(ValueA, ValueB)
+ * NUll IS_NOT_DISTINCT_FROM Value: 0
+ * NUll IS_NOT_DISTINCT_FROM Null: 1
+ * ValueA IS_NOT_DISTINCT_FROM ValueB: EQUALS(ValueA, ValueB)
  *
  * Not this operator only takes column names for now.
  * SQL Syntax:
- *    columnA IS_DISTINCT_FROM columnB
+ *    columnA IS_NOT_DISTINCT_FROM columnB
  *
  * Sample Usage:
- *    IS_DISTINCT_FROM(columnA, columnB)
+ *    IS_NOT_DISTINCT_FROM(columnA, columnB)
  */
-public class IsDistinctFromTransformFunction extends DistinctFromTransformFunction {
-  public IsDistinctFromTransformFunction() {
-    super(true);
+public class IsNotDistinctFromTransformFunction extends DistinctFromTransformFunction {
+  public IsNotDistinctFromTransformFunction() {
+    super(false);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -202,6 +202,8 @@ public class TransformFunctionFactory {
     typeToImplementation.put(TransformFunctionType.IS_NULL, IsNullTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.IS_NOT_NULL,
         IsNotNullTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.IS_DISTINCT_FROM, IsDistinctFromTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.IS_NOT_DISTINCT_FROM, IsNotDistinctFromTransformFunction.class);
 
     // Trignometric functions
     typeToImplementation.put(TransformFunctionType.SIN, SinTransformFunction.class);
@@ -216,8 +218,6 @@ public class TransformFunctionFactory {
     typeToImplementation.put(TransformFunctionType.TANH, TanhTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.DEGREES, DegreesTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.RADIANS, RadiansTransformFunction.class);
-
-    typeToImplementation.put(TransformFunctionType.IS_DISTINCT_FROM, IsDisinctFromTransformFunction.class);
 
     Map<String, Class<? extends TransformFunction>> registry = new HashMap<>(typeToImplementation.size());
     for (Map.Entry<TransformFunctionType, Class<? extends TransformFunction>> entry : typeToImplementation.entrySet()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -217,6 +217,8 @@ public class TransformFunctionFactory {
     typeToImplementation.put(TransformFunctionType.DEGREES, DegreesTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.RADIANS, RadiansTransformFunction.class);
 
+    typeToImplementation.put(TransformFunctionType.IS_DISTINCT_FROM, IsDisinctFromTransformFunction.class);
+
     Map<String, Class<? extends TransformFunction>> registry = new HashMap<>(typeToImplementation.size());
     for (Map.Entry<TransformFunctionType, Class<? extends TransformFunction>> entry : typeToImplementation.entrySet()) {
       for (String alias : entry.getKey().getAliases()) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DistinctFromTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DistinctFromTransformFunctionTest.java
@@ -1,0 +1,295 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.core.operator.DocIdSetOperator;
+import org.apache.pinot.core.operator.ProjectionOperator;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+import org.apache.pinot.core.operator.filter.MatchAllFilterOperator;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class DistinctFromTransformFunctionTest {
+  private static final String ENABLE_NULL_SEGMENT_NAME = "testSegment1";
+  private static final String DISABLE_NULL_SEGMENT_NAME = "testSegment2";
+  private static final String IS_DISTINCT_FROM = "is_distinct_from";
+  private static final String IS_NOT_DISTINCT_FROM = "is_not_distinct_from";
+  private static final Random RANDOM = new Random();
+
+  private static final int NUM_ROWS = 1000;
+  private static final String INT_SV_COLUMN = "intSV";
+  private static final String INT_SV_NULL_COLUMN = "intSV2";
+  private final int[] _intSVValues = new int[NUM_ROWS];
+  private Map<String, DataSource> _enableNullDataSourceMap;
+  private Map<String, DataSource> _disableNullDataSourceMap;
+  private ProjectionBlock _enableNullProjectionBlock;
+  private ProjectionBlock _disableNullProjectionBlock;
+  protected static final int VALUE_MOD = 3;
+
+  private static String getIndexDirPath(String segmentName) {
+    return FileUtils.getTempDirectoryPath() + File.separator + segmentName;
+  }
+
+  private static Map<String, DataSource> getDataSourceMap(Schema schema, List<GenericRow> rows, String segmentName)
+      throws Exception {
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(segmentName).setNullHandlingEnabled(true).build();
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setOutDir(getIndexDirPath(segmentName));
+    config.setSegmentName(segmentName);
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(config, new GenericRowRecordReader(rows));
+    driver.build();
+    IndexSegment indexSegment =
+        ImmutableSegmentLoader.load(new File(getIndexDirPath(segmentName), segmentName), ReadMode.heap);
+    Set<String> columnNames = indexSegment.getPhysicalColumnNames();
+    Map<String, DataSource> enableNullDataSourceMap = new HashMap<>(columnNames.size());
+    for (String columnName : columnNames) {
+      enableNullDataSourceMap.put(columnName, indexSegment.getDataSource(columnName));
+    }
+    return enableNullDataSourceMap;
+  }
+
+  private static ProjectionBlock getProjectionBlock(Map<String, DataSource> dataSourceMap) {
+    return new ProjectionOperator(dataSourceMap,
+        new DocIdSetOperator(new MatchAllFilterOperator(NUM_ROWS), DocIdSetPlanNode.MAX_DOC_PER_CALL)).nextBlock();
+  }
+
+  private static boolean isEqualRow(int i) {
+    return i % VALUE_MOD == 0;
+  }
+
+  private static boolean isNotEqualRow(int i) {
+    return i % VALUE_MOD == 1;
+  }
+
+  private static boolean isNullRow(int i) {
+    return i % VALUE_MOD == 2;
+  }
+
+  @BeforeClass
+  public void setup()
+      throws Exception {
+    // Set up two tables: one with null option enable, the other with null option disable.
+    // Each table has two int columns.
+    // One column with every row filled in with random integer number.
+    // The other column has 1/3 rows equal to first column, 1/3 rows not equal to first column and 1/3 null rows.
+    FileUtils.deleteQuietly(new File(getIndexDirPath(DISABLE_NULL_SEGMENT_NAME)));
+    FileUtils.deleteQuietly(new File(getIndexDirPath(ENABLE_NULL_SEGMENT_NAME)));
+    for (int i = 0; i < NUM_ROWS; i++) {
+      _intSVValues[i] = RANDOM.nextInt();
+    }
+    List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      Map<String, Object> map = new HashMap<>();
+      map.put(INT_SV_COLUMN, _intSVValues[i]);
+      if (isEqualRow(i)) {
+        map.put(INT_SV_NULL_COLUMN, _intSVValues[i]);
+      } else if (isNotEqualRow(i)) {
+        map.put(INT_SV_NULL_COLUMN, _intSVValues[i] + 1);
+      } else if (isNullRow(i)) {
+        map.put(INT_SV_NULL_COLUMN, null);
+      }
+      GenericRow row = new GenericRow();
+      row.init(map);
+      rows.add(row);
+    }
+
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(INT_SV_COLUMN, FieldSpec.DataType.INT)
+        .addSingleValueDimension(INT_SV_NULL_COLUMN, FieldSpec.DataType.INT).build();
+    _enableNullDataSourceMap = getDataSourceMap(schema, rows, ENABLE_NULL_SEGMENT_NAME);
+    _enableNullProjectionBlock = getProjectionBlock(_enableNullDataSourceMap);
+    _disableNullDataSourceMap = getDataSourceMap(schema, rows, DISABLE_NULL_SEGMENT_NAME);
+    _disableNullProjectionBlock = getProjectionBlock(_disableNullDataSourceMap);
+  }
+
+  protected void testTransformFunction(ExpressionContext expression, boolean[] expectedValues,
+      ProjectionBlock projectionBlock)
+      throws Exception {
+    int[] intValues = getTransformFunctionInstance(expression).transformToIntValuesSV(projectionBlock);
+    long[] longValues = getTransformFunctionInstance(expression).transformToLongValuesSV(projectionBlock);
+    float[] floatValues = getTransformFunctionInstance(expression).transformToFloatValuesSV(projectionBlock);
+    double[] doubleValues = getTransformFunctionInstance(expression).transformToDoubleValuesSV(projectionBlock);
+    String[] stringValues = getTransformFunctionInstance(expression).transformToStringValuesSV(projectionBlock);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      Assert.assertEquals(intValues[i] == 1, expectedValues[i]);
+      Assert.assertEquals(longValues[i] == 1, expectedValues[i]);
+      Assert.assertEquals(floatValues[i] == 1, expectedValues[i]);
+      Assert.assertEquals(doubleValues[i] == 1, expectedValues[i]);
+      Assert.assertEquals(stringValues[i], Boolean.toString(expectedValues[i]));
+    }
+  }
+
+  private TransformFunction getTransformFunctionInstance(ExpressionContext expression) {
+    return TransformFunctionFactory.get(expression, _enableNullDataSourceMap);
+  }
+
+  // Test that left column of the operator has null values and right column is not null.
+  @Test
+  public void testDistinctFromLeftNull()
+      throws Exception {
+    ExpressionContext isDistinctFromExpression = RequestContextUtils.getExpression(
+        String.format("%s(%s, %s)", IS_DISTINCT_FROM, INT_SV_NULL_COLUMN, INT_SV_COLUMN));
+    TransformFunction isDistinctFromTransformFunction =
+        TransformFunctionFactory.get(isDistinctFromExpression, _enableNullDataSourceMap);
+    Assert.assertEquals(isDistinctFromTransformFunction.getName(), "is_distinct_from");
+    ExpressionContext isNotDistinctFromExpression = RequestContextUtils.getExpression(
+        String.format("%s(%s, %s)", IS_NOT_DISTINCT_FROM, INT_SV_NULL_COLUMN, INT_SV_COLUMN));
+    TransformFunction isNotDistinctFromTransformFunction =
+        TransformFunctionFactory.get(isNotDistinctFromExpression, _enableNullDataSourceMap);
+    Assert.assertEquals(isNotDistinctFromTransformFunction.getName(), "is_not_distinct_from");
+    boolean[] isDistinctFromExpectedIntValues = new boolean[NUM_ROWS];
+    boolean[] isNotDistinctFromExpectedIntValues = new boolean[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      if (isEqualRow(i)) {
+        isDistinctFromExpectedIntValues[i] = false;
+        isNotDistinctFromExpectedIntValues[i] = true;
+      } else if (isNotEqualRow(i)) {
+        isDistinctFromExpectedIntValues[i] = true;
+        isNotDistinctFromExpectedIntValues[i] = false;
+      } else if (isNullRow(i)) {
+        isDistinctFromExpectedIntValues[i] = true;
+        isNotDistinctFromExpectedIntValues[i] = false;
+      }
+    }
+    testTransformFunction(isDistinctFromExpression, isDistinctFromExpectedIntValues, _enableNullProjectionBlock);
+    testTransformFunction(isNotDistinctFromExpression, isNotDistinctFromExpectedIntValues, _enableNullProjectionBlock);
+    testTransformFunction(isDistinctFromExpression, isDistinctFromExpectedIntValues, _disableNullProjectionBlock);
+    testTransformFunction(isNotDistinctFromExpression, isNotDistinctFromExpectedIntValues, _disableNullProjectionBlock);
+  }
+
+  // Test that right column of the operator has null values and left column is not null.
+  @Test
+  public void testDistinctFromRightNull()
+      throws Exception {
+    ExpressionContext isDistinctFromExpression = RequestContextUtils.getExpression(
+        String.format("%s(%s, %s)", IS_DISTINCT_FROM, INT_SV_COLUMN, INT_SV_NULL_COLUMN));
+    TransformFunction isDistinctFromTransformFunction =
+        TransformFunctionFactory.get(isDistinctFromExpression, _enableNullDataSourceMap);
+    Assert.assertEquals(isDistinctFromTransformFunction.getName(), "is_distinct_from");
+    ExpressionContext isNotDistinctFromExpression = RequestContextUtils.getExpression(
+        String.format("%s(%s, %s)", IS_NOT_DISTINCT_FROM, INT_SV_COLUMN, INT_SV_NULL_COLUMN));
+    TransformFunction isNotDistinctFromTransformFunction =
+        TransformFunctionFactory.get(isNotDistinctFromExpression, _enableNullDataSourceMap);
+    Assert.assertEquals(isNotDistinctFromTransformFunction.getName(), "is_not_distinct_from");
+    boolean[] isDistinctFromExpectedIntValues = new boolean[NUM_ROWS];
+    boolean[] isNotDistinctFromExpectedIntValues = new boolean[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      if (isEqualRow(i)) {
+        isDistinctFromExpectedIntValues[i] = false;
+        isNotDistinctFromExpectedIntValues[i] = true;
+      } else if (isNotEqualRow(i)) {
+        isDistinctFromExpectedIntValues[i] = true;
+        isNotDistinctFromExpectedIntValues[i] = false;
+      } else if (isNullRow(i)) {
+        isDistinctFromExpectedIntValues[i] = true;
+        isNotDistinctFromExpectedIntValues[i] = false;
+      }
+    }
+    testTransformFunction(isDistinctFromExpression, isDistinctFromExpectedIntValues, _enableNullProjectionBlock);
+    testTransformFunction(isNotDistinctFromExpression, isNotDistinctFromExpectedIntValues, _enableNullProjectionBlock);
+    testTransformFunction(isDistinctFromExpression, isDistinctFromExpectedIntValues, _disableNullProjectionBlock);
+    testTransformFunction(isNotDistinctFromExpression, isNotDistinctFromExpectedIntValues, _disableNullProjectionBlock);
+  }
+
+  // Test the cases where both left and right columns of th operator has null values.
+  @Test
+  public void testDistinctFromBothNull()
+      throws Exception {
+    ExpressionContext isDistinctFromExpression = RequestContextUtils.getExpression(
+        String.format("%s(%s, %s)", IS_DISTINCT_FROM, INT_SV_NULL_COLUMN, INT_SV_NULL_COLUMN));
+    TransformFunction isDistinctFromTransformFunction =
+        TransformFunctionFactory.get(isDistinctFromExpression, _enableNullDataSourceMap);
+    Assert.assertEquals(isDistinctFromTransformFunction.getName(), "is_distinct_from");
+    ExpressionContext isNotDistinctFromExpression = RequestContextUtils.getExpression(
+        String.format("%s(%s, %s)", IS_NOT_DISTINCT_FROM, INT_SV_NULL_COLUMN, INT_SV_NULL_COLUMN));
+    TransformFunction isNotDistinctFromTransformFunction =
+        TransformFunctionFactory.get(isNotDistinctFromExpression, _enableNullDataSourceMap);
+    Assert.assertEquals(isNotDistinctFromTransformFunction.getName(), "is_not_distinct_from");
+    boolean[] isDistinctFromExpectedIntValues = new boolean[NUM_ROWS];
+    boolean[] isNotDistinctFromExpectedIntValues = new boolean[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      isDistinctFromExpectedIntValues[i] = false;
+      isNotDistinctFromExpectedIntValues[i] = true;
+    }
+    testTransformFunction(isDistinctFromExpression, isDistinctFromExpectedIntValues, _enableNullProjectionBlock);
+    testTransformFunction(isNotDistinctFromExpression, isNotDistinctFromExpectedIntValues, _enableNullProjectionBlock);
+    testTransformFunction(isDistinctFromExpression, isDistinctFromExpectedIntValues, _disableNullProjectionBlock);
+    testTransformFunction(isNotDistinctFromExpression, isNotDistinctFromExpectedIntValues, _disableNullProjectionBlock);
+  }
+
+  // Test that non-column-names appear in one side of the operator.
+  @Test
+  public void testIllegalColumnName()
+      throws Exception {
+    ExpressionContext isDistinctFromExpression = RequestContextUtils.getExpression(
+        String.format("%s(%d, %s)", IS_DISTINCT_FROM, _intSVValues[0], INT_SV_NULL_COLUMN));
+    ExpressionContext isNotDistinctFromExpression = RequestContextUtils.getExpression(
+        String.format("%s(%d, %s)", IS_NOT_DISTINCT_FROM, _intSVValues[0], INT_SV_NULL_COLUMN));
+
+    Assert.assertThrows(RuntimeException.class, () -> {
+      TransformFunctionFactory.get(isDistinctFromExpression, _enableNullDataSourceMap);
+    });
+    Assert.assertThrows(RuntimeException.class, () -> {
+      TransformFunctionFactory.get(isNotDistinctFromExpression, _enableNullDataSourceMap);
+    });
+  }
+
+  // Test that more than 2 arguments appear for the operator.
+  @Test
+  public void testIllegalNumArgs()
+      throws Exception {
+    ExpressionContext isDistinctFromExpression = RequestContextUtils.getExpression(
+        String.format("%s(%s, %s, %s)", IS_DISTINCT_FROM, INT_SV_COLUMN, INT_SV_NULL_COLUMN, INT_SV_COLUMN));
+    ExpressionContext isNotDistinctFromExpression = RequestContextUtils.getExpression(
+        String.format("%s(%s, %s, %s)", IS_NOT_DISTINCT_FROM, INT_SV_COLUMN, INT_SV_NULL_COLUMN, INT_SV_COLUMN));
+
+    Assert.assertThrows(RuntimeException.class, () -> {
+      TransformFunctionFactory.get(isDistinctFromExpression, _enableNullDataSourceMap);
+    });
+    Assert.assertThrows(RuntimeException.class, () -> {
+      TransformFunctionFactory.get(isNotDistinctFromExpression, _enableNullDataSourceMap);
+    });
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DistinctFromTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DistinctFromTransformFunctionTest.java
@@ -50,11 +50,12 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+
 public class DistinctFromTransformFunctionTest {
   private static final String ENABLE_NULL_SEGMENT_NAME = "testSegment1";
   private static final String DISABLE_NULL_SEGMENT_NAME = "testSegment2";
-  private static final String IS_DISTINCT_FROM = "is_distinct_from";
-  private static final String IS_NOT_DISTINCT_FROM = "is_not_distinct_from";
+  private static final String IS_DISTINCT_FROM_EXPR = "%s IS DISTINCT FROM %s";
+  private static final String IS_NOT_DISTINCT_FROM_EXPR = "%s IS NOT DISTINCT FROM %s";
   private static final Random RANDOM = new Random();
 
   private static final int NUM_ROWS = 1000;
@@ -145,13 +146,17 @@ public class DistinctFromTransformFunctionTest {
   }
 
   protected void testTransformFunction(ExpressionContext expression, boolean[] expectedValues,
-      ProjectionBlock projectionBlock)
+      ProjectionBlock projectionBlock, Map<String, DataSource> dataSourceMap)
       throws Exception {
-    int[] intValues = getTransformFunctionInstance(expression).transformToIntValuesSV(projectionBlock);
-    long[] longValues = getTransformFunctionInstance(expression).transformToLongValuesSV(projectionBlock);
-    float[] floatValues = getTransformFunctionInstance(expression).transformToFloatValuesSV(projectionBlock);
-    double[] doubleValues = getTransformFunctionInstance(expression).transformToDoubleValuesSV(projectionBlock);
-    String[] stringValues = getTransformFunctionInstance(expression).transformToStringValuesSV(projectionBlock);
+    int[] intValues = getTransformFunctionInstance(expression, dataSourceMap).transformToIntValuesSV(projectionBlock);
+    long[] longValues =
+        getTransformFunctionInstance(expression, dataSourceMap).transformToLongValuesSV(projectionBlock);
+    float[] floatValues =
+        getTransformFunctionInstance(expression, dataSourceMap).transformToFloatValuesSV(projectionBlock);
+    double[] doubleValues =
+        getTransformFunctionInstance(expression, dataSourceMap).transformToDoubleValuesSV(projectionBlock);
+    String[] stringValues =
+        getTransformFunctionInstance(expression, dataSourceMap).transformToStringValuesSV(projectionBlock);
     for (int i = 0; i < NUM_ROWS; i++) {
       Assert.assertEquals(intValues[i] == 1, expectedValues[i]);
       Assert.assertEquals(longValues[i] == 1, expectedValues[i]);
@@ -161,21 +166,22 @@ public class DistinctFromTransformFunctionTest {
     }
   }
 
-  private TransformFunction getTransformFunctionInstance(ExpressionContext expression) {
-    return TransformFunctionFactory.get(expression, _enableNullDataSourceMap);
+  private TransformFunction getTransformFunctionInstance(ExpressionContext expression,
+      Map<String, DataSource> dataSourceMap) {
+    return TransformFunctionFactory.get(expression, dataSourceMap);
   }
 
   // Test that left column of the operator has null values and right column is not null.
   @Test
   public void testDistinctFromLeftNull()
       throws Exception {
-    ExpressionContext isDistinctFromExpression = RequestContextUtils.getExpression(
-        String.format("%s(%s, %s)", IS_DISTINCT_FROM, INT_SV_NULL_COLUMN, INT_SV_COLUMN));
+    ExpressionContext isDistinctFromExpression =
+        RequestContextUtils.getExpression(String.format(IS_DISTINCT_FROM_EXPR, INT_SV_NULL_COLUMN, INT_SV_COLUMN));
     TransformFunction isDistinctFromTransformFunction =
         TransformFunctionFactory.get(isDistinctFromExpression, _enableNullDataSourceMap);
     Assert.assertEquals(isDistinctFromTransformFunction.getName(), "is_distinct_from");
-    ExpressionContext isNotDistinctFromExpression = RequestContextUtils.getExpression(
-        String.format("%s(%s, %s)", IS_NOT_DISTINCT_FROM, INT_SV_NULL_COLUMN, INT_SV_COLUMN));
+    ExpressionContext isNotDistinctFromExpression =
+        RequestContextUtils.getExpression(String.format(IS_NOT_DISTINCT_FROM_EXPR, INT_SV_NULL_COLUMN, INT_SV_COLUMN));
     TransformFunction isNotDistinctFromTransformFunction =
         TransformFunctionFactory.get(isNotDistinctFromExpression, _enableNullDataSourceMap);
     Assert.assertEquals(isNotDistinctFromTransformFunction.getName(), "is_not_distinct_from");
@@ -193,23 +199,27 @@ public class DistinctFromTransformFunctionTest {
         isNotDistinctFromExpectedIntValues[i] = false;
       }
     }
-    testTransformFunction(isDistinctFromExpression, isDistinctFromExpectedIntValues, _enableNullProjectionBlock);
-    testTransformFunction(isNotDistinctFromExpression, isNotDistinctFromExpectedIntValues, _enableNullProjectionBlock);
-    testTransformFunction(isDistinctFromExpression, isDistinctFromExpectedIntValues, _disableNullProjectionBlock);
-    testTransformFunction(isNotDistinctFromExpression, isNotDistinctFromExpectedIntValues, _disableNullProjectionBlock);
+    testTransformFunction(isDistinctFromExpression, isDistinctFromExpectedIntValues, _enableNullProjectionBlock,
+        _enableNullDataSourceMap);
+    testTransformFunction(isNotDistinctFromExpression, isNotDistinctFromExpectedIntValues, _enableNullProjectionBlock,
+        _enableNullDataSourceMap);
+    testTransformFunction(isDistinctFromExpression, isDistinctFromExpectedIntValues, _disableNullProjectionBlock,
+        _disableNullDataSourceMap);
+    testTransformFunction(isNotDistinctFromExpression, isNotDistinctFromExpectedIntValues, _disableNullProjectionBlock,
+        _disableNullDataSourceMap);
   }
 
   // Test that right column of the operator has null values and left column is not null.
   @Test
   public void testDistinctFromRightNull()
       throws Exception {
-    ExpressionContext isDistinctFromExpression = RequestContextUtils.getExpression(
-        String.format("%s(%s, %s)", IS_DISTINCT_FROM, INT_SV_COLUMN, INT_SV_NULL_COLUMN));
+    ExpressionContext isDistinctFromExpression =
+        RequestContextUtils.getExpression(String.format(IS_DISTINCT_FROM_EXPR, INT_SV_COLUMN, INT_SV_NULL_COLUMN));
     TransformFunction isDistinctFromTransformFunction =
         TransformFunctionFactory.get(isDistinctFromExpression, _enableNullDataSourceMap);
     Assert.assertEquals(isDistinctFromTransformFunction.getName(), "is_distinct_from");
-    ExpressionContext isNotDistinctFromExpression = RequestContextUtils.getExpression(
-        String.format("%s(%s, %s)", IS_NOT_DISTINCT_FROM, INT_SV_COLUMN, INT_SV_NULL_COLUMN));
+    ExpressionContext isNotDistinctFromExpression =
+        RequestContextUtils.getExpression(String.format(IS_NOT_DISTINCT_FROM_EXPR, INT_SV_COLUMN, INT_SV_NULL_COLUMN));
     TransformFunction isNotDistinctFromTransformFunction =
         TransformFunctionFactory.get(isNotDistinctFromExpression, _enableNullDataSourceMap);
     Assert.assertEquals(isNotDistinctFromTransformFunction.getName(), "is_not_distinct_from");
@@ -227,23 +237,27 @@ public class DistinctFromTransformFunctionTest {
         isNotDistinctFromExpectedIntValues[i] = false;
       }
     }
-    testTransformFunction(isDistinctFromExpression, isDistinctFromExpectedIntValues, _enableNullProjectionBlock);
-    testTransformFunction(isNotDistinctFromExpression, isNotDistinctFromExpectedIntValues, _enableNullProjectionBlock);
-    testTransformFunction(isDistinctFromExpression, isDistinctFromExpectedIntValues, _disableNullProjectionBlock);
-    testTransformFunction(isNotDistinctFromExpression, isNotDistinctFromExpectedIntValues, _disableNullProjectionBlock);
+    testTransformFunction(isDistinctFromExpression, isDistinctFromExpectedIntValues, _enableNullProjectionBlock,
+        _enableNullDataSourceMap);
+    testTransformFunction(isNotDistinctFromExpression, isNotDistinctFromExpectedIntValues, _enableNullProjectionBlock,
+        _enableNullDataSourceMap);
+    testTransformFunction(isDistinctFromExpression, isDistinctFromExpectedIntValues, _disableNullProjectionBlock,
+        _disableNullDataSourceMap);
+    testTransformFunction(isNotDistinctFromExpression, isNotDistinctFromExpectedIntValues, _disableNullProjectionBlock,
+        _disableNullDataSourceMap);
   }
 
   // Test the cases where both left and right columns of th operator has null values.
   @Test
   public void testDistinctFromBothNull()
       throws Exception {
-    ExpressionContext isDistinctFromExpression = RequestContextUtils.getExpression(
-        String.format("%s(%s, %s)", IS_DISTINCT_FROM, INT_SV_NULL_COLUMN, INT_SV_NULL_COLUMN));
+    ExpressionContext isDistinctFromExpression =
+        RequestContextUtils.getExpression(String.format(IS_DISTINCT_FROM_EXPR, INT_SV_NULL_COLUMN, INT_SV_NULL_COLUMN));
     TransformFunction isDistinctFromTransformFunction =
         TransformFunctionFactory.get(isDistinctFromExpression, _enableNullDataSourceMap);
     Assert.assertEquals(isDistinctFromTransformFunction.getName(), "is_distinct_from");
     ExpressionContext isNotDistinctFromExpression = RequestContextUtils.getExpression(
-        String.format("%s(%s, %s)", IS_NOT_DISTINCT_FROM, INT_SV_NULL_COLUMN, INT_SV_NULL_COLUMN));
+        String.format(IS_NOT_DISTINCT_FROM_EXPR, INT_SV_NULL_COLUMN, INT_SV_NULL_COLUMN));
     TransformFunction isNotDistinctFromTransformFunction =
         TransformFunctionFactory.get(isNotDistinctFromExpression, _enableNullDataSourceMap);
     Assert.assertEquals(isNotDistinctFromTransformFunction.getName(), "is_not_distinct_from");
@@ -253,20 +267,24 @@ public class DistinctFromTransformFunctionTest {
       isDistinctFromExpectedIntValues[i] = false;
       isNotDistinctFromExpectedIntValues[i] = true;
     }
-    testTransformFunction(isDistinctFromExpression, isDistinctFromExpectedIntValues, _enableNullProjectionBlock);
-    testTransformFunction(isNotDistinctFromExpression, isNotDistinctFromExpectedIntValues, _enableNullProjectionBlock);
-    testTransformFunction(isDistinctFromExpression, isDistinctFromExpectedIntValues, _disableNullProjectionBlock);
-    testTransformFunction(isNotDistinctFromExpression, isNotDistinctFromExpectedIntValues, _disableNullProjectionBlock);
+    testTransformFunction(isDistinctFromExpression, isDistinctFromExpectedIntValues, _enableNullProjectionBlock,
+        _enableNullDataSourceMap);
+    testTransformFunction(isNotDistinctFromExpression, isNotDistinctFromExpectedIntValues, _enableNullProjectionBlock,
+        _enableNullDataSourceMap);
+    testTransformFunction(isDistinctFromExpression, isDistinctFromExpectedIntValues, _disableNullProjectionBlock,
+        _disableNullDataSourceMap);
+    testTransformFunction(isNotDistinctFromExpression, isNotDistinctFromExpectedIntValues, _disableNullProjectionBlock,
+        _disableNullDataSourceMap);
   }
 
   // Test that non-column-names appear in one side of the operator.
   @Test
   public void testIllegalColumnName()
       throws Exception {
-    ExpressionContext isDistinctFromExpression = RequestContextUtils.getExpression(
-        String.format("%s(%d, %s)", IS_DISTINCT_FROM, _intSVValues[0], INT_SV_NULL_COLUMN));
+    ExpressionContext isDistinctFromExpression =
+        RequestContextUtils.getExpression(String.format(IS_DISTINCT_FROM_EXPR, _intSVValues[0], INT_SV_NULL_COLUMN));
     ExpressionContext isNotDistinctFromExpression = RequestContextUtils.getExpression(
-        String.format("%s(%d, %s)", IS_NOT_DISTINCT_FROM, _intSVValues[0], INT_SV_NULL_COLUMN));
+        String.format(IS_NOT_DISTINCT_FROM_EXPR, _intSVValues[0], INT_SV_NULL_COLUMN));
 
     Assert.assertThrows(RuntimeException.class, () -> {
       TransformFunctionFactory.get(isDistinctFromExpression, _enableNullDataSourceMap);
@@ -281,9 +299,9 @@ public class DistinctFromTransformFunctionTest {
   public void testIllegalNumArgs()
       throws Exception {
     ExpressionContext isDistinctFromExpression = RequestContextUtils.getExpression(
-        String.format("%s(%s, %s, %s)", IS_DISTINCT_FROM, INT_SV_COLUMN, INT_SV_NULL_COLUMN, INT_SV_COLUMN));
+        String.format("is_distinct_from(%s, %s, %s)", INT_SV_COLUMN, INT_SV_NULL_COLUMN, INT_SV_COLUMN));
     ExpressionContext isNotDistinctFromExpression = RequestContextUtils.getExpression(
-        String.format("%s(%s, %s, %s)", IS_NOT_DISTINCT_FROM, INT_SV_COLUMN, INT_SV_NULL_COLUMN, INT_SV_COLUMN));
+        String.format("is_not_distinct_from(%s, %s, %s)", INT_SV_COLUMN, INT_SV_NULL_COLUMN, INT_SV_COLUMN));
 
     Assert.assertThrows(RuntimeException.class, () -> {
       TransformFunctionFactory.get(isDistinctFromExpression, _enableNullDataSourceMap);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
@@ -174,12 +174,16 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
       throws Exception {
     String query = "SELECT salary IS DISTINCT FROM salary FROM " + getTableName();
     testQuery(query);
+    query = "SELECT salary FROM " + getTableName() + " where salary IS DISTINCT FROM salary";
+    testQuery(query);
   }
 
   @Test
   public void testCaseWithIsNotDistinctFrom()
       throws Exception {
     String query = "SELECT description IS NOT DISTINCT FROM description FROM " + getTableName();
+    testQuery(query);
+    query = "SELECT description FROM " + getTableName() + " where description IS NOT DISTINCT FROM description";
     testQuery(query);
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
@@ -168,4 +168,18 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
     String query = "SELECT CASE WHEN description IS NOT NULL THEN 1 ELSE 0 END FROM " + getTableName();
     testQuery(query);
   }
+
+  @Test
+  public void testCaseWithIsDistinctFrom()
+      throws Exception {
+    String query = "SELECT salary IS DISTINCT FROM salary FROM " + getTableName();
+    testQuery(query);
+  }
+
+  @Test
+  public void testCaseWithIsNotDistinctFrom()
+      throws Exception {
+    String query = "SELECT description IS NOT DISTINCT FROM description FROM " + getTableName();
+    testQuery(query);
+  }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
     KIND, either express or implied.  See the License for the
     specific language governing permissions and limitations
     under the License.
-
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     KIND, either express or implied.  See the License for the
     specific language governing permissions and limitations
     under the License.
+
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">


### PR DESCRIPTION
The operators IsDistinctFrom and IsNotDistinctFrom only supports column names as argument for now. 
When null option is disabled, the row is considered as not null by default.  
Expected value:
Null is IsDistinctFrom ValueA: True
Null is IsDistinctFrom Null: False
ValueA is IsDistinctFrom ValueB: NotEquals(ValueA, ValueB)
Null is IsNotDistinctFrom ValueA: False
Null is IsNotDistinctFrom Null: True
ValueA is IsNotDistinctFrom ValueB: Equals(ValueA, ValueB)

Example Usage:
ColumnA IsDistinctFrom ColumnB
ColumnA IsNotDistinctFrom ColumnB
