### PR TITLE
[Feature] Support boolean literals equals and notEquals

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ComparisonFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ComparisonFunctions.java
@@ -20,6 +20,13 @@ package org.apache.pinot.common.function.scalar;
 
 import org.apache.pinot.spi.annotations.ScalarFunction;
 
+
+/*
+ * All functions are registered with a) function name and function param types b) function names and number of function
+ * params.
+ * To enable function param type matching, primitive type function argument has to be wrapped as Object class because
+ * literal is always an Object type.
+ */
 public class ComparisonFunctions {
 
   private static final double DOUBLE_COMPARISON_TOLERANCE = 1e-7d;
@@ -48,14 +55,24 @@ public class ComparisonFunctions {
   }
 
   @ScalarFunction
-  public static boolean notEquals(double a, double b) {
+  public static boolean notEquals(Double a, Double b) {
     return Math.abs(a - b) >= DOUBLE_COMPARISON_TOLERANCE;
   }
 
   @ScalarFunction
-  public static boolean equals(double a, double b) {
+  public static boolean notEquals(Boolean a, Boolean b) {
+    return !a.equals(b);
+  }
+
+  @ScalarFunction
+  public static boolean equals(Double a, Double b) {
     // To avoid approximation errors
     return Math.abs(a - b) < DOUBLE_COMPARISON_TOLERANCE;
+  }
+
+  @ScalarFunction
+  public static boolean equals(Boolean a, Boolean b) {
+    return a.equals(b);
   }
 
   @ScalarFunction

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/ExpressionContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/ExpressionContext.java
@@ -35,10 +35,13 @@ public class ExpressionContext {
   }
 
   private final Type _type;
-  private final String _value;
+
+  // TODO: Get rid of the wrapper for primitive types since it is expensive.
+  private final Object _value;
+
   private final FunctionContext _function;
 
-  public static ExpressionContext forLiteral(String literal) {
+  public static ExpressionContext forLiteral(Object literal) {
     return new ExpressionContext(Type.LITERAL, literal, null);
   }
 
@@ -50,7 +53,7 @@ public class ExpressionContext {
     return new ExpressionContext(Type.FUNCTION, null, function);
   }
 
-  private ExpressionContext(Type type, String value, FunctionContext function) {
+  private ExpressionContext(Type type, Object value, FunctionContext function) {
     _type = type;
     _value = value;
     _function = function;
@@ -60,12 +63,20 @@ public class ExpressionContext {
     return _type;
   }
 
+  public String getLiteralTypeName(){
+    if(_value == null){
+      return "null";
+    }
+    return _value.getClass().getTypeName();
+  }
+
+  // TODO: change the return type to raw type to save deserialize/serialize cost.
   public String getLiteral() {
-    return _value;
+    return _value.toString();
   }
 
   public String getIdentifier() {
-    return _value;
+    return _value.toString();
   }
 
   public FunctionContext getFunction() {
@@ -78,7 +89,7 @@ public class ExpressionContext {
   public void getColumns(Set<String> columns) {
     if (_type == Type.IDENTIFIER) {
       if (!_value.equals("*")) {
-        columns.add(_value);
+        columns.add(_value.toString());
       }
     } else if (_type == Type.FUNCTION) {
       _function.getColumns(columns);
@@ -110,9 +121,9 @@ public class ExpressionContext {
   public String toString() {
     switch (_type) {
       case LITERAL:
-        return '\'' + _value + '\'';
+        return '\'' + _value.toString() + '\'';
       case IDENTIFIER:
-        return _value;
+        return _value.toString();
       case FUNCTION:
         return _function.toString();
       default:

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
@@ -66,7 +66,7 @@ public class RequestContextUtils {
   public static ExpressionContext getExpression(Expression thriftExpression) {
     switch (thriftExpression.getType()) {
       case LITERAL:
-        return ExpressionContext.forLiteral(thriftExpression.getLiteral().getFieldValue().toString());
+        return ExpressionContext.forLiteral(thriftExpression.getLiteral().getFieldValue());
       case IDENTIFIER:
         return ExpressionContext.forIdentifier(thriftExpression.getIdentifier().getName());
       case FUNCTION:

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/CompileTimeFunctionsInvoker.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/CompileTimeFunctionsInvoker.java
@@ -68,9 +68,9 @@ public class CompileTimeFunctionsInvoker implements QueryRewriter {
       }
       operands.set(i, operand);
     }
-    String functionName = function.getOperator();
     if (compilable) {
-      FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, numOperands);
+      // Set operand types.
+      FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(function);
       if (functionInfo != null) {
         Object[] arguments = new Object[numOperands];
         for (int i = 0; i < numOperands; i++) {

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionDefinitionRegistryTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionDefinitionRegistryTest.java
@@ -22,10 +22,7 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.annotations.ScalarFunction;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 
 public class FunctionDefinitionRegistryTest {
@@ -60,16 +57,34 @@ public class FunctionDefinitionRegistryTest {
   }
 
   @ScalarFunction(names = {"testFunc1", "testFunc2"})
-  public static String testScalarFunction(long randomArg1, String randomArg2) {
+  public static String testScalarFunction(Long randomArg1, String randomArg2) {
+    return null;
+  }
+
+  @ScalarFunction(names = {"testFunc2"})
+  public static String testScalarFunction2(Long randomArg1, Long randomArg2) {
     return null;
   }
 
   @Test
   public void testScalarFunctionNames() {
-    assertNotNull(FunctionRegistry.getFunctionInfo("testFunc1", 2));
-    assertNotNull(FunctionRegistry.getFunctionInfo("testFunc2", 2));
-    assertNull(FunctionRegistry.getFunctionInfo("testScalarFunction", 2));
-    assertNull(FunctionRegistry.getFunctionInfo("testFunc1", 1));
-    assertNull(FunctionRegistry.getFunctionInfo("testFunc2", 1));
+    assertNotNull(FunctionRegistry.getFunctionInfo("testFunc1", 2, ""));
+    assertNotNull(FunctionRegistry.getFunctionInfo("testFunc2", 2, ""));
+    assertNull(FunctionRegistry.getFunctionInfo("testScalarFunction", 2, ""));
+    assertNull(FunctionRegistry.getFunctionInfo("testFunc1", 1, ""));
+    assertNull(FunctionRegistry.getFunctionInfo("testFunc2", 1, ""));
+    FunctionInfo func2LongString =
+        FunctionRegistry.getFunctionInfo("testFunc2", 2, "java.lang.Long,java.lang.String");
+    assertNotNull(func2LongString);
+    Class[] paramTypes = func2LongString.getMethod().getParameterTypes();
+    assertEquals(paramTypes.length, 2);
+    assertEquals(paramTypes[0].getTypeName(), "java.lang.Long");
+    assertEquals(paramTypes[1].getTypeName(), "java.lang.String");
+    FunctionInfo func2LongLong = FunctionRegistry.getFunctionInfo("testFunc2", 2, "java.lang.Long,java.lang.Long");
+    assertNotNull(func2LongLong);
+    Class[] paramTypes2 = func2LongLong.getMethod().getParameterTypes();
+    assertEquals(paramTypes2.length, 2);
+    assertEquals(paramTypes2[0].getTypeName(), "java.lang.Long");
+    assertEquals(paramTypes2[1].getTypeName(), "java.lang.Long");
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
@@ -446,7 +446,7 @@ public class TableResizer {
         _argumentExtractors[i] = argumentExtractor;
         argumentTypes[i] = argumentExtractor.getValueType();
       }
-      _postAggregationFunction = new PostAggregationFunction(function.getFunctionName(), argumentTypes);
+      _postAggregationFunction = new PostAggregationFunction(function, argumentTypes);
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -275,7 +275,6 @@ public class TransformFunctionFactory {
         String functionName = canonicalize(function.getFunctionName());
         List<ExpressionContext> arguments = function.getArguments();
         int numArguments = arguments.size();
-
         TransformFunction transformFunction;
         Class<? extends TransformFunction> transformFunctionClass = TRANSFORM_FUNCTION_MAP.get(functionName);
         if (transformFunctionClass != null) {
@@ -287,7 +286,7 @@ public class TransformFunctionFactory {
           }
         } else {
           // Scalar function
-          FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, numArguments);
+          FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(function);
           if (functionInfo == null) {
             if (FunctionRegistry.containsFunction(functionName)) {
               throw new BadQueryRequestException(

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/statement/StringPredicateFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/statement/StringPredicateFilterOptimizer.java
@@ -116,7 +116,7 @@ public class StringPredicateFilterOptimizer implements StatementOptimizer {
       // Check if the function returns STRING as output.
       Function function = expression.getFunctionCall();
       FunctionInfo functionInfo =
-          FunctionRegistry.getFunctionInfo(function.getOperator(), function.getOperands().size());
+          FunctionRegistry.getFunctionInfo(function);
       return functionInfo != null && functionInfo.getMethod().getReturnType() == String.class;
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunction.java
@@ -23,6 +23,7 @@ import org.apache.pinot.common.function.FunctionInfo;
 import org.apache.pinot.common.function.FunctionInvoker;
 import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.common.function.FunctionUtils;
+import org.apache.pinot.common.request.context.FunctionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.common.utils.PinotDataType;
 
@@ -35,16 +36,17 @@ public class PostAggregationFunction {
   private final PinotDataType[] _argumentTypes;
   private final ColumnDataType _resultType;
 
-  public PostAggregationFunction(String functionName, ColumnDataType[] argumentTypes) {
+  public PostAggregationFunction(FunctionContext function, ColumnDataType[] argumentTypes) {
+    String functionName = function.getFunctionName();
     int numArguments = argumentTypes.length;
-    FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, numArguments);
+
+    FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(function);
     if (functionInfo == null) {
       if (FunctionRegistry.containsFunction(functionName)) {
         throw new IllegalArgumentException(
-          String.format("Unsupported function: %s with %d parameters", functionName, numArguments));
+            String.format("Unsupported function: %s with %d parameters", functionName, numArguments));
       } else {
-        throw new IllegalArgumentException(
-          String.format("Unsupported function: %s not found", functionName));
+        throw new IllegalArgumentException(String.format("Unsupported function: %s not found", functionName));
       }
     }
     _functionInvoker = new FunctionInvoker(functionInfo);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/PostAggregationHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/PostAggregationHandler.java
@@ -161,7 +161,7 @@ public class PostAggregationHandler implements ValueExtractorFactory {
         _argumentExtractors[i] = argumentExtractor;
         argumentTypes[i] = argumentExtractor.getColumnDataType();
       }
-      _postAggregationFunction = new PostAggregationFunction(function.getFunctionName(), argumentTypes);
+      _postAggregationFunction = new PostAggregationFunction(function, argumentTypes);
     }
 
     @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluatorTest.java
@@ -96,6 +96,24 @@ public class InbuiltFunctionEvaluatorTest {
   }
 
   @Test
+  public void testEqualsFunctionWithBooleanLiteral() {
+    String expression = "(true = true) = true";
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression);
+    assertTrue(evaluator.getArguments().isEmpty());
+    GenericRow row = new GenericRow();
+    assertEquals(evaluator.evaluate(row), true);
+  }
+
+  @Test
+  public void testNotEqualsFunctionWithBooleanLiteral() {
+    String expression = "(true != true) = true";
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression);
+    assertTrue(evaluator.getArguments().isEmpty());
+    GenericRow row = new GenericRow();
+    assertEquals(evaluator.evaluate(row), false);
+  }
+
+  @Test
   public void testNestedFunction() {
     String expression = "reverse(reverse(testColumn))";
     InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -89,6 +89,7 @@ import static org.apache.pinot.controller.helix.core.PinotHelixResourceManager.E
 import static org.apache.pinot.controller.helix.core.PinotHelixResourceManager.EXTERNAL_VIEW_ONLINE_SEGMENTS_MAX_WAIT_MS;
 import static org.testng.Assert.*;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 
 /**
@@ -964,6 +965,43 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         "aGVsbG8h");
     assertEquals(response.get("resultTable").get("rows").get(0).get(10).asText(),
         "hello!");
+  }
+
+  @Test
+  public void testBooleanLiteralsFunc()
+      throws Exception {
+    // Test boolean equal true case.
+    String sqlQuery =
+        "SELECT (true = true) = true FROM mytable";
+    JsonNode response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode rows = response.get("resultTable").get("rows");
+    assertTrue(response.get("exceptions").isEmpty());
+    assertEquals(rows.size(), 1);
+    assertTrue(rows.get(0).get(0).asBoolean());
+    // Test boolean equal false case.
+    sqlQuery =
+        "SELECT (true = true) = false FROM mytable";
+    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    rows = response.get("resultTable").get("rows");
+    assertTrue(response.get("exceptions").isEmpty());
+    assertEquals(rows.size(), 1);
+    assertFalse(rows.get(0).get(0).asBoolean());
+    // Test boolean not equal true case.
+    sqlQuery =
+        "SELECT true != false FROM mytable";
+    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    rows = response.get("resultTable").get("rows");
+    assertTrue(response.get("exceptions").isEmpty());
+    assertEquals(rows.size(), 1);
+    assertTrue(rows.get(0).get(0).asBoolean());
+    // Test boolean not equal false case.
+    sqlQuery =
+        "SELECT true != true FROM mytable";
+    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    rows = response.get("resultTable").get("rows");
+    assertTrue(response.get("exceptions").isEmpty());
+    assertEquals(rows.size(), 1);
+    assertFalse(rows.get(0).get(0).asBoolean());
   }
 
   @Test(dependsOnMethods = "testBloomFilterTriggering")

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
@@ -78,7 +78,7 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
             Preconditions.checkState(numArguments == 1, "NOT function expects 1 argument, got: %s", numArguments);
             return new NotExecutionNode(childNodes[0]);
           default:
-            FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, numArguments);
+            FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(function);
             if (functionInfo == null) {
               if (FunctionRegistry.containsFunction(functionName)) {
                 throw new IllegalStateException(

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
     KIND, either express or implied.  See the License for the
     specific language governing permissions and limitations
     under the License.
-
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     KIND, either express or implied.  See the License for the
     specific language governing permissions and limitations
     under the License.
+
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">


### PR DESCRIPTION
Support boolean literal evaluation, eg. true = true, (true = true) != false
1) Save literal value as an object
2) Register scalar function with func names and argument types. If a function cannot be found via function function names and argument types, look for functions through func names and # of params by default.
3) Currently, we only support equal and notEqual type matching for boolean and double. 

