### PR TITLE
[Feature] Support function registry with arg types

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
@@ -18,15 +18,22 @@
  */
 package org.apache.pinot.common.function;
 
-import com.google.common.base.Preconditions;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.FunctionContext;
+import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.spi.annotations.ScalarFunction;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.utils.PinotReflectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -34,6 +41,13 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Registry for scalar functions.
+ *
+ * The registry registers functions using canonical functionName and argument type as DataType.
+ * It doesn't differentiate function name in different canonical forms or argument types whose DataType is the same such
+ * as primitive numerical type and its wrapper class.
+ *
+ * To be backward compatible, the registry falls back functionName + param number matching when there are no type match
+ * for parameters.
  * <p>TODO: Merge FunctionRegistry and FunctionDefinitionRegistry to provide one single registry for all functions.
  */
 public class FunctionRegistry {
@@ -41,7 +55,39 @@ public class FunctionRegistry {
   }
 
   private static final Logger LOGGER = LoggerFactory.getLogger(FunctionRegistry.class);
+
+  // Map from function name to parameter types to function info.
+  private static final Map<String, Map<List<FieldSpec.DataType>, FunctionInfo>> FUNC_PARAM_INFO_MAP = new HashMap<>();
+
+  // FUNCTION_INFO_MAP is still used to be backward compatible.
+  // When we support all sql data types, we can deprecate this.
+  @Deprecated
   private static final Map<String, Map<Integer, FunctionInfo>> FUNCTION_INFO_MAP = new HashMap<>();
+
+  private static List<FieldSpec.DataType> getParamTypes(Class<?>[] types) {
+    List<FieldSpec.DataType> paramTypes = new ArrayList<>();
+    for (Class<?> t : types) {
+      paramTypes.add(FunctionUtils.getDataType(t));
+    }
+    return paramTypes;
+  }
+
+  /**
+   * Returns the {@link FunctionInfo} associated with the given function name and number of parameters, or {@code null}
+   * if there is no matching method. This method should be called after the FunctionRegistry is initialized and all
+   * methods are already registered.
+   *
+   * Assuming functionName is canonicalized.
+   */
+  @Nullable
+  private static FunctionInfo getFunctionInfo(String functionName, int numParameters) {
+    Map<Integer, FunctionInfo> functionInfoMap = FUNCTION_INFO_MAP.get(functionName);
+    return functionInfoMap != null ? functionInfoMap.get(numParameters) : null;
+  }
+
+  private static String canonicalize(String functionName) {
+    return StringUtils.remove(functionName, '_').toLowerCase();
+  }
 
   /**
    * Registers the scalar functions via reflection.
@@ -92,11 +138,17 @@ public class FunctionRegistry {
    * Registers a method with the given function name.
    */
   public static void registerFunction(String functionName, Method method, boolean nullableParameters) {
-    FunctionInfo functionInfo = new FunctionInfo(method, method.getDeclaringClass(), nullableParameters);
-    String canonicalName = canonicalize(functionName);
+    final FunctionInfo functionInfo = new FunctionInfo(method, method.getDeclaringClass(), nullableParameters);
+    final String canonicalName = canonicalize(functionName);
     Map<Integer, FunctionInfo> functionInfoMap = FUNCTION_INFO_MAP.computeIfAbsent(canonicalName, k -> new HashMap<>());
-    Preconditions.checkState(functionInfoMap.put(method.getParameterCount(), functionInfo) == null,
-        "Function: %s with %s parameters is already registered", functionName, method.getParameterCount());
+    // Only put one default implementation for # of params.
+    if (!functionInfoMap.containsKey(method.getParameterCount())) {
+      functionInfoMap.put(method.getParameterCount(), functionInfo);
+    }
+    List<FieldSpec.DataType> paramTypes = getParamTypes(method.getParameterTypes());
+    Map<List<FieldSpec.DataType>, FunctionInfo> functionParamInfoMap =
+        FUNC_PARAM_INFO_MAP.computeIfAbsent(canonicalName, k -> new HashMap<>());
+    functionParamInfoMap.put(paramTypes, functionInfo);
   }
 
   /**
@@ -107,17 +159,48 @@ public class FunctionRegistry {
   }
 
   /**
-   * Returns the {@link FunctionInfo} associated with the given function name and number of parameters, or {@code null}
-   * if there is no matching method. This method should be called after the FunctionRegistry is initialized and all
-   * methods are already registered.
+   * All functions should be directly or indirectly registered via this call to ensure function name is canonical.
    */
   @Nullable
-  public static FunctionInfo getFunctionInfo(String functionName, int numParameters) {
-    Map<Integer, FunctionInfo> functionInfoMap = FUNCTION_INFO_MAP.get(canonicalize(functionName));
-    return functionInfoMap != null ? functionInfoMap.get(numParameters) : null;
+  public static FunctionInfo getFunctionInfo(String functionName, List<FieldSpec.DataType> dataTypes) {
+    String canonicalFunctionName = canonicalize(functionName);
+    Map<List<FieldSpec.DataType>, FunctionInfo> paramMaps =
+        FUNC_PARAM_INFO_MAP.getOrDefault(canonicalFunctionName, null);
+    FunctionInfo info = paramMaps.getOrDefault(dataTypes, null);
+    if (info == null) {
+      return getFunctionInfo(canonicalFunctionName, dataTypes.size());
+    }
+    return info;
   }
 
-  private static String canonicalize(String functionName) {
-    return StringUtils.remove(functionName, '_').toLowerCase();
+  @Nullable
+  public static FunctionInfo getFunctionInfo(Function function) {
+    String functionName = function.getOperator();
+    List<Expression> operands = function.getOperands();
+    List<FieldSpec.DataType> args = new ArrayList<>();
+    for (Expression exp : operands) {
+      ExpressionContext ctx = ExpressionContext.forLiteralContext(exp.getLiteral());
+      args.add(ctx.getLiteralContext().getType());
+    }
+    return getFunctionInfo(functionName, args);
+  }
+
+  @Nullable
+  public static FunctionInfo getFunctionInfo(FunctionContext function) {
+    List<ExpressionContext> args = function.getArguments();
+    List<FieldSpec.DataType> argTypes = new ArrayList<>();
+    for (ExpressionContext exp : args) {
+      argTypes.add(exp.getLiteralContext().getType());
+    }
+    return getFunctionInfo(function.getFunctionName(), argTypes);
+  }
+
+  @Nullable
+  public static FunctionInfo getFunctionInfo(String functionName, DataSchema.ColumnDataType[] argTypes) {
+    List<FieldSpec.DataType> paramTypes = new ArrayList<>();
+    for (DataSchema.ColumnDataType type : argTypes) {
+      paramTypes.add(FunctionUtils.getDataType(type));
+    }
+    return getFunctionInfo(functionName, paramTypes);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
@@ -127,6 +127,19 @@ public class FunctionUtils {
     put(Object.class, ColumnDataType.OBJECT);
   }};
 
+  private static final Map<ColumnDataType, DataType> DATA_TYPE_COLUMN_MAP = new HashMap<ColumnDataType, DataType>() {{
+    put(ColumnDataType.INT, DataType.INT);
+    put(ColumnDataType.LONG, DataType.LONG);
+    put(ColumnDataType.FLOAT, DataType.FLOAT);
+    put(ColumnDataType.DOUBLE, DataType.DOUBLE);
+    put(ColumnDataType.BIG_DECIMAL, DataType.BIG_DECIMAL);
+    put(ColumnDataType.BOOLEAN, DataType.BOOLEAN);
+    put(ColumnDataType.TIMESTAMP, DataType.TIMESTAMP);
+    put(ColumnDataType.STRING, DataType.STRING);
+    put(ColumnDataType.BYTES, DataType.BYTES);
+    // TODO: figure out the rest of type mapping.
+  }};
+
   /**
    * Returns the corresponding PinotDataType for the given parameter class, or {@code null} if there is no one matching.
    */
@@ -157,5 +170,13 @@ public class FunctionUtils {
   @Nullable
   public static ColumnDataType getColumnDataType(Class<?> clazz) {
     return COLUMN_DATA_TYPE_MAP.get(clazz);
+  }
+
+  /**
+   * Returns the corresponding DataType for the ColumnDataType, or {@code null} if there is no one matching.
+   */
+  @Nullable
+  public static DataType getDataType(ColumnDataType columnType) {
+    return DATA_TYPE_COLUMN_MAP.get(columnType);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/Expression.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/Expression.java
@@ -236,6 +236,13 @@ public class Expression implements org.apache.thrift.TBase<Expression, Expressio
 
   @org.apache.thrift.annotation.Nullable
   public Literal getLiteral() {
+    if(this.literal == null || this.literal.getFieldValue() == null){
+      System.out.println("liuyao getLiteral:null");
+    } else {
+      Literal._Fields type = this.literal.getSetField();
+      System.out.println("liuyao type:" + type);
+      System.out.println("liuyao getLiteral:" + this.literal.getFieldValue().getClass() + " value:" + this.literal.getFieldValue().toString());
+    }
     return this.literal;
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/Expression.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/Expression.java
@@ -236,13 +236,6 @@ public class Expression implements org.apache.thrift.TBase<Expression, Expressio
 
   @org.apache.thrift.annotation.Nullable
   public Literal getLiteral() {
-    if(this.literal == null || this.literal.getFieldValue() == null){
-      System.out.println("liuyao getLiteral:null");
-    } else {
-      Literal._Fields type = this.literal.getSetField();
-      System.out.println("liuyao type:" + type);
-      System.out.println("liuyao getLiteral:" + this.literal.getFieldValue().getClass() + " value:" + this.literal.getFieldValue().toString());
-    }
     return this.literal;
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/ExpressionContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/ExpressionContext.java
@@ -34,21 +34,21 @@ import org.apache.pinot.spi.data.FieldSpec;
  */
 public class ExpressionContext {
   public enum Type {
-    IDENTIFIER, FUNCTION, LITERAL_CONTEXT
+    LITERAL, IDENTIFIER, FUNCTION,
   }
 
   private final Type _type;
   private final String _value;
   private final FunctionContext _function;
-  // Only set when the _type is LITERAL_CONTEXT
+  // Only set when the _type is LITERAL
   @Nullable
   private final LiteralContext _literal;
 
   public static ExpressionContext forLiteralContext(Literal literal){
-    return new ExpressionContext(Type.LITERAL_CONTEXT, null, null, new LiteralContext(literal));
+    return new ExpressionContext(Type.LITERAL, null, null, new LiteralContext(literal));
   }
   public static ExpressionContext forLiteralContext(FieldSpec.DataType type, Object val){
-    return new ExpressionContext(Type.LITERAL_CONTEXT, null, null, new LiteralContext(type, val));
+    return new ExpressionContext(Type.LITERAL, null, null, new LiteralContext(type, val));
   }
 
   public static ExpressionContext forIdentifier(String identifier) {
@@ -66,7 +66,7 @@ public class ExpressionContext {
     _literal = literal;
   }
 
-  // TODO: Deprecate the usage of literal string.
+  @Deprecated
   public String getLiteralString() {
     if (_literal == null || _literal.getValue() == null) {
       return "";
@@ -122,7 +122,7 @@ public class ExpressionContext {
     if (_type == Type.FUNCTION) {
       return hash + _function.hashCode();
     }
-    if (_type == Type.LITERAL_CONTEXT) {
+    if (_type == Type.LITERAL) {
       return hash + _literal.hashCode();
     }
     return hash + 31 * _value.hashCode();
@@ -131,7 +131,7 @@ public class ExpressionContext {
   @Override
   public String toString() {
     switch (_type) {
-      case LITERAL_CONTEXT:
+      case LITERAL:
         return _literal.toString();
       case IDENTIFIER:
         return _value;

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/FunctionContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/FunctionContext.java
@@ -27,7 +27,7 @@ import java.util.Set;
  * The {@code FunctionContext} class represents the function in the expression.
  * <p>Pinot currently supports 2 types of functions: Aggregation (e.g. SUM, MAX) and Transform (e.g. ADD, SUB).
  */
-public class FunctionContext {
+public class FunctionContext extends ExpressionContext {
   public enum Type {
     AGGREGATION, TRANSFORM
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/FunctionContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/FunctionContext.java
@@ -27,7 +27,7 @@ import java.util.Set;
  * The {@code FunctionContext} class represents the function in the expression.
  * <p>Pinot currently supports 2 types of functions: Aggregation (e.g. SUM, MAX) and Transform (e.g. ADD, SUB).
  */
-public class FunctionContext extends ExpressionContext {
+public class FunctionContext {
   public enum Type {
     AGGREGATION, TRANSFORM
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
@@ -1,19 +1,129 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.common.request.context;
 
+import com.google.common.base.Preconditions;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.spi.data.FieldSpec;
 
 
+/**
+ * The {@code LiteralContext} class represents a literal in the query.
+ * <p>This includes both value and type information. We translate thrift literal to this representation in server.
+ * Currently, only Boolean literal is correctly encoded in thrift and passed in.
+ * All integers are encoded as LONG in thrift, and the other numerical types are encoded as DOUBLE.
+ * The remaining types are encoded as STRING.
+ */
+public class LiteralContext {
+  // TODO: Support all of the types for sql.
+  private FieldSpec.DataType _type;
+  @Nullable
+  private Object _value;
 
+  private static FieldSpec.DataType convertThriftTypeToDataType(Literal._Fields fields) {
+    switch (fields) {
+      case BOOL_VALUE:
+        return FieldSpec.DataType.BOOLEAN;
+      case SHORT_VALUE:
+      case INT_VALUE:
+        return FieldSpec.DataType.INT;
+      case LONG_VALUE:
+        return FieldSpec.DataType.LONG;
+      case DOUBLE_VALUE:
+        return FieldSpec.DataType.DOUBLE;
+      case STRING_VALUE:
+        return FieldSpec.DataType.STRING;
+      default:
+        throw new UnsupportedOperationException("Unsupported literal type:" + fields);
+    }
+  }
+
+  private static Class<?> convertDataTypeToJavaType(FieldSpec.DataType dataType) {
+    switch (dataType) {
+      case FLOAT:
+        return Float.class;
+      case STRING:
+        return String.class;
+      case DOUBLE:
+        return Double.class;
+      case INT:
+        return Integer.class;
+      case BOOLEAN:
+        return Boolean.class;
+      case LONG:
+        return Long.class;
+      default:
+        throw new UnsupportedOperationException("Unsupported dataType:" + dataType);
+    }
+  }
+
+  public LiteralContext(Literal literal) {
+    _type = convertThriftTypeToDataType(literal.getSetField());
+    _value = literal.getFieldValue();
+  }
+
+  public FieldSpec.DataType getType() {
+    return _type;
+  }
+
+  @Nullable
+  public Object getValue() {
+    return _value;
+  }
+
+  public LiteralContext(FieldSpec.DataType type, Object value) {
+    Preconditions.checkArgument(convertDataTypeToJavaType(type) == value.getClass(),
+        "Unmatched data type: " + type + " java type: " + value.getClass());
+    _type = type;
+    _value = value;
+  }
+
+  @Override
+  public int hashCode() {
+    if (_value == null) {
+      return 31 * 31 * _type.hashCode();
+    }
+    return 31 * 31 * _type.hashCode() + 31 * _value.hashCode();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof LiteralContext)) {
+      return false;
+    }
+    LiteralContext that = (LiteralContext) o;
+    boolean typeEql = _type.equals(that._type);
+    boolean valEql = Objects.equals(_value, that._value);
+
+    return typeEql && valEql;
+  }
+
+  @Override
+  public String toString() {
+    if (_value == null) {
+      return '\'' + "" + '\'';
+    }
+    return _type.toString() + "(" + '\'' + _value.toString() + '\'' + ")";
+  }
 }
-
-
-//  union Literal {
-//    1: optional bool boolValue;
-//    2: optional byte byteValue;
-//    3: optional i16 shortValue;
-//    4: optional i32 intValue;
-//    5: optional i64 longValue;
-//    6: optional double doubleValue;
-//    7: optional string stringValue;
-//    8: optional binary binaryValue;
-//    }

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
@@ -1,0 +1,19 @@
+package org.apache.pinot.common.request.context;
+
+import org.apache.pinot.spi.data.FieldSpec;
+
+
+
+}
+
+
+//  union Literal {
+//    1: optional bool boolValue;
+//    2: optional byte byteValue;
+//    3: optional i16 shortValue;
+//    4: optional i32 intValue;
+//    5: optional i64 longValue;
+//    6: optional double doubleValue;
+//    7: optional string stringValue;
+//    8: optional binary binaryValue;
+//    }

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
@@ -64,16 +64,12 @@ public class RequestContextUtils {
    * Converts the given Thrift {@link Expression} into an {@link ExpressionContext}.
    */
   public static ExpressionContext getExpression(Expression thriftExpression) {
-    System.out.println("liuyao get expression");
     switch (thriftExpression.getType()) {
       case LITERAL:
-        System.out.println("liuyao: literal type:" + thriftExpression.getLiteral().getFieldValue().getClass());
-        return ExpressionContext.forLiteral(thriftExpression.getLiteral().getFieldValue().toString());
+        return ExpressionContext.forLiteralContext(thriftExpression.getLiteral());
       case IDENTIFIER:
-        System.out.println("liuyao get identifier");
         return ExpressionContext.forIdentifier(thriftExpression.getIdentifier().getName());
       case FUNCTION:
-        System.out.println("liuyao get function");
         return ExpressionContext.forFunction(getFunction(thriftExpression.getFunctionCall()));
       default:
         throw new IllegalStateException();
@@ -252,7 +248,7 @@ public class RequestContextUtils {
       case IDENTIFIER:
         return new FilterContext(FilterContext.Type.PREDICATE, null,
             new EqPredicate(filterExpression, getStringValue(RequestUtils.getLiteralExpression(true))));
-      case LITERAL:
+      case LITERAL_CONTEXT:
         // TODO: Handle literals
         throw new IllegalStateException();
       default:
@@ -356,10 +352,10 @@ public class RequestContextUtils {
   }
 
   private static String getStringValue(ExpressionContext expressionContext) {
-    if (expressionContext.getType() != ExpressionContext.Type.LITERAL) {
+    if(expressionContext.getType() != ExpressionContext.Type.LITERAL_CONTEXT){
       throw new BadQueryRequestException(
           "Pinot does not support column or function on the right-hand side of the predicate");
     }
-    return expressionContext.getLiteral();
+    return expressionContext.getLiteralString();
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
@@ -248,7 +248,7 @@ public class RequestContextUtils {
       case IDENTIFIER:
         return new FilterContext(FilterContext.Type.PREDICATE, null,
             new EqPredicate(filterExpression, getStringValue(RequestUtils.getLiteralExpression(true))));
-      case LITERAL_CONTEXT:
+      case LITERAL:
         // TODO: Handle literals
         throw new IllegalStateException();
       default:
@@ -352,7 +352,7 @@ public class RequestContextUtils {
   }
 
   private static String getStringValue(ExpressionContext expressionContext) {
-    if(expressionContext.getType() != ExpressionContext.Type.LITERAL_CONTEXT){
+    if(expressionContext.getType() != ExpressionContext.Type.LITERAL){
       throw new BadQueryRequestException(
           "Pinot does not support column or function on the right-hand side of the predicate");
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
@@ -64,12 +64,16 @@ public class RequestContextUtils {
    * Converts the given Thrift {@link Expression} into an {@link ExpressionContext}.
    */
   public static ExpressionContext getExpression(Expression thriftExpression) {
+    System.out.println("liuyao get expression");
     switch (thriftExpression.getType()) {
       case LITERAL:
+        System.out.println("liuyao: literal type:" + thriftExpression.getLiteral().getFieldValue().getClass());
         return ExpressionContext.forLiteral(thriftExpression.getLiteral().getFieldValue().toString());
       case IDENTIFIER:
+        System.out.println("liuyao get identifier");
         return ExpressionContext.forIdentifier(thriftExpression.getIdentifier().getName());
       case FUNCTION:
+        System.out.println("liuyao get function");
         return ExpressionContext.forFunction(getFunction(thriftExpression.getFunctionCall()));
       default:
         throw new IllegalStateException();

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -21,14 +21,10 @@ package org.apache.pinot.common.utils.request;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
-import java.sql.Types;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNumericLiteral;
-import org.apache.calcite.sql.type.ExtraSqlTypes;
-import org.apache.calcite.sql.type.SqlTypeFamily;
-import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
@@ -120,12 +116,13 @@ public class RequestUtils {
       }
     } else {
       // TODO: Support null literal and other types.
-      switch(node.getTypeName()){
+      switch (node.getTypeName()) {
         case BOOLEAN:
           literal.setBoolValue(node.booleanValue());
           break;
         default:
           literal.setStringValue(StringUtils.replace(node.toValue(), "''", "'"));
+          break;
       }
     }
     expression.setLiteral(literal);
@@ -179,8 +176,8 @@ public class RequestUtils {
     if (object instanceof byte[]) {
       return RequestUtils.getLiteralExpression((byte[]) object);
     }
-    if(object instanceof Boolean){
-      return RequestUtils.getLiteralExpression((Boolean) object);
+    if (object instanceof Boolean) {
+      return RequestUtils.getLiteralExpression(((Boolean) object).booleanValue());
     }
     return RequestUtils.getLiteralExpression(object.toString());
   }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/AliasApplier.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/AliasApplier.java
@@ -89,7 +89,6 @@ public class AliasApplier implements QueryRewriter {
         expression.setType(aliasExpression.getType());
         expression.setIdentifier(aliasExpression.getIdentifier());
         expression.setFunctionCall(aliasExpression.getFunctionCall());
-        System.out.println("liuyao set literal:" + aliasExpression.getLiteral().getSetField() + " " + aliasExpression.getLiteral().getFieldValue());
         expression.setLiteral(aliasExpression.getLiteral());
       }
       return;

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/AliasApplier.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/AliasApplier.java
@@ -89,6 +89,7 @@ public class AliasApplier implements QueryRewriter {
         expression.setType(aliasExpression.getType());
         expression.setIdentifier(aliasExpression.getIdentifier());
         expression.setFunctionCall(aliasExpression.getFunctionCall());
+        System.out.println("liuyao set literal:" + aliasExpression.getLiteral().getSetField() + " " + aliasExpression.getLiteral().getFieldValue());
         expression.setLiteral(aliasExpression.getLiteral());
       }
       return;

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/CompileTimeFunctionsInvoker.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/CompileTimeFunctionsInvoker.java
@@ -68,9 +68,8 @@ public class CompileTimeFunctionsInvoker implements QueryRewriter {
       }
       operands.set(i, operand);
     }
-    String functionName = function.getOperator();
     if (compilable) {
-      FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, numOperands);
+      FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(function);
       if (functionInfo != null) {
         Object[] arguments = new Object[numOperands];
         for (int i = 0; i < numOperands; i++) {

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionDefinitionRegistryTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionDefinitionRegistryTest.java
@@ -18,14 +18,14 @@
  */
 package org.apache.pinot.common.function;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.annotations.ScalarFunction;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 
 public class FunctionDefinitionRegistryTest {
@@ -64,12 +64,46 @@ public class FunctionDefinitionRegistryTest {
     return null;
   }
 
+  @ScalarFunction(names = {"testFunc2"})
+  public static String testScalarFunction2(long randomArg1, Long randomArg2) {
+    return null;
+  }
+
+  // Test that function matches with parameter counts
   @Test
-  public void testScalarFunctionNames() {
-    assertNotNull(FunctionRegistry.getFunctionInfo("testFunc1", 2));
-    assertNotNull(FunctionRegistry.getFunctionInfo("testFunc2", 2));
-    assertNull(FunctionRegistry.getFunctionInfo("testScalarFunction", 2));
-    assertNull(FunctionRegistry.getFunctionInfo("testFunc1", 1));
-    assertNull(FunctionRegistry.getFunctionInfo("testFunc2", 1));
+  public void testScalarFunctionNamesMatch() {
+    List<FieldSpec.DataType> funcArgs1 = new ArrayList<>();
+    funcArgs1.add(FieldSpec.DataType.LONG);
+    funcArgs1.add(FieldSpec.DataType.INT);
+    assertNotNull(FunctionRegistry.getFunctionInfo("testFunc1", funcArgs1));
+    assertNotNull(FunctionRegistry.getFunctionInfo("testFunc2", funcArgs1));
+    assertNull(FunctionRegistry.getFunctionInfo("testScalarFunction", funcArgs1));
+    List<FieldSpec.DataType> funcArgs2 = new ArrayList<>();
+    funcArgs2.add(FieldSpec.DataType.LONG);
+    assertNull(FunctionRegistry.getFunctionInfo("testFunc1", funcArgs2));
+    assertNull(FunctionRegistry.getFunctionInfo("testFunc2", funcArgs2));
+  }
+
+  // Test that function register can do type matching
+  @Test
+  public void testScalarFunctionTypeMatch() {
+    List<FieldSpec.DataType> funcArgs3 = new ArrayList<>();
+    funcArgs3.add(FieldSpec.DataType.LONG);
+    funcArgs3.add(FieldSpec.DataType.LONG);
+    FunctionInfo func2LongLong = FunctionRegistry.getFunctionInfo("testFunc2", funcArgs3);
+    assertNotNull(func2LongLong);
+    Class[] paramTypes = func2LongLong.getMethod().getParameterTypes();
+    assertEquals(paramTypes.length, 2);
+    assertEquals(paramTypes[0].getTypeName(), "long");
+    assertEquals(paramTypes[1].getTypeName(), "java.lang.Long");
+    List<FieldSpec.DataType> funcArgs1 = new ArrayList<>();
+    funcArgs1.add(FieldSpec.DataType.LONG);
+    funcArgs1.add(FieldSpec.DataType.STRING);
+    FunctionInfo func2LongString = FunctionRegistry.getFunctionInfo("testFunc2", funcArgs1);
+    assertNotNull(func2LongString);
+    Class[] paramTypes2 = func2LongString.getMethod().getParameterTypes();
+    assertEquals(paramTypes2.length, 2);
+    assertEquals(paramTypes2[0].getTypeName(), "long");
+    assertEquals(paramTypes2[1].getTypeName(), "java.lang.String");
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
@@ -123,8 +123,8 @@ public class TableResizer {
    * Helper method to construct a OrderByValueExtractor based on the given expression.
    */
   private OrderByValueExtractor getOrderByValueExtractor(ExpressionContext expression) {
-    if (expression.getType() == ExpressionContext.Type.LITERAL) {
-      return new LiteralExtractor(expression.getLiteral());
+    if (expression.getType() == ExpressionContext.Type.LITERAL_CONTEXT) {
+      return new LiteralExtractor(expression.getLiteralString());
     }
     Integer groupByExpressionIndex = _groupByExpressionIndexMap.get(expression);
     if (groupByExpressionIndex != null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
@@ -123,7 +123,7 @@ public class TableResizer {
    * Helper method to construct a OrderByValueExtractor based on the given expression.
    */
   private OrderByValueExtractor getOrderByValueExtractor(ExpressionContext expression) {
-    if (expression.getType() == ExpressionContext.Type.LITERAL_CONTEXT) {
+    if (expression.getType() == ExpressionContext.Type.LITERAL) {
       return new LiteralExtractor(expression.getLiteralString());
     }
     Integer groupByExpressionIndex = _groupByExpressionIndexMap.get(expression);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
@@ -72,10 +72,10 @@ public class H3InclusionIndexFilterOperator extends BaseFilterOperator {
 
     if (arguments.get(0).getType() == ExpressionContext.Type.IDENTIFIER) {
       _h3IndexReader = segment.getDataSource(arguments.get(0).getIdentifier()).getH3Index();
-      _geometry = GeometrySerializer.deserialize(BytesUtils.toBytes(arguments.get(1).getLiteral()));
+      _geometry = GeometrySerializer.deserialize(BytesUtils.toBytes(arguments.get(1).getLiteralString()));
     } else {
       _h3IndexReader = segment.getDataSource(arguments.get(1).getIdentifier()).getH3Index();
-      _geometry = GeometrySerializer.deserialize(BytesUtils.toBytes(arguments.get(0).getLiteral()));
+      _geometry = GeometrySerializer.deserialize(BytesUtils.toBytes(arguments.get(0).getLiteralString()));
     }
     // must be some h3 index
     assert _h3IndexReader != null : "the column must have H3 index setup.";

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3IndexFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3IndexFilterOperator.java
@@ -67,10 +67,12 @@ public class H3IndexFilterOperator extends BaseFilterOperator {
     Coordinate coordinate;
     if (arguments.get(0).getType() == ExpressionContext.Type.IDENTIFIER) {
       _h3IndexReader = segment.getDataSource(arguments.get(0).getIdentifier()).getH3Index();
-      coordinate = GeometrySerializer.deserialize(BytesUtils.toBytes(arguments.get(1).getLiteral())).getCoordinate();
+      coordinate =
+          GeometrySerializer.deserialize(BytesUtils.toBytes(arguments.get(1).getLiteralString())).getCoordinate();
     } else {
       _h3IndexReader = segment.getDataSource(arguments.get(1).getIdentifier()).getH3Index();
-      coordinate = GeometrySerializer.deserialize(BytesUtils.toBytes(arguments.get(0).getLiteral())).getCoordinate();
+      coordinate =
+          GeometrySerializer.deserialize(BytesUtils.toBytes(arguments.get(0).getLiteralString())).getCoordinate();
     }
     assert _h3IndexReader != null;
     int resolution = _h3IndexReader.getH3IndexResolution().getLowestResolution();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.operator.transform.function;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.sql.Timestamp;
@@ -26,6 +27,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.pinot.common.request.context.LiteralContext;
 import org.apache.pinot.common.utils.PinotDataType;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
@@ -41,6 +43,7 @@ import org.apache.pinot.spi.utils.BytesUtils;
  * TODO: Preserve the type of the literal instead of inferring the type from the string
  */
 public class LiteralTransformFunction implements TransformFunction {
+  // TODO: Deprecate the string representation of literal.
   private final String _literal;
   private final DataType _dataType;
   private final int _intLiteral;
@@ -58,21 +61,24 @@ public class LiteralTransformFunction implements TransformFunction {
   private String[] _stringResult;
   private byte[][] _bytesResult;
 
-  public LiteralTransformFunction(String literal) {
-    _literal = literal;
-    _dataType = inferLiteralDataType(literal);
-    if (_dataType.isNumeric()) {
-      _bigDecimalLiteral = new BigDecimal(_literal);
-    } else if (_dataType == DataType.BOOLEAN) {
-      _bigDecimalLiteral = PinotDataType.BOOLEAN.toBigDecimal(Boolean.valueOf(literal));
-    } else if (_dataType == DataType.TIMESTAMP) {
-      // inferLiteralDataType successfully interpreted the literal as TIMESTAMP. _bigDecimalLiteral is populated and
-      // assigned to _longLiteral.
-      _bigDecimalLiteral = PinotDataType.TIMESTAMP.toBigDecimal(Timestamp.valueOf(literal));
+  public LiteralTransformFunction(LiteralContext literalContext) {
+    Preconditions.checkNotNull(literalContext);
+    _literal = literalContext.getValue() == null ? "" : literalContext.getValue().toString();
+    if (literalContext.getType() == DataType.BOOLEAN) {
+      _bigDecimalLiteral = PinotDataType.BOOLEAN.toBigDecimal(literalContext.getValue());
+      _dataType = DataType.BOOLEAN;
     } else {
-      _bigDecimalLiteral = BigDecimal.ZERO;
+      _dataType = inferLiteralDataType(_literal);
+      if (_dataType.isNumeric()) {
+        _bigDecimalLiteral = new BigDecimal(_literal);
+      } else if (_dataType == DataType.TIMESTAMP) {
+        // inferLiteralDataType successfully interpreted the literal as TIMESTAMP. _bigDecimalLiteral is populated and
+        // assigned to _longLiteral.
+        _bigDecimalLiteral = PinotDataType.TIMESTAMP.toBigDecimal(Timestamp.valueOf(_literal));
+      } else {
+        _bigDecimalLiteral = BigDecimal.ZERO;
+      }
     }
-
     _intLiteral = _bigDecimalLiteral.intValue();
     _longLiteral = _bigDecimalLiteral.longValue();
     _floatLiteral = _bigDecimalLiteral.floatValue();
@@ -99,13 +105,6 @@ public class LiteralTransformFunction implements TransformFunction {
       }
     } catch (Exception e) {
       // Ignored
-    }
-
-    // Try to interpret the literal as BOOLEAN
-    // NOTE: Intentionally use equals() instead of equalsIgnoreCase() here because boolean literal will always be parsed
-    //       into lowercase string. We don't want to parse string "TRUE" as boolean.
-    if (literal.equals("true") || literal.equals("false")) {
-      return DataType.BOOLEAN;
     }
 
     // Try to interpret the literal as TIMESTAMP
@@ -163,7 +162,7 @@ public class LiteralTransformFunction implements TransformFunction {
           Arrays.fill(intResult, _intLiteral);
         }
       } else {
-        Arrays.fill(intResult, _literal.equals("true") ? 1 : 0);
+        Arrays.fill(intResult, _intLiteral);
       }
       _intResult = intResult;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -315,7 +315,7 @@ public class TransformFunctionFactory {
       case IDENTIFIER:
         String columnName = expression.getIdentifier();
         return new IdentifierTransformFunction(columnName, dataSourceMap.get(columnName));
-      case LITERAL_CONTEXT:
+      case LITERAL:
         return queryContext == null ? new LiteralTransformFunction(expression.getLiteralContext())
             : queryContext.getOrComputeSharedValue(LiteralTransformFunction.class, expression.getLiteralContext(),
                 LiteralTransformFunction::new);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -315,9 +315,9 @@ public class TransformFunctionFactory {
       case IDENTIFIER:
         String columnName = expression.getIdentifier();
         return new IdentifierTransformFunction(columnName, dataSourceMap.get(columnName));
-      case LITERAL:
-        return queryContext == null ? new LiteralTransformFunction(expression.getLiteral())
-            : queryContext.getOrComputeSharedValue(LiteralTransformFunction.class, expression.getLiteral(),
+      case LITERAL_CONTEXT:
+        return queryContext == null ? new LiteralTransformFunction(expression.getLiteralContext())
+            : queryContext.getOrComputeSharedValue(LiteralTransformFunction.class, expression.getLiteralContext(),
                 LiteralTransformFunction::new);
       default:
         throw new IllegalStateException();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -289,7 +289,7 @@ public class TransformFunctionFactory {
           }
         } else {
           // Scalar function
-          FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, numArguments);
+          FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(function);
           if (functionInfo == null) {
             if (FunctionRegistry.containsFunction(functionName)) {
               throw new BadQueryRequestException(

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -138,7 +138,7 @@ public class FilterPlanNode implements PlanNode {
     for (ExpressionContext argument : arguments) {
       if (argument.getType() == ExpressionContext.Type.IDENTIFIER) {
         columnName = argument.getIdentifier();
-      } else if (argument.getType() == ExpressionContext.Type.LITERAL_CONTEXT) {
+      } else if (argument.getType() == ExpressionContext.Type.LITERAL) {
         findLiteral = true;
       }
     }
@@ -170,14 +170,14 @@ public class FilterPlanNode implements PlanNode {
     // TODO: handle nested geography/geometry conversion functions
     if (functionName.equals("stwithin")) {
       if (arguments.get(0).getType() == ExpressionContext.Type.IDENTIFIER
-          && arguments.get(1).getType() == ExpressionContext.Type.LITERAL_CONTEXT) {
+          && arguments.get(1).getType() == ExpressionContext.Type.LITERAL) {
         String columnName = arguments.get(0).getIdentifier();
         return _indexSegment.getDataSource(columnName).getH3Index() != null;
       }
       return false;
     } else {
       if (arguments.get(1).getType() == ExpressionContext.Type.IDENTIFIER
-          && arguments.get(0).getType() == ExpressionContext.Type.LITERAL_CONTEXT) {
+          && arguments.get(0).getType() == ExpressionContext.Type.LITERAL) {
         String columnName = arguments.get(1).getIdentifier();
         return _indexSegment.getDataSource(columnName).getH3Index() != null;
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -138,7 +138,7 @@ public class FilterPlanNode implements PlanNode {
     for (ExpressionContext argument : arguments) {
       if (argument.getType() == ExpressionContext.Type.IDENTIFIER) {
         columnName = argument.getIdentifier();
-      } else if (argument.getType() == ExpressionContext.Type.LITERAL) {
+      } else if (argument.getType() == ExpressionContext.Type.LITERAL_CONTEXT) {
         findLiteral = true;
       }
     }
@@ -170,14 +170,14 @@ public class FilterPlanNode implements PlanNode {
     // TODO: handle nested geography/geometry conversion functions
     if (functionName.equals("stwithin")) {
       if (arguments.get(0).getType() == ExpressionContext.Type.IDENTIFIER
-          && arguments.get(1).getType() == ExpressionContext.Type.LITERAL) {
+          && arguments.get(1).getType() == ExpressionContext.Type.LITERAL_CONTEXT) {
         String columnName = arguments.get(0).getIdentifier();
         return _indexSegment.getDataSource(columnName).getH3Index() != null;
       }
       return false;
     } else {
       if (arguments.get(1).getType() == ExpressionContext.Type.IDENTIFIER
-          && arguments.get(0).getType() == ExpressionContext.Type.LITERAL) {
+          && arguments.get(0).getType() == ExpressionContext.Type.LITERAL_CONTEXT) {
         String columnName = arguments.get(1).getIdentifier();
         return _indexSegment.getDataSource(columnName).getH3Index() != null;
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -164,7 +164,7 @@ public class AggregationFunctionFactory {
             if (arguments.size() == 3) {
               ExpressionContext timeCol = arguments.get(1);
               ExpressionContext dataType = arguments.get(2);
-              if (dataType.getType() != ExpressionContext.Type.LITERAL_CONTEXT) {
+              if (dataType.getType() != ExpressionContext.Type.LITERAL) {
                 throw new IllegalArgumentException("Third argument of firstWithTime Function should be literal."
                     + " The function can be used as firstWithTime(dataColumn, timeColumn, 'dataType')");
               }
@@ -194,7 +194,7 @@ public class AggregationFunctionFactory {
             if (arguments.size() == 3) {
               ExpressionContext timeCol = arguments.get(1);
               ExpressionContext dataType = arguments.get(2);
-              if (dataType.getType() != ExpressionContext.Type.LITERAL_CONTEXT) {
+              if (dataType.getType() != ExpressionContext.Type.LITERAL) {
                 throw new IllegalArgumentException("Third argument of lastWithTime Function should be literal."
                     + " The function can be used as lastWithTime(dataColumn, timeColumn, 'dataType')");
               }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -101,7 +101,7 @@ public class AggregationFunctionFactory {
         } else if (numArguments == 2) {
           // Double arguments percentile (e.g. percentile(foo, 99), percentileTDigest(bar, 95), etc.) where the
           // second argument is a decimal number from 0.0 to 100.0.
-          double percentile = parsePercentileToDouble(arguments.get(1).getLiteral());
+          double percentile = parsePercentileToDouble(arguments.get(1).getLiteralString());
           if (remainingFunctionName.isEmpty()) {
             // Percentile
             return new PercentileAggregationFunction(firstArgument, percentile);
@@ -164,12 +164,12 @@ public class AggregationFunctionFactory {
             if (arguments.size() == 3) {
               ExpressionContext timeCol = arguments.get(1);
               ExpressionContext dataType = arguments.get(2);
-              if (dataType.getType() != ExpressionContext.Type.LITERAL) {
+              if (dataType.getType() != ExpressionContext.Type.LITERAL_CONTEXT) {
                 throw new IllegalArgumentException("Third argument of firstWithTime Function should be literal."
                     + " The function can be used as firstWithTime(dataColumn, timeColumn, 'dataType')");
               }
               FieldSpec.DataType fieldDataType
-                  = FieldSpec.DataType.valueOf(dataType.getLiteral().toUpperCase());
+                  = FieldSpec.DataType.valueOf(dataType.getLiteralString().toUpperCase());
               switch (fieldDataType) {
                 case BOOLEAN:
                 case INT:
@@ -194,11 +194,11 @@ public class AggregationFunctionFactory {
             if (arguments.size() == 3) {
               ExpressionContext timeCol = arguments.get(1);
               ExpressionContext dataType = arguments.get(2);
-              if (dataType.getType() != ExpressionContext.Type.LITERAL) {
+              if (dataType.getType() != ExpressionContext.Type.LITERAL_CONTEXT) {
                 throw new IllegalArgumentException("Third argument of lastWithTime Function should be literal."
                     + " The function can be used as lastWithTime(dataColumn, timeColumn, 'dataType')");
               }
-              FieldSpec.DataType fieldDataType = FieldSpec.DataType.valueOf(dataType.getLiteral().toUpperCase());
+              FieldSpec.DataType fieldDataType = FieldSpec.DataType.valueOf(dataType.getLiteralString().toUpperCase());
               switch (fieldDataType) {
                 case BOOLEAN:
                 case INT:

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountHLLAggregationFunction.java
@@ -48,7 +48,7 @@ public class DistinctCountHLLAggregationFunction extends BaseSingleInputAggregat
     Preconditions.checkArgument(numExpressions <= 2, "DistinctCountHLL expects 1 or 2 arguments, got: %s",
         numExpressions);
     if (arguments.size() == 2) {
-      _log2m = Integer.parseInt(arguments.get(1).getLiteral());
+      _log2m = Integer.parseInt(arguments.get(1).getLiteralString());
     } else {
       _log2m = CommonConstants.Helix.DEFAULT_HYPERLOGLOG_LOG2M;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartHLLAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountSmartHLLAggregationFunction.java
@@ -68,7 +68,7 @@ public class DistinctCountSmartHLLAggregationFunction extends BaseSingleInputAgg
     super(arguments.get(0));
 
     if (arguments.size() > 1) {
-      Parameters parameters = new Parameters(arguments.get(1).getLiteral());
+      Parameters parameters = new Parameters(arguments.get(1).getLiteralString());
       _threshold = parameters._threshold;
       _log2m = parameters._log2m;
     } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
@@ -99,7 +99,7 @@ public class DistinctCountThetaSketchAggregationFunction
     int numArguments = arguments.size();
     if (numArguments > 1) {
       ExpressionContext paramsExpression = arguments.get(1);
-      Preconditions.checkArgument(paramsExpression.getType() == ExpressionContext.Type.LITERAL_CONTEXT,
+      Preconditions.checkArgument(paramsExpression.getType() == ExpressionContext.Type.LITERAL,
           "Second argument of DISTINCT_COUNT_THETA_SKETCH aggregation function must be literal (parameters)");
       Parameters parameters = new Parameters(paramsExpression.getLiteralString());
       int nominalEntries = parameters.getNominalEntries();
@@ -127,7 +127,7 @@ public class DistinctCountThetaSketchAggregationFunction
       _filterEvaluators = new ArrayList<>(numArguments - 3);
       for (int i = 2; i < numArguments - 1; i++) {
         ExpressionContext filterExpression = arguments.get(i);
-        Preconditions.checkArgument(filterExpression.getType() == ExpressionContext.Type.LITERAL_CONTEXT,
+        Preconditions.checkArgument(filterExpression.getType() == ExpressionContext.Type.LITERAL,
             "Third to second last argument of DISTINCT_COUNT_THETA_SKETCH aggregation function must be literal "
                 + "(filter expression)");
         FilterContext filter =
@@ -140,7 +140,7 @@ public class DistinctCountThetaSketchAggregationFunction
 
       // Process the post-aggregation expression
       ExpressionContext postAggregationExpression = arguments.get(numArguments - 1);
-      Preconditions.checkArgument(postAggregationExpression.getType() == ExpressionContext.Type.LITERAL_CONTEXT,
+      Preconditions.checkArgument(postAggregationExpression.getType() == ExpressionContext.Type.LITERAL,
           "Last argument of DISTINCT_COUNT_THETA_SKETCH aggregation function must be literal (post-aggregation "
               + "expression)");
       Expression expr = CalciteSqlParser.compileToExpression(postAggregationExpression.getLiteralString());
@@ -1052,7 +1052,7 @@ public class DistinctCountThetaSketchAggregationFunction
    * Returns whether the post-aggregation expression contains the default sketch ($0).
    */
   private static boolean validatePostAggregationExpression(ExpressionContext expression, int numFilters) {
-    Preconditions.checkArgument(expression.getType() != ExpressionContext.Type.LITERAL_CONTEXT,
+    Preconditions.checkArgument(expression.getType() != ExpressionContext.Type.LITERAL,
         "Post-aggregation expression should not contain literal expression: %s", expression.toString());
     if (expression.getType() == ExpressionContext.Type.IDENTIFIER) {
       int sketchId = extractSketchId(expression.getIdentifier());

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/HistogramAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/HistogramAggregationFunction.java
@@ -67,9 +67,9 @@ public class HistogramAggregationFunction extends BaseSingleInputAggregationFunc
       _upper = _bucketEdges[_bucketEdges.length - 1];
     } else {
       _isEqualLength = true;
-      _lower = Double.parseDouble(arguments.get(1).getLiteral());
-      _upper = Double.parseDouble(arguments.get(2).getLiteral());
-      int numBins = Integer.parseInt(arguments.get(3).getLiteral());
+      _lower = Double.parseDouble(arguments.get(1).getLiteralString());
+      _upper = Double.parseDouble(arguments.get(2).getLiteralString());
+      int numBins = Integer.parseInt(arguments.get(3).getLiteralString());
       Preconditions.checkArgument(_upper > _lower,
           "The right most edge must be greater than left most edge, given %s and %s", _lower, _upper);
       Preconditions.checkArgument(numBins > 0, "The number of bins must be greater than zero, given %s", numBins);
@@ -96,7 +96,7 @@ public class HistogramAggregationFunction extends BaseSingleInputAggregationFunc
     Preconditions.checkArgument(len > 1, "The number of bin edges must be greater than 1");
     double[] ret = new double[len];
     for (int i = 0; i < len; i++) {
-      ret[i] = Double.parseDouble(arrayStr.get(i).getLiteral());
+      ret[i] = Double.parseDouble(arrayStr.get(i).getLiteralString());
       if (i > 0) {
         Preconditions.checkState(ret[i] > ret[i - 1], "The bin edges must be strictly increasing");
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IdSetAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IdSetAggregationFunction.java
@@ -76,7 +76,7 @@ public class IdSetAggregationFunction extends BaseSingleInputAggregationFunction
       _fpp = IdSets.DEFAULT_FPP;
     } else {
       ExpressionContext parametersExpression = arguments.get(1);
-      Preconditions.checkArgument(parametersExpression.getType() == ExpressionContext.Type.LITERAL_CONTEXT,
+      Preconditions.checkArgument(parametersExpression.getType() == ExpressionContext.Type.LITERAL,
           "Second argument of IdSet must be literal (parameters)");
 
       int sizeThresholdInBytes = IdSets.DEFAULT_SIZE_THRESHOLD_IN_BYTES;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IdSetAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IdSetAggregationFunction.java
@@ -76,13 +76,13 @@ public class IdSetAggregationFunction extends BaseSingleInputAggregationFunction
       _fpp = IdSets.DEFAULT_FPP;
     } else {
       ExpressionContext parametersExpression = arguments.get(1);
-      Preconditions.checkArgument(parametersExpression.getType() == ExpressionContext.Type.LITERAL,
+      Preconditions.checkArgument(parametersExpression.getType() == ExpressionContext.Type.LITERAL_CONTEXT,
           "Second argument of IdSet must be literal (parameters)");
 
       int sizeThresholdInBytes = IdSets.DEFAULT_SIZE_THRESHOLD_IN_BYTES;
       int expectedInsertions = IdSets.DEFAULT_EXPECTED_INSERTIONS;
       double fpp = IdSets.DEFAULT_FPP;
-      String parametersString = parametersExpression.getLiteral();
+      String parametersString = parametersExpression.getLiteralString();
       StringUtils.deleteWhitespace(parametersString);
       String[] keyValuePairs = StringUtils.split(parametersString, PARAMETER_DELIMITER);
       for (String keyValuePair : keyValuePairs) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ModeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/ModeAggregationFunction.java
@@ -68,7 +68,7 @@ public class ModeAggregationFunction extends BaseSingleInputAggregationFunction<
     int numArguments = arguments.size();
     Preconditions.checkArgument(numArguments <= 2, "Mode expects at most 2 arguments, got: %s", numArguments);
     if (numArguments > 1) {
-      _multiModeReducerType = MultiModeReducerType.valueOf(arguments.get(1).getLiteral());
+      _multiModeReducerType = MultiModeReducerType.valueOf(arguments.get(1).getLiteralString());
     } else {
       _multiModeReducerType = MultiModeReducerType.MIN;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunction.java
@@ -60,14 +60,14 @@ public class PercentileSmartTDigestAggregationFunction extends BaseSingleInputAg
   public PercentileSmartTDigestAggregationFunction(List<ExpressionContext> arguments) {
     super(arguments.get(0));
     try {
-      _percentile = Double.parseDouble(arguments.get(1).getLiteral());
+      _percentile = Double.parseDouble(arguments.get(1).getLiteralString());
     } catch (Exception e) {
       throw new IllegalArgumentException(
           "Second argument of PERCENTILE_SMART_TDIGEST aggregation function must be a double literal (percentile)");
     }
     Preconditions.checkArgument(_percentile >= 0 && _percentile <= 100, "Invalid percentile: %s", _percentile);
     if (arguments.size() > 2) {
-      Parameters parameters = new Parameters(arguments.get(2).getLiteral());
+      Parameters parameters = new Parameters(arguments.get(2).getLiteralString());
       _compression = parameters._compression;
       _threshold = parameters._threshold;
     } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumPrecisionAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumPrecisionAggregationFunction.java
@@ -57,9 +57,9 @@ public class SumPrecisionAggregationFunction extends BaseSingleInputAggregationF
     int numArguments = arguments.size();
     Preconditions.checkArgument(numArguments <= 3, "SumPrecision expects at most 3 arguments, got: %s", numArguments);
     if (numArguments > 1) {
-      _precision = Integer.valueOf(arguments.get(1).getLiteral());
+      _precision = Integer.valueOf(arguments.get(1).getLiteralString());
       if (numArguments > 2) {
-        _scale = Integer.valueOf(arguments.get(2).getLiteral());
+        _scale = Integer.valueOf(arguments.get(2).getLiteralString());
       } else {
         _scale = null;
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -605,7 +605,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       Preconditions.checkState(arguments.size() == 2,
           "IN_PARTITIONED_SUBQUERY requires 2 arguments: expression, subquery");
       ExpressionContext subqueryExpression = arguments.get(1);
-      Preconditions.checkState(subqueryExpression.getType() == ExpressionContext.Type.LITERAL_CONTEXT,
+      Preconditions.checkState(subqueryExpression.getType() == ExpressionContext.Type.LITERAL,
           "Second argument of IN_PARTITIONED_SUBQUERY must be a literal (subquery)");
       QueryContext subquery = QueryContextConverterUtils.getQueryContext(subqueryExpression.getLiteralString());
       // Subquery should be an ID_SET aggregation only query

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/statement/StringPredicateFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/statement/StringPredicateFilterOptimizer.java
@@ -115,8 +115,7 @@ public class StringPredicateFilterOptimizer implements StatementOptimizer {
     if (expressionType == ExpressionType.FUNCTION) {
       // Check if the function returns STRING as output.
       Function function = expression.getFunctionCall();
-      FunctionInfo functionInfo =
-          FunctionRegistry.getFunctionInfo(function.getOperator(), function.getOperands().size());
+      FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(function);
       return functionInfo != null && functionInfo.getMethod().getReturnType() == String.class;
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunction.java
@@ -37,7 +37,7 @@ public class PostAggregationFunction {
 
   public PostAggregationFunction(String functionName, ColumnDataType[] argumentTypes) {
     int numArguments = argumentTypes.length;
-    FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, numArguments);
+    FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, argumentTypes);
     if (functionInfo == null) {
       if (FunctionRegistry.containsFunction(functionName)) {
         throw new IllegalArgumentException(

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseGapfillProcessor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseGapfillProcessor.java
@@ -83,16 +83,16 @@ abstract class BaseGapfillProcessor {
 
     List<ExpressionContext> args = _gapFillSelection.getFunction().getArguments();
 
-    _dateTimeFormatter = new DateTimeFormatSpec(args.get(1).getLiteral());
-    _gapfillDateTimeGranularity = new DateTimeGranularitySpec(args.get(4).getLiteral());
-    if (args.get(5).getLiteral() == null) {
+    _dateTimeFormatter = new DateTimeFormatSpec(args.get(1).getLiteralString());
+    _gapfillDateTimeGranularity = new DateTimeGranularitySpec(args.get(4).getLiteralString());
+    if (args.get(5).getLiteralString() == null) {
       _postGapfillDateTimeGranularity = _gapfillDateTimeGranularity;
     } else {
-      _postGapfillDateTimeGranularity = new DateTimeGranularitySpec(args.get(5).getLiteral());
+      _postGapfillDateTimeGranularity = new DateTimeGranularitySpec(args.get(5).getLiteralString());
     }
-    String start = args.get(2).getLiteral();
+    String start = args.get(2).getLiteralString();
     _startMs = truncate(_dateTimeFormatter.fromFormatToMillis(start));
-    String end = args.get(3).getLiteral();
+    String end = args.get(3).getLiteralString();
     _endMs = truncate(_dateTimeFormatter.fromFormatToMillis(end));
     _gapfillTimeBucketSize = _gapfillDateTimeGranularity.granularityToMillis();
     _postGapfillTimeBucketSize = _postGapfillDateTimeGranularity.granularityToMillis();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillFilterHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillFilterHandler.java
@@ -65,9 +65,9 @@ public class GapfillFilterHandler implements ValueExtractorFactory {
   @Override
   public ValueExtractor getValueExtractor(ExpressionContext expression) {
     expression = GapfillUtils.stripGapfill(expression);
-    if (expression.getType() == ExpressionContext.Type.LITERAL) {
+    if (expression.getType() == ExpressionContext.Type.LITERAL_CONTEXT) {
       // Literal
-      return new LiteralValueExtractor(expression.getLiteral());
+      return new LiteralValueExtractor(expression.getLiteralString());
     }
 
     if (expression.getType() == ExpressionContext.Type.IDENTIFIER) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillFilterHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillFilterHandler.java
@@ -65,7 +65,7 @@ public class GapfillFilterHandler implements ValueExtractorFactory {
   @Override
   public ValueExtractor getValueExtractor(ExpressionContext expression) {
     expression = GapfillUtils.stripGapfill(expression);
-    if (expression.getType() == ExpressionContext.Type.LITERAL_CONTEXT) {
+    if (expression.getType() == ExpressionContext.Type.LITERAL) {
       // Literal
       return new LiteralValueExtractor(expression.getLiteralString());
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillProcessor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillProcessor.java
@@ -305,10 +305,10 @@ public class GapfillProcessor extends BaseGapfillProcessor {
     if (expressionContext != null && expressionContext.getFunction() != null && GapfillUtils
         .isFill(expressionContext)) {
       List<ExpressionContext> args = expressionContext.getFunction().getArguments();
-      if (args.get(1).getLiteral() == null) {
+      if (args.get(1).getLiteralString() == null) {
         throw new UnsupportedOperationException("Wrong Sql.");
       }
-      GapfillUtils.FillType fillType = GapfillUtils.FillType.valueOf(args.get(1).getLiteral());
+      GapfillUtils.FillType fillType = GapfillUtils.FillType.valueOf(args.get(1).getLiteralString());
       if (fillType == GapfillUtils.FillType.FILL_DEFAULT_VALUE) {
         // TODO: may fill the default value from sql in the future.
         return GapfillUtils.getDefaultValue(dataType);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/PostAggregationHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/PostAggregationHandler.java
@@ -106,9 +106,9 @@ public class PostAggregationHandler implements ValueExtractorFactory {
    */
   @Override
   public ValueExtractor getValueExtractor(ExpressionContext expression) {
-    if (expression.getType() == ExpressionContext.Type.LITERAL) {
+    if (expression.getType() == ExpressionContext.Type.LITERAL_CONTEXT) {
       // Literal
-      return new LiteralValueExtractor(expression.getLiteral());
+      return new LiteralValueExtractor(expression.getLiteralString());
     }
     if (_numGroupByExpressions > 0) {
       Integer groupByExpressionIndex = _groupByExpressionIndexMap.get(expression);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/PostAggregationHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/PostAggregationHandler.java
@@ -106,7 +106,7 @@ public class PostAggregationHandler implements ValueExtractorFactory {
    */
   @Override
   public ValueExtractor getValueExtractor(ExpressionContext expression) {
-    if (expression.getType() == ExpressionContext.Type.LITERAL_CONTEXT) {
+    if (expression.getType() == ExpressionContext.Type.LITERAL) {
       // Literal
       return new LiteralValueExtractor(expression.getLiteralString());
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/SumAvgGapfillProcessor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/SumAvgGapfillProcessor.java
@@ -66,7 +66,7 @@ class SumAvgGapfillProcessor extends BaseGapfillProcessor {
         }
         ExpressionContext arg = expressionContext.getFunction().getArguments().get(0);
         for (int j = 0; j < dataSchema.getColumnNames().length; j++) {
-          if (arg.getLiteral().equalsIgnoreCase(dataSchema.getColumnName(j))) {
+          if (arg.getLiteralString().equalsIgnoreCase(dataSchema.getColumnName(j))) {
             _sumArgIndexes[i] = j;
             break;
           }

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/GapfillUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/GapfillUtils.java
@@ -168,12 +168,13 @@ public class GapfillUtils {
         "Gapfill Expression should be function.");
     List<ExpressionContext> args = gapFillSelection.getFunction().getArguments();
     Preconditions.checkArgument(args.size() > 5, "Gapfill does not have correct number of arguments.");
-    Preconditions.checkArgument(args.get(1).getLiteral() != null,
+    Preconditions.checkArgument(args.get(1).getLiteralContext() != null,
         "The second argument of Gapfill should be TimeFormatter.");
-    Preconditions.checkArgument(args.get(2).getLiteral() != null,
+    Preconditions.checkArgument(args.get(2).getLiteralContext() != null,
         "The third argument of Gapfill should be start time.");
-    Preconditions.checkArgument(args.get(3).getLiteral() != null, "The fourth argument of Gapfill should be end time.");
-    Preconditions.checkArgument(args.get(4).getLiteral() != null,
+    Preconditions.checkArgument(args.get(3).getLiteralContext() != null,
+        "The fourth argument of Gapfill should be end time.");
+    Preconditions.checkArgument(args.get(4).getLiteralContext() != null,
         "The fifth argument of Gapfill should be time bucket size.");
 
     ExpressionContext timeseriesOn = GapfillUtils.getTimeSeriesOnExpressionContext(gapFillSelection);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunctionTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
+import org.apache.pinot.common.request.context.LiteralContext;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -33,8 +34,12 @@ public class LiteralTransformFunctionTest {
     Assert.assertEquals(LiteralTransformFunction.inferLiteralDataType("1.2"), DataType.FLOAT);
     Assert.assertEquals(LiteralTransformFunction.inferLiteralDataType("41241241.2412"), DataType.DOUBLE);
     Assert.assertEquals(LiteralTransformFunction.inferLiteralDataType("1.7976931348623159e+308"), DataType.BIG_DECIMAL);
-    Assert.assertEquals(LiteralTransformFunction.inferLiteralDataType("true"), DataType.BOOLEAN);
-    Assert.assertEquals(LiteralTransformFunction.inferLiteralDataType("false"), DataType.BOOLEAN);
     Assert.assertEquals(LiteralTransformFunction.inferLiteralDataType("2020-02-02 20:20:20.20"), DataType.TIMESTAMP);
+    LiteralTransformFunction trueBoolean = new LiteralTransformFunction(new LiteralContext(DataType.BOOLEAN, true));
+    Assert.assertEquals(trueBoolean.getResultMetadata().getDataType(), DataType.BOOLEAN);
+    Assert.assertEquals(trueBoolean.getLiteral(), "true");
+    LiteralTransformFunction falseBoolean = new LiteralTransformFunction(new LiteralContext(DataType.BOOLEAN, false));
+    Assert.assertEquals(falseBoolean.getResultMetadata().getDataType(), DataType.BOOLEAN);
+    Assert.assertEquals(falseBoolean.getLiteral(), "false");
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/QueryOverrideWithHintsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/QueryOverrideWithHintsTest.java
@@ -41,6 +41,7 @@ import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.testng.annotations.Test;
@@ -115,29 +116,32 @@ public class QueryOverrideWithHintsTest {
     expressionContext2 = ExpressionContext.forIdentifier("");
     assertNotEquals(expressionContext1, expressionContext2);
     assertNotEquals(expressionContext1.hashCode(), expressionContext2.hashCode());
-
-    expressionContext1 = ExpressionContext.forLiteral("abc");
-    expressionContext2 = ExpressionContext.forLiteral("abc");
+    expressionContext1 = ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, "abc");
+    expressionContext2 = ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, "abc");
     assertEquals(expressionContext1, expressionContext2);
     assertEquals(expressionContext1.hashCode(), expressionContext2.hashCode());
-    expressionContext2 = ExpressionContext.forLiteral("abcd");
+    expressionContext2 = ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, "abcd");
     assertNotEquals(expressionContext1, expressionContext2);
     assertNotEquals(expressionContext1.hashCode(), expressionContext2.hashCode());
-    expressionContext2 = ExpressionContext.forLiteral("");
+    expressionContext2 = ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, "");
     assertNotEquals(expressionContext1, expressionContext2);
     assertNotEquals(expressionContext1.hashCode(), expressionContext2.hashCode());
 
     expressionContext1 = ExpressionContext.forFunction(new FunctionContext(FunctionContext.Type.TRANSFORM, "func1",
-        ImmutableList.of(ExpressionContext.forIdentifier("abc"), ExpressionContext.forLiteral("abc"))));
+        ImmutableList.of(ExpressionContext.forIdentifier("abc"),
+            ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, "abc"))));
     expressionContext2 = ExpressionContext.forFunction(new FunctionContext(FunctionContext.Type.TRANSFORM, "func1",
-        ImmutableList.of(ExpressionContext.forIdentifier("abc"), ExpressionContext.forLiteral("abc"))));
+        ImmutableList.of(ExpressionContext.forIdentifier("abc"),
+            ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, "abc"))));
     assertEquals(expressionContext1, expressionContext2);
     assertEquals(expressionContext1.hashCode(), expressionContext2.hashCode());
 
     expressionContext1 = ExpressionContext.forFunction(new FunctionContext(FunctionContext.Type.TRANSFORM, "datetrunc",
-        ImmutableList.of(ExpressionContext.forLiteral("DAY"), ExpressionContext.forLiteral("event_time_ts"))));
+        ImmutableList.of(ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, "DAY"),
+            ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, "event_time_ts"))));
     expressionContext2 = ExpressionContext.forFunction(new FunctionContext(FunctionContext.Type.TRANSFORM, "datetrunc",
-        ImmutableList.of(ExpressionContext.forLiteral("DAY"), ExpressionContext.forLiteral("event_time_ts"))));
+        ImmutableList.of(ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, "DAY"),
+            ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, "event_time_ts"))));
     assertEquals(expressionContext1, expressionContext2);
     assertEquals(expressionContext1.hashCode(), expressionContext2.hashCode());
   }
@@ -146,11 +150,13 @@ public class QueryOverrideWithHintsTest {
   public void testOverrideFilterWithExpressionOverrideHints() {
     ExpressionContext dateTruncFunctionExpr = ExpressionContext.forFunction(
         new FunctionContext(FunctionContext.Type.TRANSFORM, "dateTrunc", new ArrayList<>(new ArrayList<>(
-            ImmutableList.of(ExpressionContext.forLiteral("MONTH"), ExpressionContext.forIdentifier("ts"))))));
+            ImmutableList.of(ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, "MONTH"),
+                ExpressionContext.forIdentifier("ts"))))));
     ExpressionContext timestampIndexColumn = ExpressionContext.forIdentifier("$ts$MONTH");
     ExpressionContext equalsExpression = ExpressionContext.forFunction(
-        new FunctionContext(FunctionContext.Type.TRANSFORM, "EQUALS",
-            new ArrayList<>(ImmutableList.of(dateTruncFunctionExpr, ExpressionContext.forLiteral("1000")))));
+        new FunctionContext(FunctionContext.Type.TRANSFORM, "EQUALS", new ArrayList<>(
+            ImmutableList.of(dateTruncFunctionExpr,
+                ExpressionContext.forLiteralContext(FieldSpec.DataType.INT, 1000)))));
     FilterContext filter = RequestContextUtils.getFilter(equalsExpression);
     Map<ExpressionContext, ExpressionContext> hints = ImmutableMap.of(dateTruncFunctionExpr, timestampIndexColumn);
     InstancePlanMakerImplV2.overrideWithExpressionHints(filter, _indexSegment, hints);
@@ -170,35 +176,41 @@ public class QueryOverrideWithHintsTest {
   public void testOverrideWithExpressionOverrideHints() {
     ExpressionContext dateTruncFunctionExpr = ExpressionContext.forFunction(
         new FunctionContext(FunctionContext.Type.TRANSFORM, "dateTrunc", new ArrayList<>(
-            ImmutableList.of(ExpressionContext.forLiteral("MONTH"), ExpressionContext.forIdentifier("ts")))));
+            ImmutableList.of(ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, "MONTH"),
+                ExpressionContext.forIdentifier("ts")))));
     ExpressionContext timestampIndexColumn = ExpressionContext.forIdentifier("$ts$MONTH");
     ExpressionContext equalsExpression = ExpressionContext.forFunction(
-        new FunctionContext(FunctionContext.Type.TRANSFORM, "EQUALS",
-            new ArrayList<>(ImmutableList.of(dateTruncFunctionExpr, ExpressionContext.forLiteral("1000")))));
+        new FunctionContext(FunctionContext.Type.TRANSFORM, "EQUALS", new ArrayList<>(
+            ImmutableList.of(dateTruncFunctionExpr,
+                ExpressionContext.forLiteralContext(FieldSpec.DataType.INT, 1000)))));
     Map<ExpressionContext, ExpressionContext> hints = ImmutableMap.of(dateTruncFunctionExpr, timestampIndexColumn);
     ExpressionContext newEqualsExpression =
         InstancePlanMakerImplV2.overrideWithExpressionHints(equalsExpression, _indexSegment, hints);
     assertEquals(newEqualsExpression.getFunction().getFunctionName(), "equals");
     assertEquals(newEqualsExpression.getFunction().getArguments().get(0), timestampIndexColumn);
-    assertEquals(newEqualsExpression.getFunction().getArguments().get(1), ExpressionContext.forLiteral("1000"));
+    assertEquals(newEqualsExpression.getFunction().getArguments().get(1),
+        ExpressionContext.forLiteralContext(FieldSpec.DataType.INT, 1000));
   }
 
   @Test
   public void testNotOverrideWithExpressionOverrideHints() {
     ExpressionContext dateTruncFunctionExpr = ExpressionContext.forFunction(
         new FunctionContext(FunctionContext.Type.TRANSFORM, "dateTrunc", new ArrayList<>(
-            ImmutableList.of(ExpressionContext.forLiteral("DAY"), ExpressionContext.forIdentifier("ts")))));
+            ImmutableList.of(ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, "DAY"),
+                ExpressionContext.forIdentifier("ts")))));
     ExpressionContext timestampIndexColumn = ExpressionContext.forIdentifier("$ts$DAY");
     ExpressionContext equalsExpression = ExpressionContext.forFunction(
-        new FunctionContext(FunctionContext.Type.TRANSFORM, "EQUALS",
-            new ArrayList<>(ImmutableList.of(dateTruncFunctionExpr, ExpressionContext.forLiteral("1000")))));
+        new FunctionContext(FunctionContext.Type.TRANSFORM, "EQUALS", new ArrayList<>(
+            ImmutableList.of(dateTruncFunctionExpr,
+                ExpressionContext.forLiteralContext(FieldSpec.DataType.INT, 1000)))));
     Map<ExpressionContext, ExpressionContext> hints = ImmutableMap.of(dateTruncFunctionExpr, timestampIndexColumn);
     ExpressionContext newEqualsExpression =
         InstancePlanMakerImplV2.overrideWithExpressionHints(equalsExpression, _indexSegment, hints);
     assertEquals(newEqualsExpression.getFunction().getFunctionName(), "equals");
     // No override as the physical column is not in the index segment.
     assertEquals(newEqualsExpression.getFunction().getArguments().get(0), dateTruncFunctionExpr);
-    assertEquals(newEqualsExpression.getFunction().getArguments().get(1), ExpressionContext.forLiteral("1000"));
+    assertEquals(newEqualsExpression.getFunction().getArguments().get(1),
+        ExpressionContext.forLiteralContext(FieldSpec.DataType.INT, 1000));
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
@@ -37,6 +37,7 @@ import org.apache.pinot.core.query.aggregation.function.CountAggregationFunction
 import org.apache.pinot.core.query.aggregation.function.MinAggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.SumAggregationFunction;
 import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -55,12 +56,6 @@ public class BrokerRequestToQueryContextConverterTest {
     return count;
   }
 
-  @Test
-  public void testLiteral(){
-    String query = "SELECT DISTINCT foo, bar, foobar FROM testTable ORDER BY bar DESC, foo LIMIT 15";
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
-
-  }
   @Test
   public void testHardcodedQueries() {
     // Select *
@@ -183,12 +178,14 @@ public class BrokerRequestToQueryContextConverterTest {
           new FunctionContext(FunctionContext.Type.TRANSFORM, "add",
               Arrays.asList(ExpressionContext.forIdentifier("foo"), ExpressionContext.forFunction(
                   new FunctionContext(FunctionContext.Type.TRANSFORM, "add",
-                      Arrays.asList(ExpressionContext.forIdentifier("bar"), ExpressionContext.forLiteral("123"))))))));
-      assertEquals(selectExpressions.get(0).toString(), "add(foo,add(bar,'123'))");
+                      Arrays.asList(ExpressionContext.forIdentifier("bar"),
+                          ExpressionContext.forLiteralContext(FieldSpec.DataType.LONG, Long.valueOf(123)))))))));
+      assertEquals(selectExpressions.get(0).toString(), "add(foo,add(bar,LONG('123')))");
       assertEquals(selectExpressions.get(1), ExpressionContext.forFunction(
           new FunctionContext(FunctionContext.Type.TRANSFORM, "sub",
-              Arrays.asList(ExpressionContext.forLiteral("456"), ExpressionContext.forIdentifier("foobar")))));
-      assertEquals(selectExpressions.get(1).toString(), "sub('456',foobar)");
+              Arrays.asList(ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, "456"),
+                  ExpressionContext.forIdentifier("foobar")))));
+      assertEquals(selectExpressions.get(1).toString(), "sub(STRING('456'),foobar)");
       assertEquals(getAliasCount(queryContext.getAliasList()), 0);
       assertNull(queryContext.getFilter());
       assertNull(queryContext.getGroupByExpressions());
@@ -197,8 +194,9 @@ public class BrokerRequestToQueryContextConverterTest {
       assertEquals(orderByExpressions.size(), 1);
       assertEquals(orderByExpressions.get(0), new OrderByExpressionContext(ExpressionContext.forFunction(
           new FunctionContext(FunctionContext.Type.TRANSFORM, "sub",
-              Arrays.asList(ExpressionContext.forLiteral("456"), ExpressionContext.forIdentifier("foobar")))), true));
-      assertEquals(orderByExpressions.get(0).toString(), "sub('456',foobar) ASC");
+              Arrays.asList(ExpressionContext.forLiteralContext(FieldSpec.DataType.LONG, Long.valueOf(456)),
+                  ExpressionContext.forIdentifier("foobar")))), true));
+      assertEquals(orderByExpressions.get(0).toString(), "sub(LONG('456'),foobar) ASC");
       assertNull(queryContext.getHavingFilter());
       assertEquals(queryContext.getLimit(), 20);
       assertEquals(queryContext.getOffset(), 30);
@@ -206,6 +204,17 @@ public class BrokerRequestToQueryContextConverterTest {
       assertTrue(QueryContextUtils.isSelectionQuery(queryContext));
       assertFalse(QueryContextUtils.isAggregationQuery(queryContext));
       assertFalse(QueryContextUtils.isDistinctQuery(queryContext));
+    }
+
+    // Boolean literal parsing
+    {
+      String query = "SELECT true = true FROM testTable;";
+      QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
+      assertEquals(queryContext.getTableName(), "testTable");
+      List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
+      assertEquals(selectExpressions.size(), 1);
+      assertEquals(selectExpressions.get(0), ExpressionContext.forLiteralContext(FieldSpec.DataType.BOOLEAN, true));
+      assertEquals(selectExpressions.get(0).toString(), "BOOLEAN('true')");
     }
 
     // Aggregation group-by with transform, order-by
@@ -491,10 +500,12 @@ public class BrokerRequestToQueryContextConverterTest {
       assertEquals(function.getFunctionName(), "distinctcountthetasketch");
       List<ExpressionContext> arguments = function.getArguments();
       assertEquals(arguments.get(0), ExpressionContext.forIdentifier("foo"));
-      assertEquals(arguments.get(1), ExpressionContext.forLiteral("nominalEntries=1000"));
-      assertEquals(arguments.get(2), ExpressionContext.forLiteral("bar='a'"));
-      assertEquals(arguments.get(3), ExpressionContext.forLiteral("bar='b'"));
-      assertEquals(arguments.get(4), ExpressionContext.forLiteral("SET_INTERSECT($1, $2)"));
+      assertEquals(arguments.get(1),
+          ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, "nominalEntries=1000"));
+      assertEquals(arguments.get(2), ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, "bar='a'"));
+      assertEquals(arguments.get(3), ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, "bar='b'"));
+      assertEquals(arguments.get(4),
+          ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, "SET_INTERSECT($1, $2)"));
       assertEquals(queryContext.getColumns(), new HashSet<>(Arrays.asList("foo", "bar")));
       assertFalse(QueryContextUtils.isSelectionQuery(queryContext));
       assertTrue(QueryContextUtils.isAggregationQuery(queryContext));

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
@@ -56,6 +56,12 @@ public class BrokerRequestToQueryContextConverterTest {
   }
 
   @Test
+  public void testLiteral(){
+    String query = "SELECT DISTINCT foo, bar, foobar FROM testTable ORDER BY bar DESC, foo LIMIT 15";
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
+
+  }
+  @Test
   public void testHardcodedQueries() {
     // Select *
     {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -2791,4 +2791,40 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertEquals(jobStatus.get("metadata").get("jobType").asText(), "RELOAD_ALL_SEGMENTS");
     return jobStatus.get("totalSegmentCount").asInt() == jobStatus.get("successCount").asInt();
   }
+
+  @Test
+  public void testBooleanLiteralsFunc()
+      throws Exception {
+    // Test boolean equal true case.
+    String sqlQuery = "SELECT (true = true) = true FROM mytable";
+    JsonNode response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode rows = response.get("resultTable").get("rows");
+    assertTrue(response.get("exceptions").isEmpty());
+    assertEquals(rows.size(), 1);
+    assertTrue(rows.get(0).get(0).asBoolean());
+//    // Test boolean equal false case.
+//    sqlQuery =
+//        "SELECT (true = true) = false FROM mytable";
+//    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+//    rows = response.get("resultTable").get("rows");
+//    assertTrue(response.get("exceptions").isEmpty());
+//    assertEquals(rows.size(), 1);
+//    assertFalse(rows.get(0).get(0).asBoolean());
+//    // Test boolean not equal true case.
+//    sqlQuery =
+//        "SELECT true != false FROM mytable";
+//    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+//    rows = response.get("resultTable").get("rows");
+//    assertTrue(response.get("exceptions").isEmpty());
+//    assertEquals(rows.size(), 1);
+//    assertTrue(rows.get(0).get(0).asBoolean());
+//    // Test boolean not equal false case.
+//    sqlQuery =
+//        "SELECT true != true FROM mytable";
+//    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+//    rows = response.get("resultTable").get("rows");
+//    assertTrue(response.get("exceptions").isEmpty());
+//    assertEquals(rows.size(), 1);
+//    assertFalse(rows.get(0).get(0).asBoolean());
+  }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -1688,7 +1688,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     JsonNode resultTable = response.get("resultTable");
     JsonNode dataSchema = resultTable.get("dataSchema");
     assertEquals(dataSchema.get("columnNames").toString(),
-        "[\"timeconvert(DaysSinceEpoch,'DAYS','SECONDS')\",\"count(*)\"]");
+        "[\"timeconvert(DaysSinceEpoch,STRING('DAYS'),STRING('SECONDS'))\",\"count(*)\"]");
     assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"LONG\",\"LONG\"]");
     JsonNode rows = resultTable.get("rows");
     assertEquals(rows.size(), 10);
@@ -1703,7 +1703,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
     assertEquals(dataSchema.get("columnNames").toString(),
-        "[\"datetimeconvert(DaysSinceEpoch,'1:DAYS:EPOCH','1:HOURS:EPOCH','1:HOURS')\",\"count(*)\"]");
+        "[\"datetimeconvert(DaysSinceEpoch,STRING('1:DAYS:EPOCH'),STRING('1:HOURS:EPOCH'),STRING('1:HOURS'))\","
+            + "\"count(*)\"]");
     assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"LONG\",\"LONG\"]");
     rows = resultTable.get("rows");
     assertEquals(rows.size(), 10);
@@ -1718,7 +1719,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
     assertEquals(dataSchema.get("columnNames").toString(),
-        "[\"add(DaysSinceEpoch,DaysSinceEpoch,'15')\",\"count(*)\"]");
+        "[\"add(DaysSinceEpoch,DaysSinceEpoch,LONG('15'))\",\"count(*)\"]");
     assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"DOUBLE\",\"LONG\"]");
     rows = resultTable.get("rows");
     assertEquals(rows.size(), 10);
@@ -1732,7 +1733,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     response = postQuery(query);
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
-    assertEquals(dataSchema.get("columnNames").toString(), "[\"sub(DaysSinceEpoch,'25')\",\"count(*)\"]");
+    assertEquals(dataSchema.get("columnNames").toString(), "[\"sub(DaysSinceEpoch,LONG('25'))\",\"count(*)\"]");
     assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"DOUBLE\",\"LONG\"]");
     rows = resultTable.get("rows");
     assertEquals(rows.size(), 10);
@@ -1746,7 +1747,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     response = postQuery(query);
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
-    assertEquals(dataSchema.get("columnNames").toString(), "[\"mult(DaysSinceEpoch,'24','3600')\",\"count(*)\"]");
+    assertEquals(dataSchema.get("columnNames").toString(),
+        "[\"mult(DaysSinceEpoch,LONG('24'),LONG('3600'))\",\"count(*)\"]");
     assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"DOUBLE\",\"LONG\"]");
     rows = resultTable.get("rows");
     assertEquals(rows.size(), 10);
@@ -1760,7 +1762,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     response = postQuery(query);
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
-    assertEquals(dataSchema.get("columnNames").toString(), "[\"div(DaysSinceEpoch,'2')\",\"count(*)\"]");
+    assertEquals(dataSchema.get("columnNames").toString(), "[\"div(DaysSinceEpoch,LONG('2'))\",\"count(*)\"]");
     assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"DOUBLE\",\"LONG\"]");
     rows = resultTable.get("rows");
     assertEquals(rows.size(), 10);
@@ -1789,7 +1791,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
     assertEquals(dataSchema.get("columnNames").toString(),
-        "[\"arraylength(valuein(DivAirports,'DFW','ORD'))\",\"count(*)\"]");
+        "[\"arraylength(valuein(DivAirports,STRING('DFW'),STRING('ORD')))\",\"count(*)\"]");
     assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"INT\",\"LONG\"]");
     rows = resultTable.get("rows");
     assertEquals(rows.size(), 3);
@@ -1811,7 +1813,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     response = postQuery(query);
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
-    assertEquals(dataSchema.get("columnNames").toString(), "[\"valuein(DivAirports,'DFW','ORD')\",\"count(*)\"]");
+    assertEquals(dataSchema.get("columnNames").toString(),
+        "[\"valuein(DivAirports,STRING('DFW'),STRING('ORD'))\",\"count(*)\"]");
     assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"STRING\",\"LONG\"]");
     rows = resultTable.get("rows");
     assertEquals(rows.size(), 2);
@@ -1832,7 +1835,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     JsonNode response = postQuery(query);
     JsonNode resultTable = response.get("resultTable");
     JsonNode dataSchema = resultTable.get("dataSchema");
-    assertEquals(dataSchema.get("columnNames").toString(), "[\"max(timeconvert(DaysSinceEpoch,'DAYS','SECONDS'))\"]");
+    assertEquals(dataSchema.get("columnNames").toString(),
+        "[\"max(timeconvert(DaysSinceEpoch,STRING('DAYS'),STRING('SECONDS')))\"]");
     assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"DOUBLE\"]");
     JsonNode rows = resultTable.get("rows");
     assertEquals(rows.size(), 1);
@@ -1844,7 +1848,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     response = postQuery(query);
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
-    assertEquals(dataSchema.get("columnNames").toString(), "[\"min(div(DaysSinceEpoch,'2'))\"]");
+    assertEquals(dataSchema.get("columnNames").toString(), "[\"min(div(DaysSinceEpoch,LONG('2')))\"]");
     assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"DOUBLE\"]");
     rows = resultTable.get("rows");
     assertEquals(rows.size(), 1);
@@ -1861,7 +1865,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     JsonNode resultTable = response.get("resultTable");
     JsonNode dataSchema = resultTable.get("dataSchema");
     assertEquals(dataSchema.get("columnNames").toString(),
-        "[\"DaysSinceEpoch\",\"timeconvert(DaysSinceEpoch,'DAYS','SECONDS')\"]");
+        "[\"DaysSinceEpoch\",\"timeconvert(DaysSinceEpoch,STRING('DAYS'),STRING('SECONDS'))\"]");
     assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"INT\",\"LONG\"]");
     JsonNode rows = response.get("resultTable").get("rows");
     assertEquals(rows.size(), 10);
@@ -1877,7 +1881,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
     assertEquals(dataSchema.get("columnNames").toString(),
-        "[\"DaysSinceEpoch\",\"timeconvert(DaysSinceEpoch,'DAYS','SECONDS')\"]");
+        "[\"DaysSinceEpoch\",\"timeconvert(DaysSinceEpoch,STRING('DAYS'),STRING('SECONDS'))\"]");
     assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"INT\",\"LONG\"]");
     rows = response.get("resultTable").get("rows");
     assertEquals(rows.size(), 10000);
@@ -1896,7 +1900,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
     assertEquals(dataSchema.get("columnNames").toString(),
-        "[\"DaysSinceEpoch\",\"timeconvert(DaysSinceEpoch,'DAYS','SECONDS')\"]");
+        "[\"DaysSinceEpoch\",\"timeconvert(DaysSinceEpoch,STRING('DAYS'),STRING('SECONDS'))\"]");
     assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"INT\",\"LONG\"]");
     rows = response.get("resultTable").get("rows");
     assertEquals(rows.size(), 10000);
@@ -2802,29 +2806,26 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertTrue(response.get("exceptions").isEmpty());
     assertEquals(rows.size(), 1);
     assertTrue(rows.get(0).get(0).asBoolean());
-//    // Test boolean equal false case.
-//    sqlQuery =
-//        "SELECT (true = true) = false FROM mytable";
-//    response = postQuery(sqlQuery, _brokerBaseApiUrl);
-//    rows = response.get("resultTable").get("rows");
-//    assertTrue(response.get("exceptions").isEmpty());
-//    assertEquals(rows.size(), 1);
-//    assertFalse(rows.get(0).get(0).asBoolean());
-//    // Test boolean not equal true case.
-//    sqlQuery =
-//        "SELECT true != false FROM mytable";
-//    response = postQuery(sqlQuery, _brokerBaseApiUrl);
-//    rows = response.get("resultTable").get("rows");
-//    assertTrue(response.get("exceptions").isEmpty());
-//    assertEquals(rows.size(), 1);
-//    assertTrue(rows.get(0).get(0).asBoolean());
-//    // Test boolean not equal false case.
-//    sqlQuery =
-//        "SELECT true != true FROM mytable";
-//    response = postQuery(sqlQuery, _brokerBaseApiUrl);
-//    rows = response.get("resultTable").get("rows");
-//    assertTrue(response.get("exceptions").isEmpty());
-//    assertEquals(rows.size(), 1);
-//    assertFalse(rows.get(0).get(0).asBoolean());
+    // Test boolean equal false case.
+    sqlQuery = "SELECT (true = true) = false FROM mytable";
+    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    rows = response.get("resultTable").get("rows");
+    assertTrue(response.get("exceptions").isEmpty());
+    assertEquals(rows.size(), 1);
+    assertFalse(rows.get(0).get(0).asBoolean());
+    // Test boolean not equal true case.
+    sqlQuery = "SELECT true != false FROM mytable";
+    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    rows = response.get("resultTable").get("rows");
+    assertTrue(response.get("exceptions").isEmpty());
+    assertEquals(rows.size(), 1);
+    assertTrue(rows.get(0).get(0).asBoolean());
+    // Test boolean not equal false case.
+    sqlQuery = "SELECT true != true FROM mytable";
+    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    rows = response.get("resultTable").get("rows");
+    assertTrue(response.get("exceptions").isEmpty());
+    assertEquals(rows.size(), 1);
+    assertFalse(rows.get(0).get(0).asBoolean());
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -206,7 +206,7 @@ public class AggregateOperator extends BaseOperator<TransferableBlock> {
             ExpressionContext.forIdentifier(String.valueOf(aggregationFunctionInputRef)));
       // COUNT(*) is rewritten to SUM(1)
       case "COUNT":
-        return new SumAggregationFunction(ExpressionContext.forLiteral("1"));
+        return new SumAggregationFunction(ExpressionContext.forLiteralContext(FieldSpec.DataType.INT, 1));
       default:
         throw new IllegalStateException(
             "Unexpected value: " + ((RexExpression.FunctionCall) aggCall).getFunctionName());

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorUtils.java
@@ -18,8 +18,12 @@
  */
 package org.apache.pinot.query.runtime.operator;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class OperatorUtils {
@@ -63,5 +67,13 @@ public class OperatorUtils {
   public static String canonicalizeFunctionName(String functionName) {
     functionName = OPERATOR_TOKEN_MAPPING.getOrDefault(functionName, functionName);
     return functionName;
+  }
+
+  public static List<FieldSpec.DataType> getParamTypes(List<RexExpression> operandExpressions) {
+    List<FieldSpec.DataType> args = new ArrayList<>();
+    for (RexExpression exp : operandExpressions) {
+      args.add(exp.getDataType());
+    }
+    return args;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/FunctionOperand.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/FunctionOperand.java
@@ -44,7 +44,7 @@ public class FunctionOperand extends TransformOperand {
     }
     FunctionInfo functionInfo =
         FunctionRegistry.getFunctionInfo(OperatorUtils.canonicalizeFunctionName(functionCall.getFunctionName()),
-            operandExpressions.size());
+            OperatorUtils.getParamTypes(operandExpressions));
     Preconditions.checkNotNull(functionInfo, "Cannot find function with Name: " + functionCall.getFunctionName());
     _functionInvoker = new FunctionInvoker(functionInfo);
     _resultName = computeColumnName(functionCall.getFunctionName(), _childOperandList);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
@@ -78,7 +78,7 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
             Preconditions.checkState(numArguments == 1, "NOT function expects 1 argument, got: %s", numArguments);
             return new NotExecutionNode(childNodes[0]);
           default:
-            FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, numArguments);
+            FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(function);
             if (functionInfo == null) {
               if (FunctionRegistry.containsFunction(functionName)) {
                 throw new IllegalStateException(

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
@@ -53,8 +53,8 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
 
   private ExecutableNode planExecution(ExpressionContext expression) {
     switch (expression.getType()) {
-      case LITERAL:
-        return new ConstantExecutionNode(expression.getLiteral());
+      case LITERAL_CONTEXT:
+        return new ConstantExecutionNode(expression.getLiteralString());
       case IDENTIFIER:
         String columnName = expression.getIdentifier();
         ColumnExecutionNode columnExecutionNode = new ColumnExecutionNode(columnName, _arguments.size());

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
@@ -53,7 +53,7 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
 
   private ExecutableNode planExecution(ExpressionContext expression) {
     switch (expression.getType()) {
-      case LITERAL_CONTEXT:
+      case LITERAL:
         return new ConstantExecutionNode(expression.getLiteralString());
       case IDENTIFIER:
         String columnName = expression.getIdentifier();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -1408,7 +1408,7 @@ public class MutableSegmentImpl implements MutableSegment {
           AggregationFunctionType.getAggregationFunctionType(functionContext.getFunctionName());
 
       columnNameToAggregator.put(config.getColumnName(),
-          Pair.of(argument.getLiteral(), ValueAggregatorFactory.getValueAggregator(functionType)));
+          Pair.of(argument.getLiteralString(), ValueAggregatorFactory.getValueAggregator(functionType)));
     }
 
     return columnNameToAggregator;


### PR DESCRIPTION
1) Functions are registered using FunctionName and  DataType (converted from Java type)
2) To make this fully work, we have to support all literal passing from SqlNode to Thrift so we can support all LiteralType
