### PR TITLE
Using `usageHelp` instead of deprecated `help`  in picocli commands

### DIFF
--- a/pinot-perf/src/main/java/org/apache/pinot/perf/RawIndexBenchmark.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/RawIndexBenchmark.java
@@ -96,7 +96,7 @@ public class RawIndexBenchmark {
       description = "Number of consecutive docIds to lookup")
   private int _numConsecutiveLookups = DEFAULT_NUM_CONSECUTIVE_LOOKUP;
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
+  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, usageHelp = true,
       description = "print this message")
   private boolean _help = false;
 
@@ -303,6 +303,10 @@ public class RawIndexBenchmark {
     RawIndexBenchmark benchmark = new RawIndexBenchmark();
     CommandLine commandLine = new CommandLine(benchmark);
     commandLine.parseArgs(args);
+    if (commandLine.isUsageHelpRequested() || commandLine.parseArgs(args).matchedArgs().size() == 0) {
+      commandLine.usage(System.out);
+      return;
+    }
     benchmark.run();
   }
 }

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/RawIndexBenchmark.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/RawIndexBenchmark.java
@@ -302,8 +302,8 @@ public class RawIndexBenchmark {
       throws Exception {
     RawIndexBenchmark benchmark = new RawIndexBenchmark();
     CommandLine commandLine = new CommandLine(benchmark);
-    commandLine.parseArgs(args);
-    if (commandLine.isUsageHelpRequested() || commandLine.parseArgs(args).matchedArgs().size() == 0) {
+    CommandLine.ParseResult result = commandLine.parseArgs(args);
+    if (commandLine.isUsageHelpRequested() || result.matchedArgs().size() == 0) {
       commandLine.usage(System.out);
       return;
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/AutoAddInvertedIndexTool.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/AutoAddInvertedIndexTool.java
@@ -71,13 +71,18 @@ public class AutoAddInvertedIndexTool extends AbstractBaseCommand implements Com
   private boolean _help = false;
 
   @Override
-  public String description() {
-    return "Automatically add inverted index to tables based on the settings. Currently only support 'QUERY' strategy";
+  public boolean getHelp() {
+    return _help;
   }
 
   @Override
-  public boolean getHelp() {
-    return _help;
+  public String getName() {
+    return getClass().getSimpleName();
+  }
+
+  @Override
+  public String description() {
+    return "Automatically add inverted index to tables based on the settings. Currently only support 'QUERY' strategy";
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/AutoAddInvertedIndexTool.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/AutoAddInvertedIndexTool.java
@@ -66,23 +66,18 @@ public class AutoAddInvertedIndexTool extends AbstractBaseCommand implements Com
           + AutoAddInvertedIndex.DEFAULT_MAX_NUM_INVERTED_INDEX_ADDED)
   private int _maxNumInvertedIndex = AutoAddInvertedIndex.DEFAULT_MAX_NUM_INVERTED_INDEX_ADDED;
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
+  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, usageHelp = true,
       description = "Print this message.")
   private boolean _help = false;
 
   @Override
-  public boolean getHelp() {
-    return _help;
-  }
-
-  @Override
-  public String getName() {
-    return getClass().getSimpleName();
-  }
-
-  @Override
   public String description() {
     return "Automatically add inverted index to tables based on the settings. Currently only support 'QUERY' strategy";
+  }
+
+  @Override
+  public boolean getHelp() {
+    return _help;
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotToolLauncher.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotToolLauncher.java
@@ -20,7 +20,6 @@ package org.apache.pinot.tools;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.log4j.PropertyConfigurator;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.tools.filesystem.PinotFSBenchmarkRunner;
 import org.apache.pinot.tools.perf.PerfBenchmarkRunner;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotToolLauncher.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotToolLauncher.java
@@ -20,6 +20,7 @@ package org.apache.pinot.tools;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.log4j.PropertyConfigurator;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.tools.filesystem.PinotFSBenchmarkRunner;
 import org.apache.pinot.tools.perf.PerfBenchmarkRunner;
@@ -43,7 +44,7 @@ public class PinotToolLauncher {
     SUBCOMMAND_MAP.put("SegmentDump", new SegmentDumpTool());
   }
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
+  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, usageHelp = true,
       description = "Print this message.")
   boolean _help = false;
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/SegmentDumpTool.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/SegmentDumpTool.java
@@ -148,12 +148,12 @@ public class SegmentDumpTool extends AbstractBaseCommand implements Command {
       throws Exception {
     SegmentDumpTool tool = new SegmentDumpTool();
     CommandLine commandLine = new CommandLine(tool);
-    commandLine.parseArgs(args);
-    if (commandLine.isUsageHelpRequested()) {
+    CommandLine.ParseResult result = commandLine.parseArgs(args);
+    if (commandLine.isUsageHelpRequested() || result.matchedArgs().size() == 0) {
       commandLine.usage(System.out);
-    } else {
-      tool.execute();
+      return;
     }
+    tool.execute();
   }
 
   public String getName() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/SegmentDumpTool.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/SegmentDumpTool.java
@@ -50,12 +50,9 @@ public class SegmentDumpTool extends AbstractBaseCommand implements Command {
   @CommandLine.Option(names = {"-dumpStarTree"})
   private boolean _dumpStarTree = false;
 
-  public void doMain(String[] args)
-      throws Exception {
-    CommandLine commandLine = new CommandLine(this);
-    commandLine.parseArgs(args);
-    dump();
-  }
+  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, usageHelp = true,
+      description = "Print this message.")
+  private boolean _help = false;
 
   private void dump()
       throws Exception {
@@ -149,7 +146,14 @@ public class SegmentDumpTool extends AbstractBaseCommand implements Command {
 
   public static void main(String[] args)
       throws Exception {
-    new SegmentDumpTool().doMain(args);
+    SegmentDumpTool tool = new SegmentDumpTool();
+    CommandLine commandLine = new CommandLine(tool);
+    commandLine.parseArgs(args);
+    if (commandLine.isUsageHelpRequested()) {
+      commandLine.usage(System.out);
+    } else {
+      tool.execute();
+    }
   }
 
   public String getName() {
@@ -170,6 +174,6 @@ public class SegmentDumpTool extends AbstractBaseCommand implements Command {
 
   @Override
   public boolean getHelp() {
-    return false;
+    return _help;
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/UpdateSegmentState.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/UpdateSegmentState.java
@@ -60,7 +60,7 @@ public class UpdateSegmentState extends AbstractBaseCommand implements Command {
   @CommandLine.Option(names = {"-fix"}, required = false, description = "Update IDEALSTATE values (OFFLINE->ONLINE).")
   private boolean _fix = false;
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
+  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, usageHelp = true,
       description = "Print this message.")
   private boolean _help = false;
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/ValidateTableRetention.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/ValidateTableRetention.java
@@ -40,7 +40,7 @@ public class ValidateTableRetention extends AbstractBaseCommand implements Comma
           + " default: " + TableRetentionValidator.DEFAULT_DURATION_IN_DAYS_THRESHOLD)
   private long _durationInDaysThreshold = TableRetentionValidator.DEFAULT_DURATION_IN_DAYS_THRESHOLD;
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
+  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, usageHelp = true,
       description = "Print this message.")
   private boolean _help = false;
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RealtimeProvisioningHelperCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RealtimeProvisioningHelperCommand.java
@@ -350,12 +350,12 @@ public class RealtimeProvisioningHelperCommand extends AbstractBaseAdminCommand 
       throws IOException {
     RealtimeProvisioningHelperCommand rtProvisioningHelper = new RealtimeProvisioningHelperCommand();
     CommandLine cmdLine = new CommandLine(rtProvisioningHelper);
-    cmdLine.parseArgs(args);
-    if (rtProvisioningHelper.getHelp()) {
+    CommandLine.ParseResult result = cmdLine.parseArgs(args);
+    if (result.isUsageHelpRequested() || result.matchedArgs().size() == 0) {
       cmdLine.usage(System.out);
       rtProvisioningHelper.printUsage();
-    } else {
-      rtProvisioningHelper.execute();
+      return;
     }
+    rtProvisioningHelper.execute();
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RealtimeProvisioningHelperCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RealtimeProvisioningHelperCommand.java
@@ -100,7 +100,7 @@ public class RealtimeProvisioningHelperCommand extends AbstractBaseAdminCommand 
       description = "Maximum memory per host that can be used for pinot data (e.g. 250G, 100M). Default 48g")
   private String _maxUsableHostMemory = "48G";
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, help = true)
+  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, usageHelp = true)
   private boolean _help = false;
 
   public RealtimeProvisioningHelperCommand setTableConfigFile(String tableConfigFile) {
@@ -186,7 +186,7 @@ public class RealtimeProvisioningHelperCommand extends AbstractBaseAdminCommand 
   @Override
   public void printExamples() {
     StringBuilder builder = new StringBuilder();
-    builder.append("\n\nThis command allows you to estimate the capacity needed for provisioning realtime hosts")
+    builder.append("\n\nThis command allows you to estimate the capacity needed for provisioning realtime hosts. ")
         .append("It assumes that there is no upper limit to the amount of memory you can mmap").append(
         "\nIf you have a hybrid table, then consult the push frequency setting in your offline table specify it in "
             + "the -pushFrequency argument").append(
@@ -197,7 +197,7 @@ public class RealtimeProvisioningHelperCommand extends AbstractBaseAdminCommand 
         "\nDoing so will let this program assume that you are willing to take a page hit when querying older data")
         .append("\nand optimize memory and number of hosts accordingly.")
         .append("\n See https://docs.pinot.apache.org/operators/operating-pinot/tuning/realtime for details");
-    System.out.println(builder.toString());
+    System.out.println(builder);
   }
 
   @Override
@@ -343,6 +343,19 @@ public class RealtimeProvisioningHelperCommand extends AbstractBaseAdminCommand 
     } catch (Exception e) {
       throw new RuntimeException(
           String.format("Cannot read schema file '%s' to '%s' object.", file, clazz.getSimpleName()), e);
+    }
+  }
+
+  public static void main(String[] args)
+      throws IOException {
+    RealtimeProvisioningHelperCommand rtProvisioningHelper = new RealtimeProvisioningHelperCommand();
+    CommandLine cmdLine = new CommandLine(rtProvisioningHelper);
+    cmdLine.parseArgs(args);
+    if (rtProvisioningHelper.getHelp()) {
+      cmdLine.usage(System.out);
+      rtProvisioningHelper.printUsage();
+    } else {
+      rtProvisioningHelper.execute();
     }
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
@@ -193,7 +193,11 @@ public class PerfBenchmarkRunner extends AbstractBaseCommand implements Command 
       throws Exception {
     PerfBenchmarkRunner perfBenchmarkRunner = new PerfBenchmarkRunner();
     CommandLine commandLine = new CommandLine(perfBenchmarkRunner);
-    commandLine.parseArgs(args);
+    CommandLine.ParseResult result = commandLine.parseArgs(args);
+    if (result.isUsageHelpRequested() || result.matchedArgs().size() == 0) {
+      commandLine.usage(System.out);
+      return;
+    }
     commandLine.execute();
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
@@ -80,7 +80,7 @@ public class PerfBenchmarkRunner extends AbstractBaseCommand implements Command 
       description = "Comma separated bloom filter columns to be created (non-batch load).")
   private String _bloomFilterColumns;
 
-  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true,
+  @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, usageHelp = true,
       description = "Print this message.")
   private boolean _help = false;
 
@@ -194,11 +194,6 @@ public class PerfBenchmarkRunner extends AbstractBaseCommand implements Command 
     PerfBenchmarkRunner perfBenchmarkRunner = new PerfBenchmarkRunner();
     CommandLine commandLine = new CommandLine(perfBenchmarkRunner);
     commandLine.parseArgs(args);
-
-    if (perfBenchmarkRunner._help) {
-      perfBenchmarkRunner.printUsage();
-    } else {
-      perfBenchmarkRunner.execute();
-    }
+    commandLine.execute();
   }
 }

--- a/pinot-tools/src/main/resources/conf/pinot-tools-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/pinot-tools-log4j2.xml
@@ -21,10 +21,10 @@
 -->
 <Configuration>
   <Appenders>
-    <Console name="console" target="SYSTEM_OUT"/>
+    <Console name="console" target="SYSTEM_OUT" follow="true" />
   </Appenders>
   <Loggers>
-    <Root level="info" additivity="false">
+    <Root level="info">
       <AppenderRef ref="console"/>
     </Root>
     <Logger name="org.apache.pinot" level="info" additivity="false"/>


### PR DESCRIPTION
Some of the commands don't print help properly due to the use of a deprecated `help` annotation. This PT attempts to clean-up some of the commands launched by `PinotToolLauncher`. 

Labels: `cleanup` 
