### PR TITLE
Fix the bug of hybrid table request using the same request id

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/grpc/GrpcRequestBuilder.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/grpc/GrpcRequestBuilder.java
@@ -33,7 +33,7 @@ import org.apache.thrift.protocol.TCompactProtocol;
 
 
 public class GrpcRequestBuilder {
-  private int _requestId;
+  private long _requestId;
   private String _brokerId = "unknown";
   private boolean _enableTrace;
   private boolean _enableStreaming;
@@ -42,7 +42,7 @@ public class GrpcRequestBuilder {
   private BrokerRequest _brokerRequest;
   private List<String> _segments;
 
-  public GrpcRequestBuilder setRequestId(int requestId) {
+  public GrpcRequestBuilder setRequestId(long requestId) {
     _requestId = requestId;
     return this;
   }
@@ -84,7 +84,7 @@ public class GrpcRequestBuilder {
         "Query and segmentsToQuery must be set");
 
     Map<String, String> metadata = new HashMap<>();
-    metadata.put(Request.MetadataKeys.REQUEST_ID, Integer.toString(_requestId));
+    metadata.put(Request.MetadataKeys.REQUEST_ID, Long.toString(_requestId));
     metadata.put(Request.MetadataKeys.BROKER_ID, _brokerId);
     metadata.put(Request.MetadataKeys.ENABLE_TRACE, Boolean.toString(_enableTrace));
     metadata.put(Request.MetadataKeys.ENABLE_STREAMING, Boolean.toString(_enableStreaming));

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseReduceService.java
@@ -161,7 +161,7 @@ public abstract class BaseReduceService {
       Map<String, String> metadata = dataTable.getMetadata();
       // Reduce on trace info.
       if (_enableTrace) {
-        _traceInfo.put(routingInstance.getHostname(), metadata.get(MetadataKey.TRACE_INFO.getName()));
+        _traceInfo.put(routingInstance.getShortName(), metadata.get(MetadataKey.TRACE_INFO.getName()));
       }
 
       // Reduce on exceptions.

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
@@ -62,7 +62,6 @@ public abstract class QueryScheduler {
   private static final String INVALID_NUM_RESIZES = "-1";
   private static final String INVALID_RESIZE_TIME_MS = "-1";
   private static final String QUERY_LOG_MAX_RATE_KEY = "query.log.maxRatePerSecond";
-  private static final String ENABLE_QUERY_CANCELLATION_KEY = "enable.query.cancellation";
   private static final double DEFAULT_QUERY_LOG_MAX_RATE = 10_000d;
   protected final ServerMetrics _serverMetrics;
   protected final QueryExecutor _queryExecutor;

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/InstanceRequestHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/InstanceRequestHandler.java
@@ -152,9 +152,9 @@ public class InstanceRequestHandler extends SimpleChannelInboundHandler<ByteBuf>
 
       // Send error response
       String hexString = requestBytes != null ? BytesUtils.toHexString(requestBytes) : "";
-      long reqestId = instanceRequest != null ? instanceRequest.getRequestId() : 0;
+      long requestId = instanceRequest != null ? instanceRequest.getRequestId() : 0;
       LOGGER.error("Exception while processing instance request: {}", hexString, e);
-      sendErrorResponse(ctx, reqestId, tableNameWithType, queryArrivalTimeMs, DataTableFactory.getEmptyDataTable(), e);
+      sendErrorResponse(ctx, requestId, tableNameWithType, queryArrivalTimeMs, DataTableFactory.getEmptyDataTable(), e);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
@@ -102,10 +102,14 @@ public class QueryRouter {
     }
     if (realtimeBrokerRequest != null) {
       assert realtimeRoutingTable != null;
+      // NOTE: When both OFFLINE and REALTIME request exist, use negative request id for REALTIME to differentiate
+      //       from the OFFLINE one
+      long realtimeRequestId = offlineBrokerRequest == null ? requestId : -requestId;
       for (Map.Entry<ServerInstance, List<String>> entry : realtimeRoutingTable.entrySet()) {
         ServerRoutingInstance serverRoutingInstance =
             entry.getKey().toServerRoutingInstance(TableType.REALTIME, preferTls);
-        InstanceRequest instanceRequest = getInstanceRequest(requestId, realtimeBrokerRequest, entry.getValue());
+        InstanceRequest instanceRequest =
+            getInstanceRequest(realtimeRequestId, realtimeBrokerRequest, entry.getValue());
         requestMap.put(serverRoutingInstance, instanceRequest);
       }
     }
@@ -167,7 +171,8 @@ public class QueryRouter {
 
   void receiveDataTable(ServerRoutingInstance serverRoutingInstance, DataTable dataTable, int responseSize,
       int deserializationTimeMs) {
-    long requestId = Long.parseLong(dataTable.getMetadata().get(MetadataKey.REQUEST_ID.getName()));
+    // NOTE: For hybrid table, REALTIME request has negative request id
+    long requestId = Math.abs(Long.parseLong(dataTable.getMetadata().get(MetadataKey.REQUEST_ID.getName())));
     AsyncQueryResponse asyncQueryResponse = _asyncQueryResponseMap.get(requestId);
 
     // Query future might be null if the query is already done (maybe due to failure)

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -210,6 +210,18 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
   }
 
   @Test
+  public void testQueryTracing()
+      throws Exception {
+    JsonNode jsonNode = postQuery("SET trace = true; SELECT COUNT(*) FROM " + getTableName());
+    Assert.assertEquals(jsonNode.get("resultTable").get("rows").get(0).get(0).asLong(), getCountStarResult());
+    Assert.assertTrue(jsonNode.get("exceptions").isEmpty());
+    JsonNode traceInfo = jsonNode.get("traceInfo");
+    Assert.assertEquals(traceInfo.size(), 2);
+    Assert.assertTrue(traceInfo.has("localhost_O"));
+    Assert.assertTrue(traceInfo.has("localhost_R"));
+  }
+
+  @Test
   @Override
   public void testHardcodedQueries()
       throws Exception {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracer.java
@@ -25,34 +25,36 @@ package org.apache.pinot.spi.trace;
  */
 public interface Tracer {
 
-    /**
-     * Registers the requestId on the current thread. This means the request will be traced.
-     * @param requestId the requestId
-     */
-    void register(long requestId);
+  /**
+   * Registers the requestId on the current thread. This means the request will be traced.
+   * TODO: Consider using string id or random id. Currently different broker might send query with the same request id.
+   *
+   * @param requestId the requestId
+   */
+  void register(long requestId);
 
-    /**
-     * Detach a trace from the current thread.
-     */
-    void unregister();
+  /**
+   * Detach a trace from the current thread.
+   */
+  void unregister();
 
-    /**
-     *
-     * @param clazz the enclosing context, e.g. Operator, PlanNode, BlockValSet...
-     * @return a new scope which MUST be closed on the current thread.
-     */
-    InvocationScope createScope(Class<?> clazz);
+  /**
+   *
+   * @param clazz the enclosing context, e.g. Operator, PlanNode, BlockValSet...
+   * @return a new scope which MUST be closed on the current thread.
+   */
+  InvocationScope createScope(Class<?> clazz);
 
-    /**
-     * Starts
-     * @return the request record
-     */
-    default RequestScope createRequestScope() {
-        return new DefaultRequestContext();
-    }
+  /**
+   * Starts
+   * @return the request record
+   */
+  default RequestScope createRequestScope() {
+    return new DefaultRequestContext();
+  }
 
-    /**
-     * @return the active recording
-     */
-    InvocationRecording activeRecording();
+  /**
+   * @return the active recording
+   */
+  InvocationRecording activeRecording();
 }


### PR DESCRIPTION
Currently when querying a hybrid table, 2 requests (one for OFFLINE and one for REALTIME) are sent to the servers, but with the same request id. It can cause problem for 2 modules:
- Tracing
- Query cancellation

This PR fixes the bug by using negative request id for REALTIME request in hybrid table.