### PR TITLE
refactor LLRealtimeSegmentDataManager

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -36,6 +36,7 @@ import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.indexsegment.mutable.MutableSegmentImpl;
+import org.apache.pinot.segment.local.realtime.converter.ColumnDescriptionsContainer;
 import org.apache.pinot.segment.local.realtime.converter.RealtimeSegmentConverter;
 import org.apache.pinot.segment.local.realtime.impl.RealtimeSegmentConfig;
 import org.apache.pinot.segment.local.recordtransformer.CompositeTransformer;
@@ -284,11 +285,12 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
           _segmentLogger.info("Indexed {} raw events", _realtimeSegment.getNumDocsIndexed());
           File tempSegmentFolder = new File(_resourceTmpDir, "tmp-" + System.currentTimeMillis());
           // lets convert the segment now
+          ColumnDescriptionsContainer cdc = new ColumnDescriptionsContainer(_sortedColumn, _invertedIndexColumns,
+              Collections.emptyList(), Collections.emptyList(), _noDictionaryColumns, _varLengthDictionaryColumns);
           RealtimeSegmentConverter converter =
               new RealtimeSegmentConverter(_realtimeSegment, null, tempSegmentFolder.getAbsolutePath(),
-                  schema, _tableNameWithType, tableConfig, segmentZKMetadata.getSegmentName(), _sortedColumn,
-                  _invertedIndexColumns, Collections.emptyList(), Collections.emptyList(), _noDictionaryColumns,
-                  _varLengthDictionaryColumns, indexingConfig.isNullHandlingEnabled());
+                  schema, _tableNameWithType, tableConfig, segmentZKMetadata.getSegmentName(), cdc,
+                  indexingConfig.isNullHandlingEnabled());
 
           _segmentLogger.info("Trying to build segment");
           final long buildStartTime = System.nanoTime();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -36,7 +36,7 @@ import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.indexsegment.mutable.MutableSegmentImpl;
-import org.apache.pinot.segment.local.realtime.converter.ColumnDescriptionsContainer;
+import org.apache.pinot.segment.local.realtime.converter.ColumnIndicesForRealtimeTable;
 import org.apache.pinot.segment.local.realtime.converter.RealtimeSegmentConverter;
 import org.apache.pinot.segment.local.realtime.impl.RealtimeSegmentConfig;
 import org.apache.pinot.segment.local.recordtransformer.CompositeTransformer;
@@ -276,15 +276,15 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
           updateCurrentDocumentCountMetrics();
           _segmentLogger.info("Indexed {} raw events", _realtimeSegment.getNumDocsIndexed());
           File tempSegmentFolder = new File(_resourceTmpDir, "tmp-" + System.currentTimeMillis());
+          ColumnIndicesForRealtimeTable columnIndicesForRealtimeTable =
+              new ColumnIndicesForRealtimeTable(_sortedColumn, _invertedIndexColumns, Collections.emptyList(),
+                  Collections.emptyList(), new ArrayList<>(indexLoadingConfig.getNoDictionaryColumns()),
+                  new ArrayList<>(indexLoadingConfig.getVarLengthDictionaryColumns()));
           // lets convert the segment now
-          ColumnDescriptionsContainer cdc = new ColumnDescriptionsContainer(_sortedColumn, _invertedIndexColumns,
-              Collections.emptyList(), Collections.emptyList(),
-              new ArrayList<>(indexLoadingConfig.getNoDictionaryColumns()),
-              new ArrayList<>(indexLoadingConfig.getVarLengthDictionaryColumns()));
           RealtimeSegmentConverter converter =
               new RealtimeSegmentConverter(_realtimeSegment, null, tempSegmentFolder.getAbsolutePath(),
-                  schema, _tableNameWithType, tableConfig, segmentZKMetadata.getSegmentName(), cdc,
-                  indexingConfig.isNullHandlingEnabled());
+                  schema, _tableNameWithType, tableConfig, segmentZKMetadata.getSegmentName(),
+                  columnIndicesForRealtimeTable, indexingConfig.isNullHandlingEnabled());
 
           _segmentLogger.info("Trying to build segment");
           final long buildStartTime = System.nanoTime();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -94,8 +94,6 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
   private final String _sortedColumn;
   private final List<String> _invertedIndexColumns;
