### PR TITLE
fix missing information in pinot realtime quickstart yml

### DIFF
--- a/kubernetes/helm/pinot/README.md
+++ b/kubernetes/helm/pinot/README.md
@@ -273,8 +273,8 @@ helm install --namespace "pinot-quickstart"  --name kafka incubator/kafka --set 
 #### Create Kafka topic
 
 ```bash
-kubectl -n pinot-quickstart exec kafka-0 -- kafka-topics --zookeeper kafka-zookeeper:2181 --topic flights-realtime --create --partitions 1 --replication-factor 1
-kubectl -n pinot-quickstart exec kafka-0 -- kafka-topics --zookeeper kafka-zookeeper:2181 --topic flights-realtime-avro --create --partitions 1 --replication-factor 1
+kubectl -n pinot-quickstart exec kafka-0 -- kafka-topics --bootstrap-server kafka-0:9092 --topic flights-realtime --create --partitions 1 --replication-factor 1
+kubectl -n pinot-quickstart exec kafka-0 -- kafka-topics --bootstrap-server kafka-0:9092 --topic flights-realtime-avro --create --partitions 1 --replication-factor 1
 ```
 
 #### Load data into Kafka and create Pinot schema/table

--- a/kubernetes/helm/pinot/README.md
+++ b/kubernetes/helm/pinot/README.md
@@ -273,8 +273,8 @@ helm install --namespace "pinot-quickstart"  --name kafka incubator/kafka --set 
 #### Create Kafka topic
 
 ```bash
-kubectl -n pinot-quickstart exec kafka-0 -- kafka-topics --bootstrap-server kafka-0:9092 --topic flights-realtime --create --partitions 1 --replication-factor 1
-kubectl -n pinot-quickstart exec kafka-0 -- kafka-topics --bootstrap-server kafka-0:9092 --topic flights-realtime-avro --create --partitions 1 --replication-factor 1
+kubectl -n pinot-quickstart exec kafka-0 -- kafka-topics.sh --bootstrap-server kafka-0:9092 --topic flights-realtime --create --partitions 1 --replication-factor 1
+kubectl -n pinot-quickstart exec kafka-0 -- kafka-topics.sh --bootstrap-server kafka-0:9092 --topic flights-realtime-avro --create --partitions 1 --replication-factor 1
 ```
 
 #### Load data into Kafka and create Pinot schema/table

--- a/kubernetes/helm/pinot/pinot-realtime-quickstart.yml
+++ b/kubernetes/helm/pinot/pinot-realtime-quickstart.yml
@@ -71,7 +71,7 @@ data:
         "retentionTimeValue": "3650",
         "segmentPushType": "APPEND",
         "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
-        "schemaName": "airlineStats",
+        "schemaName": "airlineStatsAvro",
         "replication": "1",
         "replicasPerPartition": "1"
       },
@@ -435,6 +435,344 @@ data:
     ],
     "schemaName": "airlineStats"
     }
