### PR TITLE
add SegmentTierAssigner and refine restful APIs to get segment tier info

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -83,6 +83,7 @@ import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentMa
 import org.apache.pinot.controller.helix.core.realtime.PinotRealtimeSegmentManager;
 import org.apache.pinot.controller.helix.core.realtime.SegmentCompletionManager;
 import org.apache.pinot.controller.helix.core.relocation.SegmentRelocator;
+import org.apache.pinot.controller.helix.core.relocation.SegmentTierAssigner;
 import org.apache.pinot.controller.helix.core.retention.RetentionManager;
 import org.apache.pinot.controller.helix.core.statemodel.LeadControllerResourceMasterSlaveStateModelFactory;
 import org.apache.pinot.controller.helix.core.util.HelixSetupUtils;
@@ -151,6 +152,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
   protected RealtimeSegmentValidationManager _realtimeSegmentValidationManager;
   protected BrokerResourceValidationManager _brokerResourceValidationManager;
   protected SegmentRelocator _segmentRelocator;
+  protected SegmentTierAssigner _segmentTierAssigner;
   protected RetentionManager _retentionManager;
   protected SegmentStatusChecker _segmentStatusChecker;
   protected PinotTaskManager _taskManager;
@@ -679,6 +681,9 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     _segmentRelocator = new SegmentRelocator(_helixResourceManager, _leadControllerManager, _config, _controllerMetrics,
         _executorService);
     periodicTasks.add(_segmentRelocator);
+    _segmentTierAssigner =
+        new SegmentTierAssigner(_helixResourceManager, _leadControllerManager, _config, _controllerMetrics);
+    periodicTasks.add(_segmentTierAssigner);
     _minionInstancesCleanupTask =
         new MinionInstancesCleanupTask(_helixResourceManager, _leadControllerManager, _config, _controllerMetrics);
     periodicTasks.add(_minionInstancesCleanupTask);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -184,6 +184,10 @@ public class ControllerConf extends PinotConfiguration {
         "controller.realtimeSegmentRelocation.initialDelayInSeconds";
     public static final String SEGMENT_RELOCATOR_INITIAL_DELAY_IN_SECONDS =
         "controller.segmentRelocator.initialDelayInSeconds";
+    public static final String SEGMENT_TIER_ASSIGNER_FREQUENCY_PERIOD =
+        "controller.segmentTierAssigner.frequencyPeriod";
+    public static final String SEGMENT_TIER_ASSIGNER_INITIAL_DELAY_IN_SECONDS =
+        "controller.segmentTierAssigner.initialDelayInSeconds";
 
     // The flag to indicate if controller periodic job will fix the missing LLC segment deep store copy.
     // Default value is false.
@@ -214,6 +218,7 @@ public class ControllerConf extends PinotConfiguration {
 
     private static final int DEFAULT_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS = 24 * 60 * 60;
     private static final int DEFAULT_SEGMENT_RELOCATOR_FREQUENCY_IN_SECONDS = 60 * 60;
+    private static final int DEFAULT_SEGMENT_TIER_ASSIGNER_FREQUENCY_IN_SECONDS = 60 * 60;
   }
 
   private static final String SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS = "server.request.timeoutSeconds";
@@ -847,6 +852,17 @@ public class ControllerConf extends PinotConfiguration {
               ControllerPeriodicTasksConf.getRandomInitialDelayInSeconds());
     }
     return segmentRelocatorInitialDelaySeconds;
