### PR TITLE
[hotfix] upgrade cache action version

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           java-version: 11
       # Step that does that actual cache save and restore
-      - uses: actions/cache@V3
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -165,7 +165,7 @@ jobs:
         with:
           java-version: 1.8
       # Step that does that actual cache save and restore
-      - uses: actions/cache@V3
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -203,7 +203,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       # Step that does that actual cache save and restore
-      - uses: actions/cache@V3
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           java-version: 11
       # Step that does that actual cache save and restore
-      - uses: actions/cache@v1
+      - uses: actions/cache@V3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -122,7 +122,7 @@ jobs:
         with:
           java-version: 11
       # Step that does that actual cache save and restore
-      - uses: actions/cache@v1
+      - uses: actions/cache@v3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -165,7 +165,7 @@ jobs:
         with:
           java-version: 1.8
       # Step that does that actual cache save and restore
-      - uses: actions/cache@v1
+      - uses: actions/cache@V3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -203,7 +203,7 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
       # Step that does that actual cache save and restore
-      - uses: actions/cache@v1
+      - uses: actions/cache@V3
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
recently we've been seeing action cache v1 stuck for long time. upgrading to latest v3 version