### PR TITLE
[multi-stage] allow configurable timeout

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -136,10 +136,11 @@ public class QueryRunner {
         LOGGER.debug("Acquired transferable block: {}", blockCounter++);
       }
     } else {
-      long requestId = Long.parseLong(requestMetadataMap.get("REQUEST_ID"));
+      long requestId = Long.parseLong(requestMetadataMap.get(QueryConfig.KEY_OF_BROKER_REQUEST_ID));
+      long timeoutMs = Long.parseLong(requestMetadataMap.get(QueryConfig.KEY_OF_BROKER_REQUEST_TIMEOUT_MS));
       StageNode stageRoot = distributedStagePlan.getStageRoot();
-      OpChain rootOperator = PhysicalPlanVisitor.build(stageRoot, new PlanRequestContext(
-          _mailboxService, requestId, stageRoot.getStageId(), _hostname, _port, distributedStagePlan.getMetadataMap()));
+      OpChain rootOperator = PhysicalPlanVisitor.build(stageRoot, new PlanRequestContext(_mailboxService, requestId,
+          stageRoot.getStageId(), timeoutMs, _hostname, _port, distributedStagePlan.getMetadataMap()));
       scheduler.register(rootOperator);
     }
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
@@ -70,7 +70,7 @@ public class PhysicalPlanVisitor implements StageNodeVisitor<Operator<Transferab
     List<ServerInstance> sendingInstances = context.getMetadataMap().get(node.getSenderStageId()).getServerInstances();
     return new MailboxReceiveOperator(context.getMailboxService(), sendingInstances,
         node.getExchangeType(), context.getHostName(), context.getPort(),
-        context.getRequestId(), node.getSenderStageId(), null);
+        context.getRequestId(), node.getSenderStageId(), context.getTimeoutMs());
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanRequestContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanRequestContext.java
@@ -28,15 +28,18 @@ public class PlanRequestContext {
   protected final MailboxService<TransferableBlock> _mailboxService;
   protected final long _requestId;
   protected final int _stageId;
+  private final long _timeoutMs;
   protected final String _hostName;
   protected final int _port;
   protected final Map<Integer, StageMetadata> _metadataMap;
 
+
   public PlanRequestContext(MailboxService<TransferableBlock> mailboxService, long requestId, int stageId,
-      String hostName, int port, Map<Integer, StageMetadata> metadataMap) {
+      long timeoutMs, String hostName, int port, Map<Integer, StageMetadata> metadataMap) {
     _mailboxService = mailboxService;
     _requestId = requestId;
     _stageId = stageId;
+    _timeoutMs = timeoutMs;
     _hostName = hostName;
     _port = port;
     _metadataMap = metadataMap;
@@ -48,6 +51,10 @@ public class PlanRequestContext {
 
   public int getStageId() {
     return _stageId;
+  }
+
+  public long getTimeoutMs() {
+    return _timeoutMs;
   }
 
   public String getHostName() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestContext.java
@@ -41,9 +41,9 @@ public class ServerPlanRequestContext extends PlanRequestContext {
   protected InstanceRequest _instanceRequest;
 
   public ServerPlanRequestContext(MailboxService<TransferableBlock> mailboxService, long requestId, int stageId,
-      String hostName, int port, Map<Integer, StageMetadata> metadataMap, PinotQuery pinotQuery, TableType tableType,
-      TimeBoundaryInfo timeBoundaryInfo) {
-    super(mailboxService, requestId, stageId, hostName, port, metadataMap);
+      long timeoutMs, String hostName, int port, Map<Integer, StageMetadata> metadataMap, PinotQuery pinotQuery,
+      TableType tableType, TimeBoundaryInfo timeBoundaryInfo) {
+    super(mailboxService, requestId, stageId, timeoutMs, hostName, port, metadataMap);
     _pinotQuery = pinotQuery;
     _tableType = tableType;
     _timeBoundaryInfo = timeBoundaryInfo;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryConfig.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryConfig.java
@@ -22,19 +22,42 @@ package org.apache.pinot.query.service;
  * Configuration for setting up query runtime.
  */
 public class QueryConfig {
-  public static final long DEFAULT_TIMEOUT_NANO = 10_000_000_000L;
-
+  /**
+   * Configuration for mailbox data block size
+   */
   public static final String KEY_OF_MAX_INBOUND_QUERY_DATA_BLOCK_SIZE_BYTES = "pinot.query.runner.max.msg.size.bytes";
   public static final int DEFAULT_MAX_INBOUND_QUERY_DATA_BLOCK_SIZE_BYTES = 16 * 1024 * 1024;
 
+  public static final String KEY_OF_MAILBOX_TIMEOUT_MS = "pinot.query.runner.mailbox.timeout.ms";
+  public static final long DEFAULT_MAILBOX_TIMEOUT_MS = 10_000L;
+
+  /**
+   * Configuration for server port, port that opens and accepts
+   * {@link org.apache.pinot.query.runtime.plan.DistributedStagePlan} and start executing query stages.
+   */
   public static final String KEY_OF_QUERY_SERVER_PORT = "pinot.query.server.port";
   public static final int DEFAULT_QUERY_SERVER_PORT = 0;
 
+  /**
+   * Configuration for mailbox hostname and port, this hostname and port opens streaming channel to receive
+   * {@link org.apache.pinot.common.datablock.DataBlock}.
+   */
   public static final String KEY_OF_QUERY_RUNNER_HOSTNAME = "pinot.query.runner.hostname";
   public static final String DEFAULT_QUERY_RUNNER_HOSTNAME = "localhost";
-  // query runner port is the mailbox port.
   public static final String KEY_OF_QUERY_RUNNER_PORT = "pinot.query.runner.port";
   public static final int DEFAULT_QUERY_RUNNER_PORT = 0;
+
+  /**
+   * Configuration keys for {@link org.apache.pinot.common.proto.Worker.QueryRequest} extra metadata.
+   */
+  public static final String KEY_OF_BROKER_REQUEST_ID = "pinot.query.runner.broker.request.id";
+  public static final String KEY_OF_BROKER_REQUEST_TIMEOUT_MS = "pinot.query.runner.broker.request.timeout.ms";
+
+  /**
+   * Configuration keys for {@link org.apache.pinot.common.proto.Worker.QueryResponse} extra metadata.
+   */
+  public static final String KEY_OF_SERVER_RESPONSE_STATUS_ERROR = "ERROR";
+  public static final String KEY_OF_SERVER_RESPONSE_STATUS_OK = "OK";
 
   private QueryConfig() {
     // do not instantiate.

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryServer.java
@@ -104,7 +104,8 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
 
     // return dispatch successful.
     // TODO: return meaningful value here.
-    responseObserver.onNext(Worker.QueryResponse.newBuilder().putMetadata("OK", "OK").build());
+    responseObserver.onNext(Worker.QueryResponse.newBuilder()
+        .putMetadata(QueryConfig.KEY_OF_SERVER_RESPONSE_STATUS_OK, "").build());
     responseObserver.onCompleted();
 
     // start a new GRPC ctx has all the values as the current context, but won't be cancelled

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/QueryDispatcherTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/QueryDispatcherTest.java
@@ -78,7 +78,7 @@ public class QueryDispatcherTest extends QueryTestSet {
       throws Exception {
     QueryPlan queryPlan = _queryEnvironment.planQuery(sql);
     QueryDispatcher dispatcher = new QueryDispatcher();
-    int reducerStageId = dispatcher.submit(RANDOM_REQUEST_ID_GEN.nextLong(), queryPlan);
+    int reducerStageId = dispatcher.submit(RANDOM_REQUEST_ID_GEN.nextLong(), queryPlan, 10_000L);
     Assert.assertTrue(PlannerUtils.isRootStage(reducerStageId));
     dispatcher.shutdown();
   }


### PR DESCRIPTION
this enables configuration for timeout on a query (global timeout)
- honor's broker request timeout setting and the default 10,000ms
- accepts query option config using `timeoutMs`

TODO:
Currently, this logic is equivalently defining the mailbox timeout to be the query timeout. thus several follow up is:
- Support configuration for individual stage timeout;
- Support configuration for operator timeout, such as individual mailbox operator timeout.
- allow the above to be
  - derived based on global timeout or 
  - read from individual stage timeout configurations 
  - [maybe] extracted from query options at runtime
