### PR TITLE
AdaptiveServerSelection: Fix timer

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/adaptiveserverselector/AdaptiveServerSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/adaptiveserverselector/AdaptiveServerSelectorTest.java
@@ -279,7 +279,7 @@ public class AdaptiveServerSelectorTest {
     for (int ii = 0; ii < 10; ii++) {
       for (String server : _servers) {
         latencyMap.computeIfAbsent(server,
-            k -> new ExponentialMovingAverage(alpha, autodecayWindowMs, warmupDurationMs, avgInitializationVal));
+            k -> new ExponentialMovingAverage(alpha, autodecayWindowMs, warmupDurationMs, avgInitializationVal, null));
         latencyMap.get(server).compute(2);
 
         serverRoutingStatsManager.recordStatsUponResponseArrival(-1, server, 2);

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/ExponentialMovingAverageTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/ExponentialMovingAverageTest.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.common.utils;
 
 import java.util.Random;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -26,20 +28,21 @@ import static org.testng.Assert.assertTrue;
 
 
 public class ExponentialMovingAverageTest {
+  ScheduledExecutorService _executorService = Executors.newSingleThreadScheduledExecutor();
 
   @Test
   public void testAvgInitialization() {
-    assertEquals(new ExponentialMovingAverage(0.5, -1, 0, 1.0).getAverage(), 1.0);
-    assertEquals(new ExponentialMovingAverage(0.5, -1, 0, 0.123).getAverage(), 0.123);
-    assertEquals(new ExponentialMovingAverage(0.5, -1, 0, 88.0).getAverage(), 88.0);
-    assertEquals(new ExponentialMovingAverage(0.5, -1, 0, 0.0).getAverage(), 0.0);
+    assertEquals(new ExponentialMovingAverage(0.5, -1, 0, 1.0, _executorService).getAverage(), 1.0);
+    assertEquals(new ExponentialMovingAverage(0.5, -1, 0, 0.123, _executorService).getAverage(), 0.123);
+    assertEquals(new ExponentialMovingAverage(0.5, -1, 0, 88.0, _executorService).getAverage(), 88.0);
+    assertEquals(new ExponentialMovingAverage(0.5, -1, 0, 0.0, _executorService).getAverage(), 0.0);
   }
 
   @Test
   public void testWarmUpDuration()
       throws InterruptedException {
     // Test 1. Set warmupDurationMs to 5 seconds.
-    ExponentialMovingAverage average = new ExponentialMovingAverage(0.5, -1, 5000, 0.0);
+    ExponentialMovingAverage average = new ExponentialMovingAverage(0.5, -1, 5000, 0.0, _executorService);
     Random rand = new Random();
     for (int ii = 0; ii < 10; ii++) {
       average.compute(rand.nextDouble());
@@ -50,7 +53,7 @@ public class ExponentialMovingAverageTest {
     assertEquals(average.getAverage(), 0.5);
 
     // Test 2
-    average = new ExponentialMovingAverage(0.5, -1, 0, 0.0);
+    average = new ExponentialMovingAverage(0.5, -1, 0, 0.0, _executorService);
     average.compute(1.0);
     assertEquals(average.getAverage(), 0.5);
   }
@@ -58,7 +61,7 @@ public class ExponentialMovingAverageTest {
   @Test
   public void testAverage() {
     // Test 1.
-    ExponentialMovingAverage average = new ExponentialMovingAverage(1.0, -1, 0, 0.0);
+    ExponentialMovingAverage average = new ExponentialMovingAverage(1.0, -1, 0, 0.0, _executorService);
     assertEquals(average.getAverage(), 0.0);
     average.compute(0.5);
     assertEquals(average.getAverage(), 0.5);
@@ -68,7 +71,7 @@ public class ExponentialMovingAverageTest {
     assertEquals(average.getAverage(), 10.0);
 
     // Test 2.
-    average = new ExponentialMovingAverage(0.5, -1, 0, 0.0);
+    average = new ExponentialMovingAverage(0.5, -1, 0, 0.0, _executorService);
     assertEquals(average.getAverage(), 0.0);
     average.compute(0.1);
     assertEquals(average.getAverage(), 0.05);
@@ -78,7 +81,7 @@ public class ExponentialMovingAverageTest {
     assertEquals(average.getAverage(), 0.7625);
 
     // Test 3
-    average = new ExponentialMovingAverage(0.3, -1, 0, 0.0);
+    average = new ExponentialMovingAverage(0.3, -1, 0, 0.0, _executorService);
     assertEquals(average.getAverage(), 0.0);
     average.compute(1.0);
     assertEquals(average.getAverage(), 0.3);
@@ -92,7 +95,7 @@ public class ExponentialMovingAverageTest {
   public void testAutoDecay()
       throws InterruptedException {
     // Test 1: Test decay
-    ExponentialMovingAverage average = new ExponentialMovingAverage(0.3, 10, 0, 0.0);
+    ExponentialMovingAverage average = new ExponentialMovingAverage(0.3, 10, 0, 0.0, _executorService);
     average.compute(10.0);
     double currAvg = average.getAverage();
 
@@ -102,7 +105,7 @@ public class ExponentialMovingAverageTest {
     }
 
     // Test 2: Test no decay
-    average = new ExponentialMovingAverage(1.0, -1, 0, 0);
+    average = new ExponentialMovingAverage(1.0, -1, 0, 0, _executorService);
     average.compute(10.0);
     currAvg = average.getAverage();
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsEntry.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsEntry.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.transport.server.routing.stats;
 
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.pinot.common.utils.ExponentialMovingAverage;
 
@@ -42,14 +43,17 @@ public class ServerRoutingStatsEntry {
   private final int _hybridScoreExponent;
 
   public ServerRoutingStatsEntry(String serverInstanceId, double alphaEMA, long autoDecayWindowMsEMA,
-      long warmupDurationMsEMA, double avgInitializationValEMA, int scoreExponent) {
+      long warmupDurationMsEMA, double avgInitializationValEMA, int scoreExponent,
+      ScheduledExecutorService periodicTaskExecutor) {
     _serverInstanceId = serverInstanceId;
     _serverLock = new ReentrantReadWriteLock();
 
     _inFlighRequestsEMA =
-        new ExponentialMovingAverage(alphaEMA, autoDecayWindowMsEMA, warmupDurationMsEMA, avgInitializationValEMA);
+        new ExponentialMovingAverage(alphaEMA, autoDecayWindowMsEMA, warmupDurationMsEMA, avgInitializationValEMA,
+            periodicTaskExecutor);
     _latencyMsEMA =
-        new ExponentialMovingAverage(alphaEMA, autoDecayWindowMsEMA, warmupDurationMsEMA, avgInitializationValEMA);
+        new ExponentialMovingAverage(alphaEMA, autoDecayWindowMsEMA, warmupDurationMsEMA, avgInitializationValEMA,
+            periodicTaskExecutor);
 
     _hybridScoreExponent = scoreExponent;
   }


### PR DESCRIPTION
Label = BugFix

`ExponentialWeightedMovingAverage` class currently uses a `Timer` to periodically autoDecay the value if there are no updates. We maintain stats for each Server. So if there number of servers are too many,  the number JVM threads could blow up.

In this PR we create a ScheduledThreadPoolExecutor with just a single thread. This thread is responsible for processing all the periodic tasks. 