### PR TITLE
Fix JsonExtractScalar when no value is extracted

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
@@ -966,7 +966,7 @@ public enum PinotDataType {
     if (value instanceof String) {
       try {
         // Try to parse the string as JSON first
-        return JsonUtils.stringToJsonNode((String) value).toString();
+        return JsonUtils.stringToJsonNodeWithBigDecimal((String) value).toString();
       } catch (JsonParseException jpe) {
         // String does not represent a well-formed JSON. Ignore this exception because we are going to try to convert
         // Java String object to JSON string.

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/evaluators/DefaultJsonPathEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/evaluators/DefaultJsonPathEvaluator.java
@@ -42,8 +42,8 @@ import org.apache.pinot.spi.utils.JsonUtils;
 public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
 
   // This ObjectMapper requires special configurations, hence we can't use pinot JsonUtils here.
-  private static final ObjectMapper OBJECT_MAPPER_WITH_BIG_DECIMAL = new ObjectMapper()
-      .configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true);
+  private static final ObjectMapper OBJECT_MAPPER_WITH_BIG_DECIMAL =
+      new ObjectMapper().enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS);
 
   private static final ParseContext JSON_PARSER_CONTEXT = JsonPath.using(
       new Configuration.ConfigurationBuilder().jsonProvider(new JacksonJsonProvider())
@@ -423,40 +423,80 @@ public final class DefaultJsonPathEvaluator implements JsonPathEvaluator {
     }
   }
 
+  @Nullable
   private <T> T extractFromBytes(Dictionary dictionary, int dictId) {
-    return JSON_PARSER_CONTEXT.parseUtf8(dictionary.getBytesValue(dictId)).read(_jsonPath);
+    try {
+      return JSON_PARSER_CONTEXT.parseUtf8(dictionary.getBytesValue(dictId)).read(_jsonPath);
+    } catch (Exception e) {
+      return null;
+    }
   }
 
+  @Nullable
   private <T, R extends ForwardIndexReaderContext> T extractFromBytes(ForwardIndexReader<R> reader, R context,
       int docId) {
-    return JSON_PARSER_CONTEXT.parseUtf8(reader.getBytes(docId, context)).read(_jsonPath);
+    try {
+      return JSON_PARSER_CONTEXT.parseUtf8(reader.getBytes(docId, context)).read(_jsonPath);
+    } catch (Exception e) {
+      return null;
+    }
   }
 
+  @Nullable
   private <T> T extractFromBytesWithExactBigDecimal(Dictionary dictionary, int dictId) {
-    return JSON_PARSER_CONTEXT_WITH_BIG_DECIMAL.parseUtf8(dictionary.getBytesValue(dictId)).read(_jsonPath);
+    try {
+      return JSON_PARSER_CONTEXT_WITH_BIG_DECIMAL.parseUtf8(dictionary.getBytesValue(dictId)).read(_jsonPath);
+    } catch (Exception e) {
+      return null;
+    }
   }
 
+  @Nullable
   private <R extends ForwardIndexReaderContext> BigDecimal extractFromBytesWithExactBigDecimal(
       ForwardIndexReader<R> reader, R context, int docId) {
-    return JSON_PARSER_CONTEXT_WITH_BIG_DECIMAL.parseUtf8(reader.getBytes(docId, context)).read(_jsonPath);
+    try {
+      return JSON_PARSER_CONTEXT_WITH_BIG_DECIMAL.parseUtf8(reader.getBytes(docId, context)).read(_jsonPath);
+    } catch (Exception e) {
+      return null;
+    }
   }
 
+  @Nullable
   private <T> T extractFromString(Dictionary dictionary, int dictId) {
-    return JSON_PARSER_CONTEXT.parse(dictionary.getStringValue(dictId)).read(_jsonPath);
+    try {
+      return JSON_PARSER_CONTEXT.parse(dictionary.getStringValue(dictId)).read(_jsonPath);
+    } catch (Exception e) {
+      return null;
+    }
   }
 
+  @Nullable
   private <T, R extends ForwardIndexReaderContext> T extractFromString(ForwardIndexReader<R> reader, R context,
       int docId) {
-    return JSON_PARSER_CONTEXT.parseUtf8(reader.getBytes(docId, context)).read(_jsonPath);
+    try {
+      return JSON_PARSER_CONTEXT.parseUtf8(reader.getBytes(docId, context)).read(_jsonPath);
+    } catch (Exception e) {
+      return null;
+    }
   }
 
+  @Nullable
   private <T> T extractFromStringWithExactBigDecimal(Dictionary dictionary, int dictId) {
-    return JSON_PARSER_CONTEXT_WITH_BIG_DECIMAL.parse(dictionary.getStringValue(dictId)).read(_jsonPath);
+    try {
+      return JSON_PARSER_CONTEXT_WITH_BIG_DECIMAL.parse(dictionary.getStringValue(dictId)).read(_jsonPath);
+    } catch (Exception e) {
+      return null;
+    }
   }
 
+  @Nullable
   private <R extends ForwardIndexReaderContext> BigDecimal extractFromStringWithExactBigDecimal(
       ForwardIndexReader<R> reader, R context, int docId) {
-    return JSON_PARSER_CONTEXT_WITH_BIG_DECIMAL.parseUtf8(reader.getBytes(docId, context)).read(_jsonPath);
+    try {
+      return JSON_PARSER_CONTEXT_WITH_BIG_DECIMAL.parseUtf8(reader.getBytes(docId, context)).read(_jsonPath);
+    } catch (Exception e) {
+      return null;
+    }
   }
 
   private void processValue(int index, Object value, int defaultValue, int[] valueBuffer) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
@@ -88,6 +88,7 @@ public abstract class BaseTransformFunctionTest {
   protected static final String TIME_COLUMN = "timeColumn";
   protected static final String TIMESTAMP_COLUMN = "timestampColumn";
   protected static final String JSON_COLUMN = "json";
+  protected static final String DEFAULT_JSON_COLUMN = "defaultJson";
   protected final int[] _intSVValues = new int[NUM_ROWS];
   protected final long[] _longSVValues = new long[NUM_ROWS];
   protected final float[] _floatSVValues = new float[NUM_ROWS];
@@ -184,7 +185,8 @@ public abstract class BaseTransformFunctionTest {
         .addSingleValueDimension(STRING_SV_COLUMN, FieldSpec.DataType.STRING)
         .addSingleValueDimension(STRING_ALPHANUM_SV_COLUMN, FieldSpec.DataType.STRING)
         .addSingleValueDimension(BYTES_SV_COLUMN, FieldSpec.DataType.BYTES)
-        .addSingleValueDimension(JSON_COLUMN, FieldSpec.DataType.STRING, Integer.MAX_VALUE, null)
+        .addSingleValueDimension(JSON_COLUMN, FieldSpec.DataType.JSON)
+        .addSingleValueDimension(DEFAULT_JSON_COLUMN, FieldSpec.DataType.JSON)
         .addMultiValueDimension(INT_MV_COLUMN, FieldSpec.DataType.INT)
         .addMultiValueDimension(LONG_MV_COLUMN, FieldSpec.DataType.LONG)
         .addMultiValueDimension(FLOAT_MV_COLUMN, FieldSpec.DataType.FLOAT)

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectReader;
@@ -79,6 +80,9 @@ public class JsonUtils {
   public static final ObjectReader DEFAULT_READER = DEFAULT_MAPPER.reader();
   public static final ObjectWriter DEFAULT_WRITER = DEFAULT_MAPPER.writer();
   public static final ObjectWriter DEFAULT_PRETTY_WRITER = DEFAULT_MAPPER.writerWithDefaultPrettyPrinter();
+  public static final ObjectReader READER_WITH_BIG_DECIMAL =
+      new ObjectMapper().enable(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS).reader();
+
   public static final TypeReference<HashMap<String, Object>> MAP_TYPE_REFERENCE =
       new TypeReference<HashMap<String, Object>>() {
       };
@@ -143,6 +147,11 @@ public class JsonUtils {
     return DEFAULT_READER.readTree(jsonString);
   }
 
+  public static JsonNode stringToJsonNodeWithBigDecimal(String jsonString)
+      throws IOException {
+    return READER_WITH_BIG_DECIMAL.readTree(jsonString);
+  }
+
   public static <T> T fileToObject(File jsonFile, Class<T> valueType)
       throws IOException {
     return DEFAULT_READER.forType(valueType).readValue(jsonFile);
@@ -168,8 +177,7 @@ public class JsonUtils {
   public static JsonNode fileToFirstJsonNode(File jsonFile)
       throws IOException {
     JsonFactory jf = new JsonFactory();
-    try (InputStream inputStream = new FileInputStream(jsonFile);
-        JsonParser jp = jf.createParser(inputStream)) {
+    try (InputStream inputStream = new FileInputStream(jsonFile); JsonParser jp = jf.createParser(inputStream)) {
       jp.setCodec(DEFAULT_MAPPER);
       jp.nextToken();
       if (jp.hasCurrentToken()) {


### PR DESCRIPTION
Fix 2 bugs:
- When the json extract evaluation is pushed down, return default value when json is not well formatted or is `"null"`
- Preserve BIG_DECIMAL within the JSON field