### PR TITLE
fix distinct result return

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/DistinctResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/DistinctResultsBlock.java
@@ -24,13 +24,11 @@ import java.util.Collection;
 import java.util.List;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
-import org.apache.pinot.core.common.datatable.DataTableBuilder;
-import org.apache.pinot.core.common.datatable.DataTableBuilderFactory;
 import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.query.aggregation.function.DistinctAggregationFunction;
 import org.apache.pinot.core.query.distinct.DistinctTable;
 import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 
 
 /**
@@ -70,13 +68,8 @@ public class DistinctResultsBlock extends BaseResultsBlock {
   @Override
   public DataTable getDataTable(QueryContext queryContext)
       throws IOException {
-    String[] columnNames = new String[]{_distinctFunction.getColumnName()};
-    ColumnDataType[] columnDataTypes = new ColumnDataType[]{ColumnDataType.OBJECT};
-    DataTableBuilder dataTableBuilder =
-        DataTableBuilderFactory.getDataTableBuilder(new DataSchema(columnNames, columnDataTypes));
-    dataTableBuilder.startRow();
-    dataTableBuilder.setColumn(0, _distinctTable);
-    dataTableBuilder.finishRow();
-    return dataTableBuilder.build();
+    Collection<Object[]> rows = getRows(queryContext);
+    return SelectionOperatorUtils.getDataTableFromRows(rows, _distinctTable.getDataSchema(),
+        queryContext.isNullHandlingEnabled());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
@@ -35,7 +35,9 @@ import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.query.aggregation.function.DistinctAggregationFunction;
 import org.apache.pinot.core.query.distinct.DistinctTable;
 import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
+import org.roaringbitmap.RoaringBitmap;
 
 
 /**
@@ -65,13 +67,43 @@ public class DistinctDataTableReducer implements DataTableReducer {
     // inside a DataTable
 
     // Gather all non-empty DistinctTables
+    // TODO: until we upgrade to newer version of pinot, we have to keep both code path. remove after 0.12.0 release.
+    // This is to work with server rolling upgrade when partially returned as DistinctTable Obj and partially regular
+    // DataTable; if all returns are DataTable we can directly merge with priority queue (with dedup).
     List<DistinctTable> nonEmptyDistinctTables = new ArrayList<>(dataTableMap.size());
     for (DataTable dataTable : dataTableMap.values()) {
-      DataTable.CustomObject customObject = dataTable.getCustomObject(0, 0);
-      assert customObject != null;
-      DistinctTable distinctTable = ObjectSerDeUtils.deserialize(customObject);
-      if (!distinctTable.isEmpty()) {
-        nonEmptyDistinctTables.add(distinctTable);
+      // Do not use the cached data schema because it might be either single object (legacy) or normal data table
+      dataSchema = dataTable.getDataSchema();
+      int numColumns = dataSchema.size();
+      if (numColumns == 1 && dataSchema.getColumnDataType(0) == ColumnDataType.OBJECT) {
+        // DistinctTable is still being returned as a single object
+        DataTable.CustomObject customObject = dataTable.getCustomObject(0, 0);
+        assert customObject != null;
+        DistinctTable distinctTable = ObjectSerDeUtils.deserialize(customObject);
+        if (!distinctTable.isEmpty()) {
+          nonEmptyDistinctTables.add(distinctTable);
+        }
+      } else {
+        // DistinctTable is being returned as normal data table
+        int numRows = dataTable.getNumberOfRows();
+        if (numRows > 0) {
+          List<Record> records = new ArrayList<>(numRows);
+          if (_queryContext.isNullHandlingEnabled()) {
+            RoaringBitmap[] nullBitmaps = new RoaringBitmap[numColumns];
+            for (int coldId = 0; coldId < numColumns; coldId++) {
+              nullBitmaps[coldId] = dataTable.getNullRowIds(coldId);
+            }
+            for (int rowId = 0; rowId < numRows; rowId++) {
+              records.add(new Record(
+                  SelectionOperatorUtils.extractRowFromDataTableWithNullHandling(dataTable, rowId, nullBitmaps)));
+            }
+          } else {
+            for (int rowId = 0; rowId < numRows; rowId++) {
+              records.add(new Record(SelectionOperatorUtils.extractRowFromDataTable(dataTable, rowId)));
+            }
+          }
+          nonEmptyDistinctTables.add(new DistinctTable(dataSchema, records));
+        }
       }
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -420,6 +420,24 @@ public class SelectionOperatorUtils {
   }
 
   /**
+   * Extract a selection row from {@link DataTable} with potential null values. (Broker side)
+   *
+   * @param dataTable data table.
+   * @param rowId row id.
+   * @return selection row.
+   */
+  public static Object[] extractRowFromDataTableWithNullHandling(DataTable dataTable, int rowId,
+      RoaringBitmap[] nullBitmaps) {
+    Object[] row = extractRowFromDataTable(dataTable, rowId);
+    for (int colId = 0; colId < nullBitmaps.length; colId++) {
+      if (nullBitmaps[colId] != null && nullBitmaps[colId].contains(rowId)) {
+        row[colId] = null;
+      }
+    }
+    return row;
+  }
+
+  /**
    * Reduces a collection of {@link DataTable}s to selection rows for selection queries without <code>ORDER BY</code>.
    * (Broker side)
    */
