### PR TITLE
[multistage] support like and regex like

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -27,6 +27,7 @@ import java.util.Base64;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.utils.RegexpPatternConverterUtils;
 import org.apache.pinot.spi.annotations.ScalarFunction;
 
 
@@ -724,5 +725,17 @@ public class StringFunctions {
   public static String regexpReplace(String inputStr, String matchStr, String replaceStr, int matchStartPos,
       int occurence) {
     return regexpReplace(inputStr, matchStr, replaceStr, matchStartPos, occurence, "");
+  }
+
+  @ScalarFunction
+  public static boolean regexpLike(String inputStr, String regexPatternStr) {
+    Pattern pattern = Pattern.compile(regexPatternStr, Pattern.UNICODE_CASE | Pattern.CASE_INSENSITIVE);
+    return pattern.matcher(inputStr).find();
+  }
+
+  @ScalarFunction
+  public static boolean like(String inputStr, String likePatternStr) {
+    String regexPatternStr = RegexpPatternConverterUtils.likeToRegexpLike(likePatternStr);
+    return regexpLike(inputStr, regexPatternStr);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/FilterOperand.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/FilterOperand.java
@@ -107,12 +107,27 @@ public abstract class FilterOperand extends TransformOperand {
           }
         };
       default:
-        throw new UnsupportedOperationException("Unsupported filter predicate: " + functionCall.getFunctionName());
+        return new BooleanFunction(functionCall, dataSchema);
     }
   }
 
   @Override
   public abstract Boolean apply(Object[] row);
+
+  private static class BooleanFunction extends FilterOperand {
+    private final FunctionOperand _func;
+
+    public BooleanFunction(RexExpression.FunctionCall functionCall, DataSchema dataSchema) {
+      FunctionOperand func = (FunctionOperand) TransformOperand.toTransformOperand(functionCall, dataSchema);
+      Preconditions.checkState(func.getResultType() == DataSchema.ColumnDataType.BOOLEAN);
+      _func = func;
+    }
+
+    @Override
+    public Boolean apply(Object[] row) {
+      return (Boolean) _func.apply(row);
+    }
+  }
 
   private static class BooleanInputRef extends FilterOperand {
     private final RexExpression.InputRef _inputRef;

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryTestSet.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryTestSet.java
@@ -211,9 +211,6 @@ public class QueryTestSet {
         new Object[]{"SELECT col1 FROM a WHERE col2 LIKE '%o%'"},
         new Object[]{"SELECT a.col1, b.col1 FROM a JOIN b ON a.col3 = b.col3 WHERE a.col2 LIKE b.col1"},
         new Object[]{"SELECT a.col1 LIKE b.col1 FROM a JOIN b ON a.col3 = b.col3"},
-        new Object[]{"SELECT col1 FROM a WHERE REGEXP_LIKE(col2, '.*o.*')"},
-        new Object[]{"SELECT a.col1, b.col1 FROM a JOIN b ON a.col3 = b.col3 WHERE REGEXP_LIKE(a.col2, b.col1)"},
-        new Object[]{"SELECT REGEXP_LIKE(a.col1, b.col1) FROM a JOIN b ON a.col3 = b.col3"},
     };
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryTestSet.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryTestSet.java
@@ -206,6 +206,14 @@ public class QueryTestSet {
         new Object[]{"SELECT COALESCE(SUM(col3), 0) FROM a WHERE col1 = 'foo' AND col1 = 'bar'"},
         new Object[]{"SELECT SUM(CAST(col3 AS INTEGER)) FROM a HAVING MIN(col3) BETWEEN 1 AND 0"},
         new Object[]{"SELECT col1, COUNT(col3) FROM a GROUP BY col1 HAVING SUM(col3) > 40 AND SUM(col3) < 30"},
+
+        // Test functions
+        new Object[]{"SELECT col1 FROM a WHERE col2 LIKE '%o%'"},
+        new Object[]{"SELECT a.col1, b.col1 FROM a JOIN b ON a.col3 = b.col3 WHERE a.col2 LIKE b.col1"},
+        new Object[]{"SELECT a.col1 LIKE b.col1 FROM a JOIN b ON a.col3 = b.col3"},
+        new Object[]{"SELECT col1 FROM a WHERE REGEXP_LIKE(col2, '.*o.*')"},
+        new Object[]{"SELECT a.col1, b.col1 FROM a JOIN b ON a.col3 = b.col3 WHERE REGEXP_LIKE(a.col2, b.col1)"},
+        new Object[]{"SELECT REGEXP_LIKE(a.col1, b.col1) FROM a JOIN b ON a.col3 = b.col3"},
     };
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
@@ -161,6 +161,10 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
         //   - on intermediate stage
         new Object[]{"SELECT dateTrunc('DAY', round(a.ts, b.ts)) FROM a JOIN b "
             + "ON a.col1 = b.col1 AND a.col2 = b.col2", 15},
+
+        // test regexpLike
+        new Object[]{"SELECT a.col1, b.col1 FROM a JOIN b ON a.col3 = b.col3 WHERE regexpLike(a.col2, b.col1)", 9},
+        new Object[]{"SELECT regexpLike(a.col1, b.col1) FROM a JOIN b ON a.col3 = b.col3", 39},
     };
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
@@ -118,6 +118,8 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
         return Double.compare((Double) l, ((Number) r).doubleValue());
       } else if (l instanceof String) {
         return ((String) l).compareTo((String) r);
+      } else if (l instanceof Boolean) {
+        return ((Boolean) l).compareTo((Boolean) r);
       } else {
         throw new RuntimeException("non supported type " + l.getClass());
       }


### PR DESCRIPTION
Support like and regex like

This prompts another v1 legacy issue, not all function evaluation has predicate/transform/scalar version - needs a clean up to make sure any function that can be evaluated at predicate time / transform time, should ALWAYS be usable at reduce/multistage.