### PR TITLE
fix spammy logs for ConfluentSchemaRegistryRealtimeClusterIntegrationTest [MINOR]

### DIFF
--- a/pinot-integration-tests/src/test/resources/log4j2.xml
+++ b/pinot-integration-tests/src/test/resources/log4j2.xml
@@ -26,11 +26,6 @@
     </Console>
   </Appenders>
   <Loggers>
-    <!--Turn off the logger for KafkaConfluentSchemaRegistryAvroMessageDecoder because we intentionally inject
-     tombstones in KafkaConfluentSchemaRegistryAvroMessageDecoderRealtimeClusterIntegrationTest which can flood the log
-     -->
-    <Logger name="org.apache.pinot.plugin.inputformat.avro.confluent.KafkaConfluentSchemaRegistryAvroMessageDecoder"
-            level="off" additivity="false"/>
     <Logger name="org.apache.pinot" level="warn" additivity="false">
       <AppenderRef ref="console"/>
     </Logger>


### PR DESCRIPTION
fixes #9240 

to test the desired functionality there's no need to insert as many invalid records as valid ones, this PR changes the functionality to just insert a few for each avro file

I tested this locally and this reduces the number of `"Unknown magic byte!"` logs to 120 and re-enables logging for this test.

cc @npawar 