### PR TITLE
Add Support for IP Address Function

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
@@ -142,6 +142,22 @@ public class LiteralOnlyBrokerRequestTest {
         .compileToPinotQuery("SELECT count(*) from myTable where regexpReplace(col1, \"b(..)\", \"X$1Y\", 10 , 1, "
             + "\"m\")  = "
             + "\"fooXarYXazY\"")));
+    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(
+        CalciteSqlParser.compileToPinotQuery("select is_subnet_of('1.2.3.128/0', '192.168.5.1') from mytable")));
+    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery(
+        "select is_subnet_of('1.2.3.128/0', rtrim('192.168.5.1      ')) from mytable")));
+    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery(
+        "select is_subnet_of('123:db8:85a3::8a2e:370:7334/72', '124:db8:85a3::8a2e:370:7334') from mytable")));
+    Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(
+        CalciteSqlParser.compileToPinotQuery("select is_subnet_of('1.2.3.128/0', foo) from mytable")));
+    Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery(
+        "select count(*) from mytable where is_subnet_of('7890:db8:113::8a2e:370:7334/127', ltrim('   "
+            + "7890:db8:113::8a2e:370:7336'))")));
+    Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery(
+        "select count(*) from mytable where is_subnet_of('7890:db8:113::8a2e:370:7334/127', "
+            + "'7890:db8:113::8a2e:370:7336')")));
+    Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(
+        CalciteSqlParser.compileToPinotQuery("select count(*) from mytable where is_subnet_of(foo, bar)")));
   }
 
   @Test
@@ -157,6 +173,8 @@ public class LiteralOnlyBrokerRequestTest {
         "SELECT toUtf8('hello!') AS encoded, " + "fromUtf8(toUtf8('hello!')) AS decoded")));
     Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery(
         "SELECT toBase64(toUtf8('hello!')) AS encoded, " + "fromBase64('aGVsbG8h') AS decoded")));
+    Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery(
+        "select is_subnet_of('1.2.3.128/0', '192.168.5.1') AS booleanCol from mytable")));
   }
 
   @Test
@@ -320,6 +338,29 @@ public class LiteralOnlyBrokerRequestTest {
     Assert.assertEquals(brokerResponse.getTotalDocs(), 0);
 
     request = JsonUtils.stringToJsonNode("{\"sql\":\"SELECT fromBase64" + "(0) AS decoded\"}");
+    requestStats = Tracing.getTracer().createRequestScope();
+    brokerResponse = requestHandler.handleRequest(request, null, requestStats);
+    Assert.assertTrue(
+        brokerResponse.getProcessingExceptions().get(0).getMessage().contains("IllegalArgumentException"));
+
+    request = JsonUtils.stringToJsonNode(
+        "{\"sql\":\"SELECT is_subnet_of('2001:db8:85a3::8a2e:370:7334/62', '2001:0db8:85a3:0003:ffff:ffff:ffff:ffff')"
+            + " as booleanCol\"}");
+    requestStats = Tracing.getTracer().createRequestScope();
+    brokerResponse = requestHandler.handleRequest(request, null, requestStats);
+    resultTable = brokerResponse.getResultTable();
+    dataSchema = resultTable.getDataSchema();
+    rows = resultTable.getRows();
+    Assert.assertEquals(dataSchema.getColumnName(0), "booleanCol");
+    Assert.assertEquals(dataSchema.getColumnDataType(0), DataSchema.ColumnDataType.BOOLEAN);
+    Assert.assertEquals(rows.size(), 1);
+    Assert.assertEquals(rows.get(0).length, 1);
+    Assert.assertTrue((boolean) rows.get(0)[0]);
+    Assert.assertEquals(brokerResponse.getTotalDocs(), 0);
+
+    request = JsonUtils.stringToJsonNode(
+        "{\"sql\":\"SELECT is_subnet_of('2001:db8:85a3::8a2e:370:7334', '2001:0db8:85a3:0003:ffff:ffff:ffff:ffff') as"
+            + " booleanCol\"}");
     requestStats = Tracing.getTracer().createRequestScope();
     brokerResponse = requestHandler.handleRequest(request, null, requestStats);
     Assert.assertTrue(

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
@@ -143,21 +143,21 @@ public class LiteralOnlyBrokerRequestTest {
             + "\"m\")  = "
             + "\"fooXarYXazY\"")));
     Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(
-        CalciteSqlParser.compileToPinotQuery("select is_subnet_of('1.2.3.128/0', '192.168.5.1') from mytable")));
+        CalciteSqlParser.compileToPinotQuery("select isSubnetOf('1.2.3.128/0', '192.168.5.1') from mytable")));
     Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery(
-        "select is_subnet_of('1.2.3.128/0', rtrim('192.168.5.1      ')) from mytable")));
+        "select isSubnetOf('1.2.3.128/0', rtrim('192.168.5.1      ')) from mytable")));
     Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery(
-        "select is_subnet_of('123:db8:85a3::8a2e:370:7334/72', '124:db8:85a3::8a2e:370:7334') from mytable")));
+        "select isSubnetOf('123:db8:85a3::8a2e:370:7334/72', '124:db8:85a3::8a2e:370:7334') from mytable")));
     Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(
-        CalciteSqlParser.compileToPinotQuery("select is_subnet_of('1.2.3.128/0', foo) from mytable")));
+        CalciteSqlParser.compileToPinotQuery("select isSubnetOf('1.2.3.128/0', foo) from mytable")));
     Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery(
-        "select count(*) from mytable where is_subnet_of('7890:db8:113::8a2e:370:7334/127', ltrim('   "
+        "select count(*) from mytable where isSubnetOf('7890:db8:113::8a2e:370:7334/127', ltrim('   "
             + "7890:db8:113::8a2e:370:7336'))")));
     Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery(
-        "select count(*) from mytable where is_subnet_of('7890:db8:113::8a2e:370:7334/127', "
+        "select count(*) from mytable where isSubnetOf('7890:db8:113::8a2e:370:7334/127', "
             + "'7890:db8:113::8a2e:370:7336')")));
     Assert.assertFalse(BaseBrokerRequestHandler.isLiteralOnlyQuery(
-        CalciteSqlParser.compileToPinotQuery("select count(*) from mytable where is_subnet_of(foo, bar)")));
+        CalciteSqlParser.compileToPinotQuery("select count(*) from mytable where isSubnetOf(foo, bar)")));
   }
 
   @Test
