### PR TITLE
[PROTOTYPE] polymorphism in function calls

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionInfo.java
@@ -19,18 +19,29 @@
 package org.apache.pinot.common.function;
 
 import java.lang.reflect.Method;
+import java.util.List;
 
 
 public class FunctionInfo {
   private final Method _method;
   private final Class<?> _clazz;
   private final boolean _nullableParameters;
+  private final List<Class<?>> _parameterTypes;
+  private final Class<?> _returnType;
+  private final boolean _narrowing;
+  private final boolean _implicitStrings;
 
-  public FunctionInfo(Method method, Class<?> clazz, boolean nullableParameters) {
+  public FunctionInfo(Method method, Class<?> clazz, boolean nullableParameters, boolean narrowing,
+      boolean implicitStrings) {
     _method = method;
     _clazz = clazz;
     _nullableParameters = nullableParameters;
+    _parameterTypes = List.of(_method.getParameterTypes());
+    _returnType = method.getReturnType();
+    _narrowing = narrowing;
+    _implicitStrings = implicitStrings;
   }
+
 
   public Method getMethod() {
     return _method;
@@ -40,7 +51,19 @@ public class FunctionInfo {
     return _clazz;
   }
 
+  public List<Class<?>> getParameterTypes() {
+    return _parameterTypes;
+  }
+
   public boolean hasNullableParameters() {
     return _nullableParameters;
+  }
+
+  public boolean isNarrowing() {
+    return _narrowing;
+  }
+
+  public boolean isImplicitStrings() {
+    return _implicitStrings;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
@@ -19,9 +19,13 @@
 package org.apache.pinot.common.function;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.Primitives;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +36,7 @@ import org.apache.calcite.schema.impl.ScalarFunctionImpl;
 import org.apache.calcite.util.NameMultimap;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.spi.annotations.ScalarFunction;
+import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.apache.pinot.spi.utils.PinotReflectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,11 +54,53 @@ public class FunctionRegistry {
 
   // TODO: consolidate the following 2
   // This FUNCTION_INFO_MAP is used by Pinot server to look up function by # of arguments
-  private static final Map<String, Map<Integer, FunctionInfo>> FUNCTION_INFO_MAP = new HashMap<>();
+  private static final Map<String, Map<List<Class<?>>, FunctionInfo>> FUNCTION_INFO_MAP = new HashMap<>();
   // This FUNCTION_MAP is used by Calcite function catalog tolook up function by function signature.
   private static final NameMultimap<Function> FUNCTION_MAP = new NameMultimap<>();
 
+  // checks casts between primitives
+  private static final Map<Class<?>, Integer> WIDENING = ImmutableMap.<Class<?>, Integer>builder()
+      .put(byte.class, 0)
+      .put(short.class, 1)
+      .put(char.class, 2)
+      .put(int.class, 3)
+      .put(long.class, 4)
+      .put(float.class, 5)
+      .put(double.class, 6)
+      .build();
+
   /**
+   * Indicates whether a type can be cast to another type, and (if it can be cast) the
+   * strictness with which the cast was executed.
+   *
+   * <p><b>NOTE</b>: the ordering of the enumeration matters, enums with lower ordinals
+   * are considered higher precedence to those with higher ordinals.
+   */
+  private enum CastType {
+    /**
+     * The types are equivalent to one another from a SQL perspective, but are represented
+     * by different Java types
+     */
+    EQUIVALENCE_CAST,
+
+    /**
+     * The types can be cast to one another under general SQL type casting rules
+     */
+    STRICT_CAST,
+
+    /**
+     * The types can be "loosely" casted to one another under custom Pinot rules - this
+     * includes implicit string casting and type narrowing
+     */
+    LOOSE_CAST,
+
+    /**
+     * Two types cannot be cast to one another
+     */
+    INVALID_CAST
+  }
+
+  /*
    * Registers the scalar functions via reflection.
    * NOTE: In order to plugin methods using reflection, the methods should be inside a class that includes ".function."
    *       in its class path. This convention can significantly reduce the time of class scanning.
@@ -70,12 +117,14 @@ public class FunctionRegistry {
         // Annotated function names
         String[] scalarFunctionNames = scalarFunction.names();
         boolean nullableParameters = scalarFunction.nullableParameters();
+        boolean narrowing = scalarFunction.supportsNarrowing();
+        boolean implicitStrings = scalarFunction.supportsImplicitStringCast();
         if (scalarFunctionNames.length > 0) {
           for (String name : scalarFunctionNames) {
-            FunctionRegistry.registerFunction(name, method, nullableParameters);
+            FunctionRegistry.registerFunction(name, method, nullableParameters, narrowing, implicitStrings);
           }
         } else {
-          FunctionRegistry.registerFunction(method, nullableParameters);
+          FunctionRegistry.registerFunction(method, nullableParameters, narrowing, implicitStrings);
         }
       }
     }
@@ -94,8 +143,9 @@ public class FunctionRegistry {
   /**
    * Registers a method with the name of the method.
    */
-  public static void registerFunction(Method method, boolean nullableParameters) {
-    registerFunction(method.getName(), method, nullableParameters);
+  public static void registerFunction(Method method, boolean nullableParameters, boolean narrowing,
+      boolean implicitStrings) {
+    registerFunction(method.getName(), method, nullableParameters, narrowing, implicitStrings);
 
     // Calcite ScalarFunctionImpl doesn't allow customized named functions. TODO: fix me.
     if (method.getAnnotation(Deprecated.class) == null) {
@@ -106,12 +156,16 @@ public class FunctionRegistry {
   /**
    * Registers a method with the given function name.
    */
-  public static void registerFunction(String functionName, Method method, boolean nullableParameters) {
-    FunctionInfo functionInfo = new FunctionInfo(method, method.getDeclaringClass(), nullableParameters);
+  public static void registerFunction(String functionName, Method method, boolean nullableParameters, boolean narrowing,
+      boolean implicitStrings) {
+    FunctionInfo functionInfo = new FunctionInfo(
+        method, method.getDeclaringClass(), nullableParameters, narrowing, implicitStrings);
     String canonicalName = canonicalize(functionName);
-    Map<Integer, FunctionInfo> functionInfoMap = FUNCTION_INFO_MAP.computeIfAbsent(canonicalName, k -> new HashMap<>());
-    Preconditions.checkState(functionInfoMap.put(method.getParameterCount(), functionInfo) == null,
-        "Function: %s with %s parameters is already registered", functionName, method.getParameterCount());
+    Map<List<Class<?>>, FunctionInfo> functionInfoMap =
+        FUNCTION_INFO_MAP.computeIfAbsent(canonicalName, k -> new HashMap<>());
+
+    Preconditions.checkState(functionInfoMap.put(functionInfo.getParameterTypes(), functionInfo) == null,
+        "Function: %s with %s parameters is already registered", functionName, functionInfo.getParameterTypes());
   }
 
   public static Map<String, List<Function>> getRegisteredCalciteFunctionMap() {
@@ -134,14 +188,113 @@ public class FunctionRegistry {
   }
 
   /**
-   * Returns the {@link FunctionInfo} associated with the given function name and number of parameters, or {@code null}
-   * if there is no matching method. This method should be called after the FunctionRegistry is initialized and all
-   * methods are already registered.
+   * Returns the {@link FunctionInfo} associated with the given function name and signature, or {@code null}
+   * if there is no matching method.
+   *
+   * <p>Note that operandTypes may include nulls, if the input at that position resolves to {@code null}.
+   * In this case, the function must support {@link FunctionInfo#hasNullableParameters()}.
+   *
+   * <p>This method should be called after the FunctionRegistry is initialized and all methods
+   * are already registered.
    */
   @Nullable
-  public static FunctionInfo getFunctionInfo(String functionName, int numParameters) {
-    Map<Integer, FunctionInfo> functionInfoMap = FUNCTION_INFO_MAP.get(canonicalize(functionName));
-    return functionInfoMap != null ? functionInfoMap.get(numParameters) : null;
+  public static FunctionInfo getFunctionInfo(String functionName, List<Class<?>> operandTypes) {
+    Map<List<Class<?>>, FunctionInfo> functionInfoMap = FUNCTION_INFO_MAP.get(canonicalize(functionName));
+
+    if (functionInfoMap == null) {
+      return null;
+    }
+
+    // try to find exact match first
+    FunctionInfo fun = functionInfoMap.get(operandTypes);
+    if (fun != null) {
+      return fun;
+    }
+
+    // find non-exact match, with nulls and casting
+    EnumMap<CastType, List<FunctionInfo>> potentialMatches = new EnumMap<>(CastType.class);
+
+    for (Map.Entry<List<Class<?>>, FunctionInfo> entry: functionInfoMap.entrySet()) {
+      List<Class<?>> funTypes = entry.getKey();
+      if (funTypes.size() != operandTypes.size()) {
+        continue;
+      }
+
+      CastType match = CastType.INVALID_CAST;
+      for (int i = 0; i < funTypes.size(); i++) {
+        Class<?> opType = operandTypes.get(i);
+        if (opType == null && entry.getValue().hasNullableParameters()) {
+          match = CastType.STRICT_CAST;
+          continue;
+        } else if (opType == null) {
+          break;
+        }
+
+        boolean stringCast = entry.getValue().isImplicitStrings();
+        boolean narrowing = entry.getValue().isNarrowing();
+        Class<?> funType = funTypes.get(i);
+
+        CastType castType = canCast(opType, funType, stringCast, narrowing);
+        if (castType == CastType.INVALID_CAST) {
+          break;
+        }
+        match = castType.compareTo(match) < 0 ? castType : match;
+      }
+
+      if (match == CastType.EQUIVALENCE_CAST) {
+        // we can early exist, we found an exact match that only differed
+        // with wrapping of primitives
+        return entry.getValue();
+      } else if (match != CastType.INVALID_CAST) {
+        potentialMatches.computeIfAbsent(match, k -> new ArrayList<>()).add(entry.getValue());
+      }
+    }
+
+    for (List<FunctionInfo> functions : potentialMatches.values()) {
+      // EnumMap maintains the natural order of iteration, so we know that the first
+      // element we get will be the bets cast type
+      if (functions.size() > 1) {
+        throw new BadQueryRequestException(
+            "Multiple equal-precedence matches for function " + functionName
+                + " with operand types " + operandTypes
+                + ": " + potentialMatches);
+      }
+
+      return functions.get(0);
+    }
+
+    // didn't find any match
+    return null;
+  }
+
+  private static CastType canCast(Class<?> srcType, Class<?> destType, boolean stringCast, boolean narrowing) {
+    Class<?> src = Primitives.isWrapperType(srcType) ? Primitives.unwrap(srcType) : srcType;
+    Class<?> dest = Primitives.isWrapperType(destType) ? Primitives.unwrap(destType) : destType;
+
+    if (src.equals(dest)) {
+      return CastType.EQUIVALENCE_CAST;
+    } else if (src.isAssignableFrom(srcType) || dest.equals(Object.class)) {
+      // primitives fail the Object.class.isAssignableFrom(<primitive.class>) check, but
+      // everything can be case to Object
+      return CastType.STRICT_CAST;
+    } else if (src.isPrimitive() && dest.isPrimitive() && (WIDENING.get(src) < WIDENING.get(dest))) {
+      // SQL semantics will allow you to pass a widening option
+      return CastType.STRICT_CAST;
+    } else if (src.isPrimitive() && dest.isPrimitive() && narrowing) {
+      // all primitives can be cast to one another if we allow narrowing, which was supported
+      // by the original Pinot logic
+      return CastType.LOOSE_CAST;
+    } else if (destType.equals(byte[].class) && srcType.equals(String.class)) {
+      // this is a custom conversion because internally we allow casting
+      // directly from String to byte[] - literals created with a byte[]
+      // are automatically
+      return CastType.LOOSE_CAST;
+    } else if (stringCast && (destType.equals(String.class) || srcType.equals(String.class))) {
+      // this is for backwards compatibility - by default
+      return CastType.LOOSE_CAST;
+    }
+
+    return CastType.INVALID_CAST;
   }
 
   private static String canonicalize(String functionName) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -50,7 +50,7 @@ public class StringFunctions {
    * @param input
    * @return reversed input in from end to start
    */
-  @ScalarFunction
+  @ScalarFunction(supportsImplicitStringCast = true)
   public static String reverse(String input) {
     return StringUtils.reverse(input);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/types/ExpressionTypeUtil.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/types/ExpressionTypeUtil.java
@@ -1,0 +1,116 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.types;
+
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.Literal;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.utils.PinotDataType;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+
+
+public class ExpressionTypeUtil {
+
+  private ExpressionTypeUtil() {
+    // utility class
+  }
+
+  public static PinotDataType getTypeForLiteral(Literal literal) {
+    if (literal.isSetBoolValue()) {
+      return PinotDataType.BOOLEAN;
+    } else if (literal.isSetBinaryValue()) {
+      return PinotDataType.BYTES;
+    } else if (literal.isSetByteValue()) {
+      return PinotDataType.BYTE;
+    } else if (literal.isSetIntValue()) {
+      return PinotDataType.INTEGER;
+    } else if (literal.isSetLongValue()) {
+      return PinotDataType.LONG;
+    } else if (literal.isSetDoubleValue()) {
+      return PinotDataType.DOUBLE;
+    } else if (literal.isSetStringValue()) {
+      return PinotDataType.STRING;
+    } else {
+      throw new IllegalArgumentException("Unexpected literal " + literal);
+    }
+  }
+
+  public static PinotDataType getType(Expression expression, Schema schema) {
+    switch (expression.getType()) {
+      case LITERAL:
+        // all literals are single-valued at this point
+        return getTypeForLiteral(expression.getLiteral());
+      case IDENTIFIER:
+        FieldSpec identifier = schema.getFieldSpecFor(expression.getIdentifier().getName());
+        if (identifier == null) {
+          throw new IllegalArgumentException("Unknown identifier " + expression.getIdentifier());
+        }
+        return PinotDataType.getPinotDataTypeForIngestion(identifier);
+      case FUNCTION:
+        // for now, all nested function calls just return OBJECT, which doesn't give us
+        // type safety but will help maintain backwards compatibility
+        return PinotDataType.OBJECT;
+      default:
+        throw new IllegalArgumentException("Unexpected expression type: " + expression.getType());
+    }
+  }
+
+  public static PinotDataType getType(ExpressionContext expressionContext, Map<String, FieldSpec> schema) {
+    return getType(expressionContext, identifier -> {
+      FieldSpec spec = schema.get(identifier);
+      if (spec == null) {
+        throw new IllegalArgumentException("Unknown identifier " + expressionContext.getIdentifier());
+      }
+      return spec;
+    });
+  }
+
+  public static PinotDataType getTypeDS(ExpressionContext expressionContext, Map<String, DataSource> schema) {
+    return getType(expressionContext, identifier -> {
+      DataSource dataSource = schema.get(identifier);
+      if (dataSource == null) {
+        throw new IllegalArgumentException("Unknown identifier " + expressionContext.getIdentifier());
+      }
+      return dataSource.getDataSourceMetadata().getFieldSpec();
+    });
+  }
+
+  private static PinotDataType getType(ExpressionContext expressionContext, Function<String, FieldSpec> schema) {
+    switch (expressionContext.getType()) {
+      case LITERAL:
+        // all literals are single-valued at this point
+        return PinotDataType.getPinotDataTypeForIngestion(
+            new DimensionFieldSpec("ignored", expressionContext.getLiteral().getType(), true));
+      case IDENTIFIER:
+        FieldSpec spec = schema.apply(expressionContext.getIdentifier());
+        return PinotDataType.getPinotDataTypeForIngestion(spec);
+      case FUNCTION:
+        // for now, all nested function calls just return OBJECT, which doesn't give us
+        // type safety but will help maintain backwards compatibility
+        return PinotDataType.OBJECT;
+      default:
+        throw new IllegalArgumentException("Unexpected expression type: " + expressionContext.getType());
+    }
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
@@ -65,7 +65,7 @@ public enum PinotDataType {
    *   - "1" -> true (for backward-compatibility where we used to use integer 1 to represent true)
    *   - Others ->  false
    */
-  BOOLEAN {
+  BOOLEAN(boolean.class) {
     @Override
     public int toInt(Object value) {
       return ((Boolean) value) ? 1 : 0;
@@ -122,7 +122,7 @@ public enum PinotDataType {
     }
   },
 
-  BYTE {
+  BYTE(byte.class) {
     @Override
     public int toInt(Object value) {
       return ((Number) value).intValue();
@@ -169,7 +169,7 @@ public enum PinotDataType {
     }
   },
 
-  CHARACTER {
+  CHARACTER(char.class) {
     @Override
     public int toInt(Object value) {
       return (int) ((Character) value);
@@ -216,7 +216,7 @@ public enum PinotDataType {
     }
   },
 
-  SHORT {
+  SHORT(short.class) {
     @Override
     public int toInt(Object value) {
       return ((Number) value).intValue();
@@ -263,7 +263,7 @@ public enum PinotDataType {
     }
   },
 
-  INTEGER {
+  INTEGER(int.class) {
     @Override
     public int toInt(Object value) {
       return (Integer) value;
@@ -315,7 +315,7 @@ public enum PinotDataType {
     }
   },
 
-  LONG {
+  LONG(long.class) {
     @Override
     public int toInt(Object value) {
       return ((Number) value).intValue();
@@ -370,7 +370,7 @@ public enum PinotDataType {
     }
   },
 
-  FLOAT {
+  FLOAT(float.class) {
     @Override
     public int toInt(Object value) {
       return ((Number) value).intValue();
@@ -422,7 +422,7 @@ public enum PinotDataType {
     }
   },
 
-  DOUBLE {
+  DOUBLE(double.class) {
     @Override
     public int toInt(Object value) {
       return ((Number) value).intValue();
@@ -478,7 +478,7 @@ public enum PinotDataType {
     }
   },
 
-  BIG_DECIMAL {
+  BIG_DECIMAL(BigDecimal.class) {
     @Override
     public int toInt(Object value) {
       return ((Number) value).intValue();
@@ -541,7 +541,7 @@ public enum PinotDataType {
    *   - SQL timestamp format (e.g. "2021-01-01 01:01:01.001")
    *   - Millis since epoch value (e.g. "1609491661001")
    */
-  TIMESTAMP {
+  TIMESTAMP(Timestamp.class) {
     @Override
     public int toInt(Object value) {
       throw new UnsupportedOperationException("Cannot convert value from TIMESTAMP to INTEGER");
@@ -598,7 +598,7 @@ public enum PinotDataType {
     }
   },
 
-  STRING {
+  STRING(String.class) {
     @Override
     public int toInt(Object value) {
       return Integer.parseInt(value.toString().trim());
@@ -652,7 +652,7 @@ public enum PinotDataType {
     }
   },
 
-  JSON {
+  JSON(String.class) {
     @Override
     public int toInt(Object value) {
       return Integer.parseInt(value.toString().trim());
@@ -711,7 +711,7 @@ public enum PinotDataType {
     }
   },
 
-  BYTES {
+  BYTES(byte[].class) {
     @Override
     public int toInt(Object value) {
       throw new UnsupportedOperationException("Cannot convert value from BYTES to INTEGER");
@@ -763,7 +763,7 @@ public enum PinotDataType {
     }
   },
 
-  OBJECT {
+  OBJECT(Object.class) {
     @Override
     public int toInt(Object value) {
       return ((Number) value).intValue();
@@ -815,7 +815,7 @@ public enum PinotDataType {
     }
   },
 
-  BYTE_ARRAY {
+  BYTE_ARRAY(byte[].class) {
     @Override
     public byte[] toBytes(Object value) {
       Object[] valueArray = (Object[]) value;
@@ -828,9 +828,9 @@ public enum PinotDataType {
     }
   },
 
-  CHARACTER_ARRAY,
+  CHARACTER_ARRAY(char[].class),
 
-  SHORT_ARRAY,
+  SHORT_ARRAY(short[].class),
 
   /*
     NOTE:
@@ -839,91 +839,101 @@ public enum PinotDataType {
       We need to keep them separately because they cannot automatically cast to the other type.
    */
 
-  PRIMITIVE_INT_ARRAY {
+  PRIMITIVE_INT_ARRAY(int[].class) {
     @Override
     public int[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toPrimitiveIntArray(value);
     }
   },
 
-  INTEGER_ARRAY {
+  INTEGER_ARRAY(Integer[].class) {
     @Override
     public Integer[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toIntegerArray(value);
     }
   },
 
-  PRIMITIVE_LONG_ARRAY {
+  PRIMITIVE_LONG_ARRAY(long[].class) {
     @Override
     public long[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toPrimitiveLongArray(value);
     }
   },
 
-  LONG_ARRAY {
+  LONG_ARRAY(Long[].class) {
     @Override
     public Long[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toLongArray(value);
     }
   },
 
-  PRIMITIVE_FLOAT_ARRAY {
+  PRIMITIVE_FLOAT_ARRAY(float[].class) {
     @Override
     public float[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toPrimitiveFloatArray(value);
     }
   },
 
-  FLOAT_ARRAY {
+  FLOAT_ARRAY(Float[].class) {
     @Override
     public Float[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toFloatArray(value);
     }
   },
 
-  PRIMITIVE_DOUBLE_ARRAY {
+  PRIMITIVE_DOUBLE_ARRAY(double[].class) {
     @Override
     public double[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toPrimitiveDoubleArray(value);
     }
   },
 
-  DOUBLE_ARRAY {
+  DOUBLE_ARRAY(Double[].class) {
     @Override
     public Double[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toDoubleArray(value);
     }
   },
 
-  BOOLEAN_ARRAY {
+  BOOLEAN_ARRAY(boolean[].class) {
     @Override
     public boolean[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toBooleanArray(value);
     }
   },
 
-  TIMESTAMP_ARRAY {
+  TIMESTAMP_ARRAY(Timestamp[].class) {
     @Override
     public Object convert(Object value, PinotDataType sourceType) {
       return sourceType.toTimestampArray(value);
     }
   },
 
-  STRING_ARRAY {
+  STRING_ARRAY(String[].class) {
     @Override
     public String[] convert(Object value, PinotDataType sourceType) {
       return sourceType.toStringArray(value);
     }
   },
 
-  BYTES_ARRAY {
+  BYTES_ARRAY(byte[][].class) {
     @Override
     public byte[][] convert(Object value, PinotDataType sourceType) {
       return sourceType.toBytesArray(value);
     }
   },
 
-  OBJECT_ARRAY;
+  OBJECT_ARRAY(Object[].class);
+
+  private final Class<?> _clazz;
+
+  PinotDataType(Class<?> clazz) {
+    _clazz = clazz;
+  }
+
+  public Class<?> getJavaClass() {
+    return _clazz;
+  }
 
   /**
    * NOTE: override toInt(), toLong(), toFloat(), toDouble(), toBoolean(), toTimestamp(), toString(), and
@@ -1311,17 +1321,49 @@ public enum PinotDataType {
     }
   }
 
+  private PinotDataType getMultiValueType(boolean primitive) {
+    switch (this) {
+      case BOOLEAN:
+        return BOOLEAN_ARRAY;
+      case BYTE:
+        return BYTE_ARRAY;
+      case CHARACTER:
+        return CHARACTER_ARRAY;
+      case SHORT:
+        return SHORT_ARRAY;
+      case INTEGER:
+        return primitive ? PRIMITIVE_INT_ARRAY : INTEGER_ARRAY;
+      case LONG:
+        return primitive ? PRIMITIVE_LONG_ARRAY : LONG_ARRAY;
+      case FLOAT:
+        return primitive ? PRIMITIVE_FLOAT_ARRAY : FLOAT_ARRAY;
+      case DOUBLE:
+        return primitive ? PRIMITIVE_DOUBLE_ARRAY : DOUBLE_ARRAY;
+      case TIMESTAMP:
+        return TIMESTAMP_ARRAY;
+      case STRING:
+        return STRING_ARRAY;
+      case BYTES:
+        return BYTES_ARRAY;
+      case OBJECT:
+        return OBJECT_ARRAY;
+      default:
+      case OBJECT_ARRAY:
+        throw new IllegalStateException("There is no multi-value type for " + this);
+    }
+  }
+
   public static PinotDataType getSingleValueType(Class<?> cls) {
-    if (cls == Integer.class) {
+    if (cls == Integer.class || cls == int.class) {
       return INTEGER;
     }
-    if (cls == Long.class) {
+    if (cls == Long.class || cls == long.class) {
       return LONG;
     }
-    if (cls == Float.class) {
+    if (cls == Float.class || cls == float.class) {
       return FLOAT;
     }
-    if (cls == Double.class) {
+    if (cls == Double.class || cls == double.class) {
       return DOUBLE;
     }
     if (cls == BigDecimal.class) {
@@ -1333,59 +1375,26 @@ public enum PinotDataType {
     if (cls == byte[].class) {
       return BYTES;
     }
-    if (cls == Boolean.class) {
+    if (cls == Boolean.class || cls == boolean.class) {
       return BOOLEAN;
     }
     if (cls == Timestamp.class) {
       return TIMESTAMP;
     }
-    if (cls == Byte.class) {
+    if (cls == Byte.class || cls == byte.class) {
       return BYTE;
     }
-    if (cls == Character.class) {
+    if (cls == Character.class || cls == char.class) {
       return CHARACTER;
     }
-    if (cls == Short.class) {
+    if (cls == Short.class || cls == short.class) {
       return SHORT;
     }
     return OBJECT;
   }
 
   public static PinotDataType getMultiValueType(Class<?> cls) {
-    if (cls == Integer.class) {
-      return INTEGER_ARRAY;
-    }
-    if (cls == Long.class) {
-      return LONG_ARRAY;
-    }
-    if (cls == Float.class) {
-      return FLOAT_ARRAY;
-    }
-    if (cls == Double.class) {
-      return DOUBLE_ARRAY;
-    }
-    if (cls == String.class) {
-      return STRING_ARRAY;
-    }
-    if (cls == Byte.class) {
-      return BYTE_ARRAY;
-    }
-    if (cls == Character.class) {
-      return CHARACTER_ARRAY;
-    }
-    if (cls == Short.class) {
-      return SHORT_ARRAY;
-    }
-    if (cls == byte[].class) {
-      return BYTES_ARRAY;
-    }
-    if (cls == Boolean.class) {
-      return BOOLEAN_ARRAY;
-    }
-    if (cls == Timestamp.class) {
-      return TIMESTAMP_ARRAY;
-    }
-    return OBJECT_ARRAY;
+    return getSingleValueType(cls).getMultiValueType(cls != null && cls.isPrimitive());
   }
 
   private static int anyToInt(Object val) {
@@ -1479,6 +1488,8 @@ public enum PinotDataType {
         return PRIMITIVE_DOUBLE_ARRAY;
       case STRING_ARRAY:
         return STRING_ARRAY;
+      case OBJECT:
+        return OBJECT;
       default:
         throw new IllegalStateException("Cannot convert ColumnDataType: " + columnDataType + " to PinotDataType");
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.function.FunctionInfo;
@@ -31,6 +32,7 @@ import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.common.function.TransformFunctionType;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FunctionContext;
+import org.apache.pinot.common.types.ExpressionTypeUtil;
 import org.apache.pinot.core.geospatial.transform.function.GeoToH3Function;
 import org.apache.pinot.core.geospatial.transform.function.StAreaFunction;
 import org.apache.pinot.core.geospatial.transform.function.StAsBinaryFunction;
@@ -292,7 +294,12 @@ public class TransformFunctionFactory {
           }
         } else {
           // Scalar function
-          FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, numArguments);
+          List<Class<?>> types =
+              arguments.stream()
+                  .map(ec -> ExpressionTypeUtil.getTypeDS(ec, dataSourceMap))
+                  .map(pdt -> pdt == null ? null : pdt.getJavaClass())
+                  .collect(Collectors.toList());
+          FunctionInfo functionInfo = FunctionRegistry.getFunctionInfo(functionName, types);
           if (functionInfo == null) {
             if (FunctionRegistry.containsFunction(functionName)) {
               throw new BadQueryRequestException(

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/filter/FunctionEvaluatorRecordFilter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/filter/FunctionEvaluatorRecordFilter.java
@@ -32,7 +32,8 @@ public class FunctionEvaluatorRecordFilter implements RecordFilter {
   private final FunctionEvaluator _filterFunctionEvaluator;
 
   public FunctionEvaluatorRecordFilter(String filterFunction) {
-    _filterFunctionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(filterFunction);
+    // TODO: is this used anywhere?
+    _filterFunctionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(filterFunction, null);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
@@ -93,7 +93,7 @@ public class SegmentMapper {
     int numPartitioners = partitionerConfigs.size();
     _partitioners = new Partitioner[numPartitioners];
     for (int i = 0; i < numPartitioners; i++) {
-      _partitioners[i] = PartitionerFactory.getPartitioner(partitionerConfigs.get(i));
+      _partitioners[i] = PartitionerFactory.getPartitioner(partitionerConfigs.get(i), _fieldSpecs);
     }
     // Time partition + partition from partitioners
     _partitionsBuffer = new String[numPartitioners + 1];

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/PartitionerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/PartitionerFactory.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.core.segment.processing.partitioner;
 
 import com.google.common.base.Preconditions;
+import java.util.List;
+import org.apache.pinot.spi.data.FieldSpec;
 
 
 /**
@@ -51,7 +53,7 @@ public final class PartitionerFactory {
   /**
    * Construct a Partitioner using the PartitioningConfig
    */
-  public static Partitioner getPartitioner(PartitionerConfig config) {
+  public static Partitioner getPartitioner(PartitionerConfig config, List<FieldSpec> fieldSpecs) {
 
     Partitioner partitioner = null;
     switch (config.getPartitionerType()) {
@@ -71,7 +73,7 @@ public final class PartitionerFactory {
       case TRANSFORM_FUNCTION:
         Preconditions.checkState(config.getTransformFunction() != null,
             "Must provide transformFunction for TRANSFORM_FUNCTION partitioner");
-        partitioner = new TransformFunctionPartitioner(config.getTransformFunction());
+        partitioner = new TransformFunctionPartitioner(config.getTransformFunction(), fieldSpecs);
         break;
       case TABLE_PARTITION_CONFIG:
         Preconditions.checkState(config.getColumnName() != null,

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/TransformFunctionPartitioner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/TransformFunctionPartitioner.java
@@ -18,8 +18,12 @@
  */
 package org.apache.pinot.core.segment.processing.partitioner;
 
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.apache.pinot.segment.local.function.FunctionEvaluator;
 import org.apache.pinot.segment.local.function.FunctionEvaluatorFactory;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 
 
@@ -30,8 +34,9 @@ public class TransformFunctionPartitioner implements Partitioner {
 
   private final FunctionEvaluator _functionEvaluator;
 
-  public TransformFunctionPartitioner(String transformFunction) {
-    _functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(transformFunction);
+  public TransformFunctionPartitioner(String transformFunction, List<FieldSpec> fieldSpecs) {
+    _functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(
+        transformFunction, fieldSpecs.stream().collect(Collectors.toMap(FieldSpec::getName, Function.identity())));
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/transformer/RecordTransformerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/transformer/RecordTransformerFactory.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.core.segment.processing.transformer;
 
+import org.apache.pinot.spi.data.Schema;
+
+
 /**
  * Factory for RecordTransformer
  */
@@ -28,9 +31,9 @@ public final class RecordTransformerFactory {
   /**
    * Construct a RecordTransformer from the config
    */
-  public static RecordTransformer getRecordTransformer(RecordTransformerConfig recordTransformerConfig) {
+  public static RecordTransformer getRecordTransformer(RecordTransformerConfig recordTransformerConfig, Schema schema) {
     if (recordTransformerConfig.getTransformFunctionsMap() != null) {
-      return new TransformFunctionRecordTransformer(recordTransformerConfig.getTransformFunctionsMap());
+      return new TransformFunctionRecordTransformer(recordTransformerConfig.getTransformFunctionsMap(), schema);
     }
     return new NoOpRecordTransformer();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/transformer/TransformFunctionRecordTransformer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/transformer/TransformFunctionRecordTransformer.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Map;
 import org.apache.pinot.segment.local.function.FunctionEvaluator;
 import org.apache.pinot.segment.local.function.FunctionEvaluatorFactory;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 
 
@@ -34,9 +35,11 @@ public class TransformFunctionRecordTransformer implements RecordTransformer {
 
   private final Map<String, FunctionEvaluator> _functionEvaluatorMap = new HashMap<>();
 
-  public TransformFunctionRecordTransformer(Map<String, String> transformFunctionMap) {
+  public TransformFunctionRecordTransformer(Map<String, String> transformFunctionMap, Schema schema) {
+    // TODO: doesn't seem to be used?
     transformFunctionMap.forEach(
-        (key, value) -> _functionEvaluatorMap.put(key, FunctionEvaluatorFactory.getExpressionEvaluator(value)));
+        (key, value) -> _functionEvaluatorMap.put(
+            key, FunctionEvaluatorFactory.getExpressionEvaluator(value, schema.getFieldSpecMap())));
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/ArithmeticFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/ArithmeticFunctionsTest.java
@@ -18,10 +18,14 @@
  */
 package org.apache.pinot.core.data.function;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.apache.pinot.segment.local.function.InbuiltFunctionEvaluator;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -33,9 +37,14 @@ import org.testng.annotations.Test;
  */
 public class ArithmeticFunctionsTest {
 
+  Map<String, FieldSpec> _schema = ImmutableMap.of(
+      "a", new DimensionFieldSpec("a", FieldSpec.DataType.INT, true),
+      "b", new DimensionFieldSpec("b", FieldSpec.DataType.INT, true)
+  );
+
   private void testFunction(String functionExpression, List<String> expectedArguments, GenericRow row,
       Object expectedResult) {
-    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(functionExpression);
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(functionExpression, _schema);
     Assert.assertEquals(evaluator.getArguments(), expectedArguments);
     Assert.assertEquals(evaluator.evaluate(row), expectedResult);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/ArrayFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/ArrayFunctionsTest.java
@@ -36,7 +36,8 @@ public class ArrayFunctionsTest {
 
   private void testFunction(String functionExpression, List<String> expectedArguments, GenericRow row,
       Object expectedResult) {
-    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(functionExpression);
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(functionExpression,
+        GenericRowToFieldSchemaMap.inferFieldMap(row));
     Assert.assertEquals(evaluator.getArguments(), expectedArguments);
     Assert.assertEquals(evaluator.evaluate(row), expectedResult);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/GenericRowToFieldSchemaMap.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/GenericRowToFieldSchemaMap.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.function;
+
+import com.google.common.collect.ImmutableMap;
+import java.lang.reflect.Array;
+import java.sql.Timestamp;
+import java.util.Map;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.readers.GenericRow;
+
+
+/**
+ * This class helps test various classes that require a schema to function,
+ * but just produce {@code GenericRow}. It makes a "best effort" attempt and
+ * users of this should take care to tailor it to their test use case.
+ */
+public class GenericRowToFieldSchemaMap {
+
+  private GenericRowToFieldSchemaMap() {
+  }
+
+  public static Map<String, FieldSpec> inferFieldMap(GenericRow row) {
+    return inferFieldMapWithDefaultType(row, null, false);
+  }
+
+  public static Map<String, FieldSpec> inferFieldMapWithDefaultType(
+      GenericRow row, FieldSpec.DataType defaultType, boolean defaultMV
+  ) {
+    ImmutableMap.Builder<String, FieldSpec> builder = ImmutableMap.<String, FieldSpec>builder();
+
+    for (Map.Entry<String, Object> entry : row.getFieldToValueMap().entrySet()) {
+      if (entry.getValue() != null) {
+        // simply ignore null values for now, have the calling test add them
+        builder.put(entry.getKey(), extractFieldSpec(entry.getKey(), entry.getValue()));
+      } else if (defaultType != null) {
+        builder.put(entry.getKey(), new DimensionFieldSpec(entry.getKey(), defaultType, defaultMV));
+      }
+    }
+
+    return builder.build();
+  }
+
+  private static FieldSpec extractFieldSpec(String key, Object value) {
+    if (value == null) {
+      throw new IllegalArgumentException("Unexpected NULL value");
+    } else if (value instanceof Integer || value instanceof Short || value instanceof Byte) {
+      return new DimensionFieldSpec(key, FieldSpec.DataType.INT, true);
+    } else if (value instanceof Long) {
+      return new DimensionFieldSpec(key, FieldSpec.DataType.LONG, true);
+    } else if (value instanceof Float) {
+      return new DimensionFieldSpec(key, FieldSpec.DataType.FLOAT, true);
+    } else if (value instanceof Double) {
+      return new DimensionFieldSpec(key, FieldSpec.DataType.DOUBLE, true);
+    } else if (value instanceof Timestamp) {
+      return new DimensionFieldSpec(key, FieldSpec.DataType.TIMESTAMP, true);
+    } else if (value instanceof byte[]) {
+      return new DimensionFieldSpec(key, FieldSpec.DataType.BYTES, true);
+    } else if (value instanceof String) {
+      return new DimensionFieldSpec(key, FieldSpec.DataType.STRING, true);
+    } else if (value instanceof Object[]) {
+      if (((Object[]) value).length == 0) {
+        throw new IllegalStateException("cannot infer type for empty array");
+      }
+      Object o = ((Object[]) value)[0];
+      if (o == null) {
+        throw new IllegalStateException("cannot infer type for array with null values");
+      }
+
+      FieldSpec singleFieldSpec = extractFieldSpec(key, o);
+      return new DimensionFieldSpec(key, singleFieldSpec.getDataType(), false);
+    } else if (value.getClass().isArray()) {
+      // this is the case for primitive arrays, which need some special handling
+      if (Array.getLength(value) == 0) {
+        throw new IllegalStateException("cannot infer type for empty array");
+      }
+      Object o = Array.get(value, 0);
+      FieldSpec fieldSpec = extractFieldSpec(key, o);
+      return new DimensionFieldSpec(key, fieldSpec.getDataType(), false);
+    }
+
+    // assume string otherwise
+    return new DimensionFieldSpec(key, FieldSpec.DataType.STRING, false);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/JsonFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/JsonFunctionsTest.java
@@ -39,7 +39,8 @@ public class JsonFunctionsTest {
 
   private void testFunction(String functionExpression, List<String> expectedArguments, GenericRow row,
       Object expectedResult) {
-    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(functionExpression);
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(functionExpression,
+        GenericRowToFieldSchemaMap.inferFieldMap(row));
     Assert.assertEquals(evaluator.getArguments(), expectedArguments);
     Assert.assertEquals(evaluator.evaluate(row), expectedResult);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/LogicalFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/LogicalFunctionsTest.java
@@ -36,7 +36,8 @@ public class LogicalFunctionsTest {
 
   private void testFunction(String functionExpression, List<String> expectedArguments, GenericRow row,
       Object expectedResult) {
-    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(functionExpression);
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(functionExpression,
+        GenericRowToFieldSchemaMap.inferFieldMap(row));
     Assert.assertEquals(evaluator.getArguments(), expectedArguments);
     Assert.assertEquals(evaluator.evaluate(row), expectedResult);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/ObjectFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/ObjectFunctionsTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.pinot.segment.local.function.InbuiltFunctionEvaluator;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -31,7 +32,9 @@ import org.testng.annotations.Test;
 public class ObjectFunctionsTest {
   private void testFunction(String functionExpression, List<String> expectedArguments, GenericRow row,
       Object expectedResult) {
-    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(functionExpression);
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(
+        functionExpression, GenericRowToFieldSchemaMap.inferFieldMapWithDefaultType(
+            row, FieldSpec.DataType.STRING, false));
     Assert.assertEquals(evaluator.getArguments(), expectedArguments);
     Assert.assertEquals(evaluator.evaluate(row), expectedResult);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
@@ -105,7 +105,10 @@ public class SchemaUtilsTest {
     }
 
     schema =
-        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("colA", DataType.STRING).build();
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+            .addSingleValueDimension("colA", DataType.STRING)
+            .addSingleValueDimension("colB", DataType.STRING)
+            .build();
     SchemaUtils.validate(schema, Lists.newArrayList(tableConfig));
 
     // realtime table
@@ -153,6 +156,7 @@ public class SchemaUtilsTest {
 
     schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
         .addDateTime(TIME_COLUMN, DataType.LONG, "1:MILLISECONDS:EPOCH", "1:HOURS")
+        .addSingleValueDimension("colB", DataType.STRING)
         .addSingleValueDimension("colA", DataType.STRING).build();
     SchemaUtils.validate(schema, Lists.newArrayList(tableConfig));
   }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutorTest.java
@@ -118,11 +118,13 @@ public class RealtimeToOfflineSegmentsTaskExecutorTest {
             .addDateTime(T, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
     Schema schemaEpochHours =
         new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension(D1, FieldSpec.DataType.STRING)
+            .addSingleValueDimension(T, FieldSpec.DataType.LONG)
             .addMetric(M1, FieldSpec.DataType.INT)
             .addDateTime(T_TRX, FieldSpec.DataType.INT, "1:HOURS:EPOCH", "1:HOURS").build();
     Schema schemaSDF =
         new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension(D1, FieldSpec.DataType.STRING)
             .addMetric(M1, FieldSpec.DataType.INT)
+            .addSingleValueDimension(T, FieldSpec.DataType.LONG)
             .addDateTime(T_TRX, FieldSpec.DataType.INT, "1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMddHH", "1:HOURS").build();
 
     List<String> d1 = Lists.newArrayList("foo", "bar", "foo", "foo", "bar");

--- a/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/src/test/java/org/apache/pinot/plugin/segmentwriter/filebased/FileBasedSegmentWriterTest.java
+++ b/pinot-plugins/pinot-segment-writer/pinot-segment-writer-file-based/src/test/java/org/apache/pinot/plugin/segmentwriter/filebased/FileBasedSegmentWriterTest.java
@@ -81,7 +81,9 @@ public class FileBasedSegmentWriterTest {
             .setTimeColumnName(TIME_COLUMN_NAME).build();
     _schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
         .addSingleValueDimension("aString", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("aSimpleMap", FieldSpec.DataType.JSON)
         .addSingleValueDimension("aSimpleMap_str", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("anAdvancedMap", FieldSpec.DataType.JSON)
         .addSingleValueDimension("anAdvancedMap_str", FieldSpec.DataType.STRING)
         .addSingleValueDimension("nullString", FieldSpec.DataType.STRING)
         .addSingleValueDimension("aBoolean", FieldSpec.DataType.BOOLEAN)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
@@ -60,7 +60,8 @@ public class CompositeTransformer implements RecordTransformer {
    */
   public static CompositeTransformer getDefaultTransformer(TableConfig tableConfig, Schema schema) {
     return new CompositeTransformer(Arrays
-        .asList(new ExpressionTransformer(tableConfig, schema), new FilterTransformer(tableConfig),
+        .asList(new ExpressionTransformer(tableConfig, schema),
+            new FilterTransformer(tableConfig, schema.getFieldSpecMap()),
             new DataTypeTransformer(tableConfig, schema), new NullValueTransformer(tableConfig, schema),
             new SanitizationTransformer(schema)));
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
@@ -57,7 +57,8 @@ public class ExpressionTransformer implements RecordTransformer {
     if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getTransformConfigs() != null) {
       for (TransformConfig transformConfig : tableConfig.getIngestionConfig().getTransformConfigs()) {
         FunctionEvaluator previous = expressionEvaluators.put(transformConfig.getColumnName(),
-            FunctionEvaluatorFactory.getExpressionEvaluator(transformConfig.getTransformFunction()));
+            FunctionEvaluatorFactory.getExpressionEvaluator(
+                transformConfig.getTransformFunction(), schema.getFieldSpecMap()));
         Preconditions
             .checkState(previous == null, "Cannot set more than one ingestion transform function on column: %s.",
                 transformConfig.getColumnName());
@@ -66,7 +67,7 @@ public class ExpressionTransformer implements RecordTransformer {
     for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
       String fieldName = fieldSpec.getName();
       if (!fieldSpec.isVirtualColumn() && !expressionEvaluators.containsKey(fieldName)) {
-        FunctionEvaluator functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec);
+        FunctionEvaluator functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec, schema);
         if (functionEvaluator != null) {
           expressionEvaluators.put(fieldName, functionEvaluator);
         }
@@ -80,7 +81,8 @@ public class ExpressionTransformer implements RecordTransformer {
             expressionEvaluators.put(
                 TimestampIndexGranularity.getColumnNameWithGranularity(fieldConfig.getName(), granularity),
                 FunctionEvaluatorFactory.getExpressionEvaluator(
-                    TimestampIndexGranularity.getTransformExpression(fieldConfig.getName(), granularity)));
+                    TimestampIndexGranularity.getTransformExpression(fieldConfig.getName(), granularity),
+                    schema.getFieldSpecMap()));
           }
         }
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/FilterTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/FilterTransformer.java
@@ -18,9 +18,11 @@
  */
 package org.apache.pinot.segment.local.recordtransformer;
 
+import java.util.Map;
 import org.apache.pinot.segment.local.function.FunctionEvaluator;
 import org.apache.pinot.segment.local.function.FunctionEvaluatorFactory;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -37,14 +39,16 @@ public class FilterTransformer implements RecordTransformer {
   private final FunctionEvaluator _evaluator;
   private final boolean _continueOnError;
 
-  public FilterTransformer(TableConfig tableConfig) {
+  public FilterTransformer(TableConfig tableConfig, Map<String, FieldSpec> schema) {
     _filterFunction = null;
     _continueOnError = tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().isContinueOnError();
 
     if (tableConfig.getIngestionConfig() != null && tableConfig.getIngestionConfig().getFilterConfig() != null) {
       _filterFunction = tableConfig.getIngestionConfig().getFilterConfig().getFilterFunction();
     }
-    _evaluator = (_filterFunction != null) ? FunctionEvaluatorFactory.getExpressionEvaluator(_filterFunction) : null;
+    _evaluator = (_filterFunction != null)
+        ? FunctionEvaluatorFactory.getExpressionEvaluator(_filterFunction, schema)
+        : null;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SanitizationTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SanitizationTransformer.java
@@ -63,7 +63,7 @@ public class SanitizationTransformer implements RecordTransformer {
         if (sanitizedValue != stringValue) {
           record.putValue(stringColumn, sanitizedValue);
         }
-      } else {
+      } else if (value != null) {
         // Multi-valued column
         Object[] values = (Object[]) value;
         int numValues = values.length;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -367,7 +367,10 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
       for (TransformConfig transformConfig : transformConfigs) {
         if (transformConfig.getColumnName().equals(column)) {
           String transformFunction = transformConfig.getTransformFunction();
-          FunctionEvaluator functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(transformFunction);
+          Map<String, FieldSpec> completeSchema = new HashMap<>(_schema.getFieldSpecMap());
+          completeSchema.putAll(_segmentMetadata.getSchema().getFieldSpecMap());
+          FunctionEvaluator functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(
+              transformFunction, completeSchema);
 
           // Check if all arguments exist in the segment
           // TODO: Support chained derived column

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
@@ -109,7 +109,7 @@ public class SchemaUtils {
         String transformFunction = fieldSpec.getTransformFunction();
         if (transformFunction != null) {
           try {
-            List<String> arguments = FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec).getArguments();
+            List<String> arguments = FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec, schema).getArguments();
             Preconditions.checkState(!arguments.contains(column),
                 "The arguments of transform function %s should not contain the destination column %s",
                 transformFunction, column);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -320,8 +320,11 @@ public final class TableConfigUtils {
             throw new IllegalStateException(
                 "Groovy filter functions are disabled for table config. Found '" + filterFunction + "'");
           }
+          if (schema == null) {
+            throw new IllegalStateException("Expected non-null schema to validate function call");
+          }
           try {
-            FunctionEvaluatorFactory.getExpressionEvaluator(filterFunction);
+            FunctionEvaluatorFactory.getExpressionEvaluator(filterFunction, schema.getFieldSpecMap());
           } catch (Exception e) {
             throw new IllegalStateException("Invalid filter function " + filterFunction, e);
           }
@@ -408,8 +411,12 @@ public final class TableConfigUtils {
                 "Groovy transform functions are disabled for table config. Found '" + transformFunction
                     + "' for column '" + columnName + "'");
           }
+          if (schema == null) {
+            throw new IllegalStateException("Expected non-null schema to validate function call");
+          }
           try {
-            expressionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(transformFunction);
+            expressionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(
+                transformFunction, schema.getFieldSpecMap());
           } catch (Exception e) {
             throw new IllegalStateException(
                 "Invalid transform function '" + transformFunction + "' for column '" + columnName + "'", e);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformerTest.java
@@ -245,6 +245,7 @@ public class ExpressionTransformerTest {
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("a", FieldSpec.DataType.STRING)
         .addSingleValueDimension("b", FieldSpec.DataType.STRING).addSingleValueDimension("c", FieldSpec.DataType.STRING)
         .addSingleValueDimension("d", FieldSpec.DataType.STRING).addSingleValueDimension("e", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("x", FieldSpec.DataType.STRING)
         .addSingleValueDimension("f", FieldSpec.DataType.STRING).build();
     List<TransformConfig> transformConfigs = Arrays.asList(
         new TransformConfig("d", "plus(x, 10)"),
@@ -295,6 +296,7 @@ public class ExpressionTransformerTest {
   public void testNonCyclicTransformFunctionSortOrder() {
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("a", FieldSpec.DataType.INT)
         .addSingleValueDimension("b", FieldSpec.DataType.INT).addSingleValueDimension("c", FieldSpec.DataType.INT)
+        .addSingleValueDimension("d", FieldSpec.DataType.INT).addSingleValueDimension("e", FieldSpec.DataType.INT)
         .build();
 
     // Define transform function dependencies: a -> (b,c), b -> d, d -> e, c -> (d,e)

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -230,7 +230,10 @@ public class TableConfigUtilsTest {
 
   @Test
   public void validateIngestionConfig() {
-    Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).build();
+    Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .addSingleValueDimension("columnX", FieldSpec.DataType.STRING)
+        .build();
+
     // null ingestion config
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(null).build();
@@ -246,7 +249,7 @@ public class TableConfigUtilsTest {
     TableConfigUtils.validate(tableConfig, schema);
 
     // valid filterFunction
-    ingestionConfig.setFilterConfig(new FilterConfig("startsWith(columnX, \"myPrefix\")"));
+    ingestionConfig.setFilterConfig(new FilterConfig("startsWith(columnX, 'myPrefix')"));
     TableConfigUtils.validate(tableConfig, schema);
 
     // valid filterFunction
@@ -286,14 +289,19 @@ public class TableConfigUtilsTest {
 
     // using a transformation column in an aggregation
     schema =
-        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addMetric("twiceSum", FieldSpec.DataType.DOUBLE).build();
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+            .addSingleValueDimension("col", FieldSpec.DataType.DOUBLE)
+            .addMetric("twiceSum", FieldSpec.DataType.DOUBLE)
+            .build();
     ingestionConfig.setTransformConfigs(Collections.singletonList(new TransformConfig("twice", "col * 2")));
     ingestionConfig.setAggregationConfigs(Collections.singletonList(new AggregationConfig("twiceSum", "SUM(twice)")));
     TableConfigUtils.validate(tableConfig, schema);
 
     // valid transform configs
     schema =
-        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+            .addSingleValueDimension("anotherCol", FieldSpec.DataType.STRING)
+            .addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
             .build();
     ingestionConfig.setAggregationConfigs(null);
     ingestionConfig.setTransformConfigs(Collections.singletonList(new TransformConfig("myCol", "reverse(anotherCol)")));
@@ -301,7 +309,10 @@ public class TableConfigUtilsTest {
 
     // valid transform configs
     schema =
-        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+            .addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+            .addSingleValueDimension("anotherCol", FieldSpec.DataType.STRING)
+            .addSingleValueDimension("x", FieldSpec.DataType.STRING)
             .addMetric("transformedCol", FieldSpec.DataType.LONG).build();
     ingestionConfig.setTransformConfigs(Arrays.asList(new TransformConfig("myCol", "reverse(anotherCol)"),
         new TransformConfig("transformedCol", "Groovy({x+y}, x, y)")));

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/annotations/ScalarFunction.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/annotations/ScalarFunction.java
@@ -46,10 +46,31 @@ public @interface ScalarFunction {
 
   boolean enabled() default true;
 
-  // If empty, FunctionsRegistry registers the method name as function name;
-  // If not empty, FunctionsRegistry only registers the function names specified here, the method name is ignored.
+  /**
+   * If empty, FunctionsRegistry registers the method name as function name;
+   * If not empty, FunctionsRegistry only registers the function names specified here, the method name is ignored.
+   */
   String[] names() default {};
 
-  // Whether the scalar function expects and can handle null arguments.
+  /**
+   * @return whether the scalar function expects and can handle null arguments.
+   */
+   // TODO: consider implementing this by checking the method signature at each parameter so it isn't all or nothing
   boolean nullableParameters() default false;
+
+  /**
+   * @return whether or not to allow narrowing (e.g. the input requires and int,
+   *         but parameter passed in is a double)
+   * @apiNote the default return value is {@code true} for backwards compatibility,
+   *         but SQL standard does not support type narrowing
+   */
+  boolean supportsNarrowing() default true;
+
+  /**
+   * @return whether or not to accept parameters that are not {@code String} for
+   *         parameters specified as {@code String}
+   * @apiNote the default return value is {@code true} for backwards compatibility,
+   *          but SQL standard does not support implicit string casts
+   */
+  boolean supportsImplicitStringCast() default true;
 }


### PR DESCRIPTION
Some inspiration: #9397 

This PR is a reference PR for a set of PRs that will follow breaking this down into less hacky, reviewable patches - it gives context in case reviewers are interested in what will come after :)

Changes:
- add backwards compatibility flags in `FunctionInfo` and `ScalarFunction` annotation to existing functions which define all the weird behaviors we have in the original function resolution logic
- adds implicit type casting based on the backwards compat flags (see logic in `FunctionRegistry`)
- convenience methods for type inference in `ExpressionTypeUtil`
- includes a hacky way to get tests to pass that didn't pass schemas into function resolution by just inferring it from the generic row
- piped down types everywhere it was necessary

This change **SHOULD NOT BE MERGED**