### PR TITLE
[multistage][bug-fix] Fix the join condition order different from join table order

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotJoinExchangeNodeInsertRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotJoinExchangeNodeInsertRule.java
@@ -25,6 +25,7 @@ import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.RelDistributions;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.JoinInfo;
 import org.apache.calcite.rel.hint.RelHint;
 import org.apache.calcite.rel.logical.LogicalExchange;
 import org.apache.calcite.rel.logical.LogicalJoin;
@@ -74,10 +75,9 @@ public class PinotJoinExchangeNodeInsertRule extends RelOptRule {
       rightExchange = LogicalExchange.create(rightInput, RelDistributions.BROADCAST_DISTRIBUTED);
     } else { // if (hints.contains(PinotRelationalHints.USE_HASH_DISTRIBUTE)) {
       RexCall joinCondition = (RexCall) join.getCondition();
-      int leftNodeOffset = join.getLeft().getRowType().getFieldCount();
-      int rightNodeOffset = join.getRight().getRowType().getFieldCount();
+      JoinInfo joinInfo = join.analyzeCondition();
       List<List<Integer>> conditions =
-          PlannerUtils.getJoinKeyFromConditions(joinCondition, leftNodeOffset, rightNodeOffset);
+          PlannerUtils.getJoinKeyFromConditions(joinCondition, joinInfo);
       leftExchange = LogicalExchange.create(leftInput, RelDistributions.hash(conditions.get(0)));
       rightExchange = LogicalExchange.create(rightInput, RelDistributions.hash(conditions.get(1)));
     }

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotJoinExchangeNodeInsertRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotJoinExchangeNodeInsertRule.java
@@ -74,12 +74,12 @@ public class PinotJoinExchangeNodeInsertRule extends RelOptRule {
       rightExchange = LogicalExchange.create(rightInput, RelDistributions.BROADCAST_DISTRIBUTED);
     } else { // if (hints.contains(PinotRelationalHints.USE_HASH_DISTRIBUTE)) {
       RexCall joinCondition = (RexCall) join.getCondition();
-      int leftNodeOffset = join.getLeft().getRowType().getFieldNames().size();
-      List<List<Integer>> conditions = PlannerUtils.getJoinKeyFromConditions(joinCondition, leftNodeOffset);
-      leftExchange = LogicalExchange.create(leftInput,
-          RelDistributions.hash(conditions.get(0)));
-      rightExchange = LogicalExchange.create(rightInput,
-          RelDistributions.hash(conditions.get(1)));
+      int leftNodeOffset = join.getLeft().getRowType().getFieldCount();
+      int rightNodeOffset = join.getRight().getRowType().getFieldCount();
+      List<List<Integer>> conditions =
+          PlannerUtils.getJoinKeyFromConditions(joinCondition, leftNodeOffset, rightNodeOffset);
+      leftExchange = LogicalExchange.create(leftInput, RelDistributions.hash(conditions.get(0)));
+      rightExchange = LogicalExchange.create(rightInput, RelDistributions.hash(conditions.get(1)));
     }
 
     RelNode newJoinNode =

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotJoinExchangeNodeInsertRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotJoinExchangeNodeInsertRule.java
@@ -29,9 +29,7 @@ import org.apache.calcite.rel.core.JoinInfo;
 import org.apache.calcite.rel.hint.RelHint;
 import org.apache.calcite.rel.logical.LogicalExchange;
 import org.apache.calcite.rel.logical.LogicalJoin;
-import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.tools.RelBuilderFactory;
-import org.apache.pinot.query.planner.PlannerUtils;
 import org.apache.pinot.query.planner.hints.PinotRelationalHints;
 
 
@@ -74,12 +72,9 @@ public class PinotJoinExchangeNodeInsertRule extends RelOptRule {
       leftExchange = LogicalExchange.create(leftInput, RelDistributions.RANDOM_DISTRIBUTED);
       rightExchange = LogicalExchange.create(rightInput, RelDistributions.BROADCAST_DISTRIBUTED);
     } else { // if (hints.contains(PinotRelationalHints.USE_HASH_DISTRIBUTE)) {
-      RexCall joinCondition = (RexCall) join.getCondition();
       JoinInfo joinInfo = join.analyzeCondition();
-      List<List<Integer>> conditions =
-          PlannerUtils.getJoinKeyFromConditions(joinCondition, joinInfo);
-      leftExchange = LogicalExchange.create(leftInput, RelDistributions.hash(conditions.get(0)));
-      rightExchange = LogicalExchange.create(rightInput, RelDistributions.hash(conditions.get(1)));
+      leftExchange = LogicalExchange.create(leftInput, RelDistributions.hash(joinInfo.leftKeys));
+      rightExchange = LogicalExchange.create(rightInput, RelDistributions.hash(joinInfo.rightKeys));
     }
 
     RelNode newJoinNode =

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/PlannerUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/PlannerUtils.java
@@ -18,16 +18,8 @@
  */
 package org.apache.pinot.query.planner;
 
-import com.google.common.base.Preconditions;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.apache.calcite.plan.RelOptUtil;
 import org.apache.calcite.rel.RelNode;
-import org.apache.calcite.rel.core.JoinInfo;
-import org.apache.calcite.rex.RexCall;
-import org.apache.calcite.rex.RexInputRef;
-import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlExplainFormat;
 import org.apache.calcite.sql.SqlExplainLevel;
 import org.slf4j.Logger;
