### PR TITLE
Close Filesystem on exit with Minion Tasks

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
@@ -298,4 +298,11 @@ public class HadoopPinotFS extends BasePinotFS {
     }
     return hadoopConf;
   }
+
+  @Override
+  public void close()
+      throws IOException {
+    _hadoopFS.close();
+    super.close();
+  }
 }

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -634,6 +634,7 @@ public class S3PinotFS extends BasePinotFS {
   @Override
   public void close()
       throws IOException {
+    _s3Client.close();
     super.close();
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutor.java
@@ -179,9 +179,8 @@ public class SegmentGenerationAndPushTaskExecutor extends BaseTaskExecutor {
     try (PinotFS outputFileFS = SegmentGenerationAndPushTaskUtils.getOutputPinotFS(taskConfigs, outputSegmentDirURI)) {
       switch (BatchConfigProperties.SegmentPushType.valueOf(pushMode.toUpperCase())) {
         case TAR:
-          try {
-            SegmentPushUtils.pushSegments(spec,
-                SegmentGenerationAndPushTaskUtils.getLocalPinotFs(), Arrays.asList(outputSegmentTarURI.toString()));
+          try (PinotFS pinotFS = SegmentGenerationAndPushTaskUtils.getLocalPinotFs()) {
+            SegmentPushUtils.pushSegments(spec, pinotFS, Arrays.asList(outputSegmentTarURI.toString()));
           } catch (RetriableOperationException | AttemptsExceededException e) {
             throw new RuntimeException(e);
           }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskGenerator.java
@@ -47,7 +47,6 @@ import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
 import org.apache.pinot.spi.filesystem.PinotFS;
-import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
@@ -324,74 +323,62 @@ public class SegmentGenerationAndPushTaskGenerator extends BaseTaskGenerator {
   private List<URI> getInputFilesFromDirectory(Map<String, String> batchConfigMap, URI inputDirURI,
       Set<String> existingSegmentInputFileURIs)
       throws Exception {
-    PinotFS inputDirFS = SegmentGenerationAndPushTaskUtils.getInputPinotFS(batchConfigMap, inputDirURI);
-    boolean closeInputFSOnExit = true;
+    try (PinotFS inputDirFS = SegmentGenerationAndPushTaskUtils.getInputPinotFS(batchConfigMap, inputDirURI)) {
 
-    if (inputDirFS == null) {
-      String fileURIScheme = inputDirURI.getScheme();
-      inputDirFS = PinotFSFactory.create(fileURIScheme);
-      // We shouldn't close FileSystem cached in the factory because it can be re-used
-      closeInputFSOnExit = false;
-    }
+      String includeFileNamePattern = batchConfigMap.get(BatchConfigProperties.INCLUDE_FILE_NAME_PATTERN);
+      String excludeFileNamePattern = batchConfigMap.get(BatchConfigProperties.EXCLUDE_FILE_NAME_PATTERN);
 
-    String includeFileNamePattern = batchConfigMap.get(BatchConfigProperties.INCLUDE_FILE_NAME_PATTERN);
-    String excludeFileNamePattern = batchConfigMap.get(BatchConfigProperties.EXCLUDE_FILE_NAME_PATTERN);
-
-    //Get list of files to process
-    String[] files;
-    try {
-      files = inputDirFS.listFiles(inputDirURI, true);
-    } catch (IOException e) {
-      if (closeInputFSOnExit) {
-        inputDirFS.close();
-      }
-      LOGGER.error("Unable to list files under URI: " + inputDirURI, e);
-      return Collections.emptyList();
-    }
-    PathMatcher includeFilePathMatcher = null;
-    if (includeFileNamePattern != null) {
-      includeFilePathMatcher = FileSystems.getDefault().getPathMatcher(includeFileNamePattern);
-    }
-    PathMatcher excludeFilePathMatcher = null;
-    if (excludeFileNamePattern != null) {
-      excludeFilePathMatcher = FileSystems.getDefault().getPathMatcher(excludeFileNamePattern);
-    }
-    List<URI> inputFileURIs = new ArrayList<>();
-    for (String file : files) {
-      LOGGER.debug("Processing file: {}", file);
-      if (includeFilePathMatcher != null) {
-        if (!includeFilePathMatcher.matches(Paths.get(file))) {
-          LOGGER.debug("Exclude file {} as it's not matching includeFilePathMatcher: {}", file, includeFileNamePattern);
-          continue;
-        }
-      }
-      if (excludeFilePathMatcher != null) {
-        if (excludeFilePathMatcher.matches(Paths.get(file))) {
-          LOGGER.debug("Exclude file {} as it's matching excludeFilePathMatcher: {}", file, excludeFileNamePattern);
-          continue;
-        }
-      }
+      //Get list of files to process
+      String[] files;
       try {
-        URI inputFileURI = SegmentGenerationUtils.getFileURI(file, inputDirURI);
-        if (existingSegmentInputFileURIs.contains(inputFileURI.toString())) {
-          LOGGER.debug("Skipping already processed inputFileURI: {}", inputFileURI);
-          continue;
-        }
-        if (inputDirFS.isDirectory(inputFileURI)) {
-          LOGGER.debug("Skipping directory: {}", inputFileURI);
-          continue;
-        }
-        inputFileURIs.add(inputFileURI);
-      } catch (Exception e) {
-        LOGGER.error("Failed to construct inputFileURI for path: {}, parent directory URI: {}", file, inputDirURI, e);
-        continue;
+        files = inputDirFS.listFiles(inputDirURI, true);
+      } catch (IOException e) {
+        LOGGER.error("Unable to list files under URI: " + inputDirURI, e);
+        return Collections.emptyList();
       }
-    }
+      PathMatcher includeFilePathMatcher = null;
+      if (includeFileNamePattern != null) {
+        includeFilePathMatcher = FileSystems.getDefault().getPathMatcher(includeFileNamePattern);
+      }
+      PathMatcher excludeFilePathMatcher = null;
+      if (excludeFileNamePattern != null) {
+        excludeFilePathMatcher = FileSystems.getDefault().getPathMatcher(excludeFileNamePattern);
+      }
+      List<URI> inputFileURIs = new ArrayList<>();
+      for (String file : files) {
+        LOGGER.debug("Processing file: {}", file);
+        if (includeFilePathMatcher != null) {
+          if (!includeFilePathMatcher.matches(Paths.get(file))) {
+            LOGGER.debug("Exclude file {} as it's not matching includeFilePathMatcher: {}",
+                file, includeFileNamePattern);
+            continue;
+          }
+        }
+        if (excludeFilePathMatcher != null) {
+          if (excludeFilePathMatcher.matches(Paths.get(file))) {
+            LOGGER.debug("Exclude file {} as it's matching excludeFilePathMatcher: {}", file, excludeFileNamePattern);
+            continue;
+          }
+        }
+        try {
+          URI inputFileURI = SegmentGenerationUtils.getFileURI(file, inputDirURI);
+          if (existingSegmentInputFileURIs.contains(inputFileURI.toString())) {
+            LOGGER.debug("Skipping already processed inputFileURI: {}", inputFileURI);
+            continue;
+          }
+          if (inputDirFS.isDirectory(inputFileURI)) {
+            LOGGER.debug("Skipping directory: {}", inputFileURI);
+            continue;
+          }
+          inputFileURIs.add(inputFileURI);
+        } catch (Exception e) {
+          LOGGER.error("Failed to construct inputFileURI for path: {}, parent directory URI: {}", file, inputDirURI, e);
+          continue;
+        }
+      }
 
-    if (closeInputFSOnExit) {
-      inputDirFS.close();
+      return inputFileURIs;
     }
-    return inputFileURIs;
   }
 
   private Set<String> getExistingSegmentInputFiles(List<SegmentZKMetadata> segmentsZKMetadata) {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskUtils.java
@@ -23,7 +23,6 @@ import java.util.Map;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
 import org.apache.pinot.spi.filesystem.PinotFS;
-import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
@@ -50,7 +49,7 @@ public class SegmentGenerationAndPushTaskUtils {
       return pinotFS;
     }
     // Fallback to use the PinotFS created by Minion Server configs
-    return PinotFSFactory.create(fileURIScheme);
+    return null;
   }
 
   static PinotFS getOutputPinotFS(Map<String, String> taskConfigs, URI fileURI)
@@ -68,7 +67,7 @@ public class SegmentGenerationAndPushTaskUtils {
       return pinotFS;
     }
     // Fallback to use the PinotFS created by Minion Server configs
-    return PinotFSFactory.create(fileURIScheme);
+    return null;
   }
 
   static PinotFS getLocalPinotFs() {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskUtils.java
@@ -22,7 +22,6 @@ import java.net.URI;
 import java.util.Map;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
-import org.apache.pinot.spi.filesystem.NoClosePinotFS;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
@@ -33,8 +32,6 @@ import org.apache.pinot.spi.utils.IngestionConfigUtils;
 public class SegmentGenerationAndPushTaskUtils {
   private SegmentGenerationAndPushTaskUtils() {
   }
-
-  private static final PinotFS LOCAL_PINOT_FS = new NoClosePinotFS(new LocalPinotFS());
 
   static PinotFS getInputPinotFS(Map<String, String> taskConfigs, URI fileURI)
       throws Exception {
@@ -71,6 +68,6 @@ public class SegmentGenerationAndPushTaskUtils {
   }
 
   static PinotFS getLocalPinotFs() {
-    return LOCAL_PINOT_FS;
+    return new LocalPinotFS();
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskUtils.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
 import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
@@ -38,7 +39,7 @@ public class SegmentGenerationAndPushTaskUtils {
       throws Exception {
     String fileURIScheme = fileURI.getScheme();
     if (fileURIScheme == null) {
-      return LOCAL_PINOT_FS;
+      return new LocalPinotFS();
     }
     // Try to create PinotFS using given Input FileSystem config always
     String fsClass = taskConfigs.get(BatchConfigProperties.INPUT_FS_CLASS);
@@ -48,14 +49,14 @@ public class SegmentGenerationAndPushTaskUtils {
       pinotFS.init(fsProps);
       return pinotFS;
     }
-    return null;
+    return PinotFSFactory.createNewInstance(fileURIScheme);
   }
 
   static PinotFS getOutputPinotFS(Map<String, String> taskConfigs, URI fileURI)
       throws Exception {
     String fileURIScheme = (fileURI == null) ? null : fileURI.getScheme();
     if (fileURIScheme == null) {
-      return LOCAL_PINOT_FS;
+      return new LocalPinotFS();
     }
     // Try to create PinotFS using given Input FileSystem config always
     String fsClass = taskConfigs.get(BatchConfigProperties.OUTPUT_FS_CLASS);
@@ -65,7 +66,7 @@ public class SegmentGenerationAndPushTaskUtils {
       pinotFS.init(fsProps);
       return pinotFS;
     }
-    return null;
+    return PinotFSFactory.createNewInstance(fileURIScheme);
   }
 
   static PinotFS getLocalPinotFs() {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskUtils.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.util.Map;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
+import org.apache.pinot.spi.filesystem.NoClosePinotFS;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
@@ -33,7 +34,7 @@ public class SegmentGenerationAndPushTaskUtils {
   private SegmentGenerationAndPushTaskUtils() {
   }
 
-  private static final PinotFS LOCAL_PINOT_FS = new LocalPinotFS();
+  private static final PinotFS LOCAL_PINOT_FS = new NoClosePinotFS(new LocalPinotFS());
 
   static PinotFS getInputPinotFS(Map<String, String> taskConfigs, URI fileURI)
       throws Exception {
@@ -49,7 +50,7 @@ public class SegmentGenerationAndPushTaskUtils {
       pinotFS.init(fsProps);
       return pinotFS;
     }
-    return PinotFSFactory.createNewInstance(fileURIScheme);
+    return PinotFSFactory.create(fileURIScheme);
   }
 
   static PinotFS getOutputPinotFS(Map<String, String> taskConfigs, URI fileURI)
@@ -66,7 +67,7 @@ public class SegmentGenerationAndPushTaskUtils {
       pinotFS.init(fsProps);
       return pinotFS;
     }
-    return PinotFSFactory.createNewInstance(fileURIScheme);
+    return PinotFSFactory.create(fileURIScheme);
   }
 
   static PinotFS getLocalPinotFs() {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskUtils.java
@@ -48,7 +48,6 @@ public class SegmentGenerationAndPushTaskUtils {
       pinotFS.init(fsProps);
       return pinotFS;
     }
-    // Fallback to use the PinotFS created by Minion Server configs
     return null;
   }
 
@@ -66,7 +65,6 @@ public class SegmentGenerationAndPushTaskUtils {
       pinotFS.init(fsProps);
       return pinotFS;
     }
-    // Fallback to use the PinotFS created by Minion Server configs
     return null;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/NoClosePinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/NoClosePinotFS.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.filesystem;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.List;
+import org.apache.pinot.spi.env.PinotConfiguration;
+
+
+public class NoClosePinotFS implements PinotFS {
+  protected final PinotFS _delegate;
+
+  public NoClosePinotFS(PinotFS delegate) {
+    _delegate = delegate;
+  }
+
+  @Override
+  public void init(PinotConfiguration config) {
+    _delegate.init(config);
+  }
+
+  @Override
+  public boolean mkdir(URI uri)
+      throws IOException {
+    return _delegate.mkdir(uri);
+  }
+
+  @Override
+  public boolean delete(URI segmentUri, boolean forceDelete)
+      throws IOException {
+    return _delegate.delete(segmentUri, forceDelete);
+  }
+
+  @Override
+  public boolean move(URI srcUri, URI dstUri, boolean overwrite)
+      throws IOException {
+    return _delegate.move(srcUri, dstUri, overwrite);
+  }
+
+  @Override
+  public boolean copy(URI srcUri, URI dstUri)
+      throws IOException {
+    return _delegate.copy(srcUri, dstUri);
+  }
+
+  @Override
+  public boolean copyDir(URI srcUri, URI dstUri)
+      throws IOException {
+    return _delegate.copyDir(srcUri, dstUri);
+  }
+
+  @Override
+  public boolean exists(URI fileUri)
+      throws IOException {
+    return _delegate.exists(fileUri);
+  }
+
+  @Override
+  public long length(URI fileUri)
+      throws IOException {
+    return _delegate.length(fileUri);
+  }
+
+  @Override
+  public String[] listFiles(URI fileUri, boolean recursive)
+      throws IOException {
+    return _delegate.listFiles(fileUri, recursive);
+  }
+
+  @Override
+  public List<FileMetadata> listFilesWithMetadata(URI fileUri, boolean recursive)
+      throws IOException {
+    return _delegate.listFilesWithMetadata(fileUri, recursive);
+  }
+
+  @Override
+  public void copyToLocalFile(URI srcUri, File dstFile)
+      throws Exception {
+    _delegate.copyToLocalFile(srcUri, dstFile);
+  }
+
+  @Override
+  public void copyFromLocalDir(File srcFile, URI dstUri)
+      throws Exception {
+    _delegate.copyFromLocalDir(srcFile, dstUri);
+  }
+
+  @Override
+  public void copyFromLocalFile(File srcFile, URI dstUri)
+      throws Exception {
+    _delegate.copyFromLocalFile(srcFile, dstUri);
+  }
+
+  @Override
+  public boolean isDirectory(URI uri)
+      throws IOException {
+    return _delegate.isDirectory(uri);
+  }
+
+  @Override
+  public long lastModified(URI uri)
+      throws IOException {
+    return _delegate.lastModified(uri);
+  }
+
+  @Override
+  public boolean touch(URI uri)
+      throws IOException {
+    return _delegate.touch(uri);
+  }
+
+  @Override
+  public InputStream open(URI uri)
+      throws IOException {
+    return _delegate.open(uri);
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/NoClosePinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/NoClosePinotFS.java
@@ -29,7 +29,7 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 public class NoClosePinotFS implements PinotFS {
   protected final PinotFS _delegate;
 
-  public NoClosePinotFS(PinotFS delegate) {
+  protected NoClosePinotFS(PinotFS delegate) {
     _delegate = delegate;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFSFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFSFactory.java
@@ -39,32 +39,22 @@ public class PinotFSFactory {
   public static final String LOCAL_PINOT_FS_SCHEME = "file";
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotFSFactory.class);
   private static final String CLASS = "class";
-  private static final Map<String, PinotFSInfo> PINOT_FS_MAP = new HashMap<String, PinotFSInfo>() {
+  private static final Map<String, PinotFS> PINOT_FS_MAP = new HashMap<String, PinotFS>() {
     {
-      put(LOCAL_PINOT_FS_SCHEME, new PinotFSInfo(null, null, new LocalPinotFS()));
+      put(LOCAL_PINOT_FS_SCHEME, new NoClosePinotFS(new LocalPinotFS()));
     }
   };
 
   public static void register(String scheme, String fsClassName, PinotConfiguration fsConfiguration) {
     try {
-      PinotFS pinotFS = createPinotFSInstance(scheme, fsClassName, fsConfiguration);
-      PinotFSInfo pinotFSInfo = new PinotFSInfo(fsClassName, fsConfiguration, pinotFS);
-      PINOT_FS_MAP.put(scheme, pinotFSInfo);
+      LOGGER.info("Initializing PinotFS for scheme {}, classname {}", scheme, fsClassName);
+      PinotFS pinotFS = PluginManager.get().createInstance(fsClassName);
+      pinotFS.init(fsConfiguration);
+      PINOT_FS_MAP.put(scheme, new NoClosePinotFS(pinotFS));
     } catch (Exception e) {
       LOGGER.error("Could not instantiate file system for class {} with scheme {}", fsClassName, scheme, e);
       throw new RuntimeException(e);
     }
-  }
-
-  private static PinotFS createPinotFSInstance(String scheme, String fsClassName, PinotConfiguration fsConfiguration)
-      throws Exception {
-    LOGGER.info("Initializing PinotFS for scheme {}, classname {}", scheme, fsClassName);
-    if (fsClassName == null && scheme.equals(LOCAL_PINOT_FS_SCHEME)) {
-      return new LocalPinotFS();
-    }
-    PinotFS pinotFS = PluginManager.get().createInstance(fsClassName);
-    pinotFS.init(fsConfiguration);
-    return pinotFS;
   }
 
   public static void init(PinotConfiguration fsFactoryConfig) {
@@ -84,21 +74,9 @@ public class PinotFSFactory {
   }
 
   public static PinotFS create(String scheme) {
-    PinotFSInfo pinotFSInfo = PINOT_FS_MAP.get(scheme);
-    Preconditions.checkState(pinotFSInfo != null, "PinotFS for scheme: %s has not been initialized", scheme);
-    return pinotFSInfo.getPinotFS();
-  }
-
-  public static PinotFS createNewInstance(String scheme) {
-    PinotFSInfo pinotFSInfo = PINOT_FS_MAP.get(scheme);
-    Preconditions.checkState(pinotFSInfo != null, "PinotFS for scheme: %s has not been initialized", scheme);
-    try {
-      return createPinotFSInstance(scheme, pinotFSInfo.getClassName(), pinotFSInfo.getConf());
-    } catch (Exception e) {
-      LOGGER.error("Could not instantiate file system for class {} with scheme {}",
-          pinotFSInfo.getClassName(), scheme, e);
-      throw new RuntimeException(e);
-    }
+    PinotFS pinotFS = PINOT_FS_MAP.get(scheme);
+    Preconditions.checkState(pinotFS != null, "PinotFS for scheme: %s has not been initialized", scheme);
+    return pinotFS;
   }
 
   public static boolean isSchemeSupported(String scheme) {
@@ -107,32 +85,8 @@ public class PinotFSFactory {
 
   public static void shutdown()
       throws IOException {
-    for (PinotFSInfo pinotFSInfo : PINOT_FS_MAP.values()) {
-      pinotFSInfo.getPinotFS().close();
-    }
-  }
-
-  private static class PinotFSInfo {
-    final String _className;
-    final PinotConfiguration _conf;
-    final PinotFS _pinotFS;
-
-    public PinotFSInfo(String className, PinotConfiguration conf, PinotFS pinotFS) {
-      _className = className;
-      _conf = conf;
-      _pinotFS = pinotFS;
-    }
-
-    public String getClassName() {
-      return _className;
-    }
-
-    public PinotConfiguration getConf() {
-      return _conf;
-    }
-
-    public PinotFS getPinotFS() {
-      return _pinotFS;
+    for (PinotFS pinotFS : PINOT_FS_MAP.values()) {
+      ((NoClosePinotFS) pinotFS)._delegate.close();
     }
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSFactoryTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSFactoryTest.java
@@ -34,7 +34,8 @@ public class PinotFSFactoryTest {
   @Test
   public void testDefaultPinotFSFactory() {
     PinotFSFactory.init(new PinotConfiguration());
-    Assert.assertTrue(PinotFSFactory.create("file") instanceof LocalPinotFS);
+    NoClosePinotFS pinotFS = (NoClosePinotFS) PinotFSFactory.create("file");
+    Assert.assertTrue(pinotFS._delegate instanceof LocalPinotFS);
   }
 
   @Test
@@ -48,14 +49,15 @@ public class PinotFSFactoryTest {
     properties.put("test.region", "us-east");
     PinotFSFactory.init(new PinotConfiguration(properties));
 
-    PinotFS testPinotFS = PinotFSFactory.create("test");
-    Assert.assertTrue(testPinotFS instanceof TestPinotFS);
-    Assert.assertEquals(((TestPinotFS) testPinotFS).getInitCalled(), 1);
-    Assert.assertEquals(((TestPinotFS) testPinotFS).getConfiguration().getProperty("accessKey"), "v1");
-    Assert.assertEquals(((TestPinotFS) testPinotFS).getConfiguration().getProperty("secretKey"), "V2");
-    Assert.assertEquals(((TestPinotFS) testPinotFS).getConfiguration().getProperty("region"), "us-east");
+    NoClosePinotFS testPinotFS = (NoClosePinotFS) PinotFSFactory.create("test");
+    Assert.assertTrue(testPinotFS._delegate instanceof TestPinotFS);
+    Assert.assertEquals(((TestPinotFS) testPinotFS._delegate).getInitCalled(), 1);
+    Assert.assertEquals(((TestPinotFS) testPinotFS._delegate).getConfiguration().getProperty("accessKey"), "v1");
+    Assert.assertEquals(((TestPinotFS) testPinotFS._delegate).getConfiguration().getProperty("secretKey"), "V2");
+    Assert.assertEquals(((TestPinotFS) testPinotFS._delegate).getConfiguration().getProperty("region"), "us-east");
 
-    Assert.assertTrue(PinotFSFactory.create("file") instanceof LocalPinotFS);
+    NoClosePinotFS pinotFS = (NoClosePinotFS) PinotFSFactory.create("file");
+    Assert.assertTrue(pinotFS._delegate instanceof LocalPinotFS);
   }
 
   public static class TestPinotFS extends BasePinotFS {


### PR DESCRIPTION
When Filesystems are created outside the factory, we should ensure that they are closed on exit. This doesn't happen a lot of times in minion tasks and leads to memory leaks such as this - 
https://coder-shankar.medium.com/aws-sdk-memory-leak-63e23dcdc6f0

