### PR TITLE
Refactor and allow InstanceResponseBlock to delay generate DataTable

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableBuilderUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableBuilderUtils.java
@@ -62,6 +62,10 @@ public class DataTableBuilderUtils {
     }
   }
 
+  public static DataTable buildEmptyDataTable() {
+    return getEmptyDataTable();
+  }
+
   /**
    * Builds an empty data table based on the broker request.
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableBuilderUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/DataTableBuilderUtils.java
@@ -18,23 +18,11 @@
  */
 package org.apache.pinot.core.common.datatable;
 
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.datatable.DataTableFactory;
 import org.apache.pinot.common.datatable.DataTableImplV2;
 import org.apache.pinot.common.datatable.DataTableImplV3;
 import org.apache.pinot.common.datatable.DataTableImplV4;
-import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
-import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
-import org.apache.pinot.core.query.aggregation.function.DistinctAggregationFunction;
-import org.apache.pinot.core.query.distinct.DistinctTable;
-import org.apache.pinot.core.query.request.context.QueryContext;
-import org.apache.pinot.core.query.request.context.utils.QueryContextUtils;
 
 
 /**
@@ -64,136 +52,5 @@ public class DataTableBuilderUtils {
 
   public static DataTable buildEmptyDataTable() {
     return getEmptyDataTable();
-  }
-
-  /**
-   * Builds an empty data table based on the broker request.
-   */
-  public static DataTable buildEmptyDataTable(QueryContext queryContext)
-      throws IOException {
-    if (QueryContextUtils.isSelectionQuery(queryContext)) {
-      return buildEmptyDataTableForSelectionQuery(queryContext);
-    } else if (QueryContextUtils.isAggregationQuery(queryContext)) {
-      return buildEmptyDataTableForAggregationQuery(queryContext);
-    } else {
-      assert QueryContextUtils.isDistinctQuery(queryContext);
-      return buildEmptyDataTableForDistinctQuery(queryContext);
-    }
-  }
-
-  /**
-   * Helper method to build an empty data table for selection query.
-   */
-  private static DataTable buildEmptyDataTableForSelectionQuery(QueryContext queryContext) {
-    List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
-    int numSelectExpressions = selectExpressions.size();
-    String[] columnNames = new String[numSelectExpressions];
-    for (int i = 0; i < numSelectExpressions; i++) {
-      columnNames[i] = selectExpressions.get(i).toString();
-    }
-    ColumnDataType[] columnDataTypes = new ColumnDataType[numSelectExpressions];
-    // NOTE: Use STRING column data type as default for selection query
-    Arrays.fill(columnDataTypes, ColumnDataType.STRING);
-    DataSchema dataSchema = new DataSchema(columnNames, columnDataTypes);
-    return DataTableBuilderFactory.getDataTableBuilder(dataSchema).build();
-  }
-
-  /**
-   * Helper method to build an empty data table for aggregation query.
-   */
-  private static DataTable buildEmptyDataTableForAggregationQuery(QueryContext queryContext)
-      throws IOException {
-    AggregationFunction[] aggregationFunctions = queryContext.getAggregationFunctions();
-    assert aggregationFunctions != null;
-    int numAggregations = aggregationFunctions.length;
-    List<ExpressionContext> groupByExpressions = queryContext.getGroupByExpressions();
-    if (groupByExpressions != null) {
-      // Aggregation group-by query
-
-      int numColumns = groupByExpressions.size() + numAggregations;
-      String[] columnNames = new String[numColumns];
-      ColumnDataType[] columnDataTypes = new ColumnDataType[numColumns];
-      int index = 0;
-      for (ExpressionContext groupByExpression : groupByExpressions) {
-        columnNames[index] = groupByExpression.toString();
-        // Use STRING column data type as default for group-by expressions
-        columnDataTypes[index] = ColumnDataType.STRING;
-        index++;
-      }
-      for (AggregationFunction aggregationFunction : aggregationFunctions) {
-        // NOTE: Use AggregationFunction.getResultColumnName() for SQL format response
-        columnNames[index] = aggregationFunction.getResultColumnName();
-        columnDataTypes[index] = aggregationFunction.getIntermediateResultColumnType();
-        index++;
-      }
-      return DataTableBuilderFactory.getDataTableBuilder(new DataSchema(columnNames, columnDataTypes)).build();
-    } else {
-      // Aggregation only query
-
-      String[] aggregationColumnNames = new String[numAggregations];
-      ColumnDataType[] columnDataTypes = new ColumnDataType[numAggregations];
-      Object[] aggregationResults = new Object[numAggregations];
-      for (int i = 0; i < numAggregations; i++) {
-        AggregationFunction aggregationFunction = aggregationFunctions[i];
-        // NOTE: For backward-compatibility, use AggregationFunction.getColumnName() for aggregation only query
-        aggregationColumnNames[i] = aggregationFunction.getColumnName();
-        columnDataTypes[i] = aggregationFunction.getIntermediateResultColumnType();
-        aggregationResults[i] =
-            aggregationFunction.extractAggregationResult(aggregationFunction.createAggregationResultHolder());
-      }
-
-      // Build the data table
-      DataTableBuilder dataTableBuilder =
-          DataTableBuilderFactory.getDataTableBuilder(new DataSchema(aggregationColumnNames, columnDataTypes));
-      dataTableBuilder.startRow();
-      for (int i = 0; i < numAggregations; i++) {
-        switch (columnDataTypes[i]) {
-          case LONG:
-            dataTableBuilder.setColumn(i, ((Number) aggregationResults[i]).longValue());
-            break;
-          case DOUBLE:
-            dataTableBuilder.setColumn(i, ((Double) aggregationResults[i]).doubleValue());
-            break;
-          case OBJECT:
-            dataTableBuilder.setColumn(i, aggregationResults[i]);
-            break;
-          default:
-            throw new UnsupportedOperationException(
-                "Unsupported aggregation column data type: " + columnDataTypes[i] + " for column: "
-                    + aggregationColumnNames[i]);
-        }
-      }
-      dataTableBuilder.finishRow();
-      return dataTableBuilder.build();
-    }
-  }
-
-  /**
-   * Helper method to build an empty data table for distinct query.
-   */
-  private static DataTable buildEmptyDataTableForDistinctQuery(QueryContext queryContext)
-      throws IOException {
-    AggregationFunction[] aggregationFunctions = queryContext.getAggregationFunctions();
-    assert aggregationFunctions != null && aggregationFunctions.length == 1
-        && aggregationFunctions[0] instanceof DistinctAggregationFunction;
-    DistinctAggregationFunction distinctAggregationFunction = (DistinctAggregationFunction) aggregationFunctions[0];
-
-    // Create the distinct table
-    String[] columnNames = distinctAggregationFunction.getColumns();
-    ColumnDataType[] columnDataTypes = new ColumnDataType[columnNames.length];
-    // NOTE: Use STRING column data type as default for distinct query
-    Arrays.fill(columnDataTypes, ColumnDataType.STRING);
-    DistinctTable distinctTable =
-        new DistinctTable(new DataSchema(columnNames, columnDataTypes), Collections.emptySet(),
-            queryContext.isNullHandlingEnabled());
-
-    // Build the data table
-    DataTableBuilder dataTableBuilder = DataTableBuilderFactory.getDataTableBuilder(
-        new DataSchema(new String[]{distinctAggregationFunction.getColumnName()},
-            new ColumnDataType[]{ColumnDataType.OBJECT}));
-    dataTableBuilder.startRow();
-    dataTableBuilder.setColumn(0, distinctTable);
-    dataTableBuilder.finishRow();
-    return dataTableBuilder.build();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/StreamingInstanceResponseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/StreamingInstanceResponseOperator.java
@@ -60,7 +60,7 @@ public class StreamingInstanceResponseOperator extends InstanceResponseOperator 
       metadataOnlyDataTable.addException(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
     }
     // return a metadata-only block.
-    MetadataResultsBlock metadataResultsBlock = new MetadataResultsBlock(instanceResponseDataTable.getDataSchema());
+    MetadataResultsBlock metadataResultsBlock = new MetadataResultsBlock(null);
     // metadata result block doesn't use query context to extract out data table.
     return new InstanceResponseBlock(metadataResultsBlock, null, metadataOnlyDataTable.getMetadata());
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/StreamingInstanceResponseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/StreamingInstanceResponseOperator.java
@@ -62,6 +62,7 @@ public class StreamingInstanceResponseOperator extends InstanceResponseOperator 
     // return a metadata-only block.
     MetadataResultsBlock metadataResultsBlock = new MetadataResultsBlock(null);
     // metadata result block doesn't use query context to extract out data table.
-    return new InstanceResponseBlock(metadataResultsBlock, null, metadataOnlyDataTable.getMetadata());
+    return new InstanceResponseBlock(metadataResultsBlock, null, metadataOnlyDataTable.getMetadata(),
+        metadataOnlyDataTable.getExceptions());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/InstanceResponseBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/InstanceResponseBlock.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.operator.blocks;
 
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.core.common.Block;
@@ -40,29 +39,16 @@ public class InstanceResponseBlock implements Block {
   private final Map<Integer, String> _exceptionMap;
 
   public InstanceResponseBlock(BaseResultsBlock baseResultsBlock, QueryContext queryContext) {
-    this(baseResultsBlock, queryContext, baseResultsBlock.computeMetadata());
+    this(baseResultsBlock, queryContext, baseResultsBlock.computeMetadata(),
+        InstanceResponseUtils.parseExceptions(baseResultsBlock.getProcessingExceptions()));
   }
 
   public InstanceResponseBlock(BaseResultsBlock baseResultsBlock, QueryContext queryContext,
-      Map<String, String> metadata) {
+      Map<String, String> metadata, Map<Integer, String> exceptionMap) {
     _queryContext = queryContext;
     _baseResultsBlock = baseResultsBlock;
     _metadata = metadata;
-    _exceptionMap = new HashMap<>();
-  }
-
-  public InstanceResponseBlock(Map<String, String> metadata) {
-    _queryContext = null;
-    _baseResultsBlock = null;
-    _metadata = metadata;
-    _exceptionMap = new HashMap<>();
-  }
-
-  public InstanceResponseBlock() {
-    _queryContext = null;
-    _baseResultsBlock = null;
-    _metadata = new HashMap<>();
-    _exceptionMap = new HashMap<>();
+    _exceptionMap = exceptionMap;
   }
 
   public QueryContext getQueryContext() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/InstanceResponseBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/InstanceResponseBlock.java
@@ -18,26 +18,71 @@
  */
 package org.apache.pinot.core.operator.blocks;
 
-import org.apache.pinot.common.datatable.DataTable;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.core.common.Block;
 import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.common.BlockDocIdValueSet;
 import org.apache.pinot.core.common.BlockMetadata;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.operator.blocks.results.BaseResultsBlock;
+import org.apache.pinot.core.query.request.context.QueryContext;
 
 
 /**
  * InstanceResponseBlock is just a holder to get InstanceResponse from InstanceResponseBlock.
  */
 public class InstanceResponseBlock implements Block {
-  private final DataTable _instanceResponseDataTable;
+  private final QueryContext _queryContext;
+  private final BaseResultsBlock _baseResultsBlock;
+  private final Map<String, String> _metadata;
+  private final Map<Integer, String> _exceptionMap;
 
-  public InstanceResponseBlock(DataTable dataTable) {
-    _instanceResponseDataTable = dataTable;
+  public InstanceResponseBlock(BaseResultsBlock baseResultsBlock, QueryContext queryContext) {
+    this(baseResultsBlock, queryContext, baseResultsBlock.computeMetadata());
   }
 
-  public DataTable getInstanceResponseDataTable() {
-    return _instanceResponseDataTable;
+  public InstanceResponseBlock(BaseResultsBlock baseResultsBlock, QueryContext queryContext,
+      Map<String, String> metadata) {
+    _queryContext = queryContext;
+    _baseResultsBlock = baseResultsBlock;
+    _metadata = metadata;
+    _exceptionMap = new HashMap<>();
+  }
+
+  public InstanceResponseBlock(Map<String, String> metadata) {
+    _queryContext = null;
+    _baseResultsBlock = null;
+    _metadata = metadata;
+    _exceptionMap = new HashMap<>();
+  }
+
+  public InstanceResponseBlock() {
+    _queryContext = null;
+    _baseResultsBlock = null;
+    _metadata = new HashMap<>();
+    _exceptionMap = new HashMap<>();
+  }
+
+  public QueryContext getQueryContext() {
+    return _queryContext;
+  }
+
+  public BaseResultsBlock getBaseResultsBlock() {
+    return _baseResultsBlock;
+  }
+
+  public Map<String, String> getInstanceResponseMetadata() {
+    return _metadata;
+  }
+
+  public Map<Integer, String> getExceptionMap() {
+    return _exceptionMap;
+  }
+
+  public void addException(ProcessingException exception) {
+    _exceptionMap.put(exception.getErrorCode(), exception.getMessage());
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/InstanceResponseUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/InstanceResponseUtils.java
@@ -1,0 +1,90 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.blocks;
+
+import java.util.Collection;
+import java.util.Map;
+import org.apache.commons.collections.MapUtils;
+import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.exception.QueryException;
+import org.apache.pinot.common.response.ProcessingException;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.datatable.DataTableBuilderUtils;
+import org.apache.pinot.core.operator.blocks.results.ExceptionResultsBlock;
+import org.apache.pinot.core.operator.blocks.results.MetadataResultsBlock;
+
+
+public final class InstanceResponseUtils {
+  private InstanceResponseUtils() {
+    // do not instantiate.
+  }
+
+  public static InstanceResponseBlock getEmptyResponse() {
+    return new InstanceResponseBlock();
+  }
+
+  public static InstanceResponseBlock getEmptyResponseBlock(DataSchema explainResultSchema) {
+    return new InstanceResponseBlock(new MetadataResultsBlock(explainResultSchema), null);
+  }
+
+  public static InstanceResponseBlock getExceptionBlock(ProcessingException exception) {
+    return new InstanceResponseBlock(new ExceptionResultsBlock(exception), null);
+  }
+
+  public static DataTable toDataTable(InstanceResponseBlock instanceResponseBlock) {
+    DataTable dataTable;
+    try {
+      if (instanceResponseBlock.getBaseResultsBlock() == null) {
+        dataTable = DataTableBuilderUtils.buildEmptyDataTable();
+        if (MapUtils.isNotEmpty(instanceResponseBlock.getExceptionMap())) {
+          for (Map.Entry<Integer, String> e : instanceResponseBlock.getExceptionMap().entrySet()) {
+            dataTable.addException(e.getKey(), e.getValue());
+          }
+        }
+        if (MapUtils.isNotEmpty(instanceResponseBlock.getInstanceResponseMetadata())) {
+          dataTable.getMetadata().putAll(instanceResponseBlock.getInstanceResponseMetadata());
+        }
+      } else {
+         dataTable = instanceResponseBlock.getBaseResultsBlock().getDataTable(instanceResponseBlock.getQueryContext());
+         dataTable.getMetadata().putAll(instanceResponseBlock.getInstanceResponseMetadata());
+      }
+      return dataTable;
+    } catch (ProcessingException pe) {
+      return toDataTable(getExceptionBlock(pe));
+    } catch (Exception e) {
+      return toDataTable(getExceptionBlock(QueryException.UNKNOWN_ERROR));
+    }
+  }
+
+  public static Collection<Object[]> toRows(InstanceResponseBlock instanceResponseBlock) {
+    try {
+      return instanceResponseBlock.getBaseResultsBlock().getRows(instanceResponseBlock.getQueryContext());
+    } catch (Exception e) {
+      throw new RuntimeException("Caught exception while building data table", e);
+    }
+  }
+
+  public static DataTable getDataSchema(InstanceResponseBlock instanceResponseBlock) {
+    try {
+      return instanceResponseBlock.getBaseResultsBlock().getDataTable(instanceResponseBlock.getQueryContext());
+    } catch (Exception e) {
+      throw new RuntimeException("Caught exception while building data table", e);
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/InstanceResponseUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/InstanceResponseUtils.java
@@ -248,8 +248,10 @@ public final class InstanceResponseUtils {
 
   public static Map<Integer, String> parseExceptions(List<ProcessingException> processingExceptions) {
     Map<Integer, String> exceptionMap = new HashMap<>();
-    for (ProcessingException processingException : processingExceptions) {
-      exceptionMap.put(processingException.getErrorCode(), processingException.getMessage());
+    if (processingExceptions != null && processingExceptions.size() > 0) {
+      for (ProcessingException processingException : processingExceptions) {
+        exceptionMap.put(processingException.getErrorCode(), processingException.getMessage());
+      }
     }
     return exceptionMap;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/InstanceResponseUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/InstanceResponseUtils.java
@@ -57,17 +57,16 @@ public final class InstanceResponseUtils {
     try {
       if (instanceResponseBlock.getBaseResultsBlock() == null) {
         dataTable = DataTableBuilderUtils.buildEmptyDataTable();
-        if (MapUtils.isNotEmpty(instanceResponseBlock.getExceptionMap())) {
-          for (Map.Entry<Integer, String> e : instanceResponseBlock.getExceptionMap().entrySet()) {
-            dataTable.addException(e.getKey(), e.getValue());
-          }
-        }
-        if (MapUtils.isNotEmpty(instanceResponseBlock.getInstanceResponseMetadata())) {
-          dataTable.getMetadata().putAll(instanceResponseBlock.getInstanceResponseMetadata());
-        }
       } else {
          dataTable = instanceResponseBlock.getBaseResultsBlock().getDataTable(instanceResponseBlock.getQueryContext());
-         dataTable.getMetadata().putAll(instanceResponseBlock.getInstanceResponseMetadata());
+      }
+      if (MapUtils.isNotEmpty(instanceResponseBlock.getExceptionMap())) {
+        for (Map.Entry<Integer, String> e : instanceResponseBlock.getExceptionMap().entrySet()) {
+          dataTable.addException(e.getKey(), e.getValue());
+        }
+      }
+      if (MapUtils.isNotEmpty(instanceResponseBlock.getInstanceResponseMetadata())) {
+        dataTable.getMetadata().putAll(instanceResponseBlock.getInstanceResponseMetadata());
       }
       return dataTable;
     } catch (ProcessingException pe) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/InstanceResponseUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/InstanceResponseUtils.java
@@ -18,25 +18,30 @@
  */
 package org.apache.pinot.core.operator.blocks;
 
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import org.apache.commons.collections.MapUtils;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.exception.QueryException;
+import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.datatable.DataTableBuilderUtils;
 import org.apache.pinot.core.operator.blocks.results.ExceptionResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.MetadataResultsBlock;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.DistinctAggregationFunction;
+import org.apache.pinot.core.query.distinct.DistinctTable;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextUtils;
 
 
 public final class InstanceResponseUtils {
   private InstanceResponseUtils() {
     // do not instantiate.
-  }
-
-  public static InstanceResponseBlock getEmptyResponse() {
-    return new InstanceResponseBlock();
   }
 
   public static InstanceResponseBlock getEmptyResponseBlock(DataSchema explainResultSchema) {
@@ -86,5 +91,137 @@ public final class InstanceResponseUtils {
     } catch (Exception e) {
       throw new RuntimeException("Caught exception while building data table", e);
     }
+  }
+
+  /**
+   * Builds an empty data table based on the broker request.
+   */
+  public static InstanceResponseBlock buildEmptyResultBlock(QueryContext queryContext)
+      throws Exception {
+    if (QueryContextUtils.isSelectionQuery(queryContext)) {
+      return buildEmptyResultForSelectionQuery(queryContext);
+    } else if (QueryContextUtils.isAggregationQuery(queryContext)) {
+      return buildEmptyResultForAggregationQuery(queryContext);
+    } else {
+      assert QueryContextUtils.isDistinctQuery(queryContext);
+      return buildEmptyResultForDistinctQuery(queryContext);
+    }
+  }
+
+  /**
+   * Helper method to build an empty data table for selection query.
+   */
+  private static InstanceResponseBlock buildEmptyResultForSelectionQuery(QueryContext queryContext) {
+    List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
+    int numSelectExpressions = selectExpressions.size();
+    String[] columnNames = new String[numSelectExpressions];
+    for (int i = 0; i < numSelectExpressions; i++) {
+      columnNames[i] = selectExpressions.get(i).toString();
+    }
+    DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[numSelectExpressions];
+    // NOTE: Use STRING column data type as default for selection query
+    Arrays.fill(columnDataTypes, DataSchema.ColumnDataType.STRING);
+    return getEmptyResponseBlock(new DataSchema(columnNames, columnDataTypes));
+  }
+
+  /**
+   * Helper method to build an empty data table for aggregation query.
+   */
+  private static InstanceResponseBlock buildEmptyResultForAggregationQuery(QueryContext queryContext)
+      throws Exception {
+    AggregationFunction[] aggregationFunctions = queryContext.getAggregationFunctions();
+    assert aggregationFunctions != null;
+    int numAggregations = aggregationFunctions.length;
+    List<ExpressionContext> groupByExpressions = queryContext.getGroupByExpressions();
+    if (groupByExpressions != null) {
+      // Aggregation group-by query
+
+      int numColumns = groupByExpressions.size() + numAggregations;
+      String[] columnNames = new String[numColumns];
+      DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[numColumns];
+      int index = 0;
+      for (ExpressionContext groupByExpression : groupByExpressions) {
+        columnNames[index] = groupByExpression.toString();
+        // Use STRING column data type as default for group-by expressions
+        columnDataTypes[index] = DataSchema.ColumnDataType.STRING;
+        index++;
+      }
+      for (AggregationFunction aggregationFunction : aggregationFunctions) {
+        // NOTE: Use AggregationFunction.getResultColumnName() for SQL format response
+        columnNames[index] = aggregationFunction.getResultColumnName();
+        columnDataTypes[index] = aggregationFunction.getIntermediateResultColumnType();
+        index++;
+      }
+      return getEmptyResponseBlock(new DataSchema(columnNames, columnDataTypes));
+    } else {
+      // Aggregation only query
+
+      String[] aggregationColumnNames = new String[numAggregations];
+      DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[numAggregations];
+      Object[] aggregationResults = new Object[numAggregations];
+      for (int i = 0; i < numAggregations; i++) {
+        AggregationFunction aggregationFunction = aggregationFunctions[i];
+        // NOTE: For backward-compatibility, use AggregationFunction.getColumnName() for aggregation only query
+        aggregationColumnNames[i] = aggregationFunction.getColumnName();
+        columnDataTypes[i] = aggregationFunction.getIntermediateResultColumnType();
+        aggregationResults[i] =
+            aggregationFunction.extractAggregationResult(aggregationFunction.createAggregationResultHolder());
+      }
+
+      // Build the result
+      InstanceResponseBlock instanceResponseBlock = getEmptyResponseBlock(
+          new DataSchema(aggregationColumnNames, columnDataTypes));
+      MetadataResultsBlock baseResultsBlock = (MetadataResultsBlock) instanceResponseBlock.getBaseResultsBlock();
+      Collection<Object[]> rows = baseResultsBlock.getRows(instanceResponseBlock.getQueryContext());
+      Object[] row = new Object[columnDataTypes.length];
+      for (int i = 0; i < numAggregations; i++) {
+        switch (columnDataTypes[i]) {
+          case LONG:
+            row[i] = ((Number) aggregationResults[i]).longValue();
+            break;
+          case DOUBLE:
+            row[i] = ((Double) aggregationResults[i]).doubleValue();
+            break;
+          case OBJECT:
+            row[i] = aggregationResults[i];
+            break;
+          default:
+            throw new UnsupportedOperationException(
+                "Unsupported aggregation column data type: " + columnDataTypes[i] + " for column: "
+                    + aggregationColumnNames[i]);
+        }
+      }
+      rows.add(row);
+      return instanceResponseBlock;
+    }
+  }
+
+  /**
+   * Helper method to build an empty data table for distinct query.
+   */
+  private static InstanceResponseBlock buildEmptyResultForDistinctQuery(QueryContext queryContext)
+      throws Exception {
+    AggregationFunction[] aggregationFunctions = queryContext.getAggregationFunctions();
+    assert aggregationFunctions != null && aggregationFunctions.length == 1
+        && aggregationFunctions[0] instanceof DistinctAggregationFunction;
+    DistinctAggregationFunction distinctAggregationFunction = (DistinctAggregationFunction) aggregationFunctions[0];
+
+    // Create the distinct table
+    String[] columnNames = distinctAggregationFunction.getColumns();
+    DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[columnNames.length];
+    // NOTE: Use STRING column data type as default for distinct query
+    Arrays.fill(columnDataTypes, DataSchema.ColumnDataType.STRING);
+    DistinctTable distinctTable =
+        new DistinctTable(new DataSchema(columnNames, columnDataTypes), Collections.emptySet(),
+            queryContext.isNullHandlingEnabled());
+
+    // Build the result
+    InstanceResponseBlock instanceResponseBlock = getEmptyResponseBlock(
+        new DataSchema(new String[]{distinctAggregationFunction.getColumnName()},
+            new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.OBJECT}));
+    MetadataResultsBlock baseResultsBlock = (MetadataResultsBlock) instanceResponseBlock.getBaseResultsBlock();
+    Collection<Object[]> rows = baseResultsBlock.getRows(instanceResponseBlock.getQueryContext());
+    rows.add(new Object[]{distinctTable});
+    return instanceResponseBlock;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/DistinctResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/DistinctResultsBlock.java
@@ -53,7 +53,7 @@ public class DistinctResultsBlock extends BaseResultsBlock {
   }
 
   @Override
-  public DataSchema getDataSchema(QueryContext queryContext) {
+  public DataSchema getDataSchema() {
     String[] columnNames = new String[]{_distinctFunction.getColumnName()};
     ColumnDataType[] columnDataTypes = new ColumnDataType[]{ColumnDataType.OBJECT};
     return new DataSchema(columnNames, columnDataTypes);
@@ -72,12 +72,11 @@ public class DistinctResultsBlock extends BaseResultsBlock {
   @Override
   public DataTable getDataTable(QueryContext queryContext)
       throws Exception {
-    DataTableBuilder dataTableBuilder = DataTableBuilderFactory.getDataTableBuilder(getDataSchema(queryContext));
+    DataTableBuilder dataTableBuilder = DataTableBuilderFactory.getDataTableBuilder(getDataSchema());
     dataTableBuilder.startRow();
     dataTableBuilder.setColumn(0, _distinctTable);
     dataTableBuilder.finishRow();
     DataTable dataTable = dataTableBuilder.build();
-    attachMetadataToDataTable(dataTable);
     return dataTable;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/DistinctResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/DistinctResultsBlock.java
@@ -18,11 +18,15 @@
  */
 package org.apache.pinot.core.operator.blocks.results;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.datatable.DataTableBuilder;
 import org.apache.pinot.core.common.datatable.DataTableBuilderFactory;
+import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.query.aggregation.function.DistinctAggregationFunction;
 import org.apache.pinot.core.query.distinct.DistinctTable;
 import org.apache.pinot.core.query.request.context.QueryContext;
@@ -49,12 +53,26 @@ public class DistinctResultsBlock extends BaseResultsBlock {
   }
 
   @Override
-  public DataTable getDataTable(QueryContext queryContext)
-      throws Exception {
+  public DataSchema getDataSchema(QueryContext queryContext) {
     String[] columnNames = new String[]{_distinctFunction.getColumnName()};
     ColumnDataType[] columnDataTypes = new ColumnDataType[]{ColumnDataType.OBJECT};
-    DataTableBuilder dataTableBuilder =
-        DataTableBuilderFactory.getDataTableBuilder(new DataSchema(columnNames, columnDataTypes));
+    return new DataSchema(columnNames, columnDataTypes);
+  }
+
+  @Override
+  public Collection<Object[]> getRows(QueryContext queryContext)
+      throws Exception {
+    List<Object[]> resultRows = new ArrayList<>(_distinctTable.size());
+    for (Record record : _distinctTable.getRecords()) {
+      resultRows.add(record.getValues());
+    }
+    return resultRows;
+  }
+
+  @Override
+  public DataTable getDataTable(QueryContext queryContext)
+      throws Exception {
+    DataTableBuilder dataTableBuilder = DataTableBuilderFactory.getDataTableBuilder(getDataSchema(queryContext));
     dataTableBuilder.startRow();
     dataTableBuilder.setColumn(0, _distinctTable);
     dataTableBuilder.finishRow();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ExceptionResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ExceptionResultsBlock.java
@@ -39,7 +39,7 @@ public class ExceptionResultsBlock extends BaseResultsBlock {
   }
 
   @Override
-  public DataSchema getDataSchema(QueryContext queryContext) {
+  public DataSchema getDataSchema() {
     return null;
   }
 
@@ -53,7 +53,6 @@ public class ExceptionResultsBlock extends BaseResultsBlock {
   public DataTable getDataTable(QueryContext queryContext)
       throws Exception {
     DataTable dataTable = DataTableBuilderUtils.getEmptyDataTable();
-    attachMetadataToDataTable(dataTable);
     return dataTable;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ExceptionResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ExceptionResultsBlock.java
@@ -18,9 +18,12 @@
  */
 package org.apache.pinot.core.operator.blocks.results;
 
+import java.util.Collection;
+import java.util.Collections;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.response.ProcessingException;
+import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.datatable.DataTableBuilderUtils;
 import org.apache.pinot.core.query.request.context.QueryContext;
 
@@ -33,6 +36,17 @@ public class ExceptionResultsBlock extends BaseResultsBlock {
 
   public ExceptionResultsBlock(Exception e) {
     this(QueryException.QUERY_EXECUTION_ERROR, e);
+  }
+
+  @Override
+  public DataSchema getDataSchema(QueryContext queryContext) {
+    return null;
+  }
+
+  @Override
+  public Collection<Object[]> getRows(QueryContext queryContext)
+      throws Exception {
+    return Collections.emptyList();
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/GroupByResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/GroupByResultsBlock.java
@@ -22,8 +22,10 @@ import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.datatable.DataTable.MetadataKey;
@@ -83,10 +85,6 @@ public class GroupByResultsBlock extends BaseResultsBlock {
     _table = table;
   }
 
-  public DataSchema getDataSchema() {
-    return _dataSchema;
-  }
-
   public AggregationGroupByResult getAggregationGroupByResult() {
     return _aggregationGroupByResult;
   }
@@ -121,6 +119,24 @@ public class GroupByResultsBlock extends BaseResultsBlock {
 
   public void setResizeTimeMs(long resizeTimeMs) {
     _resizeTimeMs = resizeTimeMs;
+  }
+
+  @Override
+  public DataSchema getDataSchema(QueryContext queryContext) {
+    return _dataSchema;
+  }
+
+  @Override
+  public Collection<Object[]> getRows(QueryContext queryContext)
+      throws Exception {
+    Preconditions.checkState(_table != null, "Cannot get DataTable from segment level results");
+    Iterator<Record> iterator = _table.iterator();
+    List<Object[]> resultRows = new ArrayList<>(_table.size());
+    while (iterator.hasNext()) {
+      Object[] values = iterator.next().getValues();
+      resultRows.add(values);
+    }
+    return resultRows;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/GroupByResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/GroupByResultsBlock.java
@@ -122,7 +122,7 @@ public class GroupByResultsBlock extends BaseResultsBlock {
   }
 
   @Override
-  public DataSchema getDataSchema(QueryContext queryContext) {
+  public DataSchema getDataSchema() {
     return _dataSchema;
   }
 
@@ -183,7 +183,6 @@ public class GroupByResultsBlock extends BaseResultsBlock {
       }
     }
     DataTable dataTable = dataTableBuilder.build();
-    attachMetadataToDataTable(dataTable);
     return dataTable;
   }
 
@@ -240,13 +239,13 @@ public class GroupByResultsBlock extends BaseResultsBlock {
   }
 
   @Override
-  protected void attachMetadataToDataTable(DataTable dataTable) {
-    super.attachMetadataToDataTable(dataTable);
-    Map<String, String> metadata = dataTable.getMetadata();
+  public Map<String, String> computeMetadata() {
+    Map<String, String> metadata = super.computeMetadata();
     if (_numGroupsLimitReached) {
       metadata.put(MetadataKey.NUM_GROUPS_LIMIT_REACHED.getName(), "true");
     }
     metadata.put(MetadataKey.NUM_RESIZES.getName(), Integer.toString(_numResizes));
     metadata.put(MetadataKey.RESIZE_TIME_MS.getName(), Long.toString(_resizeTimeMs));
+    return metadata;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/MetadataResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/MetadataResultsBlock.java
@@ -18,17 +18,45 @@
  */
 package org.apache.pinot.core.operator.blocks.results;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.datatable.DataTableBuilderUtils;
 import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 
 
 public class MetadataResultsBlock extends BaseResultsBlock {
+  private final DataSchema _dataSchema;
+  private final List<Object[]> _rows;
+
+  public MetadataResultsBlock(DataSchema dataSchema) {
+    _dataSchema = dataSchema;
+    _rows = new ArrayList<>();
+  }
+
+  @Override
+  public DataSchema getDataSchema(QueryContext queryContext) {
+    return _dataSchema;
+  }
+
+  @Override
+  public Collection<Object[]> getRows(QueryContext queryContext)
+      throws Exception {
+    return _rows;
+  }
 
   @Override
   public DataTable getDataTable(QueryContext queryContext)
       throws Exception {
-    DataTable dataTable = DataTableBuilderUtils.getEmptyDataTable();
+    DataTable dataTable;
+    if (_dataSchema == null) {
+      dataTable = DataTableBuilderUtils.getEmptyDataTable();
+    } else {
+      dataTable = SelectionOperatorUtils.getDataTableFromRows(_rows, _dataSchema, false);
+    }
     attachMetadataToDataTable(dataTable);
     return dataTable;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/MetadataResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/MetadataResultsBlock.java
@@ -38,7 +38,7 @@ public class MetadataResultsBlock extends BaseResultsBlock {
   }
 
   @Override
-  public DataSchema getDataSchema(QueryContext queryContext) {
+  public DataSchema getDataSchema() {
     return _dataSchema;
   }
 
@@ -57,7 +57,6 @@ public class MetadataResultsBlock extends BaseResultsBlock {
     } else {
       dataTable = SelectionOperatorUtils.getDataTableFromRows(_rows, _dataSchema, false);
     }
-    attachMetadataToDataTable(dataTable);
     return dataTable;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/SelectionResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/SelectionResultsBlock.java
@@ -37,12 +37,8 @@ public class SelectionResultsBlock extends BaseResultsBlock {
     _rows = rows;
   }
 
-  public DataSchema getDataSchema() {
-    return _dataSchema;
-  }
-
   @Override
-  public DataSchema getDataSchema(QueryContext queryContext) {
+  public DataSchema getDataSchema() {
     return _dataSchema;
   }
 
@@ -58,9 +54,6 @@ public class SelectionResultsBlock extends BaseResultsBlock {
   @Override
   public DataTable getDataTable(QueryContext queryContext)
       throws Exception {
-    DataTable dataTable =
-        SelectionOperatorUtils.getDataTableFromRows(_rows, _dataSchema, queryContext.isNullHandlingEnabled());
-    attachMetadataToDataTable(dataTable);
-    return dataTable;
+    return SelectionOperatorUtils.getDataTableFromRows(_rows, _dataSchema, queryContext.isNullHandlingEnabled());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/SelectionResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/SelectionResultsBlock.java
@@ -41,7 +41,17 @@ public class SelectionResultsBlock extends BaseResultsBlock {
     return _dataSchema;
   }
 
+  @Override
+  public DataSchema getDataSchema(QueryContext queryContext) {
+    return _dataSchema;
+  }
+
   public Collection<Object[]> getRows() {
+    return _rows;
+  }
+
+  @Override
+  public Collection<Object[]> getRows(QueryContext queryContext) {
     return _rows;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
@@ -140,7 +140,7 @@ public class GroupByCombineOperator extends BaseCombineOperator<GroupByResultsBl
         if (_indexedTable == null) {
           synchronized (this) {
             if (_indexedTable == null) {
-              DataSchema dataSchema = resultsBlock.getDataSchema(_queryContext);
+              DataSchema dataSchema = resultsBlock.getDataSchema();
               // NOTE: Use trimSize as resultSize on server size.
               if (_trimThreshold >= MAX_TRIM_THRESHOLD) {
                 // special case of trim threshold where it is set to max value.

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
@@ -140,7 +140,7 @@ public class GroupByCombineOperator extends BaseCombineOperator<GroupByResultsBl
         if (_indexedTable == null) {
           synchronized (this) {
             if (_indexedTable == null) {
-              DataSchema dataSchema = resultsBlock.getDataSchema();
+              DataSchema dataSchema = resultsBlock.getDataSchema(_queryContext);
               // NOTE: Use trimSize as resultSize on server size.
               if (_trimThreshold >= MAX_TRIM_THRESHOLD) {
                 // special case of trim threshold where it is set to max value.

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationOperator.java
@@ -43,15 +43,17 @@ public class AggregationOperator extends BaseOperator<AggregationResultsBlock> {
   private final TransformOperator _transformOperator;
   private final long _numTotalDocs;
   private final boolean _useStarTree;
+  private final boolean _isServerReturnFinalResult;
 
   private int _numDocsScanned = 0;
 
   public AggregationOperator(AggregationFunction[] aggregationFunctions, TransformOperator transformOperator,
-      long numTotalDocs, boolean useStarTree) {
+      long numTotalDocs, boolean useStarTree, boolean isServerReturnFinalResult) {
     _aggregationFunctions = aggregationFunctions;
     _transformOperator = transformOperator;
     _numTotalDocs = numTotalDocs;
     _useStarTree = useStarTree;
+    _isServerReturnFinalResult = isServerReturnFinalResult;
   }
 
   @Override
@@ -70,7 +72,8 @@ public class AggregationOperator extends BaseOperator<AggregationResultsBlock> {
     }
 
     // Build intermediate result block based on aggregation result from the executor
-    return new AggregationResultsBlock(_aggregationFunctions, aggregationExecutor.getResult());
+    return new AggregationResultsBlock(_aggregationFunctions, aggregationExecutor.getResult(),
+        _isServerReturnFinalResult);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FastFilteredCountOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FastFilteredCountOperator.java
@@ -38,14 +38,16 @@ public class FastFilteredCountOperator extends BaseOperator<AggregationResultsBl
   private final BaseFilterOperator _filterOperator;
   private final AggregationFunction[] _aggregationFunctions;
   private final SegmentMetadata _segmentMetadata;
+  private final boolean _isServerReturnFinalResult;
 
   private long _docsCounted;
 
   public FastFilteredCountOperator(AggregationFunction[] aggregationFunctions, BaseFilterOperator filterOperator,
-      SegmentMetadata segmentMetadata) {
+      SegmentMetadata segmentMetadata, boolean isServerReturnFinalResult) {
     _filterOperator = filterOperator;
     _segmentMetadata = segmentMetadata;
     _aggregationFunctions = aggregationFunctions;
+    _isServerReturnFinalResult = isServerReturnFinalResult;
   }
 
   @Override
@@ -65,7 +67,7 @@ public class FastFilteredCountOperator extends BaseOperator<AggregationResultsBl
     List<Object> aggregates = new ArrayList<>(1);
     aggregates.add(count);
     _docsCounted += count;
-    return new AggregationResultsBlock(_aggregationFunctions, aggregates);
+    return new AggregationResultsBlock(_aggregationFunctions, aggregates, _isServerReturnFinalResult);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredAggregationOperator.java
@@ -47,6 +47,7 @@ public class FilteredAggregationOperator extends BaseOperator<AggregationResults
   private final AggregationFunction[] _aggregationFunctions;
   private final List<Pair<AggregationFunction[], TransformOperator>> _aggFunctionsWithTransformOperator;
   private final long _numTotalDocs;
+  private final boolean _isServerReturnFinalResult;
 
   private long _numDocsScanned;
   private long _numEntriesScannedInFilter;
@@ -55,10 +56,12 @@ public class FilteredAggregationOperator extends BaseOperator<AggregationResults
   // We can potentially do away with aggregationFunctions parameter, but its cleaner to pass it in than to construct
   // it from aggFunctionsWithTransformOperator
   public FilteredAggregationOperator(AggregationFunction[] aggregationFunctions,
-      List<Pair<AggregationFunction[], TransformOperator>> aggFunctionsWithTransformOperator, long numTotalDocs) {
+      List<Pair<AggregationFunction[], TransformOperator>> aggFunctionsWithTransformOperator, long numTotalDocs,
+      boolean isServerReturnFinalResult) {
     _aggregationFunctions = aggregationFunctions;
     _aggFunctionsWithTransformOperator = aggFunctionsWithTransformOperator;
     _numTotalDocs = numTotalDocs;
+    _isServerReturnFinalResult = isServerReturnFinalResult;
   }
 
   @Override
@@ -89,7 +92,7 @@ public class FilteredAggregationOperator extends BaseOperator<AggregationResults
       _numEntriesScannedInFilter += transformOperator.getExecutionStatistics().getNumEntriesScannedInFilter();
       _numEntriesScannedPostFilter += (long) numDocsScanned * transformOperator.getNumColumnsProjected();
     }
-    return new AggregationResultsBlock(_aggregationFunctions, Arrays.asList(result));
+    return new AggregationResultsBlock(_aggregationFunctions, Arrays.asList(result), _isServerReturnFinalResult);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperator.java
@@ -67,12 +67,14 @@ public class NonScanBasedAggregationOperator extends BaseOperator<AggregationRes
   private final AggregationFunction[] _aggregationFunctions;
   private final DataSource[] _dataSources;
   private final int _numTotalDocs;
+  private final boolean _isServerReturnFinalResult;
 
   public NonScanBasedAggregationOperator(AggregationFunction[] aggregationFunctions, DataSource[] dataSources,
-      int numTotalDocs) {
+      int numTotalDocs, boolean isServerReturnFinalResult) {
     _aggregationFunctions = aggregationFunctions;
     _dataSources = dataSources;
     _numTotalDocs = numTotalDocs;
+    _isServerReturnFinalResult = isServerReturnFinalResult;
   }
 
   @Override
@@ -128,7 +130,7 @@ public class NonScanBasedAggregationOperator extends BaseOperator<AggregationRes
     }
 
     // Build intermediate result block based on aggregation result from the executor.
-    return new AggregationResultsBlock(_aggregationFunctions, aggregationResults);
+    return new AggregationResultsBlock(_aggregationFunctions, aggregationResults, _isServerReturnFinalResult);
   }
 
   private static Double getMinValue(DataSource dataSource) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOnlyCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOnlyCombineOperator.java
@@ -52,7 +52,7 @@ public class StreamingSelectionOnlyCombineOperator extends BaseCombineOperator<S
   private static final String EXPLAIN_NAME = "SELECT_STREAMING_COMBINE";
 
   // Special results block to indicate that this is the last results block for an operator
-  private static final MetadataResultsBlock LAST_RESULTS_BLOCK = new MetadataResultsBlock();
+  private static final MetadataResultsBlock LAST_RESULTS_BLOCK = new MetadataResultsBlock(null);
 
   private final StreamObserver<Server.ServerResponse> _streamObserver;
   private final int _limit;
@@ -103,6 +103,7 @@ public class StreamingSelectionOnlyCombineOperator extends BaseCombineOperator<S
       throws Exception {
     long numRowsCollected = 0;
     int numOperatorsFinished = 0;
+    DataSchema dataSchema = null;
     long endTimeMs = _queryContext.getEndTimeMs();
     while (numRowsCollected < _limit && numOperatorsFinished < _numOperators) {
       BaseResultsBlock resultsBlock =
@@ -123,7 +124,7 @@ public class StreamingSelectionOnlyCombineOperator extends BaseCombineOperator<S
         continue;
       }
       SelectionResultsBlock selectionResultsBlock = (SelectionResultsBlock) resultsBlock;
-      DataSchema dataSchema = selectionResultsBlock.getDataSchema();
+      dataSchema = selectionResultsBlock.getDataSchema();
       Collection<Object[]> rows = selectionResultsBlock.getRows();
       assert dataSchema != null && rows != null;
       numRowsCollected += rows.size();
@@ -132,7 +133,7 @@ public class StreamingSelectionOnlyCombineOperator extends BaseCombineOperator<S
       _streamObserver.onNext(StreamingResponseUtils.getDataResponse(dataTable));
     }
     // Return a metadata results block in the end
-    return new MetadataResultsBlock();
+    return new MetadataResultsBlock(dataSchema);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOnlyCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOnlyCombineOperator.java
@@ -103,7 +103,6 @@ public class StreamingSelectionOnlyCombineOperator extends BaseCombineOperator<S
       throws Exception {
     long numRowsCollected = 0;
     int numOperatorsFinished = 0;
-    DataSchema dataSchema = null;
     long endTimeMs = _queryContext.getEndTimeMs();
     while (numRowsCollected < _limit && numOperatorsFinished < _numOperators) {
       BaseResultsBlock resultsBlock =
@@ -124,7 +123,7 @@ public class StreamingSelectionOnlyCombineOperator extends BaseCombineOperator<S
         continue;
       }
       SelectionResultsBlock selectionResultsBlock = (SelectionResultsBlock) resultsBlock;
-      dataSchema = selectionResultsBlock.getDataSchema();
+      DataSchema dataSchema = selectionResultsBlock.getDataSchema();
       Collection<Object[]> rows = selectionResultsBlock.getRows();
       assert dataSchema != null && rows != null;
       numRowsCollected += rows.size();
@@ -133,7 +132,7 @@ public class StreamingSelectionOnlyCombineOperator extends BaseCombineOperator<S
       _streamObserver.onNext(StreamingResponseUtils.getDataResponse(dataTable));
     }
     // Return a metadata results block in the end
-    return new MetadataResultsBlock(dataSchema);
+    return new MetadataResultsBlock(null);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/GlobalPlanImplV0.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/GlobalPlanImplV0.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.plan;
 
 import java.util.concurrent.TimeoutException;
-import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.core.operator.InstanceResponseOperator;
 import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
 import org.slf4j.Logger;
@@ -46,7 +45,7 @@ public class GlobalPlanImplV0 implements Plan {
   }
 
   @Override
-  public DataTable execute()
+  public InstanceResponseBlock execute()
       throws TimeoutException {
     long startTime = System.currentTimeMillis();
     InstanceResponseOperator instanceResponseOperator = _instanceResponsePlanNode.run();
@@ -58,6 +57,6 @@ public class GlobalPlanImplV0 implements Plan {
     InstanceResponseBlock instanceResponseBlock = instanceResponseOperator.nextBlock();
     long endTime2 = System.currentTimeMillis();
     LOGGER.debug("InstanceResponseOperator.nextBlock() took: {}ms", endTime2 - endTime1);
-    return instanceResponseBlock.getInstanceResponseDataTable();
+    return instanceResponseBlock;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/Plan.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/Plan.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.core.plan;
 
 import java.util.concurrent.TimeoutException;
-import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 
 
@@ -33,6 +33,6 @@ public interface Plan {
   PlanNode getPlanNode();
 
   /** Execute the query plan and get the instance response. */
-  DataTable execute()
+  InstanceResponseBlock execute()
       throws TimeoutException;
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/QueryExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/QueryExecutor.java
@@ -27,6 +27,8 @@ import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.proto.Server;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
+import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
+import org.apache.pinot.core.operator.blocks.InstanceResponseUtils;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
@@ -72,6 +74,13 @@ public interface QueryExecutor {
    *   </li>
    * </ul>
    */
-  DataTable processQuery(ServerQueryRequest queryRequest, ExecutorService executorService,
-      @Nullable StreamObserver<Server.ServerResponse> responseObserver);
+  default DataTable processQuery(ServerQueryRequest queryRequest, ExecutorService executorService,
+      @Nullable StreamObserver<Server.ServerResponse> responseObserver) {
+    InstanceResponseBlock instanceResponseBlock =
+        processQueryWithInstanceResponse(queryRequest, executorService, responseObserver);
+    return InstanceResponseUtils.toDataTable(instanceResponseBlock);
+  }
+
+  InstanceResponseBlock processQueryWithInstanceResponse(ServerQueryRequest queryRequest,
+      ExecutorService executorService, @Nullable StreamObserver<Server.ServerResponse> responseObserver);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -360,7 +360,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       if (queryContext.isExplain()) {
         instanceResponseBlock = getExplainPlanResultsForNoMatchingSegment(totalSegments);
       } else {
-        instanceResponseBlock = InstanceResponseUtils.getEmptyResponse();
+        instanceResponseBlock = InstanceResponseUtils.buildEmptyResultBlock(queryContext);
       }
 
       Map<String, String> metadata = instanceResponseBlock.getInstanceResponseMetadata();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -51,10 +52,11 @@ import org.apache.pinot.core.common.ExplainPlanRows;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.common.datatable.DataTableBuilder;
-import org.apache.pinot.core.common.datatable.DataTableBuilderFactory;
-import org.apache.pinot.core.common.datatable.DataTableBuilderUtils;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
+import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
+import org.apache.pinot.core.operator.blocks.InstanceResponseUtils;
+import org.apache.pinot.core.operator.blocks.results.MetadataResultsBlock;
 import org.apache.pinot.core.operator.filter.EmptyFilterOperator;
 import org.apache.pinot.core.operator.filter.MatchAllFilterOperator;
 import org.apache.pinot.core.plan.Plan;
@@ -131,8 +133,8 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
   }
 
   @Override
-  public DataTable processQuery(ServerQueryRequest queryRequest, ExecutorService executorService,
-      @Nullable StreamObserver<Server.ServerResponse> responseObserver) {
+  public InstanceResponseBlock processQueryWithInstanceResponse(ServerQueryRequest queryRequest,
+      ExecutorService executorService, @Nullable StreamObserver<Server.ServerResponse> responseObserver) {
     if (!queryRequest.isEnableTrace()) {
       return processQueryInternal(queryRequest, executorService, responseObserver);
     }
@@ -144,7 +146,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
     }
   }
 
-  private DataTable processQueryInternal(ServerQueryRequest queryRequest, ExecutorService executorService,
+  private InstanceResponseBlock processQueryInternal(ServerQueryRequest queryRequest, ExecutorService executorService,
       @Nullable StreamObserver<Server.ServerResponse> responseObserver) {
     TimerContext timerContext = queryRequest.getTimerContext();
     TimerContext.Timer schedulerWaitTimer = timerContext.getPhaseTimer(ServerQueryPhase.SCHEDULER_WAIT);
@@ -177,20 +179,20 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       String errorMessage =
           String.format("Query scheduling took %dms (longer than query timeout of %dms) on server: %s",
               querySchedulingTimeMs, queryTimeoutMs, _instanceDataManager.getInstanceId());
-      DataTable dataTable = DataTableBuilderUtils.getEmptyDataTable();
-      dataTable.addException(QueryException.getException(QueryException.QUERY_SCHEDULING_TIMEOUT_ERROR, errorMessage));
+      InstanceResponseBlock instanceResponseBlock = InstanceResponseUtils.getExceptionBlock(
+          QueryException.getException(QueryException.QUERY_SCHEDULING_TIMEOUT_ERROR, errorMessage));
       LOGGER.error("{} while processing requestId: {}", errorMessage, requestId);
-      return dataTable;
+      return instanceResponseBlock;
     }
 
     TableDataManager tableDataManager = _instanceDataManager.getTableDataManager(tableNameWithType);
     if (tableDataManager == null) {
       String errorMessage = String.format("Failed to find table: %s on server: %s", tableNameWithType,
           _instanceDataManager.getInstanceId());
-      DataTable dataTable = DataTableBuilderUtils.getEmptyDataTable();
-      dataTable.addException(QueryException.getException(QueryException.SERVER_TABLE_MISSING_ERROR, errorMessage));
+      InstanceResponseBlock instanceResponseBlock = InstanceResponseUtils.getExceptionBlock(
+          QueryException.getException(QueryException.SERVER_TABLE_MISSING_ERROR, errorMessage));
       LOGGER.error("{} while processing requestId: {}", errorMessage, requestId);
-      return dataTable;
+      return instanceResponseBlock;
     }
 
     List<String> segmentsToQuery = queryRequest.getSegmentsToQuery();
@@ -244,17 +246,17 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       }
     }
 
-    DataTable dataTable = null;
+    InstanceResponseBlock instanceResponseBlock = null;
     try {
-      dataTable = processQuery(indexSegments, queryContext, timerContext, executorService, responseObserver,
+      instanceResponseBlock = processQuery(indexSegments, queryContext, timerContext, executorService, responseObserver,
           queryRequest.isEnableStreaming());
     } catch (Exception e) {
       _serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.QUERY_EXECUTION_EXCEPTIONS, 1);
-      dataTable = DataTableBuilderUtils.getEmptyDataTable();
       // Do not log verbose error for BadQueryRequestException and QueryCancelledException.
       if (e instanceof BadQueryRequestException) {
         LOGGER.info("Caught BadQueryRequestException while processing requestId: {}, {}", requestId, e.getMessage());
-        dataTable.addException(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
+        instanceResponseBlock = InstanceResponseUtils.getExceptionBlock(
+            QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
       } else if (e instanceof QueryCancelledException) {
         if (LOGGER.isDebugEnabled()) {
           LOGGER.debug("Cancelled while processing requestId: {}", requestId, e);
@@ -264,26 +266,28 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
         // NOTE most likely the onFailure() callback registered on query future in InstanceRequestHandler would
         // return the error table to broker sooner than here. But in case of race condition, we construct the error
         // table here too.
-        dataTable.addException(QueryException.getException(QueryException.QUERY_CANCELLATION_ERROR,
-            "Query cancelled on: " + _instanceDataManager.getInstanceId()));
+        instanceResponseBlock = InstanceResponseUtils.getExceptionBlock(QueryException.getException(
+            QueryException.QUERY_CANCELLATION_ERROR, "Query cancelled on: " + _instanceDataManager.getInstanceId()));
       } else {
         LOGGER.error("Exception processing requestId {}", requestId, e);
-        dataTable.addException(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
+        instanceResponseBlock = InstanceResponseUtils.getExceptionBlock(
+            QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
       }
     } finally {
       for (SegmentDataManager segmentDataManager : segmentDataManagers) {
         tableDataManager.releaseSegment(segmentDataManager);
       }
       if (queryRequest.isEnableTrace()) {
-        if (TraceContext.traceEnabled() && dataTable != null) {
-          dataTable.getMetadata().put(MetadataKey.TRACE_INFO.getName(), TraceContext.getTraceInfo());
+        if (TraceContext.traceEnabled() && instanceResponseBlock != null) {
+          instanceResponseBlock.getInstanceResponseMetadata().put(
+              MetadataKey.TRACE_INFO.getName(), TraceContext.getTraceInfo());
         }
       }
     }
 
     queryProcessingTimer.stopAndRecord();
     long queryProcessingTime = queryProcessingTimer.getDurationMs();
-    Map<String, String> metadata = dataTable.getMetadata();
+    Map<String, String> metadata = instanceResponseBlock.getInstanceResponseMetadata();
     metadata.put(MetadataKey.NUM_SEGMENTS_QUERIED.getName(), Integer.toString(numSegmentsAcquired));
     metadata.put(MetadataKey.TIME_USED_MS.getName(), Long.toString(queryProcessingTime));
 
@@ -301,7 +305,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
               .collect(Collectors.toList());
       int numMissingSegments = missingSegments.size();
       if (numMissingSegments > 0) {
-        dataTable.addException(QueryException.getException(QueryException.SERVER_SEGMENT_MISSING_ERROR,
+        instanceResponseBlock.addException(QueryException.getException(QueryException.SERVER_SEGMENT_MISSING_ERROR,
             String.format("%d segments %s missing on server: %s", numMissingSegments, missingSegments,
                 _instanceDataManager.getInstanceId())));
         _serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.NUM_MISSING_SEGMENTS, numMissingSegments);
@@ -326,14 +330,14 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
     }
 
     LOGGER.debug("Query processing time for request Id - {}: {}", requestId, queryProcessingTime);
-    LOGGER.debug("InstanceResponse for request Id - {}: {}", requestId, dataTable);
-    return dataTable;
+    LOGGER.debug("InstanceResponse for request Id - {}: {}", requestId, instanceResponseBlock);
+    return instanceResponseBlock;
   }
 
   // NOTE: This method might change indexSegments. Do not use it after calling this method.
-  private DataTable processQuery(List<IndexSegment> indexSegments, QueryContext queryContext, TimerContext timerContext,
-      ExecutorService executorService, @Nullable StreamObserver<Server.ServerResponse> responseObserver,
-      boolean enableStreaming)
+  private InstanceResponseBlock processQuery(List<IndexSegment> indexSegments, QueryContext queryContext,
+      TimerContext timerContext, ExecutorService executorService,
+      @Nullable StreamObserver<Server.ServerResponse> responseObserver, boolean enableStreaming)
       throws Exception {
     handleSubquery(queryContext, indexSegments, timerContext, executorService);
 
@@ -352,14 +356,14 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
     LOGGER.debug("Matched {} segments after pruning", numSelectedSegments);
     if (numSelectedSegments == 0) {
       // Only return metadata for streaming query
-      DataTable dataTable;
+      InstanceResponseBlock instanceResponseBlock;
       if (queryContext.isExplain()) {
-        dataTable = getExplainPlanResultsForNoMatchingSegment(totalSegments);
+        instanceResponseBlock = getExplainPlanResultsForNoMatchingSegment(totalSegments);
       } else {
-        dataTable = DataTableBuilderUtils.buildEmptyDataTable(queryContext);
+        instanceResponseBlock = InstanceResponseUtils.getEmptyResponse();
       }
 
-      Map<String, String> metadata = dataTable.getMetadata();
+      Map<String, String> metadata = instanceResponseBlock.getInstanceResponseMetadata();
       metadata.put(MetadataKey.TOTAL_DOCS.getName(), String.valueOf(numTotalDocs));
       metadata.put(MetadataKey.NUM_DOCS_SCANNED.getName(), "0");
       metadata.put(MetadataKey.NUM_ENTRIES_SCANNED_IN_FILTER.getName(), "0");
@@ -370,7 +374,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       metadata.put(MetadataKey.NUM_CONSUMING_SEGMENTS_MATCHED.getName(), "0");
       metadata.put(MetadataKey.NUM_SEGMENTS_PRUNED_BY_SERVER.getName(), String.valueOf(totalSegments));
       addPrunerStats(metadata, prunerStats);
-      return dataTable;
+      return instanceResponseBlock;
     } else {
       TimerContext.Timer planBuildTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.BUILD_QUERY_PLAN);
       Plan queryPlan =
@@ -380,10 +384,11 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       planBuildTimer.stopAndRecord();
 
       TimerContext.Timer planExecTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.QUERY_PLAN_EXECUTION);
-      DataTable dataTable = queryContext.isExplain() ? processExplainPlanQueries(queryPlan) : queryPlan.execute();
+      InstanceResponseBlock instanceResponseBlock = queryContext.isExplain()
+          ? processExplainPlanQueries(queryPlan) : queryPlan.execute();
       planExecTimer.stopAndRecord();
 
-      Map<String, String> metadata = dataTable.getMetadata();
+      Map<String, String> metadata = instanceResponseBlock.getInstanceResponseMetadata();
       // Update the total docs in the metadata based on the un-pruned segments
       metadata.put(MetadataKey.TOTAL_DOCS.getName(), Long.toString(numTotalDocs));
 
@@ -392,28 +397,27 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       metadata.put(MetadataKey.NUM_SEGMENTS_PRUNED_BY_SERVER.getName(), String.valueOf(prunedSegments));
       addPrunerStats(metadata, prunerStats);
 
-      return dataTable;
+      return instanceResponseBlock;
     }
   }
 
   /** @return EXPLAIN_PLAN query result {@link DataTable} when no segments get selected for query execution.*/
-  private static DataTable getExplainPlanResultsForNoMatchingSegment(int totalNumSegments) {
-    DataTableBuilder dataTableBuilder = DataTableBuilderFactory.getDataTableBuilder(DataSchema.EXPLAIN_RESULT_SCHEMA);
+  private static InstanceResponseBlock getExplainPlanResultsForNoMatchingSegment(int totalNumSegments) {
+    InstanceResponseBlock instanceResponseBlock = InstanceResponseUtils.getEmptyResponseBlock(
+        DataSchema.EXPLAIN_RESULT_SCHEMA);
     try {
-      dataTableBuilder.startRow();
-      dataTableBuilder.setColumn(0, String.format(ExplainPlanRows.PLAN_START_FORMAT, totalNumSegments));
-      dataTableBuilder.setColumn(1, ExplainPlanRows.PLAN_START_IDS);
-      dataTableBuilder.setColumn(2, ExplainPlanRows.PLAN_START_IDS);
-      dataTableBuilder.finishRow();
-      dataTableBuilder.startRow();
-      dataTableBuilder.setColumn(0, ExplainPlanRows.ALL_SEGMENTS_PRUNED_ON_SERVER);
-      dataTableBuilder.setColumn(1, 2);
-      dataTableBuilder.setColumn(2, 1);
-      dataTableBuilder.finishRow();
-    } catch (IOException ioe) {
+      MetadataResultsBlock baseResultsBlock = (MetadataResultsBlock) instanceResponseBlock.getBaseResultsBlock();
+      Collection<Object[]> rows = baseResultsBlock.getRows(instanceResponseBlock.getQueryContext());
+      rows.add(new Object[]{
+          String.format(ExplainPlanRows.PLAN_START_FORMAT, totalNumSegments),
+          ExplainPlanRows.PLAN_START_IDS,
+          ExplainPlanRows.PLAN_START_IDS
+      });
+      rows.add(new Object[]{ExplainPlanRows.ALL_SEGMENTS_PRUNED_ON_SERVER, 2, 1});
+    } catch (Exception ioe) {
       LOGGER.error("Unable to create EXPLAIN PLAN result table.", ioe);
     }
-    return dataTableBuilder.build();
+    return instanceResponseBlock;
   }
 
   /**
@@ -501,15 +505,16 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
     }
   }
 
-  /** @return EXPLAIN PLAN query result {@link DataTable}. */
-  public static DataTable processExplainPlanQueries(Plan queryPlan) {
-    DataTableBuilder dataTableBuilder = DataTableBuilderFactory.getDataTableBuilder(DataSchema.EXPLAIN_RESULT_SCHEMA);
+  /** @return EXPLAIN PLAN query result {@link InstanceResponseBlock}. */
+  public static InstanceResponseBlock processExplainPlanQueries(Plan queryPlan) {
     List<Operator> childOperators = queryPlan.getPlanNode().run().getChildOperators();
     assert childOperators.size() == 1;
     Operator root = childOperators.get(0);
     Map<Integer, List<ExplainPlanRows>> operatorDepthToRowDataMap;
     int numEmptyFilterSegments = 0;
     int numMatchAllFilterSegments = 0;
+    InstanceResponseBlock instanceResponseBlock =
+        InstanceResponseUtils.getEmptyResponseBlock(DataSchema.EXPLAIN_RESULT_SCHEMA);
 
     try {
       // Get the list of unique explain plans
@@ -518,7 +523,9 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       operatorDepthToRowDataMap.forEach((key, value) -> listOfExplainPlans.addAll(value));
 
       // Setup the combine root's explain string
-      setValueInDataTableBuilder(dataTableBuilder, root.toExplainString(), 2, 1);
+      MetadataResultsBlock baseResultsBlock = (MetadataResultsBlock) instanceResponseBlock.getBaseResultsBlock();
+      Collection<Object[]> rows = baseResultsBlock.getRows(instanceResponseBlock.getQueryContext());
+      rows.add(new Object[]{root.toExplainString(), 2, 1});
 
       // Walk through all the explain plans and create the entries in the explain plan output for each plan
       for (ExplainPlanRows explainPlanRows : listOfExplainPlans) {
@@ -526,24 +533,24 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
             explainPlanRows.isHasEmptyFilter() ? explainPlanRows.getNumSegmentsMatchingThisPlan() : 0;
         numMatchAllFilterSegments +=
             explainPlanRows.isHasMatchAllFilter() ? explainPlanRows.getNumSegmentsMatchingThisPlan() : 0;
-        setValueInDataTableBuilder(dataTableBuilder,
+        rows.add(new Object[]{
             String.format(ExplainPlanRows.PLAN_START_FORMAT, explainPlanRows.getNumSegmentsMatchingThisPlan()),
-            ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS);
+            ExplainPlanRows.PLAN_START_IDS,
+            ExplainPlanRows.PLAN_START_IDS});
         for (ExplainPlanRowData explainPlanRowData : explainPlanRows.getExplainPlanRowData()) {
-          setValueInDataTableBuilder(dataTableBuilder, explainPlanRowData.getExplainPlanString(),
-              explainPlanRowData.getOperatorId(), explainPlanRowData.getParentId());
+          rows.add(new Object[]{explainPlanRowData.getExplainPlanString(),
+              explainPlanRowData.getOperatorId(), explainPlanRowData.getParentId()});
         }
       }
-    } catch (IOException ioe) {
+    } catch (Exception ioe) {
       LOGGER.error("Unable to create EXPLAIN PLAN result table.", ioe);
     }
 
-    DataTable dataTable = dataTableBuilder.build();
-    dataTable.getMetadata()
-        .put(MetadataKey.EXPLAIN_PLAN_NUM_EMPTY_FILTER_SEGMENTS.getName(), String.valueOf(numEmptyFilterSegments));
-    dataTable.getMetadata().put(MetadataKey.EXPLAIN_PLAN_NUM_MATCH_ALL_FILTER_SEGMENTS.getName(),
-        String.valueOf(numMatchAllFilterSegments));
-    return dataTable;
+    instanceResponseBlock.getInstanceResponseMetadata().put(
+        MetadataKey.EXPLAIN_PLAN_NUM_EMPTY_FILTER_SEGMENTS.getName(), String.valueOf(numEmptyFilterSegments));
+    instanceResponseBlock.getInstanceResponseMetadata().put(
+        MetadataKey.EXPLAIN_PLAN_NUM_MATCH_ALL_FILTER_SEGMENTS.getName(), String.valueOf(numMatchAllFilterSegments));
+    return instanceResponseBlock;
   }
 
   /**
@@ -625,8 +632,9 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       // Execute the subquery
       subquery.setEndTimeMs(endTimeMs);
       // Make a clone of indexSegments because the method might modify the list
-      DataTable dataTable =
+      InstanceResponseBlock instanceResponseBlock =
           processQuery(new ArrayList<>(indexSegments), subquery, timerContext, executorService, null, false);
+      DataTable dataTable = InstanceResponseUtils.toDataTable(instanceResponseBlock);
       DataTable.CustomObject idSet = dataTable.getCustomObject(0, 0);
       Preconditions.checkState(idSet != null && idSet.getType() == ObjectSerDeUtils.ObjectType.IdSet.getValue(),
           "Result is not an IdSet");

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -288,6 +288,9 @@ public class SelectionOperatorUtils {
           case BYTES:
             dataTableBuilder.setColumn(i, (ByteArray) columnValue);
             break;
+          case OBJECT:
+            dataTableBuilder.setColumn(i, (Object) columnValue);
+            break;
 
           // Multi-value column
           case INT_ARRAY:

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datatable/DataTableBuilderUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datatable/DataTableBuilderUtilsTest.java
@@ -18,11 +18,11 @@
  */
 package org.apache.pinot.core.common.datatable;
 
-import java.io.IOException;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
+import org.apache.pinot.core.operator.blocks.InstanceResponseUtils;
 import org.apache.pinot.core.query.distinct.DistinctTable;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
@@ -36,10 +36,10 @@ public class DataTableBuilderUtilsTest {
 
   @Test
   public void testBuildEmptyDataTable()
-      throws IOException {
+      throws Exception {
     // Selection
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable WHERE foo = 'bar'");
-    DataTable dataTable = DataTableBuilderUtils.buildEmptyDataTable(queryContext);
+    DataTable dataTable = InstanceResponseUtils.toDataTable(InstanceResponseUtils.buildEmptyResultBlock(queryContext));
     DataSchema dataSchema = dataTable.getDataSchema();
     assertEquals(dataSchema.getColumnNames(), new String[]{"*"});
     assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{ColumnDataType.STRING});
@@ -48,7 +48,7 @@ public class DataTableBuilderUtilsTest {
     // Aggregation
     queryContext =
         QueryContextConverterUtils.getQueryContext("SELECT COUNT(*), SUM(a), MAX(b) FROM testTable WHERE foo = 'bar'");
-    dataTable = DataTableBuilderUtils.buildEmptyDataTable(queryContext);
+    dataTable = InstanceResponseUtils.toDataTable(InstanceResponseUtils.buildEmptyResultBlock(queryContext));
     dataSchema = dataTable.getDataSchema();
     assertEquals(dataSchema.getColumnNames(), new String[]{"count_star", "sum_a", "max_b"});
     assertEquals(dataSchema.getColumnDataTypes(),
@@ -61,7 +61,7 @@ public class DataTableBuilderUtilsTest {
     // Group-by
     queryContext = QueryContextConverterUtils.getQueryContext(
         "SELECT c, d, COUNT(*), SUM(a), MAX(b) FROM testTable WHERE foo = 'bar' GROUP BY c, d");
-    dataTable = DataTableBuilderUtils.buildEmptyDataTable(queryContext);
+    dataTable = InstanceResponseUtils.toDataTable(InstanceResponseUtils.buildEmptyResultBlock(queryContext));
     dataSchema = dataTable.getDataSchema();
     assertEquals(dataSchema.getColumnNames(), new String[]{"c", "d", "count(*)", "sum(a)", "max(b)"});
     assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
@@ -71,7 +71,7 @@ public class DataTableBuilderUtilsTest {
 
     // Distinct
     queryContext = QueryContextConverterUtils.getQueryContext("SELECT DISTINCT a, b FROM testTable WHERE foo = 'bar'");
-    dataTable = DataTableBuilderUtils.buildEmptyDataTable(queryContext);
+    dataTable = InstanceResponseUtils.toDataTable(InstanceResponseUtils.buildEmptyResultBlock(queryContext));
     dataSchema = dataTable.getDataSchema();
     assertEquals(dataSchema.getColumnNames(), new String[]{"distinct_a:b"});
     assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{ColumnDataType.OBJECT});

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/scheduler/PrioritySchedulerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/scheduler/PrioritySchedulerTest.java
@@ -44,8 +44,9 @@ import org.apache.pinot.common.datatable.DataTableFactory;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.proto.Server;
-import org.apache.pinot.core.common.datatable.DataTableBuilderUtils;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
+import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
+import org.apache.pinot.core.operator.blocks.InstanceResponseUtils;
 import org.apache.pinot.core.query.executor.QueryExecutor;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.scheduler.resources.PolicyBasedResourceManager;
@@ -297,8 +298,8 @@ public class PrioritySchedulerTest {
     }
 
     @Override
-    public DataTable processQuery(ServerQueryRequest queryRequest, ExecutorService executorService,
-        @Nullable StreamObserver<Server.ServerResponse> responseObserver) {
+    public InstanceResponseBlock processQueryWithInstanceResponse(ServerQueryRequest queryRequest,
+        ExecutorService executorService, @Nullable StreamObserver<Server.ServerResponse> responseObserver) {
       if (_useBarrier) {
         try {
           _startupBarrier.await();
@@ -306,8 +307,8 @@ public class PrioritySchedulerTest {
           throw new RuntimeException(e);
         }
       }
-      DataTable result = DataTableBuilderUtils.getEmptyDataTable();
-      result.getMetadata().put(MetadataKey.TABLE.getName(), queryRequest.getTableNameWithType());
+      InstanceResponseBlock result = InstanceResponseUtils.getEmptyResponseBlock(null);
+      result.getInstanceResponseMetadata().put(MetadataKey.TABLE.getName(), queryRequest.getTableNameWithType());
       if (_useBarrier) {
         try {
           _validationBarrier.await();


### PR DESCRIPTION
current engine serialized the results into datatable way ahead of when it is being returned to the broker.
This prevents from some optimizations that when we know the broker and servers are collocated within the same JVM we should just pass over the content directly.

Proposing to 
- create an `InstanceResponseBlock` that captures all the things in DataTable 
- but do not serialize the `BaseResultBlock`
- create interfaces that allows returning non-serialized version for optimization