### PR TITLE
Remove flaky test for RealtimeNonReplicaGroupSegmentAssignmentTest

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupSegmentAssignmentTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.controller.helix.core.assignment.segment;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
@@ -223,17 +222,13 @@ public class RealtimeNonReplicaGroupSegmentAssignmentTest {
       });
     }
 
-    // Relocated segments should be balanced (each instance should have at least 29 segments assigned)
+    // The number of relocated segments should match with the number of the original segments.
     int[] numSegmentsAssignedPerInstance =
         SegmentAssignmentUtils.getNumSegmentsAssignedPerInstance(newAssignment, COMPLETED_INSTANCES);
     assertEquals(numSegmentsAssignedPerInstance.length, NUM_COMPLETED_INSTANCES);
     int expectedTotalNumSegmentsAssigned = (NUM_SEGMENTS - NUM_PARTITIONS + numUploadedSegments) * NUM_REPLICAS;
-    int expectedMinNumSegmentsPerInstance = expectedTotalNumSegmentsAssigned / NUM_COMPLETED_INSTANCES;
     int totalNumSegmentsAssigned = 0;
     for (int numSegmentsAssigned : numSegmentsAssignedPerInstance) {
-      assertTrue(numSegmentsAssigned >= expectedMinNumSegmentsPerInstance,
-          String.format("Expect at least: %d segments assigned per instance, got: %s",
-              expectedMinNumSegmentsPerInstance, Arrays.toString(numSegmentsAssignedPerInstance)));
       totalNumSegmentsAssigned += numSegmentsAssigned;
     }
     assertEquals(totalNumSegmentsAssigned, expectedTotalNumSegmentsAssigned);
@@ -284,6 +279,9 @@ public class RealtimeNonReplicaGroupSegmentAssignmentTest {
     Map<InstancePartitionsType, InstancePartitions> onlyCompletedInstancePartitionMap =
         ImmutableMap.of(InstancePartitionsType.COMPLETED, _instancePartitionsMap.get(InstancePartitionsType.COMPLETED));
     Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
+
+    // CHECKSTYLE:OFF
+    // @formatter:off
     Map<String, List<String>> expectedUploadedSegmentToInstances = ImmutableMap.of(
         "uploadedSegment_0", ImmutableList.of("completedInstance_0", "completedInstance_1", "completedInstance_2"),
         "uploadedSegment_1", ImmutableList.of("completedInstance_3", "completedInstance_4", "completedInstance_5"),


### PR DESCRIPTION
Helix's AutoRebalanceStrategy.computePartitionAssignment() does not guarantee the minimum target number of segments to be assigned for an instance. Due to this, our unit test becomes flaky.

```

java.lang.AssertionError: Expect at least: 29 segments assigned per instance, got: [30, 30, 30, 30, 29, 29, 29, 29, 30, 28] 
Expected :true
Actual   :false
<Click to see difference>


	at org.testng.Assert.fail(Assert.java:93)
	at org.testng.Assert.failNotEquals(Assert.java:512)
	at org.testng.Assert.assertTrue(Assert.java:41)
	at org.apache.pinot.controller.helix.core.assignment.segment.RealtimeNonReplicaGroupSegmentAssignmentTest.testRelocateCompletedSegments(RealtimeNonReplicaGroupSegmentAssignmentTest.java:234)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:108)
	at org.testng.internal.Invoker.invokeMethod(Invoker.java:661)
	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:869)
	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1193)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:126)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:109)
	at org.testng.TestRunner.privateRun(TestRunner.java:744)
	at org.testng.TestRunner.run(TestRunner.java:602)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:380)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:375)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:340)
	at org.testng.SuiteRunner.run(SuiteRunner.java:289)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1301)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1226)
	at org.testng.TestNG.runSuites(TestNG.java:1144)
	at org.testng.TestNG.run(TestNG.java:1115)
	at com.intellij.rt.testng.IDEARemoteTestNG.run(IDEARemoteTestNG.java:66)
	at com.intellij.rt.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:109)
```

#9253  #9297 