### PR TITLE
add FetchPlanner interface to decide what column index to prefetch

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/prefetch/DefaultFetchPlanner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/prefetch/DefaultFetchPlanner.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.prefetch;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+import javax.annotation.Nullable;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.predicate.Predicate;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.segment.spi.FetchContext;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.store.ColumnIndexType;
+
+
+public class DefaultFetchPlanner implements FetchPlanner {
+  /**
+   * Get BloomFilter for columns present in EQ and IN predicates.
+   */
+  @Nullable
+  @Override
+  public FetchContext planFetchForPruning(IndexSegment indexSegment, QueryContext queryContext,
+      @Nullable Map<Predicate.Type, Set<String>> requestedColumns) {
+    if (requestedColumns == null) {
+      return null;
+    }
+    Set<String> columns = new HashSet<>();
+    Set<String> requested = requestedColumns.get(Predicate.Type.EQ);
+    if (CollectionUtils.isNotEmpty(requested)) {
+      columns.addAll(requested);
+    }
+    requested = requestedColumns.get(Predicate.Type.IN);
+    if (CollectionUtils.isNotEmpty(requested)) {
+      columns.addAll(requested);
+    }
+    if (columns.isEmpty()) {
+      return null;
+    }
+    Map<String, List<ColumnIndexType>> columnToIndexList = new HashMap<>();
+    for (String column : columns) {
+      DataSource dataSource = indexSegment.getDataSource(column);
+      if (dataSource.getBloomFilter() != null) {
+        columnToIndexList.put(column, Collections.singletonList(ColumnIndexType.BLOOM_FILTER));
+      }
+    }
+    if (columnToIndexList.isEmpty()) {
+      return null;
+    }
+    return new FetchContext(UUID.randomUUID(), indexSegment.getSegmentName(), columnToIndexList);
+  }
+
+  /**
+   * Fetch all kinds of index for columns accessed by the query.
+   */
+  @Override
+  public FetchContext planFetchForProcessing(IndexSegment indexSegment, QueryContext queryContext) {
+    return new FetchContext(UUID.randomUUID(), indexSegment.getSegmentName(), getColumns(indexSegment, queryContext));
+  }
+
+  private Set<String> getColumns(IndexSegment indexSegment, QueryContext queryContext) {
+    List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
+    if (selectExpressions.size() == 1 && "*".equals(selectExpressions.get(0).getIdentifier())) {
+      return indexSegment.getPhysicalColumnNames();
+    } else {
+      return queryContext.getColumns();
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/prefetch/FetchPlanner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/prefetch/FetchPlanner.java
@@ -18,10 +18,6 @@
  */
 package org.apache.pinot.core.query.prefetch;
 
-import java.util.Map;
-import java.util.Set;
-import javax.annotation.Nullable;
-import org.apache.pinot.common.request.context.predicate.Predicate;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.FetchContext;
 import org.apache.pinot.segment.spi.IndexSegment;
@@ -41,12 +37,9 @@ public interface FetchPlanner {
    *
    * @param indexSegment     segment to be pruned.
    * @param queryContext     context extracted from the query.
-   * @param requestedColumns columns requested for pruning, with predicate type they are from.
    * @return context to guide data prefetching.
    */
-  @Nullable
-  FetchContext planFetchForPruning(IndexSegment indexSegment, QueryContext queryContext,
-      @Nullable Map<Predicate.Type, Set<String>> requestedColumns);
+  FetchContext planFetchForPruning(IndexSegment indexSegment, QueryContext queryContext);
 
   /**
    * Plan what index data to prefetch to process it. For example, one can fetch all types of index for columns tracked

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/prefetch/FetchPlanner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/prefetch/FetchPlanner.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.prefetch;
+
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.request.context.predicate.Predicate;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.segment.spi.FetchContext;
+import org.apache.pinot.segment.spi.IndexSegment;
+
+
+/**
+ * FetchPlanner decides what data to prefetch for the given query to reduce the time waiting for data, which might be
+ * read from some slow storage backend, to reduce the query latency. Although the plan methods take in an indexSegment
+ * object, it should mainly access the segment metadata like what types of index it has, as the index data may not be
+ * available, but leaving this to the implementations to check and handle per their own need.
+ * TODO: this interface and the dependent classes like QueryContext should be moved to query-spi pkg, yet to be added.
+ */
+public interface FetchPlanner {
+  /**
+   * Plan what index data to prefetch to help prune the segment before processing it. For example, one can fetch bloom
+   * filter to prune the segment based on the column values in query predicates like IN or EQ.
+   *
+   * @param indexSegment     segment to be pruned.
+   * @param queryContext     context extracted from the query.
+   * @param requestedColumns columns requested for pruning, with predicate type they are from.
+   * @return context to guide data prefetching.
+   */
+  @Nullable
+  FetchContext planFetchForPruning(IndexSegment indexSegment, QueryContext queryContext,
+      @Nullable Map<Predicate.Type, Set<String>> requestedColumns);
+
+  /**
+   * Plan what index data to prefetch to process it. For example, one can fetch all types of index for columns tracked
+   * in QueryContext.
+   *
+   * @param indexSegment segment to be processed.
+   * @param queryContext context extracted from the query.
+   * @return context to guide data prefetching.
+   */
+  FetchContext planFetchForProcessing(IndexSegment indexSegment, QueryContext queryContext);
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/prefetch/FetchPlannerRegistry.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/prefetch/FetchPlannerRegistry.java
@@ -33,6 +33,12 @@ public class FetchPlannerRegistry {
         Optional.ofNullable(REGISTRATION.get()).orElseGet(DefaultFetchPlanner::new);
   }
 
+  /**
+   * Provides a custom planner to replace the default one when server starts up.
+   *
+   * @param planner a custom fetch planner overwriting the default one.
+   * @return true, if this is called for the first time.
+   */
   public static boolean registerPlanner(FetchPlanner planner) {
     return REGISTRATION.compareAndSet(null, planner);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/prefetch/FetchPlannerRegistry.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/prefetch/FetchPlannerRegistry.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.prefetch;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+
+public class FetchPlannerRegistry {
+  private static final AtomicReference<FetchPlanner> REGISTRATION = new AtomicReference<>(null);
+
+  private FetchPlannerRegistry() {
+  }
+
+  private static final class Holder {
+    public static final FetchPlanner PLANNER =
+        Optional.ofNullable(REGISTRATION.get()).orElseGet(DefaultFetchPlanner::new);
+  }
+
+  public static boolean registerPlanner(FetchPlanner planner) {
+    return REGISTRATION.compareAndSet(null, planner);
+  }
+
+  public static FetchPlanner getPlanner() {
+    return Holder.PLANNER;
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/prefetch/DefaultFetchPlannerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/prefetch/DefaultFetchPlannerTest.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.prefetch;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.request.context.predicate.Predicate;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.segment.spi.FetchContext;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.index.reader.BloomFilterReader;
+import org.apache.pinot.segment.spi.store.ColumnIndexType;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+
+public class DefaultFetchPlannerTest {
+  @Test
+  public void testPlanFetchForProcessing() {
+    DefaultFetchPlanner planner = new DefaultFetchPlanner();
+    IndexSegment indexSegment = mock(IndexSegment.class);
+    when(indexSegment.getSegmentName()).thenReturn("s0");
+    when(indexSegment.getColumnNames()).thenReturn(ImmutableSet.of("c0", "c1", "c2"));
+    String query = "SELECT COUNT(*) FROM testTable WHERE c0 = 0 OR (c1 < 10 AND c2 IN (1, 2))";
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
+    FetchContext fetchContext = planner.planFetchForProcessing(indexSegment, queryContext);
+    assertEquals(fetchContext.getSegmentName(), "s0");
+    Map<String, List<ColumnIndexType>> columns = fetchContext.getColumnToIndexList();
+    assertEquals(columns.size(), 3);
+    // null means to get all index types created for the column.
+    assertNull(columns.get("c0"));
+    assertNull(columns.get("c1"));
+    assertNull(columns.get("c2"));
+  }
+
+  @Test
+  public void testPlanFetchForPruning() {
+    DefaultFetchPlanner planner = new DefaultFetchPlanner();
+    IndexSegment indexSegment = mock(IndexSegment.class);
+    when(indexSegment.getSegmentName()).thenReturn("s0");
+    when(indexSegment.getColumnNames()).thenReturn(ImmutableSet.of("c0", "c1", "c2"));
+    String query = "SELECT COUNT(*) FROM testTable WHERE c0 = 0 OR (c1 < 10 AND c2 IN (1, 2))";
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
+    // No requested columns in EQ or IN predicate.
+    FetchContext fetchContext = planner.planFetchForPruning(indexSegment, queryContext, null);
+    assertNull(fetchContext);
+
+    // no Bloomfilter for those columns.
+    DataSource ds0 = mock(DataSource.class);
+    when(indexSegment.getDataSource("c0")).thenReturn(ds0);
+    when(ds0.getBloomFilter()).thenReturn(null);
+    DataSource ds2 = mock(DataSource.class);
+    when(indexSegment.getDataSource("c2")).thenReturn(ds2);
+    when(ds2.getBloomFilter()).thenReturn(null);
+    fetchContext = planner.planFetchForPruning(indexSegment, queryContext,
+        ImmutableMap.of(Predicate.Type.EQ, ImmutableSet.of("c0"), Predicate.Type.IN, ImmutableSet.of("c2")));
+    assertNull(fetchContext);
+
+    // Add Bloomfilter for column c0.
+    BloomFilterReader bfReader = mock(BloomFilterReader.class);
+    when(ds0.getBloomFilter()).thenReturn(bfReader);
+    fetchContext = planner.planFetchForPruning(indexSegment, queryContext,
+        ImmutableMap.of(Predicate.Type.EQ, ImmutableSet.of("c0"), Predicate.Type.IN, ImmutableSet.of("c2")));
+    assertNotNull(fetchContext);
+    assertEquals(fetchContext.getSegmentName(), "s0");
+    Map<String, List<ColumnIndexType>> columns = fetchContext.getColumnToIndexList();
+    assertEquals(columns.size(), 1);
+    List<ColumnIndexType> idxTypes = columns.get("c0");
+    assertEquals(idxTypes.size(), 1);
+    assertEquals(idxTypes.get(0), ColumnIndexType.BLOOM_FILTER);
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/FetchContext.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/FetchContext.java
@@ -83,4 +83,8 @@ public class FetchContext {
   public Map<String, List<ColumnIndexType>> getColumnToIndexList() {
     return _columnToIndexList;
   }
+
+  public boolean isEmpty() {
+    return _columnToIndexList.isEmpty();
+  }
 }


### PR DESCRIPTION
This PR adds FetchPlanner interface to encapsulate implementation details about how to decide what column index to prefetch during server side segment pruning and query planning steps. The default implementation has kept the current decision logic. 