### PR TITLE
Enhance `and` filter predicate evaluation efficiency  

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
@@ -83,7 +83,7 @@ public final class AndDocIdSet implements FilterBlockDocIdSet {
 
     // evaluate the bitmaps in the order of the lowest num docIds come first, so that we minimize the number of
     // containers (range) for comparison from the beginning, this will minimize the effort of and application
-    // bitmapBasedDocIdIterators.sort(Comparator.comparing(x -> x.getDocIds().getCardinality()));
+    bitmapBasedDocIdIterators.sort(Comparator.comparing(x -> x.getDocIds().getCardinality()));
 
     int numSortedDocIdIterators = sortedDocIdIterators.size();
     int numBitmapBasedDocIdIterators = bitmapBasedDocIdIterators.size();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
@@ -81,9 +81,9 @@ public final class AndDocIdSet implements FilterBlockDocIdSet {
       }
     }
 
-    // evaluate the bitmap and with the lowest number of matching docIds first, so that we limit the number of
-    // containers for comparison from the beginning, this will minimize the effort of and application
-    bitmapBasedDocIdIterators.sort(Comparator.comparing(x -> x.getDocIds().getCardinality()));
+    // evaluate the bitmaps in the order of the lowest num docIds come first, so that we minimize the number of
+    // containers (range) for comparison from the beginning, this will minimize the effort of and application
+    // bitmapBasedDocIdIterators.sort(Comparator.comparing(x -> x.getDocIds().getCardinality()));
 
     int numSortedDocIdIterators = sortedDocIdIterators.size();
     int numBitmapBasedDocIdIterators = bitmapBasedDocIdIterators.size();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
@@ -81,8 +81,8 @@ public final class AndDocIdSet implements FilterBlockDocIdSet {
       }
     }
 
-    // evaluate the bitmaps in the order of the lowest num docIds come first, so that we minimize the number of
-    // containers (range) for comparison from the beginning, this will minimize the effort of and application
+    // evaluate the bitmaps in the order of the lowest matching num docIds comes first, so that we minimize the number
+    // of containers (range) for comparison from the beginning, as will minimize the effort of bitmap AND application
     bitmapBasedDocIdIterators.sort(Comparator.comparing(x -> x.getDocIds().getCardinality()));
 
     int numSortedDocIdIterators = sortedDocIdIterators.size();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
@@ -81,6 +81,8 @@ public final class AndDocIdSet implements FilterBlockDocIdSet {
       }
     }
 
+    // evaluate the bitmap and with the lowest number of matching docIds first, so that we limit the number of
+    // containers for comparison from the beginning, this will minimize the effort of and application
     bitmapBasedDocIdIterators.sort(Comparator.comparing(x -> x.getDocIds().getCardinality()));
 
     int numSortedDocIdIterators = sortedDocIdIterators.size();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.operator.docidsets;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import org.apache.pinot.core.common.BlockDocIdIterator;
 import org.apache.pinot.core.operator.dociditerators.AndDocIdIterator;
@@ -79,6 +80,9 @@ public final class AndDocIdSet implements FilterBlockDocIdSet {
         remainingDocIdIterators.add(docIdIterator);
       }
     }
+
+    bitmapBasedDocIdIterators.sort(Comparator.comparing(x-> x.getDocIds().getCardinality()));
+
     int numSortedDocIdIterators = sortedDocIdIterators.size();
     int numBitmapBasedDocIdIterators = bitmapBasedDocIdIterators.size();
     int numScanBasedDocIdIterators = scanBasedDocIdIterators.size();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
@@ -81,7 +81,7 @@ public final class AndDocIdSet implements FilterBlockDocIdSet {
       }
     }
 
-    bitmapBasedDocIdIterators.sort(Comparator.comparing(x-> x.getDocIds().getCardinality()));
+    bitmapBasedDocIdIterators.sort(Comparator.comparing(x -> x.getDocIds().getCardinality()));
 
     int numSortedDocIdIterators = sortedDocIdIterators.size();
     int numBitmapBasedDocIdIterators = bitmapBasedDocIdIterators.size();

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkAndDocIdIterator.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkAndDocIdIterator.java
@@ -33,6 +33,7 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;
 import org.openjdk.jmh.runner.options.Options;
