### PR TITLE
Fix the range check for range index on raw column

### DIFF
--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/BitSlicedIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/BitSlicedIndexCreatorTest.java
@@ -42,7 +42,6 @@ import org.testng.annotations.Test;
 import static org.apache.pinot.segment.spi.V1Constants.Indexes.BITMAP_RANGE_INDEX_FILE_EXTENSION;
 import static org.apache.pinot.spi.data.FieldSpec.DataType.*;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 
 public class BitSlicedIndexCreatorTest {
@@ -160,21 +159,36 @@ public class BitSlicedIndexCreatorTest {
     File rangeIndexFile = new File(INDEX_DIR, metadata.getColumnName() + BITMAP_RANGE_INDEX_FILE_EXTENSION);
     try (PinotDataBuffer dataBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(rangeIndexFile)) {
       BitSlicedRangeIndexReader reader = new BitSlicedRangeIndexReader(dataBuffer, metadata);
-      int prev = Integer.MIN_VALUE;
-      for (int quantile : dataset.quantiles()) {
-        ImmutableRoaringBitmap reference = dataset.scan(prev, quantile);
-        ImmutableRoaringBitmap result = reader.getMatchingDocIds(prev, quantile);
-        int resultCount = reader.getNumMatchingDocs(prev, quantile);
-        assertEquals(result, reference);
-        assertEquals(resultCount, result == null ? 0 : result.getCardinality());
+      testRange(reader, dataset, Integer.MIN_VALUE, Integer.MIN_VALUE);
+      int[] quantiles = dataset.quantiles();
+      int prev = quantiles[0] - 1;
+      testRange(reader, dataset, Integer.MIN_VALUE, prev);
+      testRange(reader, dataset, prev, prev);
+      for (int quantile : quantiles) {
+        testRange(reader, dataset, prev, quantile);
+        testRange(reader, dataset, quantile, quantile);
         prev = quantile;
       }
-      ImmutableRoaringBitmap result = reader.getMatchingDocIds(prev + 1, Integer.MAX_VALUE);
-      assertTrue(result != null && result.isEmpty());
-      assertEquals(reader.getMatchingDocIds(Integer.MIN_VALUE, Integer.MAX_VALUE),
-          dataset.scan(Integer.MIN_VALUE, Integer.MAX_VALUE));
+      testRange(reader, dataset, prev, prev + 1);
+      testRange(reader, dataset, prev + 1, prev + 1);
+      testRange(reader, dataset, prev + 1, Integer.MAX_VALUE);
+      testRange(reader, dataset, Integer.MAX_VALUE, Integer.MAX_VALUE);
+      testRange(reader, dataset, Integer.MIN_VALUE, Integer.MAX_VALUE);
     } finally {
       FileUtils.forceDelete(rangeIndexFile);
+    }
+  }
+
+  private static void testRange(BitSlicedRangeIndexReader reader, Dataset<int[]> dataset, int min, int max) {
+    ImmutableRoaringBitmap reference = dataset.scan(min, max);
+    assertEquals(reader.getMatchingDocIds(min, max), reference);
+    assertEquals(reader.getNumMatchingDocs(min, max), reference.getCardinality());
+
+    // Also test reversed min/max value
+    if (min != max) {
+      reference = dataset.scan(max, min);
+      assertEquals(reader.getMatchingDocIds(max, min), reference);
+      assertEquals(reader.getNumMatchingDocs(max, min), reference.getCardinality());
     }
   }
 
@@ -190,21 +204,36 @@ public class BitSlicedIndexCreatorTest {
     File rangeIndexFile = new File(INDEX_DIR, metadata.getColumnName() + BITMAP_RANGE_INDEX_FILE_EXTENSION);
     try (PinotDataBuffer dataBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(rangeIndexFile)) {
       BitSlicedRangeIndexReader reader = new BitSlicedRangeIndexReader(dataBuffer, metadata);
-      long prev = Long.MIN_VALUE;
-      for (long quantile : dataset.quantiles()) {
-        ImmutableRoaringBitmap reference = dataset.scan(prev, quantile);
-        ImmutableRoaringBitmap result = reader.getMatchingDocIds(prev, quantile);
-        int resultCount = reader.getNumMatchingDocs(prev, quantile);
-        assertEquals(result, reference);
-        assertEquals(resultCount, result == null ? 0 : result.getCardinality());
+      testRange(reader, dataset, Long.MIN_VALUE, Long.MIN_VALUE);
+      long[] quantiles = dataset.quantiles();
+      long prev = quantiles[0] - 1;
+      testRange(reader, dataset, Long.MIN_VALUE, prev);
+      testRange(reader, dataset, prev, prev);
+      for (long quantile : quantiles) {
+        testRange(reader, dataset, prev, quantile);
+        testRange(reader, dataset, quantile, quantile);
         prev = quantile;
       }
-      ImmutableRoaringBitmap result = reader.getMatchingDocIds(prev + 1, Long.MAX_VALUE);
-      assertTrue(result != null && result.isEmpty());
-      assertEquals(reader.getMatchingDocIds(Long.MIN_VALUE, Long.MAX_VALUE),
-          dataset.scan(Long.MIN_VALUE, Long.MAX_VALUE));
+      testRange(reader, dataset, prev, prev + 1);
+      testRange(reader, dataset, prev + 1, prev + 1);
+      testRange(reader, dataset, prev + 1, Long.MAX_VALUE);
+      testRange(reader, dataset, Long.MAX_VALUE, Long.MAX_VALUE);
+      testRange(reader, dataset, Long.MIN_VALUE, Long.MAX_VALUE);
     } finally {
       FileUtils.forceDelete(rangeIndexFile);
+    }
+  }
+
+  private static void testRange(BitSlicedRangeIndexReader reader, Dataset<long[]> dataset, long min, long max) {
+    ImmutableRoaringBitmap reference = dataset.scan(min, max);
+    assertEquals(reader.getMatchingDocIds(min, max), reference);
+    assertEquals(reader.getNumMatchingDocs(min, max), reference.getCardinality());
+
+    // Also test reversed min/max value
+    if (min != max) {
+      reference = dataset.scan(max, min);
+      assertEquals(reader.getMatchingDocIds(max, min), reference);
+      assertEquals(reader.getNumMatchingDocs(max, min), reference.getCardinality());
     }
   }
 
@@ -220,21 +249,36 @@ public class BitSlicedIndexCreatorTest {
     File rangeIndexFile = new File(INDEX_DIR, metadata.getColumnName() + BITMAP_RANGE_INDEX_FILE_EXTENSION);
     try (PinotDataBuffer dataBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(rangeIndexFile)) {
       BitSlicedRangeIndexReader reader = new BitSlicedRangeIndexReader(dataBuffer, metadata);
-      float prev = Float.NEGATIVE_INFINITY;
-      for (float quantile : dataset.quantiles()) {
-        ImmutableRoaringBitmap reference = dataset.scan(prev, quantile);
-        ImmutableRoaringBitmap result = reader.getMatchingDocIds(prev, quantile);
-        int resultCount = reader.getNumMatchingDocs(prev, quantile);
-        assertEquals(result, reference);
-        assertEquals(resultCount, result == null ? 0 : result.getCardinality());
+      testRange(reader, dataset, Float.NEGATIVE_INFINITY, Float.NEGATIVE_INFINITY);
+      float[] quantiles = dataset.quantiles();
+      float prev = quantiles[0] - 1;
+      testRange(reader, dataset, Float.NEGATIVE_INFINITY, prev);
+      testRange(reader, dataset, prev, prev);
+      for (float quantile : quantiles) {
+        testRange(reader, dataset, prev, quantile);
+        testRange(reader, dataset, quantile, quantile);
         prev = quantile;
       }
-      ImmutableRoaringBitmap result = reader.getMatchingDocIds(prev + 1, Float.POSITIVE_INFINITY);
-      assertTrue(result != null && result.isEmpty());
-      assertEquals(reader.getMatchingDocIds(Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY),
-          dataset.scan(Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY));
+      testRange(reader, dataset, prev, prev + 1);
+      testRange(reader, dataset, prev + 1, prev + 1);
+      testRange(reader, dataset, prev + 1, Float.POSITIVE_INFINITY);
+      testRange(reader, dataset, Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY);
+      testRange(reader, dataset, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY);
     } finally {
       FileUtils.forceDelete(rangeIndexFile);
+    }
+  }
+
+  private static void testRange(BitSlicedRangeIndexReader reader, Dataset<float[]> dataset, float min, float max) {
+    ImmutableRoaringBitmap reference = dataset.scan(min, max);
+    assertEquals(reader.getMatchingDocIds(min, max), reference);
+    assertEquals(reader.getNumMatchingDocs(min, max), reference.getCardinality());
+
+    // Also test reversed min/max value
+    if (min != max) {
+      reference = dataset.scan(max, min);
+      assertEquals(reader.getMatchingDocIds(max, min), reference);
+      assertEquals(reader.getNumMatchingDocs(max, min), reference.getCardinality());
     }
   }
 
@@ -250,21 +294,36 @@ public class BitSlicedIndexCreatorTest {
     File rangeIndexFile = new File(INDEX_DIR, metadata.getColumnName() + BITMAP_RANGE_INDEX_FILE_EXTENSION);
     try (PinotDataBuffer dataBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(rangeIndexFile)) {
       BitSlicedRangeIndexReader reader = new BitSlicedRangeIndexReader(dataBuffer, metadata);
-      double prev = Double.NEGATIVE_INFINITY;
-      for (double quantile : dataset.quantiles()) {
-        ImmutableRoaringBitmap reference = dataset.scan(prev, quantile);
-        ImmutableRoaringBitmap result = reader.getMatchingDocIds(prev, quantile);
-        int resultCount = reader.getNumMatchingDocs(prev, quantile);
-        assertEquals(result, reference);
-        assertEquals(resultCount, result == null ? 0 : result.getCardinality());
+      testRange(reader, dataset, Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY);
+      double[] quantiles = dataset.quantiles();
+      double prev = quantiles[0] - 1;
+      testRange(reader, dataset, Double.NEGATIVE_INFINITY, prev);
+      testRange(reader, dataset, prev, prev);
+      for (double quantile : quantiles) {
+        testRange(reader, dataset, prev, quantile);
+        testRange(reader, dataset, quantile, quantile);
         prev = quantile;
       }
-      ImmutableRoaringBitmap result = reader.getMatchingDocIds(prev + 1, Double.POSITIVE_INFINITY);
-      assertTrue(result != null && result.isEmpty());
-      assertEquals(reader.getMatchingDocIds(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY),
-          dataset.scan(Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY));
+      testRange(reader, dataset, prev, prev + 1);
+      testRange(reader, dataset, prev + 1, prev + 1);
+      testRange(reader, dataset, prev + 1, Double.POSITIVE_INFINITY);
+      testRange(reader, dataset, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
+      testRange(reader, dataset, Double.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY);
     } finally {
       FileUtils.forceDelete(rangeIndexFile);
+    }
+  }
+
+  private static void testRange(BitSlicedRangeIndexReader reader, Dataset<double[]> dataset, double min, double max) {
+    ImmutableRoaringBitmap reference = dataset.scan(min, max);
+    assertEquals(reader.getMatchingDocIds(min, max), reference);
+    assertEquals(reader.getNumMatchingDocs(min, max), reference.getCardinality());
+
+    // Also test reversed min/max value
+    if (min != max) {
+      reference = dataset.scan(max, min);
+      assertEquals(reader.getMatchingDocIds(max, min), reference);
+      assertEquals(reader.getNumMatchingDocs(max, min), reference.getCardinality());
     }
   }
 


### PR DESCRIPTION
When range index is applied to a raw (no-dictionary) column, we need to check `max >= _min` before reading the range bitmap. Failing to do so will result in matching all docs instead of no docs as expected (note that negative `max - _min` will be treated as a huge unsigned long).

This PR fixes the range check, and also handles the case of `_max` value not available from the metadata

During this bug fix, found a bug in RangeIndex and tracked under the issue: https://github.com/RoaringBitmap/RoaringBitmap/issues/586