### PR TITLE
Allow hiding pinot broker swagger UI by config

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -57,6 +57,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
   public static final String BROKER_INSTANCE_ID = "brokerInstanceId";
 
   private final boolean _useHttps;
+  private final boolean _swaggerBrokerEnabled;
 
   private HttpServer _httpServer;
 
@@ -65,6 +66,8 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     packages(RESOURCE_PACKAGE);
     property(PINOT_CONFIGURATION, brokerConf);
     _useHttps = Boolean.parseBoolean(brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_SWAGGER_USE_HTTPS));
+    _swaggerBrokerEnabled = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_SWAGGER_BROKER_ENABLED,
+        CommonConstants.Broker.DEFAULT_SWAGGER_BROKER_ENABLED);
     if (brokerConf.getProperty(CommonConstants.Broker.BROKER_SERVICE_AUTO_DISCOVERY, false)) {
       register(ServiceAutoDiscoveryFeature.class);
     }
@@ -103,9 +106,8 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     } catch (IOException e) {
       throw new RuntimeException("Failed to start http server", e);
     }
-    PinotConfiguration brokerConf = (PinotConfiguration) getProperties().get(PINOT_CONFIGURATION);
-    if (brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_SWAGGER_BROKER_ENABLED,
-        CommonConstants.Broker.DEFAULT_SWAGGER_BROKER_ENABLED)) {
+
+    if (_swaggerBrokerEnabled) {
       PinotReflectionUtils.runWithLock(this::setupSwagger);
     } else {
       LOGGER.info("Hiding Swagger UI for Broker, by {}", CommonConstants.Broker.CONFIG_OF_SWAGGER_BROKER_ENABLED);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -46,9 +46,12 @@ import org.glassfish.grizzly.http.server.HttpServer;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.server.ResourceConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class BrokerAdminApiApplication extends ResourceConfig {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BrokerAdminApiApplication.class);
   private static final String RESOURCE_PACKAGE = "org.apache.pinot.broker.api.resources";
   public static final String PINOT_CONFIGURATION = "pinotConfiguration";
   public static final String BROKER_INSTANCE_ID = "brokerInstanceId";
@@ -100,7 +103,13 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     } catch (IOException e) {
       throw new RuntimeException("Failed to start http server", e);
     }
-    PinotReflectionUtils.runWithLock(this::setupSwagger);
+    PinotConfiguration brokerConf = (PinotConfiguration) getProperties().get(PINOT_CONFIGURATION);
+    if (brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_SWAGGER_BROKER_ENABLED,
+        CommonConstants.Broker.DEFAULT_SWAGGER_BROKER_ENABLED)) {
+      PinotReflectionUtils.runWithLock(this::setupSwagger);
+    } else {
+      LOGGER.info("Hiding Swagger UI for Broker, by {}", CommonConstants.Broker.CONFIG_OF_SWAGGER_BROKER_ENABLED);
+    }
   }
 
   private void setupSwagger() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -263,6 +263,8 @@ public class CommonConstants {
     public static final boolean DEFAULT_BROKER_REQUEST_CLIENT_IP_LOGGING = false;
 
     public static final String CONFIG_OF_LOGGER_ROOT_DIR = "pinot.broker.logger.root.dir";
+    public static final String CONFIG_OF_SWAGGER_BROKER_ENABLED = "pinot.broker.swagger.enabled";
+    public static final boolean DEFAULT_SWAGGER_BROKER_ENABLED = true;
 
     public static class Request {
       public static final String SQL = "sql";


### PR DESCRIPTION
## Description
Add an extra property in broker so we can hide Broker Swagger UI completely.
This is following the style in PR #7341 that can hide server Swagger UI

## Release Notes
* Introduce `pinot.broker.swagger.enabled=true` property to broker so we can hide broker swagger UI on demand
