### PR TITLE
[Bugfix] schema update bug fix

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
@@ -88,7 +88,7 @@ public class HelixBrokerStarterTest extends ControllerTest {
 
     Schema schema = new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME)
         .addDateTime(TIME_COLUMN_NAME, FieldSpec.DataType.INT, "EPOCH|DAYS", "1:DAYS").build();
-    _helixResourceManager.addSchema(schema, true);
+    _helixResourceManager.addSchema(schema, true, false);
     TableConfig offlineTableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setTimeColumnName(TIME_COLUMN_NAME)
             .setTimeType(TimeUnit.DAYS.name()).build();

--- a/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/data/SchemaTest.java
@@ -401,7 +401,7 @@ public class SchemaTest {
         .addMetric("metric", FieldSpec.DataType.INT).addMetric("metricWithDefault", FieldSpec.DataType.INT, 5)
         .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.HOURS, "time"), null)
         .addDateTime("dateTime", FieldSpec.DataType.LONG, "1:HOURS:EPOCH", "1:HOURS").build();
-    Assert.assertFalse(schema3.isBackwardCompatibleWith(oldSchema));
+    Assert.assertTrue(schema3.isBackwardCompatibleWith(oldSchema));
 
     // change datetime column
     Schema schema4 = new Schema.SchemaBuilder().addSingleValueDimension("svDimension", FieldSpec.DataType.INT)
@@ -411,7 +411,7 @@ public class SchemaTest {
         .addMetric("metric", FieldSpec.DataType.INT).addMetric("metricWithDefault", FieldSpec.DataType.INT, 5)
         .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.DAYS, "time"), null)
         .addDateTime("dateTime", FieldSpec.DataType.LONG, "2:HOURS:EPOCH", "1:HOURS").build();  // timeUnit 1 -> 2
-    Assert.assertFalse(schema4.isBackwardCompatibleWith(oldSchema));
+    Assert.assertTrue(schema4.isBackwardCompatibleWith(oldSchema));
 
     // change default value
     Schema schema5 = new Schema.SchemaBuilder().addSingleValueDimension("svDimension", FieldSpec.DataType.INT)
