### PR TITLE
Add record availability lag for Kafka connector

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
@@ -58,41 +58,8 @@ public class SegmentConsumerInfo {
     return _lastConsumedTimestamp;
   }
 
-  public PartitionOffsetInfo getPartitionOffsetInfo() {
-    return _partitionOffsetInfo;
-  }
-
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  static public class PartitionOffsetInfo {
-      @JsonProperty("currentOffsets")
-      public Map<String, String> _currentOffsets;
-
-      @JsonProperty("recordsLag")
-      public Map<String, String> _recordsLag;
-
-      @JsonProperty("latestUpstreamOffsets")
-      public Map<String, String> _latestUpstreamOffsets;
-
-      public PartitionOffsetInfo(
-          @JsonProperty("currentOffsets") Map<String, String> currentOffsets,
-          @JsonProperty("latestUpstreamOffsets") Map<String, String> latestUpstreamOffsets,
-          @JsonProperty("recordsLag") Map<String, String> recordsLag) {
-        _currentOffsets = currentOffsets;
-        _latestUpstreamOffsets = latestUpstreamOffsets;
-        _recordsLag = recordsLag;
-      }
-
-    public Map<String, String> getCurrentOffsets() {
-      return _currentOffsets;
-    }
-
-    public Map<String, String> getRecordsLag() {
-      return _recordsLag;
-    }
-
-    public Map<String, String> getLatestUpstreamOffsets() {
-      return _latestUpstreamOffsets;
-    }
+  public Map<String, String> getPartitionToOffsetMap() {
+    return _partitionToOffsetMap;
   }
 
   public PartitionOffsetInfo getPartitionOffsetInfo() {
@@ -110,13 +77,18 @@ public class SegmentConsumerInfo {
       @JsonProperty("latestUpstreamOffsets")
       public Map<String, String> _latestUpstreamOffsets;
 
+      @JsonProperty("recordsAvailabilityLag")
+      public Map<String, String> _availabilityLag;
+
       public PartitionOffsetInfo(
           @JsonProperty("currentOffsets") Map<String, String> currentOffsets,
           @JsonProperty("latestUpstreamOffsets") Map<String, String> latestUpstreamOffsets,
-          @JsonProperty("recordsLag") Map<String, String> recordsLag) {
+          @JsonProperty("recordsLag") Map<String, String> recordsLag,
+          @JsonProperty("recordsAvailabilityLag") Map<String, String> availabilityLag) {
         _currentOffsets = currentOffsets;
         _latestUpstreamOffsets = latestUpstreamOffsets;
         _recordsLag = recordsLag;
+        _availabilityLag = availabilityLag;
       }
 
     public Map<String, String> getCurrentOffsets() {
@@ -129,6 +101,10 @@ public class SegmentConsumerInfo {
 
     public Map<String, String> getLatestUpstreamOffsets() {
       return _latestUpstreamOffsets;
+    }
+
+    public Map<String, String> getAvailabilityLag() {
+      return _availabilityLag;
     }
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
@@ -58,8 +58,78 @@ public class SegmentConsumerInfo {
     return _lastConsumedTimestamp;
   }
 
-  public Map<String, String> getPartitionToOffsetMap() {
-    return _partitionToOffsetMap;
+  public PartitionOffsetInfo getPartitionOffsetInfo() {
+    return _partitionOffsetInfo;
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static public class PartitionOffsetInfo {
+      @JsonProperty("currentOffsets")
+      public Map<String, String> _currentOffsets;
+
+      @JsonProperty("recordsLag")
+      public Map<String, String> _recordsLag;
+
+      @JsonProperty("latestUpstreamOffsets")
+      public Map<String, String> _latestUpstreamOffsets;
+
+      public PartitionOffsetInfo(
+          @JsonProperty("currentOffsets") Map<String, String> currentOffsets,
+          @JsonProperty("latestUpstreamOffsets") Map<String, String> latestUpstreamOffsets,
+          @JsonProperty("recordsLag") Map<String, String> recordsLag) {
+        _currentOffsets = currentOffsets;
+        _latestUpstreamOffsets = latestUpstreamOffsets;
+        _recordsLag = recordsLag;
+      }
+
+    public Map<String, String> getCurrentOffsets() {
+      return _currentOffsets;
+    }
+
+    public Map<String, String> getRecordsLag() {
+      return _recordsLag;
+    }
+
+    public Map<String, String> getLatestUpstreamOffsets() {
+      return _latestUpstreamOffsets;
+    }
+  }
+
+  public PartitionOffsetInfo getPartitionOffsetInfo() {
+    return _partitionOffsetInfo;
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  static public class PartitionOffsetInfo {
+      @JsonProperty("currentOffsets")
+      public Map<String, String> _currentOffsets;
+
+      @JsonProperty("recordsLag")
+      public Map<String, String> _recordsLag;
+
+      @JsonProperty("latestUpstreamOffsets")
+      public Map<String, String> _latestUpstreamOffsets;
+
+      public PartitionOffsetInfo(
+          @JsonProperty("currentOffsets") Map<String, String> currentOffsets,
+          @JsonProperty("latestUpstreamOffsets") Map<String, String> latestUpstreamOffsets,
+          @JsonProperty("recordsLag") Map<String, String> recordsLag) {
+        _currentOffsets = currentOffsets;
+        _latestUpstreamOffsets = latestUpstreamOffsets;
+        _recordsLag = recordsLag;
+      }
+
+    public Map<String, String> getCurrentOffsets() {
+      return _currentOffsets;
+    }
+
+    public Map<String, String> getRecordsLag() {
+      return _recordsLag;
+    }
+
+    public Map<String, String> getLatestUpstreamOffsets() {
+      return _latestUpstreamOffsets;
+    }
   }
 
   public PartitionOffsetInfo getPartitionOffsetInfo() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
@@ -77,18 +77,18 @@ public class SegmentConsumerInfo {
     @JsonProperty("latestUpstreamOffsets")
     public Map<String, String> _latestUpstreamOffsets;
 
-    @JsonProperty("recordsAvailabilityLag")
-    public Map<String, String> _availabilityLag;
+    @JsonProperty("availabilityLagMs")
+    public Map<String, String> _availabilityLagMs;
 
     public PartitionOffsetInfo(
         @JsonProperty("currentOffsets") Map<String, String> currentOffsets,
         @JsonProperty("latestUpstreamOffsets") Map<String, String> latestUpstreamOffsets,
         @JsonProperty("recordsLag") Map<String, String> recordsLag,
-        @JsonProperty("recordsAvailabilityLag") Map<String, String> availabilityLag) {
+        @JsonProperty("availabilityLagMs") Map<String, String> availabilityLagMs) {
       _currentOffsets = currentOffsets;
       _latestUpstreamOffsets = latestUpstreamOffsets;
       _recordsLag = recordsLag;
-      _availabilityLag = availabilityLag;
+      _availabilityLagMs = availabilityLagMs;
     }
 
     public Map<String, String> getCurrentOffsets() {
@@ -103,8 +103,8 @@ public class SegmentConsumerInfo {
       return _latestUpstreamOffsets;
     }
 
-    public Map<String, String> getAvailabilityLag() {
-      return _availabilityLag;
+    public Map<String, String> getAvailabilityLagMs() {
+      return _availabilityLagMs;
     }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
@@ -68,28 +68,28 @@ public class SegmentConsumerInfo {
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   static public class PartitionOffsetInfo {
-      @JsonProperty("currentOffsets")
-      public Map<String, String> _currentOffsets;
+    @JsonProperty("currentOffsets")
+    public Map<String, String> _currentOffsets;
 
-      @JsonProperty("recordsLag")
-      public Map<String, String> _recordsLag;
+    @JsonProperty("recordsLag")
+    public Map<String, String> _recordsLag;
 
-      @JsonProperty("latestUpstreamOffsets")
-      public Map<String, String> _latestUpstreamOffsets;
+    @JsonProperty("latestUpstreamOffsets")
+    public Map<String, String> _latestUpstreamOffsets;
 
-      @JsonProperty("recordsAvailabilityLag")
-      public Map<String, String> _availabilityLag;
+    @JsonProperty("recordsAvailabilityLag")
+    public Map<String, String> _availabilityLag;
 
-      public PartitionOffsetInfo(
-          @JsonProperty("currentOffsets") Map<String, String> currentOffsets,
-          @JsonProperty("latestUpstreamOffsets") Map<String, String> latestUpstreamOffsets,
-          @JsonProperty("recordsLag") Map<String, String> recordsLag,
-          @JsonProperty("recordsAvailabilityLag") Map<String, String> availabilityLag) {
-        _currentOffsets = currentOffsets;
-        _latestUpstreamOffsets = latestUpstreamOffsets;
-        _recordsLag = recordsLag;
-        _availabilityLag = availabilityLag;
-      }
+    public PartitionOffsetInfo(
+        @JsonProperty("currentOffsets") Map<String, String> currentOffsets,
+        @JsonProperty("latestUpstreamOffsets") Map<String, String> latestUpstreamOffsets,
+        @JsonProperty("recordsLag") Map<String, String> recordsLag,
+        @JsonProperty("recordsAvailabilityLag") Map<String, String> availabilityLag) {
+      _currentOffsets = currentOffsets;
+      _latestUpstreamOffsets = latestUpstreamOffsets;
+      _recordsLag = recordsLag;
+      _availabilityLag = availabilityLag;
+    }
 
     public Map<String, String> getCurrentOffsets() {
       return _currentOffsets;
@@ -105,43 +105,6 @@ public class SegmentConsumerInfo {
 
     public Map<String, String> getAvailabilityLag() {
       return _availabilityLag;
-    }
-  }
-
-  public PartitionOffsetInfo getPartitionOffsetInfo() {
-    return _partitionOffsetInfo;
-  }
-
-  @JsonIgnoreProperties(ignoreUnknown = true)
-  static public class PartitionOffsetInfo {
-      @JsonProperty("currentOffsets")
-      public Map<String, String> _currentOffsets;
-
-      @JsonProperty("recordsLag")
-      public Map<String, String> _recordsLag;
-
-      @JsonProperty("latestUpstreamOffsets")
-      public Map<String, String> _latestUpstreamOffsets;
-
-      public PartitionOffsetInfo(
-          @JsonProperty("currentOffsets") Map<String, String> currentOffsets,
-          @JsonProperty("latestUpstreamOffsets") Map<String, String> latestUpstreamOffsets,
-          @JsonProperty("recordsLag") Map<String, String> recordsLag) {
-        _currentOffsets = currentOffsets;
-        _latestUpstreamOffsets = latestUpstreamOffsets;
-        _recordsLag = recordsLag;
-      }
-
-    public Map<String, String> getCurrentOffsets() {
-      return _currentOffsets;
-    }
-
-    public Map<String, String> getRecordsLag() {
-      return _recordsLag;
-    }
-
-    public Map<String, String> getLatestUpstreamOffsets() {
-      return _latestUpstreamOffsets;
     }
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
@@ -84,7 +84,7 @@ public class ConsumingSegmentInfoReader {
         SegmentConsumerInfo.PartitionOffsetInfo partitionOffsetInfo = info.getPartitionOffsetInfo();
         PartitionOffsetInfo offsetInfo = new PartitionOffsetInfo(partitionOffsetInfo.getCurrentOffsets(),
             partitionOffsetInfo.getLatestUpstreamOffsets(), partitionOffsetInfo.getRecordsLag(),
-            partitionOffsetInfo.getAvailabilityLag());
+            partitionOffsetInfo.getAvailabilityLagMs());
         consumingSegmentInfoMap.computeIfAbsent(info.getSegmentName(), k -> new ArrayList<>()).add(
             new ConsumingSegmentInfo(serverName, info.getConsumerState(), info.getLastConsumedTimestamp(),
                 partitionOffsetInfo.getCurrentOffsets(), offsetInfo));
@@ -238,18 +238,18 @@ public class ConsumingSegmentInfoReader {
     @JsonProperty("latestUpstreamOffsetMap")
     public Map<String, String> _latestUpstreamOffsetMap;
 
-    @JsonProperty("recordsAvailabilityLagMap")
+    @JsonProperty("availabilityLagMsMap")
     public Map<String, String> _availabilityLagMap;
 
     public PartitionOffsetInfo(
         @JsonProperty("currentOffsetsMap") Map<String, String> currentOffsetsMap,
         @JsonProperty("latestUpstreamOffsetMap") Map<String, String> latestUpstreamOffsetMap,
         @JsonProperty("recordsLagMap") Map<String, String> recordsLagMap,
-        @JsonProperty("recordsAvailabilityLagMap") Map<String, String> availabilityLagMap) {
+        @JsonProperty("availabilityLagMsMap") Map<String, String> availabilityLagMsMap) {
       _currentOffsetsMap = currentOffsetsMap;
       _latestUpstreamOffsetMap = latestUpstreamOffsetMap;
       _recordsLagMap = recordsLagMap;
-      _availabilityLagMap = availabilityLagMap;
+      _availabilityLagMap = availabilityLagMsMap;
     }
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
@@ -83,7 +83,8 @@ public class ConsumingSegmentInfoReader {
       for (SegmentConsumerInfo info : entry.getValue()) {
         SegmentConsumerInfo.PartitionOffsetInfo partitionOffsetInfo = info.getPartitionOffsetInfo();
         PartitionOffsetInfo offsetInfo = new PartitionOffsetInfo(partitionOffsetInfo.getCurrentOffsets(),
-            partitionOffsetInfo.getLatestUpstreamOffsets(), partitionOffsetInfo.getRecordsLag());
+            partitionOffsetInfo.getLatestUpstreamOffsets(), partitionOffsetInfo.getRecordsLag(),
+            partitionOffsetInfo.getAvailabilityLag());
         consumingSegmentInfoMap.computeIfAbsent(info.getSegmentName(), k -> new ArrayList<>()).add(
             new ConsumingSegmentInfo(serverName, info.getConsumerState(), info.getLastConsumedTimestamp(),
                 partitionOffsetInfo.getCurrentOffsets(), offsetInfo));
@@ -237,13 +238,18 @@ public class ConsumingSegmentInfoReader {
     @JsonProperty("latestUpstreamOffsetMap")
     public Map<String, String> _latestUpstreamOffsetMap;
 
+    @JsonProperty("recordsAvailabilityLagMap")
+    public Map<String, String> _availabilityLagMap;
+
     public PartitionOffsetInfo(
         @JsonProperty("currentOffsetsMap") Map<String, String> currentOffsetsMap,
         @JsonProperty("latestUpstreamOffsetMap") Map<String, String> latestUpstreamOffsetMap,
-        @JsonProperty("recordsLagMap") Map<String, String> recordsLagMap) {
+        @JsonProperty("recordsLagMap") Map<String, String> recordsLagMap,
+        @JsonProperty("recordsAvailabilityLagMap") Map<String, String> availabilityLagMap) {
       _currentOffsetsMap = currentOffsetsMap;
       _latestUpstreamOffsetMap = latestUpstreamOffsetMap;
       _recordsLagMap = recordsLagMap;
+      _availabilityLagMap = availabilityLagMap;
     }
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderStatelessTest.java
@@ -92,10 +92,10 @@ public class ConsumingSegmentInfoReaderStatelessTest {
         .newArrayList(
             new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "CONSUMING", 0,
                 partitionToOffset0, new SegmentConsumerInfo.PartitionOffsetInfo(
-                    partitionToOffset0, Collections.emptyMap(), Collections.emptyMap())),
+                    partitionToOffset0, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap())),
             new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0,
                 partitionToOffset1, new SegmentConsumerInfo.PartitionOffsetInfo(
-                    partitionToOffset1, Collections.emptyMap(), Collections.emptyMap()))));
+                    partitionToOffset1, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap()))));
     s0.start(uriPath, createHandler(200, s0._consumerInfos, 0));
     _serverMap.put("server0", s0);
 
@@ -104,10 +104,10 @@ public class ConsumingSegmentInfoReaderStatelessTest {
         .newArrayList(
             new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "CONSUMING", 0,
                 partitionToOffset0, new SegmentConsumerInfo.PartitionOffsetInfo(
-                    partitionToOffset0, Collections.emptyMap(), Collections.emptyMap())),
+                    partitionToOffset0, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap())),
             new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0,
                 partitionToOffset1, new SegmentConsumerInfo.PartitionOffsetInfo(
-                    partitionToOffset1, Collections.emptyMap(), Collections.emptyMap()))));
+                    partitionToOffset1, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap()))));
     s1.start(uriPath, createHandler(200, s1._consumerInfos, 0));
     _serverMap.put("server1", s1);
 
@@ -115,10 +115,10 @@ public class ConsumingSegmentInfoReaderStatelessTest {
     FakeConsumingInfoServer s2 = new FakeConsumingInfoServer(Lists
         .newArrayList(new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "NOT_CONSUMING", 0,
                 partitionToOffset0, new SegmentConsumerInfo.PartitionOffsetInfo(
-                    partitionToOffset0, Collections.emptyMap(), Collections.emptyMap())),
+                    partitionToOffset0, Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap())),
             new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0, partitionToOffset1,
                 new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset1, Collections.emptyMap(),
-                    Collections.emptyMap()))));
+                    Collections.emptyMap(), Collections.emptyMap()))));
     s2.start(uriPath, createHandler(200, s2._consumerInfos, 0));
     _serverMap.put("server2", s2);
 
