### PR TITLE
Revert "Bug fix: Add missing table config fetch for /tableConfigs list all (#9603)

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -118,7 +118,7 @@ public class TableConfigsRestletResource {
 
       ArrayNode configsList = JsonUtils.newArrayNode();
       for (String rawTableName : rawTableNames) {
-        configsList.add(getConfig(rawTableName));
+        configsList.add(rawTableName);
       }
       return configsList.toString();
     } catch (Exception e) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
@@ -21,10 +21,9 @@ package org.apache.pinot.controller.api;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.Sets;
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
 import org.apache.pinot.spi.config.TableConfigs;
@@ -375,8 +374,8 @@ public class TableConfigsRestletResourceTest {
     TableConfig offlineTableConfig = getOfflineTableConfig(tableName1);
     TableConfig realtimeTableConfig = getRealtimeTableConfig(tableName1);
     Schema schema = getSchema(tableName1);
-    TableConfigs tableConfigs1 = new TableConfigs(tableName1, schema, offlineTableConfig, null);
-    ControllerTest.sendPostRequest(_createTableConfigsUrl, tableConfigs1.toPrettyJsonString());
+    TableConfigs tableConfigs = new TableConfigs(tableName1, schema, offlineTableConfig, null);
+    ControllerTest.sendPostRequest(_createTableConfigsUrl, tableConfigs.toPrettyJsonString());
 
     // list
     String getResponse =
@@ -384,17 +383,13 @@ public class TableConfigsRestletResourceTest {
     List<String> configs = JsonUtils.stringToObject(getResponse, new TypeReference<List<String>>() {
     });
     Assert.assertEquals(configs.size(), 1);
-    TableConfigs tableConfigsResponse = JsonUtils.stringToObject(configs.get(0), TableConfigs.class);
-    Assert.assertEquals(tableConfigsResponse.getTableName(), tableConfigs1.getTableName());
-    Assert.assertEquals(tableConfigsResponse.getSchema(), tableConfigs1.getSchema());
-    Assert.assertEquals(tableConfigsResponse.getOffline().getTableName(), tableConfigs1.getOffline().getTableName());
-    Assert.assertNull(tableConfigsResponse.getRealtime());
+    Assert.assertTrue(configs.containsAll(Sets.newHashSet(tableName1)));
 
     // update to 2
-    tableConfigs1 = new TableConfigs(tableName1, schema, offlineTableConfig, realtimeTableConfig);
+    tableConfigs = new TableConfigs(tableName1, schema, offlineTableConfig, realtimeTableConfig);
     ControllerTest
         .sendPutRequest(TEST_INSTANCE.getControllerRequestURLBuilder().forTableConfigsUpdate(tableName1),
-            tableConfigs1.toPrettyJsonString());
+            tableConfigs.toPrettyJsonString());
 
     // list
     getResponse =
@@ -402,18 +397,14 @@ public class TableConfigsRestletResourceTest {
     configs = JsonUtils.stringToObject(getResponse, new TypeReference<List<String>>() {
     });
     Assert.assertEquals(configs.size(), 1);
-    tableConfigsResponse = JsonUtils.stringToObject(configs.get(0), TableConfigs.class);
-    Assert.assertEquals(tableConfigsResponse.getTableName(), tableConfigs1.getTableName());
-    Assert.assertEquals(tableConfigsResponse.getSchema(), tableConfigs1.getSchema());
-    Assert.assertEquals(tableConfigsResponse.getOffline().getTableName(), tableConfigs1.getOffline().getTableName());
-    Assert.assertEquals(tableConfigsResponse.getRealtime().getTableName(), tableConfigs1.getRealtime().getTableName());
+    Assert.assertTrue(configs.containsAll(Sets.newHashSet("testList1")));
 
     // create new
     String tableName2 = "testList2";
     offlineTableConfig = getOfflineTableConfig(tableName2);
     schema = getSchema(tableName2);
-    TableConfigs tableConfigs2 = new TableConfigs(tableName2, schema, offlineTableConfig, null);
-    ControllerTest.sendPostRequest(_createTableConfigsUrl, tableConfigs2.toPrettyJsonString());
+    tableConfigs = new TableConfigs(tableName2, schema, offlineTableConfig, null);
+    ControllerTest.sendPostRequest(_createTableConfigsUrl, tableConfigs.toPrettyJsonString());
 
     // list
     getResponse =
@@ -421,23 +412,7 @@ public class TableConfigsRestletResourceTest {
     configs = JsonUtils.stringToObject(getResponse, new TypeReference<List<String>>() {
     });
     Assert.assertEquals(configs.size(), 2);
-    Map<String, TableConfigs> tableNameToConfigs = new HashMap<>(2);
-    for (String conf : configs) {
-      TableConfigs response = JsonUtils.stringToObject(conf, TableConfigs.class);
-      tableNameToConfigs.put(response.getTableName(), response);
-    }
-    Assert.assertEquals(tableNameToConfigs.get(tableName1).getTableName(), tableConfigs1.getTableName());
-    Assert.assertEquals(tableNameToConfigs.get(tableName1).getSchema(), tableConfigs1.getSchema());
-    Assert.assertEquals(tableNameToConfigs.get(tableName1).getOffline().getTableName(),
-        tableConfigs1.getOffline().getTableName());
-    Assert.assertEquals(tableNameToConfigs.get(tableName1).getRealtime().getTableName(),
-        tableConfigs1.getRealtime().getTableName());
-
-    Assert.assertEquals(tableNameToConfigs.get(tableName2).getTableName(), tableConfigs2.getTableName());
-    Assert.assertEquals(tableNameToConfigs.get(tableName2).getSchema(), tableConfigs2.getSchema());
-    Assert.assertEquals(tableNameToConfigs.get(tableName2).getOffline().getTableName(),
-        tableConfigs2.getOffline().getTableName());
-    Assert.assertNull(tableNameToConfigs.get(tableName2).getRealtime());
+    Assert.assertTrue(configs.containsAll(Sets.newHashSet(tableName1, tableName2)));
 
     // delete 1
     ControllerTest
@@ -449,11 +424,7 @@ public class TableConfigsRestletResourceTest {
     configs = JsonUtils.stringToObject(getResponse, new TypeReference<List<String>>() {
     });
     Assert.assertEquals(configs.size(), 1);
-    tableConfigsResponse = JsonUtils.stringToObject(configs.get(0), TableConfigs.class);
-    Assert.assertEquals(tableConfigsResponse.getTableName(), tableConfigs1.getTableName());
-    Assert.assertEquals(tableConfigsResponse.getSchema(), tableConfigs1.getSchema());
-    Assert.assertEquals(tableConfigsResponse.getOffline().getTableName(), tableConfigs1.getOffline().getTableName());
-    Assert.assertEquals(tableConfigsResponse.getRealtime().getTableName(), tableConfigs1.getRealtime().getTableName());
+    Assert.assertTrue(configs.containsAll(Sets.newHashSet(tableName1)));
 
     ControllerTest
         .sendDeleteRequest(TEST_INSTANCE.getControllerRequestURLBuilder().forTableConfigsDelete(tableName1));
@@ -493,11 +464,7 @@ public class TableConfigsRestletResourceTest {
     List<String> configs = JsonUtils.stringToObject(getResponse, new TypeReference<List<String>>() {
     });
     Assert.assertEquals(configs.size(), 1);
-    tableConfigsResponse = JsonUtils.stringToObject(configs.get(0), TableConfigs.class);
-    Assert.assertEquals(tableConfigsResponse.getTableName(), tableName);
-    Assert.assertEquals(tableConfigsResponse.getSchema(), tableConfigs.getSchema());
-    Assert.assertEquals(tableConfigsResponse.getOffline().getTableName(), tableConfigs.getOffline().getTableName());
-    Assert.assertNull(tableConfigsResponse.getRealtime());
+    Assert.assertTrue(configs.containsAll(Sets.newHashSet(tableName)));
 
     // update to 2
     tableConfigs = new TableConfigs(tableName, tableConfigsResponse.getSchema(), tableConfigsResponse.getOffline(),
@@ -519,11 +486,7 @@ public class TableConfigsRestletResourceTest {
     configs = JsonUtils.stringToObject(getResponse, new TypeReference<List<String>>() {
     });
     Assert.assertEquals(configs.size(), 1);
-    tableConfigsResponse = JsonUtils.stringToObject(configs.get(0), TableConfigs.class);
-    Assert.assertEquals(tableConfigsResponse.getTableName(), tableName);
-    Assert.assertEquals(tableConfigsResponse.getSchema(), tableConfigs.getSchema());
-    Assert.assertEquals(tableConfigsResponse.getOffline().getTableName(), tableConfigs.getOffline().getTableName());
-    Assert.assertEquals(tableConfigsResponse.getRealtime().getTableName(), tableConfigs.getRealtime().getTableName());
+    Assert.assertTrue(configs.containsAll(Sets.newHashSet(tableName)));
 
     // update existing config
     schema.addField(new MetricFieldSpec("newMetric", FieldSpec.DataType.LONG));


### PR DESCRIPTION
This reverts commit 2d78b358ef491da33167d3d905273c4b8c8483b3.

`GET /tableConfigs` is to return a list of names of those existing TableConfigs in cluster. So the fix in #9603 actually broke this API contract. 

`GET /tableConfigs/{tableName}` to return the table config by name 
