### PR TITLE
Decouple ser/de from DataTable

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataTable.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.utils;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -67,8 +68,6 @@ public interface DataTable {
 
   ByteArray getBytes(int rowId, int colId);
 
-  <T> T getObject(int rowId, int colId);
-
   int[] getIntArray(int rowId, int colId);
 
   long[] getLongArray(int rowId, int colId);
@@ -80,11 +79,32 @@ public interface DataTable {
   String[] getStringArray(int rowId, int colId);
 
   @Nullable
+  CustomObject getCustomObject(int rowId, int colId);
+
+  @Nullable
   RoaringBitmap getNullRowIds(int colId);
 
   DataTable toMetadataOnlyDataTable();
 
   DataTable toDataOnlyDataTable();
+
+  class CustomObject {
+    private final int _type;
+    private final ByteBuffer _buffer;
+
+    public CustomObject(int type, ByteBuffer buffer) {
+      _type = type;
+      _buffer = buffer;
+    }
+
+    public int getType() {
+      return _type;
+    }
+
+    public ByteBuffer getBuffer() {
+      return _buffer;
+    }
+  }
 
   enum MetadataValueType {
     INT, LONG, STRING

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.common;
 
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Longs;
 import com.tdunning.math.stats.MergingDigest;
@@ -54,9 +55,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.theta.Sketch;
+import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.core.query.distinct.DistinctTable;
 import org.apache.pinot.core.query.utils.idset.IdSet;
 import org.apache.pinot.core.query.utils.idset.IdSets;
@@ -85,6 +86,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class ObjectSerDeUtils {
   private ObjectSerDeUtils() {
   }
+
+  public static final int NULL_TYPE_VALUE = 100;
 
   public enum ObjectType {
     // NOTE: DO NOT change the value, we rely on the value to indicate the object type
@@ -120,8 +123,8 @@ public class ObjectSerDeUtils {
     FloatLongPair(29),
     DoubleLongPair(30),
     StringLongPair(31),
-    CovarianceTuple(32),
-    Null(100);
+    CovarianceTuple(32);
+
     private final int _value;
 
     ObjectType(int value) {
@@ -132,11 +135,7 @@ public class ObjectSerDeUtils {
       return _value;
     }
 
-    public static ObjectType getObjectType(@Nullable Object value) {
-      if (value == null) {
-        return ObjectType.Null;
-      }
-
+    public static ObjectType getObjectType(Object value) {
       if (value instanceof String) {
         return ObjectType.String;
       } else if (value instanceof Long) {
@@ -358,8 +357,7 @@ public class ObjectSerDeUtils {
     }
   };
 
-  public static final ObjectSerDe<IntLongPair> INT_LONG_PAIR_SER_DE
-      = new ObjectSerDe<IntLongPair>() {
+  public static final ObjectSerDe<IntLongPair> INT_LONG_PAIR_SER_DE = new ObjectSerDe<IntLongPair>() {
 
     @Override
     public byte[] serialize(IntLongPair intLongPair) {
@@ -377,8 +375,7 @@ public class ObjectSerDeUtils {
     }
   };
 
-  public static final ObjectSerDe<LongLongPair> LONG_LONG_PAIR_SER_DE
-      = new ObjectSerDe<LongLongPair>() {
+  public static final ObjectSerDe<LongLongPair> LONG_LONG_PAIR_SER_DE = new ObjectSerDe<LongLongPair>() {
 
     @Override
     public byte[] serialize(LongLongPair longLongPair) {
@@ -396,8 +393,7 @@ public class ObjectSerDeUtils {
     }
   };
 
-  public static final ObjectSerDe<FloatLongPair> FLOAT_LONG_PAIR_SER_DE
-      = new ObjectSerDe<FloatLongPair>() {
+  public static final ObjectSerDe<FloatLongPair> FLOAT_LONG_PAIR_SER_DE = new ObjectSerDe<FloatLongPair>() {
 
     @Override
     public byte[] serialize(FloatLongPair floatLongPair) {
@@ -414,8 +410,7 @@ public class ObjectSerDeUtils {
       return FloatLongPair.fromByteBuffer(byteBuffer);
     }
   };
-  public static final ObjectSerDe<DoubleLongPair> DOUBLE_LONG_PAIR_SER_DE
-      = new ObjectSerDe<DoubleLongPair>() {
+  public static final ObjectSerDe<DoubleLongPair> DOUBLE_LONG_PAIR_SER_DE = new ObjectSerDe<DoubleLongPair>() {
 
     @Override
     public byte[] serialize(DoubleLongPair doubleLongPair) {
@@ -432,8 +427,7 @@ public class ObjectSerDeUtils {
       return DoubleLongPair.fromByteBuffer(byteBuffer);
     }
   };
-  public static final ObjectSerDe<StringLongPair> STRING_LONG_PAIR_SER_DE
-      = new ObjectSerDe<StringLongPair>() {
+  public static final ObjectSerDe<StringLongPair> STRING_LONG_PAIR_SER_DE = new ObjectSerDe<StringLongPair>() {
 
     @Override
     public byte[] serialize(StringLongPair stringLongPair) {
@@ -608,11 +602,11 @@ public class ObjectSerDeUtils {
       }
 
       // De-serialize each key-value pair
-      int keyTypeValue = byteBuffer.getInt();
-      int valueTypeValue = byteBuffer.getInt();
+      ObjectSerDe keySerDe = SER_DES[byteBuffer.getInt()];
+      ObjectSerDe valueSerDe = SER_DES[byteBuffer.getInt()];
       for (int i = 0; i < size; i++) {
-        Object key = ObjectSerDeUtils.deserialize(sliceByteBuffer(byteBuffer, byteBuffer.getInt()), keyTypeValue);
-        Object value = ObjectSerDeUtils.deserialize(sliceByteBuffer(byteBuffer, byteBuffer.getInt()), valueTypeValue);
+        Object key = keySerDe.deserialize(sliceByteBuffer(byteBuffer, byteBuffer.getInt()));
+        Object value = valueSerDe.deserialize(sliceByteBuffer(byteBuffer, byteBuffer.getInt()));
         map.put(key, value);
       }
       return map;
@@ -1000,12 +994,12 @@ public class ObjectSerDeUtils {
 
       // De-serialize the values
       if (size != 0) {
-        int valueType = byteBuffer.getInt();
+        ObjectSerDe serDe = SER_DES[byteBuffer.getInt()];
         for (int i = 0; i < size; i++) {
           int numBytes = byteBuffer.getInt();
           ByteBuffer slice = byteBuffer.slice();
           slice.limit(numBytes);
-          list.add(ObjectSerDeUtils.deserialize(slice, valueType));
+          list.add(serDe.deserialize(slice));
           byteBuffer.position(byteBuffer.position() + numBytes);
         }
       }
@@ -1197,31 +1191,21 @@ public class ObjectSerDeUtils {
   };
   //@formatter:on
 
-  public static byte[] serialize(Object value) {
-    return serialize(value, ObjectType.getObjectType(value)._value);
-  }
-
-  public static byte[] serialize(Object value, ObjectType objectType) {
-    return serialize(value, objectType._value);
-  }
-
   public static byte[] serialize(Object value, int objectTypeValue) {
     return SER_DES[objectTypeValue].serialize(value);
   }
 
+  public static <T> T deserialize(DataTable.CustomObject customObject) {
+    return (T) SER_DES[customObject.getType()].deserialize(customObject.getBuffer());
+  }
+
+  @VisibleForTesting
+  public static byte[] serialize(Object value) {
+    return serialize(value, ObjectType.getObjectType(value)._value);
+  }
+
+  @VisibleForTesting
   public static <T> T deserialize(byte[] bytes, ObjectType objectType) {
-    return deserialize(bytes, objectType._value);
-  }
-
-  public static <T> T deserialize(byte[] bytes, int objectTypeValue) {
-    return (T) SER_DES[objectTypeValue].deserialize(bytes);
-  }
-
-  public static <T> T deserialize(ByteBuffer byteBuffer, ObjectType objectType) {
-    return deserialize(byteBuffer, objectType._value);
-  }
-
-  public static <T> T deserialize(ByteBuffer byteBuffer, int objectTypeValue) {
-    return (T) SER_DES[objectTypeValue].deserialize(byteBuffer);
+    return (T) SER_DES[objectType._value].deserialize(bytes);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
@@ -443,14 +443,15 @@ public class DataBlockBuilder {
     builder._variableSizeDataByteArrayOutputStream.write(bytes);
   }
 
-  private static void setColumn(DataBlockBuilder builder, ByteBuffer byteBuffer, Object value)
+  // TODO: Move ser/de into AggregationFunction interface
+  private static void setColumn(DataBlockBuilder builder, ByteBuffer byteBuffer, @Nullable Object value)
       throws IOException {
     byteBuffer.putInt(builder._variableSizeDataByteArrayOutputStream.size());
-    int objectTypeValue = ObjectSerDeUtils.ObjectType.getObjectType(value).getValue();
-    if (objectTypeValue == ObjectSerDeUtils.ObjectType.Null.getValue()) {
+    if (value == null) {
       byteBuffer.putInt(0);
-      builder._variableSizeDataOutputStream.writeInt(objectTypeValue);
+      builder._variableSizeDataOutputStream.writeInt(ObjectSerDeUtils.NULL_TYPE_VALUE);
     } else {
+      int objectTypeValue = ObjectSerDeUtils.ObjectType.getObjectType(value).getValue();
       byte[] bytes = ObjectSerDeUtils.serialize(value, objectTypeValue);
       byteBuffer.putInt(bytes.length);
       builder._variableSizeDataOutputStream.writeInt(objectTypeValue);

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/BaseDataTableBuilder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/BaseDataTableBuilder.java
@@ -23,6 +23,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
@@ -94,15 +95,15 @@ public abstract class BaseDataTableBuilder implements DataTableBuilder {
   }
 
   @Override
-  public void setColumn(int colId, Object value)
+  public void setColumn(int colId, @Nullable Object value)
       throws IOException {
     _currentRowDataByteBuffer.position(_columnOffsets[colId]);
     _currentRowDataByteBuffer.putInt(_variableSizeDataByteArrayOutputStream.size());
-    int objectTypeValue = ObjectSerDeUtils.ObjectType.getObjectType(value).getValue();
-    if (objectTypeValue == ObjectSerDeUtils.ObjectType.Null.getValue()) {
+    if (value == null) {
       _currentRowDataByteBuffer.putInt(0);
-      _variableSizeDataOutputStream.writeInt(objectTypeValue);
+      _variableSizeDataOutputStream.writeInt(ObjectSerDeUtils.NULL_TYPE_VALUE);
     } else {
+      int objectTypeValue = ObjectSerDeUtils.ObjectType.getObjectType(value).getValue();
       byte[] bytes = ObjectSerDeUtils.serialize(value, objectTypeValue);
       _currentRowDataByteBuffer.putInt(bytes.length);
       _variableSizeDataOutputStream.writeInt(objectTypeValue);

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableBuilder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableBuilder.java
@@ -62,7 +62,8 @@ public interface DataTableBuilder {
   void setColumn(int colId, ByteArray value)
       throws IOException;
 
-  void setColumn(int colId, Object value)
+  // TODO: Move ser/de into AggregationFunction interface
+  void setColumn(int colId, @Nullable Object value)
       throws IOException;
 
   void setColumn(int colId, int[] values)

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -30,6 +30,7 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.common.utils.DataTable;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.operator.blocks.TransformBlock;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair;
@@ -120,6 +121,8 @@ public class AggregationFunctionUtils {
 
   /**
    * Reads the intermediate result from the {@link DataTable}.
+   *
+   * TODO: Move ser/de into AggregationFunction interface
    */
   public static Object getIntermediateResult(DataTable dataTable, ColumnDataType columnDataType, int rowId, int colId) {
     switch (columnDataType) {
@@ -128,7 +131,8 @@ public class AggregationFunctionUtils {
       case DOUBLE:
         return dataTable.getDouble(rowId, colId);
       case OBJECT:
-        return dataTable.getObject(rowId, colId);
+        DataTable.CustomObject customObject = dataTable.getCustomObject(rowId, colId);
+        return customObject != null ? ObjectSerDeUtils.deserialize(customObject) : null;
       default:
         throw new IllegalStateException("Illegal column data type in intermediate result: " + columnDataType);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
@@ -30,6 +30,7 @@ import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.common.utils.DataTable;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.query.aggregation.function.DistinctAggregationFunction;
 import org.apache.pinot.core.query.distinct.DistinctTable;
@@ -66,7 +67,9 @@ public class DistinctDataTableReducer implements DataTableReducer {
     // Gather all non-empty DistinctTables
     List<DistinctTable> nonEmptyDistinctTables = new ArrayList<>(dataTableMap.size());
     for (DataTable dataTable : dataTableMap.values()) {
-      DistinctTable distinctTable = dataTable.getObject(0, 0);
+      DataTable.CustomObject customObject = dataTable.getCustomObject(0, 0);
+      assert customObject != null;
+      DistinctTable distinctTable = ObjectSerDeUtils.deserialize(customObject);
       if (!distinctTable.isEmpty()) {
         nonEmptyDistinctTables.add(distinctTable);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -42,6 +42,7 @@ import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.common.utils.DataTable;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.data.table.ConcurrentIndexedTable;
 import org.apache.pinot.core.data.table.IndexedTable;
 import org.apache.pinot.core.data.table.Record;
@@ -313,7 +314,11 @@ public class GroupByDataTableReducer implements DataTableReducer {
                       values[colId] = dataTable.getBytes(rowId, colId);
                       break;
                     case OBJECT:
-                      values[colId] = dataTable.getObject(rowId, colId);
+                      // TODO: Move ser/de into AggregationFunction interface
+                      DataTable.CustomObject customObject = dataTable.getCustomObject(rowId, colId);
+                      if (customObject != null) {
+                        values[colId] = ObjectSerDeUtils.deserialize(customObject);
+                      }
                       break;
                     // Add other aggregation intermediate result / group-by column type supports here
                     default:

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTestUtils.java
@@ -144,7 +144,7 @@ public class DataBlockTestUtils {
       case BYTES:
         return dataBlock.getBytes(rowId, colId);
       case OBJECT:
-        return dataBlock.getObject(rowId, colId);
+        return dataBlock.getCustomObject(rowId, colId);
       case BOOLEAN_ARRAY:
       case INT_ARRAY:
         return dataBlock.getIntArray(rowId, colId);

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datatable/DataTableUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datatable/DataTableUtilsTest.java
@@ -22,13 +22,14 @@ import java.io.IOException;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.common.utils.DataTable;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.distinct.DistinctTable;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertNotNull;
 
 
 public class DataTableUtilsTest {
@@ -75,9 +76,9 @@ public class DataTableUtilsTest {
     assertEquals(dataSchema.getColumnNames(), new String[]{"distinct_a:b"});
     assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{ColumnDataType.OBJECT});
     assertEquals(dataTable.getNumberOfRows(), 1);
-    Object firstObject = dataTable.getObject(0, 0);
-    assertTrue(firstObject instanceof DistinctTable);
-    DistinctTable distinctTable = (DistinctTable) firstObject;
+    DataTable.CustomObject customObject = dataTable.getCustomObject(0, 0);
+    assertNotNull(customObject);
+    DistinctTable distinctTable = ObjectSerDeUtils.deserialize(customObject);
     assertEquals(distinctTable.size(), 0);
     assertEquals(distinctTable.getDataSchema().getColumnNames(), new String[]{"a", "b"});
     assertEquals(distinctTable.getDataSchema().getColumnDataTypes(),


### PR DESCRIPTION
Currently `DataTable` is coupled with the ser/de logic for custom object types (`ObjectSerDeUtils`), which makes it impossible to plug-in other custom object types (or aggregation function that uses custom object as intermediate result). This PR decouples the ser/de from DataTable as the first step. Next step would be adding ser/de into the `AggregationFunction` interface.