@@ -174,7 +174,7 @@ public class LiteralOnlyBrokerRequestTest {
     Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery(
         "SELECT toBase64(toUtf8('hello!')) AS encoded, " + "fromBase64('aGVsbG8h') AS decoded")));
     Assert.assertTrue(BaseBrokerRequestHandler.isLiteralOnlyQuery(CalciteSqlParser.compileToPinotQuery(
-        "select is_subnet_of('1.2.3.128/0', '192.168.5.1') AS booleanCol from mytable")));
+        "select isSubnetOf('1.2.3.128/0', '192.168.5.1') AS booleanCol from mytable")));
   }
 
   @Test
@@ -344,7 +344,7 @@ public class LiteralOnlyBrokerRequestTest {
         brokerResponse.getProcessingExceptions().get(0).getMessage().contains("IllegalArgumentException"));
 
     request = JsonUtils.stringToJsonNode(
-        "{\"sql\":\"SELECT is_subnet_of('2001:db8:85a3::8a2e:370:7334/62', '2001:0db8:85a3:0003:ffff:ffff:ffff:ffff')"
+        "{\"sql\":\"SELECT isSubnetOf('2001:db8:85a3::8a2e:370:7334/62', '2001:0db8:85a3:0003:ffff:ffff:ffff:ffff')"
             + " as booleanCol\"}");
     requestStats = Tracing.getTracer().createRequestScope();
     brokerResponse = requestHandler.handleRequest(request, null, requestStats);
