### PR TITLE
return different error code if old version is not on master

### DIFF
--- a/compatibility-verifier/checkoutAndBuild.sh
+++ b/compatibility-verifier/checkoutAndBuild.sh
@@ -53,7 +53,8 @@ function checkOut() {
   git pull origin master 1>&2 || exit 1
   # Pull the tag list so that we can check out by tag name
   git fetch --tags 1>&2 || exit 1
-  git checkout $commitHash 1>&2 || exit 1
+  # Return different error code if old version is not on master
+  git checkout $commitHash 1>&2 || exit 22 # invalid argument error code
 
   popd
 }


### PR DESCRIPTION
Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
