### PR TITLE
Disable logging for interrupted exceptions in kinesis

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
@@ -175,7 +175,9 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
       debugOrLogWarning("Encountered unknown unrecoverable AWS exception", e);
       throw new RuntimeException(e);
     } catch (AbortedException e) {
-      debugOrLogWarning("Task aborted due to exception", e);
+      if (!(e.getCause() instanceof InterruptedException)) {
+        debugOrLogWarning("Task aborted due to exception", e);
+      }
       return handleException(kinesisStartCheckpoint, recordList);
     } catch (Throwable e) {
       // non transient errors


### PR DESCRIPTION
Almost all of these logs are due to an Interrupted signal from the main thread because of fetch timeouts. It pollutes the log with irrelevant log messages and hence needs to be removed.