### PR TITLE
Reverts recommender REST API back to PUT (reverts PR #9326)

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -239,7 +239,7 @@ public class PinotTableRestletResource {
     }
   }
 
-  @GET
+  @PUT
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/tables/recommender")
   @ApiOperation(value = "Recommend config", notes = "Recommend a config with input json")


### PR DESCRIPTION
This PR reverts https://github.com/apache/pinot/pull/9326, which made a backward incompatible change without properly accounting for it, which is causing problem for our internal use-case. Additionally, using GET for this API also may not make sense due to the possibly extremely long request inputs. 

Sorry I had approved the prior PR w/o understanding all implications. 

