### PR TITLE
upgrade h3 lib from 3.7.2 to 4.0.0 to lower glibc requirement

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
     <netty.version>4.1.79.Final</netty.version>
     <reactivestreams.version>1.0.3</reactivestreams.version>
     <jts.version>1.16.1</jts.version>
-    <h3.version>3.7.2</h3.version>
+    <h3.version>4.0.0</h3.version>
     <jmh.version>1.26</jmh.version>
     <audienceannotations.version>0.13.0</audienceannotations.version>
 


### PR DESCRIPTION
This PR fixes the issue of higher glibc requirements to prevent centos 7 or ubuntu 18 to not able to run pinot.
See discussion here: https://github.com/uber/h3-java/issues/85

- [x] Tested on Mac with Intel CPU by @xiangfu0 
- [x] Tested on Mac M1 by @KKcorps 
- [x] Tested on Ubuntu 18.04.5 LTS by @xiangfu0 