+  }
+
+  public int getSegmentTierAssignerFrequencyInSeconds() {
+    return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.SEGMENT_TIER_ASSIGNER_FREQUENCY_PERIOD))
+        .map(period -> (int) convertPeriodToSeconds(period))
+        .orElse(ControllerPeriodicTasksConf.DEFAULT_SEGMENT_TIER_ASSIGNER_FREQUENCY_IN_SECONDS);
+  }
+
+  public long getSegmentTierAssignerInitialDelayInSeconds() {
+    return getProperty(ControllerPeriodicTasksConf.SEGMENT_TIER_ASSIGNER_INITIAL_DELAY_IN_SECONDS,
+        ControllerPeriodicTasksConf.getRandomInitialDelayInSeconds());
   }
 
   public long getPeriodicTaskInitialDelayInSeconds() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -218,7 +218,7 @@ public class ControllerConf extends PinotConfiguration {
 
     private static final int DEFAULT_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS = 24 * 60 * 60;
     private static final int DEFAULT_SEGMENT_RELOCATOR_FREQUENCY_IN_SECONDS = 60 * 60;
-    private static final int DEFAULT_SEGMENT_TIER_ASSIGNER_FREQUENCY_IN_SECONDS = 60 * 60;
+    private static final int DEFAULT_SEGMENT_TIER_ASSIGNER_FREQUENCY_IN_SECONDS = -1; // Disabled
   }
 
   private static final String SERVER_ADMIN_REQUEST_TIMEOUT_SECONDS = "server.request.timeoutSeconds";

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -910,11 +910,9 @@ public class PinotSegmentRestletResource {
   })
   public TableTierReader.TableTierDetails getTableTiers(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
-      @ApiParam(value = "OFFLINE|REALTIME", required = true) @QueryParam("type") String tableTypeStr,
-      @ApiParam(value = "Whether to include target tier") @QueryParam("includeTargetTier") @DefaultValue("false")
-          boolean includeTargetTier) {
+      @ApiParam(value = "OFFLINE|REALTIME", required = true) @QueryParam("type") String tableTypeStr) {
     LOGGER.info("Received a request to get storage tier for all segments for table {}", tableName);
-    return getTableTierInternal(tableName, null, tableTypeStr, includeTargetTier);
+    return getTableTierInternal(tableName, null, tableTypeStr);
   }
 
   @GET
