### PR TITLE
Handle segments outside retention time gracefully during creation

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/util/CrcUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/CrcUtilsTest.java
@@ -77,8 +77,8 @@ public class CrcUtilsTest {
     final String filePath = TestUtils.getFileFromResourceUrl(CrcUtils.class.getClassLoader().getResource(AVRO_DATA));
 
     final SegmentGeneratorConfig config = SegmentTestUtils
-        .getSegmentGenSpecWithSchemAndProjectedColumns(new File(filePath), INDEX_DIR, "daysSinceEpoch", TimeUnit.DAYS,
-            "testTable");
+        .getSegmentGenSpecWithSchemAndProjectedColumns(new File(filePath), INDEX_DIR,
+            "daysSinceEpoch", TimeUnit.SECONDS, "testTable");
     config.setSegmentNamePostfix("1");
     final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(config);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -767,26 +767,36 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
               timeInterval, timeInterval.getStartMillis(), timeInterval.getEndMillis(), timeColumnName,
               TimeUtils.VALID_TIME_INTERVAL);
         } else {
+          /*
+              When user chooses to skip the time value check in table config, we need to gracefully handle the
+              segment startTime and endTime.
+              If the startTime and endTime for the segment are simply not within the valid time range, we set them to
+              current timestamps.
+              If they are within the valid time range, we check if the endTime falls outside retention time range.
+              In case it falls outside the time range, we replace endTime with currentTime so that the segments don't
+              get instantly deleted by retention manager after getting uploaded.
+           */
           Interval timeInterval =
               new Interval(timeUnit.toMillis(startTime), timeUnit.toMillis(endTime), DateTimeZone.UTC);
           long now = System.currentTimeMillis();
           if (!TimeUtils.isValidTimeInterval(timeInterval)) {
             startTime = now;
             endTime = now;
-          }
-          SegmentsValidationAndRetentionConfig validationConfig = _config.getTableConfig().getValidationConfig();
-          String retentionTimeUnitConfig = validationConfig.getRetentionTimeUnit();
-          String retentionTimeValueConfig = validationConfig.getRetentionTimeValue();
-          try {
-            TimeUnit retentionTimeUnit = TimeUnit.valueOf(retentionTimeUnitConfig.toUpperCase());
-            long retentionTimeValue = Long.parseLong(retentionTimeValueConfig);
-            long retentionTimeMs = retentionTimeUnit.toMillis(retentionTimeValue);
-            if (endTime <= (now - retentionTimeMs)) {
-              endTime = now;
+          } else {
+            SegmentsValidationAndRetentionConfig validationConfig = _config.getTableConfig().getValidationConfig();
+            String retentionTimeUnitConfig = validationConfig.getRetentionTimeUnit();
+            String retentionTimeValueConfig = validationConfig.getRetentionTimeValue();
+            try {
+              TimeUnit retentionTimeUnit = TimeUnit.valueOf(retentionTimeUnitConfig.toUpperCase());
+              long retentionTimeValue = Long.parseLong(retentionTimeValueConfig);
+              long retentionTimeMs = retentionTimeUnit.toMillis(retentionTimeValue);
+              if (endTime <= (now - retentionTimeMs)) {
+                endTime = now;
+              }
+            } catch (Exception e) {
+              LOGGER.warn("Invalid retention time: {} {} for table: {}, skipping segment endTime check",
+                  retentionTimeUnitConfig, retentionTimeValueConfig, _config.getTableName());
             }
-          } catch (Exception e) {
-            LOGGER.warn("Invalid retention time: {} {} for table: {}, skip", retentionTimeUnitConfig,
-                retentionTimeValueConfig, _config.getTableName());
           }
         }
 


### PR DESCRIPTION
When user chooses to skip the time value check in table config, we need to gracefully handle the
segment startTime and endTime.
If the startTime and endTime for the segment are simply not within the valid time range, we set them to
current timestamps.
If they are within the valid time range, we check if the endTime falls outside retention time range.
In case it falls outside the time range, we replace endTime with currentTime so that the segments don't
get instantly deleted by retention manager after getting uploaded.