### PR TITLE
Include fmpp plugin module inside the src assembly file

### DIFF
--- a/pinot-distribution/pinot-source-assembly.xml
+++ b/pinot-distribution/pinot-source-assembly.xml
@@ -53,7 +53,7 @@
         <!-- Do not include docker, kubernetes related files -->
         <exclude>kubernetes/**</exclude>
         <exclude>docker/**</exclude>
-        <exclude>contrib/**</exclude>
+        <exclude>contrib/pinot-druid-benchmark/**</exclude>
         <exclude>thirdeye/**</exclude>
       </excludes>
     </fileSet>


### PR DESCRIPTION
- Include fmpp plugin module inside the src as it's required for building source code 