### PR TITLE
Add UI to track segment reload progress

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/ReloadStatusOp.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/ReloadStatusOp.tsx
@@ -17,11 +17,18 @@
  * under the License.
  */
 
-import React from 'react';
-import { CircularProgress, createStyles, DialogContent, DialogContentText, makeStyles, Paper, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Theme, withStyles} from '@material-ui/core';
+import React, { useEffect, useState } from 'react';
+import { CircularProgress, createStyles, DialogContent, DialogContentText, Link, makeStyles, Paper, Tab, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tabs, Theme, withStyles} from '@material-ui/core';
 import Dialog from '../../CustomDialog';
 import CloseIcon from '@material-ui/icons/Close';
 import CheckIcon from '@material-ui/icons/Check';
+import { TableData, TableSegmentJobs } from 'Models';
+import TabPanel from '../../TabPanel';
+import moment from 'moment';
+import CustomDialog from '../../CustomDialog';
+import PinotMethodUtils from '../../../utils/PinotMethodUtils';
+import CustomCodemirror from '../../CustomCodemirror';
+import SearchBar from '../../SearchBar';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -29,7 +36,7 @@ const useStyles = makeStyles((theme: Theme) =>
       textAlign: 'center'
     },
     container: {
-      maxHeight: 540,
+      height: 540,
     },
     greenColor: {
       color: theme.palette.success.main
@@ -37,6 +44,12 @@ const useStyles = makeStyles((theme: Theme) =>
     redColor: {
       color: theme.palette.error.main
     },
+    jobDetailsCodeMirror: {
+      '& .CodeMirror': { maxHeight: 400, fontSize: '1rem' },
+    },
+    jobDetailsLoading: {
+      alignSelf: "center"
+    }
   })
 );
 
