### PR TITLE
Benchmark thread cpu time

### DIFF
--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkThreadMXBeanThreadCPUTime.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkThreadMXBeanThreadCPUTime.java
@@ -53,7 +53,7 @@ public class BenchmarkThreadMXBeanThreadCPUTime {
   @Benchmark
   @BenchmarkMode(Mode.AverageTime)
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
-  public void benchAndFilterOperatorDegenerate(MyState myState, Blackhole bh) {
+  public void benchThreadMXBeanThreadCPUTime(MyState myState, Blackhole bh) {
     for (int i = 0; i < 1000; i++) {
       bh.consume(myState._threadMXBean.getCurrentThreadCpuTime());
     }

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkThreadMXBeanThreadCPUTime.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkThreadMXBeanThreadCPUTime.java
@@ -43,7 +43,8 @@ public class BenchmarkThreadMXBeanThreadCPUTime {
   public static void main(String[] args)
       throws RunnerException {
     Options opt =
-        new OptionsBuilder().include(BenchmarkThreadMXBeanThreadCPUTime.class.getSimpleName()).warmupTime(TimeValue.seconds(5))
+        new OptionsBuilder().include(BenchmarkThreadMXBeanThreadCPUTime.class.getSimpleName())
+            .warmupTime(TimeValue.seconds(5))
             .warmupIterations(3).measurementTime(TimeValue.seconds(10)).measurementIterations(5).forks(1).build();
 
     new Runner(opt).run();

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkThreadMXBeanThreadCPUTime.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkThreadMXBeanThreadCPUTime.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.ThreadMXBean;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+import org.openjdk.jmh.runner.options.TimeValue;
+
+
+@State(Scope.Benchmark)
+public class BenchmarkThreadMXBeanThreadCPUTime {
+
+  public static void main(String[] args)
+      throws RunnerException {
+    Options opt =
+        new OptionsBuilder().include(BenchmarkThreadMXBeanThreadCPUTime.class.getSimpleName()).warmupTime(TimeValue.seconds(5))
+            .warmupIterations(3).measurementTime(TimeValue.seconds(10)).measurementIterations(5).forks(1).build();
+
+    new Runner(opt).run();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  @OutputTimeUnit(TimeUnit.MILLISECONDS)
+  public void benchAndFilterOperatorDegenerate(MyState myState, Blackhole bh) {
+    for (int i = 0; i < 1000; i++) {
+      bh.consume(myState._threadMXBean.getCurrentThreadCpuTime());
+    }
+  }
+
+  @State(Scope.Benchmark)
+  public static class MyState {
+    public ThreadMXBean _threadMXBean;
+
+    @Setup(Level.Iteration)
+    public void doSetup() {
+      _threadMXBean = ManagementFactory.getThreadMXBean();
+    }
+  }
+}


### PR DESCRIPTION

<img width="625" alt="Screen Shot 2022-09-15 at 6 31 17 PM" src="https://user-images.githubusercontent.com/10736840/190537124-28a1c92f-a0ad-4fc2-88dd-c49cc3c6cca6.png">


Planning to use this for some resiliency feature. The call time is around 1/1000 ms per call