### PR TITLE
[multistage] Ensure Singleton Distribution Avoids Null Instance

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -79,6 +79,7 @@ public class MailboxReceiveOperator extends BaseOperator<TransferableBlock> {
           singletonInstance = serverInstance;
         }
       }
+      Preconditions.checkNotNull(singletonInstance, "couldn't find eligible sender for Singleton distribution");
       _sendingStageInstances = Collections.singletonList(singletonInstance);
     } else {
       _sendingStageInstances = sendingStageInstances;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -89,6 +89,7 @@ public class MailboxSendOperator extends BaseOperator<TransferableBlock> {
           singletonInstance = serverInstance;
         }
       }
+      Preconditions.checkNotNull(singletonInstance, "couldn't find eligible receiver for Singleton distribution");
       _receivingStageInstances = Collections.singletonList(singletonInstance);
     } else {
       _receivingStageInstances = receivingStageInstances;


### PR DESCRIPTION
Wanted to discuss this. Looks like we assume that singleton sends/receives should be within the same server. When making some code-changes in the past, I used to run into Null pointer exceptions since if workers for two stages are different but distribution is Singleton, then this will fail.

If this is the expected behavior I think putting the Precondition might be better.

If not, we can discuss how to handle this better.

cc: @walterddr @siddharthteotia 