### PR TITLE
Update rebalance API to return no-op when table is already balanced w/ reassignInstances

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -229,11 +229,11 @@ public class TableRebalancer {
       LOGGER.info("Table: {} is already balanced", tableNameWithType);
       if (reassignInstances) {
         if (dryRun) {
-          return new RebalanceResult(RebalanceResult.Status.DONE,
+          return new RebalanceResult(RebalanceResult.Status.NO_OP,
               "Instance reassigned in dry-run mode, table is already balanced", instancePartitionsMap,
               targetAssignment);
         } else {
-          return new RebalanceResult(RebalanceResult.Status.DONE, "Instance reassigned, table is already balanced",
+          return new RebalanceResult(RebalanceResult.Status.NO_OP, "Instance reassigned, table is already balanced",
               instancePartitionsMap, targetAssignment);
         }
       } else {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -100,7 +100,8 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setNumReplicas(NUM_REPLICAS).build();
 
     // Rebalance should fail without creating the table
-    RebalanceResult rebalanceResult = tableRebalancer.rebalance(tableConfig, new BaseConfiguration());
+    Configuration rebalanceConfig = new BaseConfiguration();
+    RebalanceResult rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.FAILED);
 
     // Create the table
@@ -115,8 +116,28 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     Map<String, Map<String, String>> oldSegmentAssignment =
         _helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields();
 
-    // Rebalance should return NO_OP status
+    // Rebalance in dry-run mode should return NO_OP status
+    rebalanceConfig = new BaseConfiguration();
     rebalanceResult = tableRebalancer.rebalance(tableConfig, new BaseConfiguration());
+    rebalanceConfig.addProperty(RebalanceConfigConstants.DRY_RUN, true);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
+
+    // Rebalance in dry-run mode with reassignInstances should return NO_OP status
+    rebalanceConfig = new BaseConfiguration();
+    rebalanceConfig.addProperty(RebalanceConfigConstants.DRY_RUN, true);
+    rebalanceConfig.addProperty(RebalanceConfigConstants.REASSIGN_INSTANCES, true);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
+
+    // Rebalance should return NO_OP status
+    rebalanceConfig = new BaseConfiguration();
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
+
+    // Rebalance with reassignInstances should return NO_OP status
+    rebalanceConfig = new BaseConfiguration();
+    rebalanceConfig.addProperty(RebalanceConfigConstants.REASSIGN_INSTANCES, true);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
 
     // All servers should be assigned to the table
@@ -139,7 +160,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     }
 
     // Rebalance in dry-run mode
-    Configuration rebalanceConfig = new BaseConfiguration();
+    rebalanceConfig = new BaseConfiguration();
     rebalanceConfig.addProperty(RebalanceConfigConstants.DRY_RUN, true);
     rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
@@ -266,7 +287,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     rebalanceConfig = new BaseConfiguration();
     rebalanceConfig.addProperty(RebalanceConfigConstants.REASSIGN_INSTANCES, true);
     rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
     assertNull(InstancePartitionsUtils.fetchInstancePartitions(_propertyStore,
         InstancePartitionsType.OFFLINE.getInstancePartitionsName(RAW_TABLE_NAME)));
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -78,6 +78,54 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     addFakeBrokerInstancesToAutoJoinHelixCluster(1, true);
   }
 
+  @Test
+  public void testRebalanceNoop() throws Exception {
+    int numServers = 3;
+    for (int i = 0; i < numServers; i++) {
+      addFakeServerInstanceToAutoJoinHelixCluster(SERVER_INSTANCE_ID_PREFIX + i, true);
+    }
+
+    TableRebalancer tableRebalancer = new TableRebalancer(_helixManager);
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setNumReplicas(NUM_REPLICAS).build();
+
+    // Create the table
+    _helixResourceManager.addTable(tableConfig);
+
+    // Add the segments
+    int numSegments = 10;
+    for (int i = 0; i < numSegments; i++) {
+      _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
+          SegmentMetadataMockUtils.mockSegmentMetadata(RAW_TABLE_NAME, SEGMENT_NAME_PREFIX + i), null);
+    }
+
+    // Table is already balanced so rebalances should all return NO_OP
+
+    // Rebalance in dry-run mode should return NO_OP status
+    Configuration rebalanceConfig = new BaseConfiguration();
+    RebalanceResult rebalanceResult = tableRebalancer.rebalance(tableConfig, new BaseConfiguration());
+    rebalanceConfig.addProperty(RebalanceConfigConstants.DRY_RUN, true);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
+
+    // Rebalance in dry-run mode with reassignInstances should return NO_OP status
+    rebalanceConfig = new BaseConfiguration();
+    rebalanceConfig.addProperty(RebalanceConfigConstants.DRY_RUN, true);
+    rebalanceConfig.addProperty(RebalanceConfigConstants.REASSIGN_INSTANCES, true);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
+
+    // Rebalance should return NO_OP status
+    rebalanceConfig = new BaseConfiguration();
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
+
+    // Rebalance with reassignInstances should return NO_OP status
+    rebalanceConfig = new BaseConfiguration();
+    rebalanceConfig.addProperty(RebalanceConfigConstants.REASSIGN_INSTANCES, true);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig);
+    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
+  }
+
   /**
    * Dropping instance from cluster requires waiting for live instance gone and removing instance related ZNodes, which
    * are not the purpose of the test, so combine different rebalance scenarios into one test:
@@ -111,34 +159,10 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     int numSegments = 10;
     for (int i = 0; i < numSegments; i++) {
       _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
-          SegmentMetadataMockUtils.mockSegmentMetadata(RAW_TABLE_NAME, SEGMENT_NAME_PREFIX + i), null);
+      SegmentMetadataMockUtils.mockSegmentMetadata(RAW_TABLE_NAME, SEGMENT_NAME_PREFIX + i), null);
     }
     Map<String, Map<String, String>> oldSegmentAssignment =
         _helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields();
-
-    // Rebalance in dry-run mode should return NO_OP status
-    rebalanceConfig = new BaseConfiguration();
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, new BaseConfiguration());
-    rebalanceConfig.addProperty(RebalanceConfigConstants.DRY_RUN, true);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
-
-    // Rebalance in dry-run mode with reassignInstances should return NO_OP status
-    rebalanceConfig = new BaseConfiguration();
-    rebalanceConfig.addProperty(RebalanceConfigConstants.DRY_RUN, true);
-    rebalanceConfig.addProperty(RebalanceConfigConstants.REASSIGN_INSTANCES, true);
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
-
-    // Rebalance should return NO_OP status
-    rebalanceConfig = new BaseConfiguration();
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
-
-    // Rebalance with reassignInstances should return NO_OP status
-    rebalanceConfig = new BaseConfiguration();
-    rebalanceConfig.addProperty(RebalanceConfigConstants.REASSIGN_INSTANCES, true);
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig);
-    assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
 
     // All servers should be assigned to the table
     Map<InstancePartitionsType, InstancePartitions> instanceAssignment = rebalanceResult.getInstanceAssignment();


### PR DESCRIPTION
For https://github.com/apache/pinot/issues/9558, I noticed that the rebalance API initially does a dry-run and short-circuits if the dry-run returns in progress or no-op here: https://github.com/apache/pinot/blob/master/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java#L681-L682. The rebalance call doesn't return no-op if the table is already rebalanced and reports done instead. This means the rebalance API will always return in progress when using `reassignInstances=true` even if the table is already balanced.

cc @antwigambrah @Jackie-Jiang 