### PR TITLE
Handle null string in CSV decoder

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVMessageDecoder.java
@@ -48,6 +48,7 @@ public class CSVMessageDecoder implements StreamMessageDecoder<byte[]> {
   private static final String CONFIG_COMMENT_MARKER = "commentMarker";
   private static final String CONFIG_CSV_ESCAPE_CHARACTER = "escapeCharacter";
   private static final String CONFIG_CSV_MULTI_VALUE_DELIMITER = "multiValueDelimiter";
+  public static final String NULL_STRING_VALUE = "nullStringValue";
 
   private CSVFormat _format;
   private CSVRecordExtractor _recordExtractor;
@@ -109,6 +110,11 @@ public class CSVMessageDecoder implements StreamMessageDecoder<byte[]> {
     String escapeChar = props.get(CONFIG_CSV_ESCAPE_CHARACTER);
     if (escapeChar != null) {
       format = format.withEscape(props.get(CONFIG_CSV_ESCAPE_CHARACTER).charAt(0));
+    }
+
+    String nullString = props.get(NULL_STRING_VALUE);
+    if (nullString != null) {
+      format = format.withNullString(nullString);
     }
 
     _format = format;

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVMessageDecoderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVMessageDecoderTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
 
 public class CSVMessageDecoderTest {
@@ -127,6 +128,27 @@ public class CSVMessageDecoderTest {
     assertEquals(destination.getValue("age"), "18");
     assertEquals(destination.getValue("gender"), "F");
     assertEquals(destination.getValue("subjects"), "mat;hs");
+  }
+
+  @Test
+  public void testNullString()
+      throws Exception {
+    Map<String, String> decoderProps = getStandardDecoderProps();
+    decoderProps.put("header", "name;age;gender;subjects");
+    decoderProps.put("delimiter", ";");
+    decoderProps.put("nullStringValue", "null");
+    CSVMessageDecoder messageDecoder = new CSVMessageDecoder();
+    messageDecoder.init(decoderProps, ImmutableSet.of("name", "age", "gender", "subjects"), "");
+    String incomingRecord = "Alice;null;F;null";
+    GenericRow destination = new GenericRow();
+    messageDecoder.decode(incomingRecord.getBytes(StandardCharsets.UTF_8), destination);
+    assertNotNull(destination.getValue("name"));
+    assertNull(destination.getValue("age"));
+    assertNotNull(destination.getValue("gender"));
+    assertNull(destination.getValue("subjects"));
+
+    assertEquals(destination.getValue("name"), "Alice");
+    assertEquals(destination.getValue("gender"), "F");
   }
 
   @Test


### PR DESCRIPTION
Currently, users can specify custom null values in CSVRecordReader but the same is missing from CSVDecoder. The PR fixes this discrepancy.