-  private final List<String> _noDictionaryColumns;
-  private final List<String> _varLengthDictionaryColumns;
   private final Logger _segmentLogger;
   private final SegmentVersion _segmentVersion;
 
@@ -151,18 +149,12 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       invertedIndexColumns.add(_sortedColumn);
     }
     _invertedIndexColumns = new ArrayList<>(invertedIndexColumns);
-
-    // No DictionaryColumns
-    _noDictionaryColumns = new ArrayList<>(indexLoadingConfig.getNoDictionaryColumns());
-
-    _varLengthDictionaryColumns = new ArrayList<>(indexLoadingConfig.getVarLengthDictionaryColumns());
-
     _streamConfig = new StreamConfig(_tableNameWithType, IngestionConfigUtils.getStreamConfigMap(tableConfig));
 
     _segmentLogger = LoggerFactory.getLogger(
         HLRealtimeSegmentDataManager.class.getName() + "_" + _segmentName + "_" + _streamConfig.getTopicName());
     _segmentLogger.info("Created segment data manager with Sorted column:{}, invertedIndexColumns:{}", _sortedColumn,
-        _invertedIndexColumns);
+        invertedIndexColumns);
 
     _segmentEndTimeThreshold = _start + _streamConfig.getFlushThresholdTimeMillis();
     _resourceTmpDir = new File(resourceDataDir, "_tmp");
