### PR TITLE
add version information to JMX metrics & component logs

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -52,6 +52,7 @@ import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metrics.BrokerGauge;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.utils.ServiceStartableUtils;
@@ -59,6 +60,7 @@ import org.apache.pinot.common.utils.ServiceStatus;
 import org.apache.pinot.common.utils.TlsUtils;
 import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
+import org.apache.pinot.common.version.PinotVersion;
 import org.apache.pinot.core.query.executor.sql.SqlQueryExecutor;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager;
@@ -216,7 +218,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
   @Override
   public void start()
       throws Exception {
-    LOGGER.info("Starting Pinot broker");
+    LOGGER.info("Starting Pinot broker (Version: {})", PinotVersion.VERSION);
     _isStarting = true;
     Utils.logVersions();
 
@@ -237,6 +239,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
         _brokerConf.getProperty(Broker.CONFIG_OF_ENABLE_TABLE_LEVEL_METRICS, Broker.DEFAULT_ENABLE_TABLE_LEVEL_METRICS),
         _brokerConf.getProperty(Broker.CONFIG_OF_ALLOWED_TABLES_FOR_EMITTING_METRICS, Collections.emptyList()));
     _brokerMetrics.initializeGlobalMeters();
+    _brokerMetrics.setValueOfGlobalGauge(BrokerGauge.VERSION, PinotVersion.VERSION, 1);
     // Set up request handling classes
     _serverRoutingStatsManager = new ServerRoutingStatsManager(_brokerConf);
     _serverRoutingStatsManager.init();

