### PR TITLE
Optimize PinotHelixResourceManager.hasTable()

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2770,7 +2770,8 @@ public class PinotHelixResourceManager {
   }
 
   public boolean hasTable(String tableNameWithType) {
-    return getAllResources().contains(tableNameWithType);
+    return _helixDataAccessor.getBaseDataAccessor()
+        .exists(_keyBuilder.idealStates(tableNameWithType).getPath(), AccessOption.PERSISTENT);
   }
 
   public boolean hasOfflineTable(String tableName) {


### PR DESCRIPTION
Currently `hasTable()` is very inefficient especially for large cluster. It first reads all table names (from ZK ideal state folder) as a list, then search the table name within the list. Instead, we can directly check if the IS node for the table exists