### PR TITLE
Sort scanning based operators by cardinality in AndDocIdSet evaluation

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ExpressionScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ExpressionScanDocIdIterator.java
@@ -268,6 +268,12 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
     return _numEntriesScanned;
   }
 
+  @Override
+  public int getCardinality() {
+    // return -1 when not applicable
+    return -1;
+  }
+
   /**
    * NOTE: This operator contains only one block.
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ExpressionScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ExpressionScanDocIdIterator.java
@@ -268,12 +268,6 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
     return _numEntriesScanned;
   }
 
-  @Override
-  public int getCardinality() {
-    // return -1 when not applicable
-    return -1;
-  }
-
   /**
    * NOTE: This operator contains only one block.
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
@@ -41,18 +41,20 @@ public final class MVScanDocIdIterator implements ScanBasedDocIdIterator {
   private final int _numDocs;
   private final int _maxNumValuesPerMVEntry;
   private final ValueMatcher _valueMatcher;
+  private final int _cardinality;
 
   private int _nextDocId = 0;
   private long _numEntriesScanned = 0L;
 
   public MVScanDocIdIterator(PredicateEvaluator predicateEvaluator, ForwardIndexReader reader, int numDocs,
-      int maxNumValuesPerMVEntry) {
+      int maxNumValuesPerMVEntry, int cardinality) {
     _predicateEvaluator = predicateEvaluator;
     _reader = reader;
     _readerContext = reader.createContext();
     _numDocs = numDocs;
     _maxNumValuesPerMVEntry = maxNumValuesPerMVEntry;
     _valueMatcher = getValueMatcher();
+    _cardinality = cardinality;
   }
 
   @Override
@@ -102,6 +104,11 @@ public final class MVScanDocIdIterator implements ScanBasedDocIdIterator {
   @Override
   public long getNumEntriesScanned() {
     return _numEntriesScanned;
+  }
+
+  @Override
+  public int getCardinality() {
+    return _cardinality;
   }
 
   private ValueMatcher getValueMatcher() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
@@ -108,7 +108,7 @@ public final class MVScanDocIdIterator implements ScanBasedDocIdIterator {
   }
 
   /**
-   * This is a crude version of
+   * This is an approximation of probability calculation in
    * org.apache.pinot.controller.recommender.rules.utils.QueryInvertedSortedIndexRecommender#percentSelected
    */
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
@@ -30,7 +30,6 @@ import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
-
 /**
  * The {@code MVScanDocIdIterator} is the scan-based iterator for MVScanDocIdSet to scan a multi-value column for the
  * matching document ids.
@@ -113,21 +112,19 @@ public final class MVScanDocIdIterator implements ScanBasedDocIdIterator {
    * org.apache.pinot.controller.recommender.rules.utils.QueryInvertedSortedIndexRecommender#percentSelected
    */
   @Override
