### PR TITLE
Improve segment name check in metadata push

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
@@ -44,6 +44,7 @@ import org.apache.pinot.common.utils.SimpleHttpResponse;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.creator.name.SegmentNameGenerator;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.filesystem.PinotFS;
@@ -237,8 +238,10 @@ public class SegmentPushUtils implements Serializable {
     for (String segmentUriPath : segmentUriToTarPathMap.keySet()) {
       String tarFilePath = segmentUriToTarPathMap.get(segmentUriPath);
       String fileName = new File(tarFilePath).getName();
-      Preconditions.checkArgument(fileName.endsWith(Constants.TAR_GZ_FILE_EXT));
-      String segmentName = fileName.substring(0, fileName.length() - Constants.TAR_GZ_FILE_EXT.length());
+      // segments stored in Pinot deep store do not have .tar.gz extension
+      String segmentName = fileName.endsWith(Constants.TAR_GZ_FILE_EXT)
+          ? fileName.substring(0, fileName.length() - Constants.TAR_GZ_FILE_EXT.length()) : fileName;
+      Preconditions.checkArgument(SegmentNameGenerator.isValidSegmentName(segmentName));
       File segmentMetadataFile = generateSegmentMetadataFile(fileSystem, URI.create(tarFilePath));
       AuthProvider authProvider = AuthProviderUtils.makeAuthProvider(spec.getAuthToken());
       try {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
@@ -44,7 +44,7 @@ import org.apache.pinot.common.utils.SimpleHttpResponse;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.segment.spi.V1Constants;
-import org.apache.pinot.segment.spi.creator.name.SegmentNameGenerator;
+import org.apache.pinot.segment.spi.creator.name.SegmentNameUtils;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.filesystem.PinotFS;
@@ -241,7 +241,7 @@ public class SegmentPushUtils implements Serializable {
       // segments stored in Pinot deep store do not have .tar.gz extension
       String segmentName = fileName.endsWith(Constants.TAR_GZ_FILE_EXT)
           ? fileName.substring(0, fileName.length() - Constants.TAR_GZ_FILE_EXT.length()) : fileName;
-      Preconditions.checkArgument(SegmentNameGenerator.isValidSegmentName(segmentName));
+      SegmentNameUtils.validatePartialOrFullSegmentName(segmentName);
       File segmentMetadataFile = generateSegmentMetadataFile(fileSystem, URI.create(tarFilePath));
       AuthProvider authProvider = AuthProviderUtils.makeAuthProvider(spec.getAuthToken());
       try {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/FixedSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/FixedSegmentNameGenerator.java
@@ -32,8 +32,8 @@ public class FixedSegmentNameGenerator implements SegmentNameGenerator {
   public FixedSegmentNameGenerator(String segmentName) {
     Preconditions.checkArgument(segmentName != null, "Missing segmentName for FixedSegmentNameGenerator");
     Preconditions
-        .checkArgument(isValidSegmentName(segmentName), "Invalid segmentName: %s for FixedSegmentNameGenerator",
-            segmentName);
+        .checkArgument(SegmentNameGenerator.isValidSegmentName(segmentName),
+            "Invalid segmentName: %s for FixedSegmentNameGenerator", segmentName);
     _segmentName = segmentName;
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGenerator.java
@@ -66,13 +66,14 @@ public class NormalizedDateSegmentNameGenerator implements SegmentNameGenerator 
     _segmentNamePrefix = segmentNamePrefix != null ? segmentNamePrefix.trim() : tableName;
     Preconditions
         .checkArgument(_segmentNamePrefix != null, "Missing segmentNamePrefix for NormalizedDateSegmentNameGenerator");
-    Preconditions.checkArgument(isValidSegmentName(_segmentNamePrefix),
+    Preconditions.checkArgument(SegmentNameGenerator.isValidSegmentName(_segmentNamePrefix),
         "Invalid segmentNamePrefix: %s for NormalizedDateSegmentNameGenerator", _segmentNamePrefix);
     _excludeSequenceId = excludeSequenceId;
     _appendPushType = "APPEND".equalsIgnoreCase(pushType);
     _segmentNamePostfix = segmentNamePostfix != null ? segmentNamePostfix.trim() : null;
     _appendUUIDToSegmentName = appendUUIDToSegmentName;
-    Preconditions.checkArgument(_segmentNamePostfix == null || isValidSegmentName(_segmentNamePostfix),
+    Preconditions.checkArgument(_segmentNamePostfix == null
+            || SegmentNameGenerator.isValidSegmentName(_segmentNamePostfix),
         "Invalid segmentNamePostfix: %s for NormalizedDateSegmentNameGenerator", _segmentNamePostfix);
 
     // Include time info for APPEND push type

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGenerator.java
@@ -66,15 +66,14 @@ public class NormalizedDateSegmentNameGenerator implements SegmentNameGenerator 
     _segmentNamePrefix = segmentNamePrefix != null ? segmentNamePrefix.trim() : tableName;
     Preconditions
         .checkArgument(_segmentNamePrefix != null, "Missing segmentNamePrefix for NormalizedDateSegmentNameGenerator");
-    Preconditions.checkArgument(SegmentNameGenerator.isValidSegmentName(_segmentNamePrefix),
-        "Invalid segmentNamePrefix: %s for NormalizedDateSegmentNameGenerator", _segmentNamePrefix);
+    SegmentNameUtils.validatePartialOrFullSegmentName(_segmentNamePrefix);
     _excludeSequenceId = excludeSequenceId;
     _appendPushType = "APPEND".equalsIgnoreCase(pushType);
     _segmentNamePostfix = segmentNamePostfix != null ? segmentNamePostfix.trim() : null;
     _appendUUIDToSegmentName = appendUUIDToSegmentName;
-    Preconditions.checkArgument(_segmentNamePostfix == null
-            || SegmentNameGenerator.isValidSegmentName(_segmentNamePostfix),
-        "Invalid segmentNamePostfix: %s for NormalizedDateSegmentNameGenerator", _segmentNamePostfix);
+    if (_segmentNamePostfix != null) {
+      SegmentNameUtils.validatePartialOrFullSegmentName(_segmentNamePostfix);
+    }
 
     // Include time info for APPEND push type
     if (_appendPushType) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SegmentNameGenerator.java
@@ -37,7 +37,7 @@ public interface SegmentNameGenerator extends Serializable {
    * @param segmentName provide segment name
    * @return true if segmentName is valid.
    */
-  default boolean isValidSegmentName(String segmentName) {
+  static boolean isValidSegmentName(String segmentName) {
     return !INVALID_SEGMENT_NAME_REGEX.matcher(segmentName).matches();
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SegmentNameGenerator.java
@@ -20,7 +20,6 @@ package org.apache.pinot.segment.spi.creator.name;
 
 import com.google.common.base.Joiner;
 import java.io.Serializable;
-import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 
 
@@ -28,18 +27,7 @@ import javax.annotation.Nullable;
  * Interface for segment name generator based on the segment sequence id and time range.
  */
 public interface SegmentNameGenerator extends Serializable {
-  Pattern INVALID_SEGMENT_NAME_REGEX = Pattern.compile(".*[\\\\/:\\*?\"<>|].*");
   Joiner JOINER = Joiner.on('_').skipNulls();
-
-  /**
-   * A handy util to validate if segment name is valid.
-   *
-   * @param segmentName provide segment name
-   * @return true if segmentName is valid.
-   */
-  static boolean isValidSegmentName(String segmentName) {
-    return !INVALID_SEGMENT_NAME_REGEX.matcher(segmentName).matches();
-  }
 
   /**
    * Generates the segment name.

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SegmentNameUtils.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SegmentNameUtils.java
@@ -36,7 +36,7 @@ public class SegmentNameUtils {
    * @param partialOrFullSegmentName provide partial or full segment name
    */
   public static void validatePartialOrFullSegmentName(String partialOrFullSegmentName) {
-    if (!INVALID_SEGMENT_NAME_REGEX.matcher(partialOrFullSegmentName).matches()) {
+    if (INVALID_SEGMENT_NAME_REGEX.matcher(partialOrFullSegmentName).matches()) {
       throw new IllegalArgumentException("Invalid partial or full segment name: " + partialOrFullSegmentName);
     }
   }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SegmentNameUtils.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SegmentNameUtils.java
@@ -18,30 +18,26 @@
  */
 package org.apache.pinot.segment.spi.creator.name;
 
-import com.google.common.base.Preconditions;
-import javax.annotation.Nullable;
+import java.util.regex.Pattern;
 
 
 /**
- * Fixed segment name generator which always returns the fixed segment name.
+ * Utils for segment names.
  */
-@SuppressWarnings("serial")
-public class FixedSegmentNameGenerator implements SegmentNameGenerator {
-  private final String _segmentName;
+public class SegmentNameUtils {
+  private static final Pattern INVALID_SEGMENT_NAME_REGEX = Pattern.compile(".*[\\\\/:\\*?\"<>|].*");
 
-  public FixedSegmentNameGenerator(String segmentName) {
-    Preconditions.checkArgument(segmentName != null, "Missing segmentName for FixedSegmentNameGenerator");
-    SegmentNameUtils.validatePartialOrFullSegmentName(segmentName);
-    _segmentName = segmentName;
+  private SegmentNameUtils() {
   }
 
-  @Override
-  public String generateSegmentName(int sequenceId, @Nullable Object minTimeValue, @Nullable Object maxTimeValue) {
-    return _segmentName;
-  }
-
-  @Override
-  public String toString() {
-    return String.format("FixedSegmentNameGenerator: segmentName=%s", _segmentName);
+  /**
+   * A handy util to validate if segment name is valid.
+   *
+   * @param partialOrFullSegmentName provide partial or full segment name
+   */
+  public static void validatePartialOrFullSegmentName(String partialOrFullSegmentName) {
+    if (!INVALID_SEGMENT_NAME_REGEX.matcher(partialOrFullSegmentName).matches()) {
+      throw new IllegalArgumentException("Invalid partial or full segment name: " + partialOrFullSegmentName);
+    }
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
@@ -48,11 +48,10 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
   public SimpleSegmentNameGenerator(String segmentNamePrefix, @Nullable String segmentNamePostfix,
       boolean appendUUIDToSegmentName) {
     Preconditions.checkArgument(segmentNamePrefix != null, "Missing segmentNamePrefix for SimpleSegmentNameGenerator");
-    Preconditions.checkArgument(SegmentNameGenerator.isValidSegmentName(segmentNamePrefix),
-        "Invalid segmentNamePrefix: %s for SimpleSegmentNameGenerator", segmentNamePrefix);
-    Preconditions.checkArgument(segmentNamePostfix == null
-            || SegmentNameGenerator.isValidSegmentName(segmentNamePostfix),
-        "Invalid segmentNamePostfix: %s for SimpleSegmentNameGenerator", segmentNamePostfix);
+    SegmentNameUtils.validatePartialOrFullSegmentName(segmentNamePrefix);
+    if (segmentNamePostfix != null) {
+      SegmentNameUtils.validatePartialOrFullSegmentName(segmentNamePostfix);
+    }
     _segmentNamePrefix = segmentNamePrefix;
     _segmentNamePostfix = segmentNamePostfix;
     _appendUUIDToSegmentName = appendUUIDToSegmentName;
@@ -60,12 +59,12 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
 
   @Override
   public String generateSegmentName(int sequenceId, @Nullable Object minTimeValue, @Nullable Object maxTimeValue) {
-    Preconditions.checkArgument(minTimeValue == null
-            || SegmentNameGenerator.isValidSegmentName(minTimeValue.toString()),
-        "Invalid minTimeValue: %s for SimpleSegmentNameGenerator", minTimeValue);
-    Preconditions.checkArgument(maxTimeValue == null
-            || SegmentNameGenerator.isValidSegmentName(maxTimeValue.toString()),
-        "Invalid maxTimeValue: %s for SimpleSegmentNameGenerator", maxTimeValue);
+    if (minTimeValue != null) {
+      SegmentNameUtils.validatePartialOrFullSegmentName(minTimeValue.toString());
+    }
+    if (maxTimeValue != null) {
+      SegmentNameUtils.validatePartialOrFullSegmentName(maxTimeValue.toString());
+    }
 
     return JOINER.join(_segmentNamePrefix, minTimeValue, maxTimeValue, _segmentNamePostfix,
         sequenceId >= 0 ? sequenceId : null, _appendUUIDToSegmentName ? UUID.randomUUID() : null);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
@@ -48,9 +48,10 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
   public SimpleSegmentNameGenerator(String segmentNamePrefix, @Nullable String segmentNamePostfix,
       boolean appendUUIDToSegmentName) {
     Preconditions.checkArgument(segmentNamePrefix != null, "Missing segmentNamePrefix for SimpleSegmentNameGenerator");
-    Preconditions.checkArgument(isValidSegmentName(segmentNamePrefix),
+    Preconditions.checkArgument(SegmentNameGenerator.isValidSegmentName(segmentNamePrefix),
         "Invalid segmentNamePrefix: %s for SimpleSegmentNameGenerator", segmentNamePrefix);
-    Preconditions.checkArgument(segmentNamePostfix == null || isValidSegmentName(segmentNamePostfix),
+    Preconditions.checkArgument(segmentNamePostfix == null
+            || SegmentNameGenerator.isValidSegmentName(segmentNamePostfix),
         "Invalid segmentNamePostfix: %s for SimpleSegmentNameGenerator", segmentNamePostfix);
     _segmentNamePrefix = segmentNamePrefix;
     _segmentNamePostfix = segmentNamePostfix;
@@ -59,9 +60,11 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
 
   @Override
   public String generateSegmentName(int sequenceId, @Nullable Object minTimeValue, @Nullable Object maxTimeValue) {
-    Preconditions.checkArgument(minTimeValue == null || isValidSegmentName(minTimeValue.toString()),
+    Preconditions.checkArgument(minTimeValue == null
+            || SegmentNameGenerator.isValidSegmentName(minTimeValue.toString()),
         "Invalid minTimeValue: %s for SimpleSegmentNameGenerator", minTimeValue);
-    Preconditions.checkArgument(maxTimeValue == null || isValidSegmentName(maxTimeValue.toString()),
+    Preconditions.checkArgument(maxTimeValue == null
+            || SegmentNameGenerator.isValidSegmentName(maxTimeValue.toString()),
         "Invalid maxTimeValue: %s for SimpleSegmentNameGenerator", maxTimeValue);
 
     return JOINER.join(_segmentNamePrefix, minTimeValue, maxTimeValue, _segmentNamePostfix,

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/FixedSegmentNameGeneratorTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/FixedSegmentNameGeneratorTest.java
@@ -34,7 +34,7 @@ public class FixedSegmentNameGeneratorTest {
       Assert.fail();
     } catch (IllegalArgumentException e) {
       // Expected
-      assertEquals(e.getMessage(), "Invalid segmentName: seg*01 for FixedSegmentNameGenerator");
+      assertEquals(e.getMessage(), "Invalid partial or full segment name: seg*01");
     }
   }
 }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGeneratorTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGeneratorTest.java
@@ -80,7 +80,7 @@ public class SimpleSegmentNameGeneratorTest {
       Assert.fail();
     } catch (IllegalArgumentException e) {
       // Expected
-      assertEquals(e.getMessage(), "Invalid maxTimeValue: 12|34 for SimpleSegmentNameGenerator");
+      assertEquals(e.getMessage(), "Invalid partial or full segment name: 12|34");
     }
   }
 }


### PR DESCRIPTION
Improve segment name check in metadata push:
1/ we can now push segments stored in Pinot deep store (owned by other tables)
2/ validate the segment name 