### PR TITLE
Exposing consumer's record lag in /consumingSegmentsInfo

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
@@ -61,34 +61,34 @@ public class SegmentConsumerInfo {
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   static public class PartitionOffsetInfo {
-      @JsonProperty("currentOffsetsMap")
-      public Map<String, String> _currentOffsetsMap;
+      @JsonProperty("currentOffsets")
+      public Map<String, String> _currentOffsets;
 
-      @JsonProperty("recordsLagMap")
-      public Map<String, String> _recordsLagMap;
+      @JsonProperty("recordsLag")
+      public Map<String, String> _recordsLag;
 
-      @JsonProperty("latestUpstreamOffsetMap")
-      public Map<String, String> _latestUpstreamOffsetMap;
+      @JsonProperty("latestUpstreamOffsets")
+      public Map<String, String> _latestUpstreamOffsets;
 
       public PartitionOffsetInfo(
-          @JsonProperty("currentOffsetsMap") Map<String, String> currentOffsetsMap,
-          @JsonProperty("latestUpstreamOffsetMap") Map<String, String> latestUpstreamOffsetMap,
-          @JsonProperty("recordsLagMap") Map<String, String> recordsLagMap) {
-        _currentOffsetsMap = currentOffsetsMap;
-        _latestUpstreamOffsetMap = latestUpstreamOffsetMap;
-        _recordsLagMap = recordsLagMap;
+          @JsonProperty("currentOffsets") Map<String, String> currentOffsets,
+          @JsonProperty("latestUpstreamOffsets") Map<String, String> latestUpstreamOffsets,
+          @JsonProperty("recordsLag") Map<String, String> recordsLag) {
+        _currentOffsets = currentOffsets;
+        _latestUpstreamOffsets = latestUpstreamOffsets;
+        _recordsLag = recordsLag;
       }
 
-    public Map<String, String> getCurrentOffsetsMap() {
-      return _currentOffsetsMap;
+    public Map<String, String> getCurrentOffsets() {
+      return _currentOffsets;
     }
 
-    public Map<String, String> getRecordsLagMap() {
-      return _recordsLagMap;
+    public Map<String, String> getRecordsLag() {
+      return _recordsLag;
     }
 
-    public Map<String, String> getLatestUpstreamOffsetMap() {
-      return _latestUpstreamOffsetMap;
+    public Map<String, String> getLatestUpstreamOffsets() {
+      return _latestUpstreamOffsets;
     }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
@@ -32,20 +32,20 @@ public class SegmentConsumerInfo {
   private final String _consumerState;
   private final long _lastConsumedTimestamp;
   private final Map<String, String> _partitionToOffsetMap;
-  private final Map<String, String> _partitionToUpstreamLatestMap;
+  private final Map<String, String> _partitionToUpstreamLatestOffsetMap;
   private final Map<String, String> _partitionToOffsetLag;
 
   public SegmentConsumerInfo(@JsonProperty("segmentName") String segmentName,
       @JsonProperty("consumerState") String consumerState,
       @JsonProperty("lastConsumedTimestamp") long lastConsumedTimestamp,
       @JsonProperty("partitionToOffsetMap") Map<String, String> partitionToOffsetMap,
-      @JsonProperty("partitionToUpstreamLatestMap") Map<String, String> partitionToUpstreamLatestMap,
+      @JsonProperty("partitionToUpstreamLatestOffsetMap") Map<String, String> partitionToUpstreamLatestMap,
       @JsonProperty("partitionToOffsetLag") Map<String, String> partitionToOffsetLagMap) {
     _segmentName = segmentName;
     _consumerState = consumerState;
     _lastConsumedTimestamp = lastConsumedTimestamp;
     _partitionToOffsetMap = partitionToOffsetMap;
-    _partitionToUpstreamLatestMap = partitionToUpstreamLatestMap;
+    _partitionToUpstreamLatestOffsetMap = partitionToUpstreamLatestMap;
     _partitionToOffsetLag = partitionToOffsetLagMap;
   }
 
@@ -66,7 +66,7 @@ public class SegmentConsumerInfo {
   }
 
   public Map<String, String> getPartitionToUpstreamLatestMap() {
-    return _partitionToUpstreamLatestMap;
+    return _partitionToUpstreamLatestOffsetMap;
   }
 
   public Map<String, String> getPartitionToOffsetLag() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
@@ -32,15 +32,21 @@ public class SegmentConsumerInfo {
   private final String _consumerState;
   private final long _lastConsumedTimestamp;
   private final Map<String, String> _partitionToOffsetMap;
+  private final Map<String, String> _partitionToUpstreamLatestMap;
+  private final Map<String, String> _partitionToOffsetLag;
 
   public SegmentConsumerInfo(@JsonProperty("segmentName") String segmentName,
       @JsonProperty("consumerState") String consumerState,
       @JsonProperty("lastConsumedTimestamp") long lastConsumedTimestamp,
-      @JsonProperty("partitionToOffsetMap") Map<String, String> partitionToOffsetMap) {
+      @JsonProperty("partitionToOffsetMap") Map<String, String> partitionToOffsetMap,
+      @JsonProperty("partitionToUpstreamLatestMap") Map<String, String> partitionToUpstreamLatestMap,
+      @JsonProperty("partitionToOffsetLag") Map<String, String> partitionToOffsetLagMap) {
     _segmentName = segmentName;
     _consumerState = consumerState;
     _lastConsumedTimestamp = lastConsumedTimestamp;
     _partitionToOffsetMap = partitionToOffsetMap;
+    _partitionToUpstreamLatestMap = partitionToUpstreamLatestMap;
+    _partitionToOffsetLag = partitionToOffsetLagMap;
   }
 
   public String getSegmentName() {
@@ -57,5 +63,13 @@ public class SegmentConsumerInfo {
 
   public Map<String, String> getPartitionToOffsetMap() {
     return _partitionToOffsetMap;
+  }
+
+  public Map<String, String> getPartitionToUpstreamLatestMap() {
+    return _partitionToUpstreamLatestMap;
+  }
+
+  public Map<String, String> getPartitionToOffsetLag() {
+    return _partitionToOffsetLag;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
@@ -31,22 +31,16 @@ public class SegmentConsumerInfo {
   private final String _segmentName;
   private final String _consumerState;
   private final long _lastConsumedTimestamp;
-  private final Map<String, String> _partitionToOffsetMap;
-  private final Map<String, String> _partitionToUpstreamLatestOffsetMap;
-  private final Map<String, String> _partitionToOffsetLag;
+  private final PartitionOffsetInfo _partitionOffsetInfo;
 
   public SegmentConsumerInfo(@JsonProperty("segmentName") String segmentName,
       @JsonProperty("consumerState") String consumerState,
       @JsonProperty("lastConsumedTimestamp") long lastConsumedTimestamp,
-      @JsonProperty("partitionToOffsetMap") Map<String, String> partitionToOffsetMap,
-      @JsonProperty("partitionToUpstreamLatestOffsetMap") Map<String, String> partitionToUpstreamLatestMap,
-      @JsonProperty("partitionToOffsetLag") Map<String, String> partitionToOffsetLagMap) {
+      @JsonProperty("partitionOffsetInfo") PartitionOffsetInfo partitionOffsetInfo) {
     _segmentName = segmentName;
     _consumerState = consumerState;
     _lastConsumedTimestamp = lastConsumedTimestamp;
-    _partitionToOffsetMap = partitionToOffsetMap;
-    _partitionToUpstreamLatestOffsetMap = partitionToUpstreamLatestMap;
-    _partitionToOffsetLag = partitionToOffsetLagMap;
+    _partitionOffsetInfo = partitionOffsetInfo;
   }
 
   public String getSegmentName() {
@@ -61,15 +55,40 @@ public class SegmentConsumerInfo {
     return _lastConsumedTimestamp;
   }
 
-  public Map<String, String> getPartitionToOffsetMap() {
-    return _partitionToOffsetMap;
+  public PartitionOffsetInfo getPartitionOffsetInfo() {
+    return _partitionOffsetInfo;
   }
 
-  public Map<String, String> getPartitionToUpstreamLatestMap() {
-    return _partitionToUpstreamLatestOffsetMap;
-  }
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static public class PartitionOffsetInfo {
+      @JsonProperty("currentOffsetsMap")
+      public Map<String, String> _currentOffsetsMap;
 
-  public Map<String, String> getPartitionToOffsetLag() {
-    return _partitionToOffsetLag;
+      @JsonProperty("recordsLagMap")
+      public Map<String, String> _recordsLagMap;
+
+      @JsonProperty("latestUpstreamOffsetMap")
+      public Map<String, String> _latestUpstreamOffsetMap;
+
+      public PartitionOffsetInfo(
+          @JsonProperty("currentOffsetsMap") Map<String, String> currentOffsetsMap,
+          @JsonProperty("latestUpstreamOffsetMap") Map<String, String> latestUpstreamOffsetMap,
+          @JsonProperty("recordsLagMap") Map<String, String> recordsLagMap) {
+        _currentOffsetsMap = currentOffsetsMap;
+        _latestUpstreamOffsetMap = latestUpstreamOffsetMap;
+        _recordsLagMap = recordsLagMap;
+      }
+
+    public Map<String, String> getCurrentOffsetsMap() {
+      return _currentOffsetsMap;
+    }
+
+    public Map<String, String> getRecordsLagMap() {
+      return _recordsLagMap;
+    }
+
+    public Map<String, String> getLatestUpstreamOffsetMap() {
+      return _latestUpstreamOffsetMap;
+    }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
@@ -31,15 +31,18 @@ public class SegmentConsumerInfo {
   private final String _segmentName;
   private final String _consumerState;
   private final long _lastConsumedTimestamp;
+  private final Map<String, String> _partitionToOffsetMap;
   private final PartitionOffsetInfo _partitionOffsetInfo;
 
   public SegmentConsumerInfo(@JsonProperty("segmentName") String segmentName,
       @JsonProperty("consumerState") String consumerState,
       @JsonProperty("lastConsumedTimestamp") long lastConsumedTimestamp,
+      @JsonProperty("partitionToOffsetMap") Map<String, String> partitionToOffsetMap,
       @JsonProperty("partitionOffsetInfo") PartitionOffsetInfo partitionOffsetInfo) {
     _segmentName = segmentName;
     _consumerState = consumerState;
     _lastConsumedTimestamp = lastConsumedTimestamp;
+    _partitionToOffsetMap = partitionToOffsetMap;
     _partitionOffsetInfo = partitionOffsetInfo;
   }
 
@@ -53,6 +56,10 @@ public class SegmentConsumerInfo {
 
   public long getLastConsumedTimestamp() {
     return _lastConsumedTimestamp;
+  }
+
+  public Map<String, String> getPartitionToOffsetMap() {
+    return _partitionToOffsetMap;
   }
 
   public PartitionOffsetInfo getPartitionOffsetInfo() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
@@ -159,7 +159,7 @@ public class PinotRealtimeTableResource {
       @ApiResponse(code = 404, message = "Table not found"),
       @ApiResponse(code = 500, message = "Internal server error")
   })
-  public ConsumingSegmentInfoReader.ConsumingSegmentsInfoMap getConsumingSegmentsInfo2(
+  public ConsumingSegmentInfoReader.ConsumingSegmentsInfoMap getConsumingSegmentsInfo(
       @ApiParam(value = "Realtime table name with or without type", required = true,
           example = "myTable | myTable_REALTIME") @PathParam("tableName") String realtimeTableName) {
     try {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
@@ -150,8 +150,9 @@ public class PinotRealtimeTableResource {
     }
   }
 
+  // TODO: remove consumingSegmentsInfo from SegmentRestletResource
   @GET
-  @Path("/tables/{tableName}/consumingSegmentsInfo")
+  @Path("/tables/{tableName}/consumingSegmentsInfo2")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Returns state of consuming segments", notes = "Gets the status of consumers from all servers")
   @ApiResponses(value = {
@@ -159,7 +160,7 @@ public class PinotRealtimeTableResource {
       @ApiResponse(code = 404, message = "Table not found"),
       @ApiResponse(code = 500, message = "Internal server error")
   })
-  public ConsumingSegmentInfoReader.ConsumingSegmentsInfoMap getConsumingSegmentsInfo(
+  public ConsumingSegmentInfoReader.ConsumingSegmentsInfoMap getConsumingSegmentsInfo2(
       @ApiParam(value = "Realtime table name with or without type", required = true,
           example = "myTable | myTable_REALTIME") @PathParam("tableName") String realtimeTableName) {
     try {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
@@ -22,9 +22,12 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiKeyAuthDefinition;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
+import java.util.concurrent.Executor;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -35,10 +38,14 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.helix.model.IdealState;
+import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
+import org.apache.pinot.controller.util.ConsumingSegmentInfoReader;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,6 +59,15 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
 @Path("/")
 public class PinotRealtimeTableResource {
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotRealtimeTableResource.class);
+
+  @Inject
+  ControllerConf _controllerConf;
+
+  @Inject
+  Executor _executor;
+
+  @Inject
+  HttpConnectionManager _connectionManager;
 
   @Inject
   PinotHelixResourceManager _pinotHelixResourceManager;
@@ -123,7 +139,7 @@ public class PinotRealtimeTableResource {
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Return pause status of a realtime table",
       notes = "Return pause status of a realtime table along with list of consuming segments.")
-  public Response getConsumptionStatus(
+  public Response getPauseStatus(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName) {
     String tableNameWithType = TableNameBuilder.REALTIME.tableNameWithType(tableName);
     validate(tableNameWithType);
@@ -131,6 +147,35 @@ public class PinotRealtimeTableResource {
       return Response.ok().entity(_pinotLLCRealtimeSegmentManager.getPauseStatus(tableNameWithType)).build();
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+  }
+
+  @GET
+  @Path("/tables/{tableName}/consumingSegmentsInfo")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Returns state of consuming segments", notes = "Gets the status of consumers from all servers")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Success"),
+      @ApiResponse(code = 404, message = "Table not found"),
+      @ApiResponse(code = 500, message = "Internal server error")
+  })
+  public ConsumingSegmentInfoReader.ConsumingSegmentsInfoMap getConsumingSegmentsInfo(
+      @ApiParam(value = "Realtime table name with or without type", required = true,
+          example = "myTable | myTable_REALTIME") @PathParam("tableName") String realtimeTableName) {
+    try {
+      TableType tableType = TableNameBuilder.getTableTypeFromTableName(realtimeTableName);
+      if (TableType.OFFLINE == tableType) {
+        throw new IllegalStateException("Cannot get consuming segments info for OFFLINE table: " + realtimeTableName);
+      }
+      String tableNameWithType = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(realtimeTableName);
+      ConsumingSegmentInfoReader consumingSegmentInfoReader =
+          new ConsumingSegmentInfoReader(_executor, _connectionManager, _pinotHelixResourceManager);
+      return consumingSegmentInfoReader
+          .getConsumingSegmentsInfo(tableNameWithType, _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
+    } catch (Exception e) {
+      throw new ControllerApplicationException(LOGGER,
+          String.format("Failed to get consuming segments info for table %s. %s", realtimeTableName, e.getMessage()),
+          Response.Status.INTERNAL_SERVER_ERROR, e);
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
@@ -150,9 +150,8 @@ public class PinotRealtimeTableResource {
     }
   }
 
-  // TODO: remove consumingSegmentsInfo from SegmentRestletResource
   @GET
-  @Path("/tables/{tableName}/consumingSegmentsInfo2")
+  @Path("/tables/{tableName}/consumingSegmentsInfo")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Returns state of consuming segments", notes = "Gets the status of consumers from all servers")
   @ApiResponses(value = {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
@@ -153,7 +153,9 @@ public class PinotRealtimeTableResource {
   @GET
   @Path("/tables/{tableName}/consumingSegmentsInfo")
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation(value = "Returns state of consuming segments", notes = "Gets the status of consumers from all servers")
+  @ApiOperation(value = "Returns state of consuming segments", notes = "Gets the status of consumers from all servers."
+      + "Note that the partitionToOffsetMap has been deprecated and will be removed in the next release. The info is "
+      + "now embedded within each partition's state as currentOffsetsMap.")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"),
       @ApiResponse(code = 404, message = "Table not found"),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -636,8 +636,9 @@ public class PinotSegmentRestletResource {
       singleSegmentName = controllerJobZKMetadata.get(CommonConstants.ControllerJob.SEGMENT_RELOAD_JOB_SEGMENT_NAME);
       serverToSegments = new HashMap<>();
       List<String> segmentList = Arrays.asList(singleSegmentName);
-      _pinotHelixResourceManager.getServers(tableNameWithType, singleSegmentName).forEach(server ->
-          serverToSegments.put(server, segmentList));
+      _pinotHelixResourceManager.getServers(tableNameWithType, singleSegmentName).forEach(server -> {
+        serverToSegments.put(server, segmentList);
+      });
     } else {
       serverToSegments = _pinotHelixResourceManager.getServerToSegmentsMap(tableNameWithType);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
@@ -85,7 +85,8 @@ public class ConsumingSegmentInfoReader {
         PartitionOffsetInfo offsetInfo = new PartitionOffsetInfo(partitionOffsetInfo.getCurrentOffsets(),
             partitionOffsetInfo.getLatestUpstreamOffsets(), partitionOffsetInfo.getRecordsLag());
         consumingSegmentInfoMap.computeIfAbsent(info.getSegmentName(), k -> new ArrayList<>()).add(
-            new ConsumingSegmentInfo(serverName, info.getConsumerState(), info.getLastConsumedTimestamp(), offsetInfo));
+            new ConsumingSegmentInfo(serverName, info.getConsumerState(), info.getLastConsumedTimestamp(),
+                partitionOffsetInfo.getCurrentOffsets(), offsetInfo));
       }
     }
     // Segments which are in CONSUMING state but found no consumer on the server
@@ -205,6 +206,9 @@ public class ConsumingSegmentInfoReader {
     public String _consumerState;
     @JsonProperty("lastConsumedTimestamp")
     public long _lastConsumedTimestamp;
+    @Deprecated
+    @JsonProperty("partitionToOffsetMap")
+    public Map<String, String> _partitionToOffsetMap;
     @JsonProperty("partitionOffsetInfo")
     public PartitionOffsetInfo _partitionOffsetInfo;
 
@@ -212,10 +216,12 @@ public class ConsumingSegmentInfoReader {
     public ConsumingSegmentInfo(@JsonProperty("serverName") String serverName,
         @JsonProperty("consumerState") String consumerState,
         @JsonProperty("lastConsumedTimestamp") long lastConsumedTimestamp,
+        @JsonProperty("partitionToOffsetMap") Map<String, String> partitionToOffsetMap,
         @JsonProperty("partitionOffsetInfo") PartitionOffsetInfo partitionOffsetInfo) {
       _serverName = serverName;
       _consumerState = consumerState;
       _lastConsumedTimestamp = lastConsumedTimestamp;
+      _partitionToOffsetMap = partitionToOffsetMap;
       _partitionOffsetInfo = partitionOffsetInfo;
     }
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
@@ -81,9 +81,11 @@ public class ConsumingSegmentInfoReader {
     for (Map.Entry<String, List<SegmentConsumerInfo>> entry : serverToSegmentConsumerInfoMap.entrySet()) {
       String serverName = entry.getKey();
       for (SegmentConsumerInfo info : entry.getValue()) {
+        SegmentConsumerInfo.PartitionOffsetInfo partitionOffsetInfo = info.getPartitionOffsetInfo();
+        PartitionOffsetInfo offsetInfo = new PartitionOffsetInfo(partitionOffsetInfo.getCurrentOffsetsMap(),
+            partitionOffsetInfo.getLatestUpstreamOffsetMap(), partitionOffsetInfo.getRecordsLagMap());
         consumingSegmentInfoMap.computeIfAbsent(info.getSegmentName(), k -> new ArrayList<>()).add(
-            new ConsumingSegmentInfo(serverName, info.getConsumerState(), info.getLastConsumedTimestamp(),
-                info.getPartitionToOffsetMap(), info.getPartitionToOffsetLag()));
+            new ConsumingSegmentInfo(serverName, info.getConsumerState(), info.getLastConsumedTimestamp(), offsetInfo));
       }
     }
     // Segments which are in CONSUMING state but found no consumer on the server
@@ -203,21 +205,39 @@ public class ConsumingSegmentInfoReader {
     public String _consumerState;
     @JsonProperty("lastConsumedTimestamp")
     public long _lastConsumedTimestamp;
-    @JsonProperty("partitionToOffsetMap")
-    public Map<String, String> _partitionToOffsetMap;
-    @JsonProperty("partitionToOffsetLagMap")
-    public Map<String, String> _partitionToOffsetLagMap;
+    @JsonProperty("partitionOffsetInfo")
+    public PartitionOffsetInfo _partitionOffsetInfo;
+
 
     public ConsumingSegmentInfo(@JsonProperty("serverName") String serverName,
         @JsonProperty("consumerState") String consumerState,
         @JsonProperty("lastConsumedTimestamp") long lastConsumedTimestamp,
-        @JsonProperty("partitionToOffsetMap") Map<String, String> partitionToOffsetMap,
-        @JsonProperty("partitionToOffsetLagMap") Map<String, String> partitionToOffsetLagMap) {
+        @JsonProperty("partitionOffsetInfo") PartitionOffsetInfo partitionOffsetInfo) {
       _serverName = serverName;
       _consumerState = consumerState;
       _lastConsumedTimestamp = lastConsumedTimestamp;
-      _partitionToOffsetMap = partitionToOffsetMap;
-      _partitionToOffsetLagMap = partitionToOffsetLagMap;
+      _partitionOffsetInfo = partitionOffsetInfo;
+    }
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static public class PartitionOffsetInfo {
+    @JsonProperty("currentOffsetsMap")
+    public Map<String, String> _currentOffsetsMap;
+
+    @JsonProperty("recordsLagMap")
+    public Map<String, String> _recordsLagMap;
+
+    @JsonProperty("latestUpstreamOffsetMap")
+    public Map<String, String> _latestUpstreamOffsetMap;
+
+    public PartitionOffsetInfo(
+        @JsonProperty("currentOffsetsMap") Map<String, String> currentOffsetsMap,
+        @JsonProperty("latestUpstreamOffsetMap") Map<String, String> latestUpstreamOffsetMap,
+        @JsonProperty("recordsLagMap") Map<String, String> recordsLagMap) {
+      _currentOffsetsMap = currentOffsetsMap;
+      _latestUpstreamOffsetMap = latestUpstreamOffsetMap;
+      _recordsLagMap = recordsLagMap;
     }
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
@@ -83,7 +83,7 @@ public class ConsumingSegmentInfoReader {
       for (SegmentConsumerInfo info : entry.getValue()) {
         consumingSegmentInfoMap.computeIfAbsent(info.getSegmentName(), k -> new ArrayList<>()).add(
             new ConsumingSegmentInfo(serverName, info.getConsumerState(), info.getLastConsumedTimestamp(),
-                info.getPartitionToOffsetMap()));
+                info.getPartitionToOffsetMap(), info.getPartitionToOffsetLag()));
       }
     }
     // Segments which are in CONSUMING state but found no consumer on the server
@@ -205,15 +205,19 @@ public class ConsumingSegmentInfoReader {
     public long _lastConsumedTimestamp;
     @JsonProperty("partitionToOffsetMap")
     public Map<String, String> _partitionToOffsetMap;
+    @JsonProperty("partitionToOffsetLagMap")
+    public Map<String, String> _partitionToOffsetLagMap;
 
     public ConsumingSegmentInfo(@JsonProperty("serverName") String serverName,
         @JsonProperty("consumerState") String consumerState,
         @JsonProperty("lastConsumedTimestamp") long lastConsumedTimestamp,
-        @JsonProperty("partitionToOffsetMap") Map<String, String> partitionToOffsetMap) {
+        @JsonProperty("partitionToOffsetMap") Map<String, String> partitionToOffsetMap,
+        @JsonProperty("partitionToOffsetLagMap") Map<String, String> partitionToOffsetLagMap) {
       _serverName = serverName;
       _consumerState = consumerState;
       _lastConsumedTimestamp = lastConsumedTimestamp;
       _partitionToOffsetMap = partitionToOffsetMap;
+      _partitionToOffsetLagMap = partitionToOffsetLagMap;
     }
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
@@ -82,8 +82,8 @@ public class ConsumingSegmentInfoReader {
       String serverName = entry.getKey();
       for (SegmentConsumerInfo info : entry.getValue()) {
         SegmentConsumerInfo.PartitionOffsetInfo partitionOffsetInfo = info.getPartitionOffsetInfo();
-        PartitionOffsetInfo offsetInfo = new PartitionOffsetInfo(partitionOffsetInfo.getCurrentOffsetsMap(),
-            partitionOffsetInfo.getLatestUpstreamOffsetMap(), partitionOffsetInfo.getRecordsLagMap());
+        PartitionOffsetInfo offsetInfo = new PartitionOffsetInfo(partitionOffsetInfo.getCurrentOffsets(),
+            partitionOffsetInfo.getLatestUpstreamOffsets(), partitionOffsetInfo.getRecordsLag());
         consumingSegmentInfoMap.computeIfAbsent(info.getSegmentName(), k -> new ArrayList<>()).add(
             new ConsumingSegmentInfo(serverName, info.getConsumerState(), info.getLastConsumedTimestamp(), offsetInfo));
       }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderStatelessTest.java
@@ -90,10 +90,10 @@ public class ConsumingSegmentInfoReaderStatelessTest {
     FakeConsumingInfoServer s0 = new FakeConsumingInfoServer(Lists
         .newArrayList(
             new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "CONSUMING", 0,
-                new SegmentConsumerInfo.PartitionOffsetInfo(
+                partitionToOffset0, new SegmentConsumerInfo.PartitionOffsetInfo(
                     partitionToOffset0, Collections.emptyMap(), Collections.emptyMap())),
             new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0,
-                new SegmentConsumerInfo.PartitionOffsetInfo(
+                partitionToOffset1, new SegmentConsumerInfo.PartitionOffsetInfo(
                     partitionToOffset1, Collections.emptyMap(), Collections.emptyMap()))));
     s0.start(uriPath, createHandler(200, s0._consumerInfos, 0));
     _serverMap.put("server0", s0);
@@ -102,10 +102,10 @@ public class ConsumingSegmentInfoReaderStatelessTest {
     FakeConsumingInfoServer s1 = new FakeConsumingInfoServer(Lists
         .newArrayList(
             new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "CONSUMING", 0,
-                new SegmentConsumerInfo.PartitionOffsetInfo(
+                partitionToOffset0, new SegmentConsumerInfo.PartitionOffsetInfo(
                     partitionToOffset0, Collections.emptyMap(), Collections.emptyMap())),
             new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0,
-                new SegmentConsumerInfo.PartitionOffsetInfo(
+                partitionToOffset1, new SegmentConsumerInfo.PartitionOffsetInfo(
                     partitionToOffset1, Collections.emptyMap(), Collections.emptyMap()))));
     s1.start(uriPath, createHandler(200, s1._consumerInfos, 0));
     _serverMap.put("server1", s1);
@@ -113,9 +113,9 @@ public class ConsumingSegmentInfoReaderStatelessTest {
     // server2 - p1 consumer CONSUMING. p0 consumer NOT_CONSUMING
     FakeConsumingInfoServer s2 = new FakeConsumingInfoServer(Lists
         .newArrayList(new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "NOT_CONSUMING", 0,
-                new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset0, Collections.emptyMap(),
-                    Collections.emptyMap())),
-            new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0,
+                partitionToOffset0, new SegmentConsumerInfo.PartitionOffsetInfo(
+                    partitionToOffset0, Collections.emptyMap(), Collections.emptyMap())),
+            new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0, partitionToOffset1,
                 new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset1, Collections.emptyMap(),
                     Collections.emptyMap()))));
     s2.start(uriPath, createHandler(200, s2._consumerInfos, 0));
@@ -124,7 +124,7 @@ public class ConsumingSegmentInfoReaderStatelessTest {
     // server3 - 1 consumer for p1. No consumer for p0
     FakeConsumingInfoServer s3 = new FakeConsumingInfoServer(
         Lists.newArrayList(new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0,
-            new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset1, Collections.emptyMap(),
+            partitionToOffset1, new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset1, Collections.emptyMap(),
                 Collections.emptyMap()))));
     s3.start(uriPath, createHandler(200, s3._consumerInfos, 0));
     _serverMap.put("server3", s3);
@@ -132,9 +132,9 @@ public class ConsumingSegmentInfoReaderStatelessTest {
     // server4 - unreachable/error/timeout
     FakeConsumingInfoServer s4 = new FakeConsumingInfoServer(Lists
         .newArrayList(new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "CONSUMING", 0,
-                new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset0, Collections.emptyMap(),
-                    Collections.emptyMap())),
-            new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0,
+                partitionToOffset0, new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset0,
+                Collections.emptyMap(), Collections.emptyMap())),
+            new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0, partitionToOffset1,
                 new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset1, Collections.emptyMap(),
                     Collections.emptyMap()))));
     s4.start(uriPath, createHandler(200, s4._consumerInfos, TIMEOUT_MSEC * EXTENDED_TIMEOUT_FACTOR));

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderStatelessTest.java
@@ -88,35 +88,46 @@ public class ConsumingSegmentInfoReaderStatelessTest {
     Map<String, String> partitionToOffset1 = new HashMap<>();
     partitionToOffset1.put("1", "150");
     FakeConsumingInfoServer s0 = new FakeConsumingInfoServer(Lists
-        .newArrayList(new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "CONSUMING", 0, partitionToOffset0),
-            new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0, partitionToOffset1)));
+        .newArrayList(
+            new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "CONSUMING", 0,
+                partitionToOffset0, Collections.emptyMap(), Collections.emptyMap()),
+            new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0,
+                partitionToOffset1, Collections.emptyMap(), Collections.emptyMap())));
     s0.start(uriPath, createHandler(200, s0._consumerInfos, 0));
     _serverMap.put("server0", s0);
 
     // server1 - 1 consumer each for p0 and p1. CONSUMING.
     FakeConsumingInfoServer s1 = new FakeConsumingInfoServer(Lists
-        .newArrayList(new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "CONSUMING", 0, partitionToOffset0),
-            new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0, partitionToOffset1)));
+        .newArrayList(
+            new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "CONSUMING", 0,
+                partitionToOffset0, Collections.emptyMap(), Collections.emptyMap()),
+            new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0,
+                partitionToOffset1, Collections.emptyMap(), Collections.emptyMap())));
     s1.start(uriPath, createHandler(200, s1._consumerInfos, 0));
     _serverMap.put("server1", s1);
 
     // server2 - p1 consumer CONSUMING. p0 consumer NOT_CONSUMING
     FakeConsumingInfoServer s2 = new FakeConsumingInfoServer(Lists
-        .newArrayList(new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "NOT_CONSUMING", 0, partitionToOffset0),
-            new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0, partitionToOffset1)));
+        .newArrayList(new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "NOT_CONSUMING", 0,
+                partitionToOffset0, Collections.emptyMap(), Collections.emptyMap()),
+            new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0,
+                partitionToOffset1, Collections.emptyMap(), Collections.emptyMap())));
     s2.start(uriPath, createHandler(200, s2._consumerInfos, 0));
     _serverMap.put("server2", s2);
 
     // server3 - 1 consumer for p1. No consumer for p0
     FakeConsumingInfoServer s3 = new FakeConsumingInfoServer(
-        Lists.newArrayList(new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0, partitionToOffset1)));
+        Lists.newArrayList(new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0,
+            partitionToOffset1, Collections.emptyMap(), Collections.emptyMap())));
     s3.start(uriPath, createHandler(200, s3._consumerInfos, 0));
     _serverMap.put("server3", s3);
 
     // server4 - unreachable/error/timeout
     FakeConsumingInfoServer s4 = new FakeConsumingInfoServer(Lists
-        .newArrayList(new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "CONSUMING", 0, partitionToOffset0),
-            new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0, partitionToOffset1)));
+        .newArrayList(new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "CONSUMING", 0,
+                partitionToOffset0, Collections.emptyMap(), Collections.emptyMap()),
+            new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0,
+                partitionToOffset1, Collections.emptyMap(), Collections.emptyMap())));
     s4.start(uriPath, createHandler(200, s4._consumerInfos, TIMEOUT_MSEC * EXTENDED_TIMEOUT_FACTOR));
     _serverMap.put("server4", s4);
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderStatelessTest.java
@@ -90,9 +90,11 @@ public class ConsumingSegmentInfoReaderStatelessTest {
     FakeConsumingInfoServer s0 = new FakeConsumingInfoServer(Lists
         .newArrayList(
             new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "CONSUMING", 0,
-                partitionToOffset0, Collections.emptyMap(), Collections.emptyMap()),
+                new SegmentConsumerInfo.PartitionOffsetInfo(
+                    partitionToOffset0, Collections.emptyMap(), Collections.emptyMap())),
             new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0,
-                partitionToOffset1, Collections.emptyMap(), Collections.emptyMap())));
+                new SegmentConsumerInfo.PartitionOffsetInfo(
+                    partitionToOffset1, Collections.emptyMap(), Collections.emptyMap()))));
     s0.start(uriPath, createHandler(200, s0._consumerInfos, 0));
     _serverMap.put("server0", s0);
 
