### PR TITLE
add scalar function support for AT TIME ZONE

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
@@ -63,6 +63,7 @@ public class FunctionRegistry {
     Set<Method> methods = PinotReflectionUtils.getMethodsThroughReflection(".*\\.function\\..*", ScalarFunction.class);
     for (Method method : methods) {
       if (!Modifier.isPublic(method.getModifiers())) {
+        LOGGER.warn("Not cataloging non-public method {}.", method.getName());
         continue;
       }
       ScalarFunction scalarFunction = method.getAnnotation(ScalarFunction.class);

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/parser/SqlAtTimeZone.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/parser/SqlAtTimeZone.java
@@ -18,25 +18,27 @@
  */
 package org.apache.pinot.sql.parsers.parser;
 
-import java.util.Arrays;
+import org.apache.calcite.sql.SqlBinaryOperator;
 import org.apache.calcite.sql.SqlKind;
-import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.SqlSpecialOperator;
-import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.SqlOperandCountRange;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.SqlOperandCountRanges;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 
-import static java.util.Objects.requireNonNull;
 
-
-public class SqlAtTimeZone extends SqlSpecialOperator {
+public class SqlAtTimeZone extends SqlBinaryOperator {
 
   public static final SqlAtTimeZone INSTANCE = new SqlAtTimeZone();
 
+  static {
+    SqlStdOperatorTable.instance().register(INSTANCE);
+  }
+
   private SqlAtTimeZone() {
     super(
-        "AT_TIME_ZONE",
+        "atTimeZone",
         SqlKind.OTHER_FUNCTION,
         32, // put this at the same precedence as LIKE (see SqlLikeOperator)
         false,
@@ -46,18 +48,7 @@ public class SqlAtTimeZone extends SqlSpecialOperator {
     );
   }
 
-  @Override
-  public ReduceResult reduceExpr(int ordinal, TokenSequence list) {
-    SqlNode left = list.node(ordinal - 1);
-    SqlNode right = list.node(ordinal + 1);
-    return new ReduceResult(ordinal - 1,
-        ordinal + 2,
-        createCall(
-            SqlParserPos.sum(
-                Arrays.asList(requireNonNull(left, "left").getParserPosition(),
-                    requireNonNull(right, "right").getParserPosition(),
-                    list.pos(ordinal))),
-            left,
-            right));
+  @Override public SqlOperandCountRange getOperandCountRange() {
+    return SqlOperandCountRanges.of(2);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.data.function;
 
 import com.google.common.collect.Lists;
+import java.sql.Timestamp;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -594,5 +595,33 @@ public class DateTimeFunctionsTest {
     }
     testMultipleInvocations(String.format("dateTimeConvert(timeCol, '%s', '%s', '%s')", inputFormatStr, outputFormatStr,
         outputGranularityStr), rows, expectedResults);
+  }
+
+  @Test
+  public void shouldConvertUTCtoDifferentTimeZone() {
+    // Given:
+    final long tsUTC = 1664384229000L; // 2022-09-28T16:57:09Z
+    GenericRow row = new GenericRow();
+    row.putValue("epochMillis", tsUTC);
+    List<String> arguments = Lists.newArrayList("epochMillis");
+
+    // Then:
+    Timestamp tsPST = Timestamp.valueOf("2022-09-28 09:57:09.0");
+    testFunction("atTimeZone(epochMillis, 'PST')", arguments, row, tsPST);
+    testFunction("atTimeZone(epochMillis, 'America/Los_Angeles')", arguments, row, tsPST);
+  }
+
+  @Test
+  public void shouldConvertUTCtoSameTimeZone() {
+    // Given:
+    final long tsUTC = 1664384229000L; // 2022-09-28T16:57:09Z
+    GenericRow row = new GenericRow();
+    row.putValue("epochMillis", tsUTC);
+    List<String> arguments = Lists.newArrayList("epochMillis");
+
+    // Then:
+    Timestamp tsPST = Timestamp.valueOf("2022-09-28 16:57:09.0");
+    testFunction("atTimeZone(epochMillis, 'UTC')", arguments, row, tsPST);
+    testFunction("atTimeZone(epochMillis, 'Greenwich')", arguments, row, tsPST);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TimestampQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TimestampQueriesTest.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.io.IOException;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -44,7 +43,6 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.AfterClass;
@@ -227,7 +225,7 @@ public class TimestampQueriesTest extends BaseQueriesTest {
     }
   }
 
-  @Test()
+  @Test
   public void shouldSupportAtTimeZoneCustomSyntax() {
     // Given:
     String query =

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -19,8 +19,6 @@
 package org.apache.pinot.query;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Properties;
 import org.apache.calcite.config.CalciteConnectionConfigImpl;
@@ -45,8 +43,6 @@ import org.apache.calcite.sql.SqlExplainLevel;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
-import org.apache.calcite.sql.util.ChainedSqlOperatorTable;
-import org.apache.calcite.sql.util.ListSqlOperatorTable;
 import org.apache.calcite.sql.util.SqlOperatorTables;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.sql2rel.StandardConvertletTable;
@@ -60,7 +56,6 @@ import org.apache.pinot.query.routing.WorkerManager;
 import org.apache.pinot.query.type.TypeFactory;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
-import org.apache.pinot.sql.parsers.parser.SqlAtTimeZone;
 
 
 /**

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.query;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Properties;
@@ -45,6 +46,8 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.util.ChainedSqlOperatorTable;
+import org.apache.calcite.sql.util.ListSqlOperatorTable;
+import org.apache.calcite.sql.util.SqlOperatorTables;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.sql2rel.StandardConvertletTable;
 import org.apache.calcite.tools.FrameworkConfig;
@@ -57,6 +60,7 @@ import org.apache.pinot.query.routing.WorkerManager;
 import org.apache.pinot.query.type.TypeFactory;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
+import org.apache.pinot.sql.parsers.parser.SqlAtTimeZone;
 
 
 /**
@@ -91,7 +95,9 @@ public class QueryEnvironment {
         new CalciteConnectionConfigImpl(catalogReaderConfigProperties));
 
     _config = Frameworks.newConfigBuilder().traitDefs()
-        .operatorTable(new ChainedSqlOperatorTable(Arrays.asList(SqlStdOperatorTable.instance(), _catalogReader)))
+        .operatorTable(SqlOperatorTables.chain(
+            SqlStdOperatorTable.instance(),
+            _catalogReader))
         .defaultSchema(_rootSchema.plus())
         .sqlToRelConverterConfig(SqlToRelConverter.config()
             .withHintStrategyTable(getHintStrategyTable())

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -257,8 +257,6 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
         new Object[]{"SELECT a.col1, SUM(a.col3) FROM a", "'a.col1' is not being grouped"},
         // empty IN clause fails compilation
         new Object[]{"SELECT a.col1 FROM a WHERE a.col1 IN ()", "Encountered \"\" at line"},
-        // AT TIME ZONE should fail
-        new Object[]{"SELECT a.col1 AT TIME ZONE 'PST' FROM a", "No match found for function signature AT_TIME_ZONE"},
     };
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
@@ -324,6 +324,9 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
         //   - on intermediate stage
         new Object[]{"SELECT dateTrunc('DAY', round(a.ts, b.ts)) FROM a JOIN b "
             + "ON a.col1 = b.col1 AND a.col2 = b.col2", 15},
+
+       // H2 doesn't support AT TIME ZONE
+        new Object[]{"SELECT ts AT TIME ZONE 'UTC', ts AT TIME ZONE 'PST' FROM a", 15},
     };
   }
 }


### PR DESCRIPTION
depends on #9477 to run the custom syntax - this PR adds the functionality to execute the `AT TIME ZONE` method and was tested using my local time zone as well as `-Duser.timezone=GMT`.