### PR TITLE
Bug fix: failure status in ingestion jobs doesn't reflect in exit code

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchDataIngestionJobCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchDataIngestionJobCommand.java
@@ -159,6 +159,7 @@ public class LaunchDataIngestionJobCommand extends AbstractBaseAdminCommand impl
 
   public static void main(String[] args) {
     PluginManager.get().init();
-    new CommandLine(new LaunchDataIngestionJobCommand()).execute(args);
+    int exitCode = new CommandLine(new LaunchDataIngestionJobCommand()).execute(args);
+    System.exit(exitCode);
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchSparkDataIngestionJobCommand.java
@@ -337,7 +337,8 @@ public class LaunchSparkDataIngestionJobCommand extends AbstractBaseAdminCommand
 
   public static void main(String[] args) {
     PluginManager.get().init();
-    new CommandLine(new LaunchSparkDataIngestionJobCommand()).execute(args);
+    int exitCode = new CommandLine(new LaunchSparkDataIngestionJobCommand()).execute(args);
+    System.exit(exitCode);
   }
 
   enum SparkType {


### PR DESCRIPTION
The CommandLine.execute method by default absorbs all the exceptions according to the documentation and only provides a proper exit code. In our ingestion job commands, we ignore this exitCode thus marking our jobs as success even in the case of failures. 

This is inline with the practice mentioned in picocli javadocs - https://picocli.info/apidocs/picocli/CommandLine.html#execute-java.lang.String...- 