@@ -359,7 +359,7 @@ public class LiteralOnlyBrokerRequestTest {
     Assert.assertEquals(brokerResponse.getTotalDocs(), 0);
 
     request = JsonUtils.stringToJsonNode(
-        "{\"sql\":\"SELECT is_subnet_of('2001:db8:85a3::8a2e:370:7334', '2001:0db8:85a3:0003:ffff:ffff:ffff:ffff') as"
+        "{\"sql\":\"SELECT isSubnetOf('2001:db8:85a3::8a2e:370:7334', '2001:0db8:85a3:0003:ffff:ffff:ffff:ffff') as"
             + " booleanCol\"}");
     requestStats = Tracing.getTracer().createRequestScope();
     brokerResponse = requestHandler.handleRequest(request, null, requestStats);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/LiteralOnlyBrokerRequestTest.java
@@ -369,8 +369,7 @@ public class LiteralOnlyBrokerRequestTest {
 
     // first argument must be in prefix format
     request = JsonUtils.stringToJsonNode(
-        "{\"sql\":\"SELECT isSubnetOf('10.34.0.32', '10.34.0.40') as"
-            + " booleanCol\"}");
+        "{\"sql\":\"SELECT isSubnetOf('105.25.245.115', '105.25.245.115') as" + " booleanCol\"}");
     requestStats = Tracing.getTracer().createRequestScope();
     brokerResponse = requestHandler.handleRequest(request, null, requestStats);
     Assert.assertTrue(
@@ -378,8 +377,7 @@ public class LiteralOnlyBrokerRequestTest {
 
     // second argument should not be a prefix
     request = JsonUtils.stringToJsonNode(
-        "{\"sql\":\"SELECT isSubnetOf('10.3.168.0/22', '10.187.84.128/26') as"
-            + " booleanCol\"}");
+        "{\"sql\":\"SELECT isSubnetOf('10.3.168.0/22', '3.175.47.239/26') as" + " booleanCol\"}");
     requestStats = Tracing.getTracer().createRequestScope();
     brokerResponse = requestHandler.handleRequest(request, null, requestStats);
     Assert.assertTrue(
@@ -387,7 +385,8 @@ public class LiteralOnlyBrokerRequestTest {
 
     // second argument should not be a prefix
     request = JsonUtils.stringToJsonNode(
-        "{\"sql\":\"SELECT isSubnetOf('2a04:f547:255:1::/64', '2620:119:50e7:101::/64') as"
+        "{\"sql\":\"SELECT isSubnetOf('5f3f:bfdb:1bbe:a824:6bf9:0fbb:d358:1889/64', "
+            + "'4275:386f:b2b5:0664:04aa:d7bd:0589:6909/64') as"
             + " booleanCol\"}");
     requestStats = Tracing.getTracer().createRequestScope();
     brokerResponse = requestHandler.handleRequest(request, null, requestStats);
@@ -396,7 +395,7 @@ public class LiteralOnlyBrokerRequestTest {
 
     // invalid prefix length
     request = JsonUtils.stringToJsonNode(
-        "{\"sql\":\"SELECT isSubnetOf('2a04:f547:255:1::/129', '2620:119:50e7:101::') as"
+        "{\"sql\":\"SELECT isSubnetOf('2001:4801:7825:103:be76:4eff::/129', '2001:4801:7825:103:be76:4eff::') as"
             + " booleanCol\"}");
     requestStats = Tracing.getTracer().createRequestScope();
     brokerResponse = requestHandler.handleRequest(request, null, requestStats);
@@ -405,8 +404,7 @@ public class LiteralOnlyBrokerRequestTest {
 
     // invalid prefix length
     request = JsonUtils.stringToJsonNode(
-        "{\"sql\":\"SELECT isSubnetOf('10.3.168.0/33', '10.187.84.128') as"
-            + " booleanCol\"}");
+        "{\"sql\":\"SELECT isSubnetOf('170.189.0.175/33', '170.189.0.175') as" + " booleanCol\"}");
     requestStats = Tracing.getTracer().createRequestScope();
     brokerResponse = requestHandler.handleRequest(request, null, requestStats);
     Assert.assertTrue(

--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -449,7 +449,6 @@
     <dependency>
       <groupId>com.github.seancfoley</groupId>
       <artifactId>ipaddress</artifactId>
-      <version>5.3.4</version>
     </dependency>
   </dependencies>
   <profiles>

--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -446,6 +446,11 @@
       <artifactId>jbcrypt</artifactId>
       <version>0.4</version>
     </dependency>
+    <dependency>
+      <groupId>com.github.seancfoley</groupId>
+      <artifactId>ipaddress</artifactId>
+      <version>5.3.4</version>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/IpAddressFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/IpAddressFunctions.java
@@ -46,13 +46,7 @@ public class IpAddressFunctions {
    * Validates IP prefix prefixStr and returns IPAddress if validated
    */
   private static IPAddress getPrefix(String prefixStr) {
-    IPAddressString prefix = new IPAddressString(prefixStr);
-    IPAddress prefixAddr;
-    try {
-      prefixAddr = prefix.toAddress();
-    } catch (AddressStringException e) {
-      throw new IllegalArgumentException("Invalid IP Address format for " + prefix);
-    }
+    IPAddress prefixAddr = getAddress(prefixStr);
     if (!prefixAddr.isPrefixed()) {
       throw new IllegalArgumentException("IP Address " + prefixStr + " should be prefixed.");
     }
@@ -78,6 +72,9 @@ public class IpAddressFunctions {
   public static boolean isSubnetOf(String ipPrefix, String ipAddress) {
     IPAddress prefix = getPrefix(ipPrefix);
     IPAddress ip = getAddress(ipAddress);
+    if (ip.isPrefixed()) {
+      throw new IllegalArgumentException("IP Address " + ipAddress + " should not be prefixed.");
+    }
     return prefix.contains(ip);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/IpAddressFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/IpAddressFunctions.java
@@ -20,6 +20,8 @@
 package org.apache.pinot.common.function.scalar;
 
 import com.google.common.net.InetAddresses;
+import inet.ipaddr.IPAddress;
+import inet.ipaddr.IPAddressString;
 import java.math.BigInteger;
 import java.net.UnknownHostException;
 import org.apache.pinot.spi.annotations.ScalarFunction;
@@ -85,11 +87,16 @@ public class IpAddressFunctions {
     return addr;
   }
 
+  @ScalarFunction
+  public static boolean isSubnetOf(String ipPrefix, String ipAddress) {
+    IPAddress prefix = new IPAddressString(ipPrefix).getAddress().toPrefixBlock();
+    return prefix.contains(new IPAddressString(ipAddress).getAddress());
+  }
   /**
    * Returns true if ipAddress is in the subnet of ipPrefix (IPv4 or IPv6)
    */
   @ScalarFunction
-  public static boolean isSubnetOf(String ipPrefix, String ipAddress)
+  public static boolean isSubnetOfV1(String ipPrefix, String ipAddress)
       throws UnknownHostException {
     String[] prefixLengthPair = fromPrefixToPair(ipPrefix);
     byte[] addr = fromStringToBytes(prefixLengthPair[0]);

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/IpAddressFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/IpAddressFunctions.java
@@ -89,8 +89,12 @@ public class IpAddressFunctions {
 
   @ScalarFunction
   public static boolean isSubnetOf(String ipPrefix, String ipAddress) {
-    IPAddress prefix = new IPAddressString(ipPrefix).getAddress().toPrefixBlock();
-    return prefix.contains(new IPAddressString(ipAddress).getAddress());
+    IPAddressString prefix = new IPAddressString(ipPrefix);
+    if (!prefix.isPrefixed()) {
+      throw new IllegalArgumentException("Invalid IP prefix: " + ipPrefix);
+    }
+    IPAddress address = prefix.getAddress().toPrefixBlock();
+    return address.contains(new IPAddressString(ipAddress).getAddress());
   }
   /**
    * Returns true if ipAddress is in the subnet of ipPrefix (IPv4 or IPv6)

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/IpAddressFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/IpAddressFunctions.java
@@ -19,15 +19,10 @@
 
 package org.apache.pinot.common.function.scalar;
 
-import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.net.InetAddress;
 import java.net.UnknownHostException;
 import org.apache.pinot.spi.annotations.ScalarFunction;
 import com.google.common.net.InetAddresses;
-
-import static java.lang.Math.max;
-import static java.lang.Math.min;
 
 
 public class IpAddressFunctions {

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/IpAddressFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/IpAddressFunctions.java
@@ -1,0 +1,124 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.common.function.scalar;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import org.apache.pinot.spi.annotations.ScalarFunction;
+import com.google.common.net.InetAddresses;
+
+import static java.lang.Math.max;
+import static java.lang.Math.min;
+
+
+public class IpAddressFunctions {
+
+  private IpAddressFunctions() {
+  }
+
+  /**
+   * Returns true if ipAddress is in the subnet of ipPrefix
+   * ipPrefix is in cidr format (IPv4 or IPv6)
+   */
+  @ScalarFunction
+  public static boolean isSubnetOf(String ipPrefix, String ipAddress)
+      throws UnknownHostException {
+    if (!ipPrefix.contains("/")) {
+      throw new IllegalArgumentException("Invalid IP prefix: " + ipPrefix);
+    }
+    byte[] address;
+    byte[] argAddress;
+    int subnetSize;
+
+    String[] prefixLengthPair = ipPrefix.split("/");
+    try {
+      address = InetAddresses.forString(prefixLengthPair[0]).getAddress();
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Invalid IP prefix: " + ipPrefix);
+    }
+    subnetSize = Integer.parseInt(prefixLengthPair[1]);
+    try {
+      argAddress = InetAddresses.forString(ipAddress).getAddress();
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Invalid IP: " + ipAddress);
+    }
+    BigInteger arg = new BigInteger(argAddress);
+    byte[] copy = new byte[address.length];
+    for (int i = 0; i < copy.length; i++) {
+      copy[i] = address[i];
+    }
+
+    if (address.length == 4) {
+      // IPv4
+      if (subnetSize < 0 || 32 < subnetSize) {
+        throw new IllegalArgumentException("Invalid IP prefix: " + ipPrefix);
+      }
+      if (subnetSize == 0) {
+        return true;
+      }
+      int shift;
+      for (int i = 0; i < 4; i++) {
+        if (32 - subnetSize > i * 8) {
+          shift = (32 - subnetSize - i * 8) < 8 ? (32 - subnetSize - i * 8) : 8;
+          address[3 - i] &= -0x1 << shift;
+        }
+      }
+      BigInteger min = new BigInteger(address);
+
+      for (int i = 0; i < 4; i++) {
+        if (32 - subnetSize > i * 8) {
+          shift = (32 - subnetSize - i * 8) < 8 ? (32 - subnetSize - i * 8) : 8;
+          copy[3 - i] |= ~(-0x1 << shift);
+        }
+      }
+      BigInteger max = new BigInteger(copy);
+      return min.compareTo(arg) <= 0 && max.compareTo(arg) >= 0;
+    } else if (address.length == 16) {
+      // IPv6
+      if (subnetSize < 0 || 128 < subnetSize) {
+        throw new IllegalArgumentException("Invalid IP prefix: " + ipPrefix);
+      }
+      if (subnetSize == 0) {
+        return true;
+      }
+      int shift;
+      for (int i = 0; i < 16; i++) {
+        if (128 - subnetSize > i * 8) {
+          shift = (128 - subnetSize - i * 8) < 8 ? (128 - subnetSize - i * 8) : 8;
+          address[15 - i] &= -0x1 << shift;
+        }
+      }
+      BigInteger min = new BigInteger(address);
+
+      for (int i = 0; i < 16; i++) {
+        if (128 - subnetSize > i * 8) {
+          shift = (128 - subnetSize - i * 8) < 8 ? (128 - subnetSize - i * 8) : 8;
+          copy[15 - i] |= ~(-0x1 << shift);
+        }
+      }
+      BigInteger max = new BigInteger(copy);
+      return min.compareTo(arg) <= 0 && max.compareTo(arg) >= 0;
+    } else {
+      throw new IllegalArgumentException("Invalid IP prefix: " + ipPrefix);
+    }
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/IpAddressFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/IpAddressFunctions.java
@@ -19,10 +19,10 @@
 
 package org.apache.pinot.common.function.scalar;
 
+import com.google.common.net.InetAddresses;
 import java.math.BigInteger;
 import java.net.UnknownHostException;
 import org.apache.pinot.spi.annotations.ScalarFunction;
-import com.google.common.net.InetAddresses;
 
 
 public class IpAddressFunctions {

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/IpAddressFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/IpAddressFunctions.java
@@ -53,10 +53,12 @@ public class IpAddressFunctions {
     try {
       address = InetAddresses.forString(ipAddress).getAddress();
     } catch (IllegalArgumentException e) {
-      throw new IllegalArgumentException("Invalid IP: " + ipAddress);
+      throw new IllegalArgumentException("Invalid IP: " + ipAddress + " due to " + e.getMessage());
     }
     if (address.length != 4 && address.length != 16) {
-      throw new IllegalArgumentException("Invalid IP: " + ipAddress);
+      throw new IllegalArgumentException(
+          "Valid IP address should have length 32 (IPv4) or 128 (IPv6). Invalid IP " + ipAddress + " has length "
+              + address.length);
     }
     return address;
   }
@@ -93,11 +95,14 @@ public class IpAddressFunctions {
     byte[] addr = fromStringToBytes(prefixLengthPair[0]);
     int subnetSize = Integer.parseInt(prefixLengthPair[1]);
     if (subnetSize < 0 || addr.length * 8 < subnetSize) {
-      throw new IllegalArgumentException("Invalid IP prefix: " + ipPrefix);
+      throw new IllegalArgumentException("Invalid subnet size " + subnetSize
+          + ". IPv4 subnet size should be in range [0, 32]. IPv6 subnet size should be in range [0, 128].");
     }
     byte[] argAddress = fromStringToBytes(ipAddress);
     if (argAddress.length != addr.length) {
-      throw new IllegalArgumentException("IP type of " + ipAddress + " is different from " + ipPrefix);
+      String argType = argAddress.length == 32 ? "IPv4" : "IPv6";
+      String addrType = addr.length == 32 ? "IPv4" : "IPv6";
+      throw new IllegalArgumentException(ipAddress + " is " + argType + ", but " + ipPrefix + " is " + addrType);
     }
     if (subnetSize == 0) {
       // all IPs are in range

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -115,8 +115,6 @@ public class RequestUtils {
       } else {
         literal.setDoubleValue(node.bigDecimalValue().doubleValue());
       }
-    } else if (node.getTypeName().equals(SqlTypeName.BOOLEAN)) {
-      literal.setBoolValue(node.booleanValue());
     } else {
       // TODO: Support null literal and other types.
       switch (node.getTypeName()) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNumericLiteral;
-import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNumericLiteral;
+import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
@@ -114,6 +115,8 @@ public class RequestUtils {
       } else {
         literal.setDoubleValue(node.bigDecimalValue().doubleValue());
       }
+    } else if (node.getTypeName().equals(SqlTypeName.BOOLEAN)) {
+      literal.setBoolValue(node.booleanValue());
     } else {
       // TODO: Support null literal and other types.
       switch (node.getTypeName()) {

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -2025,45 +2025,50 @@ public class CalciteSqlCompilerTest {
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
-    query = "select isSubnetOf('10.34.0.32/27', '10.34.0.40') from mytable";
+    query = "select isSubnetOf('130.191.23.32/27', '130.191.23.40') from mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
-    query = "select isSubnetOf('10.32.229.160/28', '10.32.229.166') from mytable";
+    query = "select isSubnetOf('130.191.23.32/26', '130.192.23.33') from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
+    Assert.assertFalse(result);
+
+    query = "select isSubnetOf('153.87.199.160/28', '153.87.199.166') from mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
-    query = "select isSubnetOf('2a04:f547:255:1::/64', '2a04:f547:255:1::2050') from mytable";
+    query = "select isSubnetOf('2001:4800:7825:103::/64', '2001:4800:7825:103::2050') from mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
-    query = "select isSubnetOf('10.154.116.0/26', '10.154.116.21') from mytable";
+    query = "select isSubnetOf('130.191.23.32/26', '130.191.23.33') from mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
-    query = "select isSubnetOf('2620:119:50e7:101::/64', '2620:119:50e7:101::9002:e15') from mytable";
+    query = "select isSubnetOf('2001:4801:7825:103:be76:4efe::/96', '2001:4801:7825:103:be76:4efe::e15') from mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
-    query = "select isSubnetOf('144.2.15.0/26', '144.2.15.28') from mytable";
+    query = "select isSubnetOf('122.152.15.0/26', '122.152.15.28') from mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
-    query = "select isSubnetOf('10.252.186.64/26', '10.252.186.79') from mytable";
+    query = "select isSubnetOf('96.141.228.254/26', '96.141.228.254') from mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
-    query = "select isSubnetOf('10.187.84.128/26', '10.187.84.178') from mytable";
+    query = "select isSubnetOf('3.175.47.128/26', '3.175.48.178') from mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
-    Assert.assertTrue(result);
+    Assert.assertFalse(result);
 
     query = "select isSubnetOf('192.168.0.1/24', '192.168.0.0') from mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -1981,6 +1981,66 @@ public class CalciteSqlCompilerTest {
     }
     Assert.assertNotNull(expectedError);
     Assert.assertTrue(expectedError instanceof SqlCompilationException);
+
+    query = "select is_subnet_of('192.168.0.1/24', '192.168.0.225') from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    String result = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
+    Assert.assertEquals(result, "true");
+
+    query = "select is_subnet_of('192.168.0.1/24', '192.168.0.1') from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    result = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
+    Assert.assertEquals(result, "true");
+
+    query = "select is_subnet_of('192.168.0.1/24', '192.168.0.0') from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    result = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
+    Assert.assertEquals(result, "true");
+
+    query = "select is_subnet_of('10.3.168.0/22', '10.3.168.123') from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    result = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
+    Assert.assertEquals(result, "true");
+
+    query = "select is_subnet_of('10.3.168.0/22', '10.3.171.255') from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    result = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
+    Assert.assertEquals(result, "true");
+
+    query = "select is_subnet_of('10.3.168.0/22', '1.2.3.1') from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    result = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
+    Assert.assertEquals(result, "false");
+
+    query = "select is_subnet_of('1.2.3.128/1', '127.255.255.255') from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    result = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
+    Assert.assertEquals(result, "true");
+
+    query = "select is_subnet_of('1.2.3.128/0', '192.168.5.1') from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    result = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
+    Assert.assertEquals(result, "true");
+
+    query = "select is_subnet_of('2001:db8:85a3::8a2e:370:7334/62', '2001:0db8:85a3:0003:ffff:ffff:ffff:ffff') from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    result = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
+    Assert.assertEquals(result, "true");
+
+    query = "select is_subnet_of('123:db8:85a3::8a2e:370:7334/72', '124:db8:85a3::8a2e:370:7334') from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    result = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
+    Assert.assertEquals(result, "false");
+
+    query = "select is_subnet_of('7890:db8:113::8a2e:370:7334/127', '7890:db8:113::8a2e:370:7336') from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    result = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
+    Assert.assertEquals(result, "false");
+
+    query = "select is_subnet_of('7890:db8:113::8a2e:370:7334/127', '7890:db8:113::8a2e:370:7335') from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    result = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
+    Assert.assertEquals(result, "true");
   }
 
   @Test

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -2022,7 +2022,9 @@ public class CalciteSqlCompilerTest {
     result = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
     Assert.assertEquals(result, "true");
 
-    query = "select is_subnet_of('2001:db8:85a3::8a2e:370:7334/62', '2001:0db8:85a3:0003:ffff:ffff:ffff:ffff') from mytable";
+    query =
+        "select is_subnet_of('2001:db8:85a3::8a2e:370:7334/62', '2001:0db8:85a3:0003:ffff:ffff:ffff:ffff') from "
+            + "mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getStringValue();
     Assert.assertEquals(result, "true");

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -363,7 +363,7 @@ public class CalciteSqlCompilerTest {
 
     {
       PinotQuery pinotQuery =
-          CalciteSqlParser.compileToPinotQuery("select * from vegetable where is_subnet_of('192.168.0.1/24', foo)");
+          CalciteSqlParser.compileToPinotQuery("select * from vegetable where isSubnetOf('192.168.0.1/24', foo)");
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.EQUALS.name());
       List<Expression> operands = func.getOperands();
@@ -374,7 +374,7 @@ public class CalciteSqlCompilerTest {
 
     {
       PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
-          "select * from vegetable where is_subnet_of('192.168.0.1/24', foo)=true AND is_subnet_of('192.168.0.1/24', "
+          "select * from vegetable where isSubnetOf('192.168.0.1/24', foo)=true AND isSubnetOf('192.168.0.1/24', "
               + "foo)");
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.AND.name());
@@ -2015,64 +2015,104 @@ public class CalciteSqlCompilerTest {
     Assert.assertNotNull(expectedError);
     Assert.assertTrue(expectedError instanceof SqlCompilationException);
 
-    query = "select is_subnet_of('192.168.0.1/24', '192.168.0.225') from mytable";
+    query = "select isSubnetOf('192.168.0.1/24', '192.168.0.225') from mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     boolean result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
-    query = "select is_subnet_of('192.168.0.1/24', '192.168.0.1') from mytable";
+    query = "select isSubnetOf('192.168.0.1/24', '192.168.0.1') from mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
-    query = "select is_subnet_of('192.168.0.1/24', '192.168.0.0') from mytable";
+    query = "select isSubnetOf('10.34.0.32/27', '10.34.0.40') from mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
-    query = "select is_subnet_of('10.3.168.0/22', '10.3.168.123') from mytable";
+    query = "select isSubnetOf('10.32.229.160/28', '10.32.229.166') from mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
-    query = "select is_subnet_of('10.3.168.0/22', '10.3.171.255') from mytable";
+    query = "select isSubnetOf('2a04:f547:255:1::/64', '2a04:f547:255:1::2050') from mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
-    query = "select is_subnet_of('10.3.168.0/22', '1.2.3.1') from mytable";
+    query = "select isSubnetOf('10.154.116.0/26', '10.154.116.21') from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
+    Assert.assertTrue(result);
+
+    query = "select isSubnetOf('2620:119:50e7:101::/64', '2620:119:50e7:101::9002:e15') from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
+    Assert.assertTrue(result);
+
+    query = "select isSubnetOf('144.2.15.0/26', '144.2.15.28') from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
+    Assert.assertTrue(result);
+
+    query = "select isSubnetOf('10.252.186.64/26', '10.252.186.79') from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
+    Assert.assertTrue(result);
+
+    query = "select isSubnetOf('10.187.84.128/26', '10.187.84.178') from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
+    Assert.assertTrue(result);
+
+    query = "select isSubnetOf('192.168.0.1/24', '192.168.0.0') from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
+    Assert.assertTrue(result);
+
+    query = "select isSubnetOf('10.3.168.0/22', '10.3.168.123') from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
+    Assert.assertTrue(result);
+
+    query = "select isSubnetOf('10.3.168.0/22', '10.3.171.255') from mytable";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
+    Assert.assertTrue(result);
+
+    query = "select isSubnetOf('10.3.168.0/22', '1.2.3.1') from mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertFalse(result);
 
-    query = "select is_subnet_of('1.2.3.128/1', '127.255.255.255') from mytable";
+    query = "select isSubnetOf('1.2.3.128/1', '127.255.255.255') from mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
-    query = "select is_subnet_of('1.2.3.128/0', '192.168.5.1') from mytable";
+    query = "select isSubnetOf('1.2.3.128/0', '192.168.5.1') from mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
     query =
-        "select is_subnet_of('2001:db8:85a3::8a2e:370:7334/62', '2001:0db8:85a3:0003:ffff:ffff:ffff:ffff') from "
+        "select isSubnetOf('2001:db8:85a3::8a2e:370:7334/62', '2001:0db8:85a3:0003:ffff:ffff:ffff:ffff') from "
             + "mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);
 
-    query = "select is_subnet_of('123:db8:85a3::8a2e:370:7334/72', '124:db8:85a3::8a2e:370:7334') from mytable";
+    query = "select isSubnetOf('123:db8:85a3::8a2e:370:7334/72', '124:db8:85a3::8a2e:370:7334') from mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertFalse(result);
 
-    query = "select is_subnet_of('7890:db8:113::8a2e:370:7334/127', '7890:db8:113::8a2e:370:7336') from mytable";
+    query = "select isSubnetOf('7890:db8:113::8a2e:370:7334/127', '7890:db8:113::8a2e:370:7336') from mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertFalse(result);
 
-    query = "select is_subnet_of('7890:db8:113::8a2e:370:7334/127', '7890:db8:113::8a2e:370:7335') from mytable";
+    query = "select isSubnetOf('7890:db8:113::8a2e:370:7334/127', '7890:db8:113::8a2e:370:7335') from mytable";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     result = pinotQuery.getSelectList().get(0).getLiteral().getBoolValue();
     Assert.assertTrue(result);

--- a/pinot-connectors/prestodb-pinot-dependencies/pinot-common-jdk8/pom.xml
+++ b/pinot-connectors/prestodb-pinot-dependencies/pinot-common-jdk8/pom.xml
@@ -430,5 +430,9 @@
       <artifactId>jbcrypt</artifactId>
       <version>0.4</version>
     </dependency>
+    <dependency>
+      <groupId>com.github.seancfoley</groupId>
+      <artifactId>ipaddress</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/pinot-core/src/test/java/org/apache/pinot/queries/IsSubnetOfQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/IsSubnetOfQueriesTest.java
@@ -27,8 +27,6 @@ import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
-import org.apache.pinot.core.operator.query.SelectionOnlyOperator;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
@@ -136,12 +134,12 @@ public class IsSubnetOfQueriesTest extends BaseQueriesTest {
     List<Object[]> rows = resultTable.getRows();
     for (int i = 0; i < rows.size(); i++) {
       Object[] row = rows.get(i);
-      boolean IPv4Result = (boolean) row[0];
-      boolean IPv6Result = (boolean) row[1];
+      boolean iPv4Result = (boolean) row[0];
+      boolean iPv6Result = (boolean) row[1];
       boolean expectedIPv4Result = (boolean) row[2];
       boolean expectedIPv6Result = (boolean) row[3];
-      assertEquals(IPv4Result, expectedIPv4Result);
-      assertEquals(IPv6Result, expectedIPv6Result);
+      assertEquals(iPv4Result, expectedIPv4Result);
+      assertEquals(iPv6Result, expectedIPv6Result);
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/IsSubnetOfQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/IsSubnetOfQueriesTest.java
@@ -1,0 +1,197 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
+import org.apache.pinot.core.operator.query.SelectionOnlyOperator;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+/**
+ * Queries test for Subnet Containment for IP Address queries.
+ */
+public class IsSubnetOfQueriesTest extends BaseQueriesTest {
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "IsSubnetOfQueriesTest");
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String SEGMENT_NAME = "testSegment";
+
+  private static final String IPv4_PREFIX_COLUMN_STRING = "IPv4prefixColumn";
+  private static final String IPv6_PREFIX_COLUMN_STRING = "IPv6prefixColumn";
+  private static final String IPv4_ADDRESS_COLUMN = "IPv4AddressColumn";
+  private static final String IPv6_ADDRESS_COLUMN = "IPv6AddressColumn";
+  // columns storing hardcoded expected results:
+  // isSubnetOf(IPv4prefixColumn, IPv4AddressColumn), isSubnetOf(IPv6prefixColumn, IPv6AddressColumn)
+  private static final String IPv4_CONTAINS_COLUMN = "IPv4ContainsColumn";
+  private static final String IPv6_CONTAINS_COLUMN = "IPv6ContainsColumn";
+
+  private static final String DEFAULT_IPv4_PREFIX = "1.2.3.128/26";
+  private static final String DEFAULT_IPv6_PREFIX = "64:fa9b::17/64";
+  private static final String DEFAULT_IPv4_ADDRESS = "1.2.3.129";
+  private static final String DEFAULT_IPv6_ADDRESS = "64:ffff::17";
+  private static final boolean DEFAULT_IPv4_CONTAINS = true;
+  private static final boolean DEFAULT_IPv6_CONTAINS = false;
+
+  private static final Schema SCHEMA = new Schema.SchemaBuilder().
+      addSingleValueDimension(IPv4_PREFIX_COLUMN_STRING, FieldSpec.DataType.STRING)
+      .addSingleValueDimension(IPv6_PREFIX_COLUMN_STRING, FieldSpec.DataType.STRING)
+      .addSingleValueDimension(IPv4_ADDRESS_COLUMN, FieldSpec.DataType.STRING)
+      .addSingleValueDimension(IPv6_ADDRESS_COLUMN, FieldSpec.DataType.STRING)
+      .addSingleValueDimension(IPv4_CONTAINS_COLUMN, FieldSpec.DataType.BOOLEAN)
+      .addSingleValueDimension(IPv6_CONTAINS_COLUMN, FieldSpec.DataType.BOOLEAN).build();
+  private static final TableConfig TABLE_CONFIG =
+      new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+  private IndexSegment _indexSegment;
+  private List<IndexSegment> _indexSegments;
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteDirectory(INDEX_DIR);
+
+    List<GenericRow> records = new ArrayList<>();
+
+    // add IPv4 test cases
+    addIPv4Row(records, "10.34.0.32/27", "10.34.0.40", true);
+    addIPv4Row(records, "10.32.229.160/28", "10.32.229.166", true);
+    addIPv4Row(records, "10.154.116.0/26", "10.154.116.21", true);
+    addIPv4Row(records, "144.2.15.0/26", "144.2.15.28", true);
+    addIPv4Row(records, "10.252.186.64/26", "10.252.186.79", true);
+    addIPv4Row(records, "10.187.84.128/26", "10.187.84.178", true);
+
+    // add IPv6 test cases
+    addIPv6Row(records, "2a04:f547:255:1::/64", "2a04:f547:255:1::2050", true);
+    addIPv6Row(records, "2620:119:50e7:101::/64", "2620:119:50e7:101::9002:e15", true);
+    addIPv6Row(records, "2001:db8:85a3::8a2e:370:7334/62", "2001:0db8:85a3:0003:ffff:ffff:ffff:ffff", true);
+
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE_CONFIG, SCHEMA);
+    segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
+    segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
+    segmentGeneratorConfig.setOutDir(INDEX_DIR.getPath());
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records));
+    driver.build();
+
+    ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.mmap);
+    _indexSegment = immutableSegment;
+    _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
+  }
+
+  @Test
+  public void testIsSubnetOf() {
+
+    // called in select
+    String query = String.format(
+        "select isSubnetOf(%s, %s) as IPv4Result, isSubnetOf(%s, %s) as IPv6Result, %s, %s from %s limit 100",
+        IPv4_PREFIX_COLUMN_STRING, IPv4_ADDRESS_COLUMN, IPv6_PREFIX_COLUMN_STRING, IPv6_ADDRESS_COLUMN,
+        IPv4_CONTAINS_COLUMN, IPv6_CONTAINS_COLUMN, RAW_TABLE_NAME);
+    BrokerResponseNative brokerResponse = getBrokerResponse(query);
+    ResultTable resultTable = brokerResponse.getResultTable();
+    DataSchema dataSchema = resultTable.getDataSchema();
+    assertEquals(dataSchema.getColumnDataTypes(),
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.BOOLEAN, DataSchema.ColumnDataType.BOOLEAN,
+            DataSchema.ColumnDataType.BOOLEAN, DataSchema.ColumnDataType.BOOLEAN});
+    List<Object[]> rows = resultTable.getRows();
+    for (int i = 0; i < rows.size(); i++) {
+      Object[] row = rows.get(i);
+      boolean IPv4Result = (boolean) row[0];
+      boolean IPv6Result = (boolean) row[1];
+      boolean expectedIPv4Result = (boolean) row[2];
+      boolean expectedIPv6Result = (boolean) row[3];
+      assertEquals(IPv4Result, expectedIPv4Result);
+      assertEquals(IPv6Result, expectedIPv6Result);
+    }
+  }
+
+
+  private void addIPv4Row(List<GenericRow> records, String prefix, String address, boolean expectedBool) {
+    // add lib call assertEquals(expectedBool, );
+    GenericRow record = new GenericRow();
+    record.putValue(IPv4_PREFIX_COLUMN_STRING, prefix);
+    record.putValue(IPv4_ADDRESS_COLUMN, address);
+    record.putValue(IPv4_CONTAINS_COLUMN, expectedBool);
+
+    record.putValue(IPv6_PREFIX_COLUMN_STRING, DEFAULT_IPv6_PREFIX);
+    record.putValue(IPv6_ADDRESS_COLUMN, DEFAULT_IPv6_ADDRESS);
+    record.putValue(IPv6_CONTAINS_COLUMN, DEFAULT_IPv6_CONTAINS);
+    records.add(record);
+  }
+
+  private void addIPv6Row(List<GenericRow> records, String prefix, String address, boolean expectedBool) {
+    // add lib call assertEquals(expectedBool, );
+    GenericRow record = new GenericRow();
+    record.putValue(IPv6_PREFIX_COLUMN_STRING, prefix);
+    record.putValue(IPv6_ADDRESS_COLUMN, address);
+    record.putValue(IPv6_CONTAINS_COLUMN, expectedBool);
+
+    record.putValue(IPv4_PREFIX_COLUMN_STRING, DEFAULT_IPv4_PREFIX);
+    record.putValue(IPv4_ADDRESS_COLUMN, DEFAULT_IPv4_ADDRESS);
+    record.putValue(IPv4_CONTAINS_COLUMN, DEFAULT_IPv4_CONTAINS);
+    records.add(record);
+  }
+
+
+  @Override
+  protected String getFilter() {
+    return null;
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    _indexSegment.destroy();
+    FileUtils.deleteDirectory(INDEX_DIR);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/IsSubnetOfQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/IsSubnetOfQueriesTest.java
@@ -93,19 +93,27 @@ public class IsSubnetOfQueriesTest extends BaseQueriesTest {
     List<GenericRow> records = new ArrayList<>();
 
     // add IPv4 test cases
-    addIPv4Row(records, "10.34.0.32/27", "10.34.0.40", true);
-    addIPv4Row(records, "10.32.229.160/28", "10.32.229.166", true);
-    addIPv4Row(records, "10.154.116.0/26", "10.154.116.21", true);
-    addIPv4Row(records, "144.2.15.0/26", "144.2.15.28", true);
-    addIPv4Row(records, "10.252.186.64/26", "10.252.186.79", true);
-    addIPv4Row(records, "10.187.84.128/26", "10.187.84.178", true);
+    addIPv4Row(records, "105.25.245.115/27", "105.25.245.98", true);
+    addIPv4Row(records, "122.152.0.204/28", "122.152.0.198", true);
+    addIPv4Row(records, "130.191.23.32/26", "130.191.23.33", true);
+    addIPv4Row(records, "122.152.15.0/26", "122.152.15.28", true);
+    addIPv4Row(records, "96.141.228.254/26", "96.141.228.254", true);
+    addIPv4Row(records, "3.175.47.128/26", "3.175.47.178", true);
+
+    addIPv4Row(records, "105.25.245.115/27", "105.25.245.0", false);
+    addIPv4Row(records, "122.152.0.204/28", "122.152.0.254", false);
+    addIPv4Row(records, "130.191.23.32/26", "130.192.23.33", false);
+    addIPv4Row(records, "122.152.15.0/26", "122.152.0.63", false);
+    addIPv4Row(records, "96.141.228.254/26", "96.141.227.254", false);
+    addIPv4Row(records, "3.175.47.128/26", "3.175.48.178", false);
+
     addIPv4Row(records, "10.3.168.0/22", "1.2.3.1", false);
     addIPv4Row(records, "1.2.3.128/26", "1.2.5.1", false);
     addIPv4Row(records, "1.2.3.128/26", "1.1.3.1", false);
 
     // add IPv6 test cases
-    addIPv6Row(records, "2a04:f547:255:1::/64", "2a04:f547:255:1::2050", true);
-    addIPv6Row(records, "2620:119:50e7:101::/64", "2620:119:50e7:101::9002:e15", true);
+    addIPv6Row(records, "2001:4800:7825:103::/64", "2001:4800:7825:103::2050", true);
+    addIPv6Row(records, "2001:4801:7825:103:be76:4efe::/96", "2001:4801:7825:103:be76:4efe::e15", true);
     addIPv6Row(records, "2001:db8:85a3::8a2e:370:7334/62", "2001:0db8:85a3:0003:ffff:ffff:ffff:ffff", true);
     addIPv6Row(records, "7890:db8:113::8a2e:370:7334/127", "7890:db8:113::8a2e:370:7336", false);
     addIPv6Row(records, "64:ff9b::17/64", "64:ffff::17", false);

--- a/pom.xml
+++ b/pom.xml
@@ -1198,16 +1198,14 @@
         <artifactId>h3</artifactId>
         <version>${h3.version}</version>
       </dependency>
+
+      <dependency>
+        <groupId>com.github.seancfoley</groupId>
+        <artifactId>ipaddress</artifactId>
+        <version>5.3.4</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
-  <dependencies>
-    <dependency>
-      <groupId>com.github.seancfoley</groupId>
-      <artifactId>ipaddress</artifactId>
-      <version>5.3.4</version>
-      <scope>compile</scope>
-    </dependency>
-  </dependencies>
   <build>
     <defaultGoal>clean install</defaultGoal>
     <extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -1200,6 +1200,14 @@
       </dependency>
     </dependencies>
   </dependencyManagement>
+  <dependencies>
+    <dependency>
+      <groupId>com.github.seancfoley</groupId>
+      <artifactId>ipaddress</artifactId>
+      <version>5.3.4</version>
+      <scope>compile</scope>
+    </dependency>
+  </dependencies>
   <build>
     <defaultGoal>clean install</defaultGoal>
     <extensions>


### PR DESCRIPTION
Label = `feature`

This PR adds a scalar function `isSubnetOff(IP_PREFIX, IP_ADDRESS)` which checks if `IP_ADDRESS` is in the subnet of  `IP_PREFIX` (this function handles both IPv4 and IPv6).

Both `IP_PREFIX` and `IP_ADDRESS` are `STRING` type.

Use Cases
`SELECT isSubnetOf('1.2.3.128/26', '1.2.3.129') FROM FOO` --> returns true  
`SELECT isSubnetOf('64:fa9b::17/64', '64:ffff::17') FROM FOO` --> returns false  