### PR TITLE
Force commit consuming segments (#9197)

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
@@ -90,6 +90,26 @@ public class PinotRealtimeTableResource {
     }
   }
 
+  @POST
+  @Path("/tables/{tableName}/forceCommit")
+  @ApiOperation(value = "Force commit the current consuming segments",
+      notes = "Force commit the current segments in consuming state and restart consumption. "
+          + "This should be used after schema/table config changes. "
+          + "Please note that this is an asynchronous operation, "
+          + "and 200 response does not mean it has actually been done already")
+  public Response forceCommit(
+      @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName) {
+    String tableNameWithType = TableNameBuilder.REALTIME.tableNameWithType(tableName);
+    validate(tableNameWithType);
+    try {
+      _pinotLLCRealtimeSegmentManager.forceCommit(tableNameWithType);
+      return Response.ok().build();
+    } catch (Exception e) {
+      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+  }
+
+
   @GET
   @Path("/tables/{tableName}/pauseStatus")
   @Produces(MediaType.APPLICATION_JSON)

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1421,6 +1421,15 @@ public class PinotLLCRealtimeSegmentManager {
   }
 
   /**
+   * Force commit the current segments in consuming state and restart consumption
+   */
+  public void forceCommit(String tableNameWithType) {
+    IdealState idealState = getIdealState(tableNameWithType);
+    Set<String> consumingSegments = findConsumingSegments(idealState);
+    sendForceCommitMessageToServers(tableNameWithType, consumingSegments);
+  }
+
+  /**
    * Pause consumption on a table by
    *   1) setting "isTablePaused" in ideal states to true and
    *   2) sending force commit messages to servers


### PR DESCRIPTION
this is a cherry-pick of #9197 

## Description
For realtime segments, if there's any changes to stream configs in the table config, the changes don't get picked up immediately in the existing consuming segments. After the existing consuming segments complete - which may take hours depending on flush thresholds defined in table config - the new consuming segments will pick up the stream config changes.
In this PR, the force commit functionality that was introduced in pause/resume feature (#8986) is used in a controller endpoint to reset the consumption of a realtime table. After "consumption reset" is issued, the current consuming segments will be forced to commit immediately and then the new consuming segments will pick up any changes in the table config.

## Testing Done
Verified the expected behavior using `LLCRealtimeClusterIntegrationTest`. During ingestion, I added a consumption rate limit parameter to the table config and then used `resetConsumption` endpoint and verified that the existing consuming segments completed and then the new consuming segments consumed according to the specified consumption rate limit.