### PR TITLE
Add support for custom null values in CSV record reader

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
@@ -92,6 +92,11 @@ public class CSVRecordReader implements RecordReader {
       Character commentMarker = config.getCommentMarker();
       format = format.withCommentMarker(commentMarker);
       format = format.withEscape(config.getEscapeCharacter());
+      String nullString = config.getNullStringValue();
+      if (nullString != null) {
+        format = format.withNullString(nullString);
+      }
+
       _format = format;
       if (config.isMultiValueDelimiterEnabled()) {
         multiValueDelimiter = config.getMultiValueDelimiter();

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderConfig.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderConfig.java
@@ -35,6 +35,7 @@ public class CSVRecordReaderConfig implements RecordReaderConfig {
   private boolean _multiValueDelimiterEnabled = true; // when false, skip parsing for multiple values
   private Character _commentMarker;   // Default is null
   private Character _escapeCharacter; // Default is null
+  private String _nullStringValue;
 
   public String getFileFormat() {
     return _fileFormat;
@@ -90,6 +91,14 @@ public class CSVRecordReaderConfig implements RecordReaderConfig {
 
   public void setEscapeCharacter(Character escapeCharacter) {
     _escapeCharacter = escapeCharacter;
+  }
+
+  public String getNullStringValue() {
+    return _nullStringValue;
+  }
+
+  public void setNullStringValue(String nullStringValue) {
+    _nullStringValue = nullStringValue;
   }
 
   @Override


### PR DESCRIPTION
Currently, we assume Nulls as empty in CSV files. However, people can have custom null values such as string `NULL`, `null`, `None` etc. The option is already supported in Apache Commons CSV Format. The PR just exposes this option to the user via `CSVRecordReaderConfig`