### PR TITLE
Fix jdk8 build issue due to missing pom dependency

### DIFF
--- a/pinot-connectors/prestodb-pinot-dependencies/pinot-java-client-jdk8/pom.xml
+++ b/pinot-connectors/prestodb-pinot-dependencies/pinot-java-client-jdk8/pom.xml
@@ -60,6 +60,11 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-common</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
This PR fixes a build failure. 

The following command fails:

```
mvn clean install -DskipTests -Pbin-dist -Pbuild-shaded-jar -Ppresto-driver --no-transfer-progress -Djdk.version=8
```

With error:

```
Error:  Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.0:compile (default-compile) on project pinot-java-client-jdk8: Compilation failure: Compilation failure: 
Error:  /home/runner/work/pinot-elr/pinot-elr/pinot/pinot-connectors/prestodb-pinot-dependencies/pinot-java-client-jdk8/src/main/java/org/apache/pinot/client/utils/ConnectionUtils.java:[28,37] error: package org.apache.pinot.common.config does not exist
Error:  /home/runner/work/pinot-elr/pinot-elr/pinot/pinot-connectors/prestodb-pinot-dependencies/pinot-java-client-jdk8/src/main/java/org/apache/pinot/client/utils/ConnectionUtils.java:[29,36] error: package org.apache.pinot.common.utils does not exist
Error:  /home/runner/work/pinot-elr/pinot-elr/pinot/pinot-connectors/prestodb-pinot-dependencies/pinot-java-client-jdk8/src/main/java/org/apache/pinot/client/utils/ConnectionUtils.java:[52,4] error: cannot find symbol
Error:    symbol:   class TlsConfig
Error:    location: class ConnectionUtils
Error:  /home/runner/work/pinot-elr/pinot-elr/pinot/pinot-connectors/prestodb-pinot-dependencies/pinot-java-client-jdk8/src/main/java/org/apache/pinot/client/utils/ConnectionUtils.java:[52,26] error: cannot find symbol
Error:    symbol:   variable TlsUtils
Error:    location: class ConnectionUtils
Error:  /home/runner/work/pinot-elr/pinot-elr/pinot/pinot-connectors/prestodb-pinot-dependencies/pinot-java-client-jdk8/src/main/java/org/apache/pinot/client/utils/ConnectionUtils.java:[54,4] error: cannot find symbol
Error:    symbol:   variable TlsUtils
Error:    location: class ConnectionUtils
Error:  /home/runner/work/pinot-elr/pinot-elr/pinot/pinot-connectors/prestodb-pinot-dependencies/pinot-java-client-jdk8/src/main/java/org/apache/pinot/client/utils/ConnectionUtils.java:[55,11] error: cannot find symbol
Error:    symbol:   variable TlsUtils
Error:    location: class ConnectionUtils
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException
Error:  
Error:  After correcting the problems, you can resume the build with the command
Error:    mvn <args> -rf :pinot-java-client-jdk8
```

This is failing because a file `ConnectionUtils.java` was added as part of PR https://github.com/apache/pinot/pull/9230 to the `pinot-java-client` which is sym-linked in the `pinot-java-client-jdk8` directory under `pinot-connector`. Compilation was failing because the pom file wasn't updated to add the new dependency on  the `pinot-common` file.

cc @siddharthteotia 