### PR TITLE
fix(sec): upgrade org.apache.kafka:kafka_2.10 to 0.10.2.2

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-0.9/pom.xml
@@ -35,7 +35,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <kafka.lib.version>0.9.0.1</kafka.lib.version>
+    <kafka.lib.version>0.10.2.2</kafka.lib.version>
     <kafka.scala.version>2.10</kafka.scala.version>
     <phase.prop>package</phase.prop>
   </properties>


### PR DESCRIPTION
### What happened？
There are 2 security vulnerabilities found in org.apache.kafka:kafka_2.10 0.9.0.1
- [CVE-2017-12610](https://www.oscs1024.com/hd/CVE-2017-12610)
- [CVE-2018-1288](https://www.oscs1024.com/hd/CVE-2018-1288)


### What did I do？
Upgrade org.apache.kafka:kafka_2.10 from 0.9.0.1 to 0.10.2.2 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS