### PR TITLE
[multistage] fix GROUP BY with no aggregate functions

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/DistinctTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/DistinctTable.java
@@ -35,6 +35,7 @@ import javax.annotation.Nullable;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.datatable.DataTableFactory;
 import org.apache.pinot.common.request.context.OrderByExpressionContext;
+import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.datatable.DataTableBuilder;
@@ -405,5 +406,25 @@ public class DistinctTable {
       }
     }
     return new DistinctTable(dataSchema, records);
+  }
+
+  public ResultTable reduceToResultTable() {
+    List<Object[]> rows = new ArrayList<>(size());
+    DataSchema dataSchema = getDataSchema();
+    ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
+    int numColumns = columnDataTypes.length;
+    Iterator<Record> iterator = getFinalResult();
+    while (iterator.hasNext()) {
+      Object[] values = iterator.next().getValues();
+      Object[] row = new Object[numColumns];
+      for (int i = 0; i < numColumns; i++) {
+        Object value = values[i];
+        if (value != null) {
+          row[i] = columnDataTypes[i].convertAndFormat(value);
+        }
+      }
+      rows.add(row);
+    }
+    return new ResultTable(dataSchema, rows);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.query.reduce;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.datatable.DataTable;
@@ -31,7 +30,6 @@ import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
-import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.query.aggregation.function.DistinctAggregationFunction;
 import org.apache.pinot.core.query.distinct.DistinctTable;
 import org.apache.pinot.core.query.request.context.QueryContext;
@@ -94,27 +92,7 @@ public class DistinctDataTableReducer implements DataTableReducer {
       for (DistinctTable distinctTable : nonEmptyDistinctTables) {
         mainDistinctTable.mergeTable(distinctTable);
       }
-      brokerResponseNative.setResultTable(reduceToResultTable(mainDistinctTable));
+      brokerResponseNative.setResultTable(mainDistinctTable.reduceToResultTable());
     }
-  }
-
-  private ResultTable reduceToResultTable(DistinctTable distinctTable) {
-    List<Object[]> rows = new ArrayList<>(distinctTable.size());
-    DataSchema dataSchema = distinctTable.getDataSchema();
-    ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
-    int numColumns = columnDataTypes.length;
-    Iterator<Record> iterator = distinctTable.getFinalResult();
-    while (iterator.hasNext()) {
-      Object[] values = iterator.next().getValues();
-      Object[] row = new Object[numColumns];
-      for (int i = 0; i < numColumns; i++) {
-        Object value = values[i];
-        if (value != null) {
-          row[i] = columnDataTypes[i].convertAndFormat(value);
-        }
-      }
-      rows.add(row);
-    }
-    return new ResultTable(dataSchema, rows);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/leaf/LeafDistinctCompatibilityOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/leaf/LeafDistinctCompatibilityOperator.java
@@ -64,7 +64,7 @@ public class LeafDistinctCompatibilityOperator extends BaseOperator<Transferable
 
     DistinctTable distinctTable = ObjectSerDeUtils.deserialize(transferableBlock.getDataBlock().getCustomObject(0, 0));
     DistinctTable mainTable = new DistinctTable(distinctTable.getDataSchema(), null,
-        DistinctExecutor.MAX_INITIAL_CAPACITY, false);
+        DistinctExecutor.MAX_INITIAL_CAPACITY, _queryContext.isNullHandlingEnabled());
 
     mainTable.mergeTable(distinctTable);
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/leaf/LeafDistinctCompatibilityOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/leaf/LeafDistinctCompatibilityOperator.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.leaf;
+
+import com.google.common.collect.ImmutableList;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.operator.BaseOperator;
+import org.apache.pinot.core.query.distinct.DistinctExecutor;
+import org.apache.pinot.core.query.distinct.DistinctTable;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+
+
+/**
+ * Utility functionality to maintain compatibility between the desired response format
+ * and internal v1 server format for GROUP BY queries:
+ * <ul>
+ *   <li>{@link org.apache.pinot.sql.parsers.rewriter.NonAggregationGroupByToDistinctQueryRewriter}
+ *   will return a result format that is not identical to the original request. This compat
+ *   utility will rewrite those blocks into the correct format.</li>
+ * </ul>
+ */
+public class LeafDistinctCompatibilityOperator extends BaseOperator<TransferableBlock> {
+
+  private final Operator<TransferableBlock> _child;
+  private final QueryContext _queryContext;
+  private final DataSchema _targetDataSchema;
+
+  public LeafDistinctCompatibilityOperator(Operator<TransferableBlock> child, QueryContext queryContext,
+      DataSchema targetDataSchema) {
+    _child = child;
+    _queryContext = queryContext;
+    _targetDataSchema = targetDataSchema;
+  }
+
+  @Override
+  protected TransferableBlock getNextBlock() {
+    TransferableBlock transferableBlock = _child.nextBlock();
+    if (TransferableBlockUtils.isEndOfStream(transferableBlock)) {
+      return transferableBlock;
+    }
+
+    DistinctTable distinctTable = ObjectSerDeUtils.deserialize(transferableBlock.getDataBlock().getCustomObject(0, 0));
+    DistinctTable mainTable = new DistinctTable(distinctTable.getDataSchema(), null,
+        DistinctExecutor.MAX_INITIAL_CAPACITY, false);
+
+    mainTable.mergeTable(distinctTable);
+
+    List<Object[]> rows = mainTable.reduceToResultTable().getRows();
+    return new TransferableBlock(rows, _targetDataSchema, BaseDataBlock.Type.ROW);
+  }
+
+  @Override
+  public List<Operator> getChildOperators() {
+    return ImmutableList.of(_child);
+  }
+
+  @Nullable
+  @Override
+  public String toExplainString() {
+    return "LEAF_GROUP_COMPAT";
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/leaf/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/leaf/LeafStageTransferableBlockOperator.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.leaf;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.DataBlockUtils;
+import org.apache.pinot.common.datablock.MetadataBlock;
+import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.operator.BaseOperator;
+import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+
+
+/**
+ * Leaf-stage transfer block opreator is used to wrap around the leaf stage process results. They are passed to the
+ * Pinot server to execute query thus only one {@link DataTable} were returned. However, to conform with the
+ * intermediate stage operators. an additional {@link MetadataBlock} needs to be transfer after the data block.
+ *
+ * <p>In order to achieve this:
+ * <ul>
+ *   <li>The leaf-stage result is split into data payload block and metadata payload block.</li>
+ *   <li>In case the leaf-stage result contains error or only metadata, we skip the data payload block.</li>
+ * </ul>
+ */
+public class LeafStageTransferableBlockOperator extends BaseOperator<TransferableBlock> {
+  private static final String EXPLAIN_NAME = "LEAF_STAGE_TRANSFER_OPERATOR";
+
+  private final BaseDataBlock _errorBlock;
+  private final List<BaseDataBlock> _baseDataBlocks;
+  private final DataSchema _dataSchema;
+  private boolean _hasTransferred;
+  private int _currentIndex;
+
+  public LeafStageTransferableBlockOperator(List<BaseDataBlock> baseDataBlocks, DataSchema dataSchema) {
+    _baseDataBlocks = baseDataBlocks;
+    _dataSchema = dataSchema;
+    _errorBlock = baseDataBlocks.stream().filter(e -> !e.getExceptions().isEmpty()).findFirst().orElse(null);
+    _currentIndex = 0;
+  }
+
+  @Override
+  public List<Operator> getChildOperators() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public String toExplainString() {
+    return EXPLAIN_NAME;
+  }
+
+  @Override
+  protected TransferableBlock getNextBlock() {
+    if (_currentIndex < 0) {
+      throw new RuntimeException("Leaf transfer terminated. next block should no longer be called.");
+    }
+    if (_errorBlock != null) {
+      _currentIndex = -1;
+      return new TransferableBlock(_errorBlock);
+    } else {
+      if (_currentIndex < _baseDataBlocks.size()) {
+        return new TransferableBlock(_baseDataBlocks.get(_currentIndex++));
+      } else {
+        _currentIndex = -1;
+        return new TransferableBlock(DataBlockUtils.getEndOfStreamDataBlock(_dataSchema));
+      }
+    }
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/utils/ServerRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/utils/ServerRequestUtils.java
@@ -55,6 +55,7 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.sql.FilterKind;
+import org.apache.pinot.sql.parsers.rewriter.NonAggregationGroupByToDistinctQueryRewriter;
 import org.apache.pinot.sql.parsers.rewriter.PredicateComparisonRewriter;
 import org.apache.pinot.sql.parsers.rewriter.QueryRewriter;
 import org.apache.pinot.sql.parsers.rewriter.QueryRewriterFactory;
@@ -69,7 +70,10 @@ import org.apache.pinot.sql.parsers.rewriter.QueryRewriterFactory;
 public class ServerRequestUtils {
   private static final int DEFAULT_LEAF_NODE_LIMIT = 10_000_000;
   private static final List<String> QUERY_REWRITERS_CLASS_NAMES =
-      ImmutableList.of(PredicateComparisonRewriter.class.getName());
+      ImmutableList.of(
+          PredicateComparisonRewriter.class.getName(),
+          NonAggregationGroupByToDistinctQueryRewriter.class.getName()
+      );
   private static final List<QueryRewriter> QUERY_REWRITERS = new ArrayList<>(
       QueryRewriterFactory.getQueryRewriters(QUERY_REWRITERS_CLASS_NAMES));
   private static final QueryOptimizer QUERY_OPTIMIZER = new QueryOptimizer();
@@ -182,12 +186,15 @@ public class ServerRequestUtils {
       pinotQuery.setSelectList(CalciteRexExpressionParser.overwriteSelectList(
           ((ProjectNode) node).getProjects(), pinotQuery));
     } else if (node instanceof AggregateNode) {
-      // set agg list
-      pinotQuery.setSelectList(CalciteRexExpressionParser.addSelectList(pinotQuery.getSelectList(),
-          ((AggregateNode) node).getAggCalls(), pinotQuery));
       // set group-by list
       pinotQuery.setGroupByList(CalciteRexExpressionParser.convertGroupByList(
           ((AggregateNode) node).getGroupSet(), pinotQuery));
+      // set agg list - the elements that are selected for an aggregate query
+      // should include all of the group by list followed by the aggregate functions
+      // if other columns are selected upstream they will be projected out in a
+      // dedicated ProjectNode
+      pinotQuery.setSelectList(CalciteRexExpressionParser.addSelectList(pinotQuery.getGroupByList(),
+          ((AggregateNode) node).getAggCalls(), pinotQuery));
     } else if (node instanceof SortNode) {
       if (((SortNode) node).getCollationKeys().size() > 0) {
         pinotQuery.setOrderByList(CalciteRexExpressionParser.convertOrderByList(((SortNode) node).getCollationKeys(),

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryTestSet.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryTestSet.java
@@ -190,6 +190,8 @@ public class QueryTestSet {
         //   - distinct value done via GROUP BY with empty expr aggregation list.
         new Object[]{"SELECT a.col2, a.col3 FROM a JOIN b ON a.col1 = b.col1 "
             + " WHERE b.col3 > 0 GROUP BY a.col2, a.col3"},
+        new Object[]{"SELECT col3 FROM a GROUP BY col3, col1"},
+        new Object[]{"SELECT AVG(col3) FROM (SELECT col1, col3 FROM a WHERE col3 > 1 GROUP BY col1, col3)"},
 
         // Test optimized constant literal.
         new Object[]{"SELECT col1 FROM a WHERE col3 > 0 AND col3 < -5"},

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
@@ -119,7 +119,7 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
       } else if (l instanceof String) {
         return ((String) l).compareTo((String) r);
       } else {
-        throw new RuntimeException("non supported type");
+        throw new RuntimeException("non supported type " + l.getClass());
       }
     };
     Comparator<Object[]> rowComp = (l, r) -> {


### PR DESCRIPTION
This PR fixes a bug where the v1 engine doesn't properly handle (at the server level) queries that have a GROUP BY but no aggregate functions or explicitly use SELECT DISTINCT.

Pretty straightforward:
- if encountering a `GROUP BY` with no aggregate, apply the appropriate rewriter
- add a reduce operator to convert the intermediate format to the expected format
- change the query select list to match (no select expressions other than what should be returned)
- two minor refactors

Testing done: added more tests in QueryRunnerTest