@@ -42,30 +34,6 @@ public class PlannerUtils {
 
   private PlannerUtils() {
     // do not instantiate.
-  }
-
-  public static List<List<Integer>> getJoinKeyFromConditions(RexCall joinCondition, JoinInfo joinInfo) {
-    List<List<Integer>> joinKeys = joinInfo.keys().stream().collect(Collectors.toCollection(ArrayList::new));
-    switch (joinCondition.getOperator().getKind()) {
-      case EQUALS:
-        RexNode left = joinCondition.getOperands().get(0);
-        RexNode right = joinCondition.getOperands().get(1);
-        Preconditions.checkState(left instanceof RexInputRef, "only reference supported");
-        Preconditions.checkState(right instanceof RexInputRef, "only reference supported");
-        return joinKeys;
-      case AND:
-        List<List<Integer>> predicateColumns = new ArrayList<>(2);
-        predicateColumns.add(new ArrayList<>());
-        predicateColumns.add(new ArrayList<>());
-        for (RexNode operand : joinCondition.getOperands()) {
-          Preconditions.checkState(operand instanceof RexCall);
-          predicateColumns.get(0).addAll(joinKeys.get(0));
-          predicateColumns.get(1).addAll(joinKeys.get(1));
-        }
-        return predicateColumns;
-      default:
-        throw new UnsupportedOperationException("Only equality JOIN conditions are supported.");
-    }
   }
 
   public static boolean isRootStage(int stageId) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToStageConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToStageConverter.java
@@ -104,8 +104,8 @@ public final class RelToStageConverter {
 
   private static StageNode convertLogicalTableScan(LogicalTableScan node, int currentStageId) {
     String tableName = node.getTable().getQualifiedName().get(0);
-    List<String> columnNames = node.getRowType().getFieldList().stream()
-        .map(RelDataTypeField::getName).collect(Collectors.toList());
+    List<String> columnNames =
+        node.getRowType().getFieldList().stream().map(RelDataTypeField::getName).collect(Collectors.toList());
     return new TableScanNode(currentStageId, toDataSchema(node.getRowType()), tableName, columnNames);
   }
 
@@ -115,8 +115,10 @@ public final class RelToStageConverter {
     RexCall joinCondition = (RexCall) node.getCondition();
 
     // Parse out all equality JOIN conditions
-    int leftNodeOffset = node.getLeft().getRowType().getFieldList().size();
-    List<List<Integer>> predicateColumns = PlannerUtils.getJoinKeyFromConditions(joinCondition, leftNodeOffset);
+    int leftNodeOffset = node.getLeft().getRowType().getFieldCount();
+    int rightNodeoffset = node.getRight().getRowType().getFieldCount();
+    List<List<Integer>> predicateColumns =
+        PlannerUtils.getJoinKeyFromConditions(joinCondition, leftNodeOffset, rightNodeoffset);
 
     FieldSelectionKeySelector leftFieldSelectionKeySelector = new FieldSelectionKeySelector(predicateColumns.get(0));
     FieldSelectionKeySelector rightFieldSelectionKeySelector = new FieldSelectionKeySelector(predicateColumns.get(1));

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToStageConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToStageConverter.java
@@ -115,10 +115,8 @@ public final class RelToStageConverter {
     RexCall joinCondition = (RexCall) node.getCondition();
 
     // Parse out all equality JOIN conditions
-    int leftNodeOffset = node.getLeft().getRowType().getFieldCount();
-    int rightNodeoffset = node.getRight().getRowType().getFieldCount();
     List<List<Integer>> predicateColumns =
-        PlannerUtils.getJoinKeyFromConditions(joinCondition, leftNodeOffset, rightNodeoffset);
+        PlannerUtils.getJoinKeyFromConditions(joinCondition, node.analyzeCondition());
 
     FieldSelectionKeySelector leftFieldSelectionKeySelector = new FieldSelectionKeySelector(predicateColumns.get(0));
     FieldSelectionKeySelector rightFieldSelectionKeySelector = new FieldSelectionKeySelector(predicateColumns.get(1));

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
@@ -81,6 +81,8 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
         // of the A JOIN B will have identical value of col3 as table C.col3 has. Since the values are cycling between
         // (1, 42, 1, 42, 1). we will have 9 1s, and 6 42s, total result count will be 9 * 9 + 6 * 6 = 117
         new Object[]{"SELECT * FROM a JOIN b ON a.col1 = b.col1 JOIN c ON a.col3 = c.col3", 117},
+        // Reverse the order of join condition and join table order.
+        new Object[]{"SELECT * FROM a JOIN b ON b.col1 = a.col1 JOIN c ON c.col3 = a.col3", 117},
 
         // Specifically table A has 15 rows (10 on server1 and 5 on server2) and table B has 5 rows (all on server1),
         // thus the final JOIN result will be 15 x 1 = 15.

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
@@ -100,6 +100,8 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
         // Specifically table A has 15 rows (10 on server1 and 5 on server2) and table B has 5 rows (all on server1),
         // thus the final JOIN result will be 15 x 1 = 15.
         new Object[]{"SELECT * FROM a JOIN b on a.col1 = b.col1 AND a.col2 = b.col2", 15},
+        // Reverse the order of join condition and join table order.
+        new Object[]{"SELECT * FROM a JOIN b on b.col1 = a.col1 AND b.col2 = a.col2", 15},
 
         // Specifically table A has 15 rows (10 on server1 and 5 on server2) and table B has 5 rows (all on server1),
         // but only 1 out of 5 rows from table A will be selected out; and all in table B will be selected.


### PR DESCRIPTION
When join condition order is different from join table order, we deduct the column ref wrong. 
This implementation fixes it by taking a look at the join condition ref and deduct the right ref hash code.