### PR TITLE
[Feature] Support Coalesce for Column Names

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -62,6 +62,7 @@ public enum TransformFunctionType {
 
   IS_NULL("is_null"),
   IS_NOT_NULL("is_not_null"),
+  COALESCE("coalesce"),
 
   AND("and"),
   OR("or"),

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CoalesceTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CoalesceTransformFunction.java
@@ -18,13 +18,15 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
+import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.function.TransformFunctionType;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.segment.spi.datasource.DataSource;
-import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.roaringbitmap.RoaringBitmap;
 
 
 /**
@@ -32,7 +34,7 @@ import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
  *
  * The results are in String format for first non-null value in the argument list.
  * If all arguments are null, return a 'null' string.
- * Note: arguments have to be column names.
+ * Note: arguments have to be column names and numeric or string types.
  *
  * Expected result:
  * Coalesce(nullColumn, columnA): columnA
@@ -45,8 +47,23 @@ import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
  */
 public class CoalesceTransformFunction extends BaseTransformFunction {
   private String[] _results;
-  private NullValueVectorReader[] _nullValueReaders;
   private TransformFunction[] _transformFunctions;
+
+  /**
+   * Returns a bit map of corresponding column.
+   * Returns an empty bitmap by default if null option is disabled.
+   */
+  private static RoaringBitmap[] getNullBitMaps(ProjectionBlock projectionBlock,
+      TransformFunction[] transformFunctions) {
+    RoaringBitmap[] roaringBitmaps = new RoaringBitmap[transformFunctions.length];
+    for (int i = 0; i < roaringBitmaps.length; i++) {
+      TransformFunction func = transformFunctions[i];
+      String columnName = ((IdentifierTransformFunction) func).getColumnName();
+      RoaringBitmap nullBitmap = projectionBlock.getBlockValueSet(columnName).getNullBitmap();
+      roaringBitmaps[i] = nullBitmap;
+    }
+    return roaringBitmaps;
+  }
 
   @Override
   public String getName() {
@@ -56,23 +73,21 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
   @Override
   public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
     int argSize = arguments.size();
-    _nullValueReaders = new NullValueVectorReader[argSize];
     _transformFunctions = new TransformFunction[argSize];
     for (int i = 0; i < argSize; i++) {
       TransformFunction func = arguments.get(i);
-      if (!(func instanceof IdentifierTransformFunction)) {
-        throw new IllegalArgumentException("Only column names are supported in COALESCE.");
-      }
-      String columnName = ((IdentifierTransformFunction) func).getColumnName();
-      NullValueVectorReader nullValueVectorReader = dataSourceMap.get(columnName).getNullValueVector();
-      _nullValueReaders[i] = nullValueVectorReader;
+      Preconditions.checkArgument(func instanceof IdentifierTransformFunction,
+          "Only column names are supported in COALESCE.");
+      FieldSpec.DataType dataType = func.getResultMetadata().getDataType().getStoredType();
+      Preconditions.checkArgument(dataType.isNumeric() || dataType == FieldSpec.DataType.STRING,
+          "Only numeric value and string are supported in COALESCE.");
       _transformFunctions[i] = func;
     }
   }
 
   @Override
   public TransformResultMetadata getResultMetadata() {
-    return STRING_MV_NO_DICTIONARY_METADATA;
+    return STRING_SV_NO_DICTIONARY_METADATA;
   }
 
   @Override
@@ -82,13 +97,14 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
       _results = new String[length];
     }
 
+    RoaringBitmap[] nullBitMaps = getNullBitMaps(projectionBlock, _transformFunctions);
     int[] docIds = projectionBlock.getDocIds();
     int width = _transformFunctions.length;
     String[][] data = new String[width][length];
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < width; j++) {
         // Consider value as null when null option is disabled.
-        if (_nullValueReaders != null && _nullValueReaders[j].isNull(docIds[i])) {
+        if (nullBitMaps[j] == null || nullBitMaps[j].contains(i)) {
           continue;
         }
         if (data[j][i] == null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CoalesceTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CoalesceTransformFunction.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.function.TransformFunctionType;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+
+
+/**
+ * The <code>CoalesceTransformFunction</code> implements the Coalesce operator.
+ *
+ * The results are in String format for first non-null value in the argument list.
+ * If all arguments are null, return a 'null' string.
+ * Note: arguments have to be column names.
+ *
+ * Expected result:
+ * Coalesce(nullColumn, columnA): columnA
+ * Coalesce(columnA, nullColumn): nullColumn
+ * Coalesce(nullColumnA, nullColumnB): "null"
+ *
+ * Note this operator only takes column names for now.
+ * SQL Syntax:
+ *    Coalesce(columnA, columnB)
+ */
+public class CoalesceTransformFunction extends BaseTransformFunction {
+  private String[] _results;
+  private NullValueVectorReader[] _nullValueReaders;
+  private TransformFunction[] _transformFunctions;
+
+  @Override
+  public String getName() {
+    return TransformFunctionType.COALESCE.getName();
+  }
+
+  @Override
+  public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
+    int argSize = arguments.size();
+    _nullValueReaders = new NullValueVectorReader[argSize];
+    _transformFunctions = new TransformFunction[argSize];
+    for (int i = 0; i < argSize; i++) {
+      TransformFunction func = arguments.get(i);
+      if (!(func instanceof IdentifierTransformFunction)) {
+        throw new IllegalArgumentException("Only column names are supported in COALESCE.");
+      }
+      String columnName = ((IdentifierTransformFunction) func).getColumnName();
+      NullValueVectorReader nullValueVectorReader = dataSourceMap.get(columnName).getNullValueVector();
+      _nullValueReaders[i] = nullValueVectorReader;
+      _transformFunctions[i] = func;
+    }
+  }
+
+  @Override
+  public TransformResultMetadata getResultMetadata() {
+    return STRING_MV_NO_DICTIONARY_METADATA;
+  }
+
+  @Override
+  public String[] transformToStringValuesSV(ProjectionBlock projectionBlock) {
+    int length = projectionBlock.getNumDocs();
+    if (_results == null || _results.length < length) {
+      _results = new String[length];
+    }
+
+    int[] docIds = projectionBlock.getDocIds();
+    int width = _transformFunctions.length;
+    String[][] data = new String[width][length];
+    for (int i = 0; i < length; i++) {
+      for (int j = 0; j < width; j++) {
+        // Consider value as null when null option is disabled.
+        if (_nullValueReaders != null && _nullValueReaders[j].isNull(docIds[i])) {
+          continue;
+        }
+        if (data[j][i] == null) {
+          data[j] = _transformFunctions[j].transformToStringValuesSV(projectionBlock);
+        }
+        // TODO: Return result as a generic type.
+        _results[i] = data[j][i];
+        break;
+      }
+      // TODO: Differentiate between null string and null value.
+      if (_results[i] == null) {
+        _results[i] = "null";
+      }
+    }
+    return _results;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -202,6 +202,7 @@ public class TransformFunctionFactory {
     typeToImplementation.put(TransformFunctionType.IS_NULL, IsNullTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.IS_NOT_NULL,
         IsNotNullTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.COALESCE, CoalesceTransformFunction.class);
 
     // Trignometric functions
     typeToImplementation.put(TransformFunctionType.SIN, SinTransformFunction.class);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CoalesceTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CoalesceTransformFunctionTest.java
@@ -51,7 +51,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 
-public class CoalesceTransformFunctionTest {
+public class CoalesceTransformFunctionTest extends BaseTransformFunctionTest {
 
   private static final String ENABLE_NULL_SEGMENT_NAME = "testSegment1";
   private static final String DISABLE_NULL_SEGMENT_NAME = "testSegment2";
@@ -183,6 +183,20 @@ public class CoalesceTransformFunctionTest {
       throws Exception {
     ExpressionContext coalesceExpr =
         RequestContextUtils.getExpression(String.format("COALESCE(%s,%s)", _stringSVValues[0], STRING_SV_COLUMN));
+    Assert.assertThrows(RuntimeException.class, () -> {
+      TransformFunctionFactory.get(coalesceExpr, _enableNullDataSourceMap);
+    });
+    Assert.assertThrows(RuntimeException.class, () -> {
+      TransformFunctionFactory.get(coalesceExpr, _disableNullDataSourceMap);
+    });
+  }
+
+  // Test that wrong data type is illegal argument.
+  @Test
+  public void testIllegalArgType()
+      throws Exception {
+    ExpressionContext coalesceExpr =
+        RequestContextUtils.getExpression(String.format("COALESCE(%s,%s)", TIMESTAMP_COLUMN, STRING_SV_COLUMN));
     Assert.assertThrows(RuntimeException.class, () -> {
       TransformFunctionFactory.get(coalesceExpr, _enableNullDataSourceMap);
     });

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CoalesceTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CoalesceTransformFunctionTest.java
@@ -1,0 +1,193 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.core.operator.DocIdSetOperator;
+import org.apache.pinot.core.operator.ProjectionOperator;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+import org.apache.pinot.core.operator.filter.MatchAllFilterOperator;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class CoalesceTransformFunctionTest {
+
+  private static final String ENABLE_NULL_SEGMENT_NAME = "testSegment1";
+  private static final String DISABLE_NULL_SEGMENT_NAME = "testSegment2";
+  private static final Random RANDOM = new Random();
+
+  private static final int NUM_ROWS = 1000;
+  private static final String INT_SV_COLUMN = "intSV";
+  private static final String STRING_SV_COLUMN = "StringSV";
+  private final int[] _intSVValues = new int[NUM_ROWS];
+  private final String[] _stringSVValues = new String[NUM_ROWS];
+  private Map<String, DataSource> _enableNullDataSourceMap;
+  private Map<String, DataSource> _disableNullDataSourceMap;
+  private ProjectionBlock _enableNullProjectionBlock;
+  private ProjectionBlock _disableNullProjectionBlock;
+
+  protected static final int INT_NULL_MOD = 3;
+
+  protected static final int STRING_NULL_MOD = 5;
+
+  private static String getIndexDirPath(String segmentName) {
+    return FileUtils.getTempDirectoryPath() + File.separator + segmentName;
+  }
+
+  private static Map<String, DataSource> getDataSourceMap(Schema schema, List<GenericRow> rows, String segmentName)
+      throws Exception {
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(segmentName).setNullHandlingEnabled(true).build();
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setOutDir(getIndexDirPath(segmentName));
+    config.setSegmentName(segmentName);
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(config, new GenericRowRecordReader(rows));
+    driver.build();
+    IndexSegment indexSegment =
+        ImmutableSegmentLoader.load(new File(getIndexDirPath(segmentName), segmentName), ReadMode.heap);
+    Set<String> columnNames = indexSegment.getPhysicalColumnNames();
+    Map<String, DataSource> enableNullDataSourceMap = new HashMap<>(columnNames.size());
+    for (String columnName : columnNames) {
+      enableNullDataSourceMap.put(columnName, indexSegment.getDataSource(columnName));
+    }
+    return enableNullDataSourceMap;
+  }
+
+  private static ProjectionBlock getProjectionBlock(Map<String, DataSource> dataSourceMap) {
+    return new ProjectionOperator(dataSourceMap,
+        new DocIdSetOperator(new MatchAllFilterOperator(NUM_ROWS), DocIdSetPlanNode.MAX_DOC_PER_CALL)).nextBlock();
+  }
+
+  private static boolean isIntNull(int i) {
+    return i % INT_NULL_MOD == 0;
+  }
+
+  private static boolean isStringNull(int i) {
+    return i % STRING_NULL_MOD == 0;
+  }
+
+  @BeforeClass
+  public void setup()
+      throws Exception {
+    // Set up two tables: one with null option enable, the other with null option disable.
+    // Each table one string column, and one int column with some rows set to null.
+    FileUtils.deleteQuietly(new File(getIndexDirPath(DISABLE_NULL_SEGMENT_NAME)));
+    FileUtils.deleteQuietly(new File(getIndexDirPath(ENABLE_NULL_SEGMENT_NAME)));
+    for (int i = 0; i < NUM_ROWS; i++) {
+      _intSVValues[i] = RANDOM.nextInt();
+      _stringSVValues[i] = "a" + RANDOM.nextInt();
+    }
+    List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      Map<String, Object> map = new HashMap<>();
+      map.put(INT_SV_COLUMN, _intSVValues[i]);
+      map.put(STRING_SV_COLUMN, _stringSVValues[i]);
+      if (isIntNull(i)) {
+        map.put(INT_SV_COLUMN, null);
+      }
+      if (isStringNull(i)) {
+        map.put(STRING_SV_COLUMN, null);
+      }
+      GenericRow row = new GenericRow();
+      row.init(map);
+      rows.add(row);
+    }
+
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(INT_SV_COLUMN, FieldSpec.DataType.INT)
+        .addSingleValueDimension(STRING_SV_COLUMN, FieldSpec.DataType.STRING).build();
+    _enableNullDataSourceMap = getDataSourceMap(schema, rows, ENABLE_NULL_SEGMENT_NAME);
+    _enableNullProjectionBlock = getProjectionBlock(_enableNullDataSourceMap);
+    _disableNullDataSourceMap = getDataSourceMap(schema, rows, DISABLE_NULL_SEGMENT_NAME);
+    _disableNullProjectionBlock = getProjectionBlock(_disableNullDataSourceMap);
+  }
+
+  protected void testTransformFunction(ExpressionContext expression, String[] expectedValues,
+      ProjectionBlock projectionBlock, Map<String, DataSource> dataSourceMap)
+      throws Exception {
+    String[] stringValues =
+        TransformFunctionFactory.get(expression, dataSourceMap).transformToStringValuesSV(projectionBlock);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      Assert.assertEquals(stringValues[i], expectedValues[i]);
+    }
+  }
+
+  // Test the Coalesce on String and Int columns where one or the other or both can be null.
+  @Test
+  public void testDistinctFromBothNull()
+      throws Exception {
+    ExpressionContext coalesceExpr =
+        RequestContextUtils.getExpression(String.format("COALESCE(%s,%s)", INT_SV_COLUMN, STRING_SV_COLUMN));
+    TransformFunction coalesceTransformFunction = TransformFunctionFactory.get(coalesceExpr, _enableNullDataSourceMap);
+    Assert.assertEquals(coalesceTransformFunction.getName(), "coalesce");
+    String[] expectedResults = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      if (isStringNull(i) && isIntNull(i)) {
+        expectedResults[i] = "null";
+      } else if (isStringNull(i)) {
+        expectedResults[i] = Integer.toString(_intSVValues[i]);
+      } else if (isIntNull(i)) {
+        expectedResults[i] = _stringSVValues[i];
+      } else {
+        expectedResults[i] = Integer.toString(_intSVValues[i]);
+      }
+    }
+    testTransformFunction(coalesceExpr, expectedResults, _enableNullProjectionBlock, _enableNullDataSourceMap);
+    testTransformFunction(coalesceExpr, expectedResults, _disableNullProjectionBlock, _disableNullDataSourceMap);
+  }
+
+  // Test that non-column-names appear in one of the argument.
+  @Test
+  public void testIllegalColumnName()
+      throws Exception {
+    ExpressionContext coalesceExpr =
+        RequestContextUtils.getExpression(String.format("COALESCE(%s,%s)", _stringSVValues[0], STRING_SV_COLUMN));
+    Assert.assertThrows(RuntimeException.class, () -> {
+      TransformFunctionFactory.get(coalesceExpr, _enableNullDataSourceMap);
+    });
+    Assert.assertThrows(RuntimeException.class, () -> {
+      TransformFunctionFactory.get(coalesceExpr, _disableNullDataSourceMap);
+    });
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
     KIND, either express or implied.  See the License for the
     specific language governing permissions and limitations
     under the License.
-
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     KIND, either express or implied.  See the License for the
     specific language governing permissions and limitations
     under the License.
+
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">


### PR DESCRIPTION
Coalesce takes a list of arguments and returns the first not null value. If all arguments are null, return a null.

This implementations transform all arguments into string and return the first non-null string value. Null is represented as string value "null"