### PR TITLE
Fix Data-Correctness Bug in GTE Comparison in BinaryOperatorTransformFunction

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
@@ -526,17 +526,17 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
 
   private int compare(long left, double right) {
     if (Math.abs(left) <= 1L << 53) {
-      return getIntResult(Double.compare(left, right));
+      return Double.compare(left, right);
     } else {
-      return getIntResult(BigDecimal.valueOf(left).compareTo(BigDecimal.valueOf(right)));
+      return BigDecimal.valueOf(left).compareTo(BigDecimal.valueOf(right));
     }
   }
 
   private int compare(double left, long right) {
     if (Math.abs(right) <= 1L << 53) {
-      return getIntResult(Double.compare(left, right));
+      return Double.compare(left, right);
     } else {
-      return getIntResult(BigDecimal.valueOf(left).compareTo(BigDecimal.valueOf(right)));
+      return BigDecimal.valueOf(left).compareTo(BigDecimal.valueOf(right));
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
@@ -400,7 +400,7 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
   private void fillLongResultArray(ProjectionBlock projectionBlock, float[] leftValues, int length) {
     long[] rightValues = _rightTransformFunction.transformToLongValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = compare(leftValues[i], rightValues[i]);
+      _results[i] = getIntResult(compare(leftValues[i], rightValues[i]));
     }
   }
 
@@ -446,7 +446,7 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
   private void fillLongResultArray(ProjectionBlock projectionBlock, double[] leftValues, int length) {
     long[] rightValues = _rightTransformFunction.transformToLongValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = compare(leftValues[i], rightValues[i]);
+      _results[i] = getIntResult(compare(leftValues[i], rightValues[i]));
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunctionTest.java
@@ -100,6 +100,15 @@ public abstract class BinaryOperatorTransformFunctionTest extends BaseTransformF
       expectedValues[i] = getExpectedValue(_stringSVValues[i].compareTo(_stringSVValues[0]));
     }
     testTransformFunction(transformFunction, expectedValues);
+
+    // Test with heterogeneous arguments (long on left-side, double on right-side)
+    expression = RequestContextUtils.getExpression(
+        String.format("%s(%s, '%s')", functionName, LONG_SV_COLUMN, _doubleSVValues[0]));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = getExpectedValue(Double.compare(_longSVValues[i], _doubleSVValues[0]));
+    }
+    testTransformFunction(transformFunction, expectedValues);
   }
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunctionTest.java
@@ -109,6 +109,15 @@ public abstract class BinaryOperatorTransformFunctionTest extends BaseTransformF
       expectedValues[i] = getExpectedValue(Double.compare(_longSVValues[i], _doubleSVValues[0]));
     }
     testTransformFunction(transformFunction, expectedValues);
+
+    // Test with heterogeneous arguments (double on left-side, long on right-side)
+    expression = RequestContextUtils.getExpression(
+        String.format("%s(%s, '%s')", functionName, DOUBLE_SV_COLUMN, _longSVValues[0]));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = getExpectedValue(Double.compare(_doubleSVValues[i], _longSVValues[0]));
+    }
+    testTransformFunction(transformFunction, expectedValues);
   }
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})


### PR DESCRIPTION
fixes #9460 

The [BinaryOperatorTransformFunction::compare](https://github.com/apache/pinot/blob/master/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java#L527) methods already call `getIntResult`, but the places where it's called calls `getIntResult` again. 

https://github.com/apache/pinot/blob/master/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java#L371

Say the comparison is: 10 >= 20

Then, the call chain is (bottom-up): Double.compare(10, 20) ==> -1 ==> getIntResult(-1) ==> 0 ==> getIntResult(0) ==> 1

Which means 10 >= 20 gets evaluated to true

cc: @yupeng9 @chenboat 