@@ -58,18 +59,18 @@ public class BenchmarkAndDocIdIterator {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void benchAndFilterOperator(MyState myState) {
+  public void benchAndFilterOperator(MyState myState, Blackhole bh) {
     for (int i = 0; i < 100; i++) {
-      new AndFilterOperator(myState._childOperators).nextBlock().getBlockDocIdSet().iterator();
+      bh.consume(new AndFilterOperator(myState._childOperators).nextBlock().getBlockDocIdSet().iterator());
     }
   }
 
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void benchAndFilterOperatorDegenerate(MyState myState) {
+  public void benchAndFilterOperatorDegenerate(MyState myState, Blackhole bh) {
     for (int i = 0; i < 100; i++) {
-      new AndFilterOperator(myState._childOperatorsNoOrdering).nextBlock().getBlockDocIdSet().iterator();
+      bh.consume(new AndFilterOperator(myState._childOperatorsNoOrdering).nextBlock().getBlockDocIdSet().iterator());
     }
   }
 

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkAndDocIdIterator.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkAndDocIdIterator.java
@@ -67,7 +67,7 @@ public class BenchmarkAndDocIdIterator {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void benchAndFilterOperatorReorderCost(MyState myState) {
+  public void benchAndFilterOperatorDegenerate(MyState myState) {
     for (int i = 0; i < 100; i++) {
       new AndFilterOperator(myState._childOperatorsNoOrdering).nextBlock().getBlockDocIdSet().iterator();
     }

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkAndDocIdIterator.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkAndDocIdIterator.java
@@ -50,7 +50,7 @@ public class BenchmarkAndDocIdIterator {
       throws RunnerException {
     Options opt =
         new OptionsBuilder().include(BenchmarkAndDocIdIterator.class.getSimpleName()).warmupTime(TimeValue.seconds(5))
-            .warmupIterations(2).measurementTime(TimeValue.seconds(10)).measurementIterations(5).forks(1).build();
+            .warmupIterations(3).measurementTime(TimeValue.seconds(10)).measurementIterations(5).forks(1).build();
 
     new Runner(opt).run();
   }

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkAndDocIdIterator.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkAndDocIdIterator.java
@@ -82,6 +82,7 @@ public class BenchmarkAndDocIdIterator {
     public void doSetup() {
       MutableRoaringBitmap[] mutableRoaringBitmap = new MutableRoaringBitmap[NUM_FILTERS];
       Random r = new Random();
+      r.setSeed(42);
       for (int i = 0; i < NUM_FILTERS; i++) {
         mutableRoaringBitmap[i] = new MutableRoaringBitmap();
         double selectedPortion = (NUM_FILTERS - i) / (2.0 * NUM_FILTERS);
@@ -92,7 +93,15 @@ public class BenchmarkAndDocIdIterator {
         }
         _childOperators.add(new BitmapBasedFilterOperator(mutableRoaringBitmap[i].toImmutableRoaringBitmap(),
             false, NUM_DOCS));
-        _childOperatorsNoOrdering.add(new BitmapBasedFilterOperator(mutableRoaringBitmap[0].toImmutableRoaringBitmap(),
+
+        mutableRoaringBitmap[i] = new MutableRoaringBitmap();
+        selectedPortion = 0.5;
+        for (int j = 0; j < NUM_DOCS; j++) {
+          if (r.nextDouble() < selectedPortion) {
+            mutableRoaringBitmap[i].add(j);
+          }
+        }
+        _childOperatorsNoOrdering.add(new BitmapBasedFilterOperator(mutableRoaringBitmap[i].toImmutableRoaringBitmap(),
             false, NUM_DOCS));
       }
     }

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkAndDocIdIterator.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkAndDocIdIterator.java
@@ -50,7 +50,7 @@ public class BenchmarkAndDocIdIterator {
       throws RunnerException {
     Options opt =
         new OptionsBuilder().include(BenchmarkAndDocIdIterator.class.getSimpleName()).warmupTime(TimeValue.seconds(5))
-            .warmupIterations(2).measurementTime(TimeValue.seconds(5)).measurementIterations(5).forks(1).build();
+            .warmupIterations(2).measurementTime(TimeValue.seconds(10)).measurementIterations(5).forks(1).build();
 
     new Runner(opt).run();
   }
@@ -59,7 +59,7 @@ public class BenchmarkAndDocIdIterator {
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public void benchAndFilterOperator(MyState myState) {
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 100; i++) {
       new AndFilterOperator(myState._childOperators).nextBlock().getBlockDocIdSet().iterator();
     }
   }
@@ -68,7 +68,7 @@ public class BenchmarkAndDocIdIterator {
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public void benchAndFilterOperatorReorderCost(MyState myState) {
-    for (int i = 0; i < 10; i++) {
+    for (int i = 0; i < 100; i++) {
       new AndFilterOperator(myState._childOperatorsNoOrdering).nextBlock().getBlockDocIdSet().iterator();
     }
   }

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkAndDocIdIterator.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkAndDocIdIterator.java
@@ -80,28 +80,28 @@ public class BenchmarkAndDocIdIterator {
 
     @Setup(Level.Trial)
     public void doSetup() {
-      MutableRoaringBitmap[] mutableRoaringBitmap = new MutableRoaringBitmap[NUM_FILTERS];
+      MutableRoaringBitmap mutableRoaringBitmap = new MutableRoaringBitmap();
       Random r = new Random();
       r.setSeed(42);
       for (int i = 0; i < NUM_FILTERS; i++) {
-        mutableRoaringBitmap[i] = new MutableRoaringBitmap();
+        mutableRoaringBitmap = new MutableRoaringBitmap();
         double selectedPortion = (NUM_FILTERS - i) / (2.0 * NUM_FILTERS);
         for (int j = 0; j < NUM_DOCS; j++) {
           if (r.nextDouble() < selectedPortion) {
-            mutableRoaringBitmap[i].add(j);
+            mutableRoaringBitmap.add(j);
           }
         }
-        _childOperators.add(new BitmapBasedFilterOperator(mutableRoaringBitmap[i].toImmutableRoaringBitmap(),
+        _childOperators.add(new BitmapBasedFilterOperator(mutableRoaringBitmap.toImmutableRoaringBitmap(),
             false, NUM_DOCS));
 
-        mutableRoaringBitmap[i] = new MutableRoaringBitmap();
-        selectedPortion = 0.5;
+        mutableRoaringBitmap = new MutableRoaringBitmap();
+        selectedPortion = 0.1;
         for (int j = 0; j < NUM_DOCS; j++) {
           if (r.nextDouble() < selectedPortion) {
-            mutableRoaringBitmap[i].add(j);
+            mutableRoaringBitmap.add(j);
           }
         }
-        _childOperatorsNoOrdering.add(new BitmapBasedFilterOperator(mutableRoaringBitmap[i].toImmutableRoaringBitmap(),
+        _childOperatorsNoOrdering.add(new BitmapBasedFilterOperator(mutableRoaringBitmap.toImmutableRoaringBitmap(),
             false, NUM_DOCS));
       }
     }

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkAndDocIdIterator.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkAndDocIdIterator.java
@@ -80,7 +80,7 @@ public class BenchmarkAndDocIdIterator {
 
     @Setup(Level.Trial)
     public void doSetup() {
-      MutableRoaringBitmap mutableRoaringBitmap = new MutableRoaringBitmap();
+      MutableRoaringBitmap mutableRoaringBitmap;
       Random r = new Random();
       r.setSeed(42);
       for (int i = 0; i < NUM_FILTERS; i++) {

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkAndDocIdIterator.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkAndDocIdIterator.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.core.operator.filter.AndFilterOperator;
+import org.apache.pinot.core.operator.filter.BaseFilterOperator;
+import org.apache.pinot.core.operator.filter.BitmapBasedFilterOperator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
+
+@State(Scope.Benchmark)
+public class BenchmarkAndDocIdIterator {
+  private static final int NUM_DOCS = 10_000;
+  private static final int NUM_FILTERS = 5;
+
+  public static void main(String[] args)
+      throws RunnerException {
+    Options opt =
+        new OptionsBuilder().include(BenchmarkAndDocIdIterator.class.getSimpleName()).warmupTime(TimeValue.seconds(5))
+            .warmupIterations(2).measurementTime(TimeValue.seconds(5)).measurementIterations(5).forks(1).build();
+
+    new Runner(opt).run();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void benchAndFilterOperator(MyState myState) {
+    for (int i = 0; i < 10; i++) {
+      new AndFilterOperator(myState._childOperators).nextBlock().getBlockDocIdSet().iterator();
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void benchAndFilterOperatorReorderCost(MyState myState) {
+    for (int i = 0; i < 10; i++) {
+      new AndFilterOperator(myState._childOperatorsNoOrdering).nextBlock().getBlockDocIdSet().iterator();
+    }
+  }
+
+  @State(Scope.Benchmark)
+  public static class MyState {
+    public List<BaseFilterOperator> _childOperators = new ArrayList<>();
+    public List<BaseFilterOperator> _childOperatorsNoOrdering = new ArrayList<>();
+
+    @Setup(Level.Trial)
+    public void doSetup() {
+      MutableRoaringBitmap[] mutableRoaringBitmap = new MutableRoaringBitmap[NUM_FILTERS];
+      Random r = new Random();
+      for (int i = 0; i < NUM_FILTERS; i++) {
+        mutableRoaringBitmap[i] = new MutableRoaringBitmap();
+        double selectedPortion = (NUM_FILTERS - i) / (2.0 * NUM_FILTERS);
+        for (int j = 0; j < NUM_DOCS; j++) {
+          if (r.nextDouble() < selectedPortion) {
+            mutableRoaringBitmap[i].add(j);
+          }
+        }
+        _childOperators.add(new BitmapBasedFilterOperator(mutableRoaringBitmap[i].toImmutableRoaringBitmap(),
+            false, NUM_DOCS));
+        _childOperatorsNoOrdering.add(new BitmapBasedFilterOperator(mutableRoaringBitmap[0].toImmutableRoaringBitmap(),
+            false, NUM_DOCS));
+      }
+    }
+  }
+}


### PR DESCRIPTION
For and connected predicates, evaluate the bitmap and with the lowest number of matching docIds first, so that we limit the number of roaring bitmap containers for comparison from the beginning, this will minimize the effort of `and` application

Running BenchmarkAndDocIdIterator:
<img width="655" alt="Screen Shot 2022-09-08 at 7 53 51 PM" src="https://user-images.githubusercontent.com/10736840/189262446-6099a75c-b732-4b2d-bfdd-445ec89564a6.png">

speedup: around **3x** after reordering suboptimal bitmap array of size 5: matching % [5/10, 4/10, 3/10, 2/10, 1/10] -> [1/10, 2/10, 3/10, 4/10, 5/10]
sorting overhead: **2.5%** 
please take a look at BenchmarkAndDocIdIterator.java for details