### PR TITLE
fix histogram null pointer exception

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/HistogramAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/HistogramAggregationFunction.java
@@ -153,9 +153,8 @@ public class HistogramAggregationFunction extends BaseSingleInputAggregationFunc
   @Override
   public DoubleArrayList extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
     DoubleArrayList aggregationResultHolderResult = aggregationResultHolder.getResult();
-    int count = aggregationResultHolderResult.size();
-    if (count < 1) {
-      throw new IllegalStateException("histogram result shouldn't be empty!");
+    if (aggregationResultHolderResult == null) {
+      return DoubleVectorOpUtils.createAndInitialize(getNumBins());
     } else {
       return aggregationResultHolderResult;
     }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/HistogramQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/HistogramQueriesTest.java
@@ -164,6 +164,14 @@ public class HistogramQueriesTest extends BaseQueriesTest {
     ResultTable resultTable = brokerResponse.getResultTable();
     List<Object[]> rows = resultTable.getRows();
     assertEquals(rows.get(0)[0], new double[]{4, 36, 360, 3600, 4000});
+
+    // Inter segment no result
+    query =
+        "SELECT HISTOGRAM(intColumn,ARRAY[0,1,10,100,1000,10000]) FROM testTable WHERE (intColumn < 0)";
+    brokerResponse = getBrokerResponse(query);
+    resultTable = brokerResponse.getResultTable();
+    rows = resultTable.getRows();
+    assertEquals(rows.get(0)[0], new double[]{0, 0, 0, 0, 0});
   }
 
   @Test


### PR DESCRIPTION
https://github.com/apache/pinot/issues/9421

histogram throws null pointer when the filter yields no rows to aggregate