+
+  airlineStatsAvro_schema.json: |-
+    {
+    "metricFieldSpecs": [
+    ],
+    "dimensionFieldSpecs": [
+      {
+        "dataType": "INT",
+        "name": "ActualElapsedTime"
+      },
+      {
+        "dataType": "INT",
+        "name": "AirTime"
+      },
+      {
+        "dataType": "INT",
+        "name": "AirlineID"
+      },
+      {
+        "dataType": "INT",
+        "name": "ArrDel15"
+      },
+      {
+        "dataType": "INT",
+        "name": "ArrDelay"
+      },
+      {
+        "dataType": "INT",
+        "name": "ArrDelayMinutes"
+      },
+      {
+        "dataType": "INT",
+        "name": "ArrTime"
+      },
+      {
+        "dataType": "STRING",
+        "name": "ArrTimeBlk"
+      },
+      {
+        "dataType": "INT",
+        "name": "ArrivalDelayGroups"
+      },
+      {
+        "dataType": "INT",
+        "name": "CRSArrTime"
+      },
+      {
+        "dataType": "INT",
+        "name": "CRSDepTime"
+      },
+      {
+        "dataType": "INT",
+        "name": "CRSElapsedTime"
+      },
+      {
+        "dataType": "STRING",
+        "name": "CancellationCode"
+      },
+      {
+        "dataType": "INT",
+        "name": "Cancelled"
+      },
+      {
+        "dataType": "STRING",
+        "name": "Carrier"
+      },
+      {
+        "dataType": "INT",
+        "name": "CarrierDelay"
+      },
+      {
+        "dataType": "INT",
+        "name": "DayOfWeek"
+      },
+      {
+        "dataType": "INT",
+        "name": "DayofMonth"
+      },
+      {
+        "dataType": "INT",
+        "name": "DepDel15"
+      },
+      {
+        "dataType": "INT",
+        "name": "DepDelay"
+      },
+      {
+        "dataType": "INT",
+        "name": "DepDelayMinutes"
+      },
+      {
+        "dataType": "INT",
+        "name": "DepTime"
+      },
+      {
+        "dataType": "STRING",
+        "name": "DepTimeBlk"
+      },
+      {
+        "dataType": "INT",
+        "name": "DepartureDelayGroups"
+      },
+      {
+        "dataType": "STRING",
+        "name": "Dest"
+      },
+      {
+        "dataType": "INT",
+        "name": "DestAirportID"
+      },
+      {
+        "dataType": "INT",
+        "name": "DestAirportSeqID"
+      },
+      {
+        "dataType": "INT",
+        "name": "DestCityMarketID"
+      },
+      {
+        "dataType": "STRING",
+        "name": "DestCityName"
+      },
+      {
+        "dataType": "STRING",
+        "name": "DestState"
+      },
+      {
+        "dataType": "INT",
+        "name": "DestStateFips"
+      },
+      {
+        "dataType": "STRING",
+        "name": "DestStateName"
+      },
+      {
+        "dataType": "INT",
+        "name": "DestWac"
+      },
+      {
+        "dataType": "INT",
+        "name": "Distance"
+      },
+      {
+        "dataType": "INT",
+        "name": "DistanceGroup"
+      },
+      {
+        "dataType": "INT",
+        "name": "DivActualElapsedTime"
+      },
+      {
+        "dataType": "INT",
+        "name": "DivAirportIDs",
+        "singleValueField": false
+      },
+      {
+        "dataType": "INT",
+        "name": "DivAirportLandings"
+      },
+      {
+        "dataType": "INT",
+        "name": "DivAirportSeqIDs",
+        "singleValueField": false
+      },
+      {
+        "dataType": "STRING",
+        "name": "DivAirports",
+        "singleValueField": false
+      },
+      {
+        "dataType": "INT",
+        "name": "DivArrDelay"
+      },
+      {
+        "dataType": "INT",
+        "name": "DivDistance"
+      },
+      {
+        "dataType": "INT",
+        "name": "DivLongestGTimes",
+        "singleValueField": false
+      },
+      {
+        "dataType": "INT",
+        "name": "DivReachedDest"
+      },
+      {
+        "dataType": "STRING",
+        "name": "DivTailNums",
+        "singleValueField": false
+      },
+      {
+        "dataType": "INT",
+        "name": "DivTotalGTimes",
+        "singleValueField": false
+      },
+      {
+        "dataType": "INT",
+        "name": "DivWheelsOffs",
+        "singleValueField": false
+      },
+      {
+        "dataType": "INT",
+        "name": "DivWheelsOns",
+        "singleValueField": false
+      },
+      {
+        "dataType": "INT",
+        "name": "Diverted"
+      },
+      {
+        "dataType": "INT",
+        "name": "FirstDepTime"
+      },
+      {
+        "dataType": "STRING",
+        "name": "FlightDate"
+      },
+      {
+        "dataType": "INT",
+        "name": "FlightNum"
+      },
+      {
+        "dataType": "INT",
+        "name": "Flights"
+      },
+      {
+        "dataType": "INT",
+        "name": "LateAircraftDelay"
+      },
+      {
+        "dataType": "INT",
+        "name": "LongestAddGTime"
+      },
+      {
+        "dataType": "INT",
+        "name": "Month"
+      },
+      {
+        "dataType": "INT",
+        "name": "NASDelay"
+      },
+      {
+        "dataType": "STRING",
+        "name": "Origin"
+      },
+      {
+        "dataType": "INT",
+        "name": "OriginAirportID"
+      },
+      {
+        "dataType": "INT",
+        "name": "OriginAirportSeqID"
+      },
+      {
+        "dataType": "INT",
+        "name": "OriginCityMarketID"
+      },
+      {
+        "dataType": "STRING",
+        "name": "OriginCityName"
+      },
+      {
+        "dataType": "STRING",
+        "name": "OriginState"
+      },
+      {
+        "dataType": "INT",
+        "name": "OriginStateFips"
+      },
+      {
+        "dataType": "STRING",
+        "name": "OriginStateName"
+      },
+      {
+        "dataType": "INT",
+        "name": "OriginWac"
+      },
+      {
+        "dataType": "INT",
+        "name": "Quarter"
+      },
+      {
+        "dataType": "STRING",
+        "name": "RandomAirports",
+        "singleValueField": false
+      },
+      {
+        "dataType": "INT",
+        "name": "SecurityDelay"
+      },
+      {
+        "dataType": "STRING",
+        "name": "TailNum"
+      },
+      {
+        "dataType": "INT",
+        "name": "TaxiIn"
+      },
+      {
+        "dataType": "INT",
+        "name": "TaxiOut"
+      },
+      {
+        "dataType": "INT",
+        "name": "Year"
+      },
+      {
+        "dataType": "INT",
+        "name": "WheelsOn"
+      },
+      {
+        "dataType": "INT",
+        "name": "WheelsOff"
+      },
+      {
+        "dataType": "INT",
+        "name": "WeatherDelay"
+      },
+      {
+        "dataType": "STRING",
+        "name": "UniqueCarrier"
+      },
+      {
+        "dataType": "INT",
+        "name": "TotalAddGTime"
+      }
+    ],
+    "dateTimeFieldSpecs": [
+      {
+        "name": "DaysSinceEpoch",
+        "dataType": "INT",
+        "format": "1:DAYS:EPOCH",
+        "granularity": "1:DAYS"
+      }
+    ],
+    "schemaName": "airlineStatsAvro"
+    }    
 ---
 apiVersion: batch/v1
 kind: Job
@@ -456,7 +794,7 @@ spec:
               mountPath: /var/pinot/examples
         - name: pinot-add-example-realtime-table-avro
           image: apachepinot/pinot:latest
-          args: [ "AddTable", "-schemaFile", "/var/pinot/examples/airlineStats_schema.json", "-tableConfigFile", "/var/pinot/examples/airlineStatsAvro_realtime_table_config.json", "-controllerHost", "pinot-controller", "-controllerPort", "9000", "-exec" ]
+          args: [ "AddTable", "-schemaFile", "/var/pinot/examples/airlineStatsAvro_schema.json", "-tableConfigFile", "/var/pinot/examples/airlineStatsAvro_realtime_table_config.json", "-controllerHost", "pinot-controller", "-controllerPort", "9000", "-exec" ]
           env:
             - name: JAVA_OPTS
               value: "-Xms4G -Xmx4G -Dpinot.admin.system.exit=true"


### PR DESCRIPTION
This fix will update the yaml file pinot-realtime-quickstart.yml with the missing avro schema configuration. It will also update the README.md file under the section Create topics. The command was changed to bootstrap-server.

this fixes #9606