### PR TITLE
[bugfix] fix column name for record metadata in quickstart

### DIFF
--- a/pinot-tools/src/main/resources/examples/stream/meetupRsvp/meetupRsvp_schema.json
+++ b/pinot-tools/src/main/resources/examples/stream/meetupRsvp/meetupRsvp_schema.json
@@ -12,7 +12,11 @@
     },
     {
       "dataType": "STRING",
-      "name": "header$producerTimestamp"
+      "name": "__metadata$offset"
+    },
+    {
+      "dataType": "STRING",
+      "name": "__metadata$recordTimestamp"
     },
     {
       "dataType": "STRING",


### PR DESCRIPTION
* header and metadata columns are prefixed with `__` 