@@ -100,34 +102,41 @@ public class ConsumingSegmentInfoReaderStatelessTest {
     FakeConsumingInfoServer s1 = new FakeConsumingInfoServer(Lists
         .newArrayList(
             new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "CONSUMING", 0,
-                partitionToOffset0, Collections.emptyMap(), Collections.emptyMap()),
+                new SegmentConsumerInfo.PartitionOffsetInfo(
+                    partitionToOffset0, Collections.emptyMap(), Collections.emptyMap())),
             new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0,
-                partitionToOffset1, Collections.emptyMap(), Collections.emptyMap())));
+                new SegmentConsumerInfo.PartitionOffsetInfo(
+                    partitionToOffset1, Collections.emptyMap(), Collections.emptyMap()))));
     s1.start(uriPath, createHandler(200, s1._consumerInfos, 0));
     _serverMap.put("server1", s1);
 
     // server2 - p1 consumer CONSUMING. p0 consumer NOT_CONSUMING
     FakeConsumingInfoServer s2 = new FakeConsumingInfoServer(Lists
         .newArrayList(new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "NOT_CONSUMING", 0,
-                partitionToOffset0, Collections.emptyMap(), Collections.emptyMap()),
+                new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset0, Collections.emptyMap(),
+                    Collections.emptyMap())),
             new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0,
