### PR TITLE
Fix record extractor when ByteBuffer can be reused

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractorTest.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.MathContext;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -34,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
 import org.apache.avro.Conversions;
 import org.apache.avro.Schema;
 import org.apache.avro.data.TimeConversions;
@@ -229,5 +231,16 @@ public class AvroRecordExtractorTest extends AbstractRecordExtractorTest {
     Assert.assertEquals(genericRow.getValue(timestampMillisColName).getClass().getSimpleName(), "Timestamp");
     Assert.assertEquals(genericRow.getValue(timestampMicrosColName), timestampMicrosColValue);
     Assert.assertEquals(genericRow.getValue(timestampMicrosColName).getClass().getSimpleName(), "Timestamp");
+  }
+
+  @Test
+  public void testReusedByteBuffer() {
+    byte[] content = new byte[100];
+    ThreadLocalRandom.current().nextBytes(content);
+    ByteBuffer byteBuffer = ByteBuffer.wrap(content);
+    AvroRecordExtractor avroRecordExtractor = new AvroRecordExtractor();
+    for (int i = 0; i < 10; i++) {
+      Assert.assertEquals(avroRecordExtractor.convertSingleValue(byteBuffer), content);
+    }
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/BaseRecordExtractor.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/BaseRecordExtractor.java
@@ -176,12 +176,11 @@ public abstract class BaseRecordExtractor<T> implements RecordExtractor<T> {
    */
   protected Object convertSingleValue(Object value) {
     if (value instanceof ByteBuffer) {
-      ByteBuffer byteBufferValue = (ByteBuffer) value;
-
-      // Use byteBufferValue.remaining() instead of byteBufferValue.capacity() so that it still works when buffer is
-      // over-sized
-      byte[] bytesValue = new byte[byteBufferValue.remaining()];
-      byteBufferValue.get(bytesValue);
+      // NOTE: ByteBuffer might be reused in some record reader implementation. Make a slice to ensure nothing is
+      //       modified in the original buffer
+      ByteBuffer slice = ((ByteBuffer) value).slice();
+      byte[] bytesValue = new byte[slice.limit()];
+      slice.get(bytesValue);
       return bytesValue;
     }
     if (value instanceof Number || value instanceof byte[]) {


### PR DESCRIPTION
Some record reader implementation might reuse the ByteBuffer (e.g. `parquet-avro 0.10.0`). Make a slice before reading to ensure nothing is modified in the original buffer