### PR TITLE
Do not create dictionary for high-cardinality columns

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -373,27 +373,32 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
       return false;
     }
 
-    // Do not create dictionaries for json or text index columns as they are high-cardinality values almost always
-    if (config.getJsonIndexCreationColumns().contains(column)
-        || config.getTextIndexCreationColumns().contains(column)) {
-      return false;
-    }
 
-    // Do not create dictionary if index size with dictionary is going to be larger than index size without dictionary
-    // This is done to reduce the cost of dictionary for high cardinality columns
-    // Off by default and needs optimizeDictionaryEnabled to be set to true
-    if (config.isOptimizeDictionaryForMetrics() && spec.isSingleValueField() && spec.getDataType().isFixedWidth()) {
-      long dictionarySize = info.getDistinctValueCount() * spec.getDataType().size();
-      long forwardIndexSize =
-          ((long) info.getTotalNumberOfEntries() * PinotDataBitSet.getNumBitsPerValue(info.getDistinctValueCount() - 1)
-              + Byte.SIZE - 1) / Byte.SIZE;
 
-      double indexWithDictSize = dictionarySize + forwardIndexSize;
-      double indexWithoutDictSize = info.getTotalNumberOfEntries() * spec.getDataType().size();
+    if (config.isOptimizeDictionary()) {
 
-      double indexSizeRatio = indexWithoutDictSize / indexWithDictSize;
-      if (indexSizeRatio <= config.getNoDictionarySizeRatioThreshold()) {
+      // Do not create dictionaries for json or text index columns as they are high-cardinality values almost always
+      if (config.getJsonIndexCreationColumns().contains(column)
+          || config.getTextIndexCreationColumns().contains(column)) {
         return false;
+      }
+
+      // Do not create dictionary if index size with dictionary is going to be larger than index size without dictionary
+      // This is done to reduce the cost of dictionary for high cardinality columns
+      // Off by default and needs optimizeDictionaryEnabled to be set to true
+      if (spec.isSingleValueField() && spec.getDataType().isFixedWidth()) {
+        long dictionarySize = info.getDistinctValueCount() * spec.getDataType().size();
+        long forwardIndexSize =
+            ((long) info.getTotalNumberOfEntries()
+                * PinotDataBitSet.getNumBitsPerValue(info.getDistinctValueCount() - 1) + Byte.SIZE - 1) / Byte.SIZE;
+
+        double indexWithDictSize = dictionarySize + forwardIndexSize;
+        double indexWithoutDictSize = info.getTotalNumberOfEntries() * spec.getDataType().size();
+
+        double indexSizeRatio = indexWithoutDictSize / indexWithDictSize;
+        if (indexSizeRatio <= config.getNoDictionarySizeRatioThreshold()) {
+          return false;
+        }
       }
     }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -373,35 +373,45 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
       return false;
     }
 
-
-
     if (config.isOptimizeDictionary()) {
 
       // Do not create dictionaries for json or text index columns as they are high-cardinality values almost always
-      if (config.getJsonIndexConfigs().containsKey(column)
-          || config.getTextIndexCreationColumns().contains(column)) {
+      if ((config.getJsonIndexConfigs().containsKey(column)
+          || config.getTextIndexCreationColumns().contains(column))) {
         return false;
       }
 
       // Do not create dictionary if index size with dictionary is going to be larger than index size without dictionary
       // This is done to reduce the cost of dictionary for high cardinality columns
-      // Off by default and needs optimizeDictionaryEnabled to be set to true
+      // Off by default and needs optimizeDictionary to be set to true
       if (spec.isSingleValueField() && spec.getDataType().isFixedWidth()) {
-        long dictionarySize = info.getDistinctValueCount() * spec.getDataType().size();
-        long forwardIndexSize =
-            ((long) info.getTotalNumberOfEntries()
-                * PinotDataBitSet.getNumBitsPerValue(info.getDistinctValueCount() - 1) + Byte.SIZE - 1) / Byte.SIZE;
-
-        double indexWithDictSize = dictionarySize + forwardIndexSize;
-        double indexWithoutDictSize = info.getTotalNumberOfEntries() * spec.getDataType().size();
-
-        double indexSizeRatio = indexWithoutDictSize / indexWithDictSize;
-        if (indexSizeRatio <= config.getNoDictionarySizeRatioThreshold()) {
-          return false;
-        }
+        return shouldCreateDictionaryWithinThreshold(info, config, spec);
       }
     }
 
+    if (config.isOptimizeDictionaryForMetrics() && !config.isOptimizeDictionary()) {
+      if (spec.isSingleValueField() && spec.getDataType().isFixedWidth() && spec.getFieldType() == FieldType.METRIC) {
+        return shouldCreateDictionaryWithinThreshold(info, config, spec);
+      }
+    }
+
+    return info.isCreateDictionary();
+  }
+
+  private boolean shouldCreateDictionaryWithinThreshold(ColumnIndexCreationInfo info,
+      SegmentGeneratorConfig config, FieldSpec spec) {
+    long dictionarySize = info.getDistinctValueCount() * spec.getDataType().size();
+    long forwardIndexSize =
+        ((long) info.getTotalNumberOfEntries()
+            * PinotDataBitSet.getNumBitsPerValue(info.getDistinctValueCount() - 1) + Byte.SIZE - 1) / Byte.SIZE;
+
+    double indexWithDictSize = dictionarySize + forwardIndexSize;
+    double indexWithoutDictSize = info.getTotalNumberOfEntries() * spec.getDataType().size();
+
+    double indexSizeRatio = indexWithoutDictSize / indexWithDictSize;
+    if (indexSizeRatio <= config.getNoDictionarySizeRatioThreshold()) {
+      return false;
+    }
     return info.isCreateDictionary();
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -378,7 +378,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
     if (config.isOptimizeDictionary()) {
 
       // Do not create dictionaries for json or text index columns as they are high-cardinality values almost always
-      if (config.getJsonIndexCreationColumns().contains(column)
+      if (config.getJsonIndexConfigs().containsKey(column)
           || config.getTextIndexCreationColumns().contains(column)) {
         return false;
       }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/DictionaryOptimiserTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/DictionaryOptimiserTest.java
@@ -139,7 +139,7 @@ public class DictionaryOptimiserTest {
     segmentGenSpec.setSegmentVersion(SegmentVersion.v1);
     segmentGenSpec.setTableName(tableName);
     segmentGenSpec.setOutDir(outputDir.getAbsolutePath());
-    segmentGenSpec.setOptimizeDictionaryForMetrics(true);
+    segmentGenSpec.setOptimizeDictionary(true);
     segmentGenSpec.setNoDictionarySizeRatioThreshold(0.9);
     return segmentGenSpec;
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/DictionaryOptimiserTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/DictionaryOptimiserTest.java
@@ -163,7 +163,11 @@ public class DictionaryOptimiserTest {
 
       final FieldSpec fieldSpec;
       if ((pinotType != null && "METRIC".equals(pinotType)) || columnName.contains("cardinality")) {
-        fieldSpec = new MetricFieldSpec();
+        if (field.schema().isUnion() && isDoubleOrFloat(field)) {
+          fieldSpec = new MetricFieldSpec();
+        } else {
+          fieldSpec = new DimensionFieldSpec();
+        }
       } else {
         fieldSpec = new DimensionFieldSpec();
       }
@@ -176,5 +180,10 @@ public class DictionaryOptimiserTest {
 
     dataStream.close();
     return schema;
+  }
+
+  private static boolean isDoubleOrFloat(org.apache.avro.Schema.Field field) {
+    return field.schema().getTypes().contains(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.DOUBLE))
+        || field.schema().getTypes().contains(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.FLOAT));
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/DictionaryOptimiserTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/DictionaryOptimiserTest.java
@@ -21,8 +21,11 @@ package org.apache.pinot.segment.local.segment.creator;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
@@ -34,6 +37,7 @@ import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
+import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
@@ -114,6 +118,11 @@ public class DictionaryOptimiserTest {
         Assert.assertFalse(heapSegment.getForwardIndex(columnName).isDictionaryEncoded(),
             "No Raw index for high cardinality columns");
       }
+
+      if (columnName.contains("key")) {
+        Assert.assertFalse(heapSegment.getSegmentMetadata().getColumnMetadataFor(columnName).hasDictionary(),
+            "Dictionary found for text index column");
+      }
     }
   }
 
@@ -128,10 +137,19 @@ public class DictionaryOptimiserTest {
     IngestionConfig ingestionConfig = new IngestionConfig();
     ingestionConfig.setRowTimeValueCheck(false);
     ingestionConfig.setSegmentTimeValueCheck(false);
+    Schema schema = extractSchemaFromAvroWithoutTime(inputAvro);
+    List<DimensionFieldSpec> stringColumns =
+        schema.getDimensionFieldSpecs().stream().filter(x -> x.getDataType() == FieldSpec.DataType.STRING).collect(
+        Collectors.toList());
+
+    List<FieldConfig> fieldConfigList = stringColumns.stream()
+        .map(x -> new FieldConfig(x.getName(), FieldConfig.EncodingType.DICTIONARY,
+        Collections.singletonList(FieldConfig.IndexType.TEXT), null, null)).collect(Collectors.toList());
+
     final SegmentGeneratorConfig segmentGenSpec =
         new SegmentGeneratorConfig(new TableConfigBuilder(TableType.OFFLINE).setTableName(tableName)
-            .setIngestionConfig(ingestionConfig).build(),
-            extractSchemaFromAvroWithoutTime(inputAvro));
+            .setIngestionConfig(ingestionConfig).setFieldConfigList(fieldConfigList).build(),
+            schema);
     segmentGenSpec.setInputFilePath(inputAvro.getAbsolutePath());
     segmentGenSpec.setTimeColumnName(timeColumn);
     segmentGenSpec.setSegmentTimeUnit(timeUnit);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -123,7 +123,7 @@ public class SegmentGeneratorConfig implements Serializable {
   private boolean _rowTimeValueCheck = false;
   private boolean _segmentTimeValueCheck = true;
   private boolean _failOnEmptySegment = false;
-  private boolean _optimizeDictionaryForMetrics = false;
+  private boolean _optimizeDictionary = false;
   private double _noDictionarySizeRatioThreshold = DEFAULT_NO_DICTIONARY_SIZE_RATIO_THRESHOLD;
 
   // constructed from FieldConfig
@@ -241,7 +241,7 @@ public class SegmentGeneratorConfig implements Serializable {
 
       _fstTypeForFSTIndex = indexingConfig.getFSTIndexType();
       _nullHandlingEnabled = indexingConfig.isNullHandlingEnabled();
-      _optimizeDictionaryForMetrics = indexingConfig.isOptimizeDictionaryForMetrics();
+      _optimizeDictionary = indexingConfig.isOptimizeDictionary();
       _noDictionarySizeRatioThreshold = indexingConfig.getNoDictionarySizeRatioThreshold();
     }
 
@@ -898,12 +898,12 @@ public class SegmentGeneratorConfig implements Serializable {
     _segmentTimeValueCheck = segmentTimeValueCheck;
   }
 
-  public boolean isOptimizeDictionaryForMetrics() {
-    return _optimizeDictionaryForMetrics;
+  public boolean isOptimizeDictionary() {
+    return _optimizeDictionary;
   }
 
-  public void setOptimizeDictionaryForMetrics(boolean optimizeDictionaryForMetrics) {
-    _optimizeDictionaryForMetrics = optimizeDictionaryForMetrics;
+  public void setOptimizeDictionary(boolean optimizeDictionary) {
+    _optimizeDictionary = optimizeDictionary;
   }
 
   public double getNoDictionarySizeRatioThreshold() {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -242,6 +242,11 @@ public class SegmentGeneratorConfig implements Serializable {
       _fstTypeForFSTIndex = indexingConfig.getFSTIndexType();
       _nullHandlingEnabled = indexingConfig.isNullHandlingEnabled();
       _optimizeDictionary = indexingConfig.isOptimizeDictionary();
+
+      // Added for backward compatibility. Only `optimizeDictionary` config should be used in the future.
+      if (indexingConfig.isOptimizeDictionaryForMetrics() && !_optimizeDictionary) {
+        _optimizeDictionary = indexingConfig.isOptimizeDictionaryForMetrics();
+      }
       _noDictionarySizeRatioThreshold = indexingConfig.getNoDictionarySizeRatioThreshold();
     }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -124,6 +124,7 @@ public class SegmentGeneratorConfig implements Serializable {
   private boolean _segmentTimeValueCheck = true;
   private boolean _failOnEmptySegment = false;
   private boolean _optimizeDictionary = false;
+  private boolean _optimizeDictionaryForMetrics = false;
   private double _noDictionarySizeRatioThreshold = DEFAULT_NO_DICTIONARY_SIZE_RATIO_THRESHOLD;
 
   // constructed from FieldConfig
@@ -241,12 +242,9 @@ public class SegmentGeneratorConfig implements Serializable {
 
       _fstTypeForFSTIndex = indexingConfig.getFSTIndexType();
       _nullHandlingEnabled = indexingConfig.isNullHandlingEnabled();
-      _optimizeDictionary = indexingConfig.isOptimizeDictionary();
 
-      // Added for backward compatibility. Only `optimizeDictionary` config should be used in the future.
-      if (indexingConfig.isOptimizeDictionaryForMetrics() && !_optimizeDictionary) {
-        _optimizeDictionary = indexingConfig.isOptimizeDictionaryForMetrics();
-      }
+      _optimizeDictionary = indexingConfig.isOptimizeDictionary();
+      _optimizeDictionaryForMetrics = indexingConfig.isOptimizeDictionaryForMetrics();
       _noDictionarySizeRatioThreshold = indexingConfig.getNoDictionarySizeRatioThreshold();
     }
 
@@ -909,6 +907,14 @@ public class SegmentGeneratorConfig implements Serializable {
 
   public void setOptimizeDictionary(boolean optimizeDictionary) {
     _optimizeDictionary = optimizeDictionary;
+  }
+
+  public boolean isOptimizeDictionaryForMetrics() {
+    return _optimizeDictionaryForMetrics;
+  }
+
+  public void setOptimizeDictionaryForMetrics(boolean optimizeDictionaryForMetrics) {
+    _optimizeDictionaryForMetrics = optimizeDictionaryForMetrics;
   }
 
   public double getNoDictionarySizeRatioThreshold() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
@@ -63,8 +63,9 @@ public class IndexingConfig extends BaseJsonConfig {
    */
   private boolean _optimizeDictionary;
 
-  // Present only for backward compatibility. Please use `optimizeDictionary` for new tables.
-  @Deprecated
+  /**
+   * Same as `optimizeDictionary` but only for metric columns.
+   */
   private boolean _optimizeDictionaryForMetrics;
 
   private double _noDictionarySizeRatioThreshold;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
@@ -57,10 +57,11 @@ public class IndexingConfig extends BaseJsonConfig {
   private boolean _nullHandlingEnabled;
 
   /**
-   * If `optimizeDictionaryForMetrics` enabled, dictionary is not created for the metric columns
-   * for which rawIndexSize / forwardIndexSize is less than the `noDictionarySizeRatioThreshold`.
+   * If `optimizeDictionaryForMetrics` enabled, dictionary is not created for the high-cardinality
+   * single-valued columns for which rawIndexSize / forwardIndexSize is less than the `noDictionarySizeRatioThreshold`.
+   * It also disables dictionary for json and text columns.
    */
-  private boolean _optimizeDictionaryForMetrics;
+  private boolean _optimizeDictionary;
   private double _noDictionarySizeRatioThreshold;
 
   // TODO: Add a new configuration related to the segment generation
@@ -293,12 +294,12 @@ public class IndexingConfig extends BaseJsonConfig {
     _nullHandlingEnabled = nullHandlingEnabled;
   }
 
-  public boolean isOptimizeDictionaryForMetrics() {
-    return _optimizeDictionaryForMetrics;
+  public boolean isOptimizeDictionary() {
+    return _optimizeDictionary;
   }
 
-  public void setOptimizeDictionaryForMetrics(boolean optimizeDictionaryForMetrics) {
-    _optimizeDictionaryForMetrics = optimizeDictionaryForMetrics;
+  public void setOptimizeDictionary(boolean optimizeDictionary) {
+    _optimizeDictionary = optimizeDictionary;
   }
 
   public double getNoDictionarySizeRatioThreshold() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
@@ -57,11 +57,16 @@ public class IndexingConfig extends BaseJsonConfig {
   private boolean _nullHandlingEnabled;
 
   /**
-   * If `optimizeDictionaryForMetrics` enabled, dictionary is not created for the high-cardinality
+   * If `optimizeDictionary` enabled, dictionary is not created for the high-cardinality
    * single-valued columns for which rawIndexSize / forwardIndexSize is less than the `noDictionarySizeRatioThreshold`.
    * It also disables dictionary for json and text columns.
    */
   private boolean _optimizeDictionary;
+
+  // Present only for backward compatibility. Please use `optimizeDictionary` for new tables.
+  @Deprecated
+  private boolean _optimizeDictionaryForMetrics;
+
   private double _noDictionarySizeRatioThreshold;
 
   // TODO: Add a new configuration related to the segment generation
@@ -300,6 +305,14 @@ public class IndexingConfig extends BaseJsonConfig {
 
   public void setOptimizeDictionary(boolean optimizeDictionary) {
     _optimizeDictionary = optimizeDictionary;
+  }
+
+  public boolean isOptimizeDictionaryForMetrics() {
+    return _optimizeDictionaryForMetrics;
+  }
+
+  public void setOptimizeDictionaryForMetrics(boolean optimizeDictionaryForMetrics) {
+    _optimizeDictionaryForMetrics = optimizeDictionaryForMetrics;
   }
 
   public double getNoDictionarySizeRatioThreshold() {


### PR DESCRIPTION
* Disable dicts for JSON and TEXT indexing columns
* Extend `optimizeDictionary` config for dimension columns with fixed width as well.

Objective is to reduce the segment size and server space/memory usage.

## Release Notes

New config added `optimizeDictionary` to reduce memory usage due to dictionaries

## Documentation

To enable this feature, add the following to your table config

```json
"tableIndexConfig" : {
 "optimizeDictionary" : true
}
```
