### PR TITLE
Add UI to show fine-grained minion task progress

### DIFF
--- a/pinot-controller/src/main/resources/app/interfaces/types.d.ts
+++ b/pinot-controller/src/main/resources/app/interfaces/types.d.ts
@@ -178,4 +178,13 @@ declare module 'Models' {
   export type UserList = {
     users: UserObject
   }
+
+  export interface TaskProgressResponse {
+    [key: string]: TaskProgressStatus[] | string;
+  }
+
+  export interface TaskProgressStatus {
+    ts: number,
+    status: string
+  }
 }

--- a/pinot-controller/src/main/resources/app/requests/index.ts
+++ b/pinot-controller/src/main/resources/app/requests/index.ts
@@ -20,7 +20,7 @@
 import { AxiosResponse } from 'axios';
 import { TableData, Instances, Instance, Tenants, ClusterConfig, TableName, TableSize,
   IdealState, QueryTables, TableSchema, SQLResult, ClusterName, ZKGetList, ZKConfig, OperationResponse,
-  BrokerList, ServerList, UserList, TableList, UserObject
+  BrokerList, ServerList, UserList, TableList, UserObject, TaskProgressResponse
 } from 'Models';
 
 const headers = {
@@ -128,6 +128,9 @@ export const getTasks = (tableName: string, taskType: string): Promise<AxiosResp
 
 export const getTaskDebug = (taskName: string): Promise<AxiosResponse<OperationResponse>> =>
   baseApi.get(`/tasks/task/${taskName}/debug?verbosity=1`, { headers: { ...headers, Accept: 'application/json' } });
+
+export const getTaskProgress = (taskName: string, subTaskName: string): Promise<AxiosResponse<TaskProgressResponse>> =>
+  baseApi.get(`/tasks/subtask/${taskName}/progress`, { headers: { ...headers, Accept: 'application/json' }, params: {subtaskNames: subTaskName} });
 
 export const getTaskGeneratorDebug = (taskName: string, taskType: string): Promise<AxiosResponse<OperationResponse>> =>
   baseApi.get(`/tasks/generator/${taskName}/${taskType}/debug`, { headers: { ...headers, Accept: 'application/json' } });

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -89,7 +89,8 @@ import {
   requestUserList,
   requestAddUser,
   requestDeleteUser,
-  requestUpdateUser
+  requestUpdateUser,
+  getTaskProgress
 } from '../requests';
 import { baseApi } from './axios-config';
 import Utils from './Utils';
@@ -830,6 +831,12 @@ const getTaskDebugData = async (taskName) => {
   return debugRes;
 };
 
+const getTaskProgressData = async (taskName, subTaskName) => {
+  const progressData = await getTaskProgress(taskName, subTaskName);
+
+  return progressData.data;
+}
+
 const getTaskGeneratorDebugData = async (taskName, taskType) => {
   const debugRes = await getTaskGeneratorDebug(taskName, taskType);
   return debugRes;
@@ -1107,6 +1114,7 @@ export default {
   getElapsedTime,
   getTasksList,
   getTaskDebugData,
+  getTaskProgressData,
   getTaskGeneratorDebugData,
   deleteSegmentOp,
   reloadSegmentOp,


### PR DESCRIPTION
What does this PR do?
- Fix: details in the `Info` panel overflow outside the container
- Add a new panel `Progress` to display fine-grained minion task progress.

Before:
<img width="1726" alt="image" src="https://user-images.githubusercontent.com/41536903/193008219-b54f0843-afa3-4404-b14a-7cde96e10e55.png">

After:
- When the response contains array of status 

https://user-images.githubusercontent.com/41536903/193007751-1df98f41-cf9c-4912-a45c-cd32c790a4ba.mp4

- When the response does not contain any status (in this case UI will display whatever backend sends as it is)

![image](https://user-images.githubusercontent.com/41536903/193004655-869b0300-623f-42a2-abc8-3b801ca77000.png)

Reviewers - @klsince @npawar @joshigaurava 