@@ -421,7 +421,7 @@ public class SchemaTest {
         .addMetric("metric", FieldSpec.DataType.INT).addMetric("metricWithDefault", FieldSpec.DataType.INT, 5)
         .addTime(new TimeGranularitySpec(FieldSpec.DataType.LONG, TimeUnit.DAYS, "time"), null)
         .addDateTime("dateTime", FieldSpec.DataType.LONG, "1:HOURS:EPOCH", "1:HOURS").build();
-    Assert.assertFalse(schema5.isBackwardCompatibleWith(oldSchema));
+    Assert.assertTrue(schema5.isBackwardCompatibleWith(oldSchema));
 
     // add a new column
     Schema schema6 = new Schema.SchemaBuilder().addSingleValueDimension("svDimension", FieldSpec.DataType.INT)
@@ -464,12 +464,12 @@ public class SchemaTest {
     Assert.assertTrue(newSchema.isBackwardCompatibleWith(oldSchema));
     Assert.assertEquals(newSchema, oldSchema);
 
-    // STRING with default to BOOLEAN without default - incompatible
+    // STRING with default to BOOLEAN without default - backward compatible change
     newSchema = new Schema.SchemaBuilder().addSingleValueDimension("svInt", FieldSpec.DataType.INT)
         .addSingleValueDimension("svString", FieldSpec.DataType.STRING)
         .addSingleValueDimension("svStringWithDefault", FieldSpec.DataType.BOOLEAN).build();
     newSchema.updateBooleanFieldsIfNeeded(oldSchema);
-    Assert.assertFalse(newSchema.isBackwardCompatibleWith(oldSchema));
+    Assert.assertTrue(newSchema.isBackwardCompatibleWith(oldSchema));
 
     // New added BOOLEAN - compatible
     newSchema = new Schema.SchemaBuilder().addSingleValueDimension("svInt", FieldSpec.DataType.INT)

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
@@ -213,7 +213,11 @@ public class PinotSchemaRestletResource {
   @ManualAuthorization // performed after parsing schema
   public ConfigSuccessResponse addSchema(
       @ApiParam(value = "Whether to override the schema if the schema exists") @DefaultValue("true")
-      @QueryParam("override") boolean override, FormDataMultiPart multiPart, @Context HttpHeaders httpHeaders,
+      @QueryParam("override") boolean override,
+      @ApiParam(value = "Whether to force overriding the schema if the schema exists") @DefaultValue("false")
+      @QueryParam("force") boolean force,
+      FormDataMultiPart multiPart,
+      @Context HttpHeaders httpHeaders,
       @Context Request request) {
     Pair<Schema, Map<String, Object>> schemaAndUnrecognizedProps =
         getSchemaAndUnrecognizedPropertiesFromMultiPart(multiPart);
@@ -222,7 +226,7 @@ public class PinotSchemaRestletResource {
     validateSchemaName(schema.getSchemaName());
     AccessControlUtils.validatePermission(schema.getSchemaName(), AccessType.CREATE, httpHeaders, endpointUrl,
         _accessControlFactory.create());
-    SuccessResponse successResponse = addSchema(schema, override);
+    SuccessResponse successResponse = addSchema(schema, override, force);
     return new ConfigSuccessResponse(successResponse.getStatus(), schemaAndUnrecognizedProps.getRight());
   }
 
@@ -240,7 +244,11 @@ public class PinotSchemaRestletResource {
   @ManualAuthorization // performed after parsing schema
   public ConfigSuccessResponse addSchema(
       @ApiParam(value = "Whether to override the schema if the schema exists") @DefaultValue("true")
-      @QueryParam("override") boolean override, String schemaJsonString, @Context HttpHeaders httpHeaders,
+      @QueryParam("override") boolean override,
+      @ApiParam(value = "Whether to force overriding the schema if the schema exists") @DefaultValue("false")
+      @QueryParam("force") boolean force,
+      String schemaJsonString,
+      @Context HttpHeaders httpHeaders,
       @Context Request request) {
     Pair<Schema, Map<String, Object>> schemaAndUnrecognizedProperties = null;
     try {
@@ -255,7 +263,7 @@ public class PinotSchemaRestletResource {
     validateSchemaName(schema.getSchemaName());
     AccessControlUtils.validatePermission(schema.getSchemaName(), AccessType.CREATE, httpHeaders, endpointUrl,
         _accessControlFactory.create());
-    SuccessResponse successResponse = addSchema(schema, override);
+    SuccessResponse successResponse = addSchema(schema, override, force);
     return new ConfigSuccessResponse(successResponse.getStatus(), schemaAndUnrecognizedProperties.getRight());
   }
 
@@ -344,13 +352,14 @@ public class PinotSchemaRestletResource {
    * Internal method to add schema
    * @param schema  schema
    * @param override  set to true to override the existing schema with the same name
+   * @param force set to true to skip all rules and force to override the existing schema with the same name
    */
-  private SuccessResponse addSchema(Schema schema, boolean override) {
+  private SuccessResponse addSchema(Schema schema, boolean override, boolean force) {
     String schemaName = schema.getSchemaName();
     validateSchemaInternal(schema);
 
     try {
-      _pinotHelixResourceManager.addSchema(schema, override);
+      _pinotHelixResourceManager.addSchema(schema, override, force);
       // Best effort notification. If controller fails at this point, no notification is given.
       LOGGER.info("Notifying metadata event for adding new schema {}", schemaName);
       _metadataEventNotifierFactory.create().notifyOnSchemaEvents(schema, SchemaEventType.CREATE);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -212,7 +212,7 @@ public class TableConfigsRestletResource {
       }
 
       try {
-        _pinotHelixResourceManager.addSchema(schema, false);
+        _pinotHelixResourceManager.addSchema(schema, false, false);
         LOGGER.info("Added schema: {}", schema.getSchemaName());
         if (offlineTableConfig != null) {
           _pinotHelixResourceManager.addTable(offlineTableConfig);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1311,16 +1311,15 @@ public class PinotHelixResourceManager {
       LOGGER.info("New schema: {} is the same as the existing schema, not updating it", schemaName);
       return;
     }
-    if (force) {
-      ZKMetadataProvider.setSchema(_propertyStore, schema);
-      LOGGER.info(
-              "[WARNING] updated schema: {} with force mode = true, it could break the existing schema", schemaName);
-      return;
-    }
-    if (!schema.isBackwardCompatibleWith(oldSchema)) {
-      // TODO: Add the reason of the incompatibility
-      throw new SchemaBackwardIncompatibleException(
-          String.format("New schema: %s is not backward-compatible with the existing schema", schemaName));
+    boolean isBackwardCompatible = schema.isBackwardCompatibleWith(oldSchema);
+    if (!isBackwardCompatible) {
+      if (force) {
+        LOGGER.warn("Force updated schema: {} which is backward incompatible with the existing schema", oldSchema);
+      } else {
+        // TODO: Add the reason of the incompatibility
+        throw new SchemaBackwardIncompatibleException(
+                String.format("New schema: %s is not backward-compatible with the existing schema", schemaName));
+      }
     }
     ZKMetadataProvider.setSchema(_propertyStore, schema);
     LOGGER.info("Updated schema: {}", schemaName);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotIngestionRestletResourceStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotIngestionRestletResourceStatelessTest.java
@@ -69,7 +69,7 @@ public class PinotIngestionRestletResourceStatelessTest extends ControllerTest {
     Schema schema =
         new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("breed", FieldSpec.DataType.STRING)
             .addSingleValueDimension("name", FieldSpec.DataType.STRING).build();
-    _helixResourceManager.addSchema(schema, true);
+    _helixResourceManager.addSchema(schema, true, false);
     _helixResourceManager.addTable(tableConfig);
 
     // Create a file with few records

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceAssignmentRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceAssignmentRestletResourceTest.java
@@ -77,7 +77,7 @@ public class PinotInstanceAssignmentRestletResourceTest {
     Schema schema = new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME)
         .addDateTime(TIME_COLUMN_NAME, DataType.INT, "1:DAYS:EPOCH", "1:DAYS")
         .build();
-    TEST_INSTANCE.getHelixResourceManager().addSchema(schema, true);
+    TEST_INSTANCE.getHelixResourceManager().addSchema(schema, true, false);
     TableConfig offlineTableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
         .setBrokerTenant(BROKER_TENANT_NAME)
         .setServerTenant(SERVER_TENANT_NAME)

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSchemaRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSchemaRestletResourceTest.java
@@ -120,20 +120,40 @@ public class PinotSchemaRestletResourceTest {
     newColumnFieldSpec.setDataType(DataType.BOOLEAN);
 
     // Update the schema with addSchema api and override on
-    resp = ControllerTest.sendMultipartPostRequest(addSchemaUrl, schema.toSingleLineJsonString());
+    resp = ControllerTest.sendMultipartPutRequest(addSchemaUrl, schema.toSingleLineJsonString());
+    Assert.assertEquals(resp.getStatusCode(), 400);
+
+    // Update the schema with addSchema api and override on, force on
+    resp = ControllerTest.sendMultipartPutRequest(addSchemaUrl + "?force=true", schema.toSingleLineJsonString());
     Assert.assertEquals(resp.getStatusCode(), 200);
 
-    // Change another column data type from STRING to BOOLEAN
-    newColumnFieldSpec2.setDataType(DataType.BOOLEAN);
+    // Change another column max length from default 512 to 2000
+    newColumnFieldSpec2.setMaxLength(2000);
+    // Change another column default null value from default "null" to "0"
+    newColumnFieldSpec2.setDefaultNullValue("0");
 
-    // Update the schema with updateSchema api
+    // Update the schema with addSchema api and override on
+    resp = ControllerTest.sendMultipartPutRequest(addSchemaUrl, schema.toSingleLineJsonString());
+    Assert.assertEquals(resp.getStatusCode(), 200);
+
+    // Get the schema and verify the default null value and max length have been changed
+    remoteSchema = Schema.fromString(ControllerTest.sendGetRequest(getSchemaUrl));
+    Assert.assertEquals(remoteSchema.getFieldSpecFor(newColumnFieldSpec.getName()).getMaxLength(), 2000);
+    Assert.assertEquals(remoteSchema.getFieldSpecFor(newColumnFieldSpec2.getName()).getDefaultNullValue(), "0");
+
+    // Change another column max length from 1000
+    newColumnFieldSpec2.setMaxLength(1000);
+    // Change another column default null value from default "null" to "1"
+    newColumnFieldSpec2.setDefaultNullValue("1");
+
+    // Update the schema with updateSchema api and override on
     resp = ControllerTest.sendMultipartPutRequest(updateSchemaUrl, schema.toSingleLineJsonString());
     Assert.assertEquals(resp.getStatusCode(), 200);
 
-    // Get the schema and verify the data types are not changed
+    // Get the schema and verify the default null value and max length have been changed
     remoteSchema = Schema.fromString(ControllerTest.sendGetRequest(getSchemaUrl));
-    Assert.assertEquals(remoteSchema.getFieldSpecFor(newColumnFieldSpec.getName()).getDataType(), DataType.STRING);
-    Assert.assertEquals(remoteSchema.getFieldSpecFor(newColumnFieldSpec2.getName()).getDataType(), DataType.STRING);
+    Assert.assertEquals(remoteSchema.getFieldSpecFor(newColumnFieldSpec.getName()).getMaxLength(), 1000);
+    Assert.assertEquals(remoteSchema.getFieldSpecFor(newColumnFieldSpec2.getName()).getDefaultNullValue(), "1");
 
     // Add a new BOOLEAN column
     DimensionFieldSpec newColumnFieldSpec3 = new DimensionFieldSpec("newColumn3", DataType.BOOLEAN, true);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSchemaRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSchemaRestletResourceTest.java
@@ -119,10 +119,6 @@ public class PinotSchemaRestletResourceTest {
     // Change the column data type from STRING to BOOLEAN
     newColumnFieldSpec.setDataType(DataType.BOOLEAN);
 
-    // Update the schema with addSchema api and override on
-    resp = ControllerTest.sendMultipartPutRequest(addSchemaUrl, schema.toSingleLineJsonString());
-    Assert.assertEquals(resp.getStatusCode(), 400);
-
     // Update the schema with addSchema api and override on, force on
     resp = ControllerTest.sendMultipartPutRequest(addSchemaUrl + "?force=true", schema.toSingleLineJsonString());
     Assert.assertEquals(resp.getStatusCode(), 200);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSchemaRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotSchemaRestletResourceTest.java
@@ -120,7 +120,7 @@ public class PinotSchemaRestletResourceTest {
     newColumnFieldSpec.setDataType(DataType.BOOLEAN);
 
     // Update the schema with addSchema api and override on, force on
-    resp = ControllerTest.sendMultipartPutRequest(addSchemaUrl + "?force=true", schema.toSingleLineJsonString());
+    resp = ControllerTest.sendMultipartPostRequest(addSchemaUrl + "?force=true", schema.toSingleLineJsonString());
     Assert.assertEquals(resp.getStatusCode(), 200);
 
     // Change another column max length from default 512 to 2000
@@ -129,12 +129,12 @@ public class PinotSchemaRestletResourceTest {
     newColumnFieldSpec2.setDefaultNullValue("0");
 
     // Update the schema with addSchema api and override on
-    resp = ControllerTest.sendMultipartPutRequest(addSchemaUrl, schema.toSingleLineJsonString());
+    resp = ControllerTest.sendMultipartPostRequest(addSchemaUrl, schema.toSingleLineJsonString());
     Assert.assertEquals(resp.getStatusCode(), 200);
 
     // Get the schema and verify the default null value and max length have been changed
     remoteSchema = Schema.fromString(ControllerTest.sendGetRequest(getSchemaUrl));
-    Assert.assertEquals(remoteSchema.getFieldSpecFor(newColumnFieldSpec.getName()).getMaxLength(), 2000);
+    Assert.assertEquals(remoteSchema.getFieldSpecFor(newColumnFieldSpec2.getName()).getMaxLength(), 2000);
     Assert.assertEquals(remoteSchema.getFieldSpecFor(newColumnFieldSpec2.getName()).getDefaultNullValue(), "0");
 
     // Change another column max length from 1000
@@ -148,7 +148,7 @@ public class PinotSchemaRestletResourceTest {
 
     // Get the schema and verify the default null value and max length have been changed
     remoteSchema = Schema.fromString(ControllerTest.sendGetRequest(getSchemaUrl));
-    Assert.assertEquals(remoteSchema.getFieldSpecFor(newColumnFieldSpec.getName()).getMaxLength(), 1000);
+    Assert.assertEquals(remoteSchema.getFieldSpecFor(newColumnFieldSpec2.getName()).getMaxLength(), 1000);
     Assert.assertEquals(remoteSchema.getFieldSpecFor(newColumnFieldSpec2.getName()).getDefaultNullValue(), "1");
 
     // Add a new BOOLEAN column

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/upload/ZKOperatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/upload/ZKOperatorTest.java
@@ -90,7 +90,7 @@ public class ZKOperatorTest {
         new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setTimeColumnName(TIME_COLUMN)
             .setStreamConfigs(getStreamConfigs()).setLLC(true).setNumReplicas(1).build();
 
-    _resourceManager.addSchema(schema, false);
+    _resourceManager.addSchema(schema, false, false);
     _resourceManager.addTable(offlineTableConfig);
     _resourceManager.addTable(realtimeTableConfig);
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/TableCacheTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/TableCacheTest.java
@@ -73,7 +73,7 @@ public class TableCacheTest {
     Schema schema =
         new Schema.SchemaBuilder().setSchemaName(SCHEMA_NAME).addSingleValueDimension("testColumn", DataType.INT)
             .build();
-    TEST_INSTANCE.getHelixResourceManager().addSchema(schema, false);
+    TEST_INSTANCE.getHelixResourceManager().addSchema(schema, false, false);
     // Wait for at most 10 seconds for the callback to add the schema to the cache
     TestUtils.waitForCondition(aVoid -> tableCache.getSchema(SCHEMA_NAME) != null, 10_000L,
         "Failed to add the schema to the cache");

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -536,4 +536,19 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
     // Sort fieldspecs based on their name
     return _name.compareTo(otherSpec._name);
   }
+
+  /***
+   * Return true if it is backward compatible with the old FieldSpec.
+   * Backward compatibility requires
+   * all other fields except DefaultNullValue and Max Length should be retained.
+   *
+   * @param oldFieldSpec
+   * @return
+   */
+  public boolean isBackwardCompatibleWith(FieldSpec oldFieldSpec) {
+
+    return EqualityUtils.isEqual(_name, oldFieldSpec._name)
+            && EqualityUtils.isEqual(_dataType, oldFieldSpec._dataType)
+            && EqualityUtils.isEqual(_isSingleValueField, oldFieldSpec._isSingleValueField);
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -690,9 +690,10 @@ public final class Schema implements Serializable {
 
   /**
    * Check whether the current schema is backward compatible with oldSchema.
+   *
    * Backward compatibility requires
    * (1) all columns in oldSchema should be retained.
-   * (2) only DefaultNullValue and Max length can be overriden, other fields should be retained.
+   * (2) all column fieldSpecs should be backward compatible with the old ones.
    *
    * @param oldSchema old schema
    */
@@ -706,22 +707,7 @@ public final class Schema implements Serializable {
       FieldSpec oldSchemaFieldSpec = entry.getValue();
       FieldSpec fieldSpec = getFieldSpecFor(oldSchemaColumnName);
 
-      if (EqualityUtils.isSameReference(fieldSpec, oldSchemaFieldSpec)) {
-        continue;
-      }
-
-      if ((fieldSpec == null && oldSchemaFieldSpec != null) || (fieldSpec != null && oldSchemaFieldSpec == null)) {
-        return false;
-      }
-
-      boolean isBackward = EqualityUtils.isEqual(fieldSpec.getName(), oldSchemaFieldSpec.getName())
-              && EqualityUtils.isEqual(fieldSpec.getDataType(), oldSchemaFieldSpec.getDataType())
-              && EqualityUtils.isEqual(fieldSpec.isSingleValueField(), oldSchemaFieldSpec.isSingleValueField())
-              && EqualityUtils.isEqual(fieldSpec.getTransformFunction(), oldSchemaFieldSpec.getTransformFunction())
-              && EqualityUtils.
-              isEqual(fieldSpec.getVirtualColumnProvider(), oldSchemaFieldSpec.getVirtualColumnProvider());
-
-      if (!isBackward) {
+      if (!fieldSpec.isBackwardCompatibleWith(oldSchemaFieldSpec)) {
         return false;
       }
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -690,7 +690,9 @@ public final class Schema implements Serializable {
 
   /**
    * Check whether the current schema is backward compatible with oldSchema.
-   * Backward compatibility requires all columns and fieldSpec in oldSchema should be retained.
+   * Backward compatibility requires
+   * (1) all columns in oldSchema should be retained.
+   * (2) only DefaultNullValue and Max length can be overriden, other fields should be retained.
    *
    * @param oldSchema old schema
    */
@@ -703,7 +705,23 @@ public final class Schema implements Serializable {
       }
       FieldSpec oldSchemaFieldSpec = entry.getValue();
       FieldSpec fieldSpec = getFieldSpecFor(oldSchemaColumnName);
-      if (!fieldSpec.equals(oldSchemaFieldSpec)) {
+
+      if (EqualityUtils.isSameReference(fieldSpec, oldSchemaFieldSpec)) {
+        continue;
+      }
+
+      if ((fieldSpec == null && oldSchemaFieldSpec != null) || (fieldSpec != null && oldSchemaFieldSpec == null)) {
+        return false;
+      }
+
+      boolean isBackward = EqualityUtils.isEqual(fieldSpec.getName(), oldSchemaFieldSpec.getName())
+              && EqualityUtils.isEqual(fieldSpec.getDataType(), oldSchemaFieldSpec.getDataType())
+              && EqualityUtils.isEqual(fieldSpec.isSingleValueField(), oldSchemaFieldSpec.isSingleValueField())
+              && EqualityUtils.isEqual(fieldSpec.getTransformFunction(), oldSchemaFieldSpec.getTransformFunction())
+              && EqualityUtils.
+              isEqual(fieldSpec.getVirtualColumnProvider(), oldSchemaFieldSpec.getVirtualColumnProvider());
+
+      if (!isBackward) {
         return false;
       }
     }


### PR DESCRIPTION
### Description
This pr loosed schema backward compatibility checking, allowing max length and default null values to be changed. And it added a new API param `force` for POST /addSchema API with default value `false`. Once it is set to `true`, we will force overriding the existing schema.

This pr will changed two APIs, POST /addSchema and POST /updateSchema since both need to pass the backward compatibility checking. 