@@ -126,7 +126,7 @@ public class ConsumingSegmentInfoReaderStatelessTest {
     FakeConsumingInfoServer s3 = new FakeConsumingInfoServer(
         Lists.newArrayList(new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0,
             partitionToOffset1, new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset1, Collections.emptyMap(),
-                Collections.emptyMap()))));
+                Collections.emptyMap(), Collections.emptyMap()))));
     s3.start(uriPath, createHandler(200, s3._consumerInfos, 0));
     _serverMap.put("server3", s3);
 
@@ -134,10 +134,10 @@ public class ConsumingSegmentInfoReaderStatelessTest {
     FakeConsumingInfoServer s4 = new FakeConsumingInfoServer(Lists
         .newArrayList(new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_0, "CONSUMING", 0,
                 partitionToOffset0, new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset0,
-                Collections.emptyMap(), Collections.emptyMap())),
+                Collections.emptyMap(), Collections.emptyMap(), Collections.emptyMap())),
             new SegmentConsumerInfo(SEGMENT_NAME_PARTITION_1, "CONSUMING", 0, partitionToOffset1,
                 new SegmentConsumerInfo.PartitionOffsetInfo(partitionToOffset1, Collections.emptyMap(),
-                    Collections.emptyMap()))));
+                    Collections.emptyMap(), Collections.emptyMap()))));
     s4.start(uriPath, createHandler(200, s4._consumerInfos, TIMEOUT_MSEC * EXTENDED_TIMEOUT_FACTOR));
     _serverMap.put("server4", s4);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -282,6 +282,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
   private long _lastLogTime = 0;
   private int _lastConsumedCount = 0;
