### PR TITLE
[multistage] support SORT operator push-down

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/InnerSort.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/InnerSort.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import org.apache.calcite.plan.Convention;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelCollation;
+import org.apache.calcite.rel.RelCollationTraitDef;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.RelShuttle;
+import org.apache.calcite.rel.core.Sort;
+import org.apache.calcite.rex.RexNode;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+
+/**
+ * An instance of {@code Sort} which indicates that it has been pushed
+ * down to the leaf (server).
+ *
+ * <p>Implementation is copied from {@link org.apache.calcite.rel.logical.LogicalSort},
+ * which is final (so we cannot just extend it).
+ */
+public class InnerSort extends Sort {
+
+  private InnerSort(RelOptCluster cluster, RelTraitSet traitSet,
+      RelNode input, RelCollation collation, @Nullable RexNode offset, @Nullable RexNode fetch) {
+    super(cluster, traitSet, input, collation, offset, fetch);
+    assert traitSet.containsIfApplicable(Convention.NONE);
+  }
+
+  /**
+   * Creates a InnerSort.
+   *
+   * @param input     Input relational expression
+   * @param collation array of sort specifications
+   * @param offset    Expression for number of rows to discard before returning
+   *                  first row
+   * @param fetch     Expression for number of rows to fetch
+   */
+  public static InnerSort create(RelNode input, RelCollation collation,
+      @Nullable RexNode offset, @Nullable RexNode fetch) {
+    RelOptCluster cluster = input.getCluster();
+    collation = RelCollationTraitDef.INSTANCE.canonize(collation);
+    RelTraitSet traitSet =
+        input.getTraitSet().replace(Convention.NONE).replace(collation);
+    return new InnerSort(cluster, traitSet, input, collation, offset, fetch);
+  }
+
+  //~ Methods ----------------------------------------------------------------
+
+  @Override public Sort copy(RelTraitSet traitSet, RelNode newInput,
+      RelCollation newCollation, @Nullable RexNode offset, @Nullable RexNode fetch) {
+    return new InnerSort(getCluster(), traitSet, newInput, newCollation,
+        offset, fetch);
+  }
+
+  @Override public RelNode accept(RelShuttle shuttle) {
+    return shuttle.visit(this);
+  }
+}