@@ -51,19 +64,88 @@ const StyledTableCell = withStyles((theme: Theme) =>
 )(TableCell);
 
 type Props = {
-  data: any,
+  reloadStatusData: any,
+  tableJobsData: TableSegmentJobs | null,
   hideModal: (event: React.MouseEvent<HTMLElement, MouseEvent>) => void
 };
 
 export default function ReloadStatusOp({
-  data,
+  reloadStatusData,
+  tableJobsData,
   hideModal
 }: Props) {
   const classes = useStyles();
-  const segmentNames = data && Object.keys(data);
-  const indexes = data && data[segmentNames[0]]?.indexes;
+  const segmentNames = reloadStatusData && Object.keys(reloadStatusData);
+  const indexes = reloadStatusData && reloadStatusData[segmentNames[0]]?.indexes;
   const indexesKeys = indexes && Object.keys(indexes);
   const indexObjKeys = indexes && indexes[indexesKeys[0]] && Object.keys(indexes[indexesKeys[0]]) || [];
+  const [activeTab, setActiveTab] = useState(0);
+  const [segmentJobsTableData, setSegmentJobsTableData] = useState<TableData>({ records: [], columns: [] });
+  const [filteredSegmentJobsTableData, setFilteredSegmentJobsTableData] = useState<TableData>({ records: [], columns: [] });
+  const [jobDetailsDialogOpen, setJobDetailsDialogOpen] = useState<boolean>(false);
+  const [selectedJobId, setSelectedSegmentJobId] = useState<string | null>(null);
+  const [segmentJobDetails, setSegmentJobDetails] = useState(null);
+
+  useEffect(() => {
+    if(!tableJobsData) {
+      return;
+    }
+
+    const segmentJobsTableData: TableData = {
+      columns: ["Job Id", "Message Count", "Job Type", "Submitted On"],
+      records: Object.values(tableJobsData)
+        .sort((a, b) => b.submissionTimeMs - a.submissionTimeMs)
+        .map((job) => [
+          job.jobId,
+          job.messageCount,
+          job.jobType,
+          moment(+job.submissionTimeMs).format("MMMM Do YYYY, HH:mm:ss"),
+        ]),
+    };
+
+    setSegmentJobsTableData(segmentJobsTableData);
+    setFilteredSegmentJobsTableData(segmentJobsTableData);
+  }, [tableJobsData]);
+
+  useEffect(() => {
+    if(!selectedJobId) {
+      return;
+    }
+    fetchSegmentReloadStatusData(selectedJobId);
+  }, [selectedJobId]);
+
+  const fetchSegmentReloadStatusData = async (jobId: string) => {
+    const segmentJobDetails = await PinotMethodUtils.fetchSegmentReloadStatus(jobId);
+    setSegmentJobDetails(segmentJobDetails)
+  }
+
+  const handleSegmentJobIdClick = (id: string) => {
+    if(!id) {
+      return;
+    }
+    setJobDetailsDialogOpen(true);
+    setSelectedSegmentJobId(id);
+  }
+
+  const handleJobDetailsDialogClose = () => {
+    setJobDetailsDialogOpen(false);
+    setSelectedSegmentJobId(null);
+    setSegmentJobDetails(null);
+  }
+
+  const handleActiveTabChange = (_: React.ChangeEvent<{}>, newIndex: number) => {
+    setActiveTab(newIndex);
+  }
+
+  const handleJobIdSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const searchText = e.target.value;
+    const filteredRecords = segmentJobsTableData.records.filter((record) => {
+      return (record[0] as string).toLowerCase().includes(searchText.toLowerCase());
+    });
+
+    setFilteredSegmentJobsTableData((data) => ({...data, records: filteredRecords}));
+  }
+
   return (
     <Dialog
       open={true}
@@ -72,55 +154,122 @@ export default function ReloadStatusOp({
       showOkBtn={false}
       size='lg'
     >
-      {!data ?
+      {!(reloadStatusData && tableJobsData) ?
         <div className={classes.root}><CircularProgress/></div>
       :
         <DialogContent>
-          {indexes && indexesKeys && indexObjKeys ?
+          <Paper variant='outlined' >
+          <Tabs
+            value={activeTab}
+            onChange={handleActiveTabChange}
+            indicatorColor="primary"
+            textColor="primary"
+            centered
+          >
+            <Tab label="Jobs" />
+            <Tab label="Status" />
+          </Tabs>
+          </Paper>
+          <TabPanel value={activeTab} index={0}>
             <TableContainer component={Paper} className={classes.container}>
+              <SearchBar placeholder="Search by job id" onChange={handleJobIdSearchChange} />
               <Table stickyHeader aria-label="sticky table" size="small">
                 <TableHead>
                   <TableRow>
-                    <StyledTableCell></StyledTableCell>
-                    {indexObjKeys.map((o, i)=>{
+                    {filteredSegmentJobsTableData.columns.map((o, i)=>{
                       return (
-                        <StyledTableCell key={i} align="right">{o}</StyledTableCell>
+                        <StyledTableCell key={i} align="left">{o}</StyledTableCell>
                       );
                     })}
                   </TableRow>
                 </TableHead>
                 <TableBody>
-                  {indexesKeys.map((indexName, i) => {
-                    const indexObj = indexes[indexName];
-                    return (
-                      <TableRow key={i}>
-                        <StyledTableCell component="th" scope="row">
-                          {indexName}
-                        </StyledTableCell>
-                        {indexObjKeys.map((o, i)=>{
-                          let iconElement = null;
-                          if(indexObj[o].toLowerCase() === 'yes'){
-                            iconElement = <CheckIcon className={classes.greenColor}/>;
-                          } else if(indexObj[o].toLowerCase() === 'no'){
-                            iconElement = <CloseIcon className={classes.redColor}/>;
-                          } else {
-                            iconElement = indexObj[o];
-                          }
+                  {filteredSegmentJobsTableData.records.map((segmentJob, index) => (
+                    <TableRow key={index}>
+                      {segmentJob.map((data, idx) => {
+                        if(idx === 0) {
                           return (
-                            <StyledTableCell align="center" key={i}>
-                              {iconElement}
+                            <StyledTableCell align="left" key={idx}>
+                              <Link underline='always' component="button" variant="body2" onClick={() => handleSegmentJobIdClick(data as string)}>{data}</Link>
                             </StyledTableCell>
                           )
-                        })}
-                      </TableRow>
-                    )
-                  })}
+                        }
+                        return (
+                          <StyledTableCell align="left" key={idx}>
+                            {data}
+                          </StyledTableCell>
+                        )
+                      })}
+                    </TableRow>
+                  ))}
                 </TableBody>
               </Table>
             </TableContainer>
-          : 
-            <DialogContentText>No segment found in table.</DialogContentText>
-          }
+          </TabPanel>
+          <TabPanel value={activeTab} index={1}>
+            {indexes && indexesKeys && indexObjKeys ?
+              <TableContainer component={Paper} className={classes.container}>
+                <Table stickyHeader aria-label="sticky table" size="small">
+                  <TableHead>
+                    <TableRow>
+                      <StyledTableCell></StyledTableCell>
+                      {indexObjKeys.map((o, i)=>{
+                        return (
+                          <StyledTableCell key={i} align="right">{o}</StyledTableCell>
+                        );
+                      })}
+                    </TableRow>
+                  </TableHead>
+                  <TableBody>
+                    {indexesKeys.map((indexName, i) => {
+                      const indexObj = indexes[indexName];
+                      return (
+                        <TableRow key={i}>
+                          <StyledTableCell component="th" scope="row">
+                            {indexName}
+                          </StyledTableCell>
+                          {indexObjKeys.map((o, i)=>{
+                            let iconElement = null;
+                            if(indexObj[o].toLowerCase() === 'yes'){
+                              iconElement = <CheckIcon className={classes.greenColor}/>;
+                            } else if(indexObj[o].toLowerCase() === 'no'){
+                              iconElement = <CloseIcon className={classes.redColor}/>;
+                            } else {
+                              iconElement = indexObj[o];
+                            }
+                            return (
+                              <StyledTableCell align="center" key={i}>
+                                {iconElement}
+                              </StyledTableCell>
+                            )
+                          })}
+                        </TableRow>
+                      )
+                    })}
+                  </TableBody>
+                </Table>
+              </TableContainer>
+            :
+              <DialogContentText>No segment found in table.</DialogContentText>
+            }
+          </TabPanel>
+          <CustomDialog 
+            showOkBtn={false} 
+            title="Segment Job Details" 
+            open={jobDetailsDialogOpen} 
+            handleClose={handleJobDetailsDialogClose}
+          >
+            {segmentJobDetails ? (
+                <CustomCodemirror
+                  customClass={classes.jobDetailsCodeMirror}
+                  data={segmentJobDetails}
+                  isEditable={false}
+                />
+              ) : (
+                <CircularProgress className={classes.jobDetailsLoading} />
+              )
+            }
+          </CustomDialog>
         </DialogContent>
       }
     </Dialog>

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/ReloadStatusOp.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/ReloadStatusOp.tsx
@@ -124,13 +124,13 @@ export default function ReloadStatusOp({
       return;
     }
     setJobDetailsDialogOpen(true);
+    setSegmentJobDetails(null);
     setSelectedSegmentJobId(id);
   }
 
   const handleJobDetailsDialogClose = () => {
     setJobDetailsDialogOpen(false);
     setSelectedSegmentJobId(null);
-    setSegmentJobDetails(null);
   }
 
   const handleActiveTabChange = (_: React.ChangeEvent<{}>, newIndex: number) => {

--- a/pinot-controller/src/main/resources/app/components/SearchBar.tsx
+++ b/pinot-controller/src/main/resources/app/components/SearchBar.tsx
@@ -70,7 +70,7 @@ const SearchBar = (props) => {
         <SearchIcon />
       </div>
       <InputBase
-        placeholder="Search…"
+        placeholder={props.placeholder || "Search…"}
         value={props.value}
         onChange={props.onChange}
         classes={{

--- a/pinot-controller/src/main/resources/app/interfaces/types.d.ts
+++ b/pinot-controller/src/main/resources/app/interfaces/types.d.ts
@@ -187,4 +187,14 @@ declare module 'Models' {
     ts: number,
     status: string
   }
+
+  export type TableSegmentJobs = {
+    [key: string]: {
+      jobId: string,
+      messageCount: number,
+      submissionTimeMs: number,
+      jobType: string,
+      tableName: string
+    }
+  }
 }

--- a/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
@@ -19,10 +19,10 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { FormControlLabel, Grid, Switch, Tooltip } from '@material-ui/core';
+import { Box, Button, FormControlLabel, Grid, Switch, Tooltip, Typography } from '@material-ui/core';
 import { RouteComponentProps, useHistory, useLocation } from 'react-router-dom';
 import { UnControlled as CodeMirror } from 'react-codemirror2';
-import { TableData } from 'Models';
+import { TableData, TableSegmentJobs } from 'Models';
 import AppLoader from '../components/AppLoader';
 import CustomizedTables from '../components/Table';
 import TableToolbar from '../components/TableToolbar';
@@ -40,6 +40,7 @@ import Confirm from '../components/Confirm';
 import { NotificationContext } from '../components/Notification/NotificationContext';
 import Utils from '../utils/Utils';
 import InfoOutlinedIcon from '@material-ui/icons/InfoOutlined';
+import { get } from "lodash";
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -72,6 +73,10 @@ const useStyles = makeStyles((theme) => ({
     border: '1px #BDCCD9 solid',
     borderRadius: 4,
     marginBottom: 20
+  },
+  copyIdButton: {
+    paddingBlock: 0,
+    marginLeft: 10
   }
 }));
 
@@ -138,6 +143,7 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
   const [actionType, setActionType] = useState(null);
   const [showReloadStatusModal, setShowReloadStatusModal] = useState(false);
   const [reloadStatusData, setReloadStatusData] = useState(null);
+  const [tableJobsData, setTableJobsData] = useState<TableSegmentJobs | null>(null);
   const [showRebalanceServerModal, setShowRebalanceServerModal] = useState(false);
   const [schemaJSONFormat, setSchemaJSONFormat] = useState(false);
 
@@ -255,9 +261,9 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
     }
   };
 
-  const syncResponse = (result) => {
+  const syncResponse = (result, customMessage?: React.ReactNode) => {
     if(result.status){
-      dispatch({type: 'success', message: result.status, show: true});
+      dispatch({type: 'success', message: customMessage || result.status, show: true});
       fetchTableData();
       setShowEditConfig(false);
     } else {
@@ -319,19 +325,62 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
 
   const reloadSegments = async () => {
     const result = await PinotMethodUtils.reloadAllSegmentsOp(tableName, tableType);
-    syncResponse(result);
+
+    let reloadJobId = null;
+
+    try {
+      // extract reloadJobId from response
+      const statusResponseObj = JSON.parse(result.status.replace("Segment reload details: ", ""))
+      reloadJobId = get(statusResponseObj, `${tableName}.reloadJobId`, null)
+    } catch {
+      reloadJobId = null;
+    }
+
+    const handleCopyReloadJobId = () => {
+      if(!reloadJobId) {
+        return;
+      }
+      navigator.clipboard.writeText(reloadJobId);
+    }
+
+    const customMessage = (
+      <Box>
+        <Typography variant='inherit'>{result.status}</Typography>
+        <Button 
+          className={classes.copyIdButton} 
+          variant="outlined" 
+          color="inherit" 
+          size="small" 
+          onClick={handleCopyReloadJobId}
+        >
+          Copy Id
+        </Button>
+      </Box>
+    )
+    
+    syncResponse(result, reloadJobId && customMessage);
   };
 
   const handleReloadStatus = async () => {
-    const result = await PinotMethodUtils.reloadStatusOp(tableName, tableType);
-    if(result.error){
+    try{
+      setShowReloadStatusModal(true);
+      const [reloadStatusData, tableJobsData] = await Promise.all([
+        PinotMethodUtils.reloadStatusOp(tableName, tableType),
+        PinotMethodUtils.fetchTableJobs(tableName),
+      ]);
+
+      if(reloadStatusData.error || tableJobsData.error) {
+        dispatch({type: 'error', message: reloadStatusData.error || tableJobsData.error, show: true});
+        setShowReloadStatusModal(false);
+        return;
+      }
+      
+      setReloadStatusData(reloadStatusData);
+      setTableJobsData(tableJobsData);
+    } catch(error) {
+      dispatch({type: 'error', message: error, show: true});
       setShowReloadStatusModal(false);
-      dispatch({type: 'error', message: result.error, show: true});
-      setShowReloadStatusModal(false);
-      return;
     }
-    setShowReloadStatusModal(true);
-    setReloadStatusData(result);
   };
 
   const handleRebalanceBrokers = () => {
@@ -561,7 +610,8 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
         showReloadStatusModal &&
         <ReloadStatusOp
           hideModal={()=>{setShowReloadStatusModal(false); setReloadStatusData(null)}}
-          data={reloadStatusData}
+          reloadStatusData={reloadStatusData}
+          tableJobsData={tableJobsData}
         />
       }
       {showRebalanceServerModal &&

--- a/pinot-controller/src/main/resources/app/requests/index.ts
+++ b/pinot-controller/src/main/resources/app/requests/index.ts
@@ -20,7 +20,7 @@
 import { AxiosResponse } from 'axios';
 import { TableData, Instances, Instance, Tenants, ClusterConfig, TableName, TableSize,
   IdealState, QueryTables, TableSchema, SQLResult, ClusterName, ZKGetList, ZKConfig, OperationResponse,
-  BrokerList, ServerList, UserList, TableList, UserObject, TaskProgressResponse
+  BrokerList, ServerList, UserList, TableList, UserObject, TaskProgressResponse, TableSegmentJobs
 } from 'Models';
 
 const headers = {
@@ -191,6 +191,12 @@ export const reloadStatus = (tableName: string, tableType: string): Promise<Axio
 
 export const deleteSegment = (tableName: string, instanceName: string): Promise<AxiosResponse<OperationResponse>> =>
   baseApi.delete(`/segments/${tableName}/${instanceName}`, {headers});
+
+export const getTableJobs = (tableName: string): Promise<AxiosResponse<TableSegmentJobs>> => 
+  baseApi.get(`/table/${tableName}/jobs`);
+
+export const getSegmentReloadStatus = (jobId: string): Promise<AxiosResponse<OperationResponse>> =>
+  baseApi.get(`/segments/segmentReloadStatus/${jobId}`, {headers});
 
 export const deleteTable = (tableName: string): Promise<AxiosResponse<OperationResponse>> =>
   baseApi.delete(`/tables/${tableName}`, {headers});

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -57,6 +57,7 @@ import {
   getTenantTableDetails,
   getSegmentMetadata,
   reloadSegment,
+  getTableJobs,
   getClusterInfo,
   zookeeperGetList,
   zookeeperGetData,
@@ -90,7 +91,8 @@ import {
   requestAddUser,
   requestDeleteUser,
   requestUpdateUser,
-  getTaskProgress
+  getTaskProgress,
+  getSegmentReloadStatus
 } from '../requests';
 import { baseApi } from './axios-config';
 import Utils from './Utils';
@@ -866,6 +868,18 @@ const deleteSegmentOp = (tableName, segmentName) => {
   });
 };
 
+const fetchTableJobs = async (tableName: string) => {
+  const response = await getTableJobs(tableName);
+  
+  return response.data;
+}
+
+const fetchSegmentReloadStatus = async (jobId: string) => {
+  const response = await getSegmentReloadStatus(jobId);
+  
+  return response.data;
+}
+
 const updateTable = (tableName: string, table: string) => {
   return putTable(tableName, table).then((res)=>{
     return res.data;
@@ -1100,6 +1114,8 @@ export default {
   deleteInstance,
   getAllPeriodicTaskNames,
   getAllTaskTypes,
+  fetchTableJobs,
+  fetchSegmentReloadStatus,
   getTaskTypeDebugData,
   getTableData,
   getTaskInfo,


### PR DESCRIPTION
#### What does this PR do?

Add a UI to dynamically show reload status for table segments. Currently, there is no easy way to get this information other than repeatedly checking/clicking the “Reload status“ button in the UI (which depending on table size itself can take few seconds for each run) or manually tailing server logs to look for segment reloading messages.

#### Changes
- Add copy id button which will copy the segment job id from the success message. 
- List all the table jobs under `Reload Status` dialog.
- Users can also search for a specific job using the job id (which was copied previously).
- Clicking jobId will display further details.


https://user-images.githubusercontent.com/41536903/193681464-1596e53b-87c7-4e18-b600-1b63cac2cf28.mp4

Reviewers - @npawar @saurabhd336 @joshigaurava @mayankshriv 

