### PR TITLE
[Work In Progress] Avoid setting result column types to STRING when resultset is empty.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ResultsBlockUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ResultsBlockUtils.java
@@ -53,17 +53,8 @@ public class ResultsBlockUtils {
   }
 
   private static SelectionResultsBlock buildEmptySelectionQueryResults(QueryContext queryContext) {
-    List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
-    int numSelectExpressions = selectExpressions.size();
-    String[] columnNames = new String[numSelectExpressions];
-    for (int i = 0; i < numSelectExpressions; i++) {
-      columnNames[i] = selectExpressions.get(i).toString();
-    }
-    ColumnDataType[] columnDataTypes = new ColumnDataType[numSelectExpressions];
-    // NOTE: Use STRING column data type as default for selection query
-    Arrays.fill(columnDataTypes, ColumnDataType.STRING);
-    DataSchema dataSchema = new DataSchema(columnNames, columnDataTypes);
-    return new SelectionResultsBlock(dataSchema, Collections.emptyList());
+    // return result block with empty DataSchema and empty rows.
+    return new SelectionResultsBlock(new DataSchema(new String[]{}, new ColumnDataType[]{}), Collections.emptyList());
   }
 
   private static AggregationResultsBlock buildEmptyAggregationQueryResults(QueryContext queryContext) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -350,7 +350,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
     // query results. If for some reason the table doesn't contain any segments (for example when all the segments of
     // a table were deleted), then we will generate empty result that does not contain column datatypes in result
     // metadata.
-    IndexSegment firstSegment = numTotalSegments > 0 ? indexSegments.get(0): null;
+    IndexSegment firstSegment = numTotalSegments > 0 ? indexSegments.get(0) : null;
     SegmentPrunerStatistics prunerStats = new SegmentPrunerStatistics();
     List<IndexSegment> selectedSegments = _segmentPrunerService.prune(indexSegments, queryContext, prunerStats);
     segmentPruneTimer.stopAndRecord();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -490,7 +490,8 @@ public class SelectionOperatorUtils {
 
     DataSchema resultDataSchema = dataSchema;
     Map<String, Integer> columnNameToIndexMap = null;
-    if (dataSchema.getColumnNames().length != selectionColumns.size()) {
+    String[] dataSchemaColumnNames = dataSchema.getColumnNames();
+    if (dataSchemaColumnNames.length > 0 && dataSchemaColumnNames.length != selectionColumns.size()) {
       // Create updated data schema since one column can be selected multiple times.
       columnNameToIndexMap = new HashMap<>(dataSchema.getColumnNames().length);
       String[] columnNames = dataSchema.getColumnNames();

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/blocks/results/ResultsBlockUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/blocks/results/ResultsBlockUtilsTest.java
@@ -37,8 +37,8 @@ public class ResultsBlockUtilsTest {
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable WHERE foo = 'bar'");
     DataTable dataTable = ResultsBlockUtils.buildEmptyQueryResults(queryContext).getDataTable(queryContext);
     DataSchema dataSchema = dataTable.getDataSchema();
-    assertEquals(dataSchema.getColumnNames(), new String[]{"*"});
-    assertEquals(dataSchema.getColumnDataTypes(), new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING});
+    assertEquals(dataSchema.getColumnNames(), new String[]{});
+    assertEquals(dataSchema.getColumnDataTypes(), new DataSchema.ColumnDataType[]{});
     assertEquals(dataTable.getNumberOfRows(), 0);
 
     // Aggregation

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
@@ -1612,9 +1612,13 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result4.add(new Object[]{"DOC_ID_SET", 6, 5});
     result4.add(new Object[]{"FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:noIndexCol1 = '8')",
         7, 6});
-    result4.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS,
+    result4.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
         ExplainPlanRows.PLAN_START_IDS});
-    result4.add(new Object[]{"ALL_SEGMENTS_PRUNED_ON_SERVER", 3, 2});
+    result4.add(new Object[]{"SELECT(selectList:noIndexCol1, invertedIndexCol3)", 3, 2});
+    result4.add(new Object[]{"TRANSFORM_PASSTHROUGH(invertedIndexCol3, noIndexCol1)", 4, 3});
+    result4.add(new Object[]{"PROJECT(invertedIndexCol3, noIndexCol1)", 5, 4});
+    result4.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result4.add(new Object[]{"FILTER_EMPTY", 7, 6});
     check(query4, new ResultTable(DATA_SCHEMA, result4));
   }
 
