### PR TITLE
add debug string to query plan [MINOR]

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/QueryPlan.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/QueryPlan.java
@@ -22,7 +22,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.apache.calcite.util.Pair;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.query.planner.logical.LogicalPlanner;
 import org.apache.pinot.query.planner.stage.MailboxReceiveNode;
 import org.apache.pinot.query.planner.stage.StageNode;
@@ -76,7 +75,9 @@ public class QueryPlan {
   }
 
   public String debugString() {
-    if (_queryStageMap.isEmpty()) return "EMPTY";
+    if (_queryStageMap.isEmpty()) {
+      return "EMPTY";
+    }
 
     StringBuilder builder = new StringBuilder();
     debugString(builder, _queryStageMap.get(0), "", "");
@@ -93,10 +94,10 @@ public class QueryPlan {
       int senderStage = ((MailboxReceiveNode) root).getSenderStageId();
       debugString(builder, _queryStageMap.get(senderStage), childPrefix + "└── ", childPrefix + "    ");
     } else {
-      for (Iterator<StageNode> iterator = root.getInputs().iterator(); iterator.hasNext(); ) {
+      for (Iterator<StageNode> iterator = root.getInputs().iterator(); iterator.hasNext();) {
         StageNode input = iterator.next();
         if (iterator.hasNext()) {
-          debugString(builder, input, childPrefix + "├── ", childPrefix + "│   " );
+          debugString(builder, input, childPrefix + "├── ", childPrefix + "│   ");
         } else {
           debugString(builder, input, childPrefix + "└── ", childPrefix + "    ");
         }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/AggregateNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/AggregateNode.java
@@ -54,4 +54,9 @@ public class AggregateNode extends AbstractStageNode {
   public List<RexExpression> getGroupSet() {
     return _groupSet;
   }
+
+  @Override
+  public String debugString() {
+    return "AGGREGATE";
+  }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/AggregateNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/AggregateNode.java
@@ -56,7 +56,7 @@ public class AggregateNode extends AbstractStageNode {
   }
 
   @Override
-  public String debugString() {
+  public String explain() {
     return "AGGREGATE";
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/FilterNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/FilterNode.java
@@ -40,4 +40,9 @@ public class FilterNode extends AbstractStageNode {
   public RexExpression getCondition() {
     return _condition;
   }
+
+  @Override
+  public String debugString() {
+    return "FILTER";
+  }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/FilterNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/FilterNode.java
@@ -42,7 +42,7 @@ public class FilterNode extends AbstractStageNode {
   }
 
   @Override
-  public String debugString() {
+  public String explain() {
     return "FILTER";
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/JoinNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/JoinNode.java
@@ -59,6 +59,11 @@ public class JoinNode extends AbstractStageNode {
     return _joinClause;
   }
 
+  @Override
+  public String debugString() {
+    return "JOIN";
+  }
+
   public static class JoinKeys {
     @ProtoProperties
     private KeySelector<Object[], Object[]> _leftJoinKeySelector;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/JoinNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/JoinNode.java
@@ -60,7 +60,7 @@ public class JoinNode extends AbstractStageNode {
   }
 
   @Override
-  public String debugString() {
+  public String explain() {
     return "JOIN";
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/MailboxReceiveNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/MailboxReceiveNode.java
@@ -58,7 +58,7 @@ public class MailboxReceiveNode extends AbstractStageNode {
   }
 
   @Override
-  public String debugString() {
+  public String explain() {
     return "MAIL_RECEIVE";
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/MailboxReceiveNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/MailboxReceiveNode.java
@@ -56,4 +56,9 @@ public class MailboxReceiveNode extends AbstractStageNode {
   public KeySelector<Object[], Object[]> getPartitionKeySelector() {
     return _partitionKeySelector;
   }
+
+  @Override
+  public String debugString() {
+    return "MAIL_RECEIVE";
+  }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/MailboxSendNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/MailboxSendNode.java
@@ -58,7 +58,7 @@ public class MailboxSendNode extends AbstractStageNode {
   }
 
   @Override
-  public String debugString() {
+  public String explain() {
     return "MAIL_SEND";
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/MailboxSendNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/MailboxSendNode.java
@@ -56,4 +56,9 @@ public class MailboxSendNode extends AbstractStageNode {
   public KeySelector<Object[], Object[]> getPartitionKeySelector() {
     return _partitionKeySelector;
   }
+
+  @Override
+  public String debugString() {
+    return "MAIL_SEND";
+  }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/ProjectNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/ProjectNode.java
@@ -41,4 +41,9 @@ public class ProjectNode extends AbstractStageNode {
   public List<RexExpression> getProjects() {
     return _projects;
   }
+
+  @Override
+  public String debugString() {
+    return "PROJECT";
+  }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/ProjectNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/ProjectNode.java
@@ -43,7 +43,7 @@ public class ProjectNode extends AbstractStageNode {
   }
 
   @Override
-  public String debugString() {
+  public String explain() {
     return "PROJECT";
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/SortNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/SortNode.java
@@ -67,4 +67,9 @@ public class SortNode extends AbstractStageNode {
   public int getOffset() {
     return _offset;
   }
+
+  @Override
+  public String debugString() {
+    return "SORT" + (_fetch > 0 ? " (LIMIT " + _fetch + ")" : "");
+  }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/SortNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/SortNode.java
@@ -69,7 +69,7 @@ public class SortNode extends AbstractStageNode {
   }
 
   @Override
-  public String debugString() {
+  public String explain() {
     return "SORT" + (_fetch > 0 ? " (LIMIT " + _fetch + ")" : "");
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/StageNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/StageNode.java
@@ -48,4 +48,6 @@ public interface StageNode extends Serializable {
   Set<Integer> getPartitionKeys();
 
   void setPartitionKeys(Collection<Integer> partitionKeys);
+
+  String debugString();
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/StageNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/StageNode.java
@@ -49,5 +49,5 @@ public interface StageNode extends Serializable {
 
   void setPartitionKeys(Collection<Integer> partitionKeys);
 
-  String debugString();
+  String explain();
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/TableScanNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/TableScanNode.java
@@ -46,4 +46,9 @@ public class TableScanNode extends AbstractStageNode {
   public List<String> getTableScanColumns() {
     return _tableScanColumns;
   }
+
+  @Override
+  public String debugString() {
+    return "TABLE SCAN (" + _tableName + ")";
+  }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/TableScanNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/TableScanNode.java
@@ -48,7 +48,7 @@ public class TableScanNode extends AbstractStageNode {
   }
 
   @Override
-  public String debugString() {
+  public String explain() {
     return "TABLE SCAN (" + _tableName + ")";
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/ValueNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/ValueNode.java
@@ -53,7 +53,7 @@ public class ValueNode extends AbstractStageNode {
   }
 
   @Override
-  public String debugString() {
+  public String explain() {
     return "LITERAL";
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/ValueNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/ValueNode.java
@@ -51,4 +51,9 @@ public class ValueNode extends AbstractStageNode {
   public List<List<RexExpression>> getLiteralRows() {
     return _literalRows;
   }
+
+  @Override
+  public String debugString() {
+    return "LITERAL";
+  }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
@@ -57,6 +57,7 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
 
   private List<Object[]> queryRunner(String sql) {
     QueryPlan queryPlan = _queryEnvironment.planQuery(sql);
+    System.out.println(queryPlan.explain());
     Map<String, String> requestMetadataMap =
         ImmutableMap.of("REQUEST_ID", String.valueOf(RANDOM_REQUEST_ID_GEN.nextLong()));
     MailboxReceiveOperator mailboxReceiveOperator = null;

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
@@ -57,7 +57,6 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
 
   private List<Object[]> queryRunner(String sql) {
     QueryPlan queryPlan = _queryEnvironment.planQuery(sql);
-    System.out.println(queryPlan.explain());
     Map<String, String> requestMetadataMap =
         ImmutableMap.of("REQUEST_ID", String.valueOf(RANDOM_REQUEST_ID_GEN.nextLong()));
     MailboxReceiveOperator mailboxReceiveOperator = null;


### PR DESCRIPTION
Adds functionality to be able to call `QueryPlan#explain()` to see an `EXPLAIN`-like string. Here are some examples:

`SELECT * FROM b ORDER BY col1, col2 DESC LIMIT 3`
```
[0] MAIL_RECEIVE
└── [1] MAIL_SEND
    └── [1] SORT (LIMIT 3)
        └── [1] MAIL_RECEIVE
            └── [2] MAIL_SEND
                └── [2] TABLE SCAN (b) {Server_localhost_56777={REALTIME=[b1]}}
```

`SELECT a.col1, a.col3, b.col3 FROM a JOIN b ON MOD(a.col3, 2) = MOD(b.col3, 3)`
```
[0] MAIL_RECEIVE
└── [1] MAIL_SEND
    └── [1] PROJECT
        └── [1] JOIN
            ├── [1] MAIL_RECEIVE
            │   └── [2] MAIL_SEND
            │       └── [2] PROJECT
            │           └── [2] TABLE SCAN (a) {Server_localhost_56778={REALTIME=[a3]}, Server_localhost_56777={REALTIME=[a1, a2]}}
            └── [1] MAIL_RECEIVE
                └── [3] MAIL_SEND
                    └── [3] PROJECT
                        └── [3] TABLE SCAN (b) {Server_localhost_56777={REALTIME=[b1]}}
```

`SELECT col1, SUM(col3) FROM a WHERE a.col3 BETWEEN 23 AND 36 GROUP BY col1 HAVING SUM(col3) > 10.0 AND MIN(col3) <> 123 AND MAX(col3) BETWEEN 10 AND 20`
```
[0] MAIL_RECEIVE
└── [1] MAIL_SEND
    └── [1] PROJECT
        └── [1] FILTER
            └── [1] AGGREGATE
                └── [1] MAIL_RECEIVE
                    └── [2] MAIL_SEND
                        └── [2] AGGREGATE
                            └── [2] FILTER
                                └── [2] TABLE SCAN (a) {Server_localhost_56778={REALTIME=[a3]}, Server_localhost_56777={REALTIME=[a1, a2]}}
```