### PR TITLE
[pinot-spark-connector] Bump spark connector max inbound message size

### DIFF
--- a/pinot-connectors/pinot-spark-connector/src/main/scala/org/apache/pinot/connector/spark/connector/PinotGrpcServerDataFetcher.scala
+++ b/pinot-connectors/pinot-spark-connector/src/main/scala/org/apache/pinot/connector/spark/connector/PinotGrpcServerDataFetcher.scala
@@ -39,6 +39,7 @@ private[pinot] class PinotGrpcServerDataFetcher(pinotSplit: PinotSplit)
   private val channel = ManagedChannelBuilder
     .forAddress(pinotSplit.serverAndSegments.serverHost, pinotSplit.serverAndSegments.serverGrpcPort)
     .usePlaintext()
+    .maxInboundMessageSize(Int.MaxValue)
     .asInstanceOf[ManagedChannelBuilder[_]].build()
   private val pinotServerBlockingStub = PinotQueryServerGrpc.newBlockingStub(channel)
 


### PR DESCRIPTION
Updating the GRPC client configuration used by the Pinot Spark Connector to use `Int.MaxValue` for message size which effectively bumps the max message size from 4MB to ~2GBs.
Spark-Connector is intended for potentially large reads, so 4MB can be a bottleneck for certain use cases (very wide tables).

Testing:
I've tested this locally with chunk sizes exceeding 4MB. I'm not adding an explicit test case not to unnecessarily burden the test runner.
 
`bugfix` `performance`

