### PR TITLE
UI: fix incorrect task finish time

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/TaskDetail.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TaskDetail.tsx
@@ -104,7 +104,7 @@ const TaskDetail = (props) => {
             <strong>Start Time:</strong> {get(taskDebugData, 'startTime', '')}
           </Grid>
           <Grid item xs={12}>
-            <strong>Finish Time:</strong> {get(taskDebugData, 'subtaskInfos.0.finishTime', '')}
+            <strong>Finish Time:</strong> {get(taskDebugData, 'finishTime', '')}
           </Grid>
           <Grid item xs={12}>
             <strong>Number of Sub Tasks:</strong> {get(taskDebugData, 'subtaskCount.total', '')}

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -809,12 +809,11 @@ const getTasksList = async (tableName, taskType) => {
       const promiseArr = [];
       const fetchInfo = async (taskID, status) => {
         const debugData = await getTaskDebugData(taskID);
-        const startTime = moment(get(debugData, 'data.subtaskInfos.0.startTime'), 'YYYY-MM-DD hh:mm:ss');
         finalResponse.records.push([
           taskID,
           status,
-          get(debugData, 'data.subtaskInfos.0.startTime'),
-          get(debugData, 'data.subtaskInfos.0.finishTime', ''),
+          get(debugData, 'data.startTime', ''),
+          get(debugData, 'data.finishTime', ''),
           get(debugData, 'data.subtaskCount.total', 0)
         ]);
       };


### PR DESCRIPTION
### What does this PR do?
- Fix incorrect task finish time display in UI

### Description
- Earlier when fetching task details(via task debug API) there was no task level `finishTime` available.
- For the workaround UI displayed the first subtask finishTime `subTaskInfos[0].finishTime`, which is incorrect considering each task can have multiple subTasks with different finishTime.
- With the recent changes in this PR #9534, task debug API now exposes task level `finishTime`, which the UI can consume to fix the issue.

Reviewers - @klsince @npawar @joshigaurava 