### PR TITLE
fix(sec): upgrade org.freemarker:freemarker to 2.3.30

### DIFF
--- a/contrib/pinot-fmpp-maven-plugin/pom.xml
+++ b/contrib/pinot-fmpp-maven-plugin/pom.xml
@@ -18,10 +18,7 @@
     specific language governing permissions and limitations
     under the License.
 
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+--><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>pinot</artifactId>
@@ -38,7 +35,7 @@
     <pinot.root>${basedir}/../..</pinot.root>
     <maven.version>3.3.3</maven.version>
     <fmpp.version>0.9.16</fmpp.version>
-    <freemarker.version>2.3.28</freemarker.version>
+    <freemarker.version>2.3.30</freemarker.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.freemarker:freemarker 2.3.28
- [MPS-2022-12438](https://www.oscs1024.com/hd/MPS-2022-12438)


### What did I do？
Upgrade org.freemarker:freemarker from 2.3.28 to 2.3.30 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS