### PR TITLE
Adding SegmentNameGenerator type inference if not explicitly set in config

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
@@ -132,7 +132,7 @@ public class SegmentProcessorFramework {
           .createSegmentNameGenerator(tableConfig, schema, segmentNamePrefix, segmentNamePostfix, fixedSegmentName,
               false));
     } else {
-      // SimpleSegmentNameGenerator is used by default.
+      // SegmentNameGenerator will be inferred by the SegmentGeneratorConfig.
       generatorConfig.setSegmentNamePrefix(segmentNamePrefix);
       generatorConfig.setSegmentNamePostfix(segmentNamePostfix);
     }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/test/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunnerTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/test/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunnerTest.java
@@ -37,6 +37,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.Schema.SchemaBuilder;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
+import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.ingestion.batch.spec.ExecutionFrameworkSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
 import org.apache.pinot.spi.ingestion.batch.spec.RecordReaderSpec;
@@ -199,7 +200,7 @@ public class SegmentGenerationJobRunnerTest {
     // Set up for a segment name that matches our input filename, so we can validate
     // that only the first input file gets processed.
     SegmentNameGeneratorSpec nameSpec = new SegmentNameGeneratorSpec();
-    nameSpec.setType(SegmentGenerationTaskRunner.INPUT_FILE_SEGMENT_NAME_GENERATOR);
+    nameSpec.setType(BatchConfigProperties.SegmentNameGeneratorType.INPUT_FILE);
     nameSpec.getConfigs().put(SegmentGenerationTaskRunner.FILE_PATH_PATTERN, ".+/(.+)\\.csv");
     nameSpec.getConfigs().put(SegmentGenerationTaskRunner.SEGMENT_NAME_TEMPLATE, "${filePathPattern:\\1}");
     jobSpec.setSegmentNameGeneratorSpec(nameSpec);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
 import org.apache.pinot.segment.spi.creator.name.FixedSegmentNameGenerator;
+import org.apache.pinot.segment.spi.creator.name.NormalizedDateSegmentNameGenerator;
 import org.apache.pinot.segment.spi.creator.name.SegmentNameGenerator;
 import org.apache.pinot.segment.spi.creator.name.SimpleSegmentNameGenerator;
 import org.apache.pinot.segment.spi.index.creator.H3IndexConfig;
@@ -55,6 +56,8 @@ import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
+import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -94,6 +97,7 @@ public class SegmentGeneratorConfig implements Serializable {
   private String _segmentNamePrefix = null;
   private String _segmentNamePostfix = null;
   private String _segmentTimeColumnName = null;
+  private FieldSpec.DataType _segmentTimeColumnDataType = null;
   private TimeUnit _segmentTimeUnit = null;
   private String _segmentCreationTime = null;
   private String _segmentStartTime = null;
@@ -272,6 +276,7 @@ public class SegmentGeneratorConfig implements Serializable {
     if (timeColumnName != null) {
       DateTimeFieldSpec dateTimeFieldSpec = schema.getSpecForTimeColumn(timeColumnName);
       if (dateTimeFieldSpec != null) {
+        _segmentTimeColumnDataType = dateTimeFieldSpec.getDataType();
         setTimeColumnName(dateTimeFieldSpec.getName());
         setDateTimeFormatSpec(dateTimeFieldSpec.getFormatSpec());
       }
@@ -704,14 +709,36 @@ public class SegmentGeneratorConfig implements Serializable {
     if (_segmentNameGenerator != null) {
       return _segmentNameGenerator;
     }
+
+    String segmentNameGeneratorType = inferSegmentNameGeneratorType();
+    switch (segmentNameGeneratorType) {
+      case BatchConfigProperties.SegmentNameGeneratorType.FIXED:
+        return new FixedSegmentNameGenerator(_segmentName);
+      case BatchConfigProperties.SegmentNameGeneratorType.NORMALIZED_DATE:
+        return new NormalizedDateSegmentNameGenerator(_rawTableName, _segmentNamePrefix, false,
+            IngestionConfigUtils.getBatchSegmentIngestionType(_tableConfig),
+            IngestionConfigUtils.getBatchSegmentIngestionFrequency(_tableConfig), _dateTimeFormatSpec,
+            _segmentNamePostfix);
+      default:
+        return new SimpleSegmentNameGenerator(_segmentNamePrefix != null ? _segmentNamePrefix : _rawTableName,
+            _segmentNamePostfix);
+    }
+  }
+
+  /**
+   * Infers the segment name generator type based on segment generator config properties. Will default to simple
+   * SegmentNameGeneratorType.
+   */
+  public String inferSegmentNameGeneratorType() {
     if (_segmentName != null) {
-      return new FixedSegmentNameGenerator(_segmentName);
+      return BatchConfigProperties.SegmentNameGeneratorType.FIXED;
     }
-    if (_segmentNamePrefix != null) {
-      return new SimpleSegmentNameGenerator(_segmentNamePrefix, _segmentNamePostfix);
-    } else {
-      return new SimpleSegmentNameGenerator(_rawTableName, _segmentNamePostfix);
+
+    if (_segmentTimeColumnDataType == FieldSpec.DataType.STRING && _timeColumnType == TimeColumnType.SIMPLE_DATE) {
+      return BatchConfigProperties.SegmentNameGeneratorType.NORMALIZED_DATE;
     }
+
+    return BatchConfigProperties.SegmentNameGeneratorType.SIMPLE;
   }
 
   public void setSegmentNameGenerator(SegmentNameGenerator segmentNameGenerator) {


### PR DESCRIPTION
**Context**

If the Pinot time column is in simple date format, it requires that the SegmentNameGenerator type is set to `normalizedDate` ([spec](https://docs.pinot.apache.org/configuration-reference/job-specification#segment-name-generator-spec)). Often times this is missed as it defaults to `simple`. And as a result, if the time column is in String and SIMPLE_DATE_FORMAT, the segment generation will fail. E.g. see this [OSS slack thread](https://apache-pinot.slack.com/archives/C011C9JHN7R/p1664541448419409).

**Change**

This PR enhances the logic for inferring the segmentNameGenerator within the SegmentGenerationConfig in the case that the time column is string and is in simple date format.
