### PR TITLE
Check data table version on server only for null handling

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/ServerQueryRequest.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/ServerQueryRequest.java
@@ -18,12 +18,15 @@
  */
 package org.apache.pinot.core.query.request;
 
+import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.proto.Server;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.InstanceRequest;
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.core.common.datatable.DataTableFactory;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.TimerContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
@@ -56,7 +59,7 @@ public class ServerQueryRequest {
     _enableTrace = instanceRequest.isEnableTrace();
     _enableStreaming = false;
     _segmentsToQuery = instanceRequest.getSearchSegments();
-    _queryContext = QueryContextConverterUtils.getQueryContext(instanceRequest.getQuery().getPinotQuery());
+    _queryContext = getQueryContext(instanceRequest.getQuery().getPinotQuery());
     _timerContext = new TimerContext(_queryContext.getTableName(), serverMetrics, queryArrivalTimeMs);
   }
 
@@ -83,8 +86,17 @@ public class ServerQueryRequest {
     } else {
       throw new UnsupportedOperationException("Unsupported payloadType: " + payloadType);
     }
-    _queryContext = QueryContextConverterUtils.getQueryContext(brokerRequest.getPinotQuery());
+    _queryContext = getQueryContext(brokerRequest.getPinotQuery());
     _timerContext = new TimerContext(_queryContext.getTableName(), serverMetrics, queryArrivalTimeMs);
+  }
+
+  private static QueryContext getQueryContext(PinotQuery pinotQuery) {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(pinotQuery);
+    if (queryContext.isNullHandlingEnabled()) {
+      Preconditions.checkState(DataTableFactory.getDataTableVersion() >= DataTableFactory.VERSION_4,
+          "Null handling cannot be enabled for data table version smaller than 4");
+    }
+    return queryContext;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/QueryOptionsUtils.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.util;
 import com.google.common.base.Preconditions;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.apache.pinot.core.common.datatable.DataTableFactory;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionValue;
 
@@ -91,12 +90,7 @@ public class QueryOptionsUtils {
   }
 
   public static boolean isNullHandlingEnabled(Map<String, String> queryOptions) {
-    boolean nullHandlingEnabled = Boolean.parseBoolean(queryOptions.get(QueryOptionKey.ENABLE_NULL_HANDLING));
-    if (nullHandlingEnabled) {
-      Preconditions.checkState(DataTableFactory.getDataTableVersion() >= DataTableFactory.VERSION_4,
-          "Null handling cannot be enabled for data table version smaller than 4");
-    }
-    return nullHandlingEnabled;
+    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.ENABLE_NULL_HANDLING));
   }
 
   public static boolean isServerReturnFinalResult(Map<String, String> queryOptions) {


### PR DESCRIPTION
Broker doesn't have data table version set because it should be able to handle all versions, and we should not check the version on broker.
No additional test is added because data table version is a singleton and it is hard to test it in the same JVM.