--- a/pinot-query-planner/src/test/java/org/apache/calcite/rel/rules/PinotSortExchangeNodeInsertRuleTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/calcite/rel/rules/PinotSortExchangeNodeInsertRuleTest.java
@@ -1,0 +1,147 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import com.google.common.collect.ImmutableList;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelTraitSet;
+import org.apache.calcite.rel.RelCollations;
+import org.apache.calcite.rel.RelDistributions;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Exchange;
+import org.apache.calcite.rel.logical.LogicalExchange;
+import org.apache.calcite.rel.logical.LogicalSort;
+import org.apache.calcite.rel.type.RelDataTypeSystemImpl;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.sql.type.SqlTypeFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class PinotSortExchangeNodeInsertRuleTest {
+
+  private final SqlTypeFactoryImpl _types = new SqlTypeFactoryImpl(RelDataTypeSystemImpl.DEFAULT);
+  private final RexBuilder _rexBuilder = new RexBuilder(_types);
+
+  @Mock
+  private RelOptRuleCall _call;
+  @Mock
+  private RelNode _inner;
+  @Mock
+  private RelOptCluster _cluster;
+
+  private AutoCloseable _mocks;
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = MockitoAnnotations.openMocks(this);
+    Mockito.when(_inner.getCluster()).thenReturn(_cluster);
+    Mockito.when(_inner.getTraitSet()).thenReturn(RelTraitSet.createEmpty());
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void shouldMatchSort() {
+    // Given:
+    PinotSortExchangeNodeInsertRule rule = PinotSortExchangeNodeInsertRule.INSTANCE;
+    LogicalSort sort = LogicalSort.create(_inner, RelCollations.of(0),
+        _rexBuilder.makeLiteral(1, _types.createSqlType(SqlTypeName.INTEGER)),
+        _rexBuilder.makeLiteral(2, _types.createSqlType(SqlTypeName.INTEGER)));
+    Mockito.when(_call.getRelList()).thenReturn(ImmutableList.of(sort));
+    Mockito.when(_call.rel(0)).thenReturn(sort);
+
+    // When:
+    boolean matches = rule.matches(_call);
+
+    // Then:
+    Assert.assertTrue(matches, "Expected to match basic sort node.");
+  }
+
+  @Test
+  public void shouldNotMatchSortWithInnerExchange() {
+    // Given:
+    PinotSortExchangeNodeInsertRule rule = PinotSortExchangeNodeInsertRule.INSTANCE;
+    Exchange exchange = LogicalExchange.create(_inner, RelDistributions.SINGLETON);
+    LogicalSort sort = LogicalSort.create(exchange, RelCollations.of(0),
+        _rexBuilder.makeLiteral(1, _types.createSqlType(SqlTypeName.INTEGER)),
+        _rexBuilder.makeLiteral(2, _types.createSqlType(SqlTypeName.INTEGER)));
+    Mockito.when(_call.getRelList()).thenReturn(ImmutableList.of(sort));
+    Mockito.when(_call.rel(0)).thenReturn(sort);
+
+    // When:
+    boolean matches = rule.matches(_call);
+
+    // Then:
+    Assert.assertFalse(matches, "Should not match sort node that comes after an Exchange.");
+  }
+
+  @Test
+  public void shouldNotMatchInnerSort() {
+    // Given:
+    PinotSortExchangeNodeInsertRule rule = PinotSortExchangeNodeInsertRule.INSTANCE;
+    InnerSort sort = InnerSort.create(_inner, RelCollations.of(0),
+        _rexBuilder.makeLiteral(1, _types.createSqlType(SqlTypeName.INTEGER)),
+        _rexBuilder.makeLiteral(2, _types.createSqlType(SqlTypeName.INTEGER)));
+    Mockito.when(_call.getRelList()).thenReturn(ImmutableList.of(sort));
+    Mockito.when(_call.rel(0)).thenReturn(sort);
+
+    // When:
+    boolean matches = rule.matches(_call);
+
+    // Then:
+    Assert.assertFalse(matches, "Should not match inner sort node.");
+  }
+
+  @Test
+  public void shouldCreateSortBeforeAndAfterExchangeWhenMatches() {
+    // Given:
+    PinotSortExchangeNodeInsertRule rule = PinotSortExchangeNodeInsertRule.INSTANCE;
+    Exchange exchange = LogicalExchange.create(_inner, RelDistributions.SINGLETON);
+    LogicalSort sort = LogicalSort.create(exchange, RelCollations.of(0),
+        _rexBuilder.makeLiteral(1, _types.createSqlType(SqlTypeName.INTEGER)),
+        _rexBuilder.makeLiteral(2, _types.createSqlType(SqlTypeName.INTEGER)));
+    Mockito.when(_call.getRelList()).thenReturn(ImmutableList.of(sort));
+    Mockito.when(_call.rel(0)).thenReturn(sort);
+
+    // When:
+    ArgumentCaptor<RelNode> nodeCaptor = ArgumentCaptor.forClass(RelNode.class);
+    rule.onMatch(_call);
+
+    // Then:
+    Mockito.verify(_call).transformTo(nodeCaptor.capture(), Mockito.anyMap());
+    RelNode capture = nodeCaptor.getValue();
+
+    Assert.assertTrue(capture instanceof LogicalSort);
+    Assert.assertTrue(((LogicalSort) capture).getInput() instanceof LogicalExchange);
+    Assert.assertTrue(((LogicalExchange) ((LogicalSort) capture).getInput()).getInput() instanceof InnerSort);
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlock.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlock.java
@@ -123,7 +123,7 @@ public class TransferableBlock implements Block {
             throw new UnsupportedOperationException("Unable to build from container with type: " + _type);
         }
       } catch (Exception e) {
-        throw new RuntimeException("Unable to create DataBlock");
+        throw new RuntimeException("Unable to create DataBlock", e);
       }
     }
     return _dataBlock;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/WorkerQueryExecutor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/WorkerQueryExecutor.java
