### PR TITLE
Add missing properties in CSV plugin

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVMessageDecoder.java
@@ -31,6 +31,7 @@ import java.util.Objects;
 import java.util.Set;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.csv.QuoteMode;
 import org.apache.commons.lang.StringUtils;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.stream.StreamMessageDecoder;
@@ -49,6 +50,12 @@ public class CSVMessageDecoder implements StreamMessageDecoder<byte[]> {
   private static final String CONFIG_CSV_ESCAPE_CHARACTER = "escapeCharacter";
   private static final String CONFIG_CSV_MULTI_VALUE_DELIMITER = "multiValueDelimiter";
   public static final String NULL_STRING_VALUE = "nullStringValue";
+  public static final String SKIP_HEADER = "skipHeader";
+  public static final String IGNORE_EMPTY_LINES = "ignoreEmptyLines";
+  public static final String IGNORE_SURROUNDING_SPACE = "ignoreSurroundingSpace";
+  public static final String QUOTE_CHARACTER = "quoteCharacter";
+  public static final String QUOTE_MODE = "quoteMode";
+  public static final String RECORD_SEPARATOR = "recordSeparator";
 
   private CSVFormat _format;
   private CSVRecordExtractor _recordExtractor;
@@ -115,6 +122,36 @@ public class CSVMessageDecoder implements StreamMessageDecoder<byte[]> {
     String nullString = props.get(NULL_STRING_VALUE);
     if (nullString != null) {
       format = format.withNullString(nullString);
+    }
+
+    String skipHeader = props.get(SKIP_HEADER);
+    if (skipHeader != null) {
+      format = format.withSkipHeaderRecord(Boolean.parseBoolean(skipHeader));
+    }
+
+    String ignoreEmptyLines = props.get(IGNORE_EMPTY_LINES);
+    if (ignoreEmptyLines != null) {
+      format = format.withIgnoreEmptyLines(Boolean.parseBoolean(ignoreEmptyLines));
+    }
+
+    String ignoreSurroundingSpace = props.get(IGNORE_SURROUNDING_SPACE);
+    if (ignoreSurroundingSpace != null) {
+      format = format.withIgnoreSurroundingSpaces(Boolean.parseBoolean(ignoreSurroundingSpace));
+    }
+
+    String quoteCharacter = props.get(QUOTE_CHARACTER);
+    if (quoteCharacter != null) {
+      format = format.withQuote(quoteCharacter.charAt(0));
+    }
+
+    String quoteMode = props.get(QUOTE_MODE);
+    if (quoteMode != null) {
+      format = format.withQuoteMode(QuoteMode.valueOf(quoteMode));
+    }
+
+    String recordSeparator = props.get(RECORD_SEPARATOR);
+    if (recordSeparator != null) {
+      format = format.withRecordSeparator(recordSeparator);
     }
 
     _format = format;

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVMessageDecoder.java
@@ -52,7 +52,7 @@ public class CSVMessageDecoder implements StreamMessageDecoder<byte[]> {
   public static final String NULL_STRING_VALUE = "nullStringValue";
   public static final String SKIP_HEADER = "skipHeader";
   public static final String IGNORE_EMPTY_LINES = "ignoreEmptyLines";
-  public static final String IGNORE_SURROUNDING_SPACE = "ignoreSurroundingSpace";
+  public static final String IGNORE_SURROUNDING_SPACES = "ignoreSurroundingSpaces";
   public static final String QUOTE_CHARACTER = "quoteCharacter";
   public static final String QUOTE_MODE = "quoteMode";
   public static final String RECORD_SEPARATOR = "recordSeparator";
@@ -134,9 +134,9 @@ public class CSVMessageDecoder implements StreamMessageDecoder<byte[]> {
       format = format.withIgnoreEmptyLines(Boolean.parseBoolean(ignoreEmptyLines));
     }
 
-    String ignoreSurroundingSpace = props.get(IGNORE_SURROUNDING_SPACE);
-    if (ignoreSurroundingSpace != null) {
-      format = format.withIgnoreSurroundingSpaces(Boolean.parseBoolean(ignoreSurroundingSpace));
+    String ignoreSurroundingSpaces = props.get(IGNORE_SURROUNDING_SPACES);
+    if (ignoreSurroundingSpaces != null) {
+      format = format.withIgnoreSurroundingSpaces(Boolean.parseBoolean(ignoreSurroundingSpaces));
     }
 
     String quoteCharacter = props.get(QUOTE_CHARACTER);

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVParser;
 import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.csv.QuoteMode;
 import org.apache.commons.lang.StringUtils;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
@@ -80,7 +81,7 @@ public class CSVRecordReader implements RecordReader {
         }
       }
       char delimiter = config.getDelimiter();
-      format = format.withDelimiter(delimiter).withIgnoreSurroundingSpaces(true);
+      format = format.withDelimiter(delimiter);
       String csvHeader = config.getHeader();
       if (csvHeader == null) {
         format = format.withHeader();
@@ -89,9 +90,22 @@ public class CSVRecordReader implements RecordReader {
         validateHeaderForDelimiter(delimiter, csvHeader, format);
         format = format.withHeader(StringUtils.split(csvHeader, delimiter));
       }
-      Character commentMarker = config.getCommentMarker();
-      format = format.withCommentMarker(commentMarker);
+
+      format = format.withCommentMarker(config.getCommentMarker());
       format = format.withEscape(config.getEscapeCharacter());
+      format = format.withIgnoreEmptyLines(config.isIgnoreEmptyLines());
+      format = format.withIgnoreSurroundingSpaces(config.isIgnoreSurroundingSpace());
+      format = format.withSkipHeaderRecord(config.isSkipHeader());
+      format = format.withQuote(config.getQuoteCharacter());
+
+      if (config.getQuoteMode() != null) {
+        format = format.withQuoteMode(QuoteMode.valueOf(config.getQuoteMode()));
+      }
+
+      if (config.getRecordSeparator() != null) {
+        format = format.withRecordSeparator(config.getRecordSeparator());
+      }
+
       String nullString = config.getNullStringValue();
       if (nullString != null) {
         format = format.withNullString(nullString);
@@ -101,6 +115,7 @@ public class CSVRecordReader implements RecordReader {
       if (config.isMultiValueDelimiterEnabled()) {
         multiValueDelimiter = config.getMultiValueDelimiter();
       }
+
     }
     _recordExtractor = new CSVRecordExtractor();
 

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
@@ -94,7 +94,7 @@ public class CSVRecordReader implements RecordReader {
       format = format.withCommentMarker(config.getCommentMarker());
       format = format.withEscape(config.getEscapeCharacter());
       format = format.withIgnoreEmptyLines(config.isIgnoreEmptyLines());
-      format = format.withIgnoreSurroundingSpaces(config.isIgnoreSurroundingSpace());
+      format = format.withIgnoreSurroundingSpaces(config.isIgnoreSurroundingSpaces());
       format = format.withSkipHeaderRecord(config.isSkipHeader());
       format = format.withQuote(config.getQuoteCharacter());
 
@@ -115,7 +115,6 @@ public class CSVRecordReader implements RecordReader {
       if (config.isMultiValueDelimiterEnabled()) {
         multiValueDelimiter = config.getMultiValueDelimiter();
       }
-
     }
     _recordExtractor = new CSVRecordExtractor();
 

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderConfig.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderConfig.java
@@ -36,6 +36,13 @@ public class CSVRecordReaderConfig implements RecordReaderConfig {
   private Character _commentMarker;   // Default is null
   private Character _escapeCharacter; // Default is null
   private String _nullStringValue;
+  private boolean _skipHeader;
+  private boolean _ignoreEmptyLines = true;
+  private boolean _ignoreSurroundingSpace = true;
+  private Character _quoteCharacter = '"';
+  private String _quoteMode;
+  private String _recordSeparator;
+
 
   public String getFileFormat() {
     return _fileFormat;
@@ -99,6 +106,54 @@ public class CSVRecordReaderConfig implements RecordReaderConfig {
 
   public void setNullStringValue(String nullStringValue) {
     _nullStringValue = nullStringValue;
+  }
+
+  public boolean isSkipHeader() {
+    return _skipHeader;
+  }
+
+  public void setSkipHeader(boolean skipHeader) {
+    _skipHeader = skipHeader;
+  }
+
+  public boolean isIgnoreEmptyLines() {
+    return _ignoreEmptyLines;
+  }
+
+  public void setIgnoreEmptyLines(boolean ignoreEmptyLines) {
+    _ignoreEmptyLines = ignoreEmptyLines;
+  }
+
+  public boolean isIgnoreSurroundingSpace() {
+    return _ignoreSurroundingSpace;
+  }
+
+  public void setIgnoreSurroundingSpace(boolean ignoreSurroundingSpace) {
+    _ignoreSurroundingSpace = ignoreSurroundingSpace;
+  }
+
+  public Character getQuoteCharacter() {
+    return _quoteCharacter;
+  }
+
+  public void setQuoteCharacter(Character quoteCharacter) {
+    _quoteCharacter = quoteCharacter;
+  }
+
+  public String getQuoteMode() {
+    return _quoteMode;
+  }
+
+  public void setQuoteMode(String quoteMode) {
+    _quoteMode = quoteMode;
+  }
+
+  public String getRecordSeparator() {
+    return _recordSeparator;
+  }
+
+  public void setRecordSeparator(String recordSeparator) {
+    _recordSeparator = recordSeparator;
   }
 
   @Override

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderConfig.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderConfig.java
@@ -38,7 +38,7 @@ public class CSVRecordReaderConfig implements RecordReaderConfig {
   private String _nullStringValue;
   private boolean _skipHeader;
   private boolean _ignoreEmptyLines = true;
-  private boolean _ignoreSurroundingSpace = true;
+  private boolean _ignoreSurroundingSpaces = true;
   private Character _quoteCharacter = '"';
   private String _quoteMode;
   private String _recordSeparator;
@@ -124,12 +124,12 @@ public class CSVRecordReaderConfig implements RecordReaderConfig {
     _ignoreEmptyLines = ignoreEmptyLines;
   }
 
-  public boolean isIgnoreSurroundingSpace() {
-    return _ignoreSurroundingSpace;
+  public boolean isIgnoreSurroundingSpaces() {
+    return _ignoreSurroundingSpaces;
   }
 
-  public void setIgnoreSurroundingSpace(boolean ignoreSurroundingSpace) {
-    _ignoreSurroundingSpace = ignoreSurroundingSpace;
+  public void setIgnoreSurroundingSpaces(boolean ignoreSurroundingSpaces) {
+    _ignoreSurroundingSpaces = ignoreSurroundingSpaces;
   }
 
   public Character getQuoteCharacter() {


### PR DESCRIPTION
Following new configurations are being added to csv reader :

- skipHeader - Set it to true to skip header line while processing CSV data. 
- ignoreEmptyLines - Set it to true to ignore empty lines, otherwise send them as empty string and let the processing logic take care of it.
- ignoreSurroundingSpaces - Set to true to ignore the spaces around values. 
- recordSeparator - Character being used to distinguising between multiple lines.
- quoteCharacter - single character that is being used for quotes in CSV files

- quoteMode - 

```
    /**
     * Quotes all fields.
     */
    ALL,

    /**
     * Quotes fields which contain special characters such as a delimiter, quote character or any of the characters in
     * line separator.
     */
    MINIMAL,

    /**
     * Quotes all non-numeric fields.
     */
    NON_NUMERIC,

    /**
     * Never quotes fields. When the delimiter occurs in data, it is preceded by the current escape character. If the
     * escape character is not set, printing will throw an exception if any characters that require escaping are
     * encountered.
     */
    NONE
 ```   