@@ -436,13 +454,7 @@ public class SelectionOperatorUtils {
         }
         for (int rowId = 0; rowId < numRows; rowId++) {
           if (rows.size() < limit) {
-            Object[] row = extractRowFromDataTable(dataTable, rowId);
-            for (int colId = 0; colId < numColumns; colId++) {
-              if (nullBitmaps[colId] != null && nullBitmaps[colId].contains(rowId)) {
-                row[colId] = null;
-              }
-            }
-            rows.add(row);
+            rows.add(extractRowFromDataTableWithNullHandling(dataTable, rowId, nullBitmaps));
           } else {
             break;
           }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/blocks/results/ResultsBlockUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/blocks/results/ResultsBlockUtilsTest.java
@@ -21,14 +21,11 @@ package org.apache.pinot.core.operator.blocks.results;
 import java.io.IOException;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.core.common.ObjectSerDeUtils;
-import org.apache.pinot.core.query.distinct.DistinctTable;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
 
 
 public class ResultsBlockUtilsTest {
@@ -74,15 +71,9 @@ public class ResultsBlockUtilsTest {
     queryContext = QueryContextConverterUtils.getQueryContext("SELECT DISTINCT a, b FROM testTable WHERE foo = 'bar'");
     dataTable = ResultsBlockUtils.buildEmptyQueryResults(queryContext).getDataTable(queryContext);
     dataSchema = dataTable.getDataSchema();
-    assertEquals(dataSchema.getColumnNames(), new String[]{"distinct_a:b"});
-    assertEquals(dataSchema.getColumnDataTypes(), new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.OBJECT});
-    assertEquals(dataTable.getNumberOfRows(), 1);
-    DataTable.CustomObject customObject = dataTable.getCustomObject(0, 0);
-    assertNotNull(customObject);
-    DistinctTable distinctTable = ObjectSerDeUtils.deserialize(customObject);
-    assertEquals(distinctTable.size(), 0);
-    assertEquals(distinctTable.getDataSchema().getColumnNames(), new String[]{"a", "b"});
-    assertEquals(distinctTable.getDataSchema().getColumnDataTypes(),
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
+    assertEquals(dataSchema.getColumnNames(), new String[]{"a", "b"});
+    assertEquals(dataSchema.getColumnDataTypes(), new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING,
+        DataSchema.ColumnDataType.STRING});
+    assertEquals(dataTable.getNumberOfRows(), 0);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -80,13 +80,13 @@ public class MailboxReceiveOperator extends BaseOperator<TransferableBlock> {
         }
       }
 
-      // FIXME: there's a bug where singletonInstance may be null in the case of a JOIN where
-      // one side is BROADCAST and the other is SINGLETON (this is the case with nested loop
-      // joins for inequality conditions). This causes NPEs in the logs, but actually works
-      // because the side that hits the NPE doesn't expect to get any data anyway (that's the
-      // side that gets the broadcast from one side but nothing from the SINGLETON)
-      // FIXME: https://github.com/apache/pinot/issues/9592
-      _sendingStageInstances = Collections.singletonList(singletonInstance);
+      if (singletonInstance == null) {
+        // TODO: fix WorkerManager assignment, this should not happen if we properly assign workers.
+        // see: https://github.com/apache/pinot/issues/9592
+        _sendingStageInstances = Collections.emptyList();
+      } else {
+        _sendingStageInstances = Collections.singletonList(singletonInstance);
+      }
     } else {
       _sendingStageInstances = sendingStageInstances;
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -89,6 +89,7 @@ public class MailboxSendOperator extends BaseOperator<TransferableBlock> {
           singletonInstance = serverInstance;
         }
       }
+      Preconditions.checkNotNull(singletonInstance, "Unable to find receiving instance for singleton exchange");
       _receivingStageInstances = Collections.singletonList(singletonInstance);
     } else {
       _receivingStageInstances = receivingStageInstances;

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryTestSet.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryTestSet.java
@@ -190,6 +190,9 @@ public class QueryTestSet {
         //   - distinct value done via GROUP BY with empty expr aggregation list.
         new Object[]{"SELECT a.col2, a.col3 FROM a JOIN b ON a.col1 = b.col1 "
             + " WHERE b.col3 > 0 GROUP BY a.col2, a.col3"},
+        new Object[]{"SELECT col3 FROM a GROUP BY col3, col1"},
+        new Object[]{"SELECT col1 FROM a GROUP BY col3, col1"},
+        new Object[]{"SELECT AVG(col3) FROM (SELECT col1, col3 FROM a WHERE col3 > 1 GROUP BY col1, col3)"},
 
         // Test optimized constant literal.
         new Object[]{"SELECT col1 FROM a WHERE col3 > 0 AND col3 < -5"},

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
@@ -119,7 +119,7 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
       } else if (l instanceof String) {
         return ((String) l).compareTo((String) r);
       } else {
-        throw new RuntimeException("non supported type");
+        throw new RuntimeException("non supported type " + l.getClass());
       }
     };
     Comparator<Object[]> rowComp = (l, r) -> {


### PR DESCRIPTION
this is an alternative to #9570 
majorly follows the same idea, but 
- [x] instead of modifying the distinct table, directly return the final result from DistinctResultBlock
- [x] distinct table can be non-main after combine operator - thus use `getRecords` instead of `getFinalResults`

TODO
- for backward-compatibility reasons `DistinctDataTableReducer` need to handle both the object version and the normal row version of data table. thus the code is a bit complicated. 
  - we should deprecate the object version once 0.12 release is done 
  - we should optimize the reduce algorithm to be more efficient without too much format conversion'