### PR TITLE
[multisage] fix queries with LIMIT and no ORDER BY

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotSortExchangeNodeInsertRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotSortExchangeNodeInsertRule.java
@@ -29,7 +29,7 @@ import org.apache.calcite.tools.RelBuilderFactory;
 
 
 /**
- * Special rule for Pinot, this rule is fixed to always insert exchange after JOIN node.
+ * Special rule for Pinot, this rule is fixed to always insert exchange after SORT node.
  */
 public class PinotSortExchangeNodeInsertRule extends RelOptRule {
   public static final PinotSortExchangeNodeInsertRule INSTANCE =
@@ -46,7 +46,7 @@ public class PinotSortExchangeNodeInsertRule extends RelOptRule {
     }
     if (call.rel(0) instanceof Sort) {
       Sort sort = call.rel(0);
-      return sort.getCollation().getFieldCollations().size() > 0 && !PinotRuleUtils.isExchange(sort.getInput());
+      return !PinotRuleUtils.isExchange(sort.getInput());
     }
     return false;
   }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
@@ -318,9 +318,12 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
         // using join clause
         new Object[]{"SELECT * FROM a JOIN b USING (col1)", 15},
 
+        // cannot compare with H2 w/o an ORDER BY because ordering is indeterminate
+        new Object[]{"SELECT * FROM a LIMIT 2", 2},
+
         // test dateTrunc
         //   - on leaf stage
-        new Object[]{"SELECT dateTrunc('DAY', ts) FROM a LIMIT 10", 15},
+        new Object[]{"SELECT dateTrunc('DAY', ts) FROM a LIMIT 10", 10},
         //   - on intermediate stage
         new Object[]{"SELECT dateTrunc('DAY', round(a.ts, b.ts)) FROM a JOIN b "
             + "ON a.col1 = b.col1 AND a.col2 = b.col2", 15},


### PR DESCRIPTION
before this change, the optimizer would allow pushing down of LIMIT clauses without any ORDER BY. This is a problem, because it doesn't have any top-level LIMIT which would limit the final results of the query. This PR fixes that problem. 

I will follow this up with another PR that adds an additional SORT stage at the top level.