### PR TITLE
[Feature][multistage] Thread-safe query planning

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -102,13 +102,7 @@ public class QueryEnvironment {
   /**
    * Plan a SQL query.
    *
-   * <p>Noted that since Calcite's {@link org.apache.calcite.tools.Planner} is not threadsafe.
-   * Only one query query can be planned at a time. Afterwards planner needs to be reset in order to clear the
-   * state for the next planning.
-   *
-   * <p>In order for faster planning, we pre-constructed all the planner objects and use the plan-then-reset
-   * model. Thusn when using {@code QueryEnvironment#planQuery(String)}, caller should ensure that no concurrent
-   * plan execution occurs.
+   * This function is thread safe since we construct a new PlannerContext every time.
    *
    * TODO: follow benchmark and profile to measure whether it make sense for the latency-concurrency trade-off
    * between reusing plannerImpl vs. create a new planner for each query.

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -118,8 +118,7 @@ public class QueryEnvironment {
    * @return a dispatchable query plan
    */
   public QueryPlan planQuery(String sqlQuery, SqlNodeAndOptions sqlNodeAndOptions) {
-    try {
-      PlannerContext plannerContext = new PlannerContext(_config, _catalogReader, _typeFactory, _hepProgram);
+    try (PlannerContext plannerContext = new PlannerContext(_config, _catalogReader, _typeFactory, _hepProgram)) {
       plannerContext.setOptions(sqlNodeAndOptions.getOptions());
       RelNode relRoot = compileQuery(sqlNodeAndOptions.getSqlNode(), plannerContext);
       return toDispatchablePlan(relRoot, plannerContext);
@@ -140,9 +139,8 @@ public class QueryEnvironment {
    * @return the explained query plan.
    */
   public String explainQuery(String sqlQuery, SqlNodeAndOptions sqlNodeAndOptions) {
-    try {
+    try (PlannerContext plannerContext = new PlannerContext(_config, _catalogReader, _typeFactory, _hepProgram)) {
       SqlExplain explain = (SqlExplain) sqlNodeAndOptions.getSqlNode();
-      PlannerContext plannerContext = new PlannerContext(_config, _catalogReader, _typeFactory, _hepProgram);
       plannerContext.setOptions(sqlNodeAndOptions.getOptions());
       RelNode relRoot = compileQuery(explain.getExplicandum(), plannerContext);
       SqlExplainFormat format = explain.getFormat() == null ? SqlExplainFormat.DOT : explain.getFormat();

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -24,14 +24,12 @@ import java.util.Properties;
 import org.apache.calcite.config.CalciteConnectionConfigImpl;
 import org.apache.calcite.config.CalciteConnectionProperty;
 import org.apache.calcite.jdbc.CalciteSchema;
-import org.apache.calcite.plan.Contexts;
 import org.apache.calcite.plan.RelOptCluster;
-import org.apache.calcite.plan.RelOptPlanner;
 import org.apache.calcite.plan.RelOptRule;
 import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.plan.hep.HepProgram;
 import org.apache.calcite.plan.hep.HepProgramBuilder;
 import org.apache.calcite.prepare.CalciteCatalogReader;
-import org.apache.calcite.prepare.PlannerImpl;
 import org.apache.calcite.prepare.Prepare;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelRoot;
@@ -44,8 +42,6 @@ import org.apache.calcite.sql.SqlExplainFormat;
 import org.apache.calcite.sql.SqlExplainLevel;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.fun.SqlStdOperatorTable;
-import org.apache.calcite.sql.validate.SqlValidator;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.sql2rel.StandardConvertletTable;
 import org.apache.calcite.tools.FrameworkConfig;
@@ -53,11 +49,9 @@ import org.apache.calcite.tools.Frameworks;
 import org.apache.pinot.query.context.PlannerContext;
 import org.apache.pinot.query.planner.PlannerUtils;
 import org.apache.pinot.query.planner.QueryPlan;
-import org.apache.pinot.query.planner.logical.LogicalPlanner;
 import org.apache.pinot.query.planner.logical.StagePlanner;
 import org.apache.pinot.query.routing.WorkerManager;
 import org.apache.pinot.query.type.TypeFactory;
-import org.apache.pinot.query.validate.Validator;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
 
@@ -73,11 +67,10 @@ public class QueryEnvironment {
 
   // Calcite extension/plugins
   private final CalciteSchema _rootSchema;
-  private final PlannerImpl _planner;
   private final Prepare.CatalogReader _catalogReader;
   private final RelDataTypeFactory _typeFactory;
-  private final RelOptPlanner _relOptPlanner;
-  private final SqlValidator _validator;
+
+  private final HepProgram _hepProgram;
 
   // Pinot extensions
   private final Collection<RelOptRule> _logicalRuleSet;
@@ -89,15 +82,11 @@ public class QueryEnvironment {
     _workerManager = workerManager;
     _config = Frameworks.newConfigBuilder().traitDefs().build();
 
-    // Planner is not thread-safe. must be reset() after each use.
-    _planner = new PlannerImpl(_config);
-
     // catalog
     Properties catalogReaderConfigProperties = new Properties();
     catalogReaderConfigProperties.setProperty(CalciteConnectionProperty.CASE_SENSITIVE.camelName(), "true");
     _catalogReader = new CalciteCatalogReader(_rootSchema, _rootSchema.path(null), _typeFactory,
         new CalciteConnectionConfigImpl(catalogReaderConfigProperties));
-    _validator = new Validator(SqlStdOperatorTable.instance(), _catalogReader, _typeFactory);
 
     // optimizer rules
     _logicalRuleSet = PinotQueryRuleSets.LOGICAL_OPT_RULES;
@@ -107,7 +96,7 @@ public class QueryEnvironment {
     for (RelOptRule relOptRule : _logicalRuleSet) {
       hepProgramBuilder.addRuleInstance(relOptRule);
     }
-    _relOptPlanner = new LogicalPlanner(hepProgramBuilder.build(), Contexts.EMPTY_CONTEXT);
+    _hepProgram = hepProgramBuilder.build();
   }
 
   /**
@@ -130,7 +119,7 @@ public class QueryEnvironment {
    */
   public QueryPlan planQuery(String sqlQuery, SqlNodeAndOptions sqlNodeAndOptions) {
     try {
-      PlannerContext plannerContext = new PlannerContext();
+      PlannerContext plannerContext = new PlannerContext(_config, _catalogReader, _typeFactory, _hepProgram);
       plannerContext.setOptions(sqlNodeAndOptions.getOptions());
       RelNode relRoot = compileQuery(sqlNodeAndOptions.getSqlNode(), plannerContext);
       return toDispatchablePlan(relRoot, plannerContext);
@@ -153,12 +142,12 @@ public class QueryEnvironment {
   public String explainQuery(String sqlQuery, SqlNodeAndOptions sqlNodeAndOptions) {
     try {
       SqlExplain explain = (SqlExplain) sqlNodeAndOptions.getSqlNode();
-      PlannerContext plannerContext = new PlannerContext();
+      PlannerContext plannerContext = new PlannerContext(_config, _catalogReader, _typeFactory, _hepProgram);
       plannerContext.setOptions(sqlNodeAndOptions.getOptions());
       RelNode relRoot = compileQuery(explain.getExplicandum(), plannerContext);
       SqlExplainFormat format = explain.getFormat() == null ? SqlExplainFormat.DOT : explain.getFormat();
-      SqlExplainLevel level = explain.getDetailLevel() == null ? SqlExplainLevel.DIGEST_ATTRIBUTES
-          : explain.getDetailLevel();
+      SqlExplainLevel level =
+          explain.getDetailLevel() == null ? SqlExplainLevel.DIGEST_ATTRIBUTES : explain.getDetailLevel();
       return PlannerUtils.explainPlan(relRoot, format, level);
     } catch (Exception e) {
       throw new RuntimeException("Error explain query plan for: " + sqlQuery, e);
@@ -182,20 +171,15 @@ public class QueryEnvironment {
   @VisibleForTesting
   protected RelNode compileQuery(SqlNode sqlNode, PlannerContext plannerContext)
       throws Exception {
-    try {
-      SqlNode validated = validate(sqlNode);
-      RelRoot relation = toRelation(validated, plannerContext);
-      return optimize(relation, plannerContext);
-    } finally {
-      _planner.close();
-      _planner.reset();
-    }
+    SqlNode validated = validate(sqlNode, plannerContext);
+    RelRoot relation = toRelation(validated, plannerContext);
+    return optimize(relation, plannerContext);
   }
 
-  private SqlNode validate(SqlNode parsed)
+  private SqlNode validate(SqlNode parsed, PlannerContext plannerContext)
       throws Exception {
     // 2. validator to validate.
-    SqlNode validated = _validator.validate(parsed);
+    SqlNode validated = plannerContext.getValidator().validate(parsed);
     if (null == validated || !validated.getKind().belongsTo(SqlKind.QUERY)) {
       throw new IllegalArgumentException(
           String.format("unsupported SQL query, cannot validate out a valid sql from:\n%s", parsed));
@@ -206,9 +190,10 @@ public class QueryEnvironment {
   private RelRoot toRelation(SqlNode parsed, PlannerContext plannerContext) {
     // 3. convert sqlNode to relNode.
     RexBuilder rexBuilder = new RexBuilder(_typeFactory);
-    RelOptCluster cluster = RelOptCluster.create(_relOptPlanner, rexBuilder);
+    RelOptCluster cluster = RelOptCluster.create(plannerContext.getRelOptPlanner(), rexBuilder);
     SqlToRelConverter sqlToRelConverter =
-        new SqlToRelConverter(_planner, _validator, _catalogReader, cluster, StandardConvertletTable.INSTANCE,
+        new SqlToRelConverter(plannerContext.getPlanner(), plannerContext.getValidator(), _catalogReader, cluster,
+            StandardConvertletTable.INSTANCE,
             SqlToRelConverter.config().withHintStrategyTable(getHintStrategyTable(plannerContext)));
     return sqlToRelConverter.convertQuery(parsed, false, true);
   }
@@ -217,8 +202,8 @@ public class QueryEnvironment {
     // 4. optimize relNode
     // TODO: add support for traits, cost factory.
     try {
-      _relOptPlanner.setRoot(relRoot.rel);
-      return _relOptPlanner.findBestExp();
+      plannerContext.getRelOptPlanner().setRoot(relRoot.rel);
+      return plannerContext.getRelOptPlanner().findBestExp();
     } catch (Exception e) {
       throw new UnsupportedOperationException(
           "Cannot generate a valid execution plan for the given query: " + RelOptUtil.toString(relRoot.rel), e);
@@ -230,7 +215,6 @@ public class QueryEnvironment {
     StagePlanner queryStagePlanner = new StagePlanner(plannerContext, _workerManager);
     return queryStagePlanner.makePlan(relRoot);
   }
-
 
   // --------------------------------------------------------------------------
   // utils

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/context/PlannerContext.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/context/PlannerContext.java
@@ -31,13 +31,14 @@ import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.pinot.query.planner.logical.LogicalPlanner;
 import org.apache.pinot.query.validate.Validator;
 
+
 /**
  * PlannerContext is an object that holds all contextual information during planning phase.
  *
  * TODO: currently we don't support option or query rewrite.
  * It is used to hold per query context for query planning, which cannot be shared across queries.
  */
-public class PlannerContext {
+public class PlannerContext implements AutoCloseable {
   public PlannerContext(FrameworkConfig config, Prepare.CatalogReader catalogReader, RelDataTypeFactory typeFactory,
       HepProgram hepProgram) {
     _planner = new PlannerImpl(config);
@@ -71,5 +72,11 @@ public class PlannerContext {
 
   public Map<String, String> getOptions() {
     return _options;
+  }
+
+  @Override
+  public void close()
+      throws Exception {
+    _planner.close();
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/context/PlannerContext.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/context/PlannerContext.java
@@ -19,15 +19,50 @@
 package org.apache.pinot.query.context;
 
 import java.util.Map;
-
+import org.apache.calcite.plan.Contexts;
+import org.apache.calcite.plan.RelOptPlanner;
+import org.apache.calcite.plan.hep.HepProgram;
+import org.apache.calcite.prepare.PlannerImpl;
+import org.apache.calcite.prepare.Prepare;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.tools.FrameworkConfig;
+import org.apache.pinot.query.planner.logical.LogicalPlanner;
+import org.apache.pinot.query.validate.Validator;
 
 /**
  * PlannerContext is an object that holds all contextual information during planning phase.
  *
- * TODO: currently the planner context is not used since we don't support option or query rewrite. This construct is
- * here as a placeholder for the parsed out options.
+ * TODO: currently we don't support option or query rewrite.
+ * It is used to hold per query context for query planning, which cannot be shared across queries.
  */
 public class PlannerContext {
+  public PlannerContext(FrameworkConfig config, Prepare.CatalogReader catalogReader, RelDataTypeFactory typeFactory,
+      HepProgram hepProgram) {
+    _planner = new PlannerImpl(config);
+    _validator = new Validator(SqlStdOperatorTable.instance(), catalogReader, typeFactory);
+    _relOptPlanner = new LogicalPlanner(hepProgram, Contexts.EMPTY_CONTEXT);
+  }
+
+  public PlannerImpl getPlanner() {
+    return _planner;
+  }
+
+  public SqlValidator getValidator() {
+    return _validator;
+  }
+
+  public RelOptPlanner getRelOptPlanner() {
+    return _relOptPlanner;
+  }
+
+  private PlannerImpl _planner;
+
+  private SqlValidator _validator;
+
+  private RelOptPlanner _relOptPlanner;
+
   private Map<String, String> _options;
 
   public void setOptions(Map<String, String> options) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/context/PlannerContext.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/context/PlannerContext.java
@@ -39,6 +39,14 @@ import org.apache.pinot.query.validate.Validator;
  * It is used to hold per query context for query planning, which cannot be shared across queries.
  */
 public class PlannerContext implements AutoCloseable {
+  private final PlannerImpl _planner;
+
+  private final SqlValidator _validator;
+
+  private final RelOptPlanner _relOptPlanner;
+
+  private Map<String, String> _options;
+
   public PlannerContext(FrameworkConfig config, Prepare.CatalogReader catalogReader, RelDataTypeFactory typeFactory,
       HepProgram hepProgram) {
     _planner = new PlannerImpl(config);
@@ -57,14 +65,6 @@ public class PlannerContext implements AutoCloseable {
   public RelOptPlanner getRelOptPlanner() {
     return _relOptPlanner;
   }
-
-  private PlannerImpl _planner;
-
-  private SqlValidator _validator;
-
-  private RelOptPlanner _relOptPlanner;
-
-  private Map<String, String> _options;
 
   public void setOptions(Map<String, String> options) {
     _options = options;

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -20,8 +20,11 @@ package org.apache.pinot.query;
 
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.pinot.core.transport.ServerInstance;
@@ -181,22 +184,37 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
   @Test
   public void testPlanQueryMultiThread()
       throws Exception {
-    Runnable planQuery = () -> {
-      String query = "SELECT a.col1, a.ts, b.col2, b.col3 FROM a JOIN b ON a.col1 = b.col2 "
-          + "WHERE a.col3 >= 0 AND a.col2 IN  ('a', 'b') AND b.col3 < 0";
+    Map<String, ArrayList<QueryPlan>> queryPlans = new HashMap<>();
+    Lock lock = new ReentrantLock();
+    Runnable joinQuery = () -> {
+      String query = "SELECT a.col1, a.ts, b.col2, b.col3 FROM a JOIN b ON a.col1 = b.col2";
       QueryPlan queryPlan = _queryEnvironment.planQuery(query);
-      List<StageNode> intermediateStageRoots =
-          queryPlan.getStageMetadataMap().entrySet().stream().filter(e -> e.getValue().getScannedTables().size() == 0)
-              .map(e -> queryPlan.getQueryStageMap().get(e.getKey())).collect(Collectors.toList());
-      // Assert that no project of filter node for any intermediate stage because all should've been pushed down.
-      for (StageNode roots : intermediateStageRoots) {
-        assertNodeTypeNotIn(roots, ImmutableList.of(ProjectNode.class, FilterNode.class));
+      lock.lock();
+      if (!queryPlans.containsKey(queryPlan)) {
+        queryPlans.put(query, new ArrayList<>());
       }
+      queryPlans.get(query).add(queryPlan);
+      lock.unlock();
+    };
+    Runnable selectQuery = () -> {
+      String query = "SELECT * FROM a";
+      QueryPlan queryPlan = _queryEnvironment.planQuery(query);
+      lock.lock();
+      if (!queryPlans.containsKey(queryPlan)) {
+        queryPlans.put(query, new ArrayList<>());
+      }
+      queryPlans.get(query).add(queryPlan);
+      lock.unlock();
     };
     ArrayList<Thread> threads = new ArrayList<>();
     final int numThreads = 10;
     for (int i = 0; i < numThreads; i++) {
-      Thread thread = new Thread(planQuery);
+      Thread thread = null;
+      if (i % 2 == 0) {
+        thread = new Thread(joinQuery);
+      } else {
+        thread = new Thread(selectQuery);
+      }
       threads.add(thread);
     }
     for (Thread t : threads) {
@@ -204,6 +222,11 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
     }
     for (Thread t : threads) {
       t.join();
+    }
+    for (ArrayList<QueryPlan> plans : queryPlans.values()) {
+      for (QueryPlan plan : plans) {
+        Assert.assertTrue(plan.equals(plans.get(0)));
+      }
     }
   }
 
@@ -218,8 +241,7 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
     }
   }
 
-  private static boolean isOneOf(List<Class<? extends AbstractStageNode>> allowedNodeTypes,
-      StageNode node) {
+  private static boolean isOneOf(List<Class<? extends AbstractStageNode>> allowedNodeTypes, StageNode node) {
     for (Class<? extends AbstractStageNode> allowedNodeType : allowedNodeTypes) {
       if (node.getClass() == allowedNodeType) {
         return true;
@@ -230,7 +252,7 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
 
   @DataProvider(name = "testQueryExceptionDataProvider")
   private Object[][] provideQueriesWithException() {
-    return new Object[][] {
+    return new Object[][]{
         // wrong table is being used after JOIN
         new Object[]{"SELECT b.col1 - a.col3 FROM a JOIN c ON a.col1 = c.col3", "Table 'b' not found"},
         // non-agg column not being grouped
@@ -240,24 +262,30 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
 
   @DataProvider(name = "testQueryPlanDataProvider")
   private Object[][] provideQueriesWithExplainedPlan() {
-    return new Object[][] {
-        new Object[]{"EXPLAIN PLAN INCLUDING ALL ATTRIBUTES AS JSON FOR SELECT col1, col3 FROM a", "{\n"
-            + "  \"rels\": [\n" + "    {\n" + "      \"id\": \"0\",\n" + "      \"relOp\": \"LogicalTableScan\",\n"
-            + "      \"table\": [\n" + "        \"a\"\n" + "      ],\n" + "      \"inputs\": []\n" + "    },\n"
-            + "    {\n" + "      \"id\": \"1\",\n" + "      \"relOp\": \"LogicalProject\",\n" + "      \"fields\": [\n"
-            + "        \"col1\",\n" + "        \"col3\"\n" + "      ],\n" + "      \"exprs\": [\n" + "        {\n"
-            + "          \"input\": 2,\n" + "          \"name\": \"$2\"\n" + "        },\n" + "        {\n"
-            + "          \"input\": 1,\n" + "          \"name\": \"$1\"\n" + "        }\n" + "      ]\n" + "    }\n"
-            + "  ]\n" + "}"},
-        new Object[]{"EXPLAIN PLAN EXCLUDING ATTRIBUTES AS DOT FOR SELECT col1, COUNT(*) FROM a GROUP BY col1",
-            "Execution Plan\n" + "digraph {\n" + "\"LogicalExchange\\n\" -> \"LogicalAggregate\\n\" [label=\"0\"]\n"
-                + "\"LogicalAggregate\\n\" -> \"LogicalExchange\\n\" [label=\"0\"]\n"
-                + "\"LogicalTableScan\\n\" -> \"LogicalAggregate\\n\" [label=\"0\"]\n" + "}\n"},
-        new Object[]{"EXPLAIN PLAN FOR SELECT a.col1, b.col3 FROM a JOIN b ON a.col1 = b.col1", "Execution Plan\n"
-            + "LogicalProject(col1=[$0], col3=[$1])\n" + "  LogicalJoin(condition=[=($0, $2)], joinType=[inner])\n"
+    return new Object[][]{
+        new Object[]{
+            "EXPLAIN PLAN INCLUDING ALL ATTRIBUTES AS JSON FOR SELECT col1, col3 FROM a",
+            "{\n" + "  \"rels\": [\n" + "    {\n" + "      \"id\": \"0\",\n"
+                + "      \"relOp\": \"LogicalTableScan\",\n" + "      \"table\": [\n" + "        \"a\"\n" + "      ],\n"
+                + "      \"inputs\": []\n" + "    },\n" + "    {\n" + "      \"id\": \"1\",\n"
+                + "      \"relOp\": \"LogicalProject\",\n" + "      \"fields\": [\n" + "        \"col1\",\n"
+                + "        \"col3\"\n" + "      ],\n" + "      \"exprs\": [\n" + "        {\n"
+                + "          \"input\": 2,\n" + "          \"name\": \"$2\"\n" + "        },\n" + "        {\n"
+                + "          \"input\": 1,\n" + "          \"name\": \"$1\"\n" + "        }\n" + "      ]\n" + "    }\n"
+                + "  ]\n" + "}"
+        }, new Object[]{
+        "EXPLAIN PLAN EXCLUDING ATTRIBUTES AS DOT FOR SELECT col1, COUNT(*) FROM a GROUP BY col1",
+        "Execution Plan\n" + "digraph {\n" + "\"LogicalExchange\\n\" -> \"LogicalAggregate\\n\" [label=\"0\"]\n"
+            + "\"LogicalAggregate\\n\" -> \"LogicalExchange\\n\" [label=\"0\"]\n"
+            + "\"LogicalTableScan\\n\" -> \"LogicalAggregate\\n\" [label=\"0\"]\n" + "}\n"
+    }, new Object[]{
+        "EXPLAIN PLAN FOR SELECT a.col1, b.col3 FROM a JOIN b ON a.col1 = b.col1",
+        "Execution Plan\n" + "LogicalProject(col1=[$0], col3=[$1])\n"
+            + "  LogicalJoin(condition=[=($0, $2)], joinType=[inner])\n"
             + "    LogicalExchange(distribution=[hash[0]])\n" + "      LogicalProject(col1=[$2])\n"
             + "        LogicalTableScan(table=[[a]])\n" + "    LogicalExchange(distribution=[hash[1]])\n"
-            + "      LogicalProject(col3=[$1], col1=[$2])\n" + "        LogicalTableScan(table=[[b]])\n"},
+            + "      LogicalProject(col3=[$1], col1=[$2])\n" + "        LogicalTableScan(table=[[b]])\n"
+    },
     };
   }
 }

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -241,7 +241,8 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
     }
   }
 
-  private static boolean isOneOf(List<Class<? extends AbstractStageNode>> allowedNodeTypes, StageNode node) {
+  private static boolean isOneOf(List<Class<? extends AbstractStageNode>> allowedNodeTypes,
+      StageNode node) {
     for (Class<? extends AbstractStageNode> allowedNodeType : allowedNodeTypes) {
       if (node.getClass() == allowedNodeType) {
         return true;
@@ -252,7 +253,7 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
 
   @DataProvider(name = "testQueryExceptionDataProvider")
   private Object[][] provideQueriesWithException() {
-    return new Object[][]{
+    return new Object[][] {
         // wrong table is being used after JOIN
         new Object[]{"SELECT b.col1 - a.col3 FROM a JOIN c ON a.col1 = c.col3", "Table 'b' not found"},
         // non-agg column not being grouped
@@ -262,30 +263,24 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
 
   @DataProvider(name = "testQueryPlanDataProvider")
   private Object[][] provideQueriesWithExplainedPlan() {
-    return new Object[][]{
-        new Object[]{
-            "EXPLAIN PLAN INCLUDING ALL ATTRIBUTES AS JSON FOR SELECT col1, col3 FROM a",
-            "{\n" + "  \"rels\": [\n" + "    {\n" + "      \"id\": \"0\",\n"
-                + "      \"relOp\": \"LogicalTableScan\",\n" + "      \"table\": [\n" + "        \"a\"\n" + "      ],\n"
-                + "      \"inputs\": []\n" + "    },\n" + "    {\n" + "      \"id\": \"1\",\n"
-                + "      \"relOp\": \"LogicalProject\",\n" + "      \"fields\": [\n" + "        \"col1\",\n"
-                + "        \"col3\"\n" + "      ],\n" + "      \"exprs\": [\n" + "        {\n"
-                + "          \"input\": 2,\n" + "          \"name\": \"$2\"\n" + "        },\n" + "        {\n"
-                + "          \"input\": 1,\n" + "          \"name\": \"$1\"\n" + "        }\n" + "      ]\n" + "    }\n"
-                + "  ]\n" + "}"
-        }, new Object[]{
-        "EXPLAIN PLAN EXCLUDING ATTRIBUTES AS DOT FOR SELECT col1, COUNT(*) FROM a GROUP BY col1",
-        "Execution Plan\n" + "digraph {\n" + "\"LogicalExchange\\n\" -> \"LogicalAggregate\\n\" [label=\"0\"]\n"
-            + "\"LogicalAggregate\\n\" -> \"LogicalExchange\\n\" [label=\"0\"]\n"
-            + "\"LogicalTableScan\\n\" -> \"LogicalAggregate\\n\" [label=\"0\"]\n" + "}\n"
-    }, new Object[]{
-        "EXPLAIN PLAN FOR SELECT a.col1, b.col3 FROM a JOIN b ON a.col1 = b.col1",
-        "Execution Plan\n" + "LogicalProject(col1=[$0], col3=[$1])\n"
-            + "  LogicalJoin(condition=[=($0, $2)], joinType=[inner])\n"
+    return new Object[][] {
+        new Object[]{"EXPLAIN PLAN INCLUDING ALL ATTRIBUTES AS JSON FOR SELECT col1, col3 FROM a", "{\n"
+            + "  \"rels\": [\n" + "    {\n" + "      \"id\": \"0\",\n" + "      \"relOp\": \"LogicalTableScan\",\n"
+            + "      \"table\": [\n" + "        \"a\"\n" + "      ],\n" + "      \"inputs\": []\n" + "    },\n"
+            + "    {\n" + "      \"id\": \"1\",\n" + "      \"relOp\": \"LogicalProject\",\n" + "      \"fields\": [\n"
+            + "        \"col1\",\n" + "        \"col3\"\n" + "      ],\n" + "      \"exprs\": [\n" + "        {\n"
+            + "          \"input\": 2,\n" + "          \"name\": \"$2\"\n" + "        },\n" + "        {\n"
+            + "          \"input\": 1,\n" + "          \"name\": \"$1\"\n" + "        }\n" + "      ]\n" + "    }\n"
+            + "  ]\n" + "}"},
+        new Object[]{"EXPLAIN PLAN EXCLUDING ATTRIBUTES AS DOT FOR SELECT col1, COUNT(*) FROM a GROUP BY col1",
+            "Execution Plan\n" + "digraph {\n" + "\"LogicalExchange\\n\" -> \"LogicalAggregate\\n\" [label=\"0\"]\n"
+                + "\"LogicalAggregate\\n\" -> \"LogicalExchange\\n\" [label=\"0\"]\n"
+                + "\"LogicalTableScan\\n\" -> \"LogicalAggregate\\n\" [label=\"0\"]\n" + "}\n"},
+        new Object[]{"EXPLAIN PLAN FOR SELECT a.col1, b.col3 FROM a JOIN b ON a.col1 = b.col1", "Execution Plan\n"
+            + "LogicalProject(col1=[$0], col3=[$1])\n" + "  LogicalJoin(condition=[=($0, $2)], joinType=[inner])\n"
             + "    LogicalExchange(distribution=[hash[0]])\n" + "      LogicalProject(col1=[$2])\n"
             + "        LogicalTableScan(table=[[a]])\n" + "    LogicalExchange(distribution=[hash[1]])\n"
-            + "      LogicalProject(col3=[$1], col1=[$2])\n" + "        LogicalTableScan(table=[[b]])\n"
-    },
+            + "      LogicalProject(col3=[$1], col1=[$2])\n" + "        LogicalTableScan(table=[[b]])\n"},
     };
   }
 }


### PR DESCRIPTION
Move unthread safe vars needed by query planning from QueryEnv to PlannerContext.
This includes PlannerImpl, Validator and LogicalPlanner. 
In the future, we should probably have our own planner etc and move only the shared state to PlannerContext.