### PR TITLE
add table config and schema API in TableDataManager

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -187,4 +187,19 @@ public interface TableDataManager {
    * @return List of {@link SegmentErrorInfo}
    */
   Map<String, SegmentErrorInfo> getSegmentErrors();
+
+  /**
+   * Return the cached table config. It is updated when the segment list changes.
+   *
+   * @return {@link TableConfig}.
+   */
+  TableConfig getTableConfig();
+
+
+  /**
+   * Return the cached table schema. It is updated when the segment list changes.
+   *
+   * @return {@link Schema}.
+   */
+  Schema getSchema();
 }


### PR DESCRIPTION
We already pull table metadata during TableDataManager segment update. 

we should cache the TableConfig and Schema for other validations (useful for multistage engine in the future)