@@ -95,10 +95,16 @@ public class WorkerQueryExecutor {
       @Override
       public void runJob() {
         ThreadTimer executionThreadTimer = new ThreadTimer();
-        while (!TransferableBlockUtils.isEndOfStream(rootOperator.nextBlock())) {
-          LOGGER.debug("Result Block acquired");
+        try {
+          while (!TransferableBlockUtils.isEndOfStream(rootOperator.nextBlock())) {
+            LOGGER.debug("Result Block acquired");
+          }
+          LOGGER.debug("Execution time:" + executionThreadTimer.getThreadTimeNs());
+        } catch (final Exception e) {
+          LOGGER.error("Failed to execute query after {}ns. Base operator: {}.",
+              executionThreadTimer.getThreadTimeNs(), e);
+          throw e;
         }
-        LOGGER.info("Execution time:" + executionThreadTimer.getThreadTimeNs());
       }
     });
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.pinot.common.datablock.BaseDataBlock;
@@ -101,7 +102,10 @@ public class MailboxReceiveOperator extends BaseOperator<TransferableBlock> {
   @Nullable
   @Override
   public String toExplainString() {
-    return EXPLAIN_NAME;
+    return String.format("%s(%s<-[%s])",
+        EXPLAIN_NAME,
+        _exchangeType,
+        _sendingStageInstances.stream().map(this::toMailboxId).collect(Collectors.joining(",")));
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -28,6 +28,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.pinot.common.datablock.BaseDataBlock;
@@ -111,7 +112,10 @@ public class MailboxSendOperator extends BaseOperator<TransferableBlock> {
   @Nullable
   @Override
   public String toExplainString() {
-    return EXPLAIN_NAME;
+    return String.format("%s(%s->[%s])",
+        EXPLAIN_NAME,
+        _exchangeType,
+        _receivingStageInstances.stream().map(this::toMailboxId).collect(Collectors.joining(",")));
   }
 
   @Override
@@ -154,7 +158,7 @@ public class MailboxSendOperator extends BaseOperator<TransferableBlock> {
           throw new UnsupportedOperationException("Unsupported mailbox exchange type: " + _exchangeType);
       }
     } catch (Exception e) {
-      LOGGER.error("Exception occur while sending data via mailbox", e);
+      LOGGER.error("{} Exception occur while sending data.", this.toExplainString(), e);
     }
     return transferableBlock;
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryConfig.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryConfig.java
@@ -18,11 +18,14 @@
  */
 package org.apache.pinot.query.service;
 
+import java.util.concurrent.TimeUnit;
+
+
 /**
  * Configuration for setting up query runtime.
  */
 public class QueryConfig {
-  public static final long DEFAULT_TIMEOUT_NANO = 10_000_000_000L;
+  public static final long DEFAULT_TIMEOUT_NANO = TimeUnit.SECONDS.toNanos(10);
 
   public static final String KEY_OF_MAX_INBOUND_QUERY_DATA_BLOCK_BYTES_SIZE = "pinot.query.runner.max.msg.size";
   public static final int DEFAULT_MAX_INBOUND_QUERY_DATA_BLOCK_BYTES_SIZE = 128 * 1024 * 1024;

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.query;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -230,7 +231,8 @@ public class QueryServerEnclosure {
     }
   }
 
-  public void processQuery(DistributedStagePlan distributedStagePlan, Map<String, String> requestMetadataMap) {
+  public void processQuery(DistributedStagePlan distributedStagePlan, Map<String, String> requestMetadataMap)
+      throws IOException {
     _queryRunner.processQuery(distributedStagePlan, _testExecutor, requestMetadataMap);
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryTestSet.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryTestSet.java
@@ -32,6 +32,9 @@ public class QueryTestSet {
         new Object[]{"SELECT * FROM a ORDER BY col1 LIMIT 20"},
         new Object[]{"SELECT * FROM a ORDER BY col1, ts LIMIT 1, 2"},
         new Object[]{"SELECT * FROM a ORDER BY col1, ts LIMIT 2 OFFSET 1"},
+        // this tests the special case handling of scenarios where all order
+        // by columns are also select expressions
+        new Object[]{"SELECT col3, col2, col1, ts FROM a ORDER BY col1, col2, col3, ts LIMIT 10"},
 
         // No match filter
         new Object[]{"SELECT * FROM b WHERE col3 < 0.5"},

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerExceptionTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerExceptionTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.query.runtime;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
 import java.util.Map;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.query.planner.QueryPlan;
@@ -35,7 +36,8 @@ import org.testng.annotations.Test;
 public class QueryRunnerExceptionTest extends QueryRunnerTestBase {
 
   @Test(dataProvider = "testDataWithSqlExecutionExceptions")
-  public void testSqlWithExceptionMsgChecker(String sql, String exceptionMsg) {
+  public void testSqlWithExceptionMsgChecker(String sql, String exceptionMsg)
+      throws IOException {
     QueryPlan queryPlan = _queryEnvironment.planQuery(sql);
     Map<String, String> requestMetadataMap =
         ImmutableMap.of("REQUEST_ID", String.valueOf(RANDOM_REQUEST_ID_GEN.nextLong()));

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.query.runtime;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import java.io.IOException;
 import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.ArrayList;
@@ -55,7 +56,8 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
     compareRowEquals(resultRows, expectedRows);
   }
 
-  private List<Object[]> queryRunner(String sql) {
+  private List<Object[]> queryRunner(String sql)
+      throws IOException {
     QueryPlan queryPlan = _queryEnvironment.planQuery(sql);
     Map<String, String> requestMetadataMap =
         ImmutableMap.of("REQUEST_ID", String.valueOf(RANDOM_REQUEST_ID_GEN.nextLong()));

--- a/pinot-query-runtime/src/test/resources/log4j2.xml
+++ b/pinot-query-runtime/src/test/resources/log4j2.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<Configuration>
+  <Appenders>
+    <Console name="console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+    <Logger name="org.apache.pinot" level="warn" additivity="false">
+      <AppenderRef ref="console"/>
+    </Logger>
+    <Logger name="org.apache.pinot.query" level="info" additivity="false">
+      <AppenderRef ref="console"/>
+    </Logger>
+    <Root level="error">
+      <AppenderRef ref="console"/>
+    </Root>
+  </Loggers>
+</Configuration>


### PR DESCRIPTION
**What**

This PR supports `SORT` operator push-down. For example, `SELECT * FROM b ORDER BY col1, col2 DESC LIMIT 3` now produces the following plan:
```
[0] MAIL_RECEIVE
└── [1] MAIL_SEND
    └── [1] SORT (LIMIT 3)
        └── [1] MAIL_RECEIVE
            └── [2] MAIL_SEND
                └── [2] SORT (LIMIT 3)
                    └── [2] TABLE SCAN (b) {Server_localhost_54405={REALTIME=[b1]}}
```
As opposed to the old query plan:
```
[0] MAIL_RECEIVE
└── [1] MAIL_SEND
    └── [1] SORT (LIMIT 3)
        └── [1] MAIL_RECEIVE
            └── [2] MAIL_SEND
                └── [2] TABLE SCAN (b) {Server_localhost_55027={REALTIME=[b1]}}
```
Notice specifically that there are now two `SORT` operators, one right after the `TABLE SCAN` and one after the multistage engine has consolidated responses from the initial servers. 


**Why**

This allows us to only return a much smaller subset of rows from the leaf servers to the intermediate servers in the case where a `LIMIT` is applied.

**Review Notes**

1. In the v1 engine, an `ORDER BY` will cause the results to be returned from the servers in an order that may not be the requested order. See `SelectionOrderByOperator` for information about how this is computed. In order to resolve this, the broker usually leverages `SelectionOperatorService`, which I have now re-purposed to also use in the V2 engine.
2. The `InnerSort` class is required because otherwise the planner attempts to recurse forever, continuously pushing down sorts. It also makes it easy to signify that leaf nodes should return `fetch + offset` instead of `fetch` from `offset`.
3. I also snuck in some debug-ability improvements 