### PR TITLE
add support for testing using JAR resource

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SSBQueryIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SSBQueryIntegrationTest.java
@@ -39,6 +39,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.tools.utils.JarUtils;
 import org.apache.pinot.util.TestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,7 +83,16 @@ public class SSBQueryIntegrationTest extends BaseClusterIntegrationTest {
       String tableName = tableResource.getKey();
       URL resourceUrl = getClass().getClassLoader().getResource(tableResource.getValue());
       Assert.assertNotNull(resourceUrl, "Unable to find resource from: " + tableResource.getValue());
-      File resourceFile = new File(resourceUrl.getFile());
+      File resourceFile;
+      if ("jar".equals(resourceUrl.getProtocol())) {
+        String[] splits = resourceUrl.getFile().split("!");
+        File tempUnpackDir = new File(_tempDir.getAbsolutePath() + File.separator + splits[1]);
+        TestUtils.ensureDirectoriesExistAndEmpty(tempUnpackDir);
+        JarUtils.copyResourcesToDirectory(splits[0], splits[1].substring(1), tempUnpackDir.getAbsolutePath());
+        resourceFile = tempUnpackDir;
+      } else {
+        resourceFile = new File(resourceUrl.getFile());
+      }
       File dataFile = new File(resourceFile.getAbsolutePath(), "rawdata" + File.separator + tableName + ".avro");
       Assert.assertTrue(dataFile.exists(), "Unable to load resource file from URL: " + dataFile);
       File schemaFile = new File(resourceFile.getPath(), tableName + "_schema.json");


### PR DESCRIPTION
similar to [BootstrapTools](https://github.com/apache/pinot/blob/03121cf4553ebbd0251df028a55387f96db0b619/pinot-tools/src/main/java/org/apache/pinot/tools/BootstrapTableTool.java#L232). 

for some compilation usages, the SSB test resources are actually packaged in a JAR rather than locally available resource files. adding the logic to unpack it into tmp folder for the test to run correctly.