### PR TITLE
Bump up ZK version to 3.6.3

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/pom.xml
@@ -107,6 +107,11 @@
       <groupId>net.sf.jopt-simple</groupId>
       <artifactId>jopt-simple</artifactId>
     </dependency>
+    <dependency>
+      <groupId>io.dropwizard.metrics</groupId>
+      <artifactId>metrics-core</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <helix.version>1.0.4</helix.version>
     <zkclient.version>0.7</zkclient.version>
     <jackson.version>2.12.7</jackson.version>
-    <zookeeper.version>3.5.10</zookeeper.version>
+    <zookeeper.version>3.6.3</zookeeper.version>
     <async-http-client.version>2.12.3</async-http-client.version>
     <jersey.version>2.35</jersey.version>
     <grizzly.version>2.4.4</grizzly.version>


### PR DESCRIPTION
In LinkedIn the ZK version has already been bumped up to 3.6.3 and it's working as expected. 
This PR bumps up ZK version to 3.6.3 in the Apache Pinot repo.

Issue: https://github.com/apache/pinot/issues/9431