### PR TITLE
bugfix: Add missing BIG_DECIMAL support for GenericRow serde

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowDeserializer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowDeserializer.java
@@ -23,6 +23,7 @@ import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.ByteArray;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -97,6 +98,15 @@ public class GenericRowDeserializer {
             _dataBuffer.copyTo(offset, bytes);
             offset += numBytes;
             buffer.putValue(fieldName, bytes);
+            break;
+          }
+          case BIG_DECIMAL: {
+            int numBytes = _dataBuffer.getInt(offset);
+            offset += Integer.BYTES;
+            byte[] bigDecimalBytes = new byte[numBytes];
+            _dataBuffer.copyTo(offset, bigDecimalBytes);
+            offset += numBytes;
+            buffer.putValue(fieldName, BigDecimalUtils.deserialize(bigDecimalBytes));
             break;
           }
           default:
@@ -231,6 +241,24 @@ public class GenericRowDeserializer {
             byte[] bytes2 = new byte[numBytes2];
             _dataBuffer.copyTo(offset2, bytes2);
             int result = ByteArray.compare(bytes1, bytes2);
+            if (result != 0) {
+              return result;
+            }
+            offset1 += numBytes1;
+            offset2 += numBytes2;
+            break;
+          }
+          case BIG_DECIMAL: {
+            int numBytes1 = _dataBuffer.getInt(offset1);
+            offset1 += Integer.BYTES;
+            byte[] bigDecimalBytes1 = new byte[numBytes1];
+            _dataBuffer.copyTo(offset1, bigDecimalBytes1);
+            int numBytes2 = _dataBuffer.getInt(offset2);
+            offset2 += Integer.BYTES;
+            byte[] bigDecimalBytes2 = new byte[numBytes2];
+            _dataBuffer.copyTo(offset2, bigDecimalBytes2);
+            int result =
+                BigDecimalUtils.deserialize(bigDecimalBytes1).compareTo(BigDecimalUtils.deserialize(bigDecimalBytes2));
             if (result != 0) {
               return result;
             }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowDeserializer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowDeserializer.java
@@ -82,6 +82,15 @@ public class GenericRowDeserializer {
             buffer.putValue(fieldName, _dataBuffer.getDouble(offset));
             offset += Double.BYTES;
             break;
+          case BIG_DECIMAL: {
+            int numBytes = _dataBuffer.getInt(offset);
+            offset += Integer.BYTES;
+            byte[] bigDecimalBytes = new byte[numBytes];
+            _dataBuffer.copyTo(offset, bigDecimalBytes);
+            offset += numBytes;
+            buffer.putValue(fieldName, BigDecimalUtils.deserialize(bigDecimalBytes));
+            break;
+          }
           case STRING: {
             int numBytes = _dataBuffer.getInt(offset);
             offset += Integer.BYTES;
@@ -98,15 +107,6 @@ public class GenericRowDeserializer {
             _dataBuffer.copyTo(offset, bytes);
             offset += numBytes;
             buffer.putValue(fieldName, bytes);
-            break;
-          }
-          case BIG_DECIMAL: {
-            int numBytes = _dataBuffer.getInt(offset);
-            offset += Integer.BYTES;
-            byte[] bigDecimalBytes = new byte[numBytes];
-            _dataBuffer.copyTo(offset, bigDecimalBytes);
-            offset += numBytes;
-            buffer.putValue(fieldName, BigDecimalUtils.deserialize(bigDecimalBytes));
             break;
           }
           default:

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowSerializer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowSerializer.java
@@ -98,6 +98,11 @@ public class GenericRowSerializer {
           case DOUBLE:
             numBytes += Double.BYTES;
             break;
+          case BIG_DECIMAL:
+            byte[] bigDecimalBytes = BigDecimalUtils.serialize((BigDecimal) value);
+            numBytes += Integer.BYTES + bigDecimalBytes.length;
+            _objectBytes[i] = bigDecimalBytes;
+            break;
           case STRING:
             byte[] stringBytes = ((String) value).getBytes(UTF_8);
             numBytes += Integer.BYTES + stringBytes.length;
@@ -105,11 +110,6 @@ public class GenericRowSerializer {
             break;
           case BYTES:
             numBytes += Integer.BYTES + ((byte[]) value).length;
-            break;
-          case BIG_DECIMAL:
-            byte[] bigDecimalBytes = BigDecimalUtils.serialize((BigDecimal) value);
-            numBytes += Integer.BYTES + bigDecimalBytes.length;
-            _objectBytes[i] = bigDecimalBytes;
             break;
           default:
             throw new IllegalStateException("Unsupported SV stored type: " + _storedTypes[i]);
@@ -183,8 +183,8 @@ public class GenericRowSerializer {
           case DOUBLE:
             byteBuffer.putDouble((double) value);
             break;
-          case STRING:
           case BIG_DECIMAL:
+          case STRING:
             byte[] objectBytes = (byte[]) _objectBytes[i];
             byteBuffer.putInt(objectBytes.length);
             byteBuffer.put(objectBytes);

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowSerDeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowSerDeTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.segment.processing.genericrow;
 
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -27,6 +28,7 @@ import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -45,7 +47,8 @@ public class GenericRowSerDeTest {
         new DimensionFieldSpec("longSV", DataType.LONG, true), new DimensionFieldSpec("floatSV", DataType.FLOAT, true),
         new DimensionFieldSpec("doubleSV", DataType.DOUBLE, true),
         new DimensionFieldSpec("stringSV", DataType.STRING, true),
-        new DimensionFieldSpec("bytesSV", DataType.BYTES, true), new DimensionFieldSpec("nullSV", DataType.INT, true),
+        new DimensionFieldSpec("bytesSV", DataType.BYTES, true),
+        new MetricFieldSpec("bigDecimalSV", DataType.BIG_DECIMAL), new DimensionFieldSpec("nullSV", DataType.INT, true),
         new DimensionFieldSpec("intMV", DataType.INT, false), new DimensionFieldSpec("longMV", DataType.LONG, false),
         new DimensionFieldSpec("floatMV", DataType.FLOAT, false),
         new DimensionFieldSpec("doubleMV", DataType.DOUBLE, false),
@@ -59,6 +62,7 @@ public class GenericRowSerDeTest {
     _row.putValue("doubleSV", 123.0);
     _row.putValue("stringSV", "123");
     _row.putValue("bytesSV", new byte[]{1, 2, 3});
+    _row.putValue("bigDecimalSV", new BigDecimal("122333"));
     _row.putDefaultNullValue("nullSV", Integer.MAX_VALUE);
     _row.putValue("intMV", new Object[]{123, 456});
     _row.putValue("longMV", new Object[]{123L, 456L});


### PR DESCRIPTION
This PR adds missing BIG_DECIMAL support for GenericRow serialization/deserialization. It was missed when the new data type was introduce.
