### PR TITLE
feat: Cache BCrypt checkpw to enhance pinot query performance

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
@@ -101,8 +101,9 @@ public class ZkBasicAuthAccessControlFactory extends AccessControlFactory {
 
             Optional<ZkBasicAuthPrincipal> principalOpt =
               password2principal.entrySet().stream()
-                .filter(entry -> BcryptUtils.checkpw(entry.getKey(), entry.getValue().getPassword()))
-                .map(u -> u.getValue()).filter(Objects::nonNull).findFirst();
+                      .filter(entry -> BcryptUtils.checkpwWithCache(entry.getKey(), entry.getValue().getPassword(),
+                              _userCache.getUserPasswordAuthCache()))
+                      .map(u -> u.getValue()).filter(Objects::nonNull).findFirst();
 
             if (!principalOpt.isPresent()) {
                 // no matching token? reject

--- a/pinot-common/src/main/java/org/apache/pinot/common/config/provider/AccessControlUserCache.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/provider/AccessControlUserCache.java
@@ -18,10 +18,13 @@
  */
 package org.apache.pinot.common.config.provider;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.collections.CollectionUtils;
@@ -45,6 +48,7 @@ public class AccessControlUserCache {
     private static final Logger LOGGER = LoggerFactory.getLogger(AccessControlUserCache.class);
     private static final String USER_CONFIG_PARENT_PATH = "/CONFIGS/USER";
     private static final String USER_CONFIG_PATH_PREFIX = "/CONFIGS/USER/";
+    private static final int USER_PASSWORD_EXPIRE_TIME = 60 * 60 * 24;
 
     private final ZkHelixPropertyStore<ZNRecord> _propertyStore;
 
@@ -54,6 +58,8 @@ public class AccessControlUserCache {
     private final Map<String, UserConfig> _userControllerConfigMap = new ConcurrentHashMap<>();
     private final Map<String, UserConfig> _userBrokerConfigMap = new ConcurrentHashMap<>();
     private final Map<String, UserConfig> _userServerConfigMap = new ConcurrentHashMap<>();
+    private Cache<String, String> _userPasswordAuthCache = CacheBuilder.newBuilder()
+            .expireAfterWrite(USER_PASSWORD_EXPIRE_TIME, TimeUnit.SECONDS).build();
 
     public AccessControlUserCache(ZkHelixPropertyStore<ZNRecord> propertyStore) {
         _propertyStore = propertyStore;
@@ -67,6 +73,10 @@ public class AccessControlUserCache {
             }
             addUserConfigs(pathsToAdd);
         }
+    }
+
+    public Cache<String, String> getUserPasswordAuthCache() {
+        return _userPasswordAuthCache;
     }
 
     @Nullable

--- a/pinot-common/src/main/java/org/apache/pinot/common/config/provider/AccessControlUserCache.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/provider/AccessControlUserCache.java
@@ -58,7 +58,7 @@ public class AccessControlUserCache {
     private final Map<String, UserConfig> _userControllerConfigMap = new ConcurrentHashMap<>();
     private final Map<String, UserConfig> _userBrokerConfigMap = new ConcurrentHashMap<>();
     private final Map<String, UserConfig> _userServerConfigMap = new ConcurrentHashMap<>();
-    private Cache<String, String> _userPasswordAuthCache = CacheBuilder.newBuilder()
+    private final Cache<String, String> _userPasswordAuthCache = CacheBuilder.newBuilder()
             .expireAfterWrite(USER_PASSWORD_EXPIRE_TIME, TimeUnit.SECONDS).build();
 
     public AccessControlUserCache(ZkHelixPropertyStore<ZNRecord> propertyStore) {

--- a/pinot-core/src/main/java/org/apache/pinot/server/access/ZkBasicAuthAccessFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/access/ZkBasicAuthAccessFactory.java
@@ -97,7 +97,8 @@ public class ZkBasicAuthAccessFactory implements AccessControlFactory {
             Map<String, ZkBasicAuthPrincipal> password2principal = name2password.keySet().stream()
               .collect(Collectors.toMap(name2password::get, _name2principal::get));
             return password2principal.entrySet().stream()
-                .filter(entry -> BcryptUtils.checkpw(entry.getKey(), entry.getValue().getPassword()))
+                .filter(entry -> BcryptUtils.checkpwWithCache(entry.getKey(), entry.getValue().getPassword(),
+                        _userCache.getUserPasswordAuthCache()))
                 .map(u -> u.getValue())
                 .filter(Objects::nonNull)
                 .findFirst()


### PR DESCRIPTION
Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
 `performance`
2. Purpose for this pull request:
   We found a performance issue from master pinot code
   When we use zk as user and password authorization we found this function spend about 80ms for verifying
   ```isMatch = BCrypt.checkpw(pasword, encrypedPassword)```

   So this solution is to cache this function result to enhance query speed

3. Here is testing result in our lab env:
    Original code need 85ms at least  to query
    Fixed code need 1 - 10ms at least  to query
4. Related issues: https://github.com/apache/pinot/issues/9632