-                partitionToOffset1, Collections.emptyMap(), Collections.emptyMap())));
+                new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset1, Collections.emptyMap(),
+                    Collections.emptyMap()))));
     s2.start(uriPath, createHandler(200, s2._consumerInfos, 0));
     _serverMap.put("server2", s2);
 
     // server3 - 1 consumer for p1. No consumer for p0
     FakeConsumingInfoServer s3 = new FakeConsumingInfoServer(
         Lists.newArrayList(new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0,
-            partitionToOffset1, Collections.emptyMap(), Collections.emptyMap())));
+            new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset1, Collections.emptyMap(),
+                Collections.emptyMap()))));
     s3.start(uriPath, createHandler(200, s3._consumerInfos, 0));
     _serverMap.put("server3", s3);
 
     // server4 - unreachable/error/timeout
     FakeConsumingInfoServer s4 = new FakeConsumingInfoServer(Lists
         .newArrayList(new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "CONSUMING", 0,
-                partitionToOffset0, Collections.emptyMap(), Collections.emptyMap()),
+                new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset0, Collections.emptyMap(),
+                    Collections.emptyMap())),
             new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0,
-                partitionToOffset1, Collections.emptyMap(), Collections.emptyMap())));
+                new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset1, Collections.emptyMap(),
+                    Collections.emptyMap()))));
     s4.start(uriPath, createHandler(200, s4._consumerInfos, TIMEOUT_MSEC * EXTENDED_TIMEOUT_FACTOR));
     _serverMap.put("server4", s4);
   }
