### PR TITLE
fix(sec): upgrade org.testng:testng to 7.0.0-beta4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -437,7 +437,7 @@
       <dependency>
         <groupId>org.testng</groupId>
         <artifactId>testng</artifactId>
-        <version>6.11</version>
+        <version>7.0.0-beta4</version>
       </dependency>
       <dependency>
         <groupId>org.roaringbitmap</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in org.testng:testng 6.11
- [MPS-2022-11842](https://www.oscs1024.com/hd/MPS-2022-11842)


### What did I do？
Upgrade org.testng:testng from 6.11 to 7.0.0-beta4 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS