### PR TITLE
Reduce the log in tests

### DIFF
--- a/pinot-broker/src/test/resources/log4j2.xml
+++ b/pinot-broker/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-clients/pinot-java-client/src/test/resources/log4j2.xml
+++ b/pinot-clients/pinot-java-client/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/LoggerUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/LoggerUtilsTest.java
@@ -30,31 +30,45 @@ import static org.testng.Assert.*;
 
 public class LoggerUtilsTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(LoggerUtilsTest.class);
+  private static final String ROOT = "root";
+  private static final String PINOT = "org.apache.pinot";
 
   @Test
   public void testGetAllLoggers() {
     List<String> allLoggers = LoggerUtils.getAllLoggers();
-    assertEquals(allLoggers.size(), 1);
-    assertEquals(allLoggers.get(0), "root");
+    assertEquals(allLoggers.size(), 2);
+    assertEquals(allLoggers.get(0), ROOT);
+    assertEquals(allLoggers.get(1), PINOT);
   }
 
   @Test
   public void testGetLoggerInfo() {
-    Map<String, String> rootLoggerInfo = LoggerUtils.getLoggerInfo("root");
-    assertEquals(rootLoggerInfo.get("name"), "root");
-    assertEquals(rootLoggerInfo.get("level"), "WARN");
+    Map<String, String> rootLoggerInfo = LoggerUtils.getLoggerInfo(ROOT);
+    assertNotNull(rootLoggerInfo);
+    assertEquals(rootLoggerInfo.get("name"), ROOT);
+    assertEquals(rootLoggerInfo.get("level"), "ERROR");
     assertNull(rootLoggerInfo.get("filter"));
+
+    Map<String, String> pinotLoggerInfo = LoggerUtils.getLoggerInfo(PINOT);
+    assertNotNull(pinotLoggerInfo);
+    assertEquals(pinotLoggerInfo.get("name"), PINOT);
+    assertEquals(pinotLoggerInfo.get("level"), "WARN");
+    assertNull(pinotLoggerInfo.get("filter"));
 
     assertNull(LoggerUtils.getLoggerInfo("notExistLogger"));
   }
 
   @Test
   public void testChangeLoggerLevel() {
-    assertEquals(LoggerUtils.getLoggerInfo("root").get("level"), "WARN");
-    for (String level : ImmutableList.of("WARN", "INFO", "DEBUG", "ERROR", "WARN")) {
-      LoggerUtils.setLoggerLevel("root", level);
+    Map<String, String> pinotLoggerInfo = LoggerUtils.getLoggerInfo(PINOT);
+    assertNotNull(pinotLoggerInfo);
+    assertEquals(pinotLoggerInfo.get("level"), "WARN");
+    for (String level : ImmutableList.of("TRACE", "DEBUG", "INFO", "ERROR", "WARN")) {
+      LoggerUtils.setLoggerLevel(PINOT, level);
       checkLogLevel(level);
-      assertEquals(LoggerUtils.getLoggerInfo("root").get("level"), level);
+      pinotLoggerInfo = LoggerUtils.getLoggerInfo(PINOT);
+      assertNotNull(pinotLoggerInfo);
+      assertEquals(pinotLoggerInfo.get("level"), level);
     }
   }
 
@@ -67,7 +81,7 @@ public class LoggerUtilsTest {
       assertEquals(e.getMessage(), "Logger - notExistLogger not found");
     }
     try {
-      LoggerUtils.setLoggerLevel("root", "NotALevel");
+      LoggerUtils.setLoggerLevel(ROOT, "NotALevel");
       fail("Shouldn't reach here");
     } catch (RuntimeException e) {
       assertEquals(e.getMessage(), "Unrecognized logger level - NotALevel");

--- a/pinot-common/src/test/resources/log4j2.xml
+++ b/pinot-common/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-connectors/pinot-spark-connector/src/test/resources/log4j2.xml
+++ b/pinot-connectors/pinot-spark-connector/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-controller/src/test/resources/log4j2.xml
+++ b/pinot-controller/src/test/resources/log4j2.xml
@@ -19,30 +19,17 @@
     under the License.
 
 -->
-<Configuration  strict="true"
-                xmlns="http://logging.apache.org/log4j/2.0/config"
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xsi:schemaLocation="http://logging.apache.org/log4j/2.0/config
-           https://raw.githubusercontent.com/apache/logging-log4j2/2.17.1/log4j-core/src/main/resources/Log4j-config.xsd">
+<Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout pattern="%d{HH:mm:ss.SSS} %c{1} - %m%n"/>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <Logger name="org.apache.zookeeper" level="warn" additivity="false">
-      <AppenderRef ref="console"/>
-    </Logger>
-    <Logger name="org.apache.helix" level="warn" additivity="false">
-      <AppenderRef ref="console"/>
-    </Logger>
-    <Logger name="org.apache.pinot.controller" level="warn" additivity="false">
-      <AppenderRef ref="console"/>
-    </Logger>
     <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
     </Logger>
-    <Root level="none">
+    <Root level="error">
       <AppenderRef ref="console"/>
     </Root>
   </Loggers>

--- a/pinot-core/src/test/resources/log4j2.xml
+++ b/pinot-core/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HelixZNodeSizeLimitTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HelixZNodeSizeLimitTest.java
@@ -22,8 +22,6 @@ package org.apache.pinot.integration.tests;
 import com.google.common.collect.ImmutableMap;
 import java.util.Map;
 import org.apache.helix.zookeeper.constant.ZkSystemPropertyKeys;
-import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.core.config.Configurator;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
@@ -38,6 +36,7 @@ import org.testng.annotations.Test;
  * large IdealStates
  */
 public class HelixZNodeSizeLimitTest extends BaseClusterIntegrationTest {
+
   @BeforeClass
   public void setUp()
       throws Exception {
@@ -47,12 +46,6 @@ public class HelixZNodeSizeLimitTest extends BaseClusterIntegrationTest {
     // src/main/java/org/apache/helix/zookeeper/zkclient/ZkClient.java#L105
     // The below line gets executed before ZkClient.WRITE_SIZE_LIMIT is created
     System.setProperty(ZkSystemPropertyKeys.JUTE_MAXBUFFER, "4000000");
-
-    // Set log level to ERROR, as there are too many warning messages printed if warn level is used like below:
-    //   20:07:11.616 WARN [TopStateHandoffReportStage] [HelixController-pipeline-default-HelixZNodeSizeLimitTest
-    //   -(b90d2ed3_DEFAULT)] Event b90d2ed3_DEFAULT : Cannot confirm top state missing start time.
-    //   Use the current system time as the start time.
-    Configurator.setAllLevels("", Level.ERROR);
 
     TestUtils.ensureDirectoriesExistAndEmpty(_tempDir);
 
@@ -72,9 +65,6 @@ public class HelixZNodeSizeLimitTest extends BaseClusterIntegrationTest {
     stopBroker();
     stopController();
     stopZk();
-
-    // Reset log level back to warn.
-    Configurator.setAllLevels("", Level.WARN);
   }
 
   @Test

--- a/pinot-integration-tests/src/test/resources/log4j2.xml
+++ b/pinot-integration-tests/src/test/resources/log4j2.xml
@@ -22,14 +22,20 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <!--Turn off the logger for KafkaConfluentSchemaRegistryAvroMessageDecoder because we intentionally inject
+     tombstones in KafkaConfluentSchemaRegistryAvroMessageDecoderRealtimeClusterIntegrationTest which can flood the log
+     -->
+    <Logger name="org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder"
+            level="off" additivity="false"/>
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-minion/src/test/resources/log4j2.xml
+++ b/pinot-minion/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/test/resources/log4j2.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/test/resources/log4j2.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/test/resources/log4j2.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/test/resources/log4j2.xml
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-plugins/pinot-file-system/pinot-hdfs/src/test/resources/log4j2.xml
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/test/resources/log4j2.xml
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/test/resources/log4j2.xml
@@ -19,7 +19,18 @@
     under the License.
 
 -->
-
-<configuration>
-  <root level="warn"/>
-</configuration>
+<Configuration>
+  <Appenders>
+    <Console name="console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
+      <AppenderRef ref="console"/>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/resources/log4j2.xml
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/test/resources/log4j2.xml
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-plugins/pinot-input-format/pinot-json/src/test/resources/log4j2.xml
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-plugins/pinot-input-format/pinot-orc/src/test/resources/log4j2.xml
+++ b/pinot-plugins/pinot-input-format/pinot-orc/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/test/resources/log4j2.xml
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/resources/log4j2.xml
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-plugins/pinot-input-format/pinot-thrift/src/test/resources/log4j2.xml
+++ b/pinot-plugins/pinot-input-format/pinot-thrift/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/src/test/resources/log4j2.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/resources/log4j2.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/test/resources/log4j2.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-segment-local/src/test/resources/log4j2.xml
+++ b/pinot-segment-local/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-server/src/test/resources/log4j2.xml
+++ b/pinot-server/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-spi/src/test/resources/log4j2.xml
+++ b/pinot-spi/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>

--- a/pinot-tools/src/test/resources/log4j2.xml
+++ b/pinot-tools/src/test/resources/log4j2.xml
@@ -22,14 +22,15 @@
 <Configuration>
   <Appenders>
     <Console name="console" target="SYSTEM_OUT">
-      <PatternLayout>
-        <pattern>%d{HH:mm:ss.SSS} %c{1} - %m%n</pattern>
-      </PatternLayout>
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
     </Console>
   </Appenders>
   <Loggers>
-    <AsyncRoot level="warn" additivity="false">
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
-    </AsyncRoot>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
   </Loggers>
 </Configuration>


### PR DESCRIPTION
Reduce the amount of log in tests:
- Log in WARN level for Pinot library
- Log in ERROR level for non-Pinot library
Do not use async logger for tests because it can cause confusion when debugging
Turn off the logger for `KafkaConfluentSchemaRegistryAvroMessageDecoder` because we intentionally inject tombstones in `KafkaConfluentSchemaRegistryAvroMessageDecoderRealtimeClusterIntegrationTest` which can flood the log