### PR TITLE
Revert "Fix pom to use pinot-common-jdk8 for pinot-connector jkd8 java client"

### DIFF
--- a/pinot-connectors/prestodb-pinot-dependencies/pinot-java-client-jdk8/pom.xml
+++ b/pinot-connectors/prestodb-pinot-dependencies/pinot-java-client-jdk8/pom.xml
@@ -61,7 +61,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
-      <artifactId>pinot-common-jkd8</artifactId>
+      <artifactId>pinot-common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
Reverts apache/pinot#9353

Need to revert due to this error when building locally:

```
[ERROR] Failed to execute goal on project pinot-java-client-jdk8: Could not resolve dependencies for project org.apache.pinot:pinot-java-client-jdk8:jar:0.12.0-SNAPSHOT: Could not find artifact org.apache.pinot:pinot-common-jkd8:jar:0.12.0-SNAPSHOT in apache.snapshots (https://repository.apache.org/snapshots) -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
[ERROR] 
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <args> -rf :pinot-java-client-jdk8
somandal-mn2:pinot somandal$ vim pinot-connectors/p
```

@xiangfu0  (apologies for the back and forth). Any suggestion on how best to resolve this?