### PR TITLE
Fix the bug where uploaded segments cannot be deleted on real-time table

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -653,6 +654,21 @@ public class ControllerTest {
   public void dropRealtimeTable(String tableName)
       throws IOException {
     getControllerRequestClient().deleteTable(TableNameBuilder.REALTIME.tableNameWithType(tableName));
+  }
+
+  public List<String> listSegments(String tableName)
+    throws IOException {
+    return listSegments(tableName, null, false);
+  }
+
+  public List<String> listSegments(String tableName, @Nullable String tableType, boolean excludeReplacedSegments)
+      throws IOException {
+    return getControllerRequestClient().listSegments(tableName, tableType, excludeReplacedSegments);
+  }
+
+  public void dropSegment(String tableName, String segmentName)
+      throws IOException {
+    getControllerRequestClient().deleteSegment(tableName, segmentName);
   }
 
   public void dropAllSegments(String tableName, TableType tableType)

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentUploadIntegrationTest.java
@@ -37,6 +37,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 
 
 public class UpsertTableSegmentUploadIntegrationTest extends BaseClusterIntegrationTestSet {
@@ -87,7 +88,24 @@ public class UpsertTableSegmentUploadIntegrationTest extends BaseClusterIntegrat
   @AfterClass
   public void tearDown()
       throws IOException {
-    dropRealtimeTable(getTableName());
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(getTableName());
+
+    // Test dropping all segments one by one
+    List<String> segments = listSegments(realtimeTableName);
+    assertFalse(segments.isEmpty());
+    for (String segment : segments) {
+      dropSegment(realtimeTableName, segment);
+    }
+    // NOTE: There is a delay to remove the segment from property store
+    TestUtils.waitForCondition((aVoid) -> {
+      try {
+        return listSegments(realtimeTableName).isEmpty();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }, 60_000L, "Failed to drop the segments");
+
+    dropRealtimeTable(realtimeTableName);
     stopServer();
     stopBroker();
     stopController();


### PR DESCRIPTION
Related to #8283 

Since we added the support of uploading segments to real-time table, we cannot always derive the table type from the segment name. When the provided table name has the type suffix, do not try to derive the table type from the segment name.