### PR TITLE
Always pass clientId to kafka's consumer properties

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConnectionHandler.java
@@ -60,6 +60,7 @@ public abstract class KafkaPartitionLevelConnectionHandler {
     if (_config.getKafkaIsolationLevel() != null) {
       consumerProp.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, _config.getKafkaIsolationLevel());
     }
+    consumerProp.put(ConsumerConfig.CLIENT_ID_CONFIG, _clientId);
     _consumer = new KafkaConsumer<>(consumerProp);
     _topicPartition = new TopicPartition(_topic, _partition);
     _consumer.assign(Collections.singletonList(_topicPartition));

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamLevelConsumer.java
@@ -43,14 +43,11 @@ import org.slf4j.LoggerFactory;
  */
 public class KafkaStreamLevelConsumer implements StreamLevelConsumer {
 
-  private StreamMessageDecoder _messageDecoder;
-  private Logger _instanceLogger;
+  private final StreamMessageDecoder _messageDecoder;
+  private final Logger _instanceLogger;
 
-  private String _clientId;
-  private String _tableAndStreamName;
-
-  private StreamConfig _streamConfig;
-  private KafkaStreamLevelStreamConfig _kafkaStreamLevelStreamConfig;
+  private final StreamConfig _streamConfig;
+  private final KafkaStreamLevelStreamConfig _kafkaStreamLevelStreamConfig;
 
   private KafkaConsumer<Bytes, Bytes> _consumer;
   private ConsumerRecords<Bytes, Bytes> _consumerRecords;
@@ -63,13 +60,10 @@ public class KafkaStreamLevelConsumer implements StreamLevelConsumer {
 
   public KafkaStreamLevelConsumer(String clientId, String tableName, StreamConfig streamConfig,
       Set<String> sourceFields, String groupId) {
-    _clientId = clientId;
     _streamConfig = streamConfig;
     _kafkaStreamLevelStreamConfig = new KafkaStreamLevelStreamConfig(streamConfig, tableName, groupId);
 
     _messageDecoder = StreamDecoderProvider.create(streamConfig, sourceFields);
-
-    _tableAndStreamName = tableName + "-" + streamConfig.getTopicName();
     _instanceLogger = LoggerFactory
         .getLogger(KafkaStreamLevelConsumer.class.getName() + "_" + tableName + "_" + streamConfig.getTopicName());
     _instanceLogger.info("KafkaStreamLevelConsumer: streamConfig : {}", _streamConfig);


### PR DESCRIPTION
kafka consumer plugin doesn't pass the provided `clientId` into the underlying consumer properties. This leads to kafka mbeans that look like `consumer-null-87` . 
Instead, the provided `clientId` should always be set as a kafka consumer property. 