### PR TITLE
[hotfix] Add VARBINARY column to switch case branch

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToStageConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToStageConverter.java
@@ -150,6 +150,7 @@ public final class RelToStageConverter {
       case VARCHAR:
         return DataSchema.ColumnDataType.STRING;
       case BINARY:
+      case VARBINARY:
         return DataSchema.ColumnDataType.BYTES;
       default:
         throw new IllegalStateException("Unexpected RelDataTypeField: " + relDataTypeField.getType());


### PR DESCRIPTION
calcite considered bytes as VARBINARY. so adding the case branch to the switch