@@ -360,6 +369,6 @@ public class ConsumingSegmentInfoReaderStatelessTest {
       String consumerState, String partition, String offset) {
     Assert.assertTrue(serverNames.contains(info._serverName));
     Assert.assertEquals(info._consumerState, consumerState);
-    Assert.assertEquals(info._partitionToOffsetMap.get(partition), offset);
+    Assert.assertEquals(info._partitionOffsetInfo._currentOffsetsMap.get(partition), offset);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/ConsumerLagInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/ConsumerLagInfo.java
@@ -1,5 +1,0 @@
-package org.apache.pinot.core.data.manager.realtime;
-
-public abstract class ConsumerLagInfo {
-
-}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/ConsumerLagInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/ConsumerLagInfo.java
@@ -1,0 +1,5 @@
+package org.apache.pinot.core.data.manager.realtime;
+
+public abstract class ConsumerLagInfo {
+
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -51,6 +51,8 @@ import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.metrics.PinotMeter;
+import org.apache.pinot.spi.stream.ConsumerPartitionState;
+import org.apache.pinot.spi.stream.PartitionLagState;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConsumerFactory;
 import org.apache.pinot.spi.stream.StreamConsumerFactoryProvider;
@@ -421,6 +423,16 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
   @Override
   public long getLastConsumedTimestamp() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ConsumerPartitionState getConsumerPartitionState() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public PartitionLagState getPartitionToLagState(ConsumerPartitionState perPartitionState) {
     throw new UnsupportedOperationException();
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -432,7 +432,8 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   }
 
   @Override
-  public Map<String, PartitionLagState> getPartitionToLagState(List<ConsumerPartitionState> consumerPartitionState) {
+  public Map<String, PartitionLagState> getPartitionToLagState(
+      Map<String, ConsumerPartitionState> consumerPartitionStateMap) {
     throw new UnsupportedOperationException();
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -427,12 +427,12 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   }
 
   @Override
-  public ConsumerPartitionState getConsumerPartitionState() {
+  public Map<String, ConsumerPartitionState> getConsumerPartitionState() {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public PartitionLagState getPartitionToLagState(ConsumerPartitionState perPartitionState) {
+  public Map<String, PartitionLagState> getPartitionToLagState(List<ConsumerPartitionState> consumerPartitionState) {
     throw new UnsupportedOperationException();
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -34,8 +34,6 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.Utils;
@@ -831,14 +829,13 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   }
 
   @Override
-  public Map<String, PartitionLagState> getPartitionToLagState(List<ConsumerPartitionState> consumerPartitionState) {
+  public Map<String, PartitionLagState> getPartitionToLagState(
+      Map<String, ConsumerPartitionState> consumerPartitionStateMap) {
     if (_partitionMetadataProvider == null) {
       createPartitionMetadataProvider("Get Partition Lag State");
     }
     ;
-    return _partitionMetadataProvider.getCurrentPartitionLagState(
-        consumerPartitionState.stream().collect(
-            Collectors.toMap(ConsumerPartitionState::getPartitionId, Function.identity())));
+    return _partitionMetadataProvider.getCurrentPartitionLagState(consumerPartitionStateMap);
   }
 
   public StreamPartitionMsgOffset getCurrentOffset() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -832,11 +832,11 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
   @Override
   public Map<String, PartitionLagState> getPartitionToLagState(List<ConsumerPartitionState> consumerPartitionState) {
-    if (_streamMetadataProvider == null) {
-      _streamMetadataProvider = _streamConsumerFactory.createPartitionMetadataProvider(_clientId, _partitionGroupId);
+    if (_partitionMetadataProvider == null) {
+      createPartitionMetadataProvider("Get Partition Lag State");
     }
     ;
-    return _streamMetadataProvider.getCurrentPartitionLagState(
+    return _partitionMetadataProvider.getCurrentPartitionLagState(
         consumerPartitionState.stream().collect(
             Collectors.toMap(ConsumerPartitionState::getPartitionId, Function.identity())));
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -54,5 +54,13 @@ public abstract class RealtimeSegmentDataManager extends SegmentDataManager {
    */
   public abstract ConsumerState getConsumerState();
 
+  /**
+   * @return Timestamp at which the last record was indexed
+   */
   public abstract long getLastConsumedTimestamp();
+
+  /**
+   * @return Map of the partition to its lag information.
+   */
+  public abstract Map<String, ? extends ConsumerLagInfo> getPartitionLagInfo();
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.data.manager.realtime;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
@@ -65,7 +66,8 @@ public abstract class RealtimeSegmentDataManager extends SegmentDataManager {
    * @return Per-partition consumer's status, which typically includes last consumed message timestamp,
    * latest available upstream offset etc
    */
-  public abstract ConsumerPartitionState getConsumerPartitionState();
+  public abstract Map<String, ConsumerPartitionState> getConsumerPartitionState();
 
-  public abstract PartitionLagState getPartitionToLagState(ConsumerPartitionState consumerPartitionState);
+  public abstract Map<String, PartitionLagState> getPartitionToLagState(
+      List<ConsumerPartitionState> consumerPartitionState);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.data.manager.realtime;
 
-import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
@@ -69,5 +68,5 @@ public abstract class RealtimeSegmentDataManager extends SegmentDataManager {
   public abstract Map<String, ConsumerPartitionState> getConsumerPartitionState();
 
   public abstract Map<String, PartitionLagState> getPartitionToLagState(
-      List<ConsumerPartitionState> consumerPartitionState);
+      Map<String, ConsumerPartitionState> consumerPartitionStateMap);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -25,6 +25,8 @@ import org.apache.pinot.segment.local.io.writer.impl.DirectMemoryManager;
 import org.apache.pinot.segment.local.io.writer.impl.MmapMemoryManager;
 import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
+import org.apache.pinot.spi.stream.ConsumerPartitionState;
+import org.apache.pinot.spi.stream.PartitionLagState;
 import org.apache.pinot.spi.utils.CommonConstants.ConsumerState;
 
 
@@ -60,7 +62,10 @@ public abstract class RealtimeSegmentDataManager extends SegmentDataManager {
   public abstract long getLastConsumedTimestamp();
 
   /**
-   * @return Map of the partition to its lag information.
+   * @return Per-partition consumer's status, which typically includes last consumed message timestamp,
+   * latest available upstream offset etc
    */
-  public abstract Map<String, ? extends ConsumerLagInfo> getPartitionLagInfo();
+  public abstract ConsumerPartitionState getConsumerPartitionState();
+
+  public abstract PartitionLagState getPartitionToLagState(ConsumerPartitionState consumerPartitionState);
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaConsumerPartitionLag.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaConsumerPartitionLag.java
@@ -22,13 +22,13 @@ import org.apache.pinot.spi.stream.PartitionLagState;
 
 
 public class KafkaConsumerPartitionLag extends PartitionLagState {
-  private final String _offsetLag;
+  private final String _recordsLag;
 
-  public KafkaConsumerPartitionLag(String offsetLag) {
-    _offsetLag = offsetLag;
+  public KafkaConsumerPartitionLag(String recordsLag) {
+    _recordsLag = recordsLag;
   }
 
-  public String getOffsetLag() {
-    return _offsetLag;
+  public String getRecordsLag() {
+    return _recordsLag;
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaConsumerPartitionLag.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaConsumerPartitionLag.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.kafka20;
+
+import org.apache.pinot.spi.stream.PartitionLagState;
+
+
+public class KafkaConsumerPartitionLag extends PartitionLagState {
+  private final String _offsetLag;
+
+  public KafkaConsumerPartitionLag(String offsetLag) {
+    _offsetLag = offsetLag;
+  }
+
+  public String getOffsetLag() {
+    return _offsetLag;
+  }
+}

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
@@ -122,13 +122,6 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
         perPartitionLag.put(entry.getKey(), new KafkaConsumerPartitionLag("UNKNOWN"));
       }
     }
-/*    _consumer.metrics().forEach((k, v) -> {
-      if (k.name().equals("records-lag")) {
-        perPartitionLag.put("parititonId", new KafkaConsumerPartitionLag(null,
-            String.valueOf((v.metricValue()))));
-      }
-    });*/
-
     return perPartitionLag;
   }
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
@@ -150,7 +150,7 @@ public class DebugResource {
                   Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getUpstreamLatestOffset().toString())
               ),
               partitionLagStateMap.entrySet().stream().collect(
-                  Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getOffsetLag())
+                  Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getRecordsLag())
               ));
     }
     return segmentConsumerInfo;

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
@@ -145,13 +145,13 @@ public class DebugResource {
               segmentDataManager.getSegmentName(),
               realtimeSegmentDataManager.getConsumerState().toString(),
               realtimeSegmentDataManager.getLastConsumedTimestamp(),
-              realtimeSegmentDataManager.getPartitionToCurrentOffset(),
-              partitionStateMap.entrySet().stream().collect(
-                  Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getUpstreamLatestOffset().toString())
-              ),
-              partitionLagStateMap.entrySet().stream().collect(
-                  Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getRecordsLag())
-              ));
+              new SegmentConsumerInfo.PartitionOffsetInfo(realtimeSegmentDataManager.getPartitionToCurrentOffset(),
+                  partitionStateMap.entrySet().stream().collect(
+                      Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getUpstreamLatestOffset().toString())
+                  ),
+                  partitionLagStateMap.entrySet().stream().collect(
+                      Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getRecordsLag())
+                  )));
     }
     return segmentConsumerInfo;
   }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
@@ -26,6 +26,7 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -49,6 +50,7 @@ import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.server.starter.ServerInstance;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.stream.ConsumerPartitionState;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
@@ -135,10 +137,15 @@ public class DebugResource {
     if (tableType == TableType.REALTIME) {
       RealtimeSegmentDataManager realtimeSegmentDataManager = (RealtimeSegmentDataManager) segmentDataManager;
       String segmentName = segmentDataManager.getSegmentName();
+      ConsumerPartitionState partitionState = realtimeSegmentDataManager.getConsumerPartitionState();
       segmentConsumerInfo =
           new SegmentConsumerInfo(segmentName, realtimeSegmentDataManager.getConsumerState().toString(),
               realtimeSegmentDataManager.getLastConsumedTimestamp(),
-              realtimeSegmentDataManager.getPartitionToCurrentOffset());
+              realtimeSegmentDataManager.getPartitionToCurrentOffset(),
+              Collections.singletonMap(partitionState.getPartitionId(),
+                  partitionState.getUpstreamLatestOffset().toString()),
+              Collections.singletonMap(partitionState.getPartitionId(),
+                  realtimeSegmentDataManager.getPartitionToLagState(partitionState).getOffsetLag()));
     }
     return segmentConsumerInfo;
   }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
@@ -138,8 +138,8 @@ public class DebugResource {
     if (tableType == TableType.REALTIME) {
       RealtimeSegmentDataManager realtimeSegmentDataManager = (RealtimeSegmentDataManager) segmentDataManager;
       Map<String, ConsumerPartitionState> partitionStateMap = realtimeSegmentDataManager.getConsumerPartitionState();
-      Map<String, PartitionLagState> partitionLagStateMap = realtimeSegmentDataManager.getPartitionToLagState(
-          new ArrayList<>(partitionStateMap.values()));
+      Map<String, PartitionLagState> partitionLagStateMap =
+          realtimeSegmentDataManager.getPartitionToLagState(partitionStateMap);
       segmentConsumerInfo =
           new SegmentConsumerInfo(
               segmentDataManager.getSegmentName(),

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
@@ -140,12 +140,14 @@ public class DebugResource {
       Map<String, ConsumerPartitionState> partitionStateMap = realtimeSegmentDataManager.getConsumerPartitionState();
       Map<String, PartitionLagState> partitionLagStateMap =
           realtimeSegmentDataManager.getPartitionToLagState(partitionStateMap);
+      Map<String, String> partitionToCurrentOffsetMap = realtimeSegmentDataManager.getPartitionToCurrentOffset();
       segmentConsumerInfo =
           new SegmentConsumerInfo(
               segmentDataManager.getSegmentName(),
               realtimeSegmentDataManager.getConsumerState().toString(),
               realtimeSegmentDataManager.getLastConsumedTimestamp(),
-              new SegmentConsumerInfo.PartitionOffsetInfo(realtimeSegmentDataManager.getPartitionToCurrentOffset(),
+              partitionToCurrentOffsetMap,
+              new SegmentConsumerInfo.PartitionOffsetInfo(partitionToCurrentOffsetMap,
                   partitionStateMap.entrySet().stream().collect(
                       Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getUpstreamLatestOffset().toString())
                   ),

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -513,7 +513,8 @@ public class TablesResource {
       for (SegmentDataManager segmentDataManager : segmentDataManagers) {
         if (segmentDataManager instanceof RealtimeSegmentDataManager) {
           RealtimeSegmentDataManager realtimeSegmentDataManager = (RealtimeSegmentDataManager) segmentDataManager;
-          Map<String, ConsumerPartitionState> partitionStateMap = realtimeSegmentDataManager.getConsumerPartitionState();
+          Map<String, ConsumerPartitionState> partitionStateMap =
+              realtimeSegmentDataManager.getConsumerPartitionState();
           Map<String, PartitionLagState> partitionLagStateMap = realtimeSegmentDataManager.getPartitionToLagState(
               new ArrayList<>(partitionStateMap.values()));
           segmentConsumerInfoList.add(
@@ -528,7 +529,6 @@ public class TablesResource {
                       Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getRecordsLag())
                   ))
           );
-
         }
       }
     } catch (Exception e) {

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -521,13 +521,14 @@ public class TablesResource {
               new SegmentConsumerInfo(segmentDataManager.getSegmentName(),
                   realtimeSegmentDataManager.getConsumerState().toString(),
                   realtimeSegmentDataManager.getLastConsumedTimestamp(),
-                  realtimeSegmentDataManager.getPartitionToCurrentOffset(),
-                  partitionStateMap.entrySet().stream().collect(
-                      Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getUpstreamLatestOffset().toString())
-                  ),
-                  partitionLagStateMap.entrySet().stream().collect(
-                      Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getRecordsLag())
-                  ))
+                  new SegmentConsumerInfo.PartitionOffsetInfo(
+                      realtimeSegmentDataManager.getPartitionToCurrentOffset(),
+                      partitionStateMap.entrySet().stream().collect(
+                          Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getUpstreamLatestOffset().toString())
+                      ),
+                      partitionLagStateMap.entrySet().stream().collect(
+                          Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getRecordsLag())
+                      )))
           );
         }
       }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -495,7 +495,9 @@ public class TablesResource {
   @Path("tables/{realtimeTableName}/consumingSegmentsInfo")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Get the info for consumers of this REALTIME table",
-      notes = "Get consumers info from the table data manager")
+      notes = "Get consumers info from the table data manager. Note that the partitionToOffsetMap has been deprecated "
+          + "and will be removed in the next release. The info is now embedded within each partition's state as "
+          + "currentOffsetsMap")
   public List<SegmentConsumerInfo> getConsumingSegmentsInfo(
       @ApiParam(value = "Name of the REALTIME table", required = true) @PathParam("realtimeTableName")
           String realtimeTableName) {
@@ -517,12 +519,15 @@ public class TablesResource {
               realtimeSegmentDataManager.getConsumerPartitionState();
           Map<String, PartitionLagState> partitionLagStateMap =
               realtimeSegmentDataManager.getPartitionToLagState(partitionStateMap);
+          @Deprecated Map<String, String> partitiionToOffsetMap =
+              realtimeSegmentDataManager.getPartitionToCurrentOffset();
           segmentConsumerInfoList.add(
               new SegmentConsumerInfo(segmentDataManager.getSegmentName(),
                   realtimeSegmentDataManager.getConsumerState().toString(),
                   realtimeSegmentDataManager.getLastConsumedTimestamp(),
+                  partitiionToOffsetMap,
                   new SegmentConsumerInfo.PartitionOffsetInfo(
-                      realtimeSegmentDataManager.getPartitionToCurrentOffset(),
+                      partitiionToOffsetMap,
                       partitionStateMap.entrySet().stream().collect(
                           Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getUpstreamLatestOffset().toString())
                       ),

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -515,8 +515,8 @@ public class TablesResource {
           RealtimeSegmentDataManager realtimeSegmentDataManager = (RealtimeSegmentDataManager) segmentDataManager;
           Map<String, ConsumerPartitionState> partitionStateMap =
               realtimeSegmentDataManager.getConsumerPartitionState();
-          Map<String, PartitionLagState> partitionLagStateMap = realtimeSegmentDataManager.getPartitionToLagState(
-              new ArrayList<>(partitionStateMap.values()));
+          Map<String, PartitionLagState> partitionLagStateMap =
+              realtimeSegmentDataManager.getPartitionToLagState(partitionStateMap);
           segmentConsumerInfoList.add(
               new SegmentConsumerInfo(segmentDataManager.getSegmentName(),
                   realtimeSegmentDataManager.getConsumerState().toString(),

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -525,7 +525,7 @@ public class TablesResource {
                       Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getUpstreamLatestOffset().toString())
                   ),
                   partitionLagStateMap.entrySet().stream().collect(
-                      Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getOffsetLag())
+                      Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getRecordsLag())
                   ))
           );
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/ConsumerPartitionState.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/ConsumerPartitionState.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.stream;
+
+import javax.annotation.Nullable;
+
+
+/**
+ * Container for holding the current consumption state at a per-partition level
+ */
+public class ConsumerPartitionState {
+  private final String _partitionId;
+  private final StreamPartitionMsgOffset _currentOffset;
+  private final long _lastProcessedTimeMs;
+  private final StreamPartitionMsgOffset _upstreamLatestOffset;
+
+  public ConsumerPartitionState(String partitionId, StreamPartitionMsgOffset currentOffset, long lastProcessedTimeMs,
+      @Nullable StreamPartitionMsgOffset upstreamLatestOffset) {
+    _partitionId = partitionId;
+    _currentOffset = currentOffset;
+    _lastProcessedTimeMs = lastProcessedTimeMs;
+    _upstreamLatestOffset = upstreamLatestOffset;
+  }
+
+  public StreamPartitionMsgOffset getCurrentOffset() {
+    return _currentOffset;
+  }
+
+  public long getLastProcessedTimeMs() {
+    return _lastProcessedTimeMs;
+  }
+
+  public String getPartitionId() {
+    return _partitionId;
+  }
+
+  public StreamPartitionMsgOffset getUpstreamLatestOffset() {
+    return _upstreamLatestOffset;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLagState.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLagState.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.spi.stream;
+
+/**
+ * Container that can be used for holding per-partition consumer lag calculated along standard dimensions such as
+ * record pointer, time etc.
+ */
+public class PartitionLagState {
+  protected final static String NOT_CALCULATED = "NOT_CALCULATED";
+
+  /**
+   * Defines how far away the current record's offset / pointer is from upstream latest record
+   * The distance is based on actual record count.
+   */
+  public String getOffsetLag() {
+    return NOT_CALCULATED;
+  }
+
+/*  *//**
+   * Defines how far away the current record's timestamp is from upstream latest record's timestamp
+   * The distance is relative to the event time, as opposed to the ingestion time
+   *//*
+  public String getEventTimeLag() {
+    return NOT_CALCULATED;
+  }*/
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLagState.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLagState.java
@@ -34,11 +34,5 @@ public class PartitionLagState {
     return NOT_CALCULATED;
   }
 
-/*  *//**
-   * Defines how far away the current record's timestamp is from upstream latest record's timestamp
-   * The distance is relative to the event time, as opposed to the ingestion time
-   *//*
-  public String getEventTimeLag() {
-    return NOT_CALCULATED;
-  }*/
+  // TODO: Define record availability lag ($latest_record_consumption_time - $latest_record_ingestion_time)
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLagState.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLagState.java
@@ -21,7 +21,7 @@ package org.apache.pinot.spi.stream;
 
 /**
  * Container that can be used for holding per-partition consumer lag calculated along standard dimensions such as
- * record pointer, time etc.
+ * record offset, ingestion time etc.
  */
 public class PartitionLagState {
   protected final static String NOT_CALCULATED = "NOT_CALCULATED";
@@ -30,7 +30,7 @@ public class PartitionLagState {
    * Defines how far away the current record's offset / pointer is from upstream latest record
    * The distance is based on actual record count.
    */
-  public String getOffsetLag() {
+  public String getRecordsLag() {
     return NOT_CALCULATED;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
@@ -21,7 +21,9 @@ package org.apache.pinot.spi.stream;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeoutException;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;
@@ -87,4 +89,14 @@ public interface StreamMetadataProvider extends Closeable {
     }
     return newPartitionGroupMetadataList;
   }
+
+  default Map<String, PartitionLagState> getCurrentPartitionLagState(
+      Map<String, ConsumerPartitionState> currentPartitionStateMap) {
+    Map<String, PartitionLagState> result = new HashMap<>();
+    PartitionLagState unknownLagState = new UnknownLagState();
+    currentPartitionStateMap.forEach((k, v) -> result.put(k, unknownLagState));
+    return result;
+  }
+
+  class UnknownLagState extends PartitionLagState { }
 }


### PR DESCRIPTION
Re-work of the PR : https://github.com/apache/pinot/pull/8280 

Changes in this PR:
- `/consumingSegmentsInfo` API was moved into `PinotRealtimeTableResource` .
  - This returns additional per-partition map for upstream latest record offset and partition lag (when calculated)
- Introduces new API in `StreamMetadataProvider#getCurrentPartitionLagState` 
  - This PR only adds support for Kafka. 
  - Any stream connector that hasn't implemented this method will return `NOT_CALCULATED` for these new lag status
  - Additionally, connectors can extend `PartitionLagState` interface to return more custom lag definitions

Things to be addressed in a follow-up PR:
- Define a time-based lag status
- Add partition lag info for kinesis and pulsar stream