--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -36,6 +36,12 @@
   </properties>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <!-- Antlr stuff -->
     <plugins>
       <plugin>

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
@@ -26,6 +26,7 @@ import org.apache.pinot.common.Utils;
  *
  */
 public enum BrokerGauge implements AbstractMetrics.Gauge {
+  VERSION("version", true),
   QUERY_QUOTA_CAPACITY_UTILIZATION_RATE("tables", false),
   MAX_BURST_QPS("tables", false),
   QUERY_RATE_LIMIT_DISABLED("queryQuota", true),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -25,6 +25,7 @@ import org.apache.pinot.common.Utils;
  * Controller gauges.
  */
 public enum ControllerGauge implements AbstractMetrics.Gauge {
+  VERSION("version", true),
 
   REPLICATION_FROM_CONFIG("replicas", false),
   // Number of complete replicas of table in external view containing all segments online in ideal state

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/MinionGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/MinionGauge.java
@@ -22,6 +22,7 @@ import org.apache.pinot.common.Utils;
 
 
 public enum MinionGauge implements AbstractMetrics.Gauge {
+  VERSION("version", true),
   NUMBER_OF_TASKS("tasks", true);
 
   private final String _gaugeName;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -26,6 +26,7 @@ import org.apache.pinot.common.Utils;
  *
  */
 public enum ServerGauge implements AbstractMetrics.Gauge {
+  VERSION("version", true),
   DOCUMENT_COUNT("documents", false),
   SEGMENT_COUNT("segments", false),
   LLC_PARTITION_CONSUMING("state", false),

--- a/pinot-common/src/main/java/org/apache/pinot/common/version/PinotVersion.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/version/PinotVersion.java
@@ -26,8 +26,8 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * Reads the maven-setting {@code pinot-version.properties} file to extract the
- * maven version that this code was compiled against.
+ * Reads the {@code pinot-version.properties} file to extract the
+ * project version that this code was compiled against.
  */
 public class PinotVersion {
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/version/PinotVersion.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/version/PinotVersion.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.version;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Reads the maven-setting {@code pinot-version.properties} file to extract the
+ * maven version that this code was compiled against.
+ */
+public class PinotVersion {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotVersion.class);
+
+  /**
+   * The compile version of Pinot (e.g. {@code 0.12.0}). Note that this relies
+   * on <a href="https://maven.apache.org/plugins/maven-resources-plugin/examples/filter.html">
+   * Maven Filtering</a> to properly work, which means that if you access this
+   * in a local, non-maven build this will resolve to {@code UNKNOWN}.
+   */
+  public static final String VERSION;
+
+  private PinotVersion() {
+    // private constructor for utility class
+  }
+
+  static {
+    String version;
+
+    ClassLoader loader = PinotVersion.class.getClassLoader();
+    try (InputStream versionResource = loader.getResourceAsStream("pinot-version.properties")) {
+      Properties properties = new Properties();
+      properties.load(versionResource);
+      version = String.valueOf(properties.get("pinot.version"));
+    } catch (IOException e) {
+      LOGGER.error("Could not load version properties; setting version to UNKNOWN.", e);
+      version = "UNKNOWN";
+    }
+
+    // if building this via some non-maven environment (e.g. IntelliJ) it is possible that
+    // the properties file will not be properly filtered, in which case just return UNKNOWN
+    if (version.equals("${project.version}")) {
+      VERSION = "UNKNOWN";
+      LOGGER.warn("Using UNKNOWN version properties because project.version was not resolved during build.");
+    } else {
+      VERSION = version;
+    }
+  }
+}

--- a/pinot-common/src/main/resources/pinot-version.properties
+++ b/pinot-common/src/main/resources/pinot-version.properties
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+pinot.version=${project.version}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -53,6 +53,7 @@ import org.apache.helix.task.TaskDriver;
 import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.function.FunctionRegistry;
+import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.metrics.ValidationMetrics;
@@ -66,6 +67,7 @@ import org.apache.pinot.common.utils.TlsUtils;
 import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.common.utils.helix.LeadControllerUtils;
+import org.apache.pinot.common.version.PinotVersion;
 import org.apache.pinot.controller.api.ControllerAdminApiApplication;
 import org.apache.pinot.controller.api.access.AccessControlFactory;
 import org.apache.pinot.controller.api.events.MetadataEventNotifierFactory;
@@ -311,7 +313,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
 
   @Override
   public void start() {
-    LOGGER.info("Starting Pinot controller in mode: {}.", _controllerMode.name());
+    LOGGER.info("Starting Pinot controller in mode: {}. (Version: {})", _controllerMode.name(), PinotVersion.VERSION);
     Utils.logVersions();
 
     // Set up controller metrics
@@ -545,6 +547,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     _metricsRegistry = PinotMetricUtils.getPinotMetricsRegistry(_config.subset(METRICS_REGISTRY_NAME));
     _controllerMetrics = new ControllerMetrics(_config.getMetricsPrefix(), _metricsRegistry);
     _controllerMetrics.initializeGlobalMeters();
+    _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.VERSION, PinotVersion.VERSION, 1);
   }
 
   private void initPinotFSFactory() {

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
@@ -38,6 +38,7 @@ import org.apache.helix.task.TaskStateModelFactory;
 import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.config.TlsConfig;
+import org.apache.pinot.common.metrics.MinionGauge;
 import org.apache.pinot.common.metrics.MinionMeter;
 import org.apache.pinot.common.metrics.MinionMetrics;
 import org.apache.pinot.common.utils.ClientSSLContextGenerator;
@@ -46,6 +47,7 @@ import org.apache.pinot.common.utils.ServiceStatus;
 import org.apache.pinot.common.utils.TlsUtils;
 import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.common.utils.helix.HelixHelper;
+import org.apache.pinot.common.version.PinotVersion;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
 import org.apache.pinot.minion.event.EventObserverFactoryRegistry;
@@ -164,7 +166,7 @@ public abstract class BaseMinionStarter implements ServiceStartable {
   @Override
   public void start()
       throws Exception {
-    LOGGER.info("Starting Pinot minion: {}", _instanceId);
+    LOGGER.info("Starting Pinot minion: {} (Version: {})", _instanceId, PinotVersion.VERSION);
     Utils.logVersions();
     MinionContext minionContext = MinionContext.getInstance();
 
@@ -186,6 +188,7 @@ public abstract class BaseMinionStarter implements ServiceStartable {
 
     MinionMetrics minionMetrics = new MinionMetrics(_config.getMetricsPrefix(), metricsRegistry);
     minionMetrics.initializeGlobalMeters();
+    minionMetrics.setValueOfGlobalGauge(MinionGauge.VERSION, PinotVersion.VERSION, 1);
     minionContext.setMinionMetrics(minionMetrics);
 
     // Install default SSL context if necessary (even if not force-enabled everywhere)

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
@@ -28,8 +28,10 @@ import org.apache.pinot.common.config.GrpcConfig;
 import org.apache.pinot.common.config.NettyConfig;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.function.FunctionRegistry;
+import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.TlsUtils;
+import org.apache.pinot.common.version.PinotVersion;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.operator.transform.function.TransformFunction;
 import org.apache.pinot.core.operator.transform.function.TransformFunctionFactory;
@@ -88,6 +90,7 @@ public class ServerInstance {
         new ServerMetrics(serverConf.getMetricsPrefix(), metricsRegistry, serverConf.emitTableLevelMetrics(),
             serverConf.getAllowedTablesForEmittingMetrics());
     _serverMetrics.initializeGlobalMeters();
+    _serverMetrics.setValueOfGlobalGauge(ServerGauge.VERSION, PinotVersion.VERSION, 1);
 
     String instanceDataManagerClassName = serverConf.getInstanceDataManagerClassName();
     LOGGER.info("Initializing instance data manager of class: {}", instanceDataManagerClassName);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -62,6 +62,7 @@ import org.apache.pinot.common.utils.TlsUtils;
 import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.common.utils.helix.HelixHelper;
+import org.apache.pinot.common.version.PinotVersion;
 import org.apache.pinot.core.common.datatable.DataTableBuilderFactory;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeConsumptionRateManager;
@@ -494,7 +495,7 @@ public abstract class BaseServerStarter implements ServiceStartable {
   @Override
   public void start()
       throws Exception {
-    LOGGER.info("Starting Pinot server");
+    LOGGER.info("Starting Pinot server (Version: {})", PinotVersion.VERSION);
     long startTimeMs = System.currentTimeMillis();
 
     // install default SSL context if necessary (even if not force-enabled everywhere)


### PR DESCRIPTION
adds logging and JMX metrics of the Pinot Version 

for some reason, I can't get this to work in IntelliJ (but I confirmed that the output works in maven). I looked at some SO [posts](https://stackoverflow.com/questions/34343570/maven-build-is-not-filtering-properties-in-intellij) where others were having similar issues but was not able to resolve it.

<img width="1131" alt="image" src="https://user-images.githubusercontent.com/3172405/195446715-a837cea3-953a-4047-b1b3-7a838fa4ee24.png">


-----

local testing if you want to repro:

```
mvn resources:resources -pl :pinot-common
```

Then run the classes you want to run and properly resolves the `pinot-version.properties` file