### PR TITLE
consolidate FunctionRegistry for v1/v2 engines

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionInfo.java
@@ -19,6 +19,9 @@
 package org.apache.pinot.common.function;
 
 import java.lang.reflect.Method;
+import org.apache.calcite.schema.Function;
+import org.apache.calcite.schema.impl.ScalarFunctionImpl;
+import org.apache.pinot.spi.annotations.ScalarFunction;
 
 
 public class FunctionInfo {
@@ -26,10 +29,17 @@ public class FunctionInfo {
   private final Class<?> _clazz;
   private final boolean _nullableParameters;
 
-  public FunctionInfo(Method method, Class<?> clazz, boolean nullableParameters) {
-    _method = method;
-    _clazz = clazz;
-    _nullableParameters = nullableParameters;
+  public FunctionInfo(Function calciteFunction) {
+    if (!(calciteFunction instanceof ScalarFunctionImpl)) {
+      throw new IllegalArgumentException("Can only create FunctionInfo based on ScalarFunctionImpl. Got: "
+          + calciteFunction.getClass());
+    }
+
+    ScalarFunctionImpl scalarFunction = ((ScalarFunctionImpl) calciteFunction);
+    _method = scalarFunction.method;
+    _clazz = scalarFunction.method.getDeclaringClass();
+    _nullableParameters = _method.isAnnotationPresent(ScalarFunction.class)
+        && _method.getAnnotation(ScalarFunction.class).nullableParameters();
   }
 
   public Method getMethod() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.function;
 import com.google.common.collect.Iterables;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -138,11 +139,14 @@ public class FunctionRegistry {
       return null;
     }
 
-    List<Function> matchingFunctions = allFunctions
-        .stream()
-        .map(Map.Entry::getValue)
-        .filter(fun -> fun.getParameters().size() == numParameters)
-        .collect(Collectors.toList());
+    List<Function> matchingFunctions = new ArrayList<>();
+    for (Map.Entry<String, Function> allFunction : allFunctions) {
+      Function candidate = allFunction.getValue();
+      if (candidate.getParameters().size() == numParameters) {
+        matchingFunctions.add(candidate);
+      }
+    }
+
     if (matchingFunctions.size() > 1) {
       // this should never happen (yet) because we restrict the registering of multiple methods
       // with the same number of arguments and the same name

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluatorTest.java
@@ -130,7 +130,7 @@ public class InbuiltFunctionEvaluatorTest {
       throws Exception {
     MyFunc myFunc = new MyFunc();
     Method method = myFunc.getClass().getDeclaredMethod("appendToStringAndReturn", String.class);
-    FunctionRegistry.registerFunction(method, false);
+    FunctionRegistry.registerFunction(method);
     String expression = "appendToStringAndReturn('test ')";
     InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression);
     assertTrue(evaluator.getArguments().isEmpty());


### PR DESCRIPTION
This is the first PR in a set of queries to allow for polymorphism (see https://github.com/apache/pinot/pull/9600) in UDFs.

This one simply does some clean up in preparation to standardize on Calcite types for method registry/lookup.