### PR TITLE
[multistage] create pinot override SqlOpTable

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotOperatorTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotOperatorTable.java
@@ -45,6 +45,8 @@ public class PinotOperatorTable extends SqlStdOperatorTable {
 
   public static final SqlFunction COALESCE = new PinotSqlCoalesceFunction();
 
+  // TODO: clean up lazy init by using Suppliers.memorized(this::computeInstance) and make getter wrapped around
+  // supplier instance. this should replace all lazy init static objects in the codebase
   public static synchronized PinotOperatorTable instance() {
     if (_instance == null) {
       // Creates and initializes the standard operator table.
@@ -59,6 +61,9 @@ public class PinotOperatorTable extends SqlStdOperatorTable {
   /**
    * Initialize without duplicate, e.g. when 2 duplicate operator is linked with the same op
    * {@link org.apache.calcite.sql.SqlKind} it causes problem.
+   *
+   * <p>This is a direct copy of the {@link org.apache.calcite.sql.util.ReflectiveSqlOperatorTable} and can be hard to
+   * debug, suggest changing to a non-dynamic registration. Dynamic function support should happen via catalog.
    */
   public final void initNoDuplicate() {
     // Use reflection to register the expressions stored in public fields.

--- a/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotOperatorTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotOperatorTable.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.calcite.sql.fun;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.validate.SqlNameMatchers;
+import org.apache.calcite.util.Util;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
+
+
+/**
+ * {@link PinotOperatorTable} defines the {@link SqlOperator} overrides on top of the {@link SqlStdOperatorTable}.
+ *
+ * <p>The main purpose of this Pinot specific SQL operator table is to
+ * <ul>
+ *   <li>Ensure that any specific SQL validation rules can apply with Pinot override entirely over Calcite's.</li>
+ *   <li>Ability to create customer operators that are not function and cannot use
+ *     {@link org.apache.calcite.prepare.Prepare.CatalogReader} to override</li>
+ *   <li>Still maintain minimum customization and benefit from Calcite's original operator table setting.</li>
+ * </ul>
+ */
+public class PinotOperatorTable extends SqlStdOperatorTable {
+
+  private static @MonotonicNonNull PinotOperatorTable _instance;
+
+  public static final SqlFunction COALESCE = new PinotSqlCoalesceFunction();
+
+  public static synchronized PinotOperatorTable instance() {
+    if (_instance == null) {
+      // Creates and initializes the standard operator table.
+      // Uses two-phase construction, because we can't initialize the
+      // table until the constructor of the sub-class has completed.
+      _instance = new PinotOperatorTable();
+      _instance.initNoDuplicate();
+    }
+    return _instance;
+  }
+
+  /**
+   * Initialize without duplicate, e.g. when 2 duplicate operator is linked with the same op
+   * {@link org.apache.calcite.sql.SqlKind} it causes problem.
+   */
+  public final void initNoDuplicate() {
+    // Use reflection to register the expressions stored in public fields.
+    for (Field field : getClass().getFields()) {
+      try {
+        if (SqlFunction.class.isAssignableFrom(field.getType())) {
+          SqlFunction op = (SqlFunction) field.get(this);
+          if (op != null && notRegistered(op)) {
+            register(op);
+          }
+        } else if (
+            SqlOperator.class.isAssignableFrom(field.getType())) {
+          SqlOperator op = (SqlOperator) field.get(this);
+          if (op != null && notRegistered(op)) {
+            register(op);
+          }
+        }
+      } catch (IllegalArgumentException | IllegalAccessException e) {
+        throw Util.throwAsRuntime(Util.causeOrSelf(e));
+      }
+    }
+  }
+
+  private boolean notRegistered(SqlFunction op) {
+    List<SqlOperator> operatorList = new ArrayList<>();
+    lookupOperatorOverloads(op.getNameAsId(), op.getFunctionType(), op.getSyntax(), operatorList,
+        SqlNameMatchers.withCaseSensitive(false));
+    return operatorList.size() == 0;
+  }
+
+  private boolean notRegistered(SqlOperator op) {
+    List<SqlOperator> operatorList = new ArrayList<>();
+    lookupOperatorOverloads(op.getNameAsId(), null, op.getSyntax(), operatorList,
+        SqlNameMatchers.withCaseSensitive(false));
+    return operatorList.size() == 0;
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotSqlCoalesceFunction.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotSqlCoalesceFunction.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.validate.SqlValidator;
+
+
+/**
+ * Pinot supports native COALESCE function, thus no need to create CASE WHEN conversion.
+ */
+public class PinotSqlCoalesceFunction extends SqlCoalesceFunction {
+
+  @Override
+  public SqlNode rewriteCall(SqlValidator validator, SqlCall call) {
+    return call;
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -93,7 +93,6 @@ public class QueryEnvironment {
     _config = Frameworks.newConfigBuilder().traitDefs()
         .operatorTable(new ChainedSqlOperatorTable(Arrays.asList(
             PinotOperatorTable.instance(),
-//            SqlStdOperatorTable.instance(),
             _catalogReader)))
         .defaultSchema(_rootSchema.plus())
         .sqlToRelConverterConfig(SqlToRelConverter.config()

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -43,7 +43,7 @@ import org.apache.calcite.sql.SqlExplainFormat;
 import org.apache.calcite.sql.SqlExplainLevel;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
-import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.fun.PinotOperatorTable;
 import org.apache.calcite.sql.util.ChainedSqlOperatorTable;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.sql2rel.StandardConvertletTable;
@@ -91,7 +91,10 @@ public class QueryEnvironment {
         new CalciteConnectionConfigImpl(catalogReaderConfigProperties));
 
     _config = Frameworks.newConfigBuilder().traitDefs()
-        .operatorTable(new ChainedSqlOperatorTable(Arrays.asList(SqlStdOperatorTable.instance(), _catalogReader)))
+        .operatorTable(new ChainedSqlOperatorTable(Arrays.asList(
+            PinotOperatorTable.instance(),
+//            SqlStdOperatorTable.instance(),
+            _catalogReader)))
         .defaultSchema(_rootSchema.plus())
         .sqlToRelConverterConfig(SqlToRelConverter.config()
             .withHintStrategyTable(getHintStrategyTable())

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryTestSet.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryTestSet.java
@@ -207,10 +207,16 @@ public class QueryTestSet {
         new Object[]{"SELECT SUM(CAST(col3 AS INTEGER)) FROM a HAVING MIN(col3) BETWEEN 1 AND 0"},
         new Object[]{"SELECT col1, COUNT(col3) FROM a GROUP BY col1 HAVING SUM(col3) > 40 AND SUM(col3) < 30"},
 
-        // Test functions
+        // Test SQL functions
+        // TODO split these SQL functions into separate test files to share between planner and runtime
+        // LIKE function
         new Object[]{"SELECT col1 FROM a WHERE col2 LIKE '%o%'"},
         new Object[]{"SELECT a.col1, b.col1 FROM a JOIN b ON a.col3 = b.col3 WHERE a.col2 LIKE b.col1"},
         new Object[]{"SELECT a.col1 LIKE b.col1 FROM a JOIN b ON a.col3 = b.col3"},
+
+        // COALESCE function
+        new Object[]{"SELECT a.col1, COALESCE(b.col3, 0) FROM a LEFT JOIN b ON a.col1 = b.col2"},
+        new Object[]{"SELECT a.col1, COALESCE(a.col3, 0) FROM a WHERE COALESCE(a.col2, 'bar') = 'bar'"},
     };
   }
 }


### PR DESCRIPTION
- use to fix COALESCE parsing issue
- also benefit from future non-function OP registration
  - such as standard SQL LIKE but with customization.
  - or entirely customized features like #9480