### PR TITLE
[hotfix] fix cache timeout again

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -82,7 +82,7 @@ jobs:
       # Step that does that actual cache save and restore
       - uses: actions/cache@v3
         env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 10
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 10
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -126,7 +126,7 @@ jobs:
       # Step that does that actual cache save and restore
       - uses: actions/cache@v3
         env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 10
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 10
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -171,7 +171,7 @@ jobs:
       # Step that does that actual cache save and restore
       - uses: actions/cache@v3
         env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 10
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 10
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
@@ -211,7 +211,7 @@ jobs:
       # Step that does that actual cache save and restore
       - uses: actions/cache@v3
         env:
-          SEGMENT_DOWNLOAD_TIMEOUT_MIN: 10
+          SEGMENT_DOWNLOAD_TIMEOUT_MINS: 10
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
action/cache had the wrong documentation for timeout key. see: https://github.com/actions/cache/pull/959

Apparently the current setting is not picked up in many recent runs such as: 
- https://github.com/apache/pinot/actions/runs/3266963768/jobs/5371469345
- https://github.com/apache/pinot/actions/runs/3269171031/jobs/5376397264

so fixing it again