### PR TITLE
Handle Invalid timestamps

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
@@ -336,6 +336,30 @@ public class SchemaUtilsTest {
 
     schema = Schema.fromString(
         "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
+            + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\","
+            + "\"format\":\"1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd\",\"granularity\":\"1:DAYS\", \"sampleValue\" : \"19700101\"}]}");
+    checkValidationFails(schema);
+
+    schema = Schema.fromString(
+        "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
+            + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\","
+            + "\"format\":\"1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd\",\"granularity\":\"1:DAYS\", \"sampleValue\" : \"19720101\"}]}");
+    SchemaUtils.validate(schema);
+
+    schema = Schema.fromString(
+        "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
+            + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"LONG\","
+            + "\"format\":\"1:SECONDS:EPOCH\",\"granularity\":\"1:SECONDS\", \"sampleValue\" : 1663170923}]}");
+    SchemaUtils.validate(schema);
+
+    schema = Schema.fromString(
+        "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
+            + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"LONG\","
+            + "\"format\":\"1:MILLISECONDS:EPOCH\",\"granularity\":\"1:MILLISECONDS\", \"sampleValue\" : 1663170923}]}");
+    checkValidationFails(schema);
+
+    schema = Schema.fromString(
+        "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
             + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\",\"format\":\"1:HOURS:EPOCH\","
             + "\"granularity\":\"1:HOURS\"}]}");
     SchemaUtils.validate(schema);

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
@@ -337,13 +337,15 @@ public class SchemaUtilsTest {
     schema = Schema.fromString(
         "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
             + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\","
-            + "\"format\":\"1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd\",\"granularity\":\"1:DAYS\", \"sampleValue\" : \"19700101\"}]}");
+            + "\"format\":\"1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd\",\"granularity\":\"1:DAYS\","
+            + " \"sampleValue\" : \"19700101\"}]}");
     checkValidationFails(schema);
 
     schema = Schema.fromString(
         "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
             + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\","
-            + "\"format\":\"1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd\",\"granularity\":\"1:DAYS\", \"sampleValue\" : \"19720101\"}]}");
+            + "\"format\":\"1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd\",\"granularity\":\"1:DAYS\","
+            + " \"sampleValue\" : \"19720101\"}]}");
     SchemaUtils.validate(schema);
 
     schema = Schema.fromString(
@@ -355,7 +357,8 @@ public class SchemaUtilsTest {
     schema = Schema.fromString(
         "{\"schemaName\":\"testSchema\"," + "\"dimensionFieldSpecs\":[ {\"name\":\"dim1\",\"dataType\":\"STRING\"}],"
             + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"LONG\","
-            + "\"format\":\"1:MILLISECONDS:EPOCH\",\"granularity\":\"1:MILLISECONDS\", \"sampleValue\" : 1663170923}]}");
+            + "\"format\":\"1:MILLISECONDS:EPOCH\",\"granularity\":\"1:MILLISECONDS\","
+            + " \"sampleValue\" : 1663170923}]}");
     checkValidationFails(schema);
 
     schema = Schema.fromString(

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
@@ -201,8 +201,14 @@ public class SchemaUtils {
 
     Object sampleValue = dateTimeFieldSpec.getSampleValue();
     if (sampleValue != null) {
-      long sampleTimestampValue = (sampleValue instanceof String) ? formatSpec.fromFormatToMillis((String) sampleValue)
-          : formatSpec.fromFormatToMillis(String.valueOf(sampleValue));
+      long sampleTimestampValue;
+      try {
+        sampleTimestampValue = formatSpec.fromFormatToMillis(sampleValue.toString());
+      } catch (Exception e) {
+        throw new IllegalArgumentException(
+            String.format("Cannot format provided sample value: %s with provided date time spec: %s", sampleValue,
+                formatSpec));
+      }
       boolean isValidTimestamp = TimeUtils.timeValueInValidRange(sampleTimestampValue);
       Preconditions.checkArgument(isValidTimestamp,
           "Incorrect date time format. "

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
@@ -36,6 +36,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
+import org.apache.pinot.spi.utils.TimeUtils;
 
 
 /**
@@ -196,6 +197,17 @@ public class SchemaUtils {
                 sdfPattern));
         maxIndexes[idx + 1] = Math.max(maxIndexes[idx + 1], maxIndexes[idx]);
       }
+    }
+
+    Object sampleValue = dateTimeFieldSpec.getSampleValue();
+    if (sampleValue != null) {
+      long sampleTimestampValue = (sampleValue instanceof String) ? formatSpec.fromFormatToMillis((String) sampleValue)
+          : formatSpec.fromFormatToMillis(String.valueOf(sampleValue));
+      boolean isValidTimestamp = TimeUtils.timeValueInValidRange(sampleTimestampValue);
+      Preconditions.checkArgument(isValidTimestamp,
+          "Incorrect date time format. "
+              + "Converted sample value %s for date-time field spec is not in valid time-range: %s and %s",
+          sampleTimestampValue, TimeUtils.VALID_MIN_TIME_MILLIS, TimeUtils.VALID_MAX_TIME_MILLIS);
     }
 
     DateTimeGranularitySpec granularitySpec;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFieldSpec.java
@@ -24,8 +24,6 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.utils.EqualityUtils;
-import org.apache.pinot.spi.utils.TimeUtils;
-
 
 @SuppressWarnings("unused")
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -189,13 +187,15 @@ public final class DateTimeFieldSpec extends FieldSpec {
     }
 
     DateTimeFieldSpec that = (DateTimeFieldSpec) o;
-    return EqualityUtils.isEqual(_format, that._format) && EqualityUtils.isEqual(_granularity, that._granularity);
+    return EqualityUtils.isEqual(_format, that._format) && EqualityUtils.isEqual(_granularity, that._granularity)
+        && EqualityUtils.isEqual(_sampleValue, that._sampleValue);
   }
 
   @Override
   public int hashCode() {
     int result = EqualityUtils.hashCodeOf(super.hashCode(), _format);
     result = EqualityUtils.hashCodeOf(result, _granularity);
+    result = EqualityUtils.hashCodeOf(result, _sampleValue);
     return result;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFieldSpec.java
@@ -32,7 +32,7 @@ import org.apache.pinot.spi.utils.TimeUtils;
 public final class DateTimeFieldSpec extends FieldSpec {
   private String _format;
   private String _granularity;
-  private String _sampleValue;
+  private Object _sampleValue;
   private transient DateTimeFormatSpec _formatSpec;
   private transient DateTimeGranularitySpec _granularitySpec;
 
@@ -73,7 +73,7 @@ public final class DateTimeFieldSpec extends FieldSpec {
    *          the granularity will be 1:HOURS
    */
   public DateTimeFieldSpec(String name, DataType dataType, String format, String granularity,
-      @Nullable String sampleValue) {
+      @Nullable Object sampleValue) {
     super(name, dataType, true);
 
     _format = format;
@@ -138,14 +138,6 @@ public final class DateTimeFieldSpec extends FieldSpec {
       _formatSpec = formatSpec;
     }
 
-    if (_sampleValue != null) {
-      long sampleTimestampValue = _formatSpec.fromFormatToMillis(_sampleValue);
-      boolean isValidTimestamp = TimeUtils.isTimestampValid(String.valueOf(sampleTimestampValue));
-      Preconditions.checkState(isValidTimestamp,
-          "Incorrect date time format. "
-              + "Converted sample value {} for date-time field spec is not in valid time-range: {} and {}",
-          sampleTimestampValue, TimeUtils.VALID_MIN_TIME_MILLIS, TimeUtils.VALID_MAX_TIME_MILLIS);
-    }
     return formatSpec;
   }
 
@@ -158,7 +150,7 @@ public final class DateTimeFieldSpec extends FieldSpec {
     _granularity = granularity;
   }
 
-  public String getSampleValue() {
+  public Object getSampleValue() {
     return _sampleValue;
   }
 


### PR DESCRIPTION
* Add support for new `sampleValue` field to check the correct timestamp format during schema creation.