@@ -286,7 +278,9 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
           File tempSegmentFolder = new File(_resourceTmpDir, "tmp-" + System.currentTimeMillis());
           // lets convert the segment now
           ColumnDescriptionsContainer cdc = new ColumnDescriptionsContainer(_sortedColumn, _invertedIndexColumns,
-              Collections.emptyList(), Collections.emptyList(), _noDictionaryColumns, _varLengthDictionaryColumns);
+              Collections.emptyList(), Collections.emptyList(),
+              new ArrayList<>(indexLoadingConfig.getNoDictionaryColumns()),
+              new ArrayList<>(indexLoadingConfig.getVarLengthDictionaryColumns()));
           RealtimeSegmentConverter converter =
               new RealtimeSegmentConverter(_realtimeSegment, null, tempSegmentFolder.getAbsolutePath(),
                   schema, _tableNameWithType, tableConfig, segmentZKMetadata.getSegmentName(), cdc,

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -49,7 +49,7 @@ import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.core.data.manager.realtime.RealtimeConsumptionRateManager.ConsumptionRateLimiter;
 import org.apache.pinot.segment.local.dedup.PartitionDedupMetadataManager;
 import org.apache.pinot.segment.local.indexsegment.mutable.MutableSegmentImpl;
-import org.apache.pinot.segment.local.realtime.converter.ColumnDescriptionsContainer;
+import org.apache.pinot.segment.local.realtime.converter.ColumnIndicesForRealtimeTable;
 import org.apache.pinot.segment.local.realtime.converter.RealtimeSegmentConverter;
 import org.apache.pinot.segment.local.realtime.impl.RealtimeSegmentConfig;
 import org.apache.pinot.segment.local.segment.creator.TransformPipeline;
@@ -265,7 +265,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   private StreamMetadataProvider _streamMetadataProvider = null;
   private final File _resourceTmpDir;
   private final String _tableNameWithType;
-  private final ColumnDescriptionsContainer _columnDescriptionsContainer;
+  private final ColumnIndicesForRealtimeTable _columnIndicesForRealtimeTable;
   private final Logger _segmentLogger;
   private final String _tableStreamName;
   private final PinotDataBufferMemoryManager _memoryManager;
@@ -868,7 +868,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(_realtimeSegment, segmentZKPropsConfig, tempSegmentFolder.getAbsolutePath(),
               _schema, _tableNameWithType, _tableConfig, _segmentZKMetadata.getSegmentName(),
-              _columnDescriptionsContainer, _nullHandlingEnabled);
+              _columnIndicesForRealtimeTable, _nullHandlingEnabled);
       _segmentLogger.info("Trying to build segment");
       try {
         converter.build(_segmentVersion, _serverMetrics);
@@ -1330,7 +1330,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
     _nullHandlingEnabled = indexingConfig.isNullHandlingEnabled();
 
-    _columnDescriptionsContainer = new ColumnDescriptionsContainer(sortedColumn,
+    _columnIndicesForRealtimeTable = new ColumnIndicesForRealtimeTable(sortedColumn,
         new ArrayList<>(invertedIndexColumns),
         new ArrayList<>(indexLoadingConfig.getTextIndexColumns()),
         new ArrayList<>(indexLoadingConfig.getFSTIndexColumns()),
@@ -1346,7 +1346,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
             .setNoDictionaryColumns(indexLoadingConfig.getNoDictionaryColumns())
             .setVarLengthDictionaryColumns(indexLoadingConfig.getVarLengthDictionaryColumns())
             .setInvertedIndexColumns(invertedIndexColumns).setTextIndexColumns(indexLoadingConfig.getTextIndexColumns())
-            .setFSTIndexColumns(indexLoadingConfig.getFSTIndexColumns()).setJsonIndexColumns(indexLoadingConfig.getJsonIndexColumns())
+            .setFSTIndexColumns(indexLoadingConfig.getFSTIndexColumns())
+            .setJsonIndexColumns(indexLoadingConfig.getJsonIndexColumns())
             .setH3IndexConfigs(indexLoadingConfig.getH3IndexConfigs()).setSegmentZKMetadata(segmentZKMetadata)
             .setOffHeap(_isOffHeap).setMemoryManager(_memoryManager)
             .setStatsHistory(realtimeTableDataManager.getStatsHistory())
@@ -1526,7 +1527,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     if (_streamMetadataProvider != null) {
       closeStreamMetadataProvider();
     }
-    _segmentLogger.info("Creating new stream metadata provider, reason: {}", reason);
+    _segmentLogger.info("Creating new partition metadata provider, reason: {}", reason);
     _streamMetadataProvider = _streamConsumerFactory.createPartitionMetadataProvider(_clientId, _partitionGroupId);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1432,7 +1432,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       createPartitionMetadataProvider("Fetch latest stream offset");
     }
     try {
-      return _partitionMetadataProvider.fetchStreamPartitionOffset(OffsetCriteria.LARGEST_OFFSET_CRITERIA, maxWaitTimeMs);
+      return _partitionMetadataProvider.fetchStreamPartitionOffset(OffsetCriteria.LARGEST_OFFSET_CRITERIA,
+          maxWaitTimeMs);
     } catch (TimeoutException e) {
       _segmentLogger.warn(
           "Cannot fetch latest stream offset for clientId {} and partitionGroupId {} with maxWaitTime {}", _clientId,

--- a/pinot-core/src/test/java/org/apache/pinot/realtime/converter/RealtimeSegmentConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/realtime/converter/RealtimeSegmentConverterTest.java
@@ -27,7 +27,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.segment.local.indexsegment.mutable.MutableSegmentImpl;
 import org.apache.pinot.segment.local.io.writer.impl.DirectMemoryManager;
-import org.apache.pinot.segment.local.realtime.converter.ColumnDescriptionsContainer;
+import org.apache.pinot.segment.local.realtime.converter.ColumnIndicesForRealtimeTable;
 import org.apache.pinot.segment.local.realtime.converter.RealtimeSegmentConverter;
 import org.apache.pinot.segment.local.realtime.impl.RealtimeSegmentConfig;
 import org.apache.pinot.segment.local.realtime.impl.RealtimeSegmentStatsHistory;
@@ -123,7 +123,7 @@ public class RealtimeSegmentConverterTest {
     SegmentZKPropsConfig segmentZKPropsConfig = new SegmentZKPropsConfig();
     segmentZKPropsConfig.setStartOffset("1");
     segmentZKPropsConfig.setEndOffset("100");
-    ColumnDescriptionsContainer cdc = new ColumnDescriptionsContainer(indexingConfig.getSortedColumn().get(0),
+    ColumnIndicesForRealtimeTable cdc = new ColumnIndicesForRealtimeTable(indexingConfig.getSortedColumn().get(0),
         indexingConfig.getInvertedIndexColumns(), null, null,
         indexingConfig.getNoDictionaryColumns(), indexingConfig.getVarLengthDictionaryColumns());
     RealtimeSegmentConverter converter =

--- a/pinot-core/src/test/java/org/apache/pinot/realtime/converter/RealtimeSegmentConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/realtime/converter/RealtimeSegmentConverterTest.java
@@ -27,6 +27,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.segment.local.indexsegment.mutable.MutableSegmentImpl;
 import org.apache.pinot.segment.local.io.writer.impl.DirectMemoryManager;
+import org.apache.pinot.segment.local.realtime.converter.ColumnDescriptionsContainer;
 import org.apache.pinot.segment.local.realtime.converter.RealtimeSegmentConverter;
 import org.apache.pinot.segment.local.realtime.impl.RealtimeSegmentConfig;
 import org.apache.pinot.segment.local.realtime.impl.RealtimeSegmentStatsHistory;
@@ -122,11 +123,12 @@ public class RealtimeSegmentConverterTest {
     SegmentZKPropsConfig segmentZKPropsConfig = new SegmentZKPropsConfig();
     segmentZKPropsConfig.setStartOffset("1");
     segmentZKPropsConfig.setEndOffset("100");
+    ColumnDescriptionsContainer cdc = new ColumnDescriptionsContainer(indexingConfig.getSortedColumn().get(0),
+        indexingConfig.getInvertedIndexColumns(), null, null,
+        indexingConfig.getNoDictionaryColumns(), indexingConfig.getVarLengthDictionaryColumns());
     RealtimeSegmentConverter converter =
         new RealtimeSegmentConverter(mutableSegmentImpl, segmentZKPropsConfig, outputDir.getAbsolutePath(), schema,
-            tableNameWithType, tableConfig, segmentName, indexingConfig.getSortedColumn().get(0),
-            indexingConfig.getInvertedIndexColumns(), null, null, indexingConfig.getNoDictionaryColumns(),
-            indexingConfig.getVarLengthDictionaryColumns(), false);
+            tableNameWithType, tableConfig, segmentName, cdc, false);
 
     converter.build(SegmentVersion.v3, null);
     SegmentMetadataImpl metadata = new SegmentMetadataImpl(new File(outputDir, segmentName));

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumerFactory.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumerFactory.java
@@ -46,7 +46,7 @@ public class KinesisConsumerFactory extends StreamConsumerFactory {
 
   @Override
   public StreamMetadataProvider createPartitionMetadataProvider(String clientId, int partition) {
-    throw new UnsupportedOperationException();
+    return new KinesisStreamMetadataProvider(clientId, _streamConfig);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/ColumnDescriptionsContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/ColumnDescriptionsContainer.java
@@ -1,0 +1,48 @@
+package org.apache.pinot.segment.local.realtime.converter;
+
+import java.util.List;
+
+
+public class ColumnDescriptionsContainer {
+  private final String _sortedColumn;
+  private final List<String> _invertedIndexColumns;
+  private final List<String> _textIndexColumns;
+  private final List<String> _fstIndexColumns;
+  private final List<String> _noDictionaryColumns;
+  private final List<String> _varLengthDictionaryColumns;
+
+  public ColumnDescriptionsContainer(String sortedColumn, List<String> invertedIndexColumns,
+      List<String> textIndexColumns, List<String> fstIndexColumns, List<String> noDictionaryColumns,
+      List<String> varLengthDictionaryColumns) {
+    _sortedColumn = sortedColumn;
+    _invertedIndexColumns = invertedIndexColumns;
+    _textIndexColumns = textIndexColumns;
+    _fstIndexColumns = fstIndexColumns;
+    _noDictionaryColumns = noDictionaryColumns;
+    _varLengthDictionaryColumns = varLengthDictionaryColumns;
+  }
+
+  public String getSortedColumn() {
+    return _sortedColumn;
+  }
+
+  public List<String> getInvertedIndexColumns() {
+    return _invertedIndexColumns;
+  }
+
+  public List<String> getTextIndexColumns() {
+    return _textIndexColumns;
+  }
+
+  public List<String> getFstIndexColumns() {
+    return _fstIndexColumns;
+  }
+
+  public List<String> getNoDictionaryColumns() {
+    return _noDictionaryColumns;
+  }
+
+  public List<String> getVarLengthDictionaryColumns() {
+    return _varLengthDictionaryColumns;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/ColumnIndicesForRealtimeTable.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/ColumnIndicesForRealtimeTable.java
@@ -1,9 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.segment.local.realtime.converter;
 
 import java.util.List;
 
 
-public class ColumnDescriptionsContainer {
+/**
+ * Container class for holding all column indices necessary for realtime table
+ */
+public class ColumnIndicesForRealtimeTable {
   private final String _sortedColumn;
   private final List<String> _invertedIndexColumns;
   private final List<String> _textIndexColumns;
@@ -11,7 +32,7 @@ public class ColumnDescriptionsContainer {
   private final List<String> _noDictionaryColumns;
   private final List<String> _varLengthDictionaryColumns;
 
-  public ColumnDescriptionsContainer(String sortedColumn, List<String> invertedIndexColumns,
+  public ColumnIndicesForRealtimeTable(String sortedColumn, List<String> invertedIndexColumns,
       List<String> textIndexColumns, List<String> fstIndexColumns, List<String> noDictionaryColumns,
       List<String> varLengthDictionaryColumns) {
     _sortedColumn = sortedColumn;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
@@ -49,17 +49,17 @@ public class RealtimeSegmentConverter {
   private final String _segmentName;
   private final String _sortedColumn;
   private final List<String> _invertedIndexColumns;
-  private final ColumnDescriptionsContainer _columnDescriptionsContainer;
+  private final ColumnIndicesForRealtimeTable _columnIndicesForRealtimeTable;
   private final boolean _nullHandlingEnabled;
 
   public RealtimeSegmentConverter(MutableSegmentImpl realtimeSegment, SegmentZKPropsConfig segmentZKPropsConfig,
       String outputPath, Schema schema, String tableName, TableConfig tableConfig, String segmentName,
-      ColumnDescriptionsContainer cdc, boolean nullHandlingEnabled) {
+      ColumnIndicesForRealtimeTable cdc, boolean nullHandlingEnabled) {
     _realtimeSegmentImpl = realtimeSegment;
     _segmentZKPropsConfig = segmentZKPropsConfig;
     _outputPath = outputPath;
-    _columnDescriptionsContainer = cdc;
-    _invertedIndexColumns = new ArrayList<>(_columnDescriptionsContainer.getInvertedIndexColumns());
+    _columnIndicesForRealtimeTable = cdc;
+    _invertedIndexColumns = new ArrayList<>(_columnIndicesForRealtimeTable.getInvertedIndexColumns());
     if (cdc.getSortedColumn() != null) {
       _invertedIndexColumns.remove(cdc.getSortedColumn());
     }
@@ -86,8 +86,8 @@ public class RealtimeSegmentConverter {
       }
     }
 
-    if (_columnDescriptionsContainer.getVarLengthDictionaryColumns() != null) {
-      genConfig.setVarLengthDictionaryColumns(_columnDescriptionsContainer.getVarLengthDictionaryColumns());
+    if (_columnIndicesForRealtimeTable.getVarLengthDictionaryColumns() != null) {
+      genConfig.setVarLengthDictionaryColumns(_columnIndicesForRealtimeTable.getVarLengthDictionaryColumns());
     }
 
     if (segmentVersion != null) {
@@ -96,8 +96,8 @@ public class RealtimeSegmentConverter {
     genConfig.setTableName(_tableName);
     genConfig.setOutDir(_outputPath);
     genConfig.setSegmentName(_segmentName);
-    genConfig.setTextIndexCreationColumns(_columnDescriptionsContainer.getTextIndexColumns());
-    genConfig.setFSTIndexCreationColumns(_columnDescriptionsContainer.getFstIndexColumns());
+    genConfig.setTextIndexCreationColumns(_columnIndicesForRealtimeTable.getTextIndexColumns());
+    genConfig.setFSTIndexCreationColumns(_columnIndicesForRealtimeTable.getFstIndexColumns());
     SegmentPartitionConfig segmentPartitionConfig = _realtimeSegmentImpl.getSegmentPartitionConfig();
     genConfig.setSegmentPartitionConfig(segmentPartitionConfig);
     genConfig.setNullHandlingEnabled(_nullHandlingEnabled);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
@@ -49,34 +49,26 @@ public class RealtimeSegmentConverter {
   private final String _segmentName;
   private final String _sortedColumn;
   private final List<String> _invertedIndexColumns;
-  private final List<String> _textIndexColumns;
-  private final List<String> _fstIndexColumns;
-  private final List<String> _noDictionaryColumns;
-  private final List<String> _varLengthDictionaryColumns;
+  private final ColumnDescriptionsContainer _columnDescriptionsContainer;
   private final boolean _nullHandlingEnabled;
 
   public RealtimeSegmentConverter(MutableSegmentImpl realtimeSegment, SegmentZKPropsConfig segmentZKPropsConfig,
       String outputPath, Schema schema, String tableName, TableConfig tableConfig, String segmentName,
-      String sortedColumn, List<String> invertedIndexColumns, List<String> textIndexColumns,
-      List<String> fstIndexColumns, List<String> noDictionaryColumns, List<String> varLengthDictionaryColumns,
-      boolean nullHandlingEnabled) {
+      ColumnDescriptionsContainer cdc, boolean nullHandlingEnabled) {
     _realtimeSegmentImpl = realtimeSegment;
     _segmentZKPropsConfig = segmentZKPropsConfig;
     _outputPath = outputPath;
-    _invertedIndexColumns = new ArrayList<>(invertedIndexColumns);
-    if (sortedColumn != null) {
-      _invertedIndexColumns.remove(sortedColumn);
+    _columnDescriptionsContainer = cdc;
+    _invertedIndexColumns = new ArrayList<>(_columnDescriptionsContainer.getInvertedIndexColumns());
+    if (cdc.getSortedColumn() != null) {
+      _invertedIndexColumns.remove(cdc.getSortedColumn());
     }
     _dataSchema = getUpdatedSchema(schema);
-    _sortedColumn = sortedColumn;
+    _sortedColumn = cdc.getSortedColumn();
     _tableName = tableName;
     _tableConfig = tableConfig;
     _segmentName = segmentName;
-    _noDictionaryColumns = noDictionaryColumns;
-    _varLengthDictionaryColumns = varLengthDictionaryColumns;
     _nullHandlingEnabled = nullHandlingEnabled;
-    _textIndexColumns = textIndexColumns;
-    _fstIndexColumns = fstIndexColumns;
   }
 
   public void build(@Nullable SegmentVersion segmentVersion, ServerMetrics serverMetrics)
@@ -94,8 +86,8 @@ public class RealtimeSegmentConverter {
       }
     }
 
-    if (_varLengthDictionaryColumns != null) {
-      genConfig.setVarLengthDictionaryColumns(_varLengthDictionaryColumns);
+    if (_columnDescriptionsContainer.getVarLengthDictionaryColumns() != null) {
+      genConfig.setVarLengthDictionaryColumns(_columnDescriptionsContainer.getVarLengthDictionaryColumns());
     }
 
     if (segmentVersion != null) {
@@ -104,8 +96,8 @@ public class RealtimeSegmentConverter {
     genConfig.setTableName(_tableName);
     genConfig.setOutDir(_outputPath);
     genConfig.setSegmentName(_segmentName);
-    genConfig.setTextIndexCreationColumns(_textIndexColumns);
-    genConfig.setFSTIndexCreationColumns(_fstIndexColumns);
+    genConfig.setTextIndexCreationColumns(_columnDescriptionsContainer.getTextIndexColumns());
+    genConfig.setFSTIndexCreationColumns(_columnDescriptionsContainer.getFstIndexColumns());
     SegmentPartitionConfig segmentPartitionConfig = _realtimeSegmentImpl.getSegmentPartitionConfig();
     genConfig.setSegmentPartitionConfig(segmentPartitionConfig);
     genConfig.setNullHandlingEnabled(_nullHandlingEnabled);


### PR DESCRIPTION
There is no change in functionality in this PR. The changes are:
* Created a wrapper class to encapsulate all the column descriptors used in `LLRealtimeSegmentDataManager` 
* `LLRealtimeSegmentDataManager` should always use `createPartitionMetadataProvider` and not `createStreamMetadataProvider`