### PR TITLE
Fix server request sent delay to be non-negative

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
@@ -128,7 +128,7 @@ public class AsyncQueryResponse implements QueryResponse {
     _responseMap.get(serverRoutingInstance).markRequestSubmitted();
   }
 
-  void markRequestSent(ServerRoutingInstance serverRoutingInstance, long requestSentLatencyMs) {
+  void markRequestSent(ServerRoutingInstance serverRoutingInstance, int requestSentLatencyMs) {
     _responseMap.get(serverRoutingInstance).markRequestSent(requestSentLatencyMs);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
@@ -201,7 +201,7 @@ public class ServerChannels {
         ServerRoutingInstance serverRoutingInstance, byte[] requestBytes) {
       long startTimeMs = System.currentTimeMillis();
       _channel.writeAndFlush(Unpooled.wrappedBuffer(requestBytes)).addListener(f -> {
-        long requestSentLatencyMs = System.currentTimeMillis() - startTimeMs;
+        int requestSentLatencyMs = (int) (System.currentTimeMillis() - startTimeMs);
         _brokerMetrics.addTimedTableValue(rawTableName, BrokerTimer.NETTY_CONNECTION_SEND_REQUEST_LATENCY,
             requestSentLatencyMs, TimeUnit.MILLISECONDS);
         asyncQueryResponse.markRequestSent(serverRoutingInstance, requestSentLatencyMs);

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerResponse.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerResponse.java
@@ -30,7 +30,7 @@ import org.apache.pinot.common.datatable.DataTable;
 public class ServerResponse {
   private final long _startTimeMs;
   private volatile long _submitRequestTimeMs;
-  private volatile long _requestSentLatencyMs;
+  private volatile int _requestSentLatencyMs = -1;
   private volatile long _receiveDataTableTimeMs;
   private volatile DataTable _dataTable;
   private volatile int _responseSize;
@@ -54,11 +54,7 @@ public class ServerResponse {
   }
 
   public int getRequestSentDelayMs() {
-    if (_requestSentLatencyMs != 0) {
-      return (int) _requestSentLatencyMs;
-    } else {
-      return -1;
-    }
+    return _requestSentLatencyMs;
   }
 
   public int getResponseDelayMs() {
@@ -93,7 +89,7 @@ public class ServerResponse {
     _submitRequestTimeMs = System.currentTimeMillis();
   }
 
-  void markRequestSent(long requestSentLatencyMs) {
+  void markRequestSent(int requestSentLatencyMs) {
     _requestSentLatencyMs = requestSentLatencyMs;
   }
 


### PR DESCRIPTION
Currently when server request sent delay is 0 (very common case), it will be logged as -1. This PR fixes this behavior and only log -1 when the request is not successfully sent.