@@ -928,16 +926,14 @@ public class PinotSegmentRestletResource {
   public TableTierReader.TableTierDetails getSegmentTiers(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "Name of the segment", required = true) @PathParam("segmentName") @Encoded String segmentName,
-      @ApiParam(value = "OFFLINE|REALTIME", required = true) @QueryParam("type") String tableTypeStr,
-      @ApiParam(value = "Whether to include target tier") @QueryParam("includeTargetTier") @DefaultValue("false")
-          boolean includeTargetTier) {
+      @ApiParam(value = "OFFLINE|REALTIME", required = true) @QueryParam("type") String tableTypeStr) {
     segmentName = URIUtils.decode(segmentName);
     LOGGER.info("Received a request to get storage tier for segment {} in table {}", segmentName, tableName);
-    return getTableTierInternal(tableName, segmentName, tableTypeStr, includeTargetTier);
+    return getTableTierInternal(tableName, segmentName, tableTypeStr);
   }
 
   private TableTierReader.TableTierDetails getTableTierInternal(String tableName, @Nullable String segmentName,
-      @Nullable String tableTypeStr, boolean includeTargetTier) {
+      @Nullable String tableTypeStr) {
     TableType tableType = Constants.validateTableType(tableTypeStr);
     Preconditions.checkNotNull(tableType, "Table type is required to get table tiers");
     String tableNameWithType =
@@ -946,7 +942,7 @@ public class PinotSegmentRestletResource {
     TableTierReader.TableTierDetails tableTierDetails;
     try {
       tableTierDetails = tableTierReader.getTableTierDetails(tableNameWithType, segmentName,
-          _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000, includeTargetTier);
+          _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
     } catch (Throwable t) {
       throw new ControllerApplicationException(LOGGER, String
           .format("Failed to get tier info for segment: %s in table: %s of type: %s", segmentName, tableName,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentTierAssigner.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentTierAssigner.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.relocation;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.util.Collections;
+import java.util.List;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.common.tier.Tier;
+import org.apache.pinot.common.tier.TierSegmentSelector;
+import org.apache.pinot.common.utils.config.TierConfigUtils;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.LeadControllerManager;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.periodictask.ControllerPeriodicTask;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Periodic task to calculate the target tier the segment belongs to and set it into segment ZK metadata as goal
+ * state, which can be checked by servers when loading the segment to put it onto the target storage tier.
+ */
+public class SegmentTierAssigner extends ControllerPeriodicTask<Void> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentTierAssigner.class);
+
+  public SegmentTierAssigner(PinotHelixResourceManager pinotHelixResourceManager,
+      LeadControllerManager leadControllerManager, ControllerConf config, ControllerMetrics controllerMetrics) {
+    super(SegmentTierAssigner.class.getSimpleName(), config.getSegmentTierAssignerFrequencyInSeconds(),
+        config.getSegmentTierAssignerInitialDelayInSeconds(), pinotHelixResourceManager, leadControllerManager,
+        controllerMetrics);
+  }
+
+  @Override
+  protected void processTable(String tableNameWithType) {
+    TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+    Preconditions.checkState(tableConfig != null, "Failed to find table config for table: {}", tableNameWithType);
+    List<Tier> sortedTiers;
+    if (CollectionUtils.isEmpty(tableConfig.getTierConfigsList())) {
+      LOGGER.info("No tierConfigs so use default tier for segments of table: {}", tableNameWithType);
+      sortedTiers = Collections.emptyList();
+    } else {
+      LOGGER.info("Checking and updating target tiers for segments of table: {}", tableNameWithType);
+      sortedTiers = TierConfigUtils
+          .getSortedTiers(tableConfig.getTierConfigsList(), _pinotHelixResourceManager.getHelixZkManager());
+      LOGGER.debug("Sorted tiers: {} configured for table: {}", sortedTiers, tableNameWithType);
+    }
+    for (String segmentName : _pinotHelixResourceManager.getSegmentsFor(tableNameWithType, true)) {
+      updateSegmentTier(tableNameWithType, segmentName, sortedTiers);
+    }
+  }
+
+  @VisibleForTesting
+  void updateSegmentTier(String tableNameWithType, String segmentName, List<Tier> sortedTiers) {
+    ZNRecord segmentMetadataZNRecord =
+        _pinotHelixResourceManager.getSegmentMetadataZnRecord(tableNameWithType, segmentName);
+    if (segmentMetadataZNRecord == null) {
+      LOGGER.debug("No ZK metadata for segment: {} of table: {}", segmentName, tableNameWithType);
+      return;
+    }
+    Tier targetTier = null;
+    for (Tier tier : sortedTiers) {
+      TierSegmentSelector tierSegmentSelector = tier.getSegmentSelector();
+      if (tierSegmentSelector.selectSegment(tableNameWithType, segmentName)) {
+        targetTier = tier;
+        break;
+      }
+    }
+    SegmentZKMetadata segmentZKMetadata = new SegmentZKMetadata(segmentMetadataZNRecord);
+    String targetTierName = null;
+    if (targetTier == null) {
+      if (segmentZKMetadata.getTier() == null) {
+        LOGGER.debug("Segment: {} of table: {} is already on the default tier", segmentName, tableNameWithType);
+        return;
+      }
+      LOGGER.info("Segment: {} of table: {} is put back on default tier", segmentName, tableNameWithType);
+    } else {
+      targetTierName = targetTier.getName();
+      if (targetTierName.equals(segmentZKMetadata.getTier())) {
+        LOGGER.debug("Segment: {} of table: {} is already on the target tier: {}", segmentName, tableNameWithType,
+            targetTierName);
+        return;
+      }
+      LOGGER.info("Segment: {} of table: {} is put onto new tier: {}", segmentName, tableNameWithType, targetTierName);
+    }
+    // Update the tier in segment ZK metadata and write it back to ZK.
+    segmentZKMetadata.setTier(targetTierName);
+    _pinotHelixResourceManager
+        .updateZkMetadata(tableNameWithType, segmentZKMetadata, segmentMetadataZNRecord.getVersion());
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerTableTierReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerTableTierReader.java
@@ -64,6 +64,7 @@ public class ServerTableTierReader {
       }
       serverUrls.add(tierUri);
     }
+    LOGGER.debug("Getting table tier info with serverUrls: {}", serverUrls);
     CompletionServiceHelper completionServiceHelper =
         new CompletionServiceHelper(_executor, _connectionManager, endpointsToServers);
     CompletionServiceHelper.CompletionServiceResponse serviceResponse =

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableTierReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableTierReader.java
@@ -65,11 +65,9 @@ public class TableTierReader {
    *
    * @param tableNameWithType table name with type
    * @param timeoutMs timeout for reading segment tiers from servers
-   * @param includeTargetTier whether to return target tier as well
    * @return details of segment storage tiers for the given table
    */
-  public TableTierDetails getTableTierDetails(String tableNameWithType, @Nullable String segmentName, int timeoutMs,
-      boolean includeTargetTier)
+  public TableTierDetails getTableTierDetails(String tableNameWithType, @Nullable String segmentName, int timeoutMs)
       throws InvalidConfigException {
     Map<String, List<String>> serverToSegmentsMap = new HashMap<>();
     if (segmentName == null) {
@@ -94,9 +92,6 @@ public class TableTierReader {
         tableTierDetails._segmentCurrentTiers.computeIfAbsent(expectedSegment, (k) -> new HashMap<>()).put(server,
             (tableTierInfo == null) ? ERROR_RESP_NO_RESPONSE : getSegmentTier(expectedSegment, tableTierInfo));
       }
-    }
-    if (!includeTargetTier) {
-      return tableTierDetails;
     }
     if (segmentName == null) {
       for (SegmentZKMetadata segmentZKMetadata : _helixResourceManager.getSegmentsZKMetadata(tableNameWithType)) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableTierReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableTierReader.java
@@ -18,9 +18,11 @@
  */
 package org.apache.pinot.controller.util;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.BiMap;
 import java.util.Collections;
 import java.util.HashMap;
@@ -30,6 +32,7 @@ import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.pinot.common.exception.InvalidConfigException;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.restlet.resources.TableTierInfo;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 
@@ -62,9 +65,11 @@ public class TableTierReader {
    *
    * @param tableNameWithType table name with type
    * @param timeoutMs timeout for reading segment tiers from servers
+   * @param includeTargetTier whether to return target tier as well
    * @return details of segment storage tiers for the given table
    */
-  public TableTierDetails getTableTierDetails(String tableNameWithType, @Nullable String segmentName, int timeoutMs)
+  public TableTierDetails getTableTierDetails(String tableNameWithType, @Nullable String segmentName, int timeoutMs,
+      boolean includeTargetTier)
       throws InvalidConfigException {
     Map<String, List<String>> serverToSegmentsMap = new HashMap<>();
     if (segmentName == null) {
@@ -86,9 +91,22 @@ public class TableTierReader {
       List<String> expectedSegmentsOnServer = entry.getValue();
       TableTierInfo tableTierInfo = serverToTableTierInfoMap.get(server);
       for (String expectedSegment : expectedSegmentsOnServer) {
-        tableTierDetails._segmentTiers.computeIfAbsent(expectedSegment, (k) -> new HashMap<>()).put(server,
+        tableTierDetails._segmentCurrentTiers.computeIfAbsent(expectedSegment, (k) -> new HashMap<>()).put(server,
             (tableTierInfo == null) ? ERROR_RESP_NO_RESPONSE : getSegmentTier(expectedSegment, tableTierInfo));
       }
+    }
+    if (!includeTargetTier) {
+      return tableTierDetails;
+    }
+    if (segmentName == null) {
+      for (SegmentZKMetadata segmentZKMetadata : _helixResourceManager.getSegmentsZKMetadata(tableNameWithType)) {
+        tableTierDetails._segmentTargetTiers.put(segmentZKMetadata.getSegmentName(), segmentZKMetadata.getTier());
+      }
+    } else {
+      SegmentZKMetadata segmentZKMetadata = _helixResourceManager.getSegmentZKMetadata(tableNameWithType, segmentName);
+      Preconditions.checkState(segmentZKMetadata != null,
+          "No segmentZKMetadata for segment: %s of table: %s to find the target tier", segmentName, tableNameWithType);
+      tableTierDetails._segmentTargetTiers.put(segmentName, segmentZKMetadata.getTier());
     }
     return tableTierDetails;
   }
@@ -108,7 +126,9 @@ public class TableTierReader {
   @JsonIgnoreProperties(ignoreUnknown = true)
   public static class TableTierDetails {
     private final String _tableName;
-    private final Map<String/*segment*/, Map<String/*server*/, String/*tier or err*/>> _segmentTiers = new HashMap<>();
+    private final Map<String/*segment*/, Map<String/*server*/, String/*tier or err*/>> _segmentCurrentTiers =
+        new HashMap<>();
+    private final Map<String/*segment*/, String/*target tier*/> _segmentTargetTiers = new HashMap<>();
 
     TableTierDetails(String tableName) {
       _tableName = tableName;
@@ -123,7 +143,21 @@ public class TableTierReader {
     @JsonPropertyDescription("Storage tiers of segments for the given table")
     @JsonProperty("segmentTiers")
     public Map<String, Map<String, String>> getSegmentTiers() {
-      return _segmentTiers;
+      HashMap<String, Map<String, String>> segmentTiers = new HashMap<>(_segmentCurrentTiers);
+      for (Map.Entry<String, String> entry : _segmentTargetTiers.entrySet()) {
+        segmentTiers.computeIfAbsent(entry.getKey(), (s) -> new HashMap<>()).put("targetTier", entry.getValue());
+      }
+      return segmentTiers;
+    }
+
+    @JsonIgnore
+    public Map<String, Map<String, String>> getSegmentCurrentTiers() {
+      return _segmentCurrentTiers;
+    }
+
+    @JsonIgnore
+    public Map<String, String> getSegmentTargetTiers() {
+      return _segmentTargetTiers;
     }
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableTierReaderTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableTierReaderTest.java
@@ -227,7 +227,7 @@ public class TableTierReaderTest {
     when(_helix.getDataInstanceAdminEndpoints(ArgumentMatchers.<String>anySet()))
         .thenAnswer(invocationOnMock -> serverEndpoints(servers));
     TableTierReader reader = new TableTierReader(_executor, _connectionManager, _helix);
-    return reader.getTableTierDetails(tableName, segmentName, TIMEOUT_MSEC, true);
+    return reader.getTableTierDetails(tableName, segmentName, TIMEOUT_MSEC);
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableTierReaderTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableTierReaderTest.java
@@ -36,6 +36,7 @@ import java.util.concurrent.Executors;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.apache.pinot.common.exception.InvalidConfigException;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.restlet.resources.TableTierInfo;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.TableTierReader;
@@ -226,7 +227,7 @@ public class TableTierReaderTest {
     when(_helix.getDataInstanceAdminEndpoints(ArgumentMatchers.<String>anySet()))
         .thenAnswer(invocationOnMock -> serverEndpoints(servers));
     TableTierReader reader = new TableTierReader(_executor, _connectionManager, _helix);
-    return reader.getTableTierDetails(tableName, segmentName, TIMEOUT_MSEC);
+    return reader.getTableTierDetails(tableName, segmentName, TIMEOUT_MSEC, true);
   }
 
   @Test
@@ -295,11 +296,15 @@ public class TableTierReaderTest {
   @Test
   public void testGetSegmentTierInfoFromAllServers()
       throws InvalidConfigException {
+    SegmentZKMetadata segZKMeta = mock(SegmentZKMetadata.class);
+    when(segZKMeta.getTier()).thenReturn("coolTier");
+    when(_helix.getSegmentZKMetadata(ArgumentMatchers.anyString(), ArgumentMatchers.anyString())).thenReturn(segZKMeta);
     final String[] servers = {"server6", "server7", "server8", "server9"};
     TableTierReader.TableTierDetails tableTierDetails = testRunner(servers, "myTable_OFFLINE", "segX");
     assertEquals(tableTierDetails.getSegmentTiers().size(), 1);
     Map<String, String> tiersByServer = tableTierDetails.getSegmentTiers().get("segX");
-    assertEquals(tiersByServer.size(), 4);
+    assertEquals(tiersByServer.size(), 5);
+    assertEquals(tiersByServer.get("targetTier"), "coolTier");
     assertEquals(tiersByServer.get("server6"), "someTier");
     assertEquals(tiersByServer.get("server7"), "SEGMENT_MISSED_ON_SERVER");
     assertEquals(tiersByServer.get("server8"), "NO_RESPONSE_FROM_SERVER");

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerPeriodicTaskStarterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerPeriodicTaskStarterStatelessTest.java
@@ -56,7 +56,7 @@ public class ControllerPeriodicTaskStarterStatelessTest extends ControllerTest {
   }
 
   private class MockControllerStarter extends ControllerStarter {
-    private static final int NUM_PERIODIC_TASKS = 9;
+    private static final int NUM_PERIODIC_TASKS = 10;
 
     public MockControllerStarter() {
       super();

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/relocation/SegmentTierAssignerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/relocation/SegmentTierAssignerTest.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.relocation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.tier.FixedTierSegmentSelector;
+import org.apache.pinot.common.tier.Tier;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.mockito.ArgumentCaptor;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+
+public class SegmentTierAssignerTest {
+  @Test
+  public void testUpdateSegmentTierBackToDefault() {
+    String tableName = "table01_OFFLINE";
+    String segmentName = "seg01";
+    PinotHelixResourceManager helixMgrMock = mock(PinotHelixResourceManager.class);
+    when(helixMgrMock.getSegmentMetadataZnRecord(tableName, segmentName))
+        .thenReturn(createSegmentMetadataZNRecord(segmentName, "hotTier"));
+    SegmentTierAssigner assigner = new SegmentTierAssigner(helixMgrMock, null, new ControllerConf(), null);
+
+    // Move back to default as not tier configs.
+    List<Tier> sortedTiers = new ArrayList<>();
+    assigner.updateSegmentTier(tableName, "seg01", sortedTiers);
+    ArgumentCaptor<SegmentZKMetadata> recordCapture = ArgumentCaptor.forClass(SegmentZKMetadata.class);
+    verify(helixMgrMock).updateZkMetadata(eq(tableName), recordCapture.capture(), eq(10));
+    SegmentZKMetadata record = recordCapture.getValue();
+    assertNull(record.getTier());
+  }
+
+  @Test
+  public void testUpdateSegmentTierToNewTier() {
+    String tableName = "table01_OFFLINE";
+    String segmentName = "seg01";
+    PinotHelixResourceManager helixMgrMock = mock(PinotHelixResourceManager.class);
+    when(helixMgrMock.getSegmentMetadataZnRecord(tableName, segmentName))
+        .thenReturn(createSegmentMetadataZNRecord(segmentName, "hotTier"));
+    SegmentTierAssigner assigner = new SegmentTierAssigner(helixMgrMock, null, new ControllerConf(), null);
+
+    // Move back to default as not tier configs.
+    List<Tier> sortedTiers = new ArrayList<>();
+    sortedTiers.add(new Tier("coldTier", new FixedTierSegmentSelector(null, Collections.singleton("seg01")), null));
+    assigner.updateSegmentTier(tableName, "seg01", sortedTiers);
+    ArgumentCaptor<SegmentZKMetadata> recordCapture = ArgumentCaptor.forClass(SegmentZKMetadata.class);
+    verify(helixMgrMock).updateZkMetadata(eq(tableName), recordCapture.capture(), eq(10));
+    SegmentZKMetadata record = recordCapture.getValue();
+    assertEquals(record.getTier(), "coldTier");
+  }
+
+  private static ZNRecord createSegmentMetadataZNRecord(String segmentName, String tierName) {
+    ZNRecord segmentMetadataZNRecord = new ZNRecord(segmentName);
+    segmentMetadataZNRecord.setVersion(10);
+    segmentMetadataZNRecord.setSimpleField(CommonConstants.Segment.TIER, tierName);
+    return segmentMetadataZNRecord;
+  }
+}


### PR DESCRIPTION
This PR is part of the work to support multi-datadir for Pinot server as tracked by https://github.com/apache/pinot/issues/8843. 

Following up on https://github.com/apache/pinot/pull/9306, this one adds the controller side periodic task SegmentTierAssigner to calculate the target tier for segment and set it in SegmentZKMetadata, as goal state to guide servers to put segments into the right datadir (i.e. tier). 

The next PR will connect the two parts, i.e. reusing SegmentReloadMessage to notify servers to do the migration.  

## Release Note
New configs to turn on tier assigner:
1. controller.segmentTierAssigner.frequencyPeriod: -1 by default, disabled
2. controller.segmentTierAssigner.initialDelayInSeconds: 120s-300s w/ jitter by default

Extended API to query segment tiers
```
e.g. curl -X GET "http://localhost:9000/segments/airlineStats_OFFLINE/tiers?type=OFFLINE" -H "accept: application/json"
{
  "tableName": "airlineStats_OFFLINE",
  "segmentTiers": {
    "airlineStats_OFFLINE_16071_16071_0": {
      "targetTier": "coldTier",
      "Server_192.168.0.104_7000": "coldTier"
    },
    "airlineStats_OFFLINE_16072_16072_0": {
      "targetTier": "coldTier",
      "Server_192.168.0.104_7000": "coldTier"
    },
...
```
