### PR TITLE
[multistage] support NULL in data blocks

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/ColumnarDataBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/ColumnarDataBlock.java
@@ -48,6 +48,7 @@ public class ColumnarDataBlock extends BaseDataBlock {
   }
 
   protected void computeBlockObjectConstants() {
+    _fixDataSize = 0;
     if (_dataSchema != null) {
       _cumulativeColumnOffsetSizeInBytes = new int[_numColumns];
       _columnSizeInBytes = new int[_numColumns];
@@ -57,6 +58,7 @@ public class ColumnarDataBlock extends BaseDataBlock {
         _cumulativeColumnOffsetSizeInBytes[i] = cumulativeColumnOffset;
         cumulativeColumnOffset += _columnSizeInBytes[i] * _numRows;
       }
+      _fixDataSize = cumulativeColumnOffset;
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockUtils.java
@@ -28,6 +28,7 @@ import javax.annotation.Nonnull;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.common.utils.DataSchema;
+import org.roaringbitmap.RoaringBitmap;
 
 
 public final class DataBlockUtils {
@@ -74,7 +75,7 @@ public final class DataBlockUtils {
     }
   }
 
-  public static List<Object[]> extraRows(BaseDataBlock dataBlock) {
+  public static List<Object[]> extractRows(BaseDataBlock dataBlock) {
     DataSchema dataSchema = dataBlock.getDataSchema();
     DataSchema.ColumnDataType[] storedColumnDataTypes = dataSchema.getStoredColumnDataTypes();
     int numRows = dataBlock.getNumberOfRows();
@@ -132,6 +133,15 @@ public final class DataBlockUtils {
         }
       }
       rows.add(row);
+    }
+
+    for (int colId = 0; colId < numColumns; colId++) {
+      RoaringBitmap nullBitmap = dataBlock.getNullRowIds(colId);
+      if (nullBitmap != null) {
+        for (Integer rowId : nullBitmap) {
+          rows.get(rowId)[colId] = null;
+        }
+      }
     }
     return rows;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/RowDataBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/RowDataBlock.java
@@ -20,10 +20,7 @@ package org.apache.pinot.core.common.datablock;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.core.common.ObjectSerDeUtils;
-import org.roaringbitmap.RoaringBitmap;
 
 
 /**
@@ -50,31 +47,11 @@ public class RowDataBlock extends BaseDataBlock {
     computeBlockObjectConstants();
   }
 
-  @Nullable
-  @Override
-  public RoaringBitmap getNullRowIds(int colId) {
-    // _fixedSizeData stores two ints per col's null bitmap: offset, and length.
-    int position = _numRows * _rowSizeInBytes + colId * Integer.BYTES * 2;
-    if (_fixedSizeData == null || position >= _fixedSizeData.limit()) {
-      return null;
-    }
-
-    _fixedSizeData.position(position);
-    int offset = _fixedSizeData.getInt();
-    int bytesLength = _fixedSizeData.getInt();
-    if (bytesLength > 0) {
-      _variableSizeData.position(offset);
-      byte[] nullBitmapBytes = new byte[bytesLength];
-      _variableSizeData.get(nullBitmapBytes);
-      return ObjectSerDeUtils.ROARING_BITMAP_SER_DE.deserialize(nullBitmapBytes);
-    }
-    return null;
-  }
-
   protected void computeBlockObjectConstants() {
     if (_dataSchema != null) {
       _columnOffsets = new int[_numColumns];
       _rowSizeInBytes = DataBlockUtils.computeColumnOffsets(_dataSchema, _columnOffsets);
+      _fixDataSize = _numRows * _rowSizeInBytes;
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTest.java
@@ -31,6 +31,7 @@ import org.apache.pinot.core.common.datatable.DataTableFactory;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.roaringbitmap.RoaringBitmap;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 
@@ -65,8 +66,8 @@ public class DataBlockTest {
    *
    * @throws Exception
    */
-  @Test
-  public void testRowDataBlockCompatibleWithDataTableV4()
+  @Test(dataProvider = "testTypeNullPercentile")
+  public void testRowDataBlockCompatibleWithDataTableV4(int nullPercentile)
       throws Exception {
     DataSchema.ColumnDataType[] allDataTypes = DataSchema.ColumnDataType.values();
     List<DataSchema.ColumnDataType> columnDataTypes = new ArrayList<DataSchema.ColumnDataType>();
@@ -80,7 +81,7 @@ public class DataBlockTest {
 
     DataSchema dataSchema = new DataSchema(columnNames.toArray(new String[0]),
         columnDataTypes.toArray(new DataSchema.ColumnDataType[0]));
-    List<Object[]> rows = DataBlockTestUtils.getRandomRows(dataSchema, TEST_ROW_COUNT);
+    List<Object[]> rows = DataBlockTestUtils.getRandomRows(dataSchema, TEST_ROW_COUNT, nullPercentile);
     DataTableFactory.setDataTableVersion(DataTableFactory.VERSION_4);
     DataTable dataTableImpl = SelectionOperatorUtils.getDataTableFromRows(rows, dataSchema, true);
     DataTable dataBlockFromDataTable = DataBlockUtils.getDataBlock(ByteBuffer.wrap(dataTableImpl.toBytes()));
@@ -102,8 +103,8 @@ public class DataBlockTest {
     }
   }
 
-  @Test
-  public void testAllDataTypes()
+  @Test(dataProvider = "testTypeNullPercentile")
+  public void testAllDataTypes(int nullPercentile)
       throws Exception {
 
     DataSchema.ColumnDataType[] allDataTypes = DataSchema.ColumnDataType.values();
@@ -118,7 +119,7 @@ public class DataBlockTest {
 
     DataSchema dataSchema = new DataSchema(columnNames.toArray(new String[]{}),
         columnDataTypes.toArray(new DataSchema.ColumnDataType[]{}));
-    List<Object[]> rows = DataBlockTestUtils.getRandomRows(dataSchema, TEST_ROW_COUNT);
+    List<Object[]> rows = DataBlockTestUtils.getRandomRows(dataSchema, TEST_ROW_COUNT, nullPercentile);
     List<Object[]> columnars = DataBlockTestUtils.convertColumnar(dataSchema, rows);
     RowDataBlock rowBlock = DataBlockBuilder.buildFromRows(rows, dataSchema);
     ColumnarDataBlock columnarBlock = DataBlockBuilder.buildFromColumns(columnars, dataSchema);
@@ -132,5 +133,10 @@ public class DataBlockTest {
             + " of Type: " + columnDataType + "! rowValue: [" + rowVal + "], columnarValue: [" + colVal + "]");
       }
     }
+  }
+
+  @DataProvider(name = "testTypeNullPercentile")
+  public Object[][] provideTestTypeNullPercentile() {
+    return new Object[][]{new Object[]{0}, new Object[]{10}, new Object[]{100}};
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTestUtils.java
@@ -36,7 +36,7 @@ public class DataBlockTestUtils {
     // do not instantiate.
   }
 
-  public static Object[] getRandomRow(DataSchema dataSchema) {
+  public static Object[] getRandomRow(DataSchema dataSchema, int nullPercentile) {
     final int numColumns = dataSchema.getColumnNames().length;
     DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
     Object[] row = new Object[numColumns];
@@ -114,7 +114,7 @@ public class DataBlockTestUtils {
       }
       // randomly set some entry to null
       if (columnDataTypes[colId].getStoredType() != DataSchema.ColumnDataType.OBJECT) {
-        row[colId] = randomlySettingNull(10) ? null : row[colId];
+        row[colId] = randomlySettingNull(nullPercentile) ? null : row[colId];
       }
     }
     return row;
@@ -162,10 +162,10 @@ public class DataBlockTestUtils {
     }
   }
 
-  public static List<Object[]> getRandomRows(DataSchema dataSchema, int numRows) {
+  public static List<Object[]> getRandomRows(DataSchema dataSchema, int numRows, int nullPercentile) {
     List<Object[]> rows = new ArrayList<>(numRows);
     for (int i = 0; i < numRows; i++) {
-      rows.add(getRandomRow(dataSchema));
+      rows.add(getRandomRow(dataSchema, nullPercentile));
     }
     return rows;
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlock.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlock.java
@@ -83,7 +83,7 @@ public class TransferableBlock implements Block {
     if (_container == null) {
       switch (_type) {
         case ROW:
-          _container = DataBlockUtils.extraRows(_dataBlock);
+          _container = DataBlockUtils.extractRows(_dataBlock);
           break;
         case COLUMNAR:
         default:
@@ -105,10 +105,10 @@ public class TransferableBlock implements Block {
       try {
         switch (_type) {
           case ROW:
-            _dataBlock = DataBlockBuilder.buildFromRows(_container, null, _dataSchema);
+            _dataBlock = DataBlockBuilder.buildFromRows(_container, _dataSchema);
             break;
           case COLUMNAR:
-            _dataBlock = DataBlockBuilder.buildFromColumns(_container, null, _dataSchema);
+            _dataBlock = DataBlockBuilder.buildFromColumns(_container, _dataSchema);
             break;
           case METADATA:
             throw new UnsupportedOperationException("Metadata block cannot be constructed from container");

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -186,7 +186,7 @@ public class MailboxSendOperator extends BaseOperator<TransferableBlock> {
       List<BaseDataBlock> dataTableList = new ArrayList<>(partitionSize);
       for (int i = 0; i < partitionSize; i++) {
         List<Object[]> objects = temporaryRows.get(i);
-        dataTableList.add(DataBlockBuilder.buildFromRows(objects, null, dataBlock.getDataSchema()));
+        dataTableList.add(DataBlockBuilder.buildFromRows(objects, dataBlock.getDataSchema()));
       }
       return dataTableList;
     }


### PR DESCRIPTION
multistage intermediate transferrable blocks are either 
- an encoded data table or 
- a decoded list of rows. 

it should automatically convert to and from these 2 format when necessary. however since null support was added, not all the null values were place correctly. 
This PR handles null value support in decode/encode codepath. 

Prerequisite for supporting left join in https://github.com/apache/pinot/issues/9223