### PR TITLE
Fix pom to use pinot-common-jdk8 for pinot-connector jkd8 java client

### DIFF
--- a/pinot-connectors/prestodb-pinot-dependencies/pinot-java-client-jdk8/pom.xml
+++ b/pinot-connectors/prestodb-pinot-dependencies/pinot-java-client-jdk8/pom.xml
@@ -61,7 +61,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
-      <artifactId>pinot-common</artifactId>
+      <artifactId>pinot-common-jkd8</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
This PR fixes the pinot-common module added as part of PR https://github.com/apache/pinot/pull/9351 to use `pinot-common-jdk8` instead of `pinot-common`.

cc @xiangfu0 @siddharthteotia 