### PR TITLE
Improve star-tree to use star-node when the predicate matches all the non-star nodes

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/operator/StarTreeFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/operator/StarTreeFilterOperator.java
@@ -21,13 +21,12 @@ package org.apache.pinot.core.startree.operator;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Queue;
@@ -89,21 +88,6 @@ public class StarTreeFilterOperator extends BaseFilterOperator {
   private static final String EXPLAIN_NAME = "FILTER_STARTREE_INDEX";
 
   /**
-   * Helper class to wrap the information needed when traversing the star tree.
-   */
-  private static class SearchEntry {
-    final StarTreeNode _starTreeNode;
-    final Set<String> _remainingPredicateColumns;
-    final Set<String> _remainingGroupByColumns;
-
-    SearchEntry(StarTreeNode starTreeNode, Set<String> remainingPredicateColumns, Set<String> remainingGroupByColumns) {
-      _starTreeNode = starTreeNode;
-      _remainingPredicateColumns = remainingPredicateColumns;
-      _remainingGroupByColumns = remainingGroupByColumns;
-    }
-  }
-
-  /**
    * Helper class to wrap the result from traversing the star tree.
    */
   private static class StarTreeResult {
@@ -132,14 +116,7 @@ public class StarTreeFilterOperator extends BaseFilterOperator {
     _queryContext = queryContext;
     _starTreeV2 = starTreeV2;
     _predicateEvaluatorsMap = predicateEvaluatorsMap;
-
-    if (groupByColumns != null) {
-      _groupByColumns = new HashSet<>(groupByColumns);
-      // Remove columns with predicates from group-by columns because we won't use star node for that column
-      _groupByColumns.removeAll(_predicateEvaluatorsMap.keySet());
-    } else {
-      _groupByColumns = Collections.emptySet();
-    }
+    _groupByColumns = groupByColumns != null ? groupByColumns : Collections.emptySet();
   }
 
   @Override
@@ -197,14 +174,14 @@ public class StarTreeFilterOperator extends BaseFilterOperator {
         int numPredicateEvaluators = predicateEvaluators.size();
         if (numPredicateEvaluators == 1) {
           // Single predicate evaluator
-          childFilterOperators
-              .add(FilterOperatorUtils.getLeafFilterOperator(predicateEvaluators.get(0), dataSource, numDocs));
+          childFilterOperators.add(
+              FilterOperatorUtils.getLeafFilterOperator(predicateEvaluators.get(0), dataSource, numDocs));
         } else {
           // Predicate evaluators conjoined with OR
           List<BaseFilterOperator> orChildFilterOperators = new ArrayList<>(numPredicateEvaluators);
           for (PredicateEvaluator childPredicateEvaluator : predicateEvaluators) {
-            orChildFilterOperators
-                .add(FilterOperatorUtils.getLeafFilterOperator(childPredicateEvaluator, dataSource, numDocs));
+            orChildFilterOperators.add(
+                FilterOperatorUtils.getLeafFilterOperator(childPredicateEvaluator, dataSource, numDocs));
           }
           childFilterOperators.add(
               FilterOperatorUtils.getOrFilterOperator(_queryContext, orChildFilterOperators, numDocs));
@@ -223,108 +200,150 @@ public class StarTreeFilterOperator extends BaseFilterOperator {
   @Nullable
   private StarTreeResult traverseStarTree() {
     MutableRoaringBitmap matchingDocIds = new MutableRoaringBitmap();
-    Set<String> remainingPredicateColumns = new HashSet<>();
-    Map<String, IntSet> matchingDictIdsMap = new HashMap<>();
+    Set<String> globalRemainingPredicateColumns = Collections.emptySet();
+    boolean globalRemainingPredicateColumnsSet = false;
 
     StarTree starTree = _starTreeV2.getStarTree();
     List<String> dimensionNames = starTree.getDimensionNames();
     StarTreeNode starTreeRootNode = starTree.getRoot();
 
     // Use BFS to traverse the star tree
-    Queue<SearchEntry> queue = new ArrayDeque<>();
-    queue.add(new SearchEntry(starTreeRootNode, _predicateEvaluatorsMap.keySet(), _groupByColumns));
-    SearchEntry searchEntry;
-    while ((searchEntry = queue.poll()) != null) {
-      StarTreeNode starTreeNode = searchEntry._starTreeNode;
+    Queue<StarTreeNode> queue = new LinkedList<>();
+    queue.add(starTreeRootNode);
+    // Use null to mark the end of the current level
+    queue.add(null);
+    int childDimensionId = 0;
+    Set<String> remainingPredicateColumns = new HashSet<>(_predicateEvaluatorsMap.keySet());
+    Set<String> remainingGroupByColumns = new HashSet<>(_groupByColumns);
+    IntSet matchingDictIds = null;
+    while (!queue.isEmpty()) {
+      StarTreeNode starTreeNode = queue.poll();
+      if (starTreeNode == null) {
+        // Previous level finished
+        if (queue.isEmpty()) {
+          break;
+        } else {
+          String childDimension = dimensionNames.get(childDimensionId++);
+          remainingPredicateColumns.remove(childDimension);
+          remainingGroupByColumns.remove(childDimension);
+          matchingDictIds = null;
+          queue.add(null);
+          continue;
+        }
+      }
 
       // If all predicate columns and group-by columns are matched, we can use aggregated document
-      if (searchEntry._remainingPredicateColumns.isEmpty() && searchEntry._remainingGroupByColumns.isEmpty()) {
+      if (remainingPredicateColumns.isEmpty() && remainingGroupByColumns.isEmpty()) {
         matchingDocIds.add(starTreeNode.getAggregatedDocId());
-      } else {
-        // For leaf node, because we haven't exhausted all predicate columns and group-by columns, we cannot use
-        // the aggregated document. Add the range of documents for this node to the bitmap, and keep track of the
-        // remaining predicate columns for this node
-        if (starTreeNode.isLeaf()) {
-          matchingDocIds.add((long) starTreeNode.getStartDocId(), starTreeNode.getEndDocId());
-          remainingPredicateColumns.addAll(searchEntry._remainingPredicateColumns);
-        } else {
-          // For non-leaf node, proceed to next level
-          String nextDimension = dimensionNames.get(starTreeNode.getChildDimensionId());
+        continue;
+      }
 
-          // If we have predicates on next level, add matching nodes to the queue
-          if (searchEntry._remainingPredicateColumns.contains(nextDimension)) {
-            Set<String> newRemainingPredicateColumns = new HashSet<>(searchEntry._remainingPredicateColumns);
-            newRemainingPredicateColumns.remove(nextDimension);
+      // For leaf node, because we haven't exhausted all predicate columns and group-by columns, we cannot use
+      // the aggregated document. Add the range of documents for this node to the bitmap, and keep track of the
+      // remaining predicate columns for this node
+      if (starTreeNode.isLeaf()) {
+        matchingDocIds.add((long) starTreeNode.getStartDocId(), starTreeNode.getEndDocId());
+        // Only set the global remaining predicate columns once because we traverse the tree with BFS, so the first leaf
+        // node always have all the
+        if (!globalRemainingPredicateColumnsSet) {
+          if (!remainingPredicateColumns.isEmpty()) {
+            globalRemainingPredicateColumns = new HashSet<>(remainingPredicateColumns);
+          }
+          globalRemainingPredicateColumnsSet = true;
+        }
+        continue;
+      }
 
-            IntSet matchingDictIds = matchingDictIdsMap.get(nextDimension);
-            if (matchingDictIds == null) {
-              matchingDictIds = getMatchingDictIds(_predicateEvaluatorsMap.get(nextDimension));
+      // For non-leaf node, proceed to next level
+      String childDimension = dimensionNames.get(childDimensionId);
 
-              // If no matching dictionary id found, directly return null
-              if (matchingDictIds.isEmpty()) {
-                return null;
-              }
+      // Only read star-node when the dimension is not in the global remaining predicate columns or group-by columns
+      // because we cannot use star-node in such cases
+      StarTreeNode starNode = null;
+      if (!globalRemainingPredicateColumns.contains(childDimension) && !remainingGroupByColumns.contains(
+          childDimension)) {
+        starNode = starTreeNode.getChildForDimensionValue(StarTreeNode.ALL);
+      }
 
-              matchingDictIdsMap.put(nextDimension, matchingDictIds);
-            }
+      if (remainingPredicateColumns.contains(childDimension)) {
+        // Have predicates on the next level, add matching nodes to the queue
 
-            int numMatchingDictIds = matchingDictIds.size();
-            int numChildren = starTreeNode.getNumChildren();
+        // Calculate the matching dictionary ids for the child dimension
+        if (matchingDictIds == null) {
+          matchingDictIds = getMatchingDictIds(_predicateEvaluatorsMap.get(childDimension));
+        }
 
-            // If number of matching dictionary ids is large, use scan instead of binary search
-            if (numMatchingDictIds * USE_SCAN_TO_TRAVERSE_NODES_THRESHOLD > numChildren) {
-              Iterator<? extends StarTreeNode> childrenIterator = starTreeNode.getChildrenIterator();
-              while (childrenIterator.hasNext()) {
-                StarTreeNode childNode = childrenIterator.next();
-                if (matchingDictIds.contains(childNode.getDimensionValue())) {
-                  queue.add(
-                      new SearchEntry(childNode, newRemainingPredicateColumns, searchEntry._remainingGroupByColumns));
-                }
-              }
-            } else {
-              IntIterator iterator = matchingDictIds.iterator();
-              while (iterator.hasNext()) {
-                int matchingDictId = iterator.nextInt();
-                StarTreeNode childNode = starTreeNode.getChildForDimensionValue(matchingDictId);
+        // If no matching dictionary id found, directly return null
+        if (matchingDictIds.isEmpty()) {
+          return null;
+        }
 
-                // Child node might be null because the matching dictionary id might not exist under this branch
-                if (childNode != null) {
-                  queue.add(
-                      new SearchEntry(childNode, newRemainingPredicateColumns, searchEntry._remainingGroupByColumns));
-                }
-              }
-            }
-          } else {
-            // If we don't have predicate or group-by on next level, use star node if exists
-            Set<String> newRemainingGroupByColumns;
-            if (!searchEntry._remainingGroupByColumns.contains(nextDimension)) {
-              StarTreeNode starNode = starTreeNode.getChildForDimensionValue(StarTreeNode.ALL);
-              if (starNode != null) {
-                queue.add(new SearchEntry(starNode, searchEntry._remainingPredicateColumns,
-                    searchEntry._remainingGroupByColumns));
-                continue;
-              }
-              newRemainingGroupByColumns = searchEntry._remainingGroupByColumns;
-            } else {
-              newRemainingGroupByColumns = new HashSet<>(searchEntry._remainingGroupByColumns);
-              newRemainingGroupByColumns.remove(nextDimension);
-            }
+        int numMatchingDictIds = matchingDictIds.size();
+        int numChildren = starTreeNode.getNumChildren();
 
-            // Add all non-star nodes to the queue if cannot use star node
-            Iterator<? extends StarTreeNode> childrenIterator = starTreeNode.getChildrenIterator();
+        // If number of matching dictionary ids is large, use scan instead of binary search
+        if (numMatchingDictIds * USE_SCAN_TO_TRAVERSE_NODES_THRESHOLD > numChildren) {
+          Iterator<? extends StarTreeNode> childrenIterator = starTreeNode.getChildrenIterator();
+
+          // When the star-node exists, and the number of matching dictionary ids is more than or equal to the
+          // number of non-star child nodes, check if all the child nodes match the predicate, and use the
+          // star-node if so
+          if (starNode != null && numMatchingDictIds >= numChildren - 1) {
+            List<StarTreeNode> matchingChildNodes = new ArrayList<>();
             while (childrenIterator.hasNext()) {
               StarTreeNode childNode = childrenIterator.next();
-              if (childNode.getDimensionValue() != StarTreeNode.ALL) {
-                queue.add(
-                    new SearchEntry(childNode, searchEntry._remainingPredicateColumns, newRemainingGroupByColumns));
+              if (matchingDictIds.contains(childNode.getDimensionValue())) {
+                matchingChildNodes.add(childNode);
               }
+            }
+            if (matchingChildNodes.size() == numChildren - 1) {
+              // All the child nodes (except for the star-node) match the predicate, use the star-node
+              queue.add(starNode);
+            } else {
+              // Some child nodes do not match the predicate, use the matching child nodes
+              queue.addAll(matchingChildNodes);
+            }
+          } else {
+            // Cannot use the star-node, use the matching child nodes
+            while (childrenIterator.hasNext()) {
+              StarTreeNode childNode = childrenIterator.next();
+              if (matchingDictIds.contains(childNode.getDimensionValue())) {
+                queue.add(childNode);
+              }
+            }
+          }
+        } else {
+          IntIterator iterator = matchingDictIds.iterator();
+          while (iterator.hasNext()) {
+            int matchingDictId = iterator.nextInt();
+            StarTreeNode childNode = starTreeNode.getChildForDimensionValue(matchingDictId);
+
+            // Child node might be null because the matching dictionary id might not exist under this branch
+            if (childNode != null) {
+              queue.add(childNode);
+            }
+          }
+        }
+      } else {
+        // No predicate on the next level
+
+        if (starNode != null) {
+          // Star-node exists, use it
+          queue.add(starNode);
+        } else {
+          // Star-node does not exist or cannot be used, add all non-star nodes to the queue
+          Iterator<? extends StarTreeNode> childrenIterator = starTreeNode.getChildrenIterator();
+          while (childrenIterator.hasNext()) {
+            StarTreeNode childNode = childrenIterator.next();
+            if (childNode.getDimensionValue() != StarTreeNode.ALL) {
+              queue.add(childNode);
             }
           }
         }
       }
     }
 
-    return new StarTreeResult(matchingDocIds, remainingPredicateColumns);
+    return new StarTreeResult(matchingDocIds, globalRemainingPredicateColumns);
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/startree/StarTreeQueryGenerator.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/startree/StarTreeQueryGenerator.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 
 
@@ -38,6 +39,8 @@ public class StarTreeQueryGenerator {
   private static final String SELECT = "SELECT ";
   private static final String FROM = " FROM ";
   private static final String WHERE = " WHERE ";
+  private static final String GROUP_BY = " GROUP BY ";
+  private static final String ORDER_BY = " ORDER BY ";
   private static final String BETWEEN = " BETWEEN ";
   private static final String IN = " IN ";
   private static final String NOT_IN = " NOT IN ";
@@ -209,10 +212,11 @@ public class StarTreeQueryGenerator {
   }
 
   /**
-   * Randomly generate the WHERE clause of the query, may return empty string.
+   * Randomly generate the WHERE clause of the query, may return {@code null}.
    *
    * @return all predicates.
    */
+  @Nullable
   private String generatePredicates() {
     int numPredicates = RANDOM.nextInt(MAX_NUM_PREDICATES + 1);
     if (numPredicates == 0) {
@@ -244,9 +248,9 @@ public class StarTreeQueryGenerator {
   }
 
   /**
-   * Randomly generate the GROUP BY and ORDER BY section with the same columns, may return empty string.
+   * Randomly generate the group-by columns, may return {@code null}.
    */
-  private String generateGroupBysAndOrderBys() {
+  private String generateGroupByColumns() {
     int numColumns = RANDOM.nextInt(MAX_NUM_GROUP_BYS + 1);
     if (numColumns == 0) {
       return null;
@@ -254,8 +258,7 @@ public class StarTreeQueryGenerator {
 
     List<String> dimensions = new ArrayList<>(_singleValueDimensionColumns);
     Collections.shuffle(dimensions);
-    String columns = StringUtils.join(dimensions.subList(0, numColumns), ", ");
-    return String.format(" GROUP BY %s ORDER BY %s", columns, columns);
+    return StringUtils.join(dimensions.subList(0, numColumns), ", ");
   }
 
   /**
@@ -263,17 +266,21 @@ public class StarTreeQueryGenerator {
    *
    * @param aggregations aggregation section.
    * @param predicates predicate section.
-   * @param groupBysAndOrderBys group by and order by section.
+   * @param groupByColumns group-by columns.
    * @return overall query.
    */
-  private String buildQuery(String aggregations, String predicates, String groupBysAndOrderBys) {
-    StringBuilder stringBuilder = new StringBuilder(SELECT).append(aggregations);
+  private String buildQuery(String aggregations, String predicates, String groupByColumns) {
+    StringBuilder stringBuilder = new StringBuilder(SELECT);
+    if (groupByColumns != null) {
+      stringBuilder.append(groupByColumns).append(", ");
+    }
+    stringBuilder.append(aggregations);
     stringBuilder.append(FROM).append(_tableName);
     if (predicates != null) {
       stringBuilder.append(predicates);
     }
-    if (groupBysAndOrderBys != null) {
-      stringBuilder.append(groupBysAndOrderBys);
+    if (groupByColumns != null) {
+      stringBuilder.append(GROUP_BY).append(groupByColumns).append(ORDER_BY).append(groupByColumns);
     }
     return stringBuilder.toString();
   }
@@ -284,6 +291,6 @@ public class StarTreeQueryGenerator {
    * @return Return the generated query.
    */
   public String nextQuery() {
-    return buildQuery(generateAggregations(), generatePredicates(), generateGroupBysAndOrderBys());
+    return buildQuery(generateAggregations(), generatePredicates(), generateGroupByColumns());
   }
 }


### PR DESCRIPTION
When the predicate matches all the non-star nodes under a branch, we can use the star-node if it exists and the dimension is not included in the remaining predicate and group-by

Also performed the following enhancements:
- Reduce the garbage generated when traversing the star-tree by not cloning the sets
- Do not cache the per-level matching dict ids, leverage BFS and only keep one copy
- Simplify the star-tree cluster integration test to only keep one table and use query option to switch between using/not using star-tree

With all the enhancements, when running 10000 auto-generated queries in the cluster integration test, the overall time is reduced by around 50%