### PR TITLE
Fix annotation for "/recommender" endpoint

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -232,7 +232,7 @@ public class PinotTableRestletResource {
     }
   }
 
-  @PUT
+  @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/tables/recommender")
   @ApiOperation(value = "Recommend config", notes = "Recommend a config with input json")


### PR DESCRIPTION
The endpoint doesn't change any state of the system, so the AccessType annotation should be GET not PUT.