### PR TITLE
[bugfix] correct the dir for building segments in FileIngestionHelper

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
@@ -218,7 +218,7 @@ public class PinotIngestionRestletResource {
 
     FileIngestionHelper fileIngestionHelper =
         new FileIngestionHelper(tableConfig, schema, batchConfigMap, getControllerUri(),
-            new File(_controllerConf.getDataDir(), UPLOAD_DIR), authProvider);
+            new File(_controllerConf.getLocalTempDir(), UPLOAD_DIR), authProvider);
     return fileIngestionHelper.buildSegmentAndPush(payload);
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotIngestionRestletResource.java
@@ -94,8 +94,8 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
 public class PinotIngestionRestletResource {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotIngestionRestletResource.class);
-  // directory to use under the controller datadir. Controller config can be added for this later if needed.
-  private static final String UPLOAD_DIR = "upload_dir";
+  // directory to use under the controller local temp dir. Controller config can be added for this later if needed.
+  private static final String INGESTION_DIR = "ingestion_dir";
   @Inject
   PinotHelixResourceManager _pinotHelixResourceManager;
 
@@ -218,7 +218,7 @@ public class PinotIngestionRestletResource {
 
     FileIngestionHelper fileIngestionHelper =
         new FileIngestionHelper(tableConfig, schema, batchConfigMap, getControllerUri(),
-            new File(_controllerConf.getLocalTempDir(), UPLOAD_DIR), authProvider);
+            new File(_controllerConf.getLocalTempDir(), INGESTION_DIR), authProvider);
     return fileIngestionHelper.buildSegmentAndPush(payload);
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
@@ -70,16 +70,16 @@ public class FileIngestionHelper {
   private final Schema _schema;
   private final Map<String, String> _batchConfigMap;
   private final URI _controllerUri;
-  private final File _uploadDir;
+  private final File _localTempDir;
   private final AuthProvider _authProvider;
 
   public FileIngestionHelper(TableConfig tableConfig, Schema schema, Map<String, String> batchConfigMap,
-      URI controllerUri, File uploadDir, AuthProvider authProvider) {
+      URI controllerUri, File localTempDir, AuthProvider authProvider) {
     _tableConfig = tableConfig;
     _schema = schema;
     _batchConfigMap = batchConfigMap;
     _controllerUri = controllerUri;
-    _uploadDir = uploadDir;
+    _localTempDir = localTempDir;
     _authProvider = authProvider;
   }
 
@@ -89,7 +89,7 @@ public class FileIngestionHelper {
   public SuccessResponse buildSegmentAndPush(DataPayload payload)
       throws Exception {
     String tableNameWithType = _tableConfig.getTableName();
-    File workingDir = new File(_uploadDir,
+    File workingDir = new File(_localTempDir,
         String.format("%s_%s_%d", WORKING_DIR_PREFIX, tableNameWithType, System.currentTimeMillis()));
     LOGGER.info("Starting ingestion of {} payload to table: {} using working dir: {}", payload._payloadType,
         tableNameWithType, workingDir.getAbsolutePath());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.controller.api.resources.SuccessResponse;
@@ -89,8 +90,11 @@ public class FileIngestionHelper {
   public SuccessResponse buildSegmentAndPush(DataPayload payload)
       throws Exception {
     String tableNameWithType = _tableConfig.getTableName();
+    // 1. append a timestamp for easy debugging
+    // 2. append a random string to avoid using the same working directory when multiple tasks are running in parallel
     File workingDir = new File(_ingestionDir,
-        String.format("%s_%s_%d", WORKING_DIR_PREFIX, tableNameWithType, System.currentTimeMillis()));
+        String.format("%s_%s_%d_%s", WORKING_DIR_PREFIX, tableNameWithType, System.currentTimeMillis(),
+            RandomStringUtils.random(10, true, false)));
     LOGGER.info("Starting ingestion of {} payload to table: {} using working dir: {}", payload._payloadType,
         tableNameWithType, workingDir.getAbsolutePath());
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
@@ -70,16 +70,16 @@ public class FileIngestionHelper {
   private final Schema _schema;
   private final Map<String, String> _batchConfigMap;
   private final URI _controllerUri;
-  private final File _localTempDir;
+  private final File _ingestionDir;
   private final AuthProvider _authProvider;
 
   public FileIngestionHelper(TableConfig tableConfig, Schema schema, Map<String, String> batchConfigMap,
-      URI controllerUri, File localTempDir, AuthProvider authProvider) {
+      URI controllerUri, File ingestionDir, AuthProvider authProvider) {
     _tableConfig = tableConfig;
     _schema = schema;
     _batchConfigMap = batchConfigMap;
     _controllerUri = controllerUri;
-    _localTempDir = localTempDir;
+    _ingestionDir = ingestionDir;
     _authProvider = authProvider;
   }
 
@@ -89,7 +89,7 @@ public class FileIngestionHelper {
   public SuccessResponse buildSegmentAndPush(DataPayload payload)
       throws Exception {
     String tableNameWithType = _tableConfig.getTableName();
-    File workingDir = new File(_localTempDir,
+    File workingDir = new File(_ingestionDir,
         String.format("%s_%s_%d", WORKING_DIR_PREFIX, tableNameWithType, System.currentTimeMillis()));
     LOGGER.info("Starting ingestion of {} payload to table: {} using working dir: {}", payload._payloadType,
         tableNameWithType, workingDir.getAbsolutePath());

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotIngestionRestletResourceStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotIngestionRestletResourceStatelessTest.java
@@ -89,6 +89,10 @@ public class PinotIngestionRestletResourceStatelessTest extends ControllerTest {
     List<String> segments = _helixResourceManager.getSegmentsFor(TABLE_NAME_WITH_TYPE, false);
     Assert.assertEquals(segments.size(), 0);
 
+    // the ingestion dir does not exist before ingesting files
+    File ingestionDir = new File(_controllerConfig.getLocalTempDir() + "/ingestion_dir");
+    Assert.assertFalse(ingestionDir.exists());
+
     // ingest from file
     Map<String, String> batchConfigMap = new HashMap<>();
     batchConfigMap.put(BatchConfigProperties.INPUT_FORMAT, "csv");
@@ -102,6 +106,10 @@ public class PinotIngestionRestletResourceStatelessTest extends ControllerTest {
         String.format("file://%s", _inputFile.getAbsolutePath())));
     segments = _helixResourceManager.getSegmentsFor(TABLE_NAME_WITH_TYPE, false);
     Assert.assertEquals(segments.size(), 2);
+
+    // the ingestion dir exists after ingesting files. We check the existence to make sure this dir is created under
+    // _controllerConfig.getLocalTempDir()
+    Assert.assertTrue(ingestionDir.exists());
   }
 
   private void sendHttpPost(String uri)

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -91,7 +91,11 @@ public class ControllerTest {
   public static final String LOCAL_HOST = "localhost";
   public static final int DEFAULT_CONTROLLER_PORT = 18998;
   public static final String DEFAULT_DATA_DIR =
-      new File(FileUtils.getTempDirectoryPath(), "test-controller-" + System.currentTimeMillis()).getAbsolutePath();
+      new File(FileUtils.getTempDirectoryPath(), "test-controller-data-dir" + System.currentTimeMillis())
+          .getAbsolutePath();
+  public static final String DEFAULT_LOCAL_TEMP_DIR =
+      new File(FileUtils.getTempDirectoryPath(), "test-controller-local-temp-dir" + System.currentTimeMillis())
+          .getAbsolutePath();
   public static final String BROKER_INSTANCE_ID_PREFIX = "Broker_localhost_";
   public static final String SERVER_INSTANCE_ID_PREFIX = "Server_localhost_";
   public static final String MINION_INSTANCE_ID_PREFIX = "Minion_localhost_";
@@ -204,6 +208,7 @@ public class ControllerTest {
     properties.put(ControllerConf.CONTROLLER_HOST, LOCAL_HOST);
     properties.put(ControllerConf.CONTROLLER_PORT, NetUtils.findOpenPort(DEFAULT_CONTROLLER_PORT));
     properties.put(ControllerConf.DATA_DIR, DEFAULT_DATA_DIR);
+    properties.put(ControllerConf.LOCAL_TEMP_DIR, DEFAULT_LOCAL_TEMP_DIR);
     properties.put(ControllerConf.ZK_STR, getZkUrl());
     properties.put(ControllerConf.HELIX_CLUSTER_NAME, getHelixClusterName());
     // Enable groovy on the controller


### PR DESCRIPTION
1. Currently, FileIngestionHelper uses controller data dir for building segments. The working dir ends up to be `/<folder-to-start-pinot>/<controller.data.dir>/upload_dir/working_dir_<table-name>_<ts>`, which is not expected. There may be permission issue when using this dir and we may get `java.lang.IllegalStateException: Could not create directory for downloading input file locally: ...` Ideally, the working dir should be `/<controller.local.temp.dir>/ingestion_dir/working_dir_<table-name>_<ts>`. 
2. To avoid using the same working directory when multiple tasks are running in parallel, append a random string to the working dir name.