### PR TITLE
Add segment level debug API

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/DebugResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/DebugResource.java
@@ -152,10 +152,11 @@ public class DebugResource {
       @ApiResponse(code = 500, message = "Internal server error")
   })
   public TableDebugInfo.SegmentDebugInfo getSegmentDebugInfo(
-      @ApiParam(value = "Name of the table (with type)", required = true) @PathParam("tableName") String tableName,
+      @ApiParam(value = "Name of the table (with type)", required = true) @PathParam("tableName")
+          String tableNameWithType,
       @ApiParam(value = "Name of the segment", required = true) @PathParam("segmentName") String segmentName)
       throws Exception {
-    return debugSegment(tableName, segmentName);
+    return debugSegment(tableNameWithType, segmentName);
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/DebugResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/DebugResource.java
@@ -223,8 +223,8 @@ public class DebugResource {
         new TableSizeReader(_executor, _connectionManager, _controllerMetrics, _pinotHelixResourceManager);
     TableSizeReader.TableSizeDetails tableSizeDetails;
     try {
-      tableSizeDetails = tableSizeReader.getTableSizeDetails(tableNameWithType,
-          _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
+      tableSizeDetails = tableSizeReader
+          .getTableSizeDetails(tableNameWithType, _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
     } catch (Throwable t) {
       tableSizeDetails = null;
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/DebugResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/DebugResource.java
@@ -36,6 +36,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -89,9 +90,9 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
 @Api(tags = Constants.CLUSTER_TAG, authorizations = {@Authorization(value = SWAGGER_AUTHORIZATION_KEY)})
 @SwaggerDefinition(securityDefinition = @SecurityDefinition(apiKeyAuthDefinitions = @ApiKeyAuthDefinition(name =
     HttpHeaders.AUTHORIZATION, in = ApiKeyAuthDefinition.ApiKeyLocation.HEADER, key = SWAGGER_AUTHORIZATION_KEY)))
-@Path("/")
-public class TableDebugResource {
-  private static final Logger LOGGER = LoggerFactory.getLogger(TableDebugResource.class);
+@Path("/debug/")
+public class DebugResource {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DebugResource.class);
 
   @Inject
   PinotHelixResourceManager _pinotHelixResourceManager;
@@ -112,7 +113,7 @@ public class TableDebugResource {
   ControllerConf _controllerConf;
 
   @GET
-  @Path("/debug/tables/{tableName}")
+  @Path("tables/{tableName}")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Get debug information for table.", notes = "Debug information for table.")
   @ApiResponses(value = {
@@ -140,6 +141,21 @@ public class TableDebugResource {
     }
 
     return JsonUtils.objectToPrettyString(tableDebugInfos);
+  }
+
+  @GET
+  @Path("segments/{tableName}/{segmentName}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Get debug information for segment.", notes = "Debug information for segment.")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 404, message = "Segment not found"),
+      @ApiResponse(code = 500, message = "Internal server error")
+  })
+  public TableDebugInfo.SegmentDebugInfo getSegmentDebugInfo(
+      @ApiParam(value = "Name of the table (with type)", required = true) @PathParam("tableName") String tableName,
+      @ApiParam(value = "Name of the segment", required = true) @PathParam("segmentName") String segmentName)
+      throws Exception {
+    return debugSegment(tableName, segmentName);
   }
 
   /**
@@ -207,14 +223,73 @@ public class TableDebugResource {
         new TableSizeReader(_executor, _connectionManager, _controllerMetrics, _pinotHelixResourceManager);
     TableSizeReader.TableSizeDetails tableSizeDetails;
     try {
-      tableSizeDetails = tableSizeReader
-          .getTableSizeDetails(tableNameWithType, _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
+      tableSizeDetails = tableSizeReader.getTableSizeDetails(tableNameWithType,
+          _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
     } catch (Throwable t) {
       tableSizeDetails = null;
     }
 
     return (tableSizeDetails != null) ? new TableDebugInfo.TableSizeSummary(tableSizeDetails._reportedSizeInBytes,
         tableSizeDetails._estimatedSizeInBytes) : new TableDebugInfo.TableSizeSummary(-1, -1);
+  }
+
+  private TableDebugInfo.SegmentDebugInfo debugSegment(String tableNameWithType, String segmentName)
+      throws IOException {
+    IdealState idealState = _pinotHelixResourceManager.getTableIdealState(tableNameWithType);
+    if (idealState == null) {
+      return null;
+    }
+
+    ExternalView externalView = _pinotHelixResourceManager.getTableExternalView(tableNameWithType);
+    Map<String, String> evStateMap = (externalView != null) ? externalView.getStateMap(segmentName) : null;
+
+    Map<String, String> isServerToStateMap = idealState.getRecord().getMapFields().get(segmentName);
+    Set<String> serversHostingSegment = _pinotHelixResourceManager.getServers(tableNameWithType, segmentName);
+
+    int serverRequestTimeoutMs = _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000;
+    BiMap<String, String> serverToEndpoints;
+    try {
+      serverToEndpoints = _pinotHelixResourceManager.getDataInstanceAdminEndpoints(serversHostingSegment);
+    } catch (InvalidConfigException e) {
+      throw new WebApplicationException(
+          "Caught exception when getting segment debug info for table: " + tableNameWithType);
+    }
+
+    List<String> serverUrls = new ArrayList<>(serverToEndpoints.size());
+    BiMap<String, String> endpointsToServers = serverToEndpoints.inverse();
+    for (String endpoint : endpointsToServers.keySet()) {
+      String segmentDebugInfoURI = String.format("%s/debug/segments/%s/%s", endpoint, tableNameWithType, segmentName);
+      serverUrls.add(segmentDebugInfoURI);
+    }
+
+    CompletionServiceHelper completionServiceHelper =
+        new CompletionServiceHelper(_executor, _connectionManager, endpointsToServers);
+    CompletionServiceHelper.CompletionServiceResponse serviceResponse =
+        completionServiceHelper.doMultiGetRequest(serverUrls, tableNameWithType, false, serverRequestTimeoutMs);
+
+    Map<String, SegmentServerDebugInfo> serverToSegmentDebugInfo = new HashMap<>();
+    for (Map.Entry<String, String> streamResponse : serviceResponse._httpResponses.entrySet()) {
+      SegmentServerDebugInfo segmentDebugInfo =
+          JsonUtils.stringToObject(streamResponse.getValue(), SegmentServerDebugInfo.class);
+      serverToSegmentDebugInfo.put(streamResponse.getKey(), segmentDebugInfo);
+    }
+
+    Map<String, TableDebugInfo.SegmentState> segmentServerState = new HashMap<>();
+    for (String instanceName : isServerToStateMap.keySet()) {
+      String isState = isServerToStateMap.get(instanceName);
+      String evState = (evStateMap != null) ? evStateMap.get(instanceName) : null;
+      SegmentServerDebugInfo segmentServerDebugInfo = serverToSegmentDebugInfo.get(instanceName);
+
+      if (segmentServerDebugInfo != null) {
+        segmentServerState.put(instanceName,
+            new TableDebugInfo.SegmentState(isState, evState, segmentServerDebugInfo.getSegmentSize(),
+                segmentServerDebugInfo.getConsumerInfo(), segmentServerDebugInfo.getErrorInfo()));
+      } else {
+        segmentServerState.put(instanceName, new TableDebugInfo.SegmentState(isState, evState, null, null, null));
+      }
+    }
+
+    return new TableDebugInfo.SegmentDebugInfo(segmentName, segmentServerState);
   }
 
   /**

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
@@ -75,8 +75,8 @@ public class DebugResource {
   @ApiOperation(value = "Get segments debug info for this table",
       notes = "This is a debug endpoint, and won't maintain backward compatibility")
   public List<SegmentServerDebugInfo> getSegmentsDebugInfo(
-      @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableNameWithType) {
-
+      @ApiParam(value = "Name of the table (with type)", required = true) @PathParam("tableName")
+          String tableNameWithType) {
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
     return getSegmentServerDebugInfo(tableNameWithType, tableType);
   }
@@ -87,7 +87,8 @@ public class DebugResource {
   @ApiOperation(value = "Get segment debug info",
       notes = "This is a debug endpoint, and won't maintain backward compatibility")
   public SegmentServerDebugInfo getSegmentDebugInfo(
-      @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableNameWithType,
+      @ApiParam(value = "Name of the table (with type)", required = true) @PathParam("tableName")
+          String tableNameWithType,
       @ApiParam(value = "Name of the segment", required = true) @PathParam("segmentName") String segmentName) {
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
     TableDataManager tableDataManager =

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
@@ -72,13 +72,42 @@ public class DebugResource {
   @GET
   @Path("tables/{tableName}")
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation(value = "Get segments debug info for this table",
-      notes = "This is a debug endpoint, and won't maintain backward compatibility")
+  @ApiOperation(value = "Get segments debug info for this table", notes = "This is a debug endpoint, and won't "
+      + "maintain backward compatibility")
   public List<SegmentServerDebugInfo> getSegmentsDebugInfo(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableNameWithType) {
 
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
     return getSegmentServerDebugInfo(tableNameWithType, tableType);
+  }
+
+  @GET
+  @Path("segments/{tableName}/{segmentName}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Get segment debug info", notes = "This is a debug endpoint, and won't maintain backward "
+      + "compatibility")
+  public SegmentServerDebugInfo getSegmentDebugInfo(
+      @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableNameWithType,
+      @ApiParam(value = "Name of the segment", required = true) @PathParam("segmentName") String segmentName) {
+    TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
+    TableDataManager tableDataManager =
+        ServerResourceUtils.checkGetTableDataManager(_serverInstance, tableNameWithType);
+    Map<String, SegmentErrorInfo> segmentErrorsMap = tableDataManager.getSegmentErrors();
+    SegmentDataManager segmentDataManager = tableDataManager.acquireSegment(segmentName);
+    try {
+      SegmentConsumerInfo segmentConsumerInfo = getSegmentConsumerInfo(segmentDataManager, tableType);
+      long segmentSize = getSegmentSize(segmentDataManager);
+      SegmentErrorInfo segmentErrorInfo = segmentErrorsMap.get(segmentName);
+      return new SegmentServerDebugInfo(segmentName, FileUtils.byteCountToDisplaySize(segmentSize), segmentConsumerInfo,
+          segmentErrorInfo);
+    } catch (Exception e) {
+      throw new WebApplicationException(
+          "Caught exception when getting consumer info for table: " + tableNameWithType + " segment: " + segmentName);
+    } finally {
+      if (segmentDataManager != null) {
+        tableDataManager.releaseSegment(segmentDataManager);
+      }
+    }
   }
 
   private List<SegmentServerDebugInfo> getSegmentServerDebugInfo(String tableNameWithType, TableType tableType) {

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
@@ -72,8 +72,8 @@ public class DebugResource {
   @GET
   @Path("tables/{tableName}")
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation(value = "Get segments debug info for this table", notes = "This is a debug endpoint, and won't "
-      + "maintain backward compatibility")
+  @ApiOperation(value = "Get segments debug info for this table",
+      notes = "This is a debug endpoint, and won't maintain backward compatibility")
   public List<SegmentServerDebugInfo> getSegmentsDebugInfo(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableNameWithType) {
 
@@ -84,8 +84,8 @@ public class DebugResource {
   @GET
   @Path("segments/{tableName}/{segmentName}")
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation(value = "Get segment debug info", notes = "This is a debug endpoint, and won't maintain backward "
-      + "compatibility")
+  @ApiOperation(value = "Get segment debug info",
+      notes = "This is a debug endpoint, and won't maintain backward compatibility")
   public SegmentServerDebugInfo getSegmentDebugInfo(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableNameWithType,
       @ApiParam(value = "Name of the segment", required = true) @PathParam("segmentName") String segmentName) {


### PR DESCRIPTION
This PR adds a segment level debug API that aims to make the debugging of segment state mismatches easier.  The API will return the same information as the `/debug/table/{tableName}` API, but at the segment name level instead. A similar debug API has been added at the server level too. The controller API calls the server level APIs for the all the servers hosting the segment.

Sample responses:

```
curl -X GET "http://localhost:9000/debug/segments/transcript_REALTIME/transcript__0__0__20221017T0733Z" -H "accept: application/json"

{
  "segmentName": "transcript__0__0__20221017T0733Z",
  "serverState": {
    "Server_192.168.18.216_8098": {
      "idealState": "CONSUMING",
      "externalView": "CONSUMING",
      "segmentSize": "0 bytes",
      "consumerInfo": {
        "segmentName": "transcript__0__0__20221017T0733Z",
        "consumerState": "CONSUMING",
        "lastConsumedTimestamp": 1666249965431,
        "partitionToOffsetMap": {
          "0": "0"
        },
        "partitionOffsetInfo": null
      },
      "errorInfo": null
    }
  }
}
```

