### PR TITLE
Handle exception in realtime decoder gracefully

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -547,7 +547,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       RowMetadata msgMetadata = messagesAndOffsets.getStreamMessage(index).getMetadata();
       GenericRow decoderResult;
       if (decodedRow.getException() != null) {
-        if(_tableConfig.getIngestionConfig() != null
+        if (_tableConfig.getIngestionConfig() != null
             && _tableConfig.getIngestionConfig().isContinueOnError()) {
           decoderResult = new GenericRow();
           decoderResult.putValue(GenericRow.INCOMPLETE_RECORD_KEY, true);
@@ -561,7 +561,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
         decoderResult = decodedRow.getResult();
       }
 
-      if(decoderResult != null) {
+      if (decoderResult != null) {
         try {
           _transformPipeline.processRow(decoderResult, reusedResult);
         } catch (Exception e) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -549,13 +549,12 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       if (decodedRow.getException() != null) {
         if (_tableConfig.getIngestionConfig() != null
             && _tableConfig.getIngestionConfig().isContinueOnError()) {
-          decoderResult = new GenericRow();
-          decoderResult.putValue(GenericRow.INCOMPLETE_RECORD_KEY, true);
-        } else {
           decoderResult = null;
           realtimeRowsDroppedMeter =
               _serverMetrics.addMeteredTableValue(_metricKeyName, ServerMeter.INVALID_REALTIME_ROWS_DROPPED, 1,
                   realtimeRowsDroppedMeter);
+        } else {
+          throw new RuntimeException("Caught exception while decoding record", decodedRow.getException());
         }
       } else {
         decoderResult = decodedRow.getResult();

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
@@ -123,13 +123,15 @@ public class SegmentMapper {
           //noinspection unchecked
           for (GenericRow row : (Collection<GenericRow>) reuse.getValue(GenericRow.MULTIPLE_RECORDS_KEY)) {
             GenericRow transformedRow = _recordTransformer.transform(row);
-            if (transformedRow != null && IngestionUtils.shouldIngestRow(transformedRow)) {
+            if (transformedRow != null && IngestionUtils.shouldIngestRow(transformedRow,
+                _processorConfig.getTableConfig().getIngestionConfig())) {
               writeRecord(transformedRow);
             }
           }
         } else {
           GenericRow transformedRow = _recordTransformer.transform(reuse);
-          if (transformedRow != null && IngestionUtils.shouldIngestRow(transformedRow)) {
+          if (transformedRow != null && IngestionUtils.shouldIngestRow(transformedRow,
+              _processorConfig.getTableConfig().getIngestionConfig())) {
             writeRecord(transformedRow);
           }
         }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/KafkaConfluentSchemaRegistryAvroMessageDecoderRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/KafkaConfluentSchemaRegistryAvroMessageDecoderRealtimeClusterIntegrationTest.java
@@ -47,6 +47,7 @@ import org.apache.pinot.plugin.inputformat.avro.AvroUtils;
 import org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
@@ -213,6 +214,13 @@ public class KafkaConfluentSchemaRegistryAvroMessageDecoderRealtimeClusterIntegr
       configuration.setProperty(CommonConstants.Server.CONFIG_OF_ENABLE_SPLIT_COMMIT, true);
       configuration.setProperty(CommonConstants.Server.CONFIG_OF_ENABLE_COMMIT_END_WITH_METADATA, true);
     }
+  }
+
+  @Override
+  protected IngestionConfig getIngestionConfig() {
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setContinueOnError(true);
+    return ingestionConfig;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
@@ -68,7 +68,7 @@ public class CompositeTransformer implements RecordTransformer {
     return new CompositeTransformer(
         Stream.of(new ExpressionTransformer(tableConfig, schema), new FilterTransformer(tableConfig),
                 new DataTypeTransformer(tableConfig, schema), new TimeValidationTransformer(tableConfig, schema),
-                new NullValueTransformer(tableConfig, schema), new SanitizationTransformer(schema))
+                new NullValueTransformer(tableConfig, schema), new SanitizationTransformer(tableConfig, schema))
             .filter(t -> !t.isNoOp()).collect(Collectors.toList()));
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/TransformPipeline.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/TransformPipeline.java
@@ -27,6 +27,7 @@ import org.apache.pinot.segment.local.recordtransformer.CompositeTransformer;
 import org.apache.pinot.segment.local.recordtransformer.RecordTransformer;
 import org.apache.pinot.segment.local.utils.IngestionUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 
@@ -38,6 +39,7 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 public class TransformPipeline {
   private final RecordTransformer _recordTransformer;
   private final ComplexTypeTransformer _complexTypeTransformer;
+  private final IngestionConfig _ingestionConfig;
 
   /**
    * Constructs a transform pipeline with customized RecordTransformer and customized ComplexTypeTransformer
@@ -48,6 +50,7 @@ public class TransformPipeline {
       @Nullable ComplexTypeTransformer complexTypeTransformer) {
     _recordTransformer = recordTransformer;
     _complexTypeTransformer = complexTypeTransformer;
+    _ingestionConfig = null;
   }
 
   /**
@@ -61,6 +64,8 @@ public class TransformPipeline {
 
     // Create complex type transformer
     _complexTypeTransformer = ComplexTypeTransformer.getComplexTypeTransformer(tableConfig);
+
+    _ingestionConfig = tableConfig.getIngestionConfig();
   }
 
   /**
@@ -95,7 +100,7 @@ public class TransformPipeline {
 
   private void processPlainRow(GenericRow plainRow, Result reusedResult) {
     GenericRow transformedRow = _recordTransformer.transform(plainRow);
-    if (transformedRow != null && IngestionUtils.shouldIngestRow(transformedRow)) {
+    if (transformedRow != null && IngestionUtils.shouldIngestRow(transformedRow, _ingestionConfig)) {
       reusedResult.addTransformedRows(transformedRow);
       if (Boolean.TRUE.equals(transformedRow.getValue(GenericRow.INCOMPLETE_RECORD_KEY))) {
         reusedResult.incIncompleteRowCount();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -237,7 +237,16 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
         }
 
         for (GenericRow row : reusedResult.getTransformedRows()) {
-          _indexCreator.indexRow(row);
+          try {
+            _indexCreator.indexRow(row);
+          } catch (Exception e) {
+            if (!_continueOnError) {
+              throw new RuntimeException("Error occurred while indexing row", e);
+            } else {
+              incompleteRowsFound++;
+              LOGGER.debug("Error occurred while indexing row", e);
+            }
+          }
         }
         indexStopTime = System.currentTimeMillis();
         _totalIndexTime += (indexStopTime - recordReadStopTime);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
@@ -398,7 +398,7 @@ public final class IngestionUtils {
     if (Boolean.TRUE.equals(genericRow.getValue(GenericRow.SKIP_RECORD_KEY))) {
       return false;
     }
-    if (ingestionConfig != null && ingestionConfig.isSkipPartialRecords()
+    if (ingestionConfig != null && ingestionConfig.isSkipIncompleteRecords()
         && Boolean.TRUE.equals(genericRow.getValue(GenericRow.INCOMPLETE_RECORD_KEY))) {
       return false;
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
@@ -392,9 +392,18 @@ public final class IngestionUtils {
 
   /**
    * Returns false if the record contains key {@link GenericRow#SKIP_RECORD_KEY} with value true
+   * or incomplete records should not be consumed
    */
-  public static boolean shouldIngestRow(GenericRow genericRow) {
-    return !Boolean.TRUE.equals(genericRow.getValue(GenericRow.SKIP_RECORD_KEY));
+  public static boolean shouldIngestRow(GenericRow genericRow, @Nullable IngestionConfig ingestionConfig) {
+    if (Boolean.TRUE.equals(genericRow.getValue(GenericRow.SKIP_RECORD_KEY))) {
+      return false;
+    }
+    if (ingestionConfig != null && ingestionConfig.isSkipPartialRecords()
+        && Boolean.TRUE.equals(genericRow.getValue(GenericRow.INCOMPLETE_RECORD_KEY))) {
+      return false;
+    }
+
+    return true;
   }
 
   public static Long extractTimeValue(Comparable time) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
@@ -240,7 +240,7 @@ public class RecordTransformerTest {
 
   @Test
   public void testSanitationTransformer() {
-    RecordTransformer transformer = new SanitizationTransformer(SCHEMA);
+    RecordTransformer transformer = new SanitizationTransformer(TABLE_CONFIG, SCHEMA);
     GenericRow record = getRecord();
     for (int i = 0; i < NUM_ROUNDS; i++) {
       record = transformer.transform(record);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/IngestionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/IngestionConfig.java
@@ -53,7 +53,7 @@ public class IngestionConfig extends BaseJsonConfig {
 
   @JsonPropertyDescription("If set to true, the records with GenericRow.INCOMPLETE_RECORD_KEY will not be consumed."
       + "This can be helpful if user only wants to see correct data in the table")
-  private boolean _skipPartialRecords;
+  private boolean _skipIncompleteRecords;
 
   @JsonPropertyDescription("Configs related to validate time value for each record during ingestion")
   private boolean _rowTimeValueCheck;
@@ -119,8 +119,8 @@ public class IngestionConfig extends BaseJsonConfig {
     return _segmentTimeValueCheck;
   }
 
-  public boolean isSkipPartialRecords() {
-    return _skipPartialRecords;
+  public boolean isSkipIncompleteRecords() {
+    return _skipIncompleteRecords;
   }
 
   public void setBatchIngestionConfig(BatchIngestionConfig batchIngestionConfig) {
@@ -151,8 +151,8 @@ public class IngestionConfig extends BaseJsonConfig {
     _continueOnError = continueOnError;
   }
 
-  public void setSkipPartialRecords(boolean skipPartialRecords) {
-    _skipPartialRecords = skipPartialRecords;
+  public void setSkipIncompleteRecords(boolean skipIncompleteRecords) {
+    _skipIncompleteRecords = skipIncompleteRecords;
   }
 
   public void setRowTimeValueCheck(boolean rowTimeValueCheck) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/IngestionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/IngestionConfig.java
@@ -51,6 +51,10 @@ public class IngestionConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Configs related to skip any row which has error and continue during ingestion")
   private boolean _continueOnError;
 
+  @JsonPropertyDescription("If set to true, the records with GenericRow.INCOMPLETE_RECORD_KEY will not be consumed."
+      + "This can be helpful if user only wants to see correct data in the table")
+  private boolean _skipPartialRecords;
+
   @JsonPropertyDescription("Configs related to validate time value for each record during ingestion")
   private boolean _rowTimeValueCheck;
 
@@ -115,6 +119,10 @@ public class IngestionConfig extends BaseJsonConfig {
     return _segmentTimeValueCheck;
   }
 
+  public boolean isSkipPartialRecords() {
+    return _skipPartialRecords;
+  }
+
   public void setBatchIngestionConfig(BatchIngestionConfig batchIngestionConfig) {
     _batchIngestionConfig = batchIngestionConfig;
   }
@@ -141,6 +149,10 @@ public class IngestionConfig extends BaseJsonConfig {
 
   public void setContinueOnError(boolean continueOnError) {
     _continueOnError = continueOnError;
+  }
+
+  public void setSkipPartialRecords(boolean skipPartialRecords) {
+    _skipPartialRecords = skipPartialRecords;
   }
 
   public void setRowTimeValueCheck(boolean rowTimeValueCheck) {


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds graceful handling of decoder and indexing errors via continueOnError and skipIncompleteRecords flags\.

```mermaid
flowchart TD
  N0["Decode message #40;F2#41;"]:::stModified
  N1["Handle decode exception #40;F2#41;"]:::stModified
  N2["Transform row #40;F2#41;"]:::stModified
  N3["Set incomplete flag #40;F5#41;"]:::stModified
  N4["Should ingest row #40;F1#44; F6#44; F3#44; F8#41;"]:::stModified
  N5["Index row #40;F1#44; F2#44; F8#41;"]:::stModified
  N6["Handle index exception #40;F2#44; F8#41;"]:::stModified
  N0 -->|"on exception"| N1
  N0 -->|"on success"| N2
  N2 -->|"may set"| N3
  N2 -->|"then check"| N4
  N3 -->|"influence"| N4
  N4 -->|"if true"| N5
  N5 -->|"on exception"| N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager\.java — [before](https://github.com/apache/pinot/blob/91fa86b2a30e1d7ec0ac57f5ce4e22b42ad5cb4e/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java) · [after](https://github.com/apache/pinot/blob/31580475188a44bf1160280f57b5b2c3c2c70fc2/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java)
- F2: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager\.java — [before](https://github.com/apache/pinot/blob/91fa86b2a30e1d7ec0ac57f5ce4e22b42ad5cb4e/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java) · [after](https://github.com/apache/pinot/blob/31580475188a44bf1160280f57b5b2c3c2c70fc2/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java)
- F3: pinot\-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper\.java — [before](https://github.com/apache/pinot/blob/91fa86b2a30e1d7ec0ac57f5ce4e22b42ad5cb4e/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java) · [after](https://github.com/apache/pinot/blob/31580475188a44bf1160280f57b5b2c3c2c70fc2/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java)
- F5: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SanitizationTransformer\.java — [before](https://github.com/apache/pinot/blob/91fa86b2a30e1d7ec0ac57f5ce4e22b42ad5cb4e/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SanitizationTransformer.java) · [after](https://github.com/apache/pinot/blob/31580475188a44bf1160280f57b5b2c3c2c70fc2/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SanitizationTransformer.java)
- F6: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/segment/creator/TransformPipeline\.java — [before](https://github.com/apache/pinot/blob/91fa86b2a30e1d7ec0ac57f5ce4e22b42ad5cb4e/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/TransformPipeline.java) · [after](https://github.com/apache/pinot/blob/31580475188a44bf1160280f57b5b2c3c2c70fc2/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/TransformPipeline.java)
- F8: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils\.java — [before](https://github.com/apache/pinot/blob/91fa86b2a30e1d7ec0ac57f5ce4e22b42ad5cb4e/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java) · [after](https://github.com/apache/pinot/blob/31580475188a44bf1160280f57b5b2c3c2c70fc2/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjkxZmE4NmIyYTMwZTFkN2VjMGFjNTdmNWNlNGUyMmI0MmFkNWNiNGUiLCJjb250ZXh0X2hhc2giOiJiZmE4ZmJkOGUwOGEwZWU4MjI1OTUwYzY1MGM2YjlmODc3M2QzYTVkY2VjNDVmODdjYTRjZGYyZDZiMjdhMGY5IiwiZ2VuZXJhdGVkX2F0IjoxNzg5MDM2Nzc3LCJoZWFkX3NoYSI6IjMxNTgwNDc1MTg4YTQ0YmYxMTYwMjgwZjU3YjViMmMzYzJjNzBmYzIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI5MWZhODZiMmEzMGUxZDdlYzBhYzU3ZjVjZTRlMjJiNDJhZDVjYjRlIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature df1c3ed61ecb1c2dfc8c502653a01df6ddae632fb648fac575591d980062857b -->
<!-- pinot-pr-flow:end -->

This PR continues the effort from #9163 

We already added `continueOnError` flag in previous PRs to handle errors gracefully. This PR extends the same configs to handle decoder exceptions as well.
A new config flag has also been added called `skipPartialRecords` through which user can decided whether to consume these partial records or not after `continueOnError`.