### PR TITLE
[Flaky test] fix PurgeMinionClusterIntegrationTest

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -577,7 +577,6 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
    * Public API to schedule tasks (all task types) for the given table. It might be called from the non-leader
    * controller. Returns a map from the task type to the task scheduled.
    */
-  @Nullable
   public synchronized Map<String, String> scheduleTasks(String tableNameWithType) {
     return scheduleTasks(Collections.singletonList(tableNameWithType), false);
   }

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -586,11 +586,13 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
    * Get current result for "SELECT COUNT(*)".
    *
    * @return Current count start result
-   * @throws Exception
    */
-  protected long getCurrentCountStarResult()
-      throws Exception {
-    return getPinotConnection().execute("SELECT COUNT(*) FROM " + getTableName()).getResultSet(0).getLong(0);
+  protected long getCurrentCountStarResult() {
+    return getCurrentCountStarResult(getTableName());
+  }
+
+  protected long getCurrentCountStarResult(String tableName) {
+    return getPinotConnection().execute("SELECT COUNT(*) FROM " + tableName).getResultSet(0).getLong(0);
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PurgeMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PurgeMinionClusterIntegrationTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.integration.tests;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
@@ -44,7 +43,11 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
 
 /**
  * Integration test for minion task of type "PurgeTask"
@@ -70,8 +73,8 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
   @BeforeClass
   public void setUp()
       throws Exception {
-    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir1, _tarDir1,
-        _segmentDir2, _tarDir2, _segmentDir3, _tarDir3);
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir1, _tarDir1, _segmentDir2, _tarDir2, _segmentDir3,
+        _tarDir3);
 
     // Start the Pinot cluster
     startZk();
@@ -101,60 +104,54 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
     List<File> avroFiles = unpackAvroData(_tempDir);
 
     // Create and upload segments
-    ClusterIntegrationTestUtils
-        .buildSegmentsFromAvro(avroFiles, purgeTableConfig, schema, 0, _segmentDir1, _tarDir1);
-    ClusterIntegrationTestUtils
-        .buildSegmentsFromAvro(avroFiles, purgeDeltaPassedTableConfig,
-            schema, 0, _segmentDir2, _tarDir2);
-    ClusterIntegrationTestUtils
-        .buildSegmentsFromAvro(avroFiles, purgeDeltaNotPassedTableConfig,
-            schema, 0, _segmentDir3, _tarDir3);
+    ClusterIntegrationTestUtils.buildSegmentsFromAvro(avroFiles, purgeTableConfig, schema, 0, _segmentDir1, _tarDir1);
+    ClusterIntegrationTestUtils.buildSegmentsFromAvro(avroFiles, purgeDeltaPassedTableConfig, schema, 0, _segmentDir2,
+        _tarDir2);
+    ClusterIntegrationTestUtils.buildSegmentsFromAvro(avroFiles, purgeDeltaNotPassedTableConfig, schema, 0,
+        _segmentDir3, _tarDir3);
 
     uploadSegments(PURGE_FIRST_RUN_TABLE, _tarDir1);
     uploadSegments(PURGE_DELTA_PASSED_TABLE, _tarDir2);
     uploadSegments(PURGE_DELTA_NOT_PASSED_TABLE, _tarDir3);
 
-    // Initialize the query generator
-    setUpQueryGenerator(avroFiles);
     startMinion();
     setRecordPurger();
     _helixTaskResourceManager = _controllerStarter.getHelixTaskResourceManager();
     _taskManager = _controllerStarter.getTaskManager();
     _pinotHelixResourceManager = _controllerStarter.getHelixResourceManager();
 
-    //set up metadata on segment to check how code handle passed and not passed delay
-    String tablenameOfflineNotPassed = TableNameBuilder.OFFLINE.tableNameWithType(PURGE_DELTA_NOT_PASSED_TABLE);
-    String tablenameOfflinePassed = TableNameBuilder.OFFLINE.tableNameWithType(PURGE_DELTA_PASSED_TABLE);
+    // Set up segments' ZK metadata to check how code handle passed and not passed delay
+    String offlineTableNamePassed = TableNameBuilder.OFFLINE.tableNameWithType(PURGE_DELTA_PASSED_TABLE);
+    String offlineTableNameNotPassed = TableNameBuilder.OFFLINE.tableNameWithType(PURGE_DELTA_NOT_PASSED_TABLE);
 
-    //set up passed delay
-    List<SegmentZKMetadata> segmentsZKMetadataDeltaPassed = _pinotHelixResourceManager
-        .getSegmentsZKMetadata(tablenameOfflinePassed);
-
+    // Set up passed delay
+    List<SegmentZKMetadata> segmentsZKMetadataDeltaPassed =
+        _pinotHelixResourceManager.getSegmentsZKMetadata(offlineTableNamePassed);
     Map<String, String> customSegmentMetadataPassed = new HashMap<>();
-    customSegmentMetadataPassed.put(MinionConstants.PurgeTask.TASK_TYPE
-        + MinionConstants.TASK_TIME_SUFFIX, String.valueOf(System.currentTimeMillis() - 88400000));
-
+    customSegmentMetadataPassed.put(MinionConstants.PurgeTask.TASK_TYPE + MinionConstants.TASK_TIME_SUFFIX,
+        String.valueOf(System.currentTimeMillis() - 88400000));
     for (SegmentZKMetadata segmentZKMetadata : segmentsZKMetadataDeltaPassed) {
       segmentZKMetadata.setCustomMap(customSegmentMetadataPassed);
-      _pinotHelixResourceManager.updateZkMetadata(tablenameOfflinePassed, segmentZKMetadata);
+      _pinotHelixResourceManager.updateZkMetadata(offlineTableNamePassed, segmentZKMetadata);
     }
-    //set up not passed delay
-    List<SegmentZKMetadata> segmentsZKMetadataDeltaNotPassed = _pinotHelixResourceManager
-        .getSegmentsZKMetadata(tablenameOfflineNotPassed);
+
+    // Set up not passed delay
+    List<SegmentZKMetadata> segmentsZKMetadataDeltaNotPassed =
+        _pinotHelixResourceManager.getSegmentsZKMetadata(offlineTableNameNotPassed);
     Map<String, String> customSegmentMetadataNotPassed = new HashMap<>();
-    customSegmentMetadataNotPassed.put(MinionConstants.PurgeTask.TASK_TYPE
-        + MinionConstants.TASK_TIME_SUFFIX, String.valueOf(System.currentTimeMillis() - 4000));
+    customSegmentMetadataNotPassed.put(MinionConstants.PurgeTask.TASK_TYPE + MinionConstants.TASK_TIME_SUFFIX,
+        String.valueOf(System.currentTimeMillis() - 4000));
     for (SegmentZKMetadata segmentZKMetadata : segmentsZKMetadataDeltaNotPassed) {
       segmentZKMetadata.setCustomMap(customSegmentMetadataNotPassed);
-      _pinotHelixResourceManager.updateZkMetadata(tablenameOfflineNotPassed, segmentZKMetadata);
+      _pinotHelixResourceManager.updateZkMetadata(offlineTableNameNotPassed, segmentZKMetadata);
     }
   }
 
   private void setRecordPurger() {
     MinionContext minionContext = MinionContext.getInstance();
     minionContext.setRecordPurgerFactory(rawTableName -> {
-      List<String> tableNames = Arrays.asList(PURGE_FIRST_RUN_TABLE,
-          PURGE_DELTA_PASSED_TABLE, PURGE_DELTA_NOT_PASSED_TABLE);
+      List<String> tableNames =
+          Arrays.asList(PURGE_FIRST_RUN_TABLE, PURGE_DELTA_PASSED_TABLE, PURGE_DELTA_NOT_PASSED_TABLE);
       if (tableNames.contains(rawTableName)) {
         return row -> row.getValue("Quarter").equals(1);
       } else {
@@ -187,37 +184,33 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
     // Expected purge task generation :
     // 1. No previous purge run so all segment should be processed and purge metadata sould be added to the segments
     // 2. Check that we cannot run on same time two purge generation ensuring running segment will be skipped
-    // 3. Check segment metadata to ensure purgeTime is updated into the metadata
+    // 3. Check segment ZK metadata to ensure purge time is updated into the metadata
     // 4. Check after the first run of the purge if we rerun a purge task generation no task should be scheduled
-    // 5. Check the purge process itself by setting an expecting number of row
+    // 5. Check the purge process itself by setting an expecting number of rows
 
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(PURGE_FIRST_RUN_TABLE);
-
-    _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE);
+    assertNotNull(_taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
     assertTrue(_helixTaskResourceManager.getTaskQueues()
         .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.PurgeTask.TASK_TYPE)));
-      // Will not schedule task if there's incomplete task
-    assertNull(
-        _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
+    // Will not schedule task if there's incomplete task
+    assertNull(_taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
     waitForTaskToComplete();
 
-    // check that metadat
+    // Check that metadata contains expected values
     for (SegmentZKMetadata metadata : _pinotHelixResourceManager.getSegmentsZKMetadata(offlineTableName)) {
-      // Check purgeTimeIn
-      assertTrue(metadata.getCustomMap().containsKey(MinionConstants.PurgeTask.TASK_TYPE
-          + MinionConstants.TASK_TIME_SUFFIX));
+      // Check purge time
+      assertTrue(
+          metadata.getCustomMap().containsKey(MinionConstants.PurgeTask.TASK_TYPE + MinionConstants.TASK_TIME_SUFFIX));
     }
-    // should not reload a new purge as the last time purge is not greater than last + 1day (default purge delay)
-    assertNull(
-        _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
+    // Should not generate new purge task as the last time purge is not greater than last + 1day (default purge delay)
+    assertNull(_taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
 
-    // 28057 Rows with quarter = 1
-    // 115545 Totals Rows
-    // Expecting 87488 to the final time
-    String sqlQuery = "SELECT count(*) FROM " + PURGE_FIRST_RUN_TABLE;
-    JsonNode actualJson = postQuery(sqlQuery, _brokerBaseApiUrl);
-    assertTrue(actualJson.toString().contains("\"rows\":[[87488]]"),
-        "Expected results to contain: \"rows\":[[87488]] but found: " + actualJson);
+    // 28057 rows with quarter = 1
+    // 115545 totals rows
+    // Expecting 115545 - 28057 = 87488 rows after purging
+    // It might take some time for server to load the purged segments
+    TestUtils.waitForCondition(aVoid -> getCurrentCountStarResult(PURGE_FIRST_RUN_TABLE) == 87488, 60_000L,
+        "Failed to get expected purged records");
 
     // Drop the table
     dropOfflineTable(PURGE_FIRST_RUN_TABLE);
@@ -233,41 +226,37 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
   public void testPassedDelayTimePurge()
       throws Exception {
     // Expected purge task generation :
-    // 1. The purge time on this test is greater than the threshold expected (863660000 > 1d (86400000) )
+    // 1. The purge time on this test is greater than the threshold expected (88400000 > 1d (86400000))
     // 2. Check that we cannot run on same time two purge generation ensuring running segment will be skipped
-    // 3. Check segment metadata to ensure purgeTime is updated into the metadata
+    // 3. Check segment ZK metadata to ensure purge time is updated into the metadata
     // 4. Check after the first run of the purge if we rerun a purge task generation no task should be scheduled
-    // 5. Check the purge process itself by setting an expecting number of row
+    // 5. Check the purge process itself by setting an expecting number of rows
 
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(PURGE_DELTA_PASSED_TABLE);
-    _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE);
+    assertNotNull(_taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
     assertTrue(_helixTaskResourceManager.getTaskQueues()
-          .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.PurgeTask.TASK_TYPE)));
+        .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.PurgeTask.TASK_TYPE)));
     // Will not schedule task if there's incomplete task
-    assertNull(
-        _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
+    assertNull(_taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
     waitForTaskToComplete();
-    // check that metadata contains expected values
+
+    // Check that metadata contains expected values
     for (SegmentZKMetadata metadata : _pinotHelixResourceManager.getSegmentsZKMetadata(offlineTableName)) {
-      // Check purgeTimeIn
-      assertTrue(metadata.getCustomMap().containsKey(MinionConstants.PurgeTask.TASK_TYPE
-          + MinionConstants.TASK_TIME_SUFFIX));
-      //check that the purge have been run on these segments
-      assertTrue(System.currentTimeMillis() - Long.parseLong(metadata.getCustomMap()
-          .get(MinionConstants.PurgeTask.TASK_TYPE + MinionConstants.TASK_TIME_SUFFIX)) < 86400000);
+      // Check purge time
+      String purgeTime =
+          metadata.getCustomMap().get(MinionConstants.PurgeTask.TASK_TYPE + MinionConstants.TASK_TIME_SUFFIX);
+      assertNotNull(purgeTime);
+      assertTrue(System.currentTimeMillis() - Long.parseLong(purgeTime) < 86400000);
     }
-    // should not reload a new purge as the last time purge is not greater than last + 1day (default purge delay)
-    assertNull(
-        _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
+    // Should not generate new purge task as the last time purge is not greater than last + 1day (default purge delay)
+    assertNull(_taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
 
-    // 28057 Rows with quarter = 1
-    // 115545 Totals Rows
-    // Expecting 87488 to the final time
-    String sqlQuery = "SELECT count(*) FROM " + PURGE_DELTA_PASSED_TABLE;
-    JsonNode actualJson = postQuery(sqlQuery, _brokerBaseApiUrl);
-
-    assertTrue(actualJson.toString().contains("\"rows\":[[87488]]"),
-        "Expected results to contain: \"rows\":[[87488]] but found: " + actualJson);
+    // 28057 rows with quarter = 1
+    // 115545 totals rows
+    // Expecting 115545 - 28057 = 87488 rows after purging
+    // It might take some time for server to load the purged segments
+    TestUtils.waitForCondition(aVoid -> getCurrentCountStarResult(PURGE_DELTA_PASSED_TABLE) == 87488, 60_000L,
+        "Failed to get expected purged records");
 
     // Drop the table
     dropOfflineTable(PURGE_DELTA_PASSED_TABLE);
@@ -283,34 +272,28 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
   public void testNotPassedDelayTimePurge()
       throws Exception {
     // Expected no purge task generation :
-    // 1. segment purge time is set to System.currentTimeMillis() -
-    // 4000 so a new purge should not be triggered as the delay is 1d 86400000 ms
-    // 2. Check no task Have been scheduled
-    // 3. Check segment metadata to ensure purgeTime is not updated into the metadata
-    // 4. Check the purge process itself have not been runned by setting an expecting number of row
+    // 1. segment purge time is set to System.currentTimeMillis() - 4000 so a new purge should not be triggered as the
+    //    delay is 1d (86400000ms)
+    // 2. Check no task has been scheduled
+    // 3. Check segment ZK metadata to ensure purge time is not updated into the metadata
+    // 4. Check the purge process itself have not been run by setting an expecting number of rows
 
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(PURGE_DELTA_NOT_PASSED_TABLE);
 
-    //no task should be schedule as the delay is not passed
-    assertNull(
-        _taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
+    // No task should be schedule as the delay is not passed
+    assertNull(_taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
     for (SegmentZKMetadata metadata : _pinotHelixResourceManager.getSegmentsZKMetadata(offlineTableName)) {
-      assertTrue(metadata.getCustomMap().containsKey(MinionConstants.PurgeTask.TASK_TYPE
-          + MinionConstants.TASK_TIME_SUFFIX));
-      //check that the purge have not been run on these segments
-      assertTrue(System.currentTimeMillis() - Long.parseLong(metadata.getCustomMap()
-          .get(MinionConstants.PurgeTask.TASK_TYPE + MinionConstants.TASK_TIME_SUFFIX)) > 4000);
-      assertTrue(System.currentTimeMillis() - Long.parseLong(metadata.getCustomMap()
-          .get(MinionConstants.PurgeTask.TASK_TYPE + MinionConstants.TASK_TIME_SUFFIX)) < 86400000);
+      // Check purge time
+      String purgeTime =
+          metadata.getCustomMap().get(MinionConstants.PurgeTask.TASK_TYPE + MinionConstants.TASK_TIME_SUFFIX);
+      assertNotNull(purgeTime);
+      long purgeTimeMs = Long.parseLong(purgeTime);
+      assertTrue(System.currentTimeMillis() - purgeTimeMs > 4000);
+      assertTrue(System.currentTimeMillis() - purgeTimeMs < 86400000);
     }
-    // 28057 Rows with quarter = 1
-    // 115545 Totals Rows
-    // Expecting 87488 to the final time
-    String sqlQuery = "SELECT count(*) FROM " + PURGE_DELTA_NOT_PASSED_TABLE;
-    JsonNode actualJson = postQuery(sqlQuery, _brokerBaseApiUrl);
 
-    assertTrue(actualJson.toString().contains("\"rows\":[[115545]]"),
-        "Expected results to contain: \"rows\":[[115545]] but found: " + actualJson);
+    // Nothing should be purged
+    assertEquals(getCurrentCountStarResult(PURGE_DELTA_NOT_PASSED_TABLE), 115545);
 
     // Drop the table
     dropOfflineTable(PURGE_DELTA_NOT_PASSED_TABLE);
@@ -326,8 +309,8 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
         return false;
       }
       // Check if the task metadata is cleaned up
-      if (MinionTaskMetadataUtils
-          .fetchTaskMetadata(_propertyStore, MinionConstants.PurgeTask.TASK_TYPE, tableNameWithType) != null) {
+      if (MinionTaskMetadataUtils.fetchTaskMetadata(_propertyStore, MinionConstants.PurgeTask.TASK_TYPE,
+          tableNameWithType) != null) {
         return false;
       }
       return true;


### PR DESCRIPTION
Fix #9581 
Test is flaky because server might not load the purged segments immediately. Need to wait for the condition to meet.