### PR TITLE
Fix extra restlet resource test which should be stateless

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/extraresources/PinotDummyExtraRestletResource.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/extraresources/PinotDummyExtraRestletResource.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.controller.api.resources.extrapackage;
+package org.apache.pinot.controller.api.extraresources;
 
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotDummyExtraRestletResourceStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotDummyExtraRestletResourceStatelessTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.controller.api.resources;
 
-import java.util.HashMap;
 import java.util.Map;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.spi.utils.StringUtil;
@@ -34,28 +33,29 @@ import static org.testng.Assert.assertEquals;
 /**
  * Test for extra resource package registered with HTTP server
  */
-public class PinotDummyExtraRestletResourceTest {
-  private static final ControllerTest TEST_INSTANCE = ControllerTest.getInstance();
+@Test(groups = "stateless")
+public class PinotDummyExtraRestletResourceStatelessTest extends ControllerTest {
 
   @BeforeClass
   public void setUp()
       throws Exception {
-    Map<String, Object> extraProperties = new HashMap<>();
-    extraProperties.put(CONTROLLER_RESOURCE_PACKAGES, String.format("%s,%s",
-        "org.apache.pinot.controller.api.resources.extrapackage", DEFAULT_CONTROLLER_RESOURCE_PACKAGES));
-    TEST_INSTANCE.setupSharedStateAndValidate(extraProperties);
+    startZk();
+    Map<String, Object> properties = getDefaultControllerConfiguration();
+    properties.put(CONTROLLER_RESOURCE_PACKAGES,
+        DEFAULT_CONTROLLER_RESOURCE_PACKAGES + ",org.apache.pinot.controller.api.extraresources");
+    startController(properties);
   }
 
   @Test
   public void testExtraDummyResourcePackages()
       throws Exception {
-    String baseUrl = TEST_INSTANCE.getControllerBaseApiUrl();
-    String resp = ControllerTest.sendGetRequest(StringUtil.join("/", baseUrl, "testExtra"));
+    String resp = ControllerTest.sendGetRequest(StringUtil.join("/", getControllerBaseApiUrl(), "testExtra"));
     assertEquals(resp, "DummyMsg");
   }
 
   @AfterClass
   public void tearDown() {
-    TEST_INSTANCE.cleanup();
+    stopController();
+    stopZk();
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -89,12 +89,10 @@ public class ControllerTest {
   public static final String DEFAULT_TENANT = "DefaultTenant";
   public static final String LOCAL_HOST = "localhost";
   public static final int DEFAULT_CONTROLLER_PORT = 18998;
-  public static final String DEFAULT_DATA_DIR =
-      new File(FileUtils.getTempDirectoryPath(), "test-controller-data-dir" + System.currentTimeMillis())
-          .getAbsolutePath();
-  public static final String DEFAULT_LOCAL_TEMP_DIR =
-      new File(FileUtils.getTempDirectoryPath(), "test-controller-local-temp-dir" + System.currentTimeMillis())
-          .getAbsolutePath();
+  public static final String DEFAULT_DATA_DIR = new File(FileUtils.getTempDirectoryPath(),
+      "test-controller-data-dir" + System.currentTimeMillis()).getAbsolutePath();
+  public static final String DEFAULT_LOCAL_TEMP_DIR = new File(FileUtils.getTempDirectoryPath(),
+      "test-controller-local-temp-dir" + System.currentTimeMillis()).getAbsolutePath();
   public static final String BROKER_INSTANCE_ID_PREFIX = "Broker_localhost_";
   public static final String SERVER_INSTANCE_ID_PREFIX = "Server_localhost_";
   public static final String MINION_INSTANCE_ID_PREFIX = "Minion_localhost_";
@@ -657,7 +655,7 @@ public class ControllerTest {
   }
 
   public List<String> listSegments(String tableName)
-    throws IOException {
+      throws IOException {
     return listSegments(tableName, null, false);
   }
 
@@ -923,21 +921,13 @@ public class ControllerTest {
     return properties;
   }
 
-  public void startSharedTestSetup()
-      throws Exception {
-    startSharedTestSetup(Collections.emptyMap());
-  }
-
   /**
    * Initialize shared state for the TestNG default test group.
    */
-  public void startSharedTestSetup(Map<String, Object> extraProperties)
+  public void startSharedTestSetup()
       throws Exception {
     startZk();
-
-    Map<String, Object> sharedControllerConfiguration = getSharedControllerConfiguration();
-    sharedControllerConfiguration.putAll(extraProperties);
-    startController(sharedControllerConfiguration);
+    startController(getSharedControllerConfiguration());
 
     addMoreFakeBrokerInstancesToAutoJoinHelixCluster(NUM_BROKER_INSTANCES, true);
     addMoreFakeServerInstancesToAutoJoinHelixCluster(NUM_SERVER_INSTANCES, true);
@@ -962,16 +952,11 @@ public class ControllerTest {
    */
   public void setupSharedStateAndValidate()
       throws Exception {
-    setupSharedStateAndValidate(Collections.emptyMap());
-  }
-
-  public void setupSharedStateAndValidate(Map<String, Object> extraProperties)
-      throws Exception {
     if (_zookeeperInstance == null || _helixResourceManager == null) {
       // this is expected to happen only when running a single test case outside of testNG group, i.e when test
       // cases are run one at a time within IntelliJ or through maven command line. When running under a testNG
       // group, state will have already been setup by @BeforeGroups method in ControllerTestSetup.
-      startSharedTestSetup(extraProperties);
+      startSharedTestSetup();
     }
 
     // Check number of tenants


### PR DESCRIPTION
We should not set extra properties in the shared test because they are not guaranteed to be picked up.
Currently the test can pass because the extra resource is under the default path