+  private RowMetadata _lastRowMetadata;
   private String _stopReason = null;
   private final Semaphore _segBuildSemaphore;
   private final boolean _isOffHeap;
@@ -577,6 +578,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
           try {
             canTakeMore = _realtimeSegment.index(transformedRow, msgMetadata);
             indexedMessageCount++;
+            _lastRowMetadata = msgMetadata;
             realtimeRowsConsumedMeter =
                 _serverMetrics.addMeteredTableValue(_metricKeyName, ServerMeter.REALTIME_ROWS_CONSUMED, 1,
                     realtimeRowsConsumedMeter);
@@ -825,7 +827,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   public Map<String, ConsumerPartitionState> getConsumerPartitionState() {
     String partitionGroupId = String.valueOf(_partitionGroupId);
     return Collections.singletonMap(partitionGroupId, new ConsumerPartitionState(partitionGroupId, getCurrentOffset(),
-        getLastConsumedTimestamp(), fetchLatestStreamOffset(5_000)));
+        getLastConsumedTimestamp(), fetchLatestStreamOffset(5_000), _lastRowMetadata));
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -280,9 +280,11 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   private final StreamPartitionMsgOffset _startOffset;
   private final PartitionLevelStreamConfig _partitionLevelStreamConfig;
 
+  private RowMetadata _lastRowMetadata;
+  private long _lastConsumedTimestampMs = -1;
+
   private long _lastLogTime = 0;
   private int _lastConsumedCount = 0;
