### PR TITLE
Handle unique query id on server

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/GrpcBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/GrpcBrokerRequestHandler.java
@@ -100,10 +100,7 @@ public class GrpcBrokerRequestHandler extends BaseBrokerRequestHandler {
     }
     if (realtimeBrokerRequest != null) {
       assert realtimeRoutingTable != null;
-      // NOTE: When both OFFLINE and REALTIME request exist, use negative request id for REALTIME to differentiate
-      //       from the OFFLINE one
-      long realtimeRequestId = offlineBrokerRequest == null ? requestId : -requestId;
-      sendRequest(realtimeRequestId, TableType.REALTIME, realtimeBrokerRequest, realtimeRoutingTable, responseMap,
+      sendRequest(requestId, TableType.REALTIME, realtimeBrokerRequest, realtimeRoutingTable, responseMap,
           requestContext.isSampledRequest());
     }
     return _streamingReduceService.reduceOnStreamResponse(originalBrokerRequest, responseMap, timeoutMs,

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/ServerQueryRequest.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/ServerQueryRequest.java
@@ -31,7 +31,9 @@ import org.apache.pinot.core.common.datatable.DataTableBuilderFactory;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.TimerContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.core.query.utils.QueryIdUtils;
 import org.apache.pinot.spi.utils.CommonConstants.Query.Request;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
 import org.apache.thrift.TDeserializer;
 import org.apache.thrift.protocol.TCompactProtocol;
@@ -51,6 +53,10 @@ public class ServerQueryRequest {
   private final List<String> _segmentsToQuery;
   private final QueryContext _queryContext;
 
+  // Request id might not be unique across brokers or for request hitting a hybrid table. To solve that we may construct
+  // a unique query id from broker id, request id and table type.
+  private final String _queryId;
+
   // Timing information for different phases of query execution
   private final TimerContext _timerContext;
 
@@ -61,6 +67,8 @@ public class ServerQueryRequest {
     _enableStreaming = false;
     _segmentsToQuery = instanceRequest.getSearchSegments();
     _queryContext = getQueryContext(instanceRequest.getQuery().getPinotQuery());
+    _queryId = QueryIdUtils.getQueryId(_brokerId, _requestId,
+        TableNameBuilder.getTableTypeFromTableName(_queryContext.getTableName()));
     _timerContext = new TimerContext(_queryContext.getTableName(), serverMetrics, queryArrivalTimeMs);
   }
 
@@ -88,6 +96,8 @@ public class ServerQueryRequest {
       throw new UnsupportedOperationException("Unsupported payloadType: " + payloadType);
     }
     _queryContext = getQueryContext(brokerRequest.getPinotQuery());
+    _queryId = QueryIdUtils.getQueryId(_brokerId, _requestId,
+        TableNameBuilder.getTableTypeFromTableName(_queryContext.getTableName()));
     _timerContext = new TimerContext(_queryContext.getTableName(), serverMetrics, queryArrivalTimeMs);
   }
 
@@ -98,14 +108,6 @@ public class ServerQueryRequest {
           "Null handling cannot be enabled for data table version smaller than 4");
     }
     return queryContext;
-  }
-
-  /**
-   * As _requestId can be same across brokers, so use _brokerId and _requestId together to uniquely identify a query.
-   * @return unique query Id within a pinot cluster.
-   */
-  public String getQueryId() {
-    return _brokerId + "_" + _requestId;
   }
 
   public long getRequestId() {
@@ -134,6 +136,10 @@ public class ServerQueryRequest {
 
   public QueryContext getQueryContext() {
     return _queryContext;
+  }
+
+  public String getQueryId() {
+    return _queryId;
   }
 
   public TimerContext getTimerContext() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/utils/QueryIdUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/utils/QueryIdUtils.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.utils;
+
+import org.apache.pinot.spi.config.table.TableType;
+
+
+/**
+ * Utils to generate and manage the unique query id within a cluster.
+ * Request id might not be unique across brokers or for request hitting a hybrid table. To generate a unique query id
+ * within a cluster, we want to combine the broker id, request id and table type.
+ */
+public class QueryIdUtils {
+  private QueryIdUtils() {
+  }
+
+  private static final String OFFLINE_SUFFIX = "_O";
+  private static final String REALTIME_SUFFIX = "_R";
+
+  public static String getQueryId(String brokerId, long requestId, TableType tableType) {
+    return brokerId + "_" + requestId + (tableType == TableType.OFFLINE ? OFFLINE_SUFFIX : REALTIME_SUFFIX);
+  }
+
+  public static boolean hasTypeSuffix(String queryId) {
+    return queryId.endsWith(OFFLINE_SUFFIX) || queryId.endsWith(REALTIME_SUFFIX);
+  }
+
+  public static String withOfflineSuffix(String queryId) {
+    return queryId + OFFLINE_SUFFIX;
+  }
+
+  public static String withRealtimeSuffix(String queryId) {
+    return queryId + REALTIME_SUFFIX;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
@@ -106,14 +106,10 @@ public class QueryRouter {
     }
     if (realtimeBrokerRequest != null) {
       assert realtimeRoutingTable != null;
-      // NOTE: When both OFFLINE and REALTIME request exist, use negative request id for REALTIME to differentiate
-      //       from the OFFLINE one
-      long realtimeRequestId = offlineBrokerRequest == null ? requestId : -requestId;
       for (Map.Entry<ServerInstance, List<String>> entry : realtimeRoutingTable.entrySet()) {
         ServerRoutingInstance serverRoutingInstance =
             entry.getKey().toServerRoutingInstance(TableType.REALTIME, preferTls);
-        InstanceRequest instanceRequest =
-            getInstanceRequest(realtimeRequestId, realtimeBrokerRequest, entry.getValue());
+        InstanceRequest instanceRequest = getInstanceRequest(requestId, realtimeBrokerRequest, entry.getValue());
         requestMap.put(serverRoutingInstance, instanceRequest);
       }
     }
@@ -181,8 +177,7 @@ public class QueryRouter {
 
   void receiveDataTable(ServerRoutingInstance serverRoutingInstance, DataTable dataTable, int responseSize,
       int deserializationTimeMs) {
-    // NOTE: For hybrid table, REALTIME request has negative request id
-    long requestId = Math.abs(Long.parseLong(dataTable.getMetadata().get(MetadataKey.REQUEST_ID.getName())));
+    long requestId = Long.parseLong(dataTable.getMetadata().get(MetadataKey.REQUEST_ID.getName()));
     AsyncQueryResponse asyncQueryResponse = _asyncQueryResponseMap.get(requestId);
 
     // Query future might be null if the query is already done (maybe due to failure)


### PR DESCRIPTION
This PR reverts the special broker negative request id handling for hybrid table introduced in #9443, and move the handling to the server side to avoid all the logging change related to the request id.
On the server side, the unique query id is generated as `<brokerId>_<requestId>_(O|R)` for OFFLINE and REALTIME request correspondingly. For backward compatibility, when trying to cancel a query without the type suffix, server will look up both OFFLINE and REALTIME query and cancel both of them.
One behavior change is that when looking up the running queries on the server side, the returned query ids will have type suffix. This should be desired to reflect the actual queries running.