### PR TITLE
use MinionEventObserver to track finer grained task progress status on worker

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -58,6 +58,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
 
   private final boolean _useHttps;
   private final boolean _swaggerBrokerEnabled;
+  private final ExecutorService _executorService;
 
   private HttpServer _httpServer;
 
@@ -71,7 +72,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     if (brokerConf.getProperty(CommonConstants.Broker.BROKER_SERVICE_AUTO_DISCOVERY, false)) {
       register(ServiceAutoDiscoveryFeature.class);
     }
-    ExecutorService executor =
+    _executorService =
         Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("async-task-thread-%d").build());
     MultiThreadedHttpConnectionManager connMgr = new MultiThreadedHttpConnectionManager();
     connMgr.getParams().setConnectionTimeout((int) brokerConf
@@ -81,7 +82,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
       @Override
       protected void configure() {
         bind(connMgr).to(HttpConnectionManager.class);
-        bind(executor).to(Executor.class);
+        bind(_executorService).to(Executor.class);
         bind(sqlQueryExecutor).to(SqlQueryExecutor.class);
         bind(routingManager).to(BrokerRoutingManager.class);
         bind(brokerRequestHandler).to(BrokerRequestHandler.class);
@@ -142,7 +143,10 @@ public class BrokerAdminApiApplication extends ResourceConfig {
 
   public void stop() {
     if (_httpServer != null) {
+      LOGGER.info("Shutting down http server");
       _httpServer.shutdownNow();
     }
+    LOGGER.info("Shutting down executor service");
+    _executorService.shutdownNow();
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -213,6 +213,7 @@ public class ControllerConf extends PinotConfiguration {
   }
 
   private static final String SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS = "server.request.timeoutSeconds";
+  private static final String MINION_ADMIN_REQUEST_TIMEOUT_SECONDS = "minion.request.timeoutSeconds";
   private static final String SEGMENT_COMMIT_TIMEOUT_SECONDS = "controller.realtime.segment.commit.timeoutSeconds";
   private static final String DELETED_SEGMENTS_RETENTION_IN_DAYS = "controller.deleted.segments.retentionInDays";
   public static final String TABLE_MIN_REPLICAS = "table.minReplicas";
@@ -240,6 +241,7 @@ public class ControllerConf extends PinotConfiguration {
   private static final String PINOT_FS_FACTORY_CLASS_LOCAL = "controller.storage.factory.class.file";
 
   private static final int DEFAULT_SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS = 30;
+  private static final int DEFAULT_MINION_ADMIN_REQUEST_TIMEOUT_SECONDS = 30;
   private static final int DEFAULT_DELETED_SEGMENTS_RETENTION_IN_DAYS = 7;
   private static final int DEFAULT_TABLE_MIN_REPLICAS = 1;
   private static final boolean DEFAULT_ENABLE_SPLIT_COMMIT = true;
@@ -647,6 +649,14 @@ public class ControllerConf extends PinotConfiguration {
 
   public int getServerAdminRequestTimeoutSeconds() {
     return getProperty(SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS, DEFAULT_SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS);
+  }
+
+  public void setMinionAdminRequestTimeoutSeconds(int timeoutSeconds) {
+    setProperty(MINION_ADMIN_REQUEST_TIMEOUT_SECONDS, timeoutSeconds);
+  }
+
+  public int getMinionAdminRequestTimeoutSeconds() {
+    return getProperty(MINION_ADMIN_REQUEST_TIMEOUT_SECONDS, DEFAULT_MINION_ADMIN_REQUEST_TIMEOUT_SECONDS);
   }
 
   public int getDeletedSegmentsRetentionInDays() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -65,6 +65,7 @@ import org.apache.helix.task.TaskState;
 import org.apache.pinot.common.exception.TableNotFoundException;
 import org.apache.pinot.common.minion.BaseTaskGeneratorInfo;
 import org.apache.pinot.common.minion.TaskManagerStatusCache;
+import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AccessType;
 import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
@@ -143,6 +144,9 @@ public class PinotTaskRestletResource {
 
   @Inject
   HttpConnectionManager _connectionManager;
+
+  @Inject
+  ControllerConf _controllerConf;
 
   @Context
   private UriInfo _uriInfo;
@@ -423,9 +427,11 @@ public class PinotTaskRestletResource {
     httpHeaders.getRequestHeaders().keySet().forEach(header -> {
       requestHeaders.put(header, httpHeaders.getHeaderString(header));
     });
+    int timeoutMs = _controllerConf.getMinionAdminRequestTimeoutSeconds() * 1000;
     try {
       return _pinotHelixTaskResourceManager
-          .getSubtaskProgress(taskName, subtaskNames, _executor, _connectionManager, workerEndpoints, requestHeaders);
+          .getSubtaskProgress(taskName, subtaskNames, _executor, _connectionManager, workerEndpoints, requestHeaders,
+              timeoutMs);
     } catch (UnknownTaskTypeException | NoTaskScheduledException e) {
       throw new ControllerApplicationException(LOGGER, "Not task with name: " + taskName, Response.Status.NOT_FOUND, e);
     } catch (Exception e) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -404,6 +404,11 @@ public class PinotHelixResourceManager {
         .filter(instance -> InstanceTypeUtils.isController(instance.getId())).collect(Collectors.toList());
   }
 
+  public List<InstanceConfig> getAllMinionInstanceConfigs() {
+    return HelixHelper.getInstanceConfigs(_helixZkManager).stream()
+        .filter(instance -> InstanceTypeUtils.isMinion(instance.getId())).collect(Collectors.toList());
+  }
+
   /**
    * Get all instances with the given tag
    */

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManagerTest.java
@@ -1,0 +1,146 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.minion;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.helix.task.JobContext;
+import org.apache.helix.task.TaskDriver;
+import org.apache.helix.task.TaskPartitionState;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.util.CompletionServiceHelper;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class PinotHelixTaskResourceManagerTest {
+  @Test
+  public void testGetSubtaskProgressNoWorker()
+      throws Exception {
+    TaskDriver taskDriver = mock(TaskDriver.class);
+    when(taskDriver.getJobContext(anyString())).thenReturn(mock(JobContext.class));
+    CompletionServiceHelper httpHelper = mock(CompletionServiceHelper.class);
+    CompletionServiceHelper.CompletionServiceResponse httpResp =
+        new CompletionServiceHelper.CompletionServiceResponse();
+    when(httpHelper.doMultiGetRequest(any(), any(), anyBoolean(), any(), anyInt())).thenReturn(httpResp);
+    PinotHelixTaskResourceManager mgr =
+        new PinotHelixTaskResourceManager(mock(PinotHelixResourceManager.class), taskDriver);
+    // No worker to run subtasks.
+    Map<String, String> workerEndpoints = new HashMap<>();
+    String taskName = "Task_SegmentGenerationAndPushTask_someone";
+    String[] subtaskNames = new String[3];
+    for (int i = 0; i < 3; i++) {
+      subtaskNames[i] = taskName + "_" + i;
+    }
+    Map<String, String> progress =
+        mgr.getSubtaskProgress(taskName, StringUtils.join(subtaskNames, ','), httpHelper, workerEndpoints,
+            Collections.emptyMap(), 1000);
+    for (String subtaskName : subtaskNames) {
+      assertEquals(progress.get(subtaskName), "No worker has run this subtask");
+    }
+  }
+
+  @Test
+  public void testGetSubtaskProgressNoResponse()
+      throws Exception {
+    TaskDriver taskDriver = mock(TaskDriver.class);
+    JobContext jobContext = mock(JobContext.class);
+    when(taskDriver.getJobContext(anyString())).thenReturn(jobContext);
+    PinotHelixTaskResourceManager mgr =
+        new PinotHelixTaskResourceManager(mock(PinotHelixResourceManager.class), taskDriver);
+    CompletionServiceHelper httpHelper = mock(CompletionServiceHelper.class);
+    CompletionServiceHelper.CompletionServiceResponse httpResp =
+        new CompletionServiceHelper.CompletionServiceResponse();
+    when(httpHelper.doMultiGetRequest(any(), any(), anyBoolean(), any(), anyInt())).thenReturn(httpResp);
+    // Three workers to run 3 subtasks but got no progress status from workers.
+    String[] workers = new String[]{"worker01", "worker02", "worker03"};
+    Map<String, String> workerEndpoints = new HashMap<>();
+    for (String worker : workers) {
+      workerEndpoints.put(worker, "http://" + worker + ":9000");
+    }
+    String taskName = "Task_SegmentGenerationAndPushTask_someone";
+    String[] subtaskNames = new String[3];
+    Set<Integer> subtaskIds = new HashSet<>();
+    for (int i = 0; i < 3; i++) {
+      subtaskIds.add(i);
+      subtaskNames[i] = taskName + "_" + i;
+    }
+    TaskPartitionState[] helixStates =
+        new TaskPartitionState[]{TaskPartitionState.INIT, TaskPartitionState.RUNNING, TaskPartitionState.TASK_ERROR};
+    when(jobContext.getTaskIdForPartition(anyInt())).thenReturn(subtaskNames[0], subtaskNames[1], subtaskNames[2]);
+    when(jobContext.getAssignedParticipant(anyInt())).thenReturn(workers[0], workers[1], workers[2]);
+    when(jobContext.getPartitionState(anyInt())).thenReturn(helixStates[0], helixStates[1], helixStates[2]);
+    when(jobContext.getPartitionSet()).thenReturn(subtaskIds);
+    Map<String, String> progress =
+        mgr.getSubtaskProgress(taskName, StringUtils.join(subtaskNames, ','), httpHelper, workerEndpoints,
+            Collections.emptyMap(), 1000);
+    for (int i = 0; i < 3; i++) {
+      String taskProgress = progress.get(subtaskNames[i]);
+      assertTrue(taskProgress.contains(helixStates[i].name()), subtaskNames[i] + ":" + taskProgress);
+    }
+  }
+
+  @Test(expectedExceptions = RuntimeException.class)
+  public void testGetSubtaskProgressWithFailure()
+      throws Exception {
+    TaskDriver taskDriver = mock(TaskDriver.class);
+    JobContext jobContext = mock(JobContext.class);
+    when(taskDriver.getJobContext(anyString())).thenReturn(jobContext);
+    PinotHelixTaskResourceManager mgr =
+        new PinotHelixTaskResourceManager(mock(PinotHelixResourceManager.class), taskDriver);
+    CompletionServiceHelper httpHelper = mock(CompletionServiceHelper.class);
+    CompletionServiceHelper.CompletionServiceResponse httpResp =
+        new CompletionServiceHelper.CompletionServiceResponse();
+    when(httpHelper.doMultiGetRequest(any(), any(), anyBoolean(), any(), anyInt())).thenReturn(httpResp);
+    // Three workers to run 3 subtasks but got failure.
+    httpResp._failedResponseCount = 3;
+    String[] workers = new String[]{"worker01", "worker02", "worker03"};
+    Map<String, String> workerEndpoints = new HashMap<>();
+    for (String worker : workers) {
+      workerEndpoints.put(worker, "http://" + worker + ":9000");
+    }
+    String taskName = "Task_SegmentGenerationAndPushTask_someone";
+    String[] subtaskNames = new String[3];
+    Set<Integer> subtaskIds = new HashSet<>();
+    for (int i = 0; i < 3; i++) {
+      subtaskIds.add(i);
+      subtaskNames[i] = taskName + "_" + i;
+    }
+    TaskPartitionState[] helixStates =
+        new TaskPartitionState[]{TaskPartitionState.INIT, TaskPartitionState.RUNNING, TaskPartitionState.TASK_ERROR};
+    when(jobContext.getTaskIdForPartition(anyInt())).thenReturn(subtaskNames[0], subtaskNames[1], subtaskNames[2]);
+    when(jobContext.getAssignedParticipant(anyInt())).thenReturn(workers[0], workers[1], workers[2]);
+    when(jobContext.getPartitionState(anyInt())).thenReturn(helixStates[0], helixStates[1], helixStates[2]);
+    when(jobContext.getPartitionSet()).thenReturn(subtaskIds);
+    mgr.getSubtaskProgress(taskName, StringUtils.join(subtaskNames, ','), httpHelper, workerEndpoints,
+        Collections.emptyMap(), 1000);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/PinotTaskConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/PinotTaskConfig.java
@@ -41,6 +41,10 @@ public class PinotTaskConfig {
     return _taskType;
   }
 
+  public String getTaskId() {
+    return _configs.get(TASK_ID_KEY);
+  }
+
   public Map<String, String> getConfigs() {
     return _configs;
   }
@@ -53,7 +57,7 @@ public class PinotTaskConfig {
     Map<String, String> configs = new HashMap<>(helixTaskConfig.getConfigMap());
 
     // Inside Helix task config map, there are 3 extra Helix properties: TASK_COMMAND, TASK_ID, TASK_TARGET_PARTITION
-    configs.remove(TASK_ID_KEY);
+    // Note that TASK_ID_KEY is kept in configs so that task executor can retrieve the states associated with TaskId.
     configs.remove(TASK_COMMAND_KEY);
     configs.remove(TASK_TARGET_PARTITION_KEY);
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
@@ -54,7 +54,7 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
   public static final String TABLE_NAME_2 = "testTable2";
   public static final String TABLE_NAME_3 = "testTable3";
   public static final int NUM_TASKS = 2;
-  public static final int NUM_CONFIGS = 3;
+  public static final int NUM_CONFIGS = 4;
   public static final AtomicBoolean HOLD = new AtomicBoolean();
   public static final AtomicBoolean TASK_START_NOTIFIED = new AtomicBoolean();
   public static final AtomicBoolean TASK_SUCCESS_NOTIFIED = new AtomicBoolean();

--- a/pinot-minion/pom.xml
+++ b/pinot-minion/pom.xml
@@ -78,6 +78,13 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-common</artifactId>
+      <version>${project.version}</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
@@ -19,10 +19,13 @@
 package org.apache.pinot.minion;
 
 import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import javax.net.ssl.SSLContext;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -47,6 +50,7 @@ import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
 import org.apache.pinot.minion.event.EventObserverFactoryRegistry;
 import org.apache.pinot.minion.event.MinionEventObserverFactory;
+import org.apache.pinot.minion.event.MinionEventObservers;
 import org.apache.pinot.minion.executor.MinionTaskZkMetadataManager;
 import org.apache.pinot.minion.executor.PinotTaskExecutorFactory;
 import org.apache.pinot.minion.executor.TaskExecutorFactoryRegistry;
@@ -82,6 +86,7 @@ public abstract class BaseMinionStarter implements ServiceStartable {
   protected EventObserverFactoryRegistry _eventObserverFactoryRegistry;
   protected MinionAdminApiApplication _minionAdminApplication;
   protected List<ListenerConfig> _listenerConfigs;
+  protected ExecutorService _executorService;
 
   @Override
   public void init(PinotConfiguration config)
@@ -107,6 +112,9 @@ public abstract class BaseMinionStarter implements ServiceStartable {
     MinionTaskZkMetadataManager minionTaskZkMetadataManager = new MinionTaskZkMetadataManager(_helixManager);
     _taskExecutorFactoryRegistry = new TaskExecutorFactoryRegistry(minionTaskZkMetadataManager, _config);
     _eventObserverFactoryRegistry = new EventObserverFactoryRegistry(minionTaskZkMetadataManager);
+    _executorService =
+        Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("async-task-thread-%d").build());
+    MinionEventObservers.init(_config, _executorService);
   }
 
   private void setupHelixSystemProperties() {

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
@@ -319,6 +319,8 @@ public abstract class BaseMinionStarter implements ServiceStartable {
     _helixManager.disconnect();
     LOGGER.info("Deregistering service status handler");
     ServiceStatus.removeServiceStatusCallback(_instanceId);
+    LOGGER.info("Shutting down executor service");
+    _executorService.shutdownNow();
     LOGGER.info("Clean up Minion data directory");
     try {
       FileUtils.cleanDirectory(MinionContext.getInstance().getDataDir());

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResource.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResource.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.minion.api.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiKeyAuthDefinition;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import io.swagger.annotations.Authorization;
+import io.swagger.annotations.SecurityDefinition;
+import io.swagger.annotations.SwaggerDefinition;
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import org.apache.commons.lang.StringUtils;
+import org.apache.pinot.minion.event.MinionEventObserver;
+import org.apache.pinot.minion.event.MinionEventObservers;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
+
+
+/**
+ * Get finer grained progress of tasks running on the minion worker.
+ */
+@Api(tags = "Progress", authorizations = {@Authorization(value = SWAGGER_AUTHORIZATION_KEY)})
+@SwaggerDefinition(securityDefinition = @SecurityDefinition(apiKeyAuthDefinitions = @ApiKeyAuthDefinition(name =
+    HttpHeaders.AUTHORIZATION, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER, key = SWAGGER_AUTHORIZATION_KEY)))
+@Path("/")
+public class PinotTaskProgressResource {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotTaskProgressResource.class);
+
+  @GET
+  @Path("/tasks/subtask/progress")
+  @ApiOperation("Get finer grained task progress tracked in memory for the given subtasks")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error")
+  })
+  public Object getSubtaskProgress(
+      @ApiParam(value = "Sub task names separated by comma") @QueryParam("subtaskNames") String subtaskNames) {
+    try {
+      LOGGER.debug("Get progress for subtasks: {}", subtaskNames);
+      Map<String, Object> progress = new HashMap<>();
+      for (String subtaskName : StringUtils.split(subtaskNames, ',')) {
+        MinionEventObserver observer = MinionEventObservers.getInstance().getMinionEventObserver(subtaskName);
+        if (observer != null) {
+          progress.put(subtaskName, observer.getProgress());
+        }
+      }
+      return progress;
+    } catch (Exception e) {
+      throw new WebApplicationException(Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(
+          String.format("Failed to get task progress for subtasks: %s due to error: %s", subtaskNames, e.getMessage()))
+          .build());
+    }
+  }
+}

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResource.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResource.java
@@ -38,6 +38,7 @@ import javax.ws.rs.core.Response;
 import org.apache.commons.lang.StringUtils;
 import org.apache.pinot.minion.event.MinionEventObserver;
 import org.apache.pinot.minion.event.MinionEventObservers;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,10 +63,11 @@ public class PinotTaskProgressResource {
   })
   public Object getSubtaskProgress(
       @ApiParam(value = "Sub task names separated by comma") @QueryParam("subtaskNames") String subtaskNames) {
+
     try {
       LOGGER.debug("Get progress for subtasks: {}", subtaskNames);
       Map<String, Object> progress = new HashMap<>();
-      for (String subtaskName : StringUtils.split(subtaskNames, ',')) {
+      for (String subtaskName : StringUtils.split(subtaskNames, CommonConstants.Minion.TASK_LIST_SEPARATOR)) {
         MinionEventObserver observer = MinionEventObservers.getInstance().getMinionEventObserver(subtaskName);
         if (observer != null) {
           progress.put(subtaskName, observer.getProgress());

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionEventObserver.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionEventObserver.java
@@ -35,6 +35,20 @@ public interface MinionEventObserver {
   void notifyTaskStart(PinotTaskConfig pinotTaskConfig);
 
   /**
+   * Invoked to update a minion task progress status.
+   *
+   * @param pinotTaskConfig Pinot task config
+   * @param progress progress status
+   */
+  default void notifyProgress(PinotTaskConfig pinotTaskConfig, @Nullable Object progress) {
+  }
+
+  @Nullable
+  default Object getProgress() {
+    return null;
+  }
+
+  /**
    * Invoked when a minion task succeeds.
    *
    * @param pinotTaskConfig Pinot task config

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionEventObservers.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionEventObservers.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.minion.event;
+
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+import org.apache.pinot.minion.MinionConf;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class MinionEventObservers {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MinionEventObservers.class);
+
+  private static final MinionEventObservers DEFAULT_INSTANCE = new MinionEventObservers();
+  private static volatile MinionEventObservers _customInstance = null;
+
+  private final Map<String, MinionEventObserver> _taskEventObservers = new ConcurrentHashMap<>();
+  // Tasks are added roughly in time order, so use LinkedList instead of PriorityQueue for simplicity.
+  private final Queue<EndedTask> _endedTaskQueue = new LinkedList<>();
+  private final ReentrantLock _queueLock = new ReentrantLock();
+  private final Condition _availableToClean = _queueLock.newCondition();
+
+  private final long _eventObserverCleanupDelayMs;
+  private final ExecutorService _cleanupExecutor;
+
+  private MinionEventObservers() {
+    _cleanupExecutor = null;
+    _eventObserverCleanupDelayMs = 0;
+  }
+
+  private MinionEventObservers(long eventObserverCleanupDelayInSec, ExecutorService executorService) {
+    _eventObserverCleanupDelayMs = eventObserverCleanupDelayInSec * 1000;
+    _cleanupExecutor = executorService;
+    startCleanup();
+  }
+
+  private void startCleanup() {
+    if (_cleanupExecutor == null) {
+      LOGGER.info("No executor to cleanup task event observer");
+      return;
+    }
+    _cleanupExecutor.submit(() -> {
+      LOGGER.info("Start to cleanup task event observers with cleanupDelayMs: {}", _eventObserverCleanupDelayMs);
+      while (!Thread.interrupted()) {
+        _queueLock.lock();
+        try {
+          EndedTask task = _endedTaskQueue.peek();
+          if (task == null) {
+            _availableToClean.await();
+          } else {
+            long nowMs = System.currentTimeMillis();
+            if (task._endTs + _eventObserverCleanupDelayMs <= nowMs) {
+              LOGGER.info("Cleaning up event observer for task: {} that ended at: {}, now at: {} after delay: {}",
+                  task._taskId, task._endTs, nowMs, _eventObserverCleanupDelayMs);
+              _taskEventObservers.remove(task._taskId);
+              _endedTaskQueue.poll();
+            } else {
+              _availableToClean.await(task._endTs + _eventObserverCleanupDelayMs - nowMs, TimeUnit.MILLISECONDS);
+            }
+          }
+        } finally {
+          _queueLock.unlock();
+        }
+      }
+      LOGGER.info("Stop to cleanup task event observers");
+      return null;
+    });
+  }
+
+  public static void init(MinionConf config, ExecutorService executorService) {
+    // Default delay is set to 0 so that task's observer object is cleaned immediately upon task ends.
+    _customInstance = new MinionEventObservers(
+        config.getProperty(CommonConstants.Minion.CONFIG_OF_EVENT_OBSERVER_CLEANUP_DELAY_IN_SEC, 0), executorService);
+  }
+
+  public static MinionEventObservers getInstance() {
+    return _customInstance != null ? _customInstance : DEFAULT_INSTANCE;
+  }
+
+  public MinionEventObserver getMinionEventObserver(String taskId) {
+    return _taskEventObservers.get(taskId);
+  }
+
+  public void addMinionEventObserver(String taskId, MinionEventObserver eventObserver) {
+    LOGGER.debug("Keep track of event observer for task: {}", taskId);
+    _taskEventObservers.put(taskId, eventObserver);
+  }
+
+  public void removeMinionEventObserver(String taskId) {
+    if (_eventObserverCleanupDelayMs <= 0) {
+      LOGGER.debug("Clean up event observer for task: {} immediately", taskId);
+      _taskEventObservers.remove(taskId);
+      return;
+    }
+    LOGGER.debug("Clean up event observer for task: {} after delay: {}", taskId, _eventObserverCleanupDelayMs);
+    _queueLock.lock();
+    try {
+      _endedTaskQueue.offer(new EndedTask(taskId, System.currentTimeMillis()));
+      _availableToClean.signalAll();
+    } finally {
+      _queueLock.unlock();
+    }
+  }
+
+  private static class EndedTask {
+    private final String _taskId;
+    private final long _endTs;
+
+    public EndedTask(String taskId, long ts) {
+      _taskId = taskId;
+      _endTs = ts;
+    }
+  }
+}

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionEventObservers.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionEventObservers.java
@@ -48,8 +48,7 @@ public class MinionEventObservers {
   private final ExecutorService _cleanupExecutor;
 
   private MinionEventObservers() {
-    _cleanupExecutor = null;
-    _eventObserverCleanupDelayMs = 0;
+    this(0, null);
   }
 
   private MinionEventObservers(long eventObserverCleanupDelayInSec, ExecutorService executorService) {

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionProgressObserver.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionProgressObserver.java
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory;
 /**
  * A minion event observer that can track task progress status in memory.
  */
-public class MinionProgressObserver implements MinionEventObserver {
+public class MinionProgressObserver extends DefaultMinionEventObserver {
   private static final Logger LOGGER = LoggerFactory.getLogger(MinionProgressObserver.class);
 
   private static volatile long _startTs;
@@ -38,6 +38,7 @@ public class MinionProgressObserver implements MinionEventObserver {
   @Override
   public void notifyTaskStart(PinotTaskConfig pinotTaskConfig) {
     _startTs = System.currentTimeMillis();
+    super.notifyTaskStart(pinotTaskConfig);
   }
 
   public void notifyProgress(PinotTaskConfig pinotTaskConfig, @Nullable Object progress) {
@@ -45,6 +46,7 @@ public class MinionProgressObserver implements MinionEventObserver {
       LOGGER.debug("Update progress: {} for task: {}", progress, pinotTaskConfig.getTaskId());
     }
     _lastStatus = progress;
+    super.notifyProgress(pinotTaskConfig, progress);
   }
 
   @Nullable
@@ -56,18 +58,21 @@ public class MinionProgressObserver implements MinionEventObserver {
   public void notifyTaskSuccess(PinotTaskConfig pinotTaskConfig, @Nullable Object executionResult) {
     long endTs = System.currentTimeMillis();
     _lastStatus = "Task succeeded in " + (endTs - _startTs) + "ms";
+    super.notifyTaskSuccess(pinotTaskConfig, executionResult);
   }
 
   @Override
   public void notifyTaskCancelled(PinotTaskConfig pinotTaskConfig) {
     long endTs = System.currentTimeMillis();
     _lastStatus = "Task got cancelled after " + (endTs - _startTs) + "ms";
+    super.notifyTaskCancelled(pinotTaskConfig);
   }
 
   @Override
   public void notifyTaskError(PinotTaskConfig pinotTaskConfig, Exception e) {
     long endTs = System.currentTimeMillis();
     _lastStatus = "Task failed in " + (endTs - _startTs) + "ms, with error:\n" + makeStringFromException(e);
+    super.notifyTaskError(pinotTaskConfig, e);
   }
 
   private static String makeStringFromException(Exception exp) {

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionProgressObserver.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionProgressObserver.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.minion.event;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import javax.annotation.Nullable;
+import org.apache.pinot.core.minion.PinotTaskConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A minion event observer that can track task progress status in memory.
+ */
+public class MinionProgressObserver implements MinionEventObserver {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MinionProgressObserver.class);
+
+  private static volatile long _startTs;
+  private static volatile Object _lastStatus;
+
+  @Override
+  public void notifyTaskStart(PinotTaskConfig pinotTaskConfig) {
+    _startTs = System.currentTimeMillis();
+  }
+
+  public void notifyProgress(PinotTaskConfig pinotTaskConfig, @Nullable Object progress) {
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Update progress: {} for task: {}", progress, pinotTaskConfig.getTaskId());
+    }
+    _lastStatus = progress;
+  }
+
+  @Nullable
+  public Object getProgress() {
+    return _lastStatus;
+  }
+
+  @Override
+  public void notifyTaskSuccess(PinotTaskConfig pinotTaskConfig, @Nullable Object executionResult) {
+    long endTs = System.currentTimeMillis();
+    _lastStatus = "Task succeeded in " + (endTs - _startTs) + "ms";
+  }
+
+  @Override
+  public void notifyTaskCancelled(PinotTaskConfig pinotTaskConfig) {
+    long endTs = System.currentTimeMillis();
+    _lastStatus = "Task got cancelled after " + (endTs - _startTs) + "ms";
+  }
+
+  @Override
+  public void notifyTaskError(PinotTaskConfig pinotTaskConfig, Exception e) {
+    long endTs = System.currentTimeMillis();
+    _lastStatus = "Task failed in " + (endTs - _startTs) + "ms, with error:\n" + makeStringFromException(e);
+  }
+
+  private static String makeStringFromException(Exception exp) {
+    StringWriter expStr = new StringWriter();
+    try (PrintWriter pw = new PrintWriter(expStr)) {
+      exp.printStackTrace(pw);
+    }
+    return expStr.toString();
+  }
+}

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
@@ -40,6 +40,7 @@ import org.apache.pinot.minion.MinionContext;
 import org.apache.pinot.minion.event.EventObserverFactoryRegistry;
 import org.apache.pinot.minion.event.MinionEventObserver;
 import org.apache.pinot.minion.event.MinionEventObserverFactory;
+import org.apache.pinot.minion.event.MinionEventObservers;
 import org.apache.pinot.minion.exception.FatalException;
 import org.apache.pinot.minion.exception.TaskCancelledException;
 import org.apache.pinot.minion.executor.PinotTaskExecutor;
@@ -89,8 +90,10 @@ public class TaskFactoryRegistry {
                 // Set taskId in MDC so that one may config logger to route task logs to separate file.
                 MDC.put("taskId", _taskConfig.getId());
                 _minionMetrics.addValueToGlobalGauge(MinionGauge.NUMBER_OF_TASKS, 1L);
+                MinionEventObservers.getInstance().addMinionEventObserver(_taskConfig.getId(), _eventObserver);
                 return runInternal();
               } finally {
+                MinionEventObservers.getInstance().removeMinionEventObserver(_taskConfig.getId());
                 _minionMetrics.addValueToGlobalGauge(MinionGauge.NUMBER_OF_TASKS, -1L);
                 long executionTimeMs = System.currentTimeMillis() - jobDequeueTimeMs;
                 _minionMetrics

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/event/MinionEventObserversTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/event/MinionEventObserversTest.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.minion.event;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.pinot.minion.MinionConf;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.util.TestUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+
+
+public class MinionEventObserversTest {
+  @Test
+  public void testCleanupImmediately() {
+    MinionConf config = new MinionConf();
+    MinionEventObservers.init(config, null);
+    for (String taskId : new String[]{"t01", "t02", "t03"}) {
+      MinionEventObserver observer = new MinionProgressObserver();
+      MinionEventObservers.getInstance().addMinionEventObserver(taskId, observer);
+      assertSame(MinionEventObservers.getInstance().getMinionEventObserver(taskId), observer);
+      MinionEventObservers.getInstance().removeMinionEventObserver(taskId);
+      assertNull(MinionEventObservers.getInstance().getMinionEventObserver(taskId));
+    }
+  }
+
+  @Test
+  public void testCleanupWithDelay() {
+    ExecutorService executor = Executors.newCachedThreadPool();
+    MinionConf config = new MinionConf();
+    config.setProperty(CommonConstants.Minion.CONFIG_OF_EVENT_OBSERVER_CLEANUP_DELAY_IN_SEC, 2);
+    MinionEventObservers.init(config, executor);
+    String[] taskIds = new String[]{"t01", "t02", "t03"};
+    for (String taskId : taskIds) {
+      MinionEventObserver observer = new MinionProgressObserver();
+      MinionEventObservers.getInstance().addMinionEventObserver(taskId, observer);
+      assertSame(MinionEventObservers.getInstance().getMinionEventObserver(taskId), observer);
+      MinionEventObservers.getInstance().removeMinionEventObserver(taskId);
+      assertNotNull(MinionEventObservers.getInstance().getMinionEventObserver(taskId));
+    }
+    for (String taskId : taskIds) {
+      TestUtils
+          .waitForCondition(aVoid -> MinionEventObservers.getInstance().getMinionEventObserver(taskId) == null, 5000,
+              "Failed to clean up observer");
+    }
+  }
+}

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskProgressObserverFactory.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskProgressObserverFactory.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.minion.tasks.segmentgenerationandpush;
+
+import org.apache.pinot.core.common.MinionConstants;
+import org.apache.pinot.minion.event.MinionEventObserver;
+import org.apache.pinot.minion.event.MinionEventObserverFactory;
+import org.apache.pinot.minion.event.MinionProgressObserver;
+import org.apache.pinot.minion.executor.MinionTaskZkMetadataManager;
+import org.apache.pinot.spi.annotations.minion.EventObserverFactory;
+
+
+@EventObserverFactory
+public class SegmentGenerationAndPushTaskProgressObserverFactory implements MinionEventObserverFactory {
+
+  @Override
+  public void init(MinionTaskZkMetadataManager zkMetadataManager) {
+  }
+
+  @Override
+  public String getTaskType() {
+    return MinionConstants.SegmentGenerationAndPushTask.TASK_TYPE;
+  }
+
+  @Override
+  public MinionEventObserver create() {
+    return new MinionProgressObserver();
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -585,6 +585,7 @@ public class CommonConstants {
     public static final String CONFIG_OF_LOGGER_ROOT_DIR = "pinot.minion.logger.root.dir";
     public static final String CONFIG_OF_EVENT_OBSERVER_CLEANUP_DELAY_IN_SEC =
         "pinot.minion.event.observer.cleanupDelayInSec";
+    public static final char TASK_LIST_SEPARATOR = ',';
   }
 
   public static class ControllerJob {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -583,6 +583,8 @@ public class CommonConstants {
     public static final String MINION_TLS_PREFIX = "pinot.minion.tls";
     public static final String CONFIG_OF_MINION_QUERY_REWRITER_CLASS_NAMES = "pinot.minion.query.rewriter.class.names";
     public static final String CONFIG_OF_LOGGER_ROOT_DIR = "pinot.minion.logger.root.dir";
+    public static final String CONFIG_OF_EVENT_OBSERVER_CLEANUP_DELAY_IN_SEC =
+        "pinot.minion.event.observer.cleanupDelayInSec";
   }
 
   public static class ControllerJob {


### PR DESCRIPTION
This PR reuses MinionEventObserver interface to track and report fine-grained task progress status. 

Today, helix task status like RUNNING is used to indicate task progress status, but that's very coarse grained. e.g. for some long running data ingestion task, one can see 'RUNNING' status lasts for many minutes, which provides little info for the users about what's really going on in the tasks.

With the new MinionEventObserver.notifyProgress() method, the task implementor can use it to report finer grained progress status, like downloading files (n out of N), generating, compressing, and uploading segments (n out of N) etc. 

The `full` stack trace upon task failure is also tracked and kept around for a configured period to help debug the task failure.   

## Release note
1. pinot.minion.event.observer.cleanupDelayInSec to tune when to clean up the observer object after the subtask ends. 