-  private RowMetadata _lastRowMetadata;
   private String _stopReason = null;
   private final Semaphore _segBuildSemaphore;
   private final boolean _isOffHeap;
@@ -579,6 +581,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
             canTakeMore = _realtimeSegment.index(transformedRow, msgMetadata);
             indexedMessageCount++;
             _lastRowMetadata = msgMetadata;
+            _lastConsumedTimestampMs = now();
             realtimeRowsConsumedMeter =
                 _serverMetrics.addMeteredTableValue(_metricKeyName, ServerMeter.REALTIME_ROWS_CONSUMED, 1,
                     realtimeRowsConsumedMeter);
@@ -820,7 +823,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
   @Override
   public long getLastConsumedTimestamp() {
-    return _lastLogTime;
+    return _lastConsumedTimestampMs;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -581,7 +581,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
             canTakeMore = _realtimeSegment.index(transformedRow, msgMetadata);
             indexedMessageCount++;
             _lastRowMetadata = msgMetadata;
-            _lastConsumedTimestampMs = now();
+            _lastConsumedTimestampMs = System.currentTimeMillis();
             realtimeRowsConsumedMeter =
                 _serverMetrics.addMeteredTableValue(_metricKeyName, ServerMeter.REALTIME_ROWS_CONSUMED, 1,
                     realtimeRowsConsumedMeter);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -1084,6 +1084,11 @@ public class LLRealtimeSegmentDataManagerTest {
       _postConsumeStoppedCalled = true;
     }
 
+    // TODO: Some of the tests rely on specific number of calls to the `now()` method in the SegmentDataManager.
+    // This is not a good coding practice and makes the code very fragile. This needs to be fixed.
+    // Invoking now() in any part of LLRealtimeSegmentDataManager code will break the following tests:
+    // 1. LLRealtimeSegmentDataManagerTest.testShouldNotSkipUnfilteredMessagesIfNotIndexedAndRowCountThresholdIsReached
+    // 2. LLRealtimeSegmentDataManagerTest.testShouldNotSkipUnfilteredMessagesIfNotIndexedAndTimeThresholdIsReached
     @Override
     protected long now() {
       // now() is called in the constructor before _timeSupplier is set

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaConsumerPartitionLag.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaConsumerPartitionLag.java
@@ -35,7 +35,7 @@ public class KafkaConsumerPartitionLag extends PartitionLagState {
   }
 
   @Override
-  public String getRecordAvailabilityLag() {
+  public String getRecordAvailabilityLagMs() {
     return _recordAvailabilityLag;
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaConsumerPartitionLag.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaConsumerPartitionLag.java
@@ -23,12 +23,19 @@ import org.apache.pinot.spi.stream.PartitionLagState;
 
 public class KafkaConsumerPartitionLag extends PartitionLagState {
   private final String _recordsLag;
+  private final String _recordAvailabilityLag;
 
-  public KafkaConsumerPartitionLag(String recordsLag) {
+  public KafkaConsumerPartitionLag(String recordsLag, String recordAvailabilityLag) {
     _recordsLag = recordsLag;
+    _recordAvailabilityLag = recordAvailabilityLag;
   }
 
   public String getRecordsLag() {
     return _recordsLag;
+  }
+
+  @Override
+  public String getRecordAvailabilityLag() {
+    return _recordAvailabilityLag;
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaConsumerPartitionLag.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaConsumerPartitionLag.java
@@ -23,11 +23,11 @@ import org.apache.pinot.spi.stream.PartitionLagState;
 
 public class KafkaConsumerPartitionLag extends PartitionLagState {
   private final String _recordsLag;
-  private final String _recordAvailabilityLag;
+  private final String _availabilityLagMs;
 
-  public KafkaConsumerPartitionLag(String recordsLag, String recordAvailabilityLag) {
+  public KafkaConsumerPartitionLag(String recordsLag, String availabilityLagMs) {
     _recordsLag = recordsLag;
-    _recordAvailabilityLag = recordAvailabilityLag;
+    _availabilityLagMs = availabilityLagMs;
   }
 
   public String getRecordsLag() {
@@ -35,7 +35,7 @@ public class KafkaConsumerPartitionLag extends PartitionLagState {
   }
 
   @Override
-  public String getRecordAvailabilityLagMs() {
-    return _recordAvailabilityLag;
+  public String getAvailabilityLagMs() {
+    return _availabilityLagMs;
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
@@ -31,6 +31,7 @@ import org.apache.pinot.spi.stream.ConsumerPartitionState;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.PartitionLagState;
+import org.apache.pinot.spi.stream.RowMetadata;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamMetadataProvider;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
@@ -113,14 +114,27 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
       Map<String, ConsumerPartitionState> currentPartitionStateMap) {
     Map<String, PartitionLagState> perPartitionLag = new HashMap<>();
     for (Map.Entry<String, ConsumerPartitionState> entry: currentPartitionStateMap.entrySet()) {
-      StreamPartitionMsgOffset currentOffset = entry.getValue().getCurrentOffset();
-      StreamPartitionMsgOffset upstreamLatest = entry.getValue().getUpstreamLatestOffset();
+      ConsumerPartitionState partitionState = entry.getValue();
+      // Compute records-lag
+      StreamPartitionMsgOffset currentOffset = partitionState.getCurrentOffset();
+      StreamPartitionMsgOffset upstreamLatest = partitionState.getUpstreamLatestOffset();
+      String offsetLagString = "UNKNOWN";
+
       if (currentOffset instanceof LongMsgOffset && upstreamLatest instanceof LongMsgOffset) {
         long offsetLag = ((LongMsgOffset) upstreamLatest).getOffset() - ((LongMsgOffset) currentOffset).getOffset();
-        perPartitionLag.put(entry.getKey(), new KafkaConsumerPartitionLag(String.valueOf(offsetLag)));
-      } else {
-        perPartitionLag.put(entry.getKey(), new KafkaConsumerPartitionLag("UNKNOWN"));
+        offsetLagString = String.valueOf(offsetLag);
       }
+
+      // Compute record-availability
+      String recordAvailabilityLag = "UNKNOWN";
+      RowMetadata lastProcessedMessageMetadata = partitionState.getLastProcessedRowMetadata();
+      if (lastProcessedMessageMetadata != null) {
+        long availabilityLag = partitionState.getLastProcessedTimeMs() -
+            lastProcessedMessageMetadata.getRecordIngestionTimeMs();
+        recordAvailabilityLag = String.valueOf(availabilityLag);
+      }
+
+      perPartitionLag.put(entry.getKey(), new KafkaConsumerPartitionLag(offsetLagString, recordAvailabilityLag));
     }
     return perPartitionLag;
   }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
@@ -126,15 +126,15 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
       }
 
       // Compute record-availability
-      String recordAvailabilityLag = "UNKNOWN";
+      String availabilityLagMs = "UNKNOWN";
       RowMetadata lastProcessedMessageMetadata = partitionState.getLastProcessedRowMetadata();
       if (lastProcessedMessageMetadata != null && partitionState.getLastProcessedTimeMs() > 0) {
         long availabilityLag = partitionState.getLastProcessedTimeMs()
             - lastProcessedMessageMetadata.getRecordIngestionTimeMs();
-        recordAvailabilityLag = String.valueOf(availabilityLag);
+        availabilityLagMs = String.valueOf(availabilityLag);
       }
 
-      perPartitionLag.put(entry.getKey(), new KafkaConsumerPartitionLag(offsetLagString, recordAvailabilityLag));
+      perPartitionLag.put(entry.getKey(), new KafkaConsumerPartitionLag(offsetLagString, availabilityLagMs));
     }
     return perPartitionLag;
   }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
@@ -128,9 +128,9 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
       // Compute record-availability
       String recordAvailabilityLag = "UNKNOWN";
       RowMetadata lastProcessedMessageMetadata = partitionState.getLastProcessedRowMetadata();
-      if (lastProcessedMessageMetadata != null) {
-        long availabilityLag = partitionState.getLastProcessedTimeMs() -
-            lastProcessedMessageMetadata.getRecordIngestionTimeMs();
+      if (lastProcessedMessageMetadata != null && partitionState.getLastProcessedTimeMs() > 0) {
+        long availabilityLag = partitionState.getLastProcessedTimeMs()
+            - lastProcessedMessageMetadata.getRecordIngestionTimeMs();
         recordAvailabilityLag = String.valueOf(availabilityLag);
       }
 

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/server/KafkaDataProducer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/server/KafkaDataProducer.java
@@ -78,7 +78,8 @@ public class KafkaDataProducer implements StreamDataProducer {
   @Override
   public void produce(String topic, byte[] key, byte[] payload, GenericRow headers) {
     List<Header> headerList = new ArrayList<>();
-    headerList.add(new RecordHeader("producerTimestamp", String.valueOf(System.currentTimeMillis()).getBytes(
+    long nowMs = System.currentTimeMillis();
+    headerList.add(new RecordHeader("producerTimestamp", String.valueOf(nowMs).getBytes(
         StandardCharsets.UTF_8)));
     if (headers != null) {
       headers.getFieldToValueMap().forEach((k, v) -> {
@@ -88,7 +89,7 @@ public class KafkaDataProducer implements StreamDataProducer {
         }
       });
     }
-    _producer.send(new ProducerRecord<>(topic, null, key, payload, headerList));
+    _producer.send(new ProducerRecord<>(topic, null, nowMs, key, payload, headerList));
     _producer.flush();
   }
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
@@ -175,7 +175,7 @@ public class DebugResource {
       Map<String, String> recordsAvailabilityMap = new HashMap<>();
       realtimeSegmentDataManager.getPartitionToLagState(partitionStateMap).forEach((k, v) -> {
         recordsLagMap.put(k, v.getRecordsLag());
-        recordsAvailabilityMap.put(k, v.getRecordAvailabilityLagMs());
+        recordsAvailabilityMap.put(k, v.getAvailabilityLagMs());
       });
 
       segmentConsumerInfo =

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
@@ -172,10 +172,10 @@ public class DebugResource {
       Map<String, String> upstreamLatest = partitionStateMap.entrySet().stream().collect(
           Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getUpstreamLatestOffset().toString()));
       Map<String, String> recordsLagMap = new HashMap<>();
-      Map<String, String> recordsAvailabilityMap = new HashMap<>();
+      Map<String, String> availabilityLagMsMap = new HashMap<>();
       realtimeSegmentDataManager.getPartitionToLagState(partitionStateMap).forEach((k, v) -> {
         recordsLagMap.put(k, v.getRecordsLag());
-        recordsAvailabilityMap.put(k, v.getAvailabilityLagMs());
+        availabilityLagMsMap.put(k, v.getAvailabilityLagMs());
       });
 
       segmentConsumerInfo =
@@ -185,7 +185,7 @@ public class DebugResource {
               realtimeSegmentDataManager.getLastConsumedTimestamp(),
               currentOffsets,
               new SegmentConsumerInfo.PartitionOffsetInfo(currentOffsets,
-                  upstreamLatest, recordsLagMap, recordsAvailabilityMap));
+                  upstreamLatest, recordsLagMap, availabilityLagMsMap));
     }
     return segmentConsumerInfo;
   }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
@@ -175,7 +175,7 @@ public class DebugResource {
       Map<String, String> recordsAvailabilityMap = new HashMap<>();
       realtimeSegmentDataManager.getPartitionToLagState(partitionStateMap).forEach((k, v) -> {
         recordsLagMap.put(k, v.getRecordsLag());
-        recordsAvailabilityMap.put(k, v.getRecordAvailabilityLag());
+        recordsAvailabilityMap.put(k, v.getRecordAvailabilityLagMs());
       });
 
       segmentConsumerInfo =

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -517,10 +517,10 @@ public class TablesResource {
           Map<String, ConsumerPartitionState> partitionStateMap =
               realtimeSegmentDataManager.getConsumerPartitionState();
           Map<String, String> recordsLagMap = new HashMap<>();
-          Map<String, String> availabilityLagMap = new HashMap<>();
+          Map<String, String> availabilityLagMsMap = new HashMap<>();
           realtimeSegmentDataManager.getPartitionToLagState(partitionStateMap).forEach((k, v) -> {
             recordsLagMap.put(k, v.getRecordsLag());
-            availabilityLagMap.put(k, v.getRecordAvailabilityLagMs());
+            availabilityLagMsMap.put(k, v.getAvailabilityLagMs());
           });
           @Deprecated Map<String, String> partitiionToOffsetMap =
               realtimeSegmentDataManager.getPartitionToCurrentOffset();
@@ -533,7 +533,7 @@ public class TablesResource {
                       partitiionToOffsetMap,
                       partitionStateMap.entrySet().stream().collect(
                           Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getUpstreamLatestOffset().toString())
-                      ), recordsLagMap, availabilityLagMap)));
+                      ), recordsLagMap, availabilityLagMsMap)));
         }
       }
     } catch (Exception e) {

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -520,7 +520,7 @@ public class TablesResource {
           Map<String, String> availabilityLagMap = new HashMap<>();
           realtimeSegmentDataManager.getPartitionToLagState(partitionStateMap).forEach((k, v) -> {
             recordsLagMap.put(k, v.getRecordsLag());
-            availabilityLagMap.put(k, v.getRecordAvailabilityLag());
+            availabilityLagMap.put(k, v.getRecordAvailabilityLagMs());
           });
           @Deprecated Map<String, String> partitiionToOffsetMap =
               realtimeSegmentDataManager.getPartitionToCurrentOffset();

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -543,7 +543,6 @@ public class TablesResource {
         tableDataManager.releaseSegment(segmentDataManager);
       }
     }
-    
     return segmentConsumerInfoList;
   }
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -543,6 +543,7 @@ public class TablesResource {
         tableDataManager.releaseSegment(segmentDataManager);
       }
     }
+    
     return segmentConsumerInfoList;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/ConsumerPartitionState.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/ConsumerPartitionState.java
@@ -29,13 +29,15 @@ public class ConsumerPartitionState {
   private final StreamPartitionMsgOffset _currentOffset;
   private final long _lastProcessedTimeMs;
   private final StreamPartitionMsgOffset _upstreamLatestOffset;
+  private final RowMetadata _lastProcessedRowMetadata;
 
   public ConsumerPartitionState(String partitionId, StreamPartitionMsgOffset currentOffset, long lastProcessedTimeMs,
-      @Nullable StreamPartitionMsgOffset upstreamLatestOffset) {
+      @Nullable StreamPartitionMsgOffset upstreamLatestOffset, @Nullable RowMetadata lastProcessedRowMetadata) {
     _partitionId = partitionId;
     _currentOffset = currentOffset;
     _lastProcessedTimeMs = lastProcessedTimeMs;
     _upstreamLatestOffset = upstreamLatestOffset;
+    _lastProcessedRowMetadata = lastProcessedRowMetadata;
   }
 
   public StreamPartitionMsgOffset getCurrentOffset() {
@@ -52,5 +54,9 @@ public class ConsumerPartitionState {
 
   public StreamPartitionMsgOffset getUpstreamLatestOffset() {
     return _upstreamLatestOffset;
+  }
+
+  public RowMetadata getLastProcessedRowMetadata() {
+    return _lastProcessedRowMetadata;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLagState.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLagState.java
@@ -27,19 +27,18 @@ public class PartitionLagState {
   protected final static String NOT_CALCULATED = "NOT_CALCULATED";
 
   /**
-   * Defines how far away the current record's offset / pointer is from upstream latest record
+   * Defines how far behind the current record's offset / pointer is from upstream latest record
    * The distance is based on actual record count.
    */
   public String getRecordsLag() {
     return NOT_CALCULATED;
   }
 
-  // TODO: Define record availability lag ($latest_record_consumption_time - $latest_record_ingestion_time)
-
   /**
    * Defines how soon after record ingestion was the record consumed by Pinot. That is, the difference between the
    * time the record was consumed and the time at which the record was ingested upstream.
-   * @return
+   *
+   * @return Lag value in milliseconds
    */
   public String getRecordAvailabilityLag() {
     return NOT_CALCULATED;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLagState.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLagState.java
@@ -35,4 +35,13 @@ public class PartitionLagState {
   }
 
   // TODO: Define record availability lag ($latest_record_consumption_time - $latest_record_ingestion_time)
+
+  /**
+   * Defines how soon after record ingestion was the record consumed by Pinot. That is, the difference between the
+   * time the record was consumed and the time at which the record was ingested upstream.
+   * @return
+   */
+  public String getRecordAvailabilityLag() {
+    return NOT_CALCULATED;
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLagState.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLagState.java
@@ -40,7 +40,7 @@ public class PartitionLagState {
    *
    * @return Lag value in milliseconds
    */
-  public String getRecordAvailabilityLag() {
+  public String getRecordAvailabilityLagMs() {
     return NOT_CALCULATED;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLagState.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLagState.java
@@ -40,7 +40,7 @@ public class PartitionLagState {
    *
    * @return Lag value in milliseconds
    */
-  public String getRecordAvailabilityLagMs() {
+  public String getAvailabilityLagMs() {
     return NOT_CALCULATED;
   }
 }


### PR DESCRIPTION
Introduces record availability lag for realtime connectors via the rest apis - `consumingSegmentsInfo` 
 and `/debug/tables/{tableName}`


Label: `release-notes`

`/consumingSegmentsInfo` and `debug/tables/{tableName}` API now provides the following per-partition numbers for Kafka data sources:
`currentConsumingOffset`, `latestUpstreamOffset`, `recordsLag`, `availabilityLagMs` 