@@ -1773,20 +1777,22 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     List<Object[]> result1 = new ArrayList<>();
     result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result1.add(new Object[]{"COMBINE_GROUP_BY", 2, 1});
-    result1.add(new Object[]{
-        "PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
-    });
-    result1.add(new Object[]{"ALL_SEGMENTS_PRUNED_ON_SERVER", 3, 2});
-    result1.add(new Object[]{
-        "PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS, ExplainPlanRows.PLAN_START_IDS
-    });
-    result1.add(new Object[]{
-        "GROUP_BY(groupKeys:noIndexCol2, aggregations:sum(add(noIndexCol1," + "noIndexCol2)), min(noIndexCol3))", 3, 2
-    });
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+            ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"GROUP_BY(groupKeys:noIndexCol2, aggregations:sum(add(noIndexCol1,noIndexCol2)), min"
+            + "(noIndexCol3))", 3, 2});
     result1.add(new Object[]{"TRANSFORM(add(noIndexCol1,noIndexCol2), noIndexCol2, noIndexCol3)", 4, 3});
     result1.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 5, 4});
     result1.add(new Object[]{"DOC_ID_SET", 6, 5});
     result1.add(new Object[]{"FILTER_FULL_SCAN(operator:RANGE,predicate:noIndexCol1 < '3')", 7, 6});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"GROUP_BY(groupKeys:noIndexCol2, aggregations:sum(add(noIndexCol1,noIndexCol2)), min"
+            + "(noIndexCol3))", 3, 2});
+    result1.add(new Object[]{"TRANSFORM(add(noIndexCol1,noIndexCol2), noIndexCol2, noIndexCol3)", 4, 3});
+    result1.add(new Object[]{"PROJECT(noIndexCol3, noIndexCol2, noIndexCol1)", 5, 4});
+    result1.add(new Object[]{"DOC_ID_SET", 6, 5});
+    result1.add(new Object[]{"FILTER_EMPTY", 7, 6});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
   }
 
@@ -1922,7 +1928,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     List<Object[]> result8 = new ArrayList<>();
     result8.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result8.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
-    result8.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+    result8.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS,
         ExplainPlanRows.PLAN_START_IDS});
     result8.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
     result8.add(new Object[]{"FILTER_EMPTY", 4, 3});
@@ -1953,9 +1959,11 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         + "noIndexCol1 = 100 LIMIT 100";
     List<Object[]> result10 = new ArrayList<>();
     result10.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
-    result10.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+    result10.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result10.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS,
         ExplainPlanRows.PLAN_START_IDS});
-    result10.add(new Object[]{"ALL_SEGMENTS_PRUNED_ON_SERVER", 2, 1});
+    result10.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result10.add(new Object[]{"FILTER_EMPTY", 4, 3});
     check(query10, new ResultTable(DATA_SCHEMA, result10));
   }
 
@@ -2123,13 +2131,10 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     List<Object[]> result8 = new ArrayList<>();
     result8.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
     result8.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
-    result8.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+    result8.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS,
         ExplainPlanRows.PLAN_START_IDS});
     result8.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
     result8.add(new Object[]{"FILTER_EMPTY", 4, 3});
-    result8.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS,
-        ExplainPlanRows.PLAN_START_IDS});
-    result8.add(new Object[]{"ALL_SEGMENTS_PRUNED_ON_SERVER", 3, 2});
     check(query8, new ResultTable(DATA_SCHEMA, result8));
 
     // Segment 1 is pruned because 'minnie' and 'pluto' are outside the range of min-max values of the segment
@@ -2163,9 +2168,11 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
         + "invertedIndexCol3 = 'roadrunner' AND noIndexCol1 = 100 LIMIT 100";
     List<Object[]> result10 = new ArrayList<>();
     result10.add(new Object[]{"BROKER_REDUCE(limit:100)", 1, 0});
-    result10.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:4)", ExplainPlanRows.PLAN_START_IDS,
+    result10.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result10.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS,
         ExplainPlanRows.PLAN_START_IDS});
