### PR TITLE
fix(ui): table only displaying first 10 results when not explicitly paginated

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Homepage/ClusterConfig.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/ClusterConfig.tsx
@@ -47,7 +47,6 @@ const ClusterConfig = () => {
       data={tableData}
       showSearchBox={true}
       inAccordionFormat={true}
-      isPagination={false}
     />
   );
 };

--- a/pinot-controller/src/main/resources/app/components/Homepage/InstanceTable.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/InstanceTable.tsx
@@ -65,7 +65,6 @@ const InstanceTable = ({ name, instances, clusterName }: Props) => {
       inAccordionFormat={true}
       addLinks
       baseURL="/instance/"
-      isPagination
     />
   );
 };

--- a/pinot-controller/src/main/resources/app/components/Homepage/TenantsListing.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/TenantsListing.tsx
@@ -27,7 +27,6 @@ const TenantsTable = ({tenantsData}) => {
       title="Tenants"
       data={tenantsData}
       addLinks
-      isPagination
       baseURL="/tenants/"
       showSearchBox={true}
       inAccordionFormat={true}

--- a/pinot-controller/src/main/resources/app/components/Homepage/useTaskTypesTable.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/useTaskTypesTable.tsx
@@ -44,7 +44,6 @@ const useTaskTypesTable = () => {
         data={taskTypes}
         showSearchBox={true}
         inAccordionFormat={true}
-        isPagination={false}
         addLinks
         baseURL='/task-queue/'
       />

--- a/pinot-controller/src/main/resources/app/components/Query/QuerySideBar.tsx
+++ b/pinot-controller/src/main/resources/app/components/Query/QuerySideBar.tsx
@@ -98,8 +98,6 @@ const Sidebar = ({ tableList, fetchSQLData, tableSchema, selectedTable, queryLoa
             <CustomizedTables
               title="Tables"
               data={tableList}
-              isPagination={false}
-              noOfRows={tableList.records.length}
               cellClickCallback={fetchSQLData}
               isCellClickable
               showSearchBox={false}
@@ -109,8 +107,6 @@ const Sidebar = ({ tableList, fetchSQLData, tableSchema, selectedTable, queryLoa
               <CustomizedTables
                 title={`${selectedTable} schema`}
                 data={tableSchema}
-                isPagination={false}
-                noOfRows={tableSchema.records.length}
                 highlightBackground
                 showSearchBox={false}
               />

--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -292,6 +292,14 @@ export default function CustomizedTables({
     setPage(newPage);
   };
 
+  React.useEffect(() => {
+    if(isPagination) {
+      return;
+    }
+
+    setRowsPerPage(data?.records?.length);
+  }, [])
+
   const [search, setSearch] = React.useState<string>('');
 
   const timeoutId = React.useRef<NodeJS.Timeout>();

--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -53,9 +53,8 @@ import SimpleAccordion from './SimpleAccordion';
 type Props = {
   title?: string,
   data: TableData,
-  noOfRows?: number,
+  defaultRowsPerPage?: number,
   addLinks?: boolean,
-  isPagination?: boolean,
   cellClickCallback?: Function,
   isCellClickable?: boolean,
   highlightBackground?: boolean,
@@ -257,9 +256,8 @@ TablePaginationActions.propTypes = {
 export default function CustomizedTables({
   title,
   data,
-  noOfRows,
+  defaultRowsPerPage,
   addLinks,
-  isPagination,
   cellClickCallback,
   isCellClickable,
   highlightBackground,
@@ -278,7 +276,7 @@ export default function CustomizedTables({
   const [columnClicked, setColumnClicked] = React.useState('');
 
   const classes = useStyles();
-  const [rowsPerPage, setRowsPerPage] = React.useState(noOfRows || 10);
+  const [rowsPerPage, setRowsPerPage] = React.useState(defaultRowsPerPage || 10);
   const [page, setPage] = React.useState(0);
 
   const handleChangeRowsPerPage = (
@@ -291,14 +289,6 @@ export default function CustomizedTables({
   const handleChangePage = (event: unknown, newPage: number) => {
     setPage(newPage);
   };
-
-  React.useEffect(() => {
-    if(isPagination) {
-      return;
-    }
-
-    setRowsPerPage(data?.records?.length);
-  }, [])
 
   const [search, setSearch] = React.useState<string>('');
 
@@ -537,7 +527,7 @@ export default function CustomizedTables({
             </TableBody>
           </Table>
         </TableContainer>
-        {isPagination && finalData.length > 10 ? (
+        {finalData.length > 10 ? (
           <TablePagination
             rowsPerPageOptions={[5, 10, 25]}
             component="div"

--- a/pinot-controller/src/main/resources/app/components/usePeriodicTasks.tsx
+++ b/pinot-controller/src/main/resources/app/components/usePeriodicTasks.tsx
@@ -29,7 +29,6 @@ const PeriodicTaskTable = ({ tableData }) => {
       data={tableData}
       showSearchBox={true}
       inAccordionFormat={true}
-      isPagination={false}
     />
   );
 };

--- a/pinot-controller/src/main/resources/app/components/useTaskListing.tsx
+++ b/pinot-controller/src/main/resources/app/components/useTaskListing.tsx
@@ -47,7 +47,6 @@ export default function useTaskListing(props) {
         data={tasks}
         showSearchBox={true}
         inAccordionFormat={true}
-        isPagination={false}
         addLinks
         baseURL={`/task-queue/${taskType}/tables/${tableName}/task/`}
       />

--- a/pinot-controller/src/main/resources/app/pages/InstanceDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/InstanceDetails.tsx
@@ -382,7 +382,6 @@ const InstanceDetails = ({ match }: RouteComponentProps<Props>) => {
         <CustomizedTables
           title="Tables"
           data={tableData}
-          isPagination
           addLinks
           baseURL={`/instance/${instanceName}/table/`}
           showSearchBox={true}

--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -618,7 +618,6 @@ const QueryPage = () => {
                             <CustomizedTables
                               title="Query Result"
                               data={resultData}
-                              isPagination
                               isSticky={true}
                               showSearchBox={true}
                               inAccordionFormat={true}

--- a/pinot-controller/src/main/resources/app/pages/SchemaPageDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/SchemaPageDetails.tsx
@@ -258,8 +258,6 @@ const SchemaPageDetails = ({ match }: RouteComponentProps<Props>) => {
             <CustomizedTables
               title="Table Schema"
               data={tableSchema}
-              isPagination={false}
-              noOfRows={tableSchema.records.length}
               showSearchBox={true}
             />
           :

--- a/pinot-controller/src/main/resources/app/pages/SegmentDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/SegmentDetails.tsx
@@ -235,7 +235,6 @@ const SegmentDetails = ({ match }: RouteComponentProps<Props>) => {
           <CustomizedTables
             title="Replica Set"
             data={replica}
-            isPagination={true}
             showSearchBox={true}
             inAccordionFormat={true}
           />
@@ -262,7 +261,6 @@ const SegmentDetails = ({ match }: RouteComponentProps<Props>) => {
                 <CustomizedTables
                   title="Indexes"
                   data={indexes}
-                  isPagination={true}
                   showSearchBox={true}
                   inAccordionFormat={true}
                 />

--- a/pinot-controller/src/main/resources/app/pages/TablesListingPage.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TablesListingPage.tsx
@@ -122,7 +122,6 @@ const TablesListingPage = () => {
       <CustomizedTables
         title="Tables"
         data={tableData}
-        isPagination
         addLinks
         baseURL="/tenants/table/"
         showSearchBox={true}
@@ -132,7 +131,6 @@ const TablesListingPage = () => {
       <CustomizedTables
           title="Schemas"
           data={schemaDetails}
-          isPagination
           showSearchBox={true}
           inAccordionFormat={true}
           addLinks

--- a/pinot-controller/src/main/resources/app/pages/TaskDetail.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TaskDetail.tsx
@@ -119,7 +119,6 @@ const TaskDetail = (props) => {
               data={subtaskTableData}
               showSearchBox={true}
               inAccordionFormat={true}
-              isPagination={false}
               addLinks
               baseURL={`/task-queue/${taskType}/tables/${queueTableName}/task/${taskID}/sub-task/`}
             />

--- a/pinot-controller/src/main/resources/app/pages/TaskQueue.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TaskQueue.tsx
@@ -184,7 +184,6 @@ const TaskQueue = (props) => {
           data={tables}
           showSearchBox={true}
           inAccordionFormat={true}
-          isPagination={false}
           addLinks
           baseURL={`/task-queue/${taskType}/tables/`}
         />

--- a/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
@@ -499,7 +499,6 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
           <CustomizedTables
             title={"Segments - " + segmentList.records.length}
             data={segmentList}
-            isPagination={true}
             baseURL={
               tenantName && `/tenants/${tenantName}/table/${tableName}/` ||
               instanceName && `/instance/${instanceName}/table/${tableName}/` ||
@@ -515,8 +514,6 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
             <CustomizedTables
               title="Table Schema"
               data={tableSchema}
-              isPagination={false}
-              noOfRows={tableSchema.records.length}
               showSearchBox={true}
               inAccordionFormat={true}
               accordionToggleObject={{
@@ -548,8 +545,6 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
           <CustomizedTables
             title={"Instance Count - " + instanceCountData.records.length}
             data={instanceCountData}
-            isPagination={false}
-            noOfRows={instanceCountData.records.length}
             showSearchBox={true}
             inAccordionFormat={true}
           />

--- a/pinot-controller/src/main/resources/app/pages/Tenants.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Tenants.tsx
@@ -108,7 +108,6 @@ const TenantPage = ({ match }: RouteComponentProps<Props>) => {
         title={tenantName}
         data={tableData}
         tooltipData={TableTooltipData}
-        isPagination
         addLinks
         baseURL={`/tenants/${tenantName}/table/`}
         showSearchBox={true}
@@ -122,7 +121,6 @@ const TenantPage = ({ match }: RouteComponentProps<Props>) => {
               columns: ['Instance Name'],
               records: brokerData.length > 0 ? brokerData : []
             }}
-            isPagination
             addLinks
             baseURL="/instance/"
             showSearchBox={true}
@@ -136,7 +134,6 @@ const TenantPage = ({ match }: RouteComponentProps<Props>) => {
               columns: ['Instance Name'],
               records: serverData.length > 0 ? serverData : []
             }}
-            isPagination
             addLinks
             baseURL="/instance/"
             showSearchBox={true}


### PR DESCRIPTION
### Issue 
- In some tables UI only displays up to 10 rows, the user needs to search the row to be able to see it 

### Solution 
- Currently, UI handles large amount of table rows with pagination 
- The issue is we have to always explicitly pass `isPagination={true}` prop for pagination to show, and anyone can miss this easily.
- Now I have removed `isPagination` prop and set the pagination behavior as default.

> Default Behaviour now - If the table rows are less than 10 it will get displayed as it is without any pagination but if the table rows exceed 10 then the UI will show all the rows with pagination. 

### How to test

Before :
- Look at the Minion Task Manager table, if the rows are greater than 10 the UI will only display first 10 results 

After :
- If the table rows are less than 10 UI will display as it is 
- If the table rows are greater than 10 UI will display all the rows with pagination at the botton.

<img width="1394" alt="image" src="https://user-images.githubusercontent.com/41536903/191305121-60bb2e15-5e4e-43ee-ac3a-f55bcd81487b.png">

<img width="1393" alt="image" src="https://user-images.githubusercontent.com/41536903/191305279-14017e23-d16e-4420-a1d5-102759a9d8f1.png">

reviewers - @npawar @mayankshriv @joshigaurava 

