### PR TITLE
Fix time validation when data type needs to be converted

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/DataTypeTransformer.java
@@ -27,15 +27,11 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.PinotDataType;
 import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.data.DateTimeFieldSpec;
-import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.utils.TimeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -51,9 +47,6 @@ public class DataTypeTransformer implements RecordTransformer {
 
   private final Map<String, PinotDataType> _dataTypes = new HashMap<>();
   private final boolean _continueOnError;
-  private final boolean _rowTimeValueCheck;
-  private final String _timeColumnName;
-  private final DateTimeFormatSpec _timeFormatSpec;
 
   public DataTypeTransformer(TableConfig tableConfig, Schema schema) {
     for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
@@ -63,21 +56,9 @@ public class DataTypeTransformer implements RecordTransformer {
     }
     if (tableConfig.getIngestionConfig() != null) {
       _continueOnError = tableConfig.getIngestionConfig().isContinueOnError();
-      _rowTimeValueCheck = tableConfig.getIngestionConfig().isRowTimeValueCheck();
     } else {
       _continueOnError = false;
-      _rowTimeValueCheck = false;
     }
-    _timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
-
-    DateTimeFormatSpec timeColumnSpec = null;
-    if (StringUtils.isNotEmpty(_timeColumnName)) {
-      DateTimeFieldSpec dateTimeFieldSpec = schema.getSpecForTimeColumn(_timeColumnName);
-      Preconditions.checkState(dateTimeFieldSpec != null, "Failed to find spec for time column: %s from schema: %s",
-          _timeColumnName, schema.getSchemaName());
-      timeColumnSpec = dateTimeFieldSpec.getFormatSpec();
-    }
-    _timeFormatSpec = timeColumnSpec;
   }
 
   @Override
@@ -88,22 +69,6 @@ public class DataTypeTransformer implements RecordTransformer {
         Object value = record.getValue(column);
         if (value == null) {
           continue;
-        }
-
-        if (_rowTimeValueCheck && _timeFormatSpec != null && column.equals(_timeColumnName)) {
-          long timeInMs = _timeFormatSpec.fromFormatToMillis(value.toString());
-          if (!TimeUtils.timeValueInValidRange(timeInMs)) {
-            if (_continueOnError) {
-              LOGGER.debug("Time value {} is not in valid range for column: {}, must be between: {}", timeInMs,
-                  _timeColumnName, TimeUtils.VALID_TIME_INTERVAL);
-              record.putValue(column, null);
-              continue;
-            } else {
-              throw new RuntimeException(
-                  String.format("Time value %s is not in valid range for column: %s, must be between: %s", timeInMs,
-                      _timeColumnName, TimeUtils.VALID_TIME_INTERVAL));
-            }
-          }
         }
 
         PinotDataType dest = entry.getValue();
@@ -198,8 +163,8 @@ public class DataTypeTransformer implements RecordTransformer {
         return standardizedValues.get(0);
       }
       if (isSingleValue) {
-        throw new IllegalArgumentException("Cannot read single-value from Object[]: " + Arrays.toString(values)
-            + " for column: " + column);
+        throw new IllegalArgumentException(
+            "Cannot read single-value from Object[]: " + Arrays.toString(values) + " for column: " + column);
       }
       return standardizedValues.toArray();
     }
@@ -228,8 +193,8 @@ public class DataTypeTransformer implements RecordTransformer {
     if (numStandardizedValues == 1) {
       return standardizedValues.get(0);
     }
-    Preconditions
-        .checkState(!isSingleValue, "Cannot read single-value from Collection: %s for column: %s", collection, column);
+    Preconditions.checkState(!isSingleValue, "Cannot read single-value from Collection: %s for column: %s", collection,
+        column);
     return standardizedValues.toArray();
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
@@ -123,6 +123,11 @@ public class ExpressionTransformer implements RecordTransformer {
   }
 
   @Override
+  public boolean isNoOp() {
+    return _expressionEvaluators.isEmpty();
+  }
+
+  @Override
   public GenericRow transform(GenericRow record) {
     for (Map.Entry<String, FunctionEvaluator> entry : _expressionEvaluators.entrySet()) {
       String column = entry.getKey();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/FilterTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/FilterTransformer.java
@@ -48,6 +48,11 @@ public class FilterTransformer implements RecordTransformer {
   }
 
   @Override
+  public boolean isNoOp() {
+    return _evaluator == null;
+  }
+
+  @Override
   public GenericRow transform(GenericRow record) {
     if (_evaluator != null) {
       try {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformer.java
@@ -29,6 +29,13 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 public interface RecordTransformer extends Serializable {
 
   /**
+   * Returns {@code true} if the transformer is no-op (can be skipped), {@code false} otherwise.
+   */
+  default boolean isNoOp() {
+    return false;
+  }
+
+  /**
    * Transforms a record based on some custom rules.
    *
    * @param record Record to transform

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SanitizationTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SanitizationTransformer.java
@@ -49,6 +49,11 @@ public class SanitizationTransformer implements RecordTransformer {
   }
 
   @Override
+  public boolean isNoOp() {
+    return _stringColumnMaxLengthMap.isEmpty();
+  }
+
+  @Override
   public GenericRow transform(GenericRow record) {
     for (Map.Entry<String, Integer> entry : _stringColumnMaxLengthMap.entrySet()) {
       String stringColumn = entry.getKey();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/TimeValidationTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/TimeValidationTransformer.java
@@ -1,0 +1,113 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.recordtransformer;
+
+import com.google.common.base.Preconditions;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
+import org.apache.pinot.spi.data.DateTimeFieldSpec;
+import org.apache.pinot.spi.data.DateTimeFormatSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.TimeUtils;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * The {@code TimeValidationTransformer} class will validate the time column value.
+ * <p>NOTE: should put this after the {@link DataTypeTransformer} so that all values follow the data types in
+ * {@link FieldSpec}, and before the {@link NullValueTransformer} so that the invalidated value can be filled.
+ */
+public class TimeValidationTransformer implements RecordTransformer {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TimeValidationTransformer.class);
+
+  private final String _timeColumnName;
+  private final DateTimeFormatSpec _timeFormatSpec;
+  private final boolean _enableTimeValueCheck;
+  private final boolean _continueOnError;
+
+  public TimeValidationTransformer(TableConfig tableConfig, Schema schema) {
+    _timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
+    if (_timeColumnName != null) {
+      DateTimeFieldSpec dateTimeFieldSpec = schema.getSpecForTimeColumn(_timeColumnName);
+      Preconditions.checkState(dateTimeFieldSpec != null, "Failed to find spec for time column: %s from schema: %s",
+          _timeColumnName, schema.getSchemaName());
+      _timeFormatSpec = dateTimeFieldSpec.getFormatSpec();
+      IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
+      if (ingestionConfig != null) {
+        _enableTimeValueCheck = ingestionConfig.isRowTimeValueCheck();
+        _continueOnError = ingestionConfig.isContinueOnError();
+      } else {
+        _enableTimeValueCheck = false;
+        _continueOnError = false;
+      }
+    } else {
+      _timeFormatSpec = null;
+      _enableTimeValueCheck = false;
+      _continueOnError = false;
+    }
+  }
+
+  @Override
+  public boolean isNoOp() {
+    return !_enableTimeValueCheck;
+  }
+
+  @Override
+  public GenericRow transform(GenericRow record) {
+    if (!_enableTimeValueCheck) {
+      return record;
+    }
+    Object timeValue = record.getValue(_timeColumnName);
+    if (timeValue == null) {
+      return record;
+    }
+    long timeValueMs;
+    try {
+      timeValueMs = _timeFormatSpec.fromFormatToMillis(timeValue.toString());
+    } catch (Exception e) {
+      String errorMessage =
+          String.format("Caught exception while parsing time value: %s with format: %s", timeValue, _timeFormatSpec);
+      if (_continueOnError) {
+        LOGGER.debug(errorMessage);
+        record.putValue(_timeColumnName, null);
+        return record;
+      } else {
+        throw new IllegalStateException(errorMessage);
+      }
+    }
+    if (!TimeUtils.timeValueInValidRange(timeValueMs)) {
+      String errorMessage =
+          String.format("Time value: %s is not in valid range: %s", new DateTime(timeValueMs, DateTimeZone.UTC),
+              TimeUtils.VALID_TIME_INTERVAL);
+      if (_continueOnError) {
+        LOGGER.debug(errorMessage);
+        record.putValue(_timeColumnName, null);
+        return record;
+      } else {
+        throw new IllegalStateException(errorMessage);
+      }
+    }
+    return record;
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
@@ -187,15 +187,14 @@ public class RecordTransformerTest {
   }
 
   @Test
-  public void testDataTypeTransformerInvalidTimestamp() {
-    // Invalid Timestamp and Validation disabled
+  public void testTimeValidationTransformer() {
+    // Invalid timestamp, validation disabled
     String timeCol = "timeCol";
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").setTimeColumnName(timeCol).build();
     Schema schema = new Schema.SchemaBuilder().addDateTime(timeCol, DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP",
         "1:MILLISECONDS").build();
-    TableConfig tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName(timeCol).setTableName("testTable").build();
-
-    RecordTransformer transformer = new DataTypeTransformer(tableConfig, schema);
+    RecordTransformer transformer = new TimeValidationTransformer(tableConfig, schema);
     GenericRow record = getRecord();
     record.putValue(timeCol, 1L);
     for (int i = 0; i < NUM_ROUNDS; i++) {
@@ -204,15 +203,11 @@ public class RecordTransformerTest {
       assertEquals(record.getValue(timeCol), 1L);
     }
 
-    // Invalid Timestamp and Validation enabled
+    // Invalid timestamp, validation enabled
     IngestionConfig ingestionConfig = new IngestionConfig();
     ingestionConfig.setRowTimeValueCheck(true);
-    tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName(timeCol)
-            .setIngestionConfig(ingestionConfig)
-            .setTableName("testTable").build();
-
-    RecordTransformer transformerWithValidation = new DataTypeTransformer(tableConfig, schema);
+    tableConfig.setIngestionConfig(ingestionConfig);
+    RecordTransformer transformerWithValidation = new TimeValidationTransformer(tableConfig, schema);
     GenericRow record1 = getRecord();
     record1.putValue(timeCol, 1L);
     for (int i = 0; i < NUM_ROUNDS; i++) {
@@ -220,15 +215,8 @@ public class RecordTransformerTest {
     }
 
     // Invalid timestamp, validation enabled and ignoreErrors enabled
-    ingestionConfig = new IngestionConfig();
-    ingestionConfig.setRowTimeValueCheck(true);
     ingestionConfig.setContinueOnError(true);
-    tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTimeColumnName(timeCol)
-            .setIngestionConfig(ingestionConfig)
-            .setTableName("testTable").build();
-
-    transformer = new DataTypeTransformer(tableConfig, schema);
+    transformer = new TimeValidationTransformer(tableConfig, schema);
     GenericRow record2 = getRecord();
     record2.putValue(timeCol, 1L);
     for (int i = 0; i < NUM_ROUNDS; i++) {
@@ -237,8 +225,9 @@ public class RecordTransformerTest {
       assertNull(record2.getValue(timeCol));
     }
 
-    // Valid timestamp
-    transformer = new DataTypeTransformer(TABLE_CONFIG, schema);
+    // Valid timestamp, validation enabled
+    ingestionConfig.setContinueOnError(false);
+    transformer = new TimeValidationTransformer(tableConfig, schema);
     GenericRow record3 = getRecord();
     Long currentTimeMillis = System.currentTimeMillis();
     record3.putValue(timeCol, currentTimeMillis);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -115,7 +115,7 @@ public class SegmentGeneratorConfig implements Serializable {
   private boolean _onHeap = false;
   private boolean _nullHandlingEnabled = false;
   private boolean _continueOnError = false;
-  private boolean _rowTimeValueCheck = true;
+  private boolean _rowTimeValueCheck = false;
   private boolean _segmentTimeValueCheck = true;
   private boolean _failOnEmptySegment = false;
   private boolean _optimizeDictionaryForMetrics = false;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/IngestionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/IngestionConfig.java
@@ -52,7 +52,7 @@ public class IngestionConfig extends BaseJsonConfig {
   private boolean _continueOnError;
 
   @JsonPropertyDescription("Configs related to validate time value for each record during ingestion")
-  private boolean _rowTimeValueCheck = true;
+  private boolean _rowTimeValueCheck;
 
   @JsonPropertyDescription("Configs related to check time value for segment")
   private boolean _segmentTimeValueCheck = true;


### PR DESCRIPTION
Move the time validation into a separate record transformer: `TimeValidationTransformer` with the following bugfixes/enhancements:
- Before validating the time value, convert the data type properly
- Handle exception when time format parsing fails
- Disable time validation by default (consistent behavior with or without `IngestionConfig`, and the same as the old behavior before default enabled row based time validation was introduced in #9349)
- Add `isNoOp()` API to `RecordTransformer` so that no-op transformers can be skipped