### PR TITLE
delete all related minion task metadata when deleting a table

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -134,6 +134,10 @@ public class ZKMetadataProvider {
     return StringUtil.join("/", PROPERTYSTORE_SEGMENT_LINEAGE, tableNameWithType);
   }
 
+  public static String getPropertyStorePathForMinionTaskMetadataPrefix() {
+    return PROPERTYSTORE_MINION_TASK_METADATA_PREFIX;
+  }
+
   public static String constructPropertyStorePathForMinionTaskMetadata(String tableNameWithType, String taskType) {
     return StringUtil.join("/", PROPERTYSTORE_MINION_TASK_METADATA_PREFIX, tableNameWithType, taskType);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -138,6 +138,10 @@ public class ZKMetadataProvider {
     return StringUtil.join("/", PROPERTYSTORE_MINION_TASK_METADATA_PREFIX, tableNameWithType, taskType);
   }
 
+  public static String constructPropertyStorePathForMinionTaskMetadata(String tableNameWithType) {
+    return StringUtil.join("/", PROPERTYSTORE_MINION_TASK_METADATA_PREFIX, tableNameWithType);
+  }
+
   @Deprecated
   public static String constructPropertyStorePathForMinionTaskMetadataDeprecated(String taskType,
       String tableNameWithType) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
@@ -92,6 +92,12 @@ public final class MinionTaskMetadataUtils {
       throw new ZkException("Failed to delete task metadata for table: " + tableNameWithType);
     }
     // delete the minion task metadata ZNRecord MINION_TASK_METADATA/<any task type>/${tableNameWthType}
+    // TODO: another way of finding old minion task metadata path is: (1) use reflection to find all task types,
+    //   similar to what TaskGeneratorRegistry.java does (2) construct possible old minion task metadata path
+    //   using those types.
+    //   The tradeoff is: (1) the current approach uses ZK as the source of truth, so we will not miss any ZNode
+    //   (2) the other approach will reduce ZK load if there are thousands of tables, because we need to talk to
+    //   the ZK to find all its direct children in the current approach.
     List<String> childNames =
         propertyStore.getChildNames(ZKMetadataProvider.getPropertyStorePathForMinionTaskMetadataPrefix(),
             AccessOption.PERSISTENT);

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
@@ -25,7 +25,6 @@ import org.apache.helix.store.HelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.zkclient.exception.ZkException;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
-import org.apache.pinot.spi.config.table.TableType;
 import org.apache.zookeeper.data.Stat;
 
 
@@ -98,10 +97,8 @@ public final class MinionTaskMetadataUtils {
             AccessOption.PERSISTENT);
     if (childNames != null && !childNames.isEmpty()) {
       for (String child : childNames) {
-        // the child is a new path, skip it
-        if (child.endsWith(TableType.OFFLINE.toString()) || child.endsWith(TableType.REALTIME.toString())) {
-          continue;
-        }
+        // Even though some child names are not task types (e.g., in the new metadata path, the child name
+        // is a table name), it does not harm to try to delete the non-existent constructed path.
         String oldPath =
             ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataDeprecated(child, tableNameWithType);
         if (!propertyStore.remove(oldPath, AccessOption.PERSISTENT)) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
@@ -36,7 +36,7 @@ public final class MinionTaskMetadataUtils {
   }
 
   /**
-   * Fetches the ZNRecord for the given minion task and tableName. Fetch from the new path
+   * Fetches the minion task metadata ZNRecord for the given minion task and tableName. Fetch from the new path
    * MINION_TASK_METADATA/${tableNameWthType}/{taskType} if it exists; otherwise, fetch from the old path
    * MINION_TASK_METADATA/${taskType}/${tableNameWthType}.
    */
@@ -63,7 +63,7 @@ public final class MinionTaskMetadataUtils {
   }
 
   /**
-   * Deletes the ZNRecord for the given minion task and tableName, from both the new path
+   * Deletes the minion task metadata ZNRecord for the given minion task and tableName, from both the new path
    * MINION_TASK_METADATA/${tableNameWthType}/${taskType} and the old path
    * MINION_TASK_METADATA/${taskType}/${tableNameWthType}.
    */
@@ -80,9 +80,20 @@ public final class MinionTaskMetadataUtils {
   }
 
   /**
+   * Deletes the minion task metadata ZNRecord for the given tableName, from
+   * MINION_TASK_METADATA/${tableNameWthType}
+   */
+  public static void deleteTaskMetadata(HelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType) {
+    String path = ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(tableNameWithType);
+    if (!propertyStore.remove(path, AccessOption.PERSISTENT)) {
+      throw new ZkException("Failed to delete task metadata for table: " + tableNameWithType);
+    }
+  }
+
+  /**
    * Generic method for persisting {@link BaseTaskMetadata} to MINION_TASK_METADATA. The metadata will
    * be saved in the ZNode under the new path /MINION_TASK_METADATA/${tableNameWithType}/${taskType} if
-   * the old path already exists; otherwise, it will be saved in the ZNode under the old path
+   * it exists or the old path does not exist; otherwise, it will be saved in the ZNode under the old path
    * /MINION_TASK_METADATA/${taskType}/${tableNameWithType}.
    *
    * Will fail if expectedVersion does not match.

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/FakePropertyStore.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/FakePropertyStore.java
@@ -43,6 +43,15 @@ public class FakePropertyStore extends ZkHelixPropertyStore<ZNRecord> {
   }
 
   @Override
+  public List<String> getChildNames(String parentPath, int options) {
+    return _contents.keySet().stream()
+        .filter(e -> e.startsWith(parentPath))
+        .map(e -> e.replaceFirst(parentPath + "/", "").split("/")[0])
+        .distinct()
+        .collect(Collectors.toList());
+  }
+
+  @Override
   public boolean exists(String path, int options) {
     return _contents.containsKey(path);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/FakePropertyStore.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/FakePropertyStore.java
@@ -19,7 +19,9 @@
 package org.apache.pinot.common.utils.helix;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.helix.manager.zk.ZkBaseDataAccessor;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -72,7 +74,8 @@ public class FakePropertyStore extends ZkHelixPropertyStore<ZNRecord> {
 
   @Override
   public boolean remove(String path, int options) {
-    _contents.remove(path);
+    List<String> descendants = _contents.keySet().stream().filter(e -> e.startsWith(path)).collect(Collectors.toList());
+    descendants.forEach(e -> _contents.remove(e));
     return true;
   }
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
@@ -94,14 +94,29 @@ public class MinionTaskMetadataUtilsTest {
 
     // 1. ZNode MINION_TASK_METADATA/TestTable_OFFLINE and its descendants will be removed
     // 2. ZNode MINION_TASK_METADATA/<any task type>/TestTable_OFFLINE will also be removed
+    String anotherTable = "anotherTable_OFFLINE";
+    String anotherOldMinionMetadataPath =
+        ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadataDeprecated(TASK_TYPE, anotherTable);
+    DummyTaskMetadata anotherOldTaskMetadata = new DummyTaskMetadata(anotherTable, 20);
+    String anotherNewMinionMetadataPath =
+        ZKMetadataProvider.constructPropertyStorePathForMinionTaskMetadata(anotherTable, TASK_TYPE);
+    DummyTaskMetadata anotherNewTaskMetadata = new DummyTaskMetadata(anotherTable, 200);
     propertyStore = new FakePropertyStore();
     propertyStore.set(OLD_MINION_METADATA_PATH, OLD_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
     propertyStore.set(NEW_MINION_METADATA_PATH, NEW_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
+    propertyStore.set(anotherOldMinionMetadataPath, anotherOldTaskMetadata.toZNRecord(),
+        EXPECTED_VERSION, ACCESS_OPTION);
+    propertyStore.set(anotherNewMinionMetadataPath, anotherNewTaskMetadata.toZNRecord(),
+        EXPECTED_VERSION, ACCESS_OPTION);
     assertTrue(propertyStore.exists(OLD_MINION_METADATA_PATH, ACCESS_OPTION));
     assertTrue(propertyStore.exists(NEW_MINION_METADATA_PATH, ACCESS_OPTION));
+    assertTrue(propertyStore.exists(anotherOldMinionMetadataPath, ACCESS_OPTION));
+    assertTrue(propertyStore.exists(anotherNewMinionMetadataPath, ACCESS_OPTION));
     MinionTaskMetadataUtils.deleteTaskMetadata(propertyStore, TABLE_NAME_WITH_TYPE);
     assertFalse(propertyStore.exists(OLD_MINION_METADATA_PATH, ACCESS_OPTION));
     assertFalse(propertyStore.exists(NEW_MINION_METADATA_PATH, ACCESS_OPTION));
+    assertTrue(propertyStore.exists(anotherOldMinionMetadataPath, ACCESS_OPTION));
+    assertTrue(propertyStore.exists(anotherNewMinionMetadataPath, ACCESS_OPTION));
   }
 
   @Test

--- a/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
@@ -92,11 +92,15 @@ public class MinionTaskMetadataUtilsTest {
     assertFalse(propertyStore.exists(OLD_MINION_METADATA_PATH, ACCESS_OPTION));
     assertFalse(propertyStore.exists(NEW_MINION_METADATA_PATH, ACCESS_OPTION));
 
-    // ZNode MINION_TASK_METADATA/TestTable_OFFLINE and its descendants will be removed
+    // 1. ZNode MINION_TASK_METADATA/TestTable_OFFLINE and its descendants will be removed
+    // 2. ZNode MINION_TASK_METADATA/<any task type>/TestTable_OFFLINE will also be removed
     propertyStore = new FakePropertyStore();
+    propertyStore.set(OLD_MINION_METADATA_PATH, OLD_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
     propertyStore.set(NEW_MINION_METADATA_PATH, NEW_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
+    assertTrue(propertyStore.exists(OLD_MINION_METADATA_PATH, ACCESS_OPTION));
     assertTrue(propertyStore.exists(NEW_MINION_METADATA_PATH, ACCESS_OPTION));
     MinionTaskMetadataUtils.deleteTaskMetadata(propertyStore, TABLE_NAME_WITH_TYPE);
+    assertFalse(propertyStore.exists(OLD_MINION_METADATA_PATH, ACCESS_OPTION));
     assertFalse(propertyStore.exists(NEW_MINION_METADATA_PATH, ACCESS_OPTION));
   }
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
@@ -91,6 +91,13 @@ public class MinionTaskMetadataUtilsTest {
     MinionTaskMetadataUtils.deleteTaskMetadata(propertyStore, TASK_TYPE, TABLE_NAME_WITH_TYPE);
     assertFalse(propertyStore.exists(OLD_MINION_METADATA_PATH, ACCESS_OPTION));
     assertFalse(propertyStore.exists(NEW_MINION_METADATA_PATH, ACCESS_OPTION));
+
+    //
+    propertyStore = new FakePropertyStore();
+    propertyStore.set(NEW_MINION_METADATA_PATH, NEW_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
+    assertTrue(propertyStore.exists(NEW_MINION_METADATA_PATH, ACCESS_OPTION));
+    MinionTaskMetadataUtils.deleteTaskMetadata(propertyStore, TABLE_NAME_WITH_TYPE);
+    assertFalse(propertyStore.exists(NEW_MINION_METADATA_PATH, ACCESS_OPTION));
   }
 
   @Test

--- a/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
@@ -92,7 +92,7 @@ public class MinionTaskMetadataUtilsTest {
     assertFalse(propertyStore.exists(OLD_MINION_METADATA_PATH, ACCESS_OPTION));
     assertFalse(propertyStore.exists(NEW_MINION_METADATA_PATH, ACCESS_OPTION));
 
-    //
+    // ZNode MINION_TASK_METADATA/TestTable_OFFLINE and its descendants will be removed
     propertyStore = new FakePropertyStore();
     propertyStore.set(NEW_MINION_METADATA_PATH, NEW_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
     assertTrue(propertyStore.exists(NEW_MINION_METADATA_PATH, ACCESS_OPTION));

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1859,15 +1859,6 @@ public class PinotHelixResourceManager {
     LOGGER.info("Deleting table {}: Removed segment lineage", offlineTableName);
 
     // Remove task related metadata
-    MinionTaskMetadataUtils.deleteTaskMetadata(_propertyStore, MinionConstants.MergeRollupTask.TASK_TYPE,
-        offlineTableName);
-    LOGGER.info("Deleting table {}: Removed merge rollup task metadata", offlineTableName);
-
-    // Remove all task metadata
-    // TODO: This only deletes the new ZNode MINION_TASK_METADATA/${offlineTableName} but not the old one
-    //  MINION_TASK_METADATA/<task type>/${offlineTableName}, so we keep the above logic of deleting task
-    //  metadata for specific task types. The above logic should be deleted once the old ZNode is not in
-    //  use any more.
     MinionTaskMetadataUtils.deleteTaskMetadata(_propertyStore, offlineTableName);
     LOGGER.info("Deleting all task metadata for table {}", offlineTableName);
 
@@ -1929,20 +1920,7 @@ public class PinotHelixResourceManager {
     SegmentLineageAccessHelper.deleteSegmentLineage(_propertyStore, realtimeTableName);
     LOGGER.info("Deleting table {}: Removed segment lineage", realtimeTableName);
 
-    // Remove task related metadata
-    MinionTaskMetadataUtils.deleteTaskMetadata(_propertyStore, MinionConstants.MergeRollupTask.TASK_TYPE,
-        realtimeTableName);
-    LOGGER.info("Deleting table {}: Removed merge rollup task metadata", realtimeTableName);
-
-    MinionTaskMetadataUtils.deleteTaskMetadata(_propertyStore, MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE,
-        realtimeTableName);
-    LOGGER.info("Deleting table {}: Removed merge realtime to offline metadata", realtimeTableName);
-
     // Remove all task metadata
-    // TODO: This only deletes the new ZNode MINION_TASK_METADATA/${offlineTableName} but not the old one
-    //  MINION_TASK_METADATA/<task type>/${offlineTableName}, so we keep the above logic of deleting task
-    //  metadata for specific task types. The above logic should be deleted once the old ZNode is not in
-    //  use any more.
     MinionTaskMetadataUtils.deleteTaskMetadata(_propertyStore, realtimeTableName);
     LOGGER.info("Deleting all task metadata for table {}", realtimeTableName);
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -133,7 +133,6 @@ import org.apache.pinot.controller.helix.core.rebalance.RebalanceResult;
 import org.apache.pinot.controller.helix.core.rebalance.TableRebalancer;
 import org.apache.pinot.controller.helix.core.util.ZKMetadataUtils;
 import org.apache.pinot.controller.helix.starter.HelixConfig;
-import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.segment.local.utils.ReplicationUtils;
 import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.spi.config.ConfigUtils;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1859,7 +1859,7 @@ public class PinotHelixResourceManager {
 
     // Remove task related metadata
     MinionTaskMetadataUtils.deleteTaskMetadata(_propertyStore, offlineTableName);
-    LOGGER.info("Deleting table {}: Removed all task metadata", offlineTableName);
+    LOGGER.info("Deleting table {}: Removed all minion task metadata", offlineTableName);
 
     // Remove table config
     // this should always be the last step for deletion to avoid race condition in table re-create.
@@ -1921,7 +1921,7 @@ public class PinotHelixResourceManager {
 
     // Remove task related metadata
     MinionTaskMetadataUtils.deleteTaskMetadata(_propertyStore, realtimeTableName);
-    LOGGER.info("Deleting table {}: Removed all task metadata", realtimeTableName);
+    LOGGER.info("Deleting table {}: Removed all minion task metadata", realtimeTableName);
 
     // Remove groupId/partitionId mapping for HLC table
     if (instancesForTable != null) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1920,7 +1920,7 @@ public class PinotHelixResourceManager {
     SegmentLineageAccessHelper.deleteSegmentLineage(_propertyStore, realtimeTableName);
     LOGGER.info("Deleting table {}: Removed segment lineage", realtimeTableName);
 
-    // Remove all task metadata
+    // Remove task related metadata
     MinionTaskMetadataUtils.deleteTaskMetadata(_propertyStore, realtimeTableName);
     LOGGER.info("Deleting table {}: Removed all task metadata", realtimeTableName);
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1860,7 +1860,7 @@ public class PinotHelixResourceManager {
 
     // Remove task related metadata
     MinionTaskMetadataUtils.deleteTaskMetadata(_propertyStore, offlineTableName);
-    LOGGER.info("Deleting all task metadata for table {}", offlineTableName);
+    LOGGER.info("Deleting table {}: Removed all task metadata", offlineTableName);
 
     // Remove table config
     // this should always be the last step for deletion to avoid race condition in table re-create.
@@ -1922,7 +1922,7 @@ public class PinotHelixResourceManager {
 
     // Remove all task metadata
     MinionTaskMetadataUtils.deleteTaskMetadata(_propertyStore, realtimeTableName);
-    LOGGER.info("Deleting all task metadata for table {}", realtimeTableName);
+    LOGGER.info("Deleting table {}: Removed all task metadata", realtimeTableName);
 
     // Remove groupId/partitionId mapping for HLC table
     if (instancesForTable != null) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1863,6 +1863,14 @@ public class PinotHelixResourceManager {
         offlineTableName);
     LOGGER.info("Deleting table {}: Removed merge rollup task metadata", offlineTableName);
 
+    // Remove all task metadata
+    // TODO: This only deletes the new ZNode MINION_TASK_METADATA/${offlineTableName} but not the old one
+    //  MINION_TASK_METADATA/<task type>/${offlineTableName}, so we keep the above logic of deleting task
+    //  metadata for specific task types. The above logic should be deleted once the old ZNode is not in
+    //  use any more.
+    MinionTaskMetadataUtils.deleteTaskMetadata(_propertyStore, offlineTableName);
+    LOGGER.info("Deleting all task metadata for table {}", offlineTableName);
+
     // Remove table config
     // this should always be the last step for deletion to avoid race condition in table re-create.
     ZKMetadataProvider.removeResourceConfigFromPropertyStore(_propertyStore, offlineTableName);
@@ -1929,6 +1937,14 @@ public class PinotHelixResourceManager {
     MinionTaskMetadataUtils.deleteTaskMetadata(_propertyStore, MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE,
         realtimeTableName);
     LOGGER.info("Deleting table {}: Removed merge realtime to offline metadata", realtimeTableName);
+
+    // Remove all task metadata
+    // TODO: This only deletes the new ZNode MINION_TASK_METADATA/${offlineTableName} but not the old one
+    //  MINION_TASK_METADATA/<task type>/${offlineTableName}, so we keep the above logic of deleting task
+    //  metadata for specific task types. The above logic should be deleted once the old ZNode is not in
+    //  use any more.
+    MinionTaskMetadataUtils.deleteTaskMetadata(_propertyStore, realtimeTableName);
+    LOGGER.info("Deleting all task metadata for table {}", realtimeTableName);
 
     // Remove groupId/partitionId mapping for HLC table
     if (instancesForTable != null) {


### PR DESCRIPTION
Delete the ZNode 
(1) MINION_TASK_METADATA/${tableName} and its descendants 
(2) MINION_TASK_METADATA/<any task type>/${tableName} 
when deleting a table, so that 
(1) we don't need to explicitly delete each MINION_TASK_METADATA/${tableName}/${taskType} and MINION_TASK_METADATA/${taskType}/${tableName} separately.
(2) the code can also delete customized minion task metadata automatically