-  public float getEffectiveCardinality(boolean isAndDocIdSet) {
-    float numMatchingItems = _predicateEvaluator.getNumMatchingItems();
-    if (Float.isNaN(numMatchingItems) || _cardinality < 0) {
-      return ScanBasedDocIdIterator.super.getEffectiveCardinality(isAndDocIdSet);
+  public float getEstimatedCardinality(boolean isAndDocIdSet) {
+    int numMatchingItems = _predicateEvaluator.getNumMatchingItems();
+    if (numMatchingItems == Integer.MIN_VALUE || _cardinality < 0) {
+      return ScanBasedDocIdIterator.super.getEstimatedCardinality(isAndDocIdSet);
     }
-    int avgNumValuesPerMVEntry = _maxNumValuesPerMVEntry < 0
-        ? OptimizationConstants.DEFAULT_AVG_MV_ENTRIES
-        : _maxNumValuesPerMVEntry / OptimizationConstants.DEFAULT_AVG_MV_ENTRIES_DENOMINATOR;
+    int avgNumValuesPerMVEntry = _maxNumValuesPerMVEntry / OptimizationConstants.DEFAULT_AVG_MV_ENTRIES_DENOMINATOR;
 
     numMatchingItems = numMatchingItems > 0 ? numMatchingItems * avgNumValuesPerMVEntry
         : (numMatchingItems * avgNumValuesPerMVEntry + _cardinality);
 
     numMatchingItems = Math.max(Math.min(_cardinality, numMatchingItems), 0);
 
-    return _cardinality / numMatchingItems;
+    return ((float) _cardinality) / numMatchingItems;
   }
 
   private ValueMatcher getValueMatcher() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
@@ -117,7 +117,8 @@ public final class MVScanDocIdIterator implements ScanBasedDocIdIterator {
     if (numMatchingItems == Integer.MIN_VALUE || _cardinality < 0) {
       return ScanBasedDocIdIterator.super.getEstimatedCardinality(isAndDocIdSet);
     }
-    int avgNumValuesPerMVEntry = _maxNumValuesPerMVEntry / OptimizationConstants.DEFAULT_AVG_MV_ENTRIES_DENOMINATOR;
+    int avgNumValuesPerMVEntry =
+        Math.max(_maxNumValuesPerMVEntry / OptimizationConstants.DEFAULT_AVG_MV_ENTRIES_DENOMINATOR, 1);
 
     numMatchingItems = numMatchingItems > 0 ? numMatchingItems * avgNumValuesPerMVEntry
         : (numMatchingItems * avgNumValuesPerMVEntry + _cardinality);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
@@ -148,7 +148,7 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
   }
 
   /**
-   * This is a crude version of
+   * This is an approximation of probability calculation in
    * org.apache.pinot.controller.recommender.rules.utils.QueryInvertedSortedIndexRecommender#percentSelected
    */
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
@@ -152,13 +152,13 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
    * org.apache.pinot.controller.recommender.rules.utils.QueryInvertedSortedIndexRecommender#percentSelected
    */
   @Override
-  public float getEffectiveCardinality(boolean isAndDocIdSet) {
-    float numMatchingItems = _predicateEvaluator.getNumMatchingItems();
-    if (Float.isNaN(numMatchingItems) || _cardinality < 0) {
-      return ScanBasedDocIdIterator.super.getEffectiveCardinality(isAndDocIdSet);
+  public float getEstimatedCardinality(boolean isAndDocIdSet) {
+    int numMatchingItems = _predicateEvaluator.getNumMatchingItems();
+    if (numMatchingItems == Integer.MIN_VALUE || _cardinality < 0) {
+      return ScanBasedDocIdIterator.super.getEstimatedCardinality(isAndDocIdSet);
     }
     numMatchingItems = numMatchingItems > 0 ? numMatchingItems : (numMatchingItems + _cardinality);
-    return _cardinality / numMatchingItems;
+    return ((float) _cardinality) / numMatchingItems;
   }
 
   private ValueMatcher getValueMatcher(@Nullable ImmutableRoaringBitmap nullBitmap) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
@@ -46,12 +46,13 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
   private final int[] _batch = new int[OPTIMAL_ITERATOR_BATCH_SIZE];
   private int _firstMismatch;
   private int _cursor;
+  private final int _cardinality;
 
   private int _nextDocId = 0;
   private long _numEntriesScanned = 0L;
 
   public SVScanDocIdIterator(PredicateEvaluator predicateEvaluator, ForwardIndexReader reader, int numDocs,
-      @Nullable NullValueVectorReader nullValueReader) {
+      @Nullable NullValueVectorReader nullValueReader, int cardinality) {
     _predicateEvaluator = predicateEvaluator;
     _reader = reader;
     _readerContext = reader.createContext();
@@ -61,6 +62,7 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
       nullBitmap = null;
     }
     _valueMatcher = getValueMatcher(nullBitmap);
+    _cardinality = cardinality;
   }
 
   @Override
@@ -127,6 +129,11 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
   @Override
   public long getNumEntriesScanned() {
     return _numEntriesScanned;
+  }
+
+  @Override
+  public int getCardinality() {
+    return _cardinality;
   }
 
   private ValueMatcher getValueMatcher(@Nullable ImmutableRoaringBitmap nullBitmap) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
@@ -49,7 +49,7 @@ public interface ScanBasedDocIdIterator extends BlockDocIdIterator {
    * Returns the effective cardinality of the underlying data source
    */
 
-  default float getEffectiveCardinality(boolean isAndDocIdSet) {
+  default float getEstimatedCardinality(boolean isAndDocIdSet) {
     //default N/A behavior so that it always get picked in the end
     return isAndDocIdSet ? Float.NEGATIVE_INFINITY : Float.POSITIVE_INFINITY;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
@@ -46,7 +46,7 @@ public interface ScanBasedDocIdIterator extends BlockDocIdIterator {
   long getNumEntriesScanned();
 
   /**
-   * Returns the effective cardinality of the underlying data source
+   * Returns the estimated (effective) cardinality of the underlying data source
    */
 
   default float getEstimatedCardinality(boolean isAndDocIdSet) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
@@ -44,4 +44,9 @@ public interface ScanBasedDocIdIterator extends BlockDocIdIterator {
    * iteration. This method should be called after the iteration is done.
    */
   long getNumEntriesScanned();
+
+  /**
+   * Returns the cardinality of the underlying data source, -1 if not applicable.
+   */
+  int getCardinality();
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
@@ -46,7 +46,11 @@ public interface ScanBasedDocIdIterator extends BlockDocIdIterator {
   long getNumEntriesScanned();
 
   /**
-   * Returns the cardinality of the underlying data source, -1 if not applicable.
+   * Returns the effective cardinality of the underlying data source
    */
-  int getCardinality();
+
+  default float getEffectiveCardinality(boolean isAndDocIdSet) {
+    //default N/A behavior so that it always get picked in the end
+    return isAndDocIdSet ? Float.NEGATIVE_INFINITY : Float.POSITIVE_INFINITY;
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
@@ -92,8 +92,13 @@ public final class AndDocIdSet implements FilterBlockDocIdSet {
     bitmapBasedDocIdIterators.sort(Comparator.comparing(x -> x.getDocIds().getCardinality()));
 
     // Evaluate the scan based operator with the highest cardinality coming first, this potentially reduce the range of
-    // scanning from the beginning. Automatically place N/A cardinality column (-1) to the back as we want to
-    // evaluate ExpressionScanDocIdIterator in the end.
+    // scanning from the beginning. Automatically place N/A cardinality column (-1) to the back as we want to evaluate
+    // ExpressionScanDocIdIterator in the end.
+    // TODO: 1. remainingDocIdIterators currently doesn't report cardinality; therefore, right now it cannot be
+    //          prioritized even if it provides high effective cardinality, one way to do this is to let AND/OR
+    //          DocIdIterators pass up cardinality for the sort to happen recursively for nested AND OR predicates
+    //       2. range eval currently doesn't report effective cardinality but theoretically it can at least for the
+    //          dictionary backed column
     if (_cardinalityBasedRankingForScan) {
       scanBasedDocIdIterators.sort(Comparator.comparing(x -> (-x.getEstimatedCardinality(true))));
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
@@ -96,7 +96,7 @@ public final class AndDocIdSet implements FilterBlockDocIdSet {
     // ExpressionScanDocIdIterator in the end.
     // TODO: 1. remainingDocIdIterators currently doesn't report cardinality; therefore, right now it cannot be
     //          prioritized even if it provides high effective cardinality, one way to do this is to let AND/OR
-    //          DocIdIterators pass up cardinality for the sort to happen recursively for nested AND OR predicates
+    //          DocIdIterators bubble up cardinality for the sort to happen recursively for nested AND OR predicates
     //       2. range eval currently doesn't report effective cardinality but theoretically it can at least for the
     //          dictionary backed column
     if (_cardinalityBasedRankingForScan) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
@@ -92,8 +92,8 @@ public final class AndDocIdSet implements FilterBlockDocIdSet {
     bitmapBasedDocIdIterators.sort(Comparator.comparing(x -> x.getDocIds().getCardinality()));
 
     // Evaluate the scan based operator with the highest cardinality coming first, this potentially reduce the range of
-    // scanning from the beginning. Automatically place N/A cardinality column (-1) to the back as we want to evaluate
-    // ExpressionScanDocIdIterator in the end.
+    // scanning from the beginning. Automatically place N/A cardinality column (negative infinity) to the back as we
+    // want to evaluate these unestimated predicates in the end.
     // TODO: 1. remainingDocIdIterators currently doesn't report cardinality; therefore, it cannot be
     //          prioritized even if it provides high effective cardinality, one way to do this is to let AND/OR
     //          DocIdIterators bubble up cardinality for the sort to happen recursively for nested AND-OR predicates

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
@@ -97,8 +97,6 @@ public final class AndDocIdSet implements FilterBlockDocIdSet {
     // TODO: 1. remainingDocIdIterators currently doesn't report cardinality; therefore, it cannot be
     //          prioritized even if it provides high effective cardinality, one way to do this is to let AND/OR
     //          DocIdIterators bubble up cardinality for the sort to happen recursively for nested AND-OR predicates
-    //       2. range eval currently doesn't report effective cardinality but theoretically it can at least for the
-    //          dictionary backed columns
     if (_cardinalityBasedRankingForScan) {
       scanBasedDocIdIterators.sort(Comparator.comparing(x -> (-x.getEstimatedCardinality(true))));
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.collections.MapUtils;
 import org.apache.pinot.core.common.BlockDocIdIterator;
 import org.apache.pinot.core.operator.dociditerators.AndDocIdIterator;
 import org.apache.pinot.core.operator.dociditerators.BitmapBasedDocIdIterator;
@@ -58,7 +59,8 @@ public final class AndDocIdSet implements FilterBlockDocIdSet {
 
   public AndDocIdSet(List<FilterBlockDocIdSet> docIdSets, Map<String, String> queryOptions) {
     _docIdSets = docIdSets;
-    _cardinalityBasedRankingForScan = QueryOptionsUtils.isAndScanReorderingEnabled(queryOptions);
+    _cardinalityBasedRankingForScan =
+        !MapUtils.isEmpty(queryOptions) && QueryOptionsUtils.isAndScanReorderingEnabled(queryOptions);
   }
 
   @Override
@@ -93,7 +95,7 @@ public final class AndDocIdSet implements FilterBlockDocIdSet {
     // scanning from the beginning. Automatically place N/A cardinality column (-1) to the back as we want to
     // evaluate ExpressionScanDocIdIterator in the end.
     if (_cardinalityBasedRankingForScan) {
-      scanBasedDocIdIterators.sort(Comparator.comparing(x -> (-x.getEffectiveCardinality(true))));
+      scanBasedDocIdIterators.sort(Comparator.comparing(x -> (-x.getEstimatedCardinality(true))));
     }
 
     int numSortedDocIdIterators = sortedDocIdIterators.size();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
@@ -94,11 +94,11 @@ public final class AndDocIdSet implements FilterBlockDocIdSet {
     // Evaluate the scan based operator with the highest cardinality coming first, this potentially reduce the range of
     // scanning from the beginning. Automatically place N/A cardinality column (-1) to the back as we want to evaluate
     // ExpressionScanDocIdIterator in the end.
-    // TODO: 1. remainingDocIdIterators currently doesn't report cardinality; therefore, right now it cannot be
+    // TODO: 1. remainingDocIdIterators currently doesn't report cardinality; therefore, it cannot be
     //          prioritized even if it provides high effective cardinality, one way to do this is to let AND/OR
-    //          DocIdIterators bubble up cardinality for the sort to happen recursively for nested AND OR predicates
+    //          DocIdIterators bubble up cardinality for the sort to happen recursively for nested AND-OR predicates
     //       2. range eval currently doesn't report effective cardinality but theoretically it can at least for the
-    //          dictionary backed column
+    //          dictionary backed columns
     if (_cardinalityBasedRankingForScan) {
       scanBasedDocIdIterators.sort(Comparator.comparing(x -> (-x.getEstimatedCardinality(true))));
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/MVScanDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/MVScanDocIdSet.java
@@ -20,15 +20,17 @@ package org.apache.pinot.core.operator.docidsets;
 
 import org.apache.pinot.core.operator.dociditerators.MVScanDocIdIterator;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
-import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.datasource.DataSource;
 
 
 public final class MVScanDocIdSet implements FilterBlockDocIdSet {
   private final MVScanDocIdIterator _docIdIterator;
 
-  public MVScanDocIdSet(PredicateEvaluator predicateEvaluator, ForwardIndexReader<?> reader, int numDocs,
+  public MVScanDocIdSet(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs,
       int maxNumEntriesPerValue) {
-    _docIdIterator = new MVScanDocIdIterator(predicateEvaluator, reader, numDocs, maxNumEntriesPerValue);
+    _docIdIterator =
+        new MVScanDocIdIterator(predicateEvaluator, dataSource.getForwardIndex(), numDocs, maxNumEntriesPerValue,
+            dataSource.getDataSourceMetadata().getCardinality());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/MVScanDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/MVScanDocIdSet.java
@@ -27,8 +27,7 @@ public final class MVScanDocIdSet implements FilterBlockDocIdSet {
   private final MVScanDocIdIterator _docIdIterator;
 
   public MVScanDocIdSet(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs) {
-    _docIdIterator =
-        new MVScanDocIdIterator(predicateEvaluator, dataSource, numDocs);
+    _docIdIterator = new MVScanDocIdIterator(predicateEvaluator, dataSource, numDocs);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/MVScanDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/MVScanDocIdSet.java
@@ -26,11 +26,9 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
 public final class MVScanDocIdSet implements FilterBlockDocIdSet {
   private final MVScanDocIdIterator _docIdIterator;
 
-  public MVScanDocIdSet(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs,
-      int maxNumEntriesPerValue) {
+  public MVScanDocIdSet(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs) {
     _docIdIterator =
-        new MVScanDocIdIterator(predicateEvaluator, dataSource.getForwardIndex(), numDocs, maxNumEntriesPerValue,
-            dataSource.getDataSourceMetadata().getCardinality());
+        new MVScanDocIdIterator(predicateEvaluator, dataSource, numDocs);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/SVScanDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/SVScanDocIdSet.java
@@ -30,8 +30,8 @@ public final class SVScanDocIdSet implements FilterBlockDocIdSet {
   public SVScanDocIdSet(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs,
       boolean nullHandlingEnabled) {
     NullValueVectorReader nullValueVector = nullHandlingEnabled ? dataSource.getNullValueVector() : null;
-    _docIdIterator = new SVScanDocIdIterator(
-        predicateEvaluator, dataSource.getForwardIndex(), numDocs, nullValueVector);
+    _docIdIterator = new SVScanDocIdIterator(predicateEvaluator, dataSource.getForwardIndex(), numDocs, nullValueVector,
+        dataSource.getDataSourceMetadata().getCardinality());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/SVScanDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/SVScanDocIdSet.java
@@ -30,8 +30,7 @@ public final class SVScanDocIdSet implements FilterBlockDocIdSet {
   public SVScanDocIdSet(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs,
       boolean nullHandlingEnabled) {
     NullValueVectorReader nullValueVector = nullHandlingEnabled ? dataSource.getNullValueVector() : null;
-    _docIdIterator = new SVScanDocIdIterator(predicateEvaluator, dataSource.getForwardIndex(), numDocs, nullValueVector,
-        dataSource.getDataSourceMetadata().getCardinality());
+    _docIdIterator = new SVScanDocIdIterator(predicateEvaluator, dataSource, numDocs, nullValueVector);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/AndFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/AndFilterOperator.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.operator.filter;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.FilterBlock;
 import org.apache.pinot.core.operator.docidsets.AndDocIdSet;
@@ -33,9 +34,15 @@ public class AndFilterOperator extends BaseFilterOperator {
   private static final String EXPLAIN_NAME = "FILTER_AND";
 
   private final List<BaseFilterOperator> _filterOperators;
+  private final Map<String, String> _queryOptions;
+
+  public AndFilterOperator(List<BaseFilterOperator> filterOperators, Map<String, String> queryOptions) {
+    _filterOperators = filterOperators;
+    _queryOptions = queryOptions;
+  }
 
   public AndFilterOperator(List<BaseFilterOperator> filterOperators) {
-    _filterOperators = filterOperators;
+    this(filterOperators, null);
   }
 
   @Override
@@ -45,7 +52,7 @@ public class AndFilterOperator extends BaseFilterOperator {
     for (BaseFilterOperator filterOperator : _filterOperators) {
       filterBlockDocIdSets.add(filterOperator.nextBlock().getBlockDocIdSet());
     }
-    return new FilterBlock(new AndDocIdSet(filterBlockDocIdSets));
+    return new FilterBlock(new AndDocIdSet(filterBlockDocIdSets, _queryOptions));
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/CombinedFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/CombinedFilterOperator.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.operator.filter;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.FilterBlock;
 import org.apache.pinot.core.operator.docidsets.AndDocIdSet;
@@ -36,10 +37,13 @@ public class CombinedFilterOperator extends BaseFilterOperator {
 
   private final BaseFilterOperator _mainFilterOperator;
   private final BaseFilterOperator _subFilterOperator;
+  private final Map<String, String> _queryOptions;
 
-  public CombinedFilterOperator(BaseFilterOperator mainFilterOperator, BaseFilterOperator subFilterOperator) {
+  public CombinedFilterOperator(BaseFilterOperator mainFilterOperator, BaseFilterOperator subFilterOperator,
+      Map<String, String> queryOptions) {
     _mainFilterOperator = mainFilterOperator;
     _subFilterOperator = subFilterOperator;
+    _queryOptions = queryOptions;
   }
 
   @Override
@@ -57,6 +61,6 @@ public class CombinedFilterOperator extends BaseFilterOperator {
     Tracing.activeRecording().setNumChildren(2);
     FilterBlockDocIdSet mainFilterDocIdSet = _mainFilterOperator.nextBlock().getNonScanFilterBLockDocIdSet();
     FilterBlockDocIdSet subFilterDocIdSet = _subFilterOperator.nextBlock().getBlockDocIdSet();
-    return new FilterBlock(new AndDocIdSet(Arrays.asList(mainFilterDocIdSet, subFilterDocIdSet)));
+    return new FilterBlock(new AndDocIdSet(Arrays.asList(mainFilterDocIdSet, subFilterDocIdSet), _queryOptions));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
@@ -107,7 +107,7 @@ public class FilterOperatorUtils {
     } else {
       // Return the AND filter operator with re-ordered child filter operators
       FilterOperatorUtils.reorderAndFilterChildOperators(queryContext, childFilterOperators);
-      return new AndFilterOperator(childFilterOperators);
+      return new AndFilterOperator(childFilterOperators, queryContext.getQueryOptions());
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ScanBasedFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ScanBasedFilterOperator.java
@@ -51,7 +51,7 @@ public class ScanBasedFilterOperator extends BaseFilterOperator {
     if (dataSourceMetadata.isSingleValue()) {
       return new FilterBlock(new SVScanDocIdSet(_predicateEvaluator, _dataSource, _numDocs, _nullHandlingEnabled));
     } else {
-      return new FilterBlock(new MVScanDocIdSet(_predicateEvaluator, _dataSource.getForwardIndex(), _numDocs,
+      return new FilterBlock(new MVScanDocIdSet(_predicateEvaluator, _dataSource, _numDocs,
           dataSourceMetadata.getMaxNumValuesPerMVEntry()));
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ScanBasedFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ScanBasedFilterOperator.java
@@ -51,8 +51,7 @@ public class ScanBasedFilterOperator extends BaseFilterOperator {
     if (dataSourceMetadata.isSingleValue()) {
       return new FilterBlock(new SVScanDocIdSet(_predicateEvaluator, _dataSource, _numDocs, _nullHandlingEnabled));
     } else {
-      return new FilterBlock(new MVScanDocIdSet(_predicateEvaluator, _dataSource, _numDocs,
-          dataSourceMetadata.getMaxNumValuesPerMVEntry()));
+      return new FilterBlock(new MVScanDocIdSet(_predicateEvaluator, _dataSource, _numDocs));
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/EqualsPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/EqualsPredicateEvaluatorFactory.java
@@ -102,7 +102,7 @@ public class EqualsPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return 1;
     }
 
@@ -139,7 +139,7 @@ public class EqualsPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return 1;
     }
 
@@ -176,7 +176,7 @@ public class EqualsPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return 1;
     }
 
@@ -213,7 +213,7 @@ public class EqualsPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return 1;
     }
 
@@ -250,7 +250,7 @@ public class EqualsPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return 1;
     }
 
@@ -287,7 +287,7 @@ public class EqualsPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return 1;
     }
 
@@ -311,7 +311,7 @@ public class EqualsPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return 1;
     }
 
@@ -335,7 +335,7 @@ public class EqualsPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return 1;
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/EqualsPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/EqualsPredicateEvaluatorFactory.java
@@ -102,6 +102,11 @@ public class EqualsPredicateEvaluatorFactory {
     }
 
     @Override
+    public float getNumMatchingItems() {
+      return 1;
+    }
+
+    @Override
     public boolean applySV(int dictId) {
       return _matchingDictId == dictId;
     }
@@ -131,6 +136,11 @@ public class EqualsPredicateEvaluatorFactory {
     IntRawValueBasedEqPredicateEvaluator(EqPredicate eqPredicate, int matchingValue) {
       super(eqPredicate);
       _matchingValue = matchingValue;
+    }
+
+    @Override
+    public float getNumMatchingItems() {
+      return 1;
     }
 
     @Override
@@ -166,6 +176,11 @@ public class EqualsPredicateEvaluatorFactory {
     }
 
     @Override
+    public float getNumMatchingItems() {
+      return 1;
+    }
+
+    @Override
     public DataType getDataType() {
       return DataType.LONG;
     }
@@ -195,6 +210,11 @@ public class EqualsPredicateEvaluatorFactory {
     FloatRawValueBasedEqPredicateEvaluator(EqPredicate eqPredicate, float matchingValue) {
       super(eqPredicate);
       _matchingValue = matchingValue;
+    }
+
+    @Override
+    public float getNumMatchingItems() {
+      return 1;
     }
 
     @Override
@@ -230,6 +250,11 @@ public class EqualsPredicateEvaluatorFactory {
     }
 
     @Override
+    public float getNumMatchingItems() {
+      return 1;
+    }
+
+    @Override
     public DataType getDataType() {
       return DataType.DOUBLE;
     }
@@ -262,6 +287,11 @@ public class EqualsPredicateEvaluatorFactory {
     }
 
     @Override
+    public float getNumMatchingItems() {
+      return 1;
+    }
+
+    @Override
     public DataType getDataType() {
       return DataType.BIG_DECIMAL;
     }
@@ -281,6 +311,11 @@ public class EqualsPredicateEvaluatorFactory {
     }
 
     @Override
+    public float getNumMatchingItems() {
+      return 1;
+    }
+
+    @Override
     public DataType getDataType() {
       return DataType.STRING;
     }
@@ -297,6 +332,11 @@ public class EqualsPredicateEvaluatorFactory {
     BytesRawValueBasedEqPredicateEvaluator(EqPredicate eqPredicate, byte[] matchingValue) {
       super(eqPredicate);
       _matchingValue = matchingValue;
+    }
+
+    @Override
+    public float getNumMatchingItems() {
+      return 1;
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/InPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/InPredicateEvaluatorFactory.java
@@ -177,7 +177,7 @@ public class InPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return getNumMatchingDictIds();
     }
 
@@ -212,7 +212,7 @@ public class InPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return _matchingValues.size();
     }
 
@@ -249,7 +249,7 @@ public class InPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return _matchingValues.size();
     }
 
@@ -286,7 +286,7 @@ public class InPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return _matchingValues.size();
     }
 
@@ -323,7 +323,7 @@ public class InPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return _matchingValues.size();
     }
 
@@ -366,7 +366,7 @@ public class InPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return _matchingValues.size();
     }
 
@@ -390,7 +390,7 @@ public class InPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return _matchingValues.size();
     }
 
@@ -414,7 +414,7 @@ public class InPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return _matchingValues.size();
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/InPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/InPredicateEvaluatorFactory.java
@@ -177,6 +177,11 @@ public class InPredicateEvaluatorFactory {
     }
 
     @Override
+    public float getNumMatchingItems() {
+      return getNumMatchingDictIds();
+    }
+
+    @Override
     public int[] getMatchingDictIds() {
       if (_matchingDictIds == null) {
         _matchingDictIds = _matchingDictIdSet.toIntArray();
@@ -204,6 +209,11 @@ public class InPredicateEvaluatorFactory {
     IntRawValueBasedInPredicateEvaluator(InPredicate inPredicate, IntSet matchingValues) {
       super(inPredicate);
       _matchingValues = matchingValues;
+    }
+
+    @Override
+    public float getNumMatchingItems() {
+      return _matchingValues.size();
     }
 
     @Override
@@ -239,6 +249,11 @@ public class InPredicateEvaluatorFactory {
     }
 
     @Override
+    public float getNumMatchingItems() {
+      return _matchingValues.size();
+    }
+
+    @Override
     public DataType getDataType() {
       return DataType.LONG;
     }
@@ -271,6 +286,11 @@ public class InPredicateEvaluatorFactory {
     }
 
     @Override
+    public float getNumMatchingItems() {
+      return _matchingValues.size();
+    }
+
+    @Override
     public DataType getDataType() {
       return DataType.FLOAT;
     }
@@ -300,6 +320,11 @@ public class InPredicateEvaluatorFactory {
     DoubleRawValueBasedInPredicateEvaluator(InPredicate inPredicate, DoubleSet matchingValues) {
       super(inPredicate);
       _matchingValues = matchingValues;
+    }
+
+    @Override
+    public float getNumMatchingItems() {
+      return _matchingValues.size();
     }
 
     @Override
@@ -341,6 +366,11 @@ public class InPredicateEvaluatorFactory {
     }
 
     @Override
+    public float getNumMatchingItems() {
+      return _matchingValues.size();
+    }
+
+    @Override
     public DataType getDataType() {
       return DataType.BIG_DECIMAL;
     }
@@ -360,6 +390,11 @@ public class InPredicateEvaluatorFactory {
     }
 
     @Override
+    public float getNumMatchingItems() {
+      return _matchingValues.size();
+    }
+
+    @Override
     public DataType getDataType() {
       return DataType.STRING;
     }
@@ -376,6 +411,11 @@ public class InPredicateEvaluatorFactory {
     BytesRawValueBasedInPredicateEvaluator(InPredicate inPredicate, Set<ByteArray> matchingValues) {
       super(inPredicate);
       _matchingValues = matchingValues;
+    }
+
+    @Override
+    public float getNumMatchingItems() {
+      return _matchingValues.size();
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotEqualsPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotEqualsPredicateEvaluatorFactory.java
@@ -105,6 +105,11 @@ public class NotEqualsPredicateEvaluatorFactory {
     }
 
     @Override
+    public float getNumMatchingItems() {
+      return -1;
+    }
+
+    @Override
     public boolean applySV(int dictId) {
       return _nonMatchingDictId != dictId;
     }
@@ -159,6 +164,11 @@ public class NotEqualsPredicateEvaluatorFactory {
     }
 
     @Override
+    public float getNumMatchingItems() {
+      return -1;
+    }
+
+    @Override
     public DataType getDataType() {
       return DataType.INT;
     }
@@ -188,6 +198,11 @@ public class NotEqualsPredicateEvaluatorFactory {
     LongRawValueBasedNeqPredicateEvaluator(NotEqPredicate notEqPredicate, long nonMatchingValue) {
       super(notEqPredicate);
       _nonMatchingValue = nonMatchingValue;
+    }
+
+    @Override
+    public float getNumMatchingItems() {
+      return -1;
     }
 
     @Override
@@ -223,6 +238,11 @@ public class NotEqualsPredicateEvaluatorFactory {
     }
 
     @Override
+    public float getNumMatchingItems() {
+      return -1;
+    }
+
+    @Override
     public DataType getDataType() {
       return DataType.FLOAT;
     }
@@ -252,6 +272,11 @@ public class NotEqualsPredicateEvaluatorFactory {
     DoubleRawValueBasedNeqPredicateEvaluator(NotEqPredicate notEqPredicate, double nonMatchingValue) {
       super(notEqPredicate);
       _nonMatchingValue = nonMatchingValue;
+    }
+
+    @Override
+    public float getNumMatchingItems() {
+      return -1;
     }
 
     @Override
@@ -287,6 +312,11 @@ public class NotEqualsPredicateEvaluatorFactory {
     }
 
     @Override
+    public float getNumMatchingItems() {
+      return -1;
+    }
+
+    @Override
     public DataType getDataType() {
       return DataType.BIG_DECIMAL;
     }
@@ -306,6 +336,11 @@ public class NotEqualsPredicateEvaluatorFactory {
     }
 
     @Override
+    public float getNumMatchingItems() {
+      return -1;
+    }
+
+    @Override
     public DataType getDataType() {
       return DataType.STRING;
     }
@@ -322,6 +357,11 @@ public class NotEqualsPredicateEvaluatorFactory {
     BytesRawValueBasedNeqPredicateEvaluator(NotEqPredicate notEqPredicate, byte[] nonMatchingValue) {
       super(notEqPredicate);
       _nonMatchingValue = nonMatchingValue;
+    }
+
+    @Override
+    public float getNumMatchingItems() {
+      return -1;
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotEqualsPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotEqualsPredicateEvaluatorFactory.java
@@ -105,7 +105,7 @@ public class NotEqualsPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return -1;
     }
 
@@ -164,7 +164,7 @@ public class NotEqualsPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return -1;
     }
 
@@ -201,7 +201,7 @@ public class NotEqualsPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return -1;
     }
 
@@ -238,7 +238,7 @@ public class NotEqualsPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return -1;
     }
 
@@ -275,7 +275,7 @@ public class NotEqualsPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return -1;
     }
 
@@ -312,7 +312,7 @@ public class NotEqualsPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return -1;
     }
 
@@ -336,7 +336,7 @@ public class NotEqualsPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return -1;
     }
 
@@ -360,7 +360,7 @@ public class NotEqualsPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return -1;
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotInPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotInPredicateEvaluatorFactory.java
@@ -170,7 +170,7 @@ public class NotInPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return -_numNonMatchingDictIds;
     }
 
@@ -230,7 +230,7 @@ public class NotInPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return -_nonMatchingValues.size();
     }
 
@@ -267,7 +267,7 @@ public class NotInPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return -_nonMatchingValues.size();
     }
 
@@ -304,7 +304,7 @@ public class NotInPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return -_nonMatchingValues.size();
     }
 
@@ -341,7 +341,7 @@ public class NotInPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return -_nonMatchingValues.size();
     }
 
@@ -381,7 +381,7 @@ public class NotInPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return -_nonMatchingValues.size();
     }
 
@@ -405,7 +405,7 @@ public class NotInPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return -_nonMatchingValues.size();
     }
 
@@ -429,7 +429,7 @@ public class NotInPredicateEvaluatorFactory {
     }
 
     @Override
-    public float getNumMatchingItems() {
+    public int getNumMatchingItems() {
       return -_nonMatchingValues.size();
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotInPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotInPredicateEvaluatorFactory.java
@@ -170,6 +170,11 @@ public class NotInPredicateEvaluatorFactory {
     }
 
     @Override
+    public float getNumMatchingItems() {
+      return -_numNonMatchingDictIds;
+    }
+
+    @Override
     public boolean applySV(int dictId) {
       return !_nonMatchingDictIdSet.contains(dictId);
     }
@@ -225,6 +230,11 @@ public class NotInPredicateEvaluatorFactory {
     }
 
     @Override
+    public float getNumMatchingItems() {
+      return -_nonMatchingValues.size();
+    }
+
+    @Override
     public DataType getDataType() {
       return DataType.INT;
     }
@@ -254,6 +264,11 @@ public class NotInPredicateEvaluatorFactory {
     LongRawValueBasedNotInPredicateEvaluator(NotInPredicate notInPredicate, LongSet nonMatchingValues) {
       super(notInPredicate);
       _nonMatchingValues = nonMatchingValues;
+    }
+
+    @Override
+    public float getNumMatchingItems() {
+      return -_nonMatchingValues.size();
     }
 
     @Override
@@ -289,6 +304,11 @@ public class NotInPredicateEvaluatorFactory {
     }
 
     @Override
+    public float getNumMatchingItems() {
+      return -_nonMatchingValues.size();
+    }
+
+    @Override
     public DataType getDataType() {
       return DataType.FLOAT;
     }
@@ -318,6 +338,11 @@ public class NotInPredicateEvaluatorFactory {
     DoubleRawValueBasedNotInPredicateEvaluator(NotInPredicate notInPredicate, DoubleSet nonMatchingValues) {
       super(notInPredicate);
       _nonMatchingValues = nonMatchingValues;
+    }
+
+    @Override
+    public float getNumMatchingItems() {
+      return -_nonMatchingValues.size();
     }
 
     @Override
@@ -356,6 +381,11 @@ public class NotInPredicateEvaluatorFactory {
     }
 
     @Override
+    public float getNumMatchingItems() {
+      return -_nonMatchingValues.size();
+    }
+
+    @Override
     public DataType getDataType() {
       return DataType.BIG_DECIMAL;
     }
@@ -375,6 +405,11 @@ public class NotInPredicateEvaluatorFactory {
     }
 
     @Override
+    public float getNumMatchingItems() {
+      return -_nonMatchingValues.size();
+    }
+
+    @Override
     public DataType getDataType() {
       return DataType.STRING;
     }
@@ -391,6 +426,11 @@ public class NotInPredicateEvaluatorFactory {
     BytesRawValueBasedNotInPredicateEvaluator(NotInPredicate notInPredicate, Set<ByteArray> nonMatchingValues) {
       super(notInPredicate);
       _nonMatchingValues = nonMatchingValues;
+    }
+
+    @Override
+    public float getNumMatchingItems() {
+      return -_nonMatchingValues.size();
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateEvaluator.java
@@ -108,10 +108,10 @@ public interface PredicateEvaluator {
   /**
    * return the number of matching items specified by predicate
    * negative number indicates exclusive (not eq, not in) match
-   * return {@code Float.NaN} for not applicable
+   * return {@code Integer.MIN_VALUE} for not applicable
    */
-  default float getNumMatchingItems() {
-    return Float.NaN;
+  default int getNumMatchingItems() {
+    return Integer.MIN_VALUE;
   };
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateEvaluator.java
@@ -106,6 +106,15 @@ public interface PredicateEvaluator {
    */
 
   /**
+   * return the number of matching items specified by predicate
+   * negative number indicates exclusive (not eq, not in) match
+   * return {@code Float.NaN} for not applicable
+   */
+  default float getNumMatchingItems() {
+    return Float.NaN;
+  };
+
+  /**
    * Get the number of matching dictionary ids.
    */
   int getNumMatchingDictIds();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
@@ -209,6 +209,11 @@ public class RangePredicateEvaluatorFactory {
       }
       return _matchingDictIds;
     }
+
+    @Override
+    public int getNumMatchingItems() {
+      return Math.max(_numMatchingDictIds, 0);
+    }
   }
 
   private static final class UnsortedDictionaryBasedRangePredicateEvaluator
@@ -276,6 +281,11 @@ public class RangePredicateEvaluatorFactory {
             throw new IllegalStateException();
         }
       }
+    }
+
+    @Override
+    public int getNumMatchingItems() {
+      return _matchingDictIdSet == null ? super.getNumMatchingItems() : _matchingDictIdSet.size();
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -116,7 +116,7 @@ public class AggregationPlanNode implements PlanNode {
         }
         Pair<FilterPlanNode, BaseFilterOperator> pair = buildFilterOperator(currentFilterExpression);
         BaseFilterOperator wrappedFilterOperator =
-            new CombinedFilterOperator(mainPredicateFilterOperator, pair.getRight());
+            new CombinedFilterOperator(mainPredicateFilterOperator, pair.getRight(), _queryContext.getQueryOptions());
         TransformOperator newTransformOperator = buildTransformOperatorForFilteredAggregates(wrappedFilterOperator);
         // For each transform operator, associate it with the underlying expression. This allows
         // fetching the relevant TransformOperator when resolving blocks during aggregation

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.common.datatable.DataTableFactory;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionValue;
 
@@ -43,6 +44,10 @@ public class QueryOptionsUtils {
     } else {
       return null;
     }
+  }
+
+  public static boolean isAndScanReorderingEnabled(Map<String, String> queryOptions) {
+    return queryOptions.containsKey(CommonConstants.Query.OptimizationSwitches.AND_SCAN_REORDERING);
   }
 
   public static boolean isSkipUpsert(Map<String, String> queryOptions) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.util;
 import com.google.common.base.Preconditions;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.commons.collections.MapUtils;
 import org.apache.pinot.core.common.datatable.DataTableFactory;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
@@ -47,7 +48,8 @@ public class QueryOptionsUtils {
   }
 
   public static boolean isAndScanReorderingEnabled(Map<String, String> queryOptions) {
-    return queryOptions.containsKey(CommonConstants.Query.OptimizationSwitches.AND_SCAN_REORDERING);
+    return !MapUtils.isEmpty(queryOptions) &&
+        queryOptions.containsKey(CommonConstants.Query.OptimizationSwitches.AND_SCAN_REORDERING);
   }
 
   public static boolean isSkipUpsert(Map<String, String> queryOptions) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
@@ -48,8 +48,8 @@ public class QueryOptionsUtils {
   }
 
   public static boolean isAndScanReorderingEnabled(Map<String, String> queryOptions) {
-    return !MapUtils.isEmpty(queryOptions) &&
-        queryOptions.containsKey(CommonConstants.Query.OptimizationSwitches.AND_SCAN_REORDERING);
+    return !MapUtils.isEmpty(queryOptions)
+        && queryOptions.containsKey(CommonConstants.Query.OptimizationSwitches.AND_SCAN_REORDERING);
   }
 
   public static boolean isSkipUpsert(Map<String, String> queryOptions) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
@@ -21,9 +21,7 @@ package org.apache.pinot.core.util;
 import com.google.common.base.Preconditions;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.apache.commons.collections.MapUtils;
 import org.apache.pinot.core.common.datatable.DataTableFactory;
-import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionValue;
 
@@ -48,8 +46,7 @@ public class QueryOptionsUtils {
   }
 
   public static boolean isAndScanReorderingEnabled(Map<String, String> queryOptions) {
-    return !MapUtils.isEmpty(queryOptions)
-        && queryOptions.containsKey(CommonConstants.Query.OptimizationSwitches.AND_SCAN_REORDERING);
+    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.AND_SCAN_REORDERING));
   }
 
   public static boolean isSkipUpsert(Map<String, String> queryOptions) {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionSingleValueQueriesTest.java
@@ -420,7 +420,7 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     assertEquals((int) lastRow[columnIndexMap.get("column1")], 335520083);
   }
 
-  private int getVirtualColumns(DataSchema selectionDataSchema) {
+  int getVirtualColumns(DataSchema selectionDataSchema) {
     int virtualCols = 0;
     for (int i = 0; i < selectionDataSchema.size(); i++) {
       if (selectionDataSchema.getColumnName(i).startsWith("$")) {
@@ -430,7 +430,7 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     return virtualCols;
   }
 
-  private Map<String, Integer> computeColumnNameToIndexMap(DataSchema dataSchema) {
+  Map<String, Integer> computeColumnNameToIndexMap(DataSchema dataSchema) {
     Map<String, Integer> columnIndexMap = new HashMap<>();
 
     for (int i = 0; i < dataSchema.size(); i++) {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
@@ -24,7 +24,7 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.ExecutionStatistics;
 import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
-import org.apache.pinot.spi.utils.CommonConstants.Query.OptimizationSwitches;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -34,7 +34,7 @@ import static org.testng.Assert.assertTrue;
 public class ScanBasedANDFilterReorderingTest extends InnerSegmentSelectionSingleValueQueriesTest {
   private static final String SELECT_STAR_QUERY = "SELECT * FROM testTable";
   private static final String SET_AND_OPTIMIZATION = "SET "
-      + OptimizationSwitches.AND_SCAN_REORDERING + " = '';";
+      + CommonConstants.Broker.Request.QueryOptionKey.AND_SCAN_REORDERING + " = 'True';";
 
   @Test
   public void testSelectStar() {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
@@ -76,24 +76,19 @@ public class ScanBasedANDFilterReorderingTest {
 
   @Test
   public static class Test1 extends BaseQueriesTest {
+    protected static final String COUNT_STAR_QUERY = "SELECT SUM(column1) FROM testTable";
+    protected static final String FILTER1 = " WHERE column7 IN (2147483647, 211, 336, 363, 469, 565)"
+        + " AND column6 = 2147483647"
+        + " AND column3 <> 'L'";
+    protected static final String FILTER2 = " WHERE column7 IN (2147483647, 211, 336, 363, 469, 565)"
+        + " AND column6 = 3267"
+        + " AND column3 <> 'L'";
+    protected static final String FILTER3 = FILTER1 + " AND column1 > '50000000'";
     private static final String AVRO_DATA = "data" + File.separator + "test_data-mv.avro";
     private static final String SEGMENT_NAME = "testTable_1756015683_1756015683";
     private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "MultiValueRawQueriesTest");
     private static final String SET_AND_OPTIMIZATION = "SET "
         + CommonConstants.Broker.Request.QueryOptionKey.AND_SCAN_REORDERING + " = 'True';";
-
-    protected static final String COUNT_STAR_QUERY = "SELECT SUM(column1) FROM testTable";
-
-    protected static final String FILTER1 = " WHERE column7 IN (2147483647, 211, 336, 363, 469, 565)"
-        + " AND column6 = 2147483647"
-        + " AND column3 <> 'L'";
-
-    protected static final String FILTER2 = " WHERE column7 IN (2147483647, 211, 336, 363, 469, 565)"
-        + " AND column6 = 3267"
-        + " AND column3 <> 'L'";
-
-    protected static final String FILTER3 = FILTER1 + " AND column1 > '50000000'";
-
     private IndexSegment _indexSegment;
     // Contains 2 identical index segments.
     private List<IndexSegment> _indexSegments;
@@ -214,7 +209,7 @@ public class ScanBasedANDFilterReorderingTest {
       Assert.assertEquals(((Number) resultsBlock.getResults().get(0)).longValue(), 0);
 
       // Test query with optimization, bitmap + scan + range
-      aggregationOperator = getOperator(  SET_AND_OPTIMIZATION + COUNT_STAR_QUERY + FILTER3);
+      aggregationOperator = getOperator(SET_AND_OPTIMIZATION + COUNT_STAR_QUERY + FILTER3);
       resultsBlock = aggregationOperator.nextBlock();
       executionStatistics = aggregationOperator.getExecutionStatistics();
       QueriesTestUtils.testInnerSegmentExecutionStatistics(executionStatistics, 45681L, 201648L,
@@ -222,7 +217,7 @@ public class ScanBasedANDFilterReorderingTest {
       Assert.assertEquals(((Number) resultsBlock.getResults().get(0)).longValue(), 44199078145668L);
 
       // Test query without optimization, bitmap + scan + range
-      aggregationOperator = getOperator( COUNT_STAR_QUERY + FILTER3);
+      aggregationOperator = getOperator(COUNT_STAR_QUERY + FILTER3);
       resultsBlock = aggregationOperator.nextBlock();
       executionStatistics = aggregationOperator.getExecutionStatistics();
       QueriesTestUtils.testInnerSegmentExecutionStatistics(executionStatistics, 45681L, 276352L,

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.operator.BaseOperator;
+import org.apache.pinot.core.operator.ExecutionStatistics;
+import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
+import org.apache.pinot.spi.utils.CommonConstants.Query.OptimizationSwitches;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class ScanBasedANDFilterReorderingTest extends InnerSegmentSelectionSingleValueQueriesTest {
+  private static final String SELECT_STAR_QUERY = "SELECT * FROM testTable";
+  private static final String SET_AND_OPTIMIZATION = "SET "
+      + OptimizationSwitches.AND_SCAN_CARDINALITY_BASED_REORDERING + " = '';";
+
+  @Test
+  public void testSelectStar() {
+    // Test query with filter
+    BaseOperator<SelectionResultsBlock> selectionOnlyOperator = getOperator(SELECT_STAR_QUERY + FILTER);
+    SelectionResultsBlock resultsBlock = selectionOnlyOperator.nextBlock();
+    ExecutionStatistics executionStatistics = selectionOnlyOperator.getExecutionStatistics();
+    assertEquals(executionStatistics.getNumDocsScanned(), 10L);
+    assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 48241L);
+    assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 110L);
+    assertEquals(executionStatistics.getNumTotalDocs(), 30000L);
+    DataSchema selectionDataSchema = resultsBlock.getDataSchema();
+    Map<String, Integer> columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
+    assertEquals(selectionDataSchema.size(), 11);
+    assertEquals(getVirtualColumns(selectionDataSchema), 0);
+    assertTrue(columnIndexMap.containsKey("column1"));
+    assertTrue(columnIndexMap.containsKey("column11"));
+    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), DataSchema.ColumnDataType.INT);
+    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column11")),
+        DataSchema.ColumnDataType.STRING);
+    List<Object[]> selectionResult = (List<Object[]>) resultsBlock.getRows();
+    assertEquals(selectionResult.size(), 10);
+    Object[] firstRow = selectionResult.get(0);
+    assertEquals(firstRow.length, 11);
+    assertEquals(((Integer) firstRow[columnIndexMap.get("column1")]).intValue(), 351823652);
+    assertEquals((String) firstRow[columnIndexMap.get("column11")], "t");
+
+    // Test query with filter + and optimization; reduce NumEntriesScannedInFilter 48241L->35905L
+    selectionOnlyOperator = getOperator(SET_AND_OPTIMIZATION + SELECT_STAR_QUERY + FILTER);
+    resultsBlock = selectionOnlyOperator.nextBlock();
+    executionStatistics = selectionOnlyOperator.getExecutionStatistics();
+    assertEquals(executionStatistics.getNumDocsScanned(), 10L);
+    assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 35905L);
+    assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 110L);
+    assertEquals(executionStatistics.getNumTotalDocs(), 30000L);
+    selectionDataSchema = resultsBlock.getDataSchema();
+    columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
+    assertEquals(selectionDataSchema.size(), 11);
+    assertEquals(getVirtualColumns(selectionDataSchema), 0);
+    assertTrue(columnIndexMap.containsKey("column1"));
+    assertTrue(columnIndexMap.containsKey("column11"));
+    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), DataSchema.ColumnDataType.INT);
+    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column11")),
+        DataSchema.ColumnDataType.STRING);
+    selectionResult = (List<Object[]>) resultsBlock.getRows();
+    assertEquals(selectionResult.size(), 10);
+    firstRow = selectionResult.get(0);
+    assertEquals(firstRow.length, 11);
+    assertEquals(((Integer) firstRow[columnIndexMap.get("column1")]).intValue(), 351823652);
+    assertEquals((String) firstRow[columnIndexMap.get("column11")], "t");
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
@@ -231,6 +231,5 @@ public class ScanBasedANDFilterReorderingTest {
           45681L, 100000L);
       Assert.assertEquals(((Number) resultsBlock.getResults().get(0)).longValue(), 44199078145668L);
     }
-
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
@@ -76,7 +76,7 @@ public class ScanBasedANDFilterReorderingTest {
 
   @Test
   public static class MVTest extends BaseQueriesTest {
-    protected static final String COUNT_STAR_QUERY = "SELECT SUM(column1) FROM testTable";
+    protected static final String SUM_QUERY = "SELECT SUM(column1) FROM testTable";
     protected static final String FILTER1 = " WHERE column7 IN (2147483647, 211, 336, 363, 469, 565)"
         + " AND column6 = 2147483647"
         + " AND column3 <> 'L'";
@@ -178,7 +178,7 @@ public class ScanBasedANDFilterReorderingTest {
     @Test
     public void testScanBasedANDFilterReorderingOptimization1() {
       // Test query with optimization, bitmap + scan
-      AggregationOperator aggregationOperator = getOperator(SET_AND_OPTIMIZATION + COUNT_STAR_QUERY + FILTER1);
+      AggregationOperator aggregationOperator = getOperator(SET_AND_OPTIMIZATION + SUM_QUERY + FILTER1);
       AggregationResultsBlock resultsBlock = aggregationOperator.nextBlock();
       ExecutionStatistics executionStatistics = aggregationOperator.getExecutionStatistics();
       QueriesTestUtils.testInnerSegmentExecutionStatistics(executionStatistics, 46649L, 154999L,
@@ -186,7 +186,7 @@ public class ScanBasedANDFilterReorderingTest {
       Assert.assertEquals(((Number) resultsBlock.getResults().get(0)).longValue(), 44224075056091L);
 
       // Test query without optimization, bitmap + scan
-      aggregationOperator = getOperator(COUNT_STAR_QUERY + FILTER1);
+      aggregationOperator = getOperator(SUM_QUERY + FILTER1);
       resultsBlock = aggregationOperator.nextBlock();
       executionStatistics = aggregationOperator.getExecutionStatistics();
       QueriesTestUtils.testInnerSegmentExecutionStatistics(executionStatistics, 46649L, 189513L,
@@ -197,7 +197,7 @@ public class ScanBasedANDFilterReorderingTest {
     @Test
     public void testScanBasedANDFilterReorderingOptimization2() {
       // Test query with optimization, another bitmap + scan
-      AggregationOperator aggregationOperator = getOperator(SET_AND_OPTIMIZATION + COUNT_STAR_QUERY + FILTER2);
+      AggregationOperator aggregationOperator = getOperator(SET_AND_OPTIMIZATION + SUM_QUERY + FILTER2);
       AggregationResultsBlock resultsBlock = aggregationOperator.nextBlock();
       ExecutionStatistics executionStatistics = aggregationOperator.getExecutionStatistics();
       QueriesTestUtils.testInnerSegmentExecutionStatistics(executionStatistics, 0, 97458L,
@@ -205,7 +205,7 @@ public class ScanBasedANDFilterReorderingTest {
       Assert.assertEquals(((Number) resultsBlock.getResults().get(0)).longValue(), 0);
 
       // Test query without optimization, another bitmap + scan
-      aggregationOperator = getOperator(COUNT_STAR_QUERY + FILTER2);
+      aggregationOperator = getOperator(SUM_QUERY + FILTER2);
       resultsBlock = aggregationOperator.nextBlock();
       executionStatistics = aggregationOperator.getExecutionStatistics();
       QueriesTestUtils.testInnerSegmentExecutionStatistics(executionStatistics, 0, 189513L,
@@ -216,7 +216,7 @@ public class ScanBasedANDFilterReorderingTest {
     @Test
     public void testScanBasedANDFilterReorderingOptimization3() {
       // Test query with optimization, bitmap + scan + range
-      AggregationOperator aggregationOperator = getOperator(SET_AND_OPTIMIZATION + COUNT_STAR_QUERY + FILTER3);
+      AggregationOperator aggregationOperator = getOperator(SET_AND_OPTIMIZATION + SUM_QUERY + FILTER3);
       AggregationResultsBlock resultsBlock = aggregationOperator.nextBlock();
       ExecutionStatistics executionStatistics = aggregationOperator.getExecutionStatistics();
       QueriesTestUtils.testInnerSegmentExecutionStatistics(executionStatistics, 45681L, 201648L,
@@ -224,7 +224,7 @@ public class ScanBasedANDFilterReorderingTest {
       Assert.assertEquals(((Number) resultsBlock.getResults().get(0)).longValue(), 44199078145668L);
 
       // Test query without optimization, bitmap + scan + range
-      aggregationOperator = getOperator(COUNT_STAR_QUERY + FILTER3);
+      aggregationOperator = getOperator(SUM_QUERY + FILTER3);
       resultsBlock = aggregationOperator.nextBlock();
       executionStatistics = aggregationOperator.getExecutionStatistics();
       QueriesTestUtils.testInnerSegmentExecutionStatistics(executionStatistics, 45681L, 276352L,

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
@@ -75,7 +75,7 @@ import static org.testng.Assert.assertNotNull;
 public class ScanBasedANDFilterReorderingTest {
 
   @Test
-  public static class Test1 extends BaseQueriesTest {
+  public static class MVTest extends BaseQueriesTest {
     protected static final String COUNT_STAR_QUERY = "SELECT SUM(column1) FROM testTable";
     protected static final String FILTER1 = " WHERE column7 IN (2147483647, 211, 336, 363, 469, 565)"
         + " AND column6 = 2147483647"
@@ -175,6 +175,7 @@ public class ScanBasedANDFilterReorderingTest {
       return _indexSegments;
     }
 
+    @Test
     public void testScanBasedANDFilterReorderingOptimization1() {
       // Test query with optimization, bitmap + scan
       AggregationOperator aggregationOperator = getOperator(SET_AND_OPTIMIZATION + COUNT_STAR_QUERY + FILTER1);
@@ -191,11 +192,14 @@ public class ScanBasedANDFilterReorderingTest {
       QueriesTestUtils.testInnerSegmentExecutionStatistics(executionStatistics, 46649L, 189513L,
           46649L, 100000L);
       Assert.assertEquals(((Number) resultsBlock.getResults().get(0)).longValue(), 44224075056091L);
+    }
 
+    @Test
+    public void testScanBasedANDFilterReorderingOptimization2() {
       // Test query with optimization, another bitmap + scan
-      aggregationOperator = getOperator(SET_AND_OPTIMIZATION + COUNT_STAR_QUERY + FILTER2);
-      resultsBlock = aggregationOperator.nextBlock();
-      executionStatistics = aggregationOperator.getExecutionStatistics();
+      AggregationOperator aggregationOperator = getOperator(SET_AND_OPTIMIZATION + COUNT_STAR_QUERY + FILTER2);
+      AggregationResultsBlock resultsBlock = aggregationOperator.nextBlock();
+      ExecutionStatistics executionStatistics = aggregationOperator.getExecutionStatistics();
       QueriesTestUtils.testInnerSegmentExecutionStatistics(executionStatistics, 0, 97458L,
           0, 100000L);
       Assert.assertEquals(((Number) resultsBlock.getResults().get(0)).longValue(), 0);
@@ -207,11 +211,14 @@ public class ScanBasedANDFilterReorderingTest {
       QueriesTestUtils.testInnerSegmentExecutionStatistics(executionStatistics, 0, 189513L,
           0, 100000L);
       Assert.assertEquals(((Number) resultsBlock.getResults().get(0)).longValue(), 0);
+    }
 
+    @Test
+    public void testScanBasedANDFilterReorderingOptimization3() {
       // Test query with optimization, bitmap + scan + range
-      aggregationOperator = getOperator(SET_AND_OPTIMIZATION + COUNT_STAR_QUERY + FILTER3);
-      resultsBlock = aggregationOperator.nextBlock();
-      executionStatistics = aggregationOperator.getExecutionStatistics();
+      AggregationOperator aggregationOperator = getOperator(SET_AND_OPTIMIZATION + COUNT_STAR_QUERY + FILTER3);
+      AggregationResultsBlock resultsBlock = aggregationOperator.nextBlock();
+      ExecutionStatistics executionStatistics = aggregationOperator.getExecutionStatistics();
       QueriesTestUtils.testInnerSegmentExecutionStatistics(executionStatistics, 45681L, 201648L,
           45681L, 100000L);
       Assert.assertEquals(((Number) resultsBlock.getResults().get(0)).longValue(), 44199078145668L);
@@ -224,5 +231,6 @@ public class ScanBasedANDFilterReorderingTest {
           45681L, 100000L);
       Assert.assertEquals(((Number) resultsBlock.getResults().get(0)).longValue(), 44199078145668L);
     }
+
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
@@ -88,10 +88,9 @@ public class ScanBasedANDFilterReorderingTest {
         + " AND column6 = 2147483647"
         + " AND column3 <> 'L'";
 
-    protected static final String FILTER2 = " WHERE column1 > 100000000"
-        + " AND column2 BETWEEN 20000000 AND 1000000000"
-        + " AND column3 <> 'w'"
-        + " AND daysSinceEpoch = 1756015683";
+    protected static final String FILTER2 = " WHERE column7 IN (2147483647, 211, 336, 363, 469, 565)"
+        + " AND column6 = 3267"
+        + " AND column3 <> 'L'";
 
     protected static final String FILTER3 = " WHERE column1 > 100000000"
         + " AND column2 BETWEEN 20000000 AND 1000000000"
@@ -193,13 +192,29 @@ public class ScanBasedANDFilterReorderingTest {
           46649L, 100000L);
       Assert.assertEquals(((Number) resultsBlock.getResults().get(0)).longValue(), 44224075056091L);
 
-      // Test query with optimization
+      // Test query without optimization
       aggregationOperator = getOperator(COUNT_STAR_QUERY + FILTER1);
       resultsBlock = aggregationOperator.nextBlock();
       executionStatistics = aggregationOperator.getExecutionStatistics();
       QueriesTestUtils.testInnerSegmentExecutionStatistics(executionStatistics, 46649L, 189513L,
           46649L, 100000L);
       Assert.assertEquals(((Number) resultsBlock.getResults().get(0)).longValue(), 44224075056091L);
+
+      // Test query with optimization
+      aggregationOperator = getOperator(SET_AND_OPTIMIZATION + COUNT_STAR_QUERY + FILTER2);
+      resultsBlock = aggregationOperator.nextBlock();
+      executionStatistics = aggregationOperator.getExecutionStatistics();
+      QueriesTestUtils.testInnerSegmentExecutionStatistics(executionStatistics, 0, 97458,
+          0, 100000L);
+      Assert.assertEquals(((Number) resultsBlock.getResults().get(0)).longValue(), 0);
+
+      // Test query without optimization
+      aggregationOperator = getOperator(COUNT_STAR_QUERY + FILTER2);
+      resultsBlock = aggregationOperator.nextBlock();
+      executionStatistics = aggregationOperator.getExecutionStatistics();
+      QueriesTestUtils.testInnerSegmentExecutionStatistics(executionStatistics, 0, 189513L,
+          0, 100000L);
+      Assert.assertEquals(((Number) resultsBlock.getResults().get(0)).longValue(), 0);
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
@@ -18,93 +18,188 @@
  */
 package org.apache.pinot.queries;
 
+import java.io.File;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.core.operator.BaseOperator;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
 import org.apache.pinot.core.operator.ExecutionStatistics;
-import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
+import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
+import org.apache.pinot.core.operator.query.AggregationOperator;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertNotNull;
+
 
 /**
- * <p>There are totally 18 columns, 30000 records inside the original Avro file where 11 columns are selected to build
- * the index segment "test_data-sv.avro". Selected columns information are as following:
+ * The <code>BaseMultiValueQueriesTest</code> class sets up the index segment for the multi-value queries test.
+ * <p>There are totally 14 columns, 100000 records inside the original Avro file where 10 columns are selected to build
+ * the index segment. Selected columns information are as following:
  * <ul>
- *   ColumnName, FieldType, DataType, Cardinality, IsSorted, HasInvertedIndex
- *   <li>column1, METRIC, INT, 6582, F, F</li>
- *   <li>column3, METRIC, INT, 21910, F, F</li>
- *   <li>column5, DIMENSION, STRING, 1, T, F</li>
- *   <li>column6, DIMENSION, INT, 608, F, T</li>
- *   <li>column7, DIMENSION, INT, 146, F, T</li>
- *   <li>column9, DIMENSION, INT, 1737, F, F</li>
- *   <li>column11, DIMENSION, STRING, 5, F, T</li>
- *   <li>column12, DIMENSION, STRING, 5, F, F</li>
- *   <li>column17, METRIC, INT, 24, F, T</li>
- *   <li>column18, METRIC, INT, 1440, F, T</li>
- *   <li>daysSinceEpoch, TIME, INT, 2, T, F</li>
+ *   ColumnName, FieldType, DataType, Cardinality, IsSorted, HasInvertedIndex, IsMultiValueRaw
+ *   <li>column1, METRIC, INT, 51594, F, F, F</li>
+ *   <li>column2, METRIC, INT, 42242, F, F, F</li>
+ *   <li>column3, DIMENSION, STRING, 5, F, T, F</li>
+ *   <li>column4, DIMENSION, STRING, 5, F, F, F</li>
+ *   <li>column5, DIMENSION, STRING, 9, F, F, F</li>
+ *   <li>column6, DIMENSION, INT, 18499, F, F, T</li>
+ *   <li>column7, DIMENSION, INT, 359, F, F, T</li>
+ *   <li>column8, DIMENSION, INT, 850, F, T, F</li>
+ *   <li>column9, METRIC, INT, 146, F, T, F</li>
+ *   <li>column10, METRIC, INT, 3960, F, F, F</li>
+ *   <li>daysSinceEpoch, TIME, INT, 1, T, F, F</li>
  * </ul>
  */
-public class ScanBasedANDFilterReorderingTest extends InnerSegmentSelectionSingleValueQueriesTest {
-  private static final String SELECT_STAR_QUERY = "SELECT * FROM testTable";
-  private static final String SET_AND_OPTIMIZATION = "SET "
-      + CommonConstants.Broker.Request.QueryOptionKey.AND_SCAN_REORDERING + " = 'True';";
-
-  protected static final String FILTER2 =
-      " WHERE column1 in (1236291842, 1123080522) AND column3 in (455144658, 2134396823) "
-          + "AND column17 IN (635942547, 1785555661, 1284373442, 1618904660, 561673250, 1727768835, 423049234, 1799989276)";
+public class ScanBasedANDFilterReorderingTest {
 
   @Test
-  public void testSelectStar() {
-    // Test query with filter
-    BaseOperator<SelectionResultsBlock> selectionOnlyOperator = getOperator(SELECT_STAR_QUERY + FILTER2);
-    SelectionResultsBlock resultsBlock = selectionOnlyOperator.nextBlock();
-    ExecutionStatistics executionStatistics = selectionOnlyOperator.getExecutionStatistics();
-//    assertEquals(executionStatistics.getNumDocsScanned(), 10L);
-//    assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 48241L);
-//    assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 110L);
-//    assertEquals(executionStatistics.getNumTotalDocs(), 30000L);
-    DataSchema selectionDataSchema = resultsBlock.getDataSchema();
-    Map<String, Integer> columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
-//    assertEquals(selectionDataSchema.size(), 11);
-//    assertEquals(getVirtualColumns(selectionDataSchema), 0);
-//    assertTrue(columnIndexMap.containsKey("column1"));
-//    assertTrue(columnIndexMap.containsKey("column11"));
-//    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), DataSchema.ColumnDataType.INT);
-//    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column11")),
-//        DataSchema.ColumnDataType.STRING);
-    List<Object[]> selectionResult = (List<Object[]>) resultsBlock.getRows();
-//    assertEquals(selectionResult.size(), 10);
-    Object[] firstRow;
-//    assertEquals(firstRow.length, 11);
-//    assertEquals(((Integer) firstRow[columnIndexMap.get("column1")]).intValue(), 351823652);
-//    assertEquals((String) firstRow[columnIndexMap.get("column11")], "t");
+  public static class Test1 extends BaseQueriesTest {
+    private static final String AVRO_DATA = "data" + File.separator + "test_data-mv.avro";
+    private static final String SEGMENT_NAME = "testTable_1756015683_1756015683";
+    private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "MultiValueRawQueriesTest");
+    private static final String SET_AND_OPTIMIZATION = "SET "
+        + CommonConstants.Broker.Request.QueryOptionKey.AND_SCAN_REORDERING + " = 'True';";
 
-    // Test query with filter + and optimization; reduce NumEntriesScannedInFilter 48241L->35905L
-    selectionOnlyOperator = getOperator(SET_AND_OPTIMIZATION + SELECT_STAR_QUERY + FILTER2);
-    resultsBlock = selectionOnlyOperator.nextBlock();
-    executionStatistics = selectionOnlyOperator.getExecutionStatistics();
-//    assertEquals(executionStatistics.getNumDocsScanned(), 10L);
-    assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 48241L);
-    assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 110L);
-    assertEquals(executionStatistics.getNumTotalDocs(), 30000L);
-    selectionDataSchema = resultsBlock.getDataSchema();
-    columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
-    assertEquals(selectionDataSchema.size(), 11);
-    assertEquals(getVirtualColumns(selectionDataSchema), 0);
-    assertTrue(columnIndexMap.containsKey("column1"));
-    assertTrue(columnIndexMap.containsKey("column11"));
-    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), DataSchema.ColumnDataType.INT);
-    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column11")),
-        DataSchema.ColumnDataType.STRING);
-    selectionResult = (List<Object[]>) resultsBlock.getRows();
-    assertEquals(selectionResult.size(), 10);
-    firstRow = selectionResult.get(0);
-    assertEquals(firstRow.length, 11);
-    assertEquals(((Integer) firstRow[columnIndexMap.get("column1")]).intValue(), 351823652);
-    assertEquals((String) firstRow[columnIndexMap.get("column11")], "t");
+    protected static final String COUNT_STAR_QUERY = "SELECT SUM(column1) FROM testTable";
+
+    protected static final String FILTER1 = " WHERE column7 IN (2147483647, 211, 336, 363, 469, 565)"
+        + " AND column6 = 2147483647"
+        + " AND column3 <> 'L'";
+
+    protected static final String FILTER2 = " WHERE column1 > 100000000"
+        + " AND column2 BETWEEN 20000000 AND 1000000000"
+        + " AND column3 <> 'w'"
+        + " AND daysSinceEpoch = 1756015683";
+
+    protected static final String FILTER3 = " WHERE column1 > 100000000"
+        + " AND column2 BETWEEN 20000000 AND 1000000000"
+        + " AND column3 <> 'w'"
+        + " AND daysSinceEpoch = 1756015683";
+
+    private IndexSegment _indexSegment;
+    // Contains 2 identical index segments.
+    private List<IndexSegment> _indexSegments;
+
+    @BeforeTest
+    public void buildSegment()
+        throws Exception {
+      FileUtils.deleteQuietly(INDEX_DIR);
+
+      // Get resource file path.
+      URL resource = getClass().getClassLoader().getResource(AVRO_DATA);
+      assertNotNull(resource);
+      String filePath = resource.getFile();
+
+      // Build the segment schema.
+      Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable").addMetric("column1", FieldSpec.DataType.INT)
+          .addMetric("column2", FieldSpec.DataType.INT).addSingleValueDimension("column3", FieldSpec.DataType.STRING)
+          .addSingleValueDimension("column4", FieldSpec.DataType.STRING)
+          .addSingleValueDimension("column5", FieldSpec.DataType.STRING)
+          .addMultiValueDimension("column6", FieldSpec.DataType.INT)
+          .addMultiValueDimension("column7", FieldSpec.DataType.INT)
+          .addSingleValueDimension("column8", FieldSpec.DataType.INT).addMetric("column9", FieldSpec.DataType.INT)
+          .addMetric("column10", FieldSpec.DataType.INT)
+          .addTime(new TimeGranularitySpec(FieldSpec.DataType.INT, TimeUnit.DAYS, "daysSinceEpoch"), null).build();
+      // The segment generation code in SegmentColumnarIndexCreator will throw
+      // exception if start and end time in time column are not in acceptable
+      // range. For this test, we first need to fix the input avro data
+      // to have the time column values in allowed range. Until then, the check
+      // is explicitly disabled
+      IngestionConfig ingestionConfig = new IngestionConfig();
+      ingestionConfig.setSegmentTimeValueCheck(false);
+      ingestionConfig.setRowTimeValueCheck(false);
+      TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable")
+          .setTimeColumnName("daysSinceEpoch")
+          .setIngestionConfig(ingestionConfig).build();
+
+      // Create the segment generator config.
+      SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
+      segmentGeneratorConfig.setInputFilePath(filePath);
+      segmentGeneratorConfig.setTableName("testTable");
+      segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
+      segmentGeneratorConfig.setInvertedIndexCreationColumns(Arrays.asList("column3", "column8", "column9"));
+
+      // Build the index segment.
+      SegmentIndexCreationDriver driver = new SegmentIndexCreationDriverImpl();
+      driver.init(segmentGeneratorConfig);
+      driver.build();
+    }
+
+    @BeforeClass
+    public void loadSegment()
+        throws Exception {
+      IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
+      indexLoadingConfig.setInvertedIndexColumns(
+          new HashSet<>(Arrays.asList("column3", "column8", "column9")));
+      ImmutableSegment immutableSegment =
+          ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), indexLoadingConfig);
+      _indexSegment = immutableSegment;
+      _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
+    }
+
+    @AfterClass
+    public void destroySegment() {
+      _indexSegment.destroy();
+    }
+
+    @AfterTest
+    public void deleteSegment() {
+      FileUtils.deleteQuietly(INDEX_DIR);
+    }
+
+    @Override
+    protected String getFilter() {
+      return FILTER1;
+    }
+
+    @Override
+    protected IndexSegment getIndexSegment() {
+      return _indexSegment;
+    }
+
+    @Override
+    protected List<IndexSegment> getIndexSegments() {
+      return _indexSegments;
+    }
+
+    public void testMultiValueAggregationOnly() {
+      // Test query with optimization
+      AggregationOperator aggregationOperator = getOperator(SET_AND_OPTIMIZATION + COUNT_STAR_QUERY + FILTER1);
+      AggregationResultsBlock resultsBlock = aggregationOperator.nextBlock();
+      ExecutionStatistics executionStatistics = aggregationOperator.getExecutionStatistics();
+      QueriesTestUtils.testInnerSegmentExecutionStatistics(executionStatistics, 46649L, 154999L,
+          46649L, 100000L);
+      Assert.assertEquals(((Number) resultsBlock.getResults().get(0)).longValue(), 44224075056091L);
+
+      // Test query with optimization
+      aggregationOperator = getOperator(COUNT_STAR_QUERY + FILTER1);
+      resultsBlock = aggregationOperator.nextBlock();
+      executionStatistics = aggregationOperator.getExecutionStatistics();
+      QueriesTestUtils.testInnerSegmentExecutionStatistics(executionStatistics, 46649L, 189513L,
+          46649L, 100000L);
+      Assert.assertEquals(((Number) resultsBlock.getResults().get(0)).longValue(), 44224075056091L);
+    }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
@@ -30,43 +30,64 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
-
+/**
+ * <p>There are totally 18 columns, 30000 records inside the original Avro file where 11 columns are selected to build
+ * the index segment "test_data-sv.avro". Selected columns information are as following:
+ * <ul>
+ *   ColumnName, FieldType, DataType, Cardinality, IsSorted, HasInvertedIndex
+ *   <li>column1, METRIC, INT, 6582, F, F</li>
+ *   <li>column3, METRIC, INT, 21910, F, F</li>
+ *   <li>column5, DIMENSION, STRING, 1, T, F</li>
+ *   <li>column6, DIMENSION, INT, 608, F, T</li>
+ *   <li>column7, DIMENSION, INT, 146, F, T</li>
+ *   <li>column9, DIMENSION, INT, 1737, F, F</li>
+ *   <li>column11, DIMENSION, STRING, 5, F, T</li>
+ *   <li>column12, DIMENSION, STRING, 5, F, F</li>
+ *   <li>column17, METRIC, INT, 24, F, T</li>
+ *   <li>column18, METRIC, INT, 1440, F, T</li>
+ *   <li>daysSinceEpoch, TIME, INT, 2, T, F</li>
+ * </ul>
+ */
 public class ScanBasedANDFilterReorderingTest extends InnerSegmentSelectionSingleValueQueriesTest {
   private static final String SELECT_STAR_QUERY = "SELECT * FROM testTable";
   private static final String SET_AND_OPTIMIZATION = "SET "
       + CommonConstants.Broker.Request.QueryOptionKey.AND_SCAN_REORDERING + " = 'True';";
 
+  protected static final String FILTER2 =
+      " WHERE column1 in (1236291842, 1123080522) AND column3 in (455144658, 2134396823) "
+          + "AND column17 IN (635942547, 1785555661, 1284373442, 1618904660, 561673250, 1727768835, 423049234, 1799989276)";
+
   @Test
   public void testSelectStar() {
     // Test query with filter
-    BaseOperator<SelectionResultsBlock> selectionOnlyOperator = getOperator(SELECT_STAR_QUERY + FILTER);
+    BaseOperator<SelectionResultsBlock> selectionOnlyOperator = getOperator(SELECT_STAR_QUERY + FILTER2);
     SelectionResultsBlock resultsBlock = selectionOnlyOperator.nextBlock();
     ExecutionStatistics executionStatistics = selectionOnlyOperator.getExecutionStatistics();
-    assertEquals(executionStatistics.getNumDocsScanned(), 10L);
-    assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 48241L);
-    assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 110L);
-    assertEquals(executionStatistics.getNumTotalDocs(), 30000L);
+//    assertEquals(executionStatistics.getNumDocsScanned(), 10L);
+//    assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 48241L);
+//    assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 110L);
+//    assertEquals(executionStatistics.getNumTotalDocs(), 30000L);
     DataSchema selectionDataSchema = resultsBlock.getDataSchema();
     Map<String, Integer> columnIndexMap = computeColumnNameToIndexMap(selectionDataSchema);
-    assertEquals(selectionDataSchema.size(), 11);
-    assertEquals(getVirtualColumns(selectionDataSchema), 0);
-    assertTrue(columnIndexMap.containsKey("column1"));
-    assertTrue(columnIndexMap.containsKey("column11"));
-    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), DataSchema.ColumnDataType.INT);
-    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column11")),
-        DataSchema.ColumnDataType.STRING);
+//    assertEquals(selectionDataSchema.size(), 11);
+//    assertEquals(getVirtualColumns(selectionDataSchema), 0);
+//    assertTrue(columnIndexMap.containsKey("column1"));
+//    assertTrue(columnIndexMap.containsKey("column11"));
+//    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), DataSchema.ColumnDataType.INT);
+//    assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column11")),
+//        DataSchema.ColumnDataType.STRING);
     List<Object[]> selectionResult = (List<Object[]>) resultsBlock.getRows();
-    assertEquals(selectionResult.size(), 10);
-    Object[] firstRow = selectionResult.get(0);
-    assertEquals(firstRow.length, 11);
-    assertEquals(((Integer) firstRow[columnIndexMap.get("column1")]).intValue(), 351823652);
-    assertEquals((String) firstRow[columnIndexMap.get("column11")], "t");
+//    assertEquals(selectionResult.size(), 10);
+    Object[] firstRow;
+//    assertEquals(firstRow.length, 11);
+//    assertEquals(((Integer) firstRow[columnIndexMap.get("column1")]).intValue(), 351823652);
+//    assertEquals((String) firstRow[columnIndexMap.get("column11")], "t");
 
     // Test query with filter + and optimization; reduce NumEntriesScannedInFilter 48241L->35905L
-    selectionOnlyOperator = getOperator(SET_AND_OPTIMIZATION + SELECT_STAR_QUERY + FILTER);
+    selectionOnlyOperator = getOperator(SET_AND_OPTIMIZATION + SELECT_STAR_QUERY + FILTER2);
     resultsBlock = selectionOnlyOperator.nextBlock();
     executionStatistics = selectionOnlyOperator.getExecutionStatistics();
-    assertEquals(executionStatistics.getNumDocsScanned(), 10L);
+//    assertEquals(executionStatistics.getNumDocsScanned(), 10L);
     assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 48241L);
     assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 110L);
     assertEquals(executionStatistics.getNumTotalDocs(), 30000L);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
@@ -34,7 +34,7 @@ import static org.testng.Assert.assertTrue;
 public class ScanBasedANDFilterReorderingTest extends InnerSegmentSelectionSingleValueQueriesTest {
   private static final String SELECT_STAR_QUERY = "SELECT * FROM testTable";
   private static final String SET_AND_OPTIMIZATION = "SET "
-      + OptimizationSwitches.AND_SCAN_CARDINALITY_BASED_REORDERING + " = '';";
+      + OptimizationSwitches.AND_SCAN_REORDERING + " = '';";
 
   @Test
   public void testSelectStar() {
@@ -67,7 +67,7 @@ public class ScanBasedANDFilterReorderingTest extends InnerSegmentSelectionSingl
     resultsBlock = selectionOnlyOperator.nextBlock();
     executionStatistics = selectionOnlyOperator.getExecutionStatistics();
     assertEquals(executionStatistics.getNumDocsScanned(), 10L);
-    assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 35905L);
+    assertEquals(executionStatistics.getNumEntriesScannedInFilter(), 48241L);
     assertEquals(executionStatistics.getNumEntriesScannedPostFilter(), 110L);
     assertEquals(executionStatistics.getNumTotalDocs(), 30000L);
     selectionDataSchema = resultsBlock.getDataSchema();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ScanBasedANDFilterReorderingTest.java
@@ -184,7 +184,7 @@ public class ScanBasedANDFilterReorderingTest {
       return _indexSegments;
     }
 
-    public void testMultiValueAggregationOnly() {
+    public void testScanBasedANDFilterReorderingOptimization1() {
       // Test query with optimization
       AggregationOperator aggregationOperator = getOperator(SET_AND_OPTIMIZATION + COUNT_STAR_QUERY + FILTER1);
       AggregationResultsBlock resultsBlock = aggregationOperator.nextBlock();

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkScanDocIdIterators.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkScanDocIdIterators.java
@@ -123,8 +123,7 @@ public class BenchmarkScanDocIdIterators {
 
   @Benchmark
   public MutableRoaringBitmap benchmarkSVLong() {
-    return new SVScanDocIdIterator(_predicateEvaluator, _readerV2, _numDocs, null,
-        0).applyAnd(_bitmap);
+    return new SVScanDocIdIterator(_predicateEvaluator, _readerV2, _numDocs, null).applyAnd(_bitmap);
   }
 
   public static class DummyPredicateEvaluator implements PredicateEvaluator {

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkScanDocIdIterators.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkScanDocIdIterators.java
@@ -123,7 +123,8 @@ public class BenchmarkScanDocIdIterators {
 
   @Benchmark
   public MutableRoaringBitmap benchmarkSVLong() {
-    return new SVScanDocIdIterator(_predicateEvaluator, _readerV2, _numDocs, null).applyAnd(_bitmap);
+    return new SVScanDocIdIterator(_predicateEvaluator, _readerV2, _numDocs, null,
+        0).applyAnd(_bitmap);
   }
 
   public static class DummyPredicateEvaluator implements PredicateEvaluator {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -1467,10 +1467,9 @@ public class MutableSegmentImpl implements MutableSegment {
 
     DataSource toDataSource() {
       return new MutableDataSource(_fieldSpec, _numDocsIndexed, _numValuesInfo._numValues,
-          _numValuesInfo._maxNumValuesPerMVEntry, _dictionary == null ? -1 : _dictionary.length(),
-          _partitionFunction, _partitions, _minValue, _maxValue, _forwardIndex,
-          _dictionary, _invertedIndex, _rangeIndex, _textIndex, _fstIndex, _jsonIndex, _h3Index, _bloomFilter,
-          _nullValueVector);
+          _numValuesInfo._maxNumValuesPerMVEntry, _dictionary == null ? -1 : _dictionary.length(), _partitionFunction,
+          _partitions, _minValue, _maxValue, _forwardIndex, _dictionary, _invertedIndex, _rangeIndex, _textIndex,
+          _fstIndex, _jsonIndex, _h3Index, _bloomFilter, _nullValueVector);
     }
 
     @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -1467,7 +1467,8 @@ public class MutableSegmentImpl implements MutableSegment {
 
     DataSource toDataSource() {
       return new MutableDataSource(_fieldSpec, _numDocsIndexed, _numValuesInfo._numValues,
-          _numValuesInfo._maxNumValuesPerMVEntry, _partitionFunction, _partitions, _minValue, _maxValue, _forwardIndex,
+          _numValuesInfo._maxNumValuesPerMVEntry, _statsHistory.getEstimatedCardinality(_fieldSpec.getName()),
+          _partitionFunction, _partitions, _minValue, _maxValue, _forwardIndex,
           _dictionary, _invertedIndex, _rangeIndex, _textIndex, _fstIndex, _jsonIndex, _h3Index, _bloomFilter,
           _nullValueVector);
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -1467,7 +1467,7 @@ public class MutableSegmentImpl implements MutableSegment {
 
     DataSource toDataSource() {
       return new MutableDataSource(_fieldSpec, _numDocsIndexed, _numValuesInfo._numValues,
-          _numValuesInfo._maxNumValuesPerMVEntry, _statsHistory.getEstimatedCardinality(_fieldSpec.getName()),
+          _numValuesInfo._maxNumValuesPerMVEntry, _dictionary == null ? -1 : _dictionary.length(),
           _partitionFunction, _partitions, _minValue, _maxValue, _forwardIndex,
           _dictionary, _invertedIndex, _rangeIndex, _textIndex, _fstIndex, _jsonIndex, _h3Index, _bloomFilter,
           _nullValueVector);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/IntermediateIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/IntermediateIndexContainer.java
@@ -63,8 +63,7 @@ public class IntermediateIndexContainer implements Closeable {
   public DataSource toDataSource(int numDocsIndexed) {
     return new MutableDataSource(_fieldSpec, numDocsIndexed, _numValuesInfo._numValues,
         _numValuesInfo._maxNumValuesPerMVEntry, _dictionary.length(), _partitionFunction, _partitions, _minValue,
-        _maxValue, _forwardIndex,
-        _dictionary, null, null, null, null, null, null, null, null);
+        _maxValue, _forwardIndex, _dictionary, null, null, null, null, null, null, null, null);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/IntermediateIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/IntermediateIndexContainer.java
@@ -62,7 +62,8 @@ public class IntermediateIndexContainer implements Closeable {
 
   public DataSource toDataSource(int numDocsIndexed) {
     return new MutableDataSource(_fieldSpec, numDocsIndexed, _numValuesInfo._numValues,
-        _numValuesInfo._maxNumValuesPerMVEntry, _partitionFunction, _partitions, _minValue, _maxValue, _forwardIndex,
+        _numValuesInfo._maxNumValuesPerMVEntry, _dictionary.length(), _partitionFunction, _partitions, _minValue,
+        _maxValue, _forwardIndex,
         _dictionary, null, null, null, null, null, null, null, null);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/EmptyDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/EmptyDataSource.java
@@ -90,5 +90,10 @@ public class EmptyDataSource extends BaseDataSource {
     public Set<Integer> getPartitions() {
       return null;
     }
+
+    @Override
+    public int getCardinality() {
+      return 0;
+    }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/ImmutableDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/ImmutableDataSource.java
@@ -46,6 +46,7 @@ public class ImmutableDataSource extends BaseDataSource {
     final int _numDocs;
     final int _numValues;
     final int _maxNumValuesPerMVEntry;
+    final int _cardinality;
     final Comparable _minValue;
     final Comparable _maxValue;
     final PartitionFunction _partitionFunction;
@@ -65,6 +66,7 @@ public class ImmutableDataSource extends BaseDataSource {
       _maxValue = columnMetadata.getMaxValue();
       _partitionFunction = columnMetadata.getPartitionFunction();
       _partitions = columnMetadata.getPartitions();
+      _cardinality = columnMetadata.getCardinality();
     }
 
     @Override
@@ -114,6 +116,11 @@ public class ImmutableDataSource extends BaseDataSource {
     @Override
     public Set<Integer> getPartitions() {
       return _partitions;
+    }
+
+    @Override
+    public int getCardinality() {
+      return _cardinality;
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/MutableDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/MutableDataSource.java
@@ -40,14 +40,15 @@ import org.apache.pinot.spi.data.FieldSpec;
 @SuppressWarnings("rawtypes")
 public class MutableDataSource extends BaseDataSource {
 
-  public MutableDataSource(FieldSpec fieldSpec, int numDocs, int numValues, int maxNumValuesPerMVEntry,
+  public MutableDataSource(FieldSpec fieldSpec, int numDocs, int numValues, int maxNumValuesPerMVEntry, int cardinality,
       @Nullable PartitionFunction partitionFunction, @Nullable Set<Integer> partitions, @Nullable Comparable minValue,
       @Nullable Comparable maxValue, ForwardIndexReader forwardIndex, @Nullable Dictionary dictionary,
       @Nullable InvertedIndexReader invertedIndex, @Nullable RangeIndexReader rangeIndex,
       @Nullable TextIndexReader textIndex, @Nullable TextIndexReader fstIndex, @Nullable JsonIndexReader jsonIndex,
       @Nullable H3IndexReader h3Index, @Nullable BloomFilterReader bloomFilter,
       @Nullable NullValueVectorReader nullValueVector) {
-    super(new MutableDataSourceMetadata(fieldSpec, numDocs, numValues, maxNumValuesPerMVEntry, partitionFunction,
+    super(new MutableDataSourceMetadata(fieldSpec, numDocs, numValues, maxNumValuesPerMVEntry, cardinality,
+            partitionFunction,
             partitions, minValue, maxValue), forwardIndex, dictionary, invertedIndex, rangeIndex, textIndex, fstIndex,
         jsonIndex, h3Index, bloomFilter, nullValueVector);
   }
@@ -57,12 +58,14 @@ public class MutableDataSource extends BaseDataSource {
     final int _numDocs;
     final int _numValues;
     final int _maxNumValuesPerMVEntry;
+    final int _cardinality;
     final PartitionFunction _partitionFunction;
     final Set<Integer> _partitions;
     final Comparable _minValue;
     final Comparable _maxValue;
 
     MutableDataSourceMetadata(FieldSpec fieldSpec, int numDocs, int numValues, int maxNumValuesPerMVEntry,
+        int cardinality,
         @Nullable PartitionFunction partitionFunction, @Nullable Set<Integer> partitions, @Nullable Comparable minValue,
         @Nullable Comparable maxValue) {
       _fieldSpec = fieldSpec;
@@ -78,6 +81,7 @@ public class MutableDataSource extends BaseDataSource {
       }
       _minValue = minValue;
       _maxValue = maxValue;
+      _cardinality = cardinality;
     }
 
     @Override
@@ -128,6 +132,11 @@ public class MutableDataSource extends BaseDataSource {
     @Override
     public Set<Integer> getPartitions() {
       return _partitions;
+    }
+
+    @Override
+    public int getCardinality() {
+      return _cardinality;
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/MutableDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/MutableDataSource.java
@@ -65,9 +65,8 @@ public class MutableDataSource extends BaseDataSource {
     final Comparable _maxValue;
 
     MutableDataSourceMetadata(FieldSpec fieldSpec, int numDocs, int numValues, int maxNumValuesPerMVEntry,
-        int cardinality,
-        @Nullable PartitionFunction partitionFunction, @Nullable Set<Integer> partitions, @Nullable Comparable minValue,
-        @Nullable Comparable maxValue) {
+        int cardinality, @Nullable PartitionFunction partitionFunction, @Nullable Set<Integer> partitions,
+        @Nullable Comparable minValue, @Nullable Comparable maxValue) {
       _fieldSpec = fieldSpec;
       _numDocs = numDocs;
       _numValues = numValues;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeDataSource.java
@@ -93,5 +93,10 @@ public class StarTreeDataSource extends BaseDataSource {
     public Set<Integer> getPartitions() {
       return null;
     }
+
+    @Override
+    public int getCardinality() {
+      return -1;
+    }
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/DataSourceMetadata.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/DataSourceMetadata.java
@@ -93,4 +93,9 @@ public interface DataSourceMetadata {
    */
   @Nullable
   Set<Integer> getPartitions();
+
+  /**
+   * Returns the cardinality of the column, -1 if not applicable
+   */
+  int getCardinality();
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/DataSourceMetadata.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/DataSourceMetadata.java
@@ -95,7 +95,7 @@ public interface DataSourceMetadata {
   Set<Integer> getPartitions();
 
   /**
-   * Returns the cardinality of the column, -1 if not applicable
+   * Returns the cardinality of the column, {@code -1} if not applicable
    */
   int getCardinality();
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -808,6 +808,10 @@ public class CommonConstants {
       }
     }
 
+    public static class OptimizationSwitches {
+      public static final String AND_SCAN_CARDINALITY_BASED_REORDERING = "andScanCardinalityBasedReordering";
+    }
+
     public static class Range {
       public static final char DELIMITER = '\0';
       public static final char LOWER_EXCLUSIVE = '(';

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -809,7 +809,12 @@ public class CommonConstants {
     }
 
     public static class OptimizationSwitches {
-      public static final String AND_SCAN_CARDINALITY_BASED_REORDERING = "andScanCardinalityBasedReordering";
+      public static final String AND_SCAN_REORDERING = "AndScanReordering";
+    }
+
+    public static class OptimizationConstants {
+      public static final int DEFAULT_AVG_MV_ENTRIES = 3;
+      public static final int DEFAULT_AVG_MV_ENTRIES_DENOMINATOR = 5;
     }
 
     public static class Range {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -286,6 +286,8 @@ public class CommonConstants {
         public static final String USE_MULTISTAGE_ENGINE = "useMultistageEngine";
         public static final String ENABLE_NULL_HANDLING = "enableNullHandling";
         public static final String SERVER_RETURN_FINAL_RESULT = "serverReturnFinalResult";
+        // Reorder scan based predicates based on cardinality and number of selected values
+        public static final String AND_SCAN_REORDERING = "AndScanReordering";
 
         // TODO: Remove these keys (only apply to PQL) after releasing 0.11.0
         @Deprecated
@@ -808,12 +810,7 @@ public class CommonConstants {
       }
     }
 
-    public static class OptimizationSwitches {
-      public static final String AND_SCAN_REORDERING = "AndScanReordering";
-    }
-
     public static class OptimizationConstants {
-      public static final int DEFAULT_AVG_MV_ENTRIES = 3;
       public static final int DEFAULT_AVG_MV_ENTRIES_DENOMINATOR = 5;
     }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -811,7 +811,7 @@ public class CommonConstants {
     }
 
     public static class OptimizationConstants {
-      public static final int DEFAULT_AVG_MV_ENTRIES_DENOMINATOR = 5;
+      public static final int DEFAULT_AVG_MV_ENTRIES_DENOMINATOR = 2;
     }
 
     public static class Range {


### PR DESCRIPTION
Reordering the ScanBasedDocIdIterator based on their underlying column cardinality. Evaluate the high cardinality first as it **generally** helps to reduce the range from the beginning and enhance the scan efficiency. 

- Added cardinality retrieval from data source
- Put the optimization behind a flag `AndScanReordering` as there are two possible degenerations:
  - Some high cardinality column may have biased data whose distribution cannot be represented by cardinality
  - it's hard to estimate number of values selected for a range predicate on raw column