-    result10.add(new Object[]{"ALL_SEGMENTS_PRUNED_ON_SERVER", 2, 1});
+    result10.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result10.add(new Object[]{"FILTER_EMPTY", 4, 3});
     check(query10, new ResultTable(DATA_SCHEMA, result10));
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -652,11 +652,10 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     TestUtils.waitForCondition(aVoid -> {
       try {
         JsonNode testQueryResponse = postQuery(testQuery);
-        // Should not throw exception during reload
-        assertEquals(testQueryResponse.get("exceptions").size(), 0);
-        // Total docs should not change during reload
-        assertEquals(testQueryResponse.get("totalDocs").asLong(), numTotalDocs);
-        return testQueryResponse.get("resultTable").get("rows").get(0).get(0).asLong() == countStarResult;
+        // Should not throw exception during reload and total docs should not change during reload
+        return testQueryResponse.get("exceptions").size() == 0
+            && testQueryResponse.get("totalDocs").asLong() == numTotalDocs
+            && testQueryResponse.get("resultTable").get("rows").get(0).get(0).asLong() == countStarResult;
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MapTypeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MapTypeClusterIntegrationTest.java
@@ -260,19 +260,15 @@ public class MapTypeClusterIntegrationTest extends BaseClusterIntegrationTest {
     pinotResponse = postQuery(query);
     assertEquals(pinotResponse.get("exceptions").size(), 0);
 
-    // Select non-existing key with proper filter
+    // Select non-existing key with bad column name in filter
     query = "SELECT jsonExtractScalar(intKeyMapStr, '$.123', 'INT') FROM " + getTableName()
         + " WHERE jsonExtractKey(intKeyMapStr, '$.*') = \"$['123']\"";
     pinotResponse = postQuery(query);
-    assertEquals(pinotResponse.get("exceptions").size(), 0);
-    rows = pinotResponse.get("resultTable").get("rows");
-    assertEquals(rows.size(), 0);
+    assertEquals(pinotResponse.get("exceptions").size(), 1);
     query = "SELECT jsonExtractScalar(stringKeyMapStr, '$.k3', 'INT') FROM " + getTableName()
         + " WHERE jsonExtractKey(stringKeyMapStr, '$.*') = \"$['k3']\"";
     pinotResponse = postQuery(query);
-    assertEquals(pinotResponse.get("exceptions").size(), 0);
-    rows = pinotResponse.get("resultTable").get("rows");
-    assertEquals(rows.size(), 0);
+    assertEquals(pinotResponse.get("exceptions").size(), 1);
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -2822,7 +2822,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertFalse(rows.get(0).get(0).asBoolean());
   }
 
-  /** Test to make sure that query result column types are empty (see pinot github issue #9660) for empty resultset. */
+  /** Test to make sure that query result column types are set properly even when resultset is empty. */
   @Test
   public void testEmptyResult()
       throws Exception {
@@ -2832,14 +2832,15 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     int numSegmentsQueried = response.get("numSegmentsQueried").asInt();
     int numSegmentsPrunedByServer = response.get("numSegmentsPrunedByServer").asInt();
 
-    // Check to make sure that all, but one segments got pruned for this query.
+    // Check to make sure that all, but one segments got pruned for this query since we need to query at least one
+    // segment to set the result set metadata properly.
     assertEquals(numSegmentsQueried - 1, numSegmentsPrunedByServer);
 
-    // Check result column names
+    // Check result column names.
     String columnNames = response.get("resultTable").get("dataSchema").get("columnNames").toPrettyString();
     assertEquals(columnNames, "[ \"AirlineID\", \"AirTime\", \"cast(AirTime,'STRING')\", \"Carrier\" ]");
 
-    // make sure column data types are not set
+    // Make sure column data types are set properly.
     String columnDataTypes = response.get("resultTable").get("dataSchema").get("columnDataTypes").toPrettyString();
     assertEquals(columnDataTypes, "[ \"LONG\", \"INT\", \"STRING\", \"STRING\" ]");
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -2827,20 +2827,20 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   public void testEmptyResult()
       throws Exception {
     // Run a query that will return empty results
-    String query1 = "SELECT AirlineID, AirTime, Carrier FROM mytable WHERE AirlineID < 0";
+    String query1 = "SELECT AirlineID, AirTime, cast(AirTime as STRING), Carrier FROM mytable WHERE AirlineID < 0";
     JsonNode response = postQuery(query1, _brokerBaseApiUrl);
     int numSegmentsQueried = response.get("numSegmentsQueried").asInt();
     int numSegmentsPrunedByServer = response.get("numSegmentsPrunedByServer").asInt();
 
-    // Check to make sure that all segments were pruned for this query.
-    assertEquals(numSegmentsQueried, numSegmentsPrunedByServer);
+    // Check to make sure that all, but one segments got pruned for this query.
+    assertEquals(numSegmentsQueried - 1, numSegmentsPrunedByServer);
 
     // Check result column names
     String columnNames = response.get("resultTable").get("dataSchema").get("columnNames").toPrettyString();
-    assertEquals(columnNames, "[ \"AirlineID\", \"AirTime\", \"Carrier\" ]");
+    assertEquals(columnNames, "[ \"AirlineID\", \"AirTime\", \"cast(AirTime,'STRING')\", \"Carrier\" ]");
 
     // make sure column data types are not set
     String columnDataTypes = response.get("resultTable").get("dataSchema").get("columnDataTypes").toPrettyString();
-    assertEquals(columnDataTypes, "[ null, null, null ]");
+    assertEquals(columnDataTypes, "[ \"LONG\", \"INT\", \"STRING\", \"STRING\" ]");
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -1087,7 +1087,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         JsonNode queryResponse = postQuery(TEST_UPDATED_BLOOM_FILTER_QUERY);
         // Total docs should not change during reload
         assertEquals(queryResponse.get("totalDocs").asLong(), numTotalDocs);
-        return queryResponse.get("numSegmentsProcessed").asLong() == 0L;
+        return queryResponse.get("numSegmentsProcessed").asLong() == 1L;
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -2474,9 +2474,42 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     String query2 = "EXPLAIN PLAN FOR SELECT * FROM mytable WHERE FlightNum < 0";
     String response2 = postQuery(query2, _brokerBaseApiUrl).get("resultTable").toString();
 
+    System.out.println("response: " + response2);
     assertEquals(response2, "{\"dataSchema\":{\"columnNames\":[\"Operator\",\"Operator_Id\",\"Parent_Id\"],"
         + "\"columnDataTypes\":[\"STRING\",\"INT\",\"INT\"]},\"rows\":[[\"BROKER_REDUCE(limit:10)\",1,0],"
-        + "[\"PLAN_START(numSegmentsForThisPlan:12)\",-1,-1],[\"ALL_SEGMENTS_PRUNED_ON_SERVER\",2,1]]}");
+    + "[\"COMBINE_SELECT\",2,1],[\"PLAN_START(numSegmentsForThisPlan:1)\",-1,-1],[\"SELECT"
+    + "(selectList:ActualElapsedTime, AirTime, AirlineID, ArrDel15, ArrDelay, ArrDelayMinutes, ArrTime, ArrTimeBlk, "
+    + "ArrivalDelayGroups, CRSArrTime, CRSDepTime, CRSElapsedTime, CancellationCode, Cancelled, Carrier, "
+    + "CarrierDelay, DayOfWeek, DayofMonth, DaysSinceEpoch, DepDel15, DepDelay, DepDelayMinutes, DepTime, DepTimeBlk,"
+    + " DepartureDelayGroups, Dest, DestAirportID, DestAirportSeqID, DestCityMarketID, DestCityName, DestState, "
+    + "DestStateFips, DestStateName, DestWac, Distance, DistanceGroup, DivActualElapsedTime, DivAirportIDs, "
+    + "DivAirportLandings, DivAirportSeqIDs, DivAirports, DivArrDelay, DivDistance, DivLongestGTimes, DivReachedDest,"
+    + " DivTailNums, DivTotalGTimes, DivWheelsOffs, DivWheelsOns, Diverted, FirstDepTime, FlightDate, FlightNum, "
+    + "Flights, LateAircraftDelay, LongestAddGTime, Month, NASDelay, Origin, OriginAirportID, OriginAirportSeqID, "
+    + "OriginCityMarketID, OriginCityName, OriginState, OriginStateFips, OriginStateName, OriginWac, Quarter, "
+    + "RandomAirports, SecurityDelay, TailNum, TaxiIn, TaxiOut, TotalAddGTime, UniqueCarrier, WeatherDelay, "
+    + "WheelsOff, WheelsOn, Year)\",3,2],[\"TRANSFORM_PASSTHROUGH(ActualElapsedTime, AirTime, AirlineID, ArrDel15, "
+    + "ArrDelay, ArrDelayMinutes, ArrTime, ArrTimeBlk, ArrivalDelayGroups, CRSArrTime, CRSDepTime, CRSElapsedTime, "
+    + "CancellationCode, Cancelled, Carrier, CarrierDelay, DayOfWeek, DayofMonth, DaysSinceEpoch, DepDel15, DepDelay,"
+    + " DepDelayMinutes, DepTime, DepTimeBlk, DepartureDelayGroups, Dest, DestAirportID, DestAirportSeqID, "
+    + "DestCityMarketID, DestCityName, DestState, DestStateFips, DestStateName, DestWac, Distance, DistanceGroup, "
+    + "DivActualElapsedTime, DivAirportIDs, DivAirportLandings, DivAirportSeqIDs, DivAirports, DivArrDelay, "
+    + "DivDistance, DivLongestGTimes, DivReachedDest, DivTailNums, DivTotalGTimes, DivWheelsOffs, DivWheelsOns, "
+    + "Diverted, FirstDepTime, FlightDate, FlightNum, Flights, LateAircraftDelay, LongestAddGTime, Month, NASDelay, "
+    + "Origin, OriginAirportID, OriginAirportSeqID, OriginCityMarketID, OriginCityName, OriginState, OriginStateFips,"
+    + " OriginStateName, OriginWac, Quarter, RandomAirports, SecurityDelay, TailNum, TaxiIn, TaxiOut, TotalAddGTime, "
+    + "UniqueCarrier, WeatherDelay, WheelsOff, WheelsOn, Year)\",4,3],[\"PROJECT(FlightNum, Origin, Quarter, "
+    + "LateAircraftDelay, DivActualElapsedTime, DivWheelsOns, DivWheelsOffs, AirTime, ArrDel15, DivTotalGTimes, "
+    + "DepTimeBlk, DestCityMarketID, DaysSinceEpoch, DivAirportSeqIDs, DepTime, Month, CRSElapsedTime, DestStateName,"
+    + " Carrier, DestAirportID, Distance, ArrTimeBlk, DivArrDelay, SecurityDelay, LongestAddGTime, OriginWac, "
+    + "WheelsOff, DestAirportSeqID, UniqueCarrier, DivReachedDest, Diverted, ActualElapsedTime, AirlineID, "
+    + "OriginStateName, DepartureDelayGroups, DivAirportLandings, FlightDate, OriginCityName, OriginStateFips, "
+    + "OriginState, DistanceGroup, WeatherDelay, DestWac, WheelsOn, OriginAirportID, OriginCityMarketID, NASDelay, "
+    + "ArrTime, DestState, ArrivalDelayGroups, Flights, DayofMonth, RandomAirports, TotalAddGTime, CRSDepTime, "
+    + "DayOfWeek, CancellationCode, Dest, FirstDepTime, DivTailNums, DepDelayMinutes, DepDelay, TaxiIn, "
+    + "OriginAirportSeqID, DestStateFips, ArrDelay, Cancelled, DivAirportIDs, TaxiOut, CarrierDelay, DepDel15, "
+    + "DivLongestGTimes, DivAirports, DivDistance, Year, ArrDelayMinutes, CRSArrTime, TailNum, DestCityName)\",5,4],"
+    + "[\"DOC_ID_SET\",6,5],[\"FILTER_EMPTY\",7,6]]}");
   }
 
   /** Test to make sure we are properly handling string comparisons in predicates. */


### PR DESCRIPTION
The current codebase sets datatype of columns to STRING while generating an empty resultset after all segments have been pruned out (see Issue #9660 for more details). In this PR, empty result set column datatypes are not set when all segments are pruned out.
