### PR TITLE
Add support for gracefully handling the errors while transformations

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -36,6 +36,7 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   DELETE_TABLE_FAILURES("tables", false),
   REALTIME_ROWS_CONSUMED("rows", true),
   INVALID_REALTIME_ROWS_DROPPED("rows", false),
+  INCOMPLETE_REALTIME_ROWS_CONSUMED("rows", false),
   REALTIME_CONSUMPTION_EXCEPTIONS("exceptions", true),
   REALTIME_OFFSET_COMMITS("commits", true),
   REALTIME_OFFSET_COMMIT_EXCEPTIONS("exceptions", false),

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -503,6 +503,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
     PinotMeter realtimeRowsConsumedMeter = null;
     PinotMeter realtimeRowsDroppedMeter = null;
+    PinotMeter realtimeIncompleteRowsConsumedMeter = null;
 
     int indexedMessageCount = 0;
     int streamMessageCount = 0;
@@ -566,6 +567,11 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
           realtimeRowsDroppedMeter =
               _serverMetrics.addMeteredTableValue(_metricKeyName, ServerMeter.INVALID_REALTIME_ROWS_DROPPED,
                   reusedResult.getSkippedRowCount(), realtimeRowsDroppedMeter);
+        }
+        if (reusedResult.getIncompleteRowCount() > 0) {
+          realtimeIncompleteRowsConsumedMeter =
+              _serverMetrics.addMeteredTableValue(_metricKeyName, ServerMeter.INCOMPLETE_REALTIME_ROWS_CONSUMED,
+                  reusedResult.getIncompleteRowCount(), realtimeIncompleteRowsConsumedMeter);
         }
         for (GenericRow transformedRow : reusedResult.getTransformedRows()) {
           try {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -179,11 +179,11 @@ public class ComplexTypeTransformer implements RecordTransformer {
       }
       renamePrefixes(record);
     } catch (Exception e) {
-      if (_continueOnError) {
-        record.putValue(GenericRow.INCOMPLETE_RECORD_KEY, true);
-        LOGGER.debug("Caught exception while transforming complex types for record: {}", record.toString(), e);
-      } else {
+      if (!_continueOnError) {
         throw new RuntimeException("Caught exception while transforming complex types", e);
+      } else {
+        LOGGER.debug("Caught exception while transforming complex types for record: {}", record.toString(), e);
+        record.putValue(GenericRow.INCOMPLETE_RECORD_KEY, true);
       }
     }
     return record;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -30,6 +30,8 @@ import org.apache.pinot.common.function.scalar.JsonFunctions;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -83,6 +85,8 @@ import org.apache.pinot.spi.data.readers.GenericRow;
  *
  */
 public class ComplexTypeTransformer implements RecordTransformer {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ComplexTypeTransformer.class);
+
   public static final String DEFAULT_DELIMITER = ".";
   public static final ComplexTypeConfig.CollectionNotUnnestedToJson DEFAULT_COLLECTION_TO_JSON_MODE =
       ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE;
@@ -90,20 +94,22 @@ public class ComplexTypeTransformer implements RecordTransformer {
   private final String _delimiter;
   private final ComplexTypeConfig.CollectionNotUnnestedToJson _collectionNotUnnestedToJson;
   private final Map<String, String> _prefixesToRename;
+  private final boolean _continueOnError;
 
   public ComplexTypeTransformer(TableConfig tableConfig) {
     this(parseFieldsToUnnest(tableConfig), parseDelimiter(tableConfig),
-            parseCollectionNotUnnestedToJson(tableConfig), parsePrefixesToRename(tableConfig));
+            parseCollectionNotUnnestedToJson(tableConfig), parsePrefixesToRename(tableConfig), tableConfig);
   }
 
   @VisibleForTesting
   ComplexTypeTransformer(List<String> fieldsToUnnest, String delimiter) {
-    this(fieldsToUnnest, delimiter, DEFAULT_COLLECTION_TO_JSON_MODE, Collections.emptyMap());
+    this(fieldsToUnnest, delimiter, DEFAULT_COLLECTION_TO_JSON_MODE, Collections.emptyMap(), null);
   }
 
   @VisibleForTesting
   ComplexTypeTransformer(List<String> fieldsToUnnest, String delimiter,
-      ComplexTypeConfig.CollectionNotUnnestedToJson collectionNotUnnestedToJson, Map<String, String> prefixesToRename) {
+      ComplexTypeConfig.CollectionNotUnnestedToJson collectionNotUnnestedToJson, Map<String, String> prefixesToRename,
+      TableConfig tableConfig) {
     _fieldsToUnnest = new ArrayList<>(fieldsToUnnest);
     _delimiter = delimiter;
     _collectionNotUnnestedToJson = collectionNotUnnestedToJson;
@@ -111,6 +117,9 @@ public class ComplexTypeTransformer implements RecordTransformer {
     // (e.g. foo) is unnested before the child collection (e.g. foo.bar)
     Collections.sort(_fieldsToUnnest);
     _prefixesToRename = prefixesToRename;
+    _continueOnError =
+        tableConfig != null && tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig()
+            .isContinueOnError();
   }
 
   private static List<String> parseFieldsToUnnest(TableConfig tableConfig) {
@@ -163,11 +172,20 @@ public class ComplexTypeTransformer implements RecordTransformer {
 
   @Override
   public GenericRow transform(GenericRow record) {
-    flattenMap(record, new ArrayList<>(record.getFieldToValueMap().keySet()));
-    for (String collection : _fieldsToUnnest) {
-      unnestCollection(record, collection);
+    try {
+      flattenMap(record, new ArrayList<>(record.getFieldToValueMap().keySet()));
+      for (String collection : _fieldsToUnnest) {
+        unnestCollection(record, collection);
+      }
+      renamePrefixes(record);
+    } catch (Exception e) {
+      if (_continueOnError) {
+        record.putValue(GenericRow.INCOMPLETE_RECORD_KEY, true);
+        LOGGER.debug("Caught exception while transforming complex types for record: {}", record.toString(), e);
+      } else {
+        throw new RuntimeException("Caught exception while transforming complex types", e);
+      }
     }
-    renamePrefixes(record);
     return record;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformer.java
@@ -147,6 +147,7 @@ public class DataTypeTransformer implements RecordTransformer {
         } else {
           LOGGER.debug("Caught exception while transforming data type for column: {}", column, e);
           record.putValue(column, null);
+          record.putValue(GenericRow.INCOMPLETE_RECORD_KEY, true);
         }
       }
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
@@ -35,6 +35,8 @@ import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -43,6 +45,7 @@ import org.apache.pinot.spi.data.readers.GenericRow;
  * regular column for other record transformers.
  */
 public class ExpressionTransformer implements RecordTransformer {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ExpressionTransformer.class);
 
   @VisibleForTesting
   final LinkedHashMap<String, FunctionEvaluator> _expressionEvaluators = new LinkedHashMap<>();
@@ -127,15 +130,15 @@ public class ExpressionTransformer implements RecordTransformer {
       // Skip transformation if column value already exist.
       // NOTE: column value might already exist for OFFLINE data
       if (record.getValue(column) == null) {
-        if (_continueOnError) {
-          try {
-            record.putValue(column, transformFunctionEvaluator.evaluate(record));
-          } catch (Exception e) {
-            record.putValue(column, null);
+        try {
+          record.putValue(column, transformFunctionEvaluator.evaluate(record));
+        } catch (Exception e) {
+          if (!_continueOnError) {
+            throw new RuntimeException("Caught exception while evaluation transform function for column: " + column, e);
+          } else {
+            LOGGER.debug("Caught exception while evaluation transform function for column: {}", column, e);
             record.putValue(GenericRow.INCOMPLETE_RECORD_KEY, true);
           }
-        } else {
-          record.putValue(column, transformFunctionEvaluator.evaluate(record));
         }
       }
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
@@ -132,6 +132,7 @@ public class ExpressionTransformer implements RecordTransformer {
             record.putValue(column, transformFunctionEvaluator.evaluate(record));
           } catch (Exception e) {
             record.putValue(column, null);
+            record.putValue(GenericRow.INCOMPLETE_RECORD_KEY, true);
           }
         } else {
           record.putValue(column, transformFunctionEvaluator.evaluate(record));

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/FilterTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/FilterTransformer.java
@@ -22,6 +22,8 @@ import org.apache.pinot.segment.local.function.FunctionEvaluator;
 import org.apache.pinot.segment.local.function.FunctionEvaluatorFactory;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -29,24 +31,41 @@ import org.apache.pinot.spi.data.readers.GenericRow;
  * If record should be skipped, puts a special key in the record.
  */
 public class FilterTransformer implements RecordTransformer {
+  private static final Logger LOGGER = LoggerFactory.getLogger(FilterTransformer.class);
 
+  private String _filterFunction;
   private final FunctionEvaluator _evaluator;
+  private final boolean _continueOnError;
 
   public FilterTransformer(TableConfig tableConfig) {
-    String filterFunction = null;
+    _filterFunction = null;
+    _continueOnError = tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().isContinueOnError();
+
     if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getFilterConfig() != null) {
-      filterFunction = tableConfig.getIngestionConfig().getFilterConfig().getFilterFunction();
+      _filterFunction = tableConfig.getIngestionConfig().getFilterConfig().getFilterFunction();
     }
-    _evaluator = (filterFunction != null) ? FunctionEvaluatorFactory.getExpressionEvaluator(filterFunction) : null;
+    _evaluator = (_filterFunction != null) ? FunctionEvaluatorFactory.getExpressionEvaluator(_filterFunction) : null;
   }
 
   @Override
   public GenericRow transform(GenericRow record) {
     if (_evaluator != null) {
-      Object result = _evaluator.evaluate(record);
-      if (Boolean.TRUE.equals(result)) {
-        record.putValue(GenericRow.SKIP_RECORD_KEY, true);
-      }
+        try {
+          Object result = _evaluator.evaluate(record);
+          if (Boolean.TRUE.equals(result)) {
+            record.putValue(GenericRow.SKIP_RECORD_KEY, true);
+          }
+        } catch (Exception e) {
+          if (_continueOnError) {
+            record.putValue(GenericRow.INCOMPLETE_RECORD_KEY, true);
+            LOGGER.debug("Caught exception while executing filter function: {} for record: {}", _filterFunction,
+                record.toString(), e);
+          } else {
+            throw new RuntimeException(
+                String.format("Caught exception while executing filter function: %s for record: %s", _filterFunction,
+                    record.toString()), e);
+          }
+        }
     }
     return record;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/FilterTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/FilterTransformer.java
@@ -50,22 +50,22 @@ public class FilterTransformer implements RecordTransformer {
   @Override
   public GenericRow transform(GenericRow record) {
     if (_evaluator != null) {
-        try {
-          Object result = _evaluator.evaluate(record);
-          if (Boolean.TRUE.equals(result)) {
-            record.putValue(GenericRow.SKIP_RECORD_KEY, true);
-          }
-        } catch (Exception e) {
-          if (_continueOnError) {
-            record.putValue(GenericRow.INCOMPLETE_RECORD_KEY, true);
-            LOGGER.debug("Caught exception while executing filter function: {} for record: {}", _filterFunction,
-                record.toString(), e);
-          } else {
-            throw new RuntimeException(
-                String.format("Caught exception while executing filter function: %s for record: %s", _filterFunction,
-                    record.toString()), e);
-          }
+      try {
+        Object result = _evaluator.evaluate(record);
+        if (Boolean.TRUE.equals(result)) {
+          record.putValue(GenericRow.SKIP_RECORD_KEY, true);
         }
+      } catch (Exception e) {
+        if (!_continueOnError) {
+          throw new RuntimeException(
+              String.format("Caught exception while executing filter function: %s for record: %s", _filterFunction,
+                  record.toString()), e);
+        } else {
+          LOGGER.debug("Caught exception while executing filter function: {} for record: {}", _filterFunction,
+              record.toString(), e);
+          record.putValue(GenericRow.INCOMPLETE_RECORD_KEY, true);
+        }
+      }
     }
     return record;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/TransformPipeline.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/TransformPipeline.java
@@ -97,6 +97,9 @@ public class TransformPipeline {
     GenericRow transformedRow = _recordTransformer.transform(plainRow);
     if (transformedRow != null && IngestionUtils.shouldIngestRow(transformedRow)) {
       reusedResult.addTransformedRows(transformedRow);
+      if (Boolean.TRUE.equals(transformedRow.getValue(GenericRow.INCOMPLETE_RECORD_KEY))) {
+        reusedResult.incIncompleteRowCount();
+      }
     } else {
       reusedResult.incSkippedRowCount();
     }
@@ -108,6 +111,7 @@ public class TransformPipeline {
   public static class Result {
     private final List<GenericRow> _transformedRows = new ArrayList<>();
     private int _skippedRowCount = 0;
+    private int _incompleteRowCount = 0;
 
     public List<GenericRow> getTransformedRows() {
       return _transformedRows;
@@ -115,6 +119,10 @@ public class TransformPipeline {
 
     public int getSkippedRowCount() {
       return _skippedRowCount;
+    }
+
+    public int getIncompleteRowCount() {
+      return _incompleteRowCount;
     }
 
     public void addTransformedRows(GenericRow row) {
@@ -125,8 +133,13 @@ public class TransformPipeline {
       _skippedRowCount++;
     }
 
+    public void incIncompleteRowCount() {
+      _incompleteRowCount++;
+    }
+
     public void reset() {
       _skippedRowCount = 0;
+      _incompleteRowCount = 0;
       _transformedRows.clear();
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -94,6 +94,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
   private long _totalRecordReadTime = 0;
   private long _totalIndexTime = 0;
   private long _totalStatsCollectorTime = 0;
+  private boolean _continueOnError;
 
   @Override
   public void init(SegmentGeneratorConfig config)
@@ -165,6 +166,8 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
     _config = config;
     _recordReader = dataSource.getRecordReader();
     _dataSchema = config.getSchema();
+    _continueOnError = config.isContinueOnError();
+
     if (config.isFailOnEmptySegment()) {
       Preconditions.checkState(_recordReader.hasNext(), "No record in data source");
     }
@@ -209,6 +212,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
     LOGGER.info("Finished building StatsCollector!");
     LOGGER.info("Collected stats for {} documents", _totalDocs);
 
+    int incompleteRowsFound = 0;
     try {
       // Initialize the index creation using the per-column statistics information
       // TODO: _indexCreationInfoMap holds the reference to all unique values on heap (ColumnIndexCreationInfo ->
@@ -222,20 +226,29 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
       TransformPipeline.Result reusedResult = new TransformPipeline.Result();
       while (_recordReader.hasNext()) {
         long recordReadStartTime = System.currentTimeMillis();
-        long recordReadStopTime;
+        long recordReadStopTime = System.currentTimeMillis();
         long indexStopTime;
         reuse.clear();
-        GenericRow decodedRow = _recordReader.next(reuse);
-        recordReadStartTime = System.currentTimeMillis();
-        _transformPipeline.processRow(decodedRow, reusedResult);
-        recordReadStopTime = System.currentTimeMillis();
-        _totalRecordReadTime += (recordReadStopTime - recordReadStartTime);
+        try {
+          GenericRow decodedRow = _recordReader.next(reuse);
+          recordReadStartTime = System.currentTimeMillis();
+          _transformPipeline.processRow(decodedRow, reusedResult);
+          recordReadStopTime = System.currentTimeMillis();
+          _totalRecordReadTime += (recordReadStopTime - recordReadStartTime);
+        } catch (Exception e) {
+          if (_continueOnError) {
+            incompleteRowsFound++;
+            LOGGER.debug("Error occurred while reading row during indexing", e);
+            continue;
+          }
+        }
 
         for (GenericRow row : reusedResult.getTransformedRows()) {
           _indexCreator.indexRow(row);
         }
         indexStopTime = System.currentTimeMillis();
         _totalIndexTime += (indexStopTime - recordReadStopTime);
+        incompleteRowsFound += reusedResult.getIncompleteRowCount();
       }
     } catch (Exception e) {
       _indexCreator.close();
@@ -243,6 +256,12 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
     } finally {
       _recordReader.close();
     }
+
+    if (incompleteRowsFound > 0) {
+      LOGGER.warn("Incomplete data found for {} records. This can be due to error during reader or transformations",
+          incompleteRowsFound);
+    }
+
     LOGGER.info("Finished records indexing in IndexCreator!");
 
     handlePostCreation();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -236,7 +236,9 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
           recordReadStopTime = System.currentTimeMillis();
           _totalRecordReadTime += (recordReadStopTime - recordReadStartTime);
         } catch (Exception e) {
-          if (_continueOnError) {
+          if (!_continueOnError) {
+            throw new RuntimeException("Error occurred while reading row during indexing", e);
+          } else {
             incompleteRowsFound++;
             LOGGER.debug("Error occurred while reading row during indexing", e);
             continue;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
@@ -354,7 +354,7 @@ public class ComplexTypeTransformerTest {
     //   "array":"[1,2]"
     // }
     transformer = new ComplexTypeTransformer(Arrays.asList(), ".",
-            ComplexTypeConfig.CollectionNotUnnestedToJson.ALL, new HashMap<>());
+            ComplexTypeConfig.CollectionNotUnnestedToJson.ALL, new HashMap<>(), null);
     genericRow = new GenericRow();
     array = new Object[]{1, 2};
     genericRow.putValue("array", array);
@@ -400,7 +400,7 @@ public class ComplexTypeTransformerTest {
     map.put("array1", array1);
     genericRow.putValue("t", map);
     transformer = new ComplexTypeTransformer(Arrays.asList(), ".",
-            ComplexTypeConfig.CollectionNotUnnestedToJson.NONE, new HashMap<>());
+            ComplexTypeConfig.CollectionNotUnnestedToJson.NONE, new HashMap<>(), null);
     transformer.transform(genericRow);
     Assert.assertTrue(ComplexTypeTransformer.isNonPrimitiveArray(genericRow.getValue("t.array1")));
   }
@@ -411,7 +411,7 @@ public class ComplexTypeTransformerTest {
     prefixesToRename.put("map1.", "");
     prefixesToRename.put("map2", "test");
     ComplexTypeTransformer transformer = new ComplexTypeTransformer(new ArrayList<>(), ".",
-            DEFAULT_COLLECTION_TO_JSON_MODE, prefixesToRename);
+            DEFAULT_COLLECTION_TO_JSON_MODE, prefixesToRename, null);
 
     GenericRow genericRow = new GenericRow();
     genericRow.putValue("a", 1L);
@@ -426,7 +426,7 @@ public class ComplexTypeTransformerTest {
     prefixesToRename = new HashMap<>();
     prefixesToRename.put("test.", "");
     transformer = new ComplexTypeTransformer(new ArrayList<>(), ".",
-            DEFAULT_COLLECTION_TO_JSON_MODE, prefixesToRename);
+            DEFAULT_COLLECTION_TO_JSON_MODE, prefixesToRename, null);
     genericRow = new GenericRow();
     genericRow.putValue("a", 1L);
     genericRow.putValue("test.a", 2L);
@@ -441,7 +441,7 @@ public class ComplexTypeTransformerTest {
     prefixesToRename = new HashMap<>();
     prefixesToRename.put("test", "");
     transformer = new ComplexTypeTransformer(new ArrayList<>(), ".",
-            DEFAULT_COLLECTION_TO_JSON_MODE, prefixesToRename);
+            DEFAULT_COLLECTION_TO_JSON_MODE, prefixesToRename, null);
     genericRow = new GenericRow();
     genericRow.putValue("a", 1L);
     genericRow.putValue("test", 2L);
@@ -455,7 +455,7 @@ public class ComplexTypeTransformerTest {
     // case where nothing gets renamed
     prefixesToRename = new HashMap<>();
     transformer = new ComplexTypeTransformer(new ArrayList<>(), ".",
-            DEFAULT_COLLECTION_TO_JSON_MODE, prefixesToRename);
+            DEFAULT_COLLECTION_TO_JSON_MODE, prefixesToRename, null);
     genericRow = new GenericRow();
     genericRow.putValue("a", 1L);
     genericRow.putValue("test", 2L);
@@ -470,7 +470,7 @@ public class ComplexTypeTransformerTest {
     prefixesToRename.put("map1.", "");
     prefixesToRename.put("map2", "test");
     ComplexTypeTransformer transformer = new ComplexTypeTransformer(new ArrayList<>(), ".",
-            DEFAULT_COLLECTION_TO_JSON_MODE, prefixesToRename);
+            DEFAULT_COLLECTION_TO_JSON_MODE, prefixesToRename, null);
 
     // test flatten root-level tuples
     GenericRow genericRow = new GenericRow();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformerTest.java
@@ -365,7 +365,7 @@ public class ExpressionTransformerTest {
       expressionTransformer.transform(genericRow);
       Assert.fail();
     } catch (Exception e) {
-      Assert.assertEquals(e.getMessage(), "Caught exception while executing function: plus(x,'10')");
+      Assert.assertEquals(e.getCause().getMessage(), "Caught exception while executing function: plus(x,'10')");
     }
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
@@ -69,6 +69,12 @@ public class GenericRow implements Serializable {
    */
   public static final String SKIP_RECORD_KEY = "$SKIP_RECORD_KEY$";
 
+  /**
+   * This key is used by transformers to indicate some error might have occurred while doing transform on a column
+   * and a default/null value has been put in place of actual value. Only used when continueOnError is set to true
+   */
+  public static final String INCOMPLETE_RECORD_KEY = "$INCOMPLETE_RECORD_KEY$";
+
   private final Map<String, Object> _fieldToValueMap = new HashMap<>();
   private final Set<String> _nullValueFields = new HashSet<>();
 


### PR DESCRIPTION
Add support for honouring `continueOnError` during 
* complexTypeTransform
* filterTransform
* recordReader


Also, adds support for keeping track of such records using `incompleteRecordCount`