### PR TITLE
Allow ingestion of errored records with incorrect datatype

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
@@ -61,7 +61,7 @@ public class CompositeTransformer implements RecordTransformer {
   public static CompositeTransformer getDefaultTransformer(TableConfig tableConfig, Schema schema) {
     return new CompositeTransformer(Arrays
         .asList(new ExpressionTransformer(tableConfig, schema), new FilterTransformer(tableConfig),
-            new DataTypeTransformer(schema), new NullValueTransformer(tableConfig, schema),
+            new DataTypeTransformer(tableConfig, schema), new NullValueTransformer(tableConfig, schema),
             new SanitizationTransformer(schema)));
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformerTest.java
@@ -67,7 +67,7 @@ public class ExpressionTransformerTest {
         .setIngestionConfig(ingestionConfig).build();
 
     ExpressionTransformer expressionTransformer = new ExpressionTransformer(tableConfig, pinotSchema);
-    DataTypeTransformer dataTypeTransformer = new DataTypeTransformer(pinotSchema);
+    DataTypeTransformer dataTypeTransformer = new DataTypeTransformer(tableConfig, pinotSchema);
 
     // test functions from schema
     GenericRow genericRow = new GenericRow();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
@@ -173,7 +173,7 @@ public class RecordTransformerTest {
     }
 
     TableConfig tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setUseDefaultValueOnError(true).setTableName("testTable").build();
+        new TableConfigBuilder(TableType.OFFLINE).setContinueOnError(true).setTableName("testTable").build();
 
     RecordTransformer transformerWithDefaultNulls = new DataTypeTransformer(tableConfig, schema);
     GenericRow record1 = getRecord();
@@ -200,7 +200,7 @@ public class RecordTransformerTest {
     }
 
     tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName(timeCol).setUseDefaultValueOnError(true)
+        new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName(timeCol).setValidateTimeValue(true)
             .setTableName("testTable").build();
 
     RecordTransformer transformerWithDefaultNulls = new DataTypeTransformer(tableConfig, schema);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -113,6 +113,7 @@ public class SegmentGeneratorConfig implements Serializable {
   private boolean _onHeap = false;
   private boolean _skipTimeValueCheck = false;
   private boolean _nullHandlingEnabled = false;
+  private boolean _useDefaultValueOnError = false;
   private boolean _failOnEmptySegment = false;
   private boolean _optimizeDictionaryForMetrics = false;
   private double _noDictionarySizeRatioThreshold = DEFAULT_NO_DICTIONARY_SIZE_RATIO_THRESHOLD;
@@ -223,6 +224,7 @@ public class SegmentGeneratorConfig implements Serializable {
       _fstTypeForFSTIndex = tableConfig.getIndexingConfig().getFSTIndexType();
 
       _nullHandlingEnabled = indexingConfig.isNullHandlingEnabled();
+      _useDefaultValueOnError = indexingConfig.useDefaultValueOnError();
       _optimizeDictionaryForMetrics = indexingConfig.isOptimizeDictionaryForMetrics();
       _noDictionarySizeRatioThreshold = indexingConfig.getNoDictionarySizeRatioThreshold();
     }
@@ -782,6 +784,14 @@ public class SegmentGeneratorConfig implements Serializable {
 
   public void setNullHandlingEnabled(boolean nullHandlingEnabled) {
     _nullHandlingEnabled = nullHandlingEnabled;
+  }
+
+  public boolean useDefaultValueOnError() {
+    return _useDefaultValueOnError;
+  }
+
+  public void setUseDefaultValueOnError(boolean useDefaultValueOnError) {
+    _useDefaultValueOnError = useDefaultValueOnError;
   }
 
   public boolean isOptimizeDictionaryForMetrics() {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -113,7 +113,8 @@ public class SegmentGeneratorConfig implements Serializable {
   private boolean _onHeap = false;
   private boolean _skipTimeValueCheck = false;
   private boolean _nullHandlingEnabled = false;
-  private boolean _useDefaultValueOnError = false;
+  private boolean _continueOnError = false;
+  private boolean _validateTimeValue = false;
   private boolean _failOnEmptySegment = false;
   private boolean _optimizeDictionaryForMetrics = false;
   private double _noDictionarySizeRatioThreshold = DEFAULT_NO_DICTIONARY_SIZE_RATIO_THRESHOLD;
@@ -224,7 +225,8 @@ public class SegmentGeneratorConfig implements Serializable {
       _fstTypeForFSTIndex = tableConfig.getIndexingConfig().getFSTIndexType();
 
       _nullHandlingEnabled = indexingConfig.isNullHandlingEnabled();
-      _useDefaultValueOnError = indexingConfig.useDefaultValueOnError();
+      _continueOnError = indexingConfig.isContinueOnError();
+      _validateTimeValue = indexingConfig.isValidateTimeValue();
       _optimizeDictionaryForMetrics = indexingConfig.isOptimizeDictionaryForMetrics();
       _noDictionarySizeRatioThreshold = indexingConfig.getNoDictionarySizeRatioThreshold();
     }
@@ -786,12 +788,20 @@ public class SegmentGeneratorConfig implements Serializable {
     _nullHandlingEnabled = nullHandlingEnabled;
   }
 
-  public boolean useDefaultValueOnError() {
-    return _useDefaultValueOnError;
+  public boolean isContinueOnError() {
+    return _continueOnError;
   }
 
-  public void setUseDefaultValueOnError(boolean useDefaultValueOnError) {
-    _useDefaultValueOnError = useDefaultValueOnError;
+  public void setContinueOnError(boolean continueOnError) {
+    _continueOnError = continueOnError;
+  }
+
+  public boolean isValidateTimeValue() {
+    return _validateTimeValue;
+  }
+
+  public void setValidateTimeValue(boolean validateTimeValue) {
+    _validateTimeValue = validateTimeValue;
   }
 
   public boolean isOptimizeDictionaryForMetrics() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
@@ -53,6 +53,7 @@ public class IndexingConfig extends BaseJsonConfig {
   private SegmentPartitionConfig _segmentPartitionConfig;
   private boolean _aggregateMetrics;
   private boolean _nullHandlingEnabled;
+  private boolean _useDefaultValueOnError;
 
   /**
    * If `optimizeDictionaryForMetrics` enabled, dictionary is not created for the metric columns
@@ -281,6 +282,14 @@ public class IndexingConfig extends BaseJsonConfig {
 
   public void setNullHandlingEnabled(boolean nullHandlingEnabled) {
     _nullHandlingEnabled = nullHandlingEnabled;
+  }
+
+  public boolean useDefaultValueOnError() {
+    return _useDefaultValueOnError;
+  }
+
+  public void setUseDefaultValueOnError(boolean useDefaultValueOnError) {
+    _useDefaultValueOnError = useDefaultValueOnError;
   }
 
   public boolean isOptimizeDictionaryForMetrics() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
@@ -53,7 +53,8 @@ public class IndexingConfig extends BaseJsonConfig {
   private SegmentPartitionConfig _segmentPartitionConfig;
   private boolean _aggregateMetrics;
   private boolean _nullHandlingEnabled;
-  private boolean _useDefaultValueOnError;
+  private boolean _continueOnError;
+  private boolean _validateTimeValue;
 
   /**
    * If `optimizeDictionaryForMetrics` enabled, dictionary is not created for the metric columns
@@ -284,12 +285,20 @@ public class IndexingConfig extends BaseJsonConfig {
     _nullHandlingEnabled = nullHandlingEnabled;
   }
 
-  public boolean useDefaultValueOnError() {
-    return _useDefaultValueOnError;
+  public boolean isContinueOnError() {
+    return _continueOnError;
   }
 
-  public void setUseDefaultValueOnError(boolean useDefaultValueOnError) {
-    _useDefaultValueOnError = useDefaultValueOnError;
+  public void setContinueOnError(boolean continueOnError) {
+    _continueOnError = continueOnError;
+  }
+
+  public boolean isValidateTimeValue() {
+    return _validateTimeValue;
+  }
+
+  public void setValidateTimeValue(boolean validateTimeValue) {
+    _validateTimeValue = validateTimeValue;
   }
 
   public boolean isOptimizeDictionaryForMetrics() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -97,7 +97,8 @@ public class TableConfigBuilder {
   private Map<String, String> _streamConfigs;
   private SegmentPartitionConfig _segmentPartitionConfig;
   private boolean _nullHandlingEnabled;
-  private boolean _useDefaultValueOnError;
+  private boolean _continueOnError;
+  private boolean _validateTimeValue;
   private List<String> _varLengthDictionaryColumns;
   private List<StarTreeIndexConfig> _starTreeIndexConfigs;
   private List<String> _jsonIndexColumns;
@@ -310,8 +311,13 @@ public class TableConfigBuilder {
     return this;
   }
 
-  public TableConfigBuilder setUseDefaultValueOnError(boolean useDefaultValueOnError) {
-    _useDefaultValueOnError = useDefaultValueOnError;
+  public TableConfigBuilder setContinueOnError(boolean continueOnError) {
+    _continueOnError = continueOnError;
+    return this;
+  }
+
+  public TableConfigBuilder setValidateTimeValue(boolean validateTimeValue) {
+    _validateTimeValue = validateTimeValue;
     return this;
   }
 
@@ -426,7 +432,8 @@ public class TableConfigBuilder {
     indexingConfig.setStreamConfigs(_streamConfigs);
     indexingConfig.setSegmentPartitionConfig(_segmentPartitionConfig);
     indexingConfig.setNullHandlingEnabled(_nullHandlingEnabled);
-    indexingConfig.setUseDefaultValueOnError(_useDefaultValueOnError);
+    indexingConfig.setContinueOnError(_continueOnError);
+    indexingConfig.setValidateTimeValue(_validateTimeValue);
     indexingConfig.setVarLengthDictionaryColumns(_varLengthDictionaryColumns);
     indexingConfig.setStarTreeIndexConfigs(_starTreeIndexConfigs);
     indexingConfig.setJsonIndexColumns(_jsonIndexColumns);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -97,6 +97,7 @@ public class TableConfigBuilder {
   private Map<String, String> _streamConfigs;
   private SegmentPartitionConfig _segmentPartitionConfig;
   private boolean _nullHandlingEnabled;
+  private boolean _useDefaultValueOnError;
   private List<String> _varLengthDictionaryColumns;
   private List<StarTreeIndexConfig> _starTreeIndexConfigs;
   private List<String> _jsonIndexColumns;
@@ -309,6 +310,11 @@ public class TableConfigBuilder {
     return this;
   }
 
+  public TableConfigBuilder setUseDefaultValueOnError(boolean useDefaultValueOnError) {
+    _useDefaultValueOnError = useDefaultValueOnError;
+    return this;
+  }
+
   public TableConfigBuilder setCustomConfig(TableCustomConfig customConfig) {
     _customConfig = customConfig;
     return this;
@@ -420,6 +426,7 @@ public class TableConfigBuilder {
     indexingConfig.setStreamConfigs(_streamConfigs);
     indexingConfig.setSegmentPartitionConfig(_segmentPartitionConfig);
     indexingConfig.setNullHandlingEnabled(_nullHandlingEnabled);
+    indexingConfig.setUseDefaultValueOnError(_useDefaultValueOnError);
     indexingConfig.setVarLengthDictionaryColumns(_varLengthDictionaryColumns);
     indexingConfig.setStarTreeIndexConfigs(_starTreeIndexConfigs);
     indexingConfig.setJsonIndexColumns(_jsonIndexColumns);


### PR DESCRIPTION
Currently, if there is an exception during data type transform, we simply stop the ingestion and throw the error. The PR introduces a config so that if user sets `useDefaultValueOnError: true` in the tableConfig, we simply use `null` or defaultValue  instead of throwing error for the particular column or record. 