### PR TITLE
[multistage] partial operator chain execution

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
@@ -47,16 +47,20 @@ public final class DataBlockUtils {
   }
 
   public static MetadataBlock getErrorDataBlock(Map<Integer, String> exceptions) {
-    MetadataBlock errorBlock = new MetadataBlock();
+    MetadataBlock errorBlock = new MetadataBlock(MetadataBlock.MetadataBlockType.ERROR);
     for (Map.Entry<Integer, String> exception : exceptions.entrySet()) {
       errorBlock.addException(exception.getKey(), exception.getValue());
     }
     return errorBlock;
   }
 
-  public static MetadataBlock getEndOfStreamDataBlock(DataSchema dataSchema) {
+  public static MetadataBlock getEndOfStreamDataBlock() {
     // TODO: add query statistics metadata for the block.
-    return new MetadataBlock(dataSchema);
+    return new MetadataBlock(MetadataBlock.MetadataBlockType.EOS);
+  }
+
+  public static MetadataBlock getNoOpBlock() {
+    return new MetadataBlock(MetadataBlock.MetadataBlockType.NOOP);
   }
 
   public static BaseDataBlock getDataBlock(ByteBuffer byteBuffer)

--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/MetadataBlock.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/MetadataBlock.java
@@ -18,28 +18,118 @@
  */
 package org.apache.pinot.common.datablock;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import org.apache.pinot.common.utils.DataSchema;
 
 
 /**
- * Wrapper for row-wise data table. It stores data in row-major format.
+ * A block type to indicate some metadata about the current processing state.
+ * For the different types of metadata blocks see {@link MetadataBlockType}.
  */
 public class MetadataBlock extends BaseDataBlock {
-  private static final int VERSION = 1;
 
-  public MetadataBlock() {
-    super(0, null, new String[0], new byte[]{0}, new byte[]{0});
+  private static final ObjectMapper JSON = new ObjectMapper();
+
+  @VisibleForTesting
+  static final int VERSION = 1;
+
+  public enum MetadataBlockType {
+    /**
+     * Indicates that this block is the final block to be sent
+     * (End Of Stream) as part of an operator chain computation.
+     */
+    EOS,
+
+    /**
+     * An {@code ERROR} metadata block indicates that there was
+     * some error during computation. To retrieve the error that
+     * occurred, use {@link MetadataBlock#getExceptions()}
+     */
+    ERROR,
+
+    /**
+     * A {@code NOOP} metadata block can be sent at any point to
+     * and should be ignored by downstream - it is often used to
+     * indicate that the operator chain either has nothing to process
+     * or has processed data but is not yet ready to emit a result
+     * block.
+     */
+    NOOP;
+
+    MetadataBlockType() {
+    }
   }
 
-  public MetadataBlock(DataSchema dataSchema) {
-    super(0, dataSchema, new String[0], new byte[]{0}, new byte[]{0});
+  /**
+   * Used to serialize the contents of the metadata block conveniently and in
+   * a backwards compatible way. Use JSON because the performance of metadata block
+   * SerDe should not be a bottleneck.
+   */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @VisibleForTesting
+  static class Contents {
+
+    private String _type;
+
+    @JsonCreator
+    public Contents(@JsonProperty("type") String type) {
+      _type = type;
+    }
+
+    @JsonCreator
+    public Contents() {
+      _type = null;
+    }
+
+    public String getType() {
+      return _type;
+    }
+
+    public void setType(String type) {
+      _type = type;
+    }
+  }
+
+  private final Contents _contents;
+
+  public MetadataBlock(MetadataBlockType type) {
+    super(0, null, new String[0], new byte[]{0}, toContents(new Contents(type.name())));
+    _contents = new Contents(type.name());
+  }
+
+  private static byte[] toContents(Contents type) {
+    try {
+      return JSON.writeValueAsBytes(type);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   public MetadataBlock(ByteBuffer byteBuffer)
       throws IOException {
     super(byteBuffer);
+    if (_variableSizeDataBytes != null) {
+      _contents = JSON.readValue(_variableSizeDataBytes, Contents.class);
+    } else {
+      _contents = new Contents();
+    }
+  }
+
+  public MetadataBlockType getType() {
+    String type = _contents.getType();
+
+    // if type is null, then we're reading a legacy block where we didn't encode any
+    // data. assume that it is an EOS block if there's no exceptions and an ERROR block
+    // otherwise
+    return type == null
+        ? (getExceptions().isEmpty() ? MetadataBlockType.EOS : MetadataBlockType.ERROR)
+        : MetadataBlockType.valueOf(type);
   }
 
   @Override
@@ -49,12 +139,12 @@ public class MetadataBlock extends BaseDataBlock {
 
   @Override
   protected int getOffsetInFixedBuffer(int rowId, int colId) {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException("Metadata block uses JSON encoding for field access");
   }
 
   @Override
   protected int positionOffsetInVariableBufferAndGetLength(int rowId, int colId) {
-    throw new UnsupportedOperationException();
+    throw new UnsupportedOperationException("Metadata block uses JSON encoding for field access");
   }
 
   @Override
@@ -64,6 +154,6 @@ public class MetadataBlock extends BaseDataBlock {
 
   @Override
   public MetadataBlock toDataOnlyDataTable() {
-    return new MetadataBlock(_dataSchema);
+    throw new UnsupportedOperationException();
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/datablock/MetadataBlockTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/datablock/MetadataBlockTest.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.datablock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.pinot.common.datatable.DataTable;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+public class MetadataBlockTest {
+
+  @Test
+  public void shouldEncodeContentsAsJSON()
+      throws Exception {
+    // Given:
+    MetadataBlock.MetadataBlockType type = MetadataBlock.MetadataBlockType.EOS;
+
+    // When:
+    MetadataBlock metadataBlock = new MetadataBlock(type);
+
+    // Then:
+    byte[] expected = new ObjectMapper().writeValueAsBytes(new MetadataBlock.Contents("EOS"));
+    assertEquals(metadataBlock._variableSizeDataBytes, expected);
+  }
+
+  @Test
+  public void shouldDefaultToEosWithNoErrorsOnLegacyMetadataBlock()
+      throws IOException {
+    // Given:
+    // MetadataBlock used to be encoded without any data, we should make sure that
+    // during rollout or if server versions are mismatched that we can still handle
+    // the old format
+    OldMetadataBlock legacyBlock = new OldMetadataBlock();
+    byte[] bytes = legacyBlock.toBytes();
+
+    // When:
+    ByteBuffer buff = ByteBuffer.wrap(bytes);
+    buff.getInt(); // consume the version information before decoding
+    MetadataBlock metadataBlock = new MetadataBlock(buff);
+
+    // Then:
+    assertEquals(metadataBlock.getType(), MetadataBlock.MetadataBlockType.EOS);
+  }
+
+  @Test
+  public void shouldDefaultToErrorOnLegacyMetadataBlockWithErrors()
+      throws IOException {
+    // Given:
+    // MetadataBlock used to be encoded without any data, we should make sure that
+    // during rollout or if server versions are mismatched that we can still handle
+    // the old format
+    OldMetadataBlock legacyBlock = new OldMetadataBlock();
+    legacyBlock.addException(250, "timeout");
+    byte[] bytes = legacyBlock.toBytes();
+
+    // When:
+    ByteBuffer buff = ByteBuffer.wrap(bytes);
+    buff.getInt(); // consume the version information before decoding
+    MetadataBlock metadataBlock = new MetadataBlock(buff);
+
+    // Then:
+    assertEquals(metadataBlock.getType(), MetadataBlock.MetadataBlockType.ERROR);
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void shouldThrowExceptionWhenUsingReadMethods() {
+    // Given:
+    MetadataBlock block = new MetadataBlock(MetadataBlock.MetadataBlockType.EOS);
+
+    // When:
+    // (should through exception)
+    block.getInt(0, 0);
+  }
+
+  /**
+   * This is mostly just used as an internal serialization tool
+   */
+  private static class OldMetadataBlock extends BaseDataBlock {
+
+    public OldMetadataBlock() {
+      super(0, null, new String[0], new byte[0], new byte[0]);
+    }
+
+    @Override
+    protected int getDataBlockVersionType() {
+      return MetadataBlock.VERSION + (Type.METADATA.ordinal() << DataBlockUtils.VERSION_TYPE_SHIFT);
+    }
+
+    @Override
+    protected int getOffsetInFixedBuffer(int rowId, int colId) {
+      return 0;
+    }
+
+    @Override
+    protected int positionOffsetInVariableBufferAndGetLength(int rowId, int colId) {
+      return 0;
+    }
+
+    @Override
+    public DataTable toMetadataOnlyDataTable() {
+      return null;
+    }
+
+    @Override
+    public DataTable toDataOnlyDataTable() {
+      return null;
+    }
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTest.java
@@ -58,7 +58,6 @@ public class DataBlockTest {
 
     BaseDataBlock dataBlock = DataBlockUtils.getErrorDataBlock(originalException);
     dataBlock.addException(processingException);
-    Assert.assertNull(dataBlock.getDataSchema());
     Assert.assertEquals(dataBlock.getNumberOfRows(), 0);
 
     // Assert processing exception and original exception both matches.

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -253,7 +253,7 @@ public class QueryRunner {
           return new TransferableBlock(_baseDataBlocks.get(_currentIndex++));
         } else {
           _currentIndex = -1;
-          return new TransferableBlock(DataBlockUtils.getEndOfStreamDataBlock(_dataSchema));
+          return new TransferableBlock(DataBlockUtils.getEndOfStreamDataBlock());
         }
       }
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtils.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import org.apache.pinot.common.datablock.BaseDataBlock;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.datablock.RowDataBlock;
-import org.apache.pinot.common.utils.DataSchema;
 
 
 public final class TransferableBlockUtils {
@@ -34,8 +33,12 @@ public final class TransferableBlockUtils {
     // do not instantiate.
   }
 
-  public static TransferableBlock getEndOfStreamTransferableBlock(DataSchema dataSchema) {
-    return new TransferableBlock(DataBlockUtils.getEndOfStreamDataBlock(dataSchema));
+  public static TransferableBlock getEndOfStreamTransferableBlock() {
+    return new TransferableBlock(DataBlockUtils.getEndOfStreamDataBlock());
+  }
+
+  public static TransferableBlock getNoOpTransferableBlock() {
+    return new TransferableBlock(DataBlockUtils.getNoOpBlock());
   }
 
   public static TransferableBlock getErrorTransferableBlock(Exception e) {
@@ -48,6 +51,10 @@ public final class TransferableBlockUtils {
 
   public static boolean isEndOfStream(TransferableBlock transferableBlock) {
     return transferableBlock.isEndOfStreamBlock();
+  }
+
+  public static boolean isNoOpBlock(TransferableBlock transferableBlock) {
+    return transferableBlock.isNoOpBlock();
   }
 
   /**

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/WorkerQueryExecutor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/WorkerQueryExecutor.java
@@ -79,11 +79,15 @@ public class WorkerQueryExecutor {
     executorService.submit(new TraceRunnable() {
       @Override
       public void runJob() {
-        ThreadTimer executionThreadTimer = new ThreadTimer();
-        while (!TransferableBlockUtils.isEndOfStream(rootOperator.nextBlock())) {
-          LOGGER.debug("Result Block acquired");
+        try {
+          ThreadTimer executionThreadTimer = new ThreadTimer();
+          while (!TransferableBlockUtils.isEndOfStream(rootOperator.nextBlock())) {
+            LOGGER.debug("Result Block acquired");
+          }
+          LOGGER.info("Execution time:" + executionThreadTimer.getThreadTimeNs());
+        } catch (Exception e) {
+          LOGGER.error("Failed to execute query!", e);
         }
-        LOGGER.info("Execution time:" + executionThreadTimer.getThreadTimeNs());
       }
     });
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -25,7 +25,6 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.pinot.common.datablock.BaseDataBlock;
-import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.data.table.Key;
@@ -99,11 +98,17 @@ public class HashJoinOperator extends BaseOperator<TransferableBlock> {
 
   @Override
   protected TransferableBlock getNextBlock() {
-    // Build JOIN hash table
-    buildBroadcastHashTable();
+    if (!_isHashTableBuilt) {
+      // Build JOIN hash table
+      buildBroadcastHashTable();
+    }
+
     if (_upstreamErrorBlock != null) {
       return _upstreamErrorBlock;
+    } else if (!_isHashTableBuilt) {
+      return TransferableBlockUtils.getNoOpTransferableBlock();
     }
+
     // JOIN each left block with the right block.
     try {
       return buildJoinedDataBlock(_leftTableOperator.nextBlock());
@@ -113,54 +118,58 @@ public class HashJoinOperator extends BaseOperator<TransferableBlock> {
   }
 
   private void buildBroadcastHashTable() {
-    if (!_isHashTableBuilt) {
-      TransferableBlock rightBlock = _rightTableOperator.nextBlock();
-      while (!TransferableBlockUtils.isEndOfStream(rightBlock)) {
-        List<Object[]> container = rightBlock.getContainer();
-        // put all the rows into corresponding hash collections keyed by the key selector function.
-        for (Object[] row : container) {
-          List<Object[]> hashCollection =
-              _broadcastHashTable.computeIfAbsent(new Key(_rightKeySelector.getKey(row)), k -> new ArrayList<>());
-          hashCollection.add(row);
-        }
-        rightBlock = _rightTableOperator.nextBlock();
-      }
-      if (rightBlock.isErrorBlock()) {
-        _upstreamErrorBlock = rightBlock;
-      }
+    TransferableBlock rightBlock = _rightTableOperator.nextBlock();
+    if (rightBlock.isErrorBlock()) {
+      _upstreamErrorBlock = rightBlock;
+      return;
+    }
+
+    if (TransferableBlockUtils.isEndOfStream(rightBlock)) {
       _isHashTableBuilt = true;
+      return;
+    } else if (TransferableBlockUtils.isNoOpBlock(rightBlock)) {
+      return;
+    }
+
+    List<Object[]> container = rightBlock.getContainer();
+    // put all the rows into corresponding hash collections keyed by the key selector function.
+    for (Object[] row : container) {
+      List<Object[]> hashCollection =
+          _broadcastHashTable.computeIfAbsent(new Key(_rightKeySelector.getKey(row)), k -> new ArrayList<>());
+      hashCollection.add(row);
     }
   }
 
   private TransferableBlock buildJoinedDataBlock(TransferableBlock leftBlock)
       throws Exception {
-    if (!TransferableBlockUtils.isEndOfStream(leftBlock)) {
-      List<Object[]> rows = new ArrayList<>();
-      List<Object[]> container = leftBlock.getContainer();
-      for (Object[] leftRow : container) {
-        List<Object[]> hashCollection = _broadcastHashTable.getOrDefault(
-            new Key(_leftKeySelector.getKey(leftRow)), Collections.emptyList());
-        // If it is a left join and right table is empty, we return left rows.
-        if (hashCollection.isEmpty() && _joinType == JoinRelType.LEFT) {
-          rows.add(joinRow(leftRow, null));
-        } else {
-          // If it is other type of join.
-          for (Object[] rightRow : hashCollection) {
-            Object[] resultRow = joinRow(leftRow, rightRow);
-            if (_joinClauseEvaluators.isEmpty() || _joinClauseEvaluators.stream().allMatch(
-              evaluator -> evaluator.apply(resultRow))) {
-              rows.add(resultRow);
-            }
+    if (leftBlock.isErrorBlock()) {
+      _upstreamErrorBlock = leftBlock;
+      return _upstreamErrorBlock;
+    } else if (TransferableBlockUtils.isEndOfStream(leftBlock) || TransferableBlockUtils.isNoOpBlock(leftBlock)) {
+      return leftBlock;
+    }
+
+    List<Object[]> rows = new ArrayList<>();
+    List<Object[]> container = leftBlock.getContainer();
+    for (Object[] leftRow : container) {
+      List<Object[]> hashCollection = _broadcastHashTable.getOrDefault(
+          new Key(_leftKeySelector.getKey(leftRow)), Collections.emptyList());
+      // If it is a left join and right table is empty, we return left rows.
+      if (hashCollection.isEmpty() && _joinType == JoinRelType.LEFT) {
+        rows.add(joinRow(leftRow, null));
+      } else {
+        // If it is other type of join.
+        for (Object[] rightRow : hashCollection) {
+          Object[] resultRow = joinRow(leftRow, rightRow);
+          if (_joinClauseEvaluators.isEmpty() || _joinClauseEvaluators.stream().allMatch(
+            evaluator -> evaluator.apply(resultRow))) {
+            rows.add(resultRow);
           }
         }
       }
-      return new TransferableBlock(rows, _resultSchema, BaseDataBlock.Type.ROW);
-    } else if (leftBlock.isErrorBlock()) {
-      _upstreamErrorBlock = leftBlock;
-      return _upstreamErrorBlock;
-    } else {
-      return new TransferableBlock(DataBlockUtils.getEndOfStreamDataBlock(_resultSchema));
     }
+
+    return new TransferableBlock(rows, _resultSchema, BaseDataBlock.Type.ROW);
   }
 
   private Object[] joinRow(Object[] leftRow, @Nullable Object[] rightRow) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
@@ -61,7 +61,7 @@ public class LiteralValueOperator extends BaseOperator<TransferableBlock> {
       _isLiteralBlockReturned = true;
       return _rexLiteralBlock;
     } else {
-      return TransferableBlockUtils.getEndOfStreamTransferableBlock(_dataSchema);
+      return TransferableBlockUtils.getEndOfStreamTransferableBlock();
     }
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -114,7 +114,20 @@ public class MailboxSendOperator extends BaseOperator<TransferableBlock> {
 
   @Override
   protected TransferableBlock getNextBlock() {
-    TransferableBlock transferableBlock = _dataTableBlockBaseOperator.nextBlock();
+    TransferableBlock transferableBlock;
+    try {
+      transferableBlock = _dataTableBlockBaseOperator.nextBlock();
+    } catch (final Exception e) {
+      // ideally, MailboxSendOperator doesn't ever throw an exception because
+      // it will just get swallowed, in this scenario at least we can forward
+      // any upstream exceptions as an error  block
+      transferableBlock = TransferableBlockUtils.getErrorTransferableBlock(e);
+    }
+
+    if (TransferableBlockUtils.isNoOpBlock(transferableBlock)) {
+      return transferableBlock;
+    }
+
     boolean isEndOfStream = TransferableBlockUtils.isEndOfStream(transferableBlock);
     BaseDataBlock.Type type = transferableBlock.getType();
     try {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryConfig.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryConfig.java
@@ -22,7 +22,7 @@ package org.apache.pinot.query.service;
  * Configuration for setting up query runtime.
  */
 public class QueryConfig {
-  public static final long DEFAULT_TIMEOUT_NANO = 10_000_000_000L;
+  public static final long DEFAULT_TIMEOUT_NANO = 100_000_000_000L;
 
   public static final String KEY_OF_MAX_INBOUND_QUERY_DATA_BLOCK_SIZE_BYTES = "pinot.query.runner.max.msg.size.bytes";
   public static final int DEFAULT_MAX_INBOUND_QUERY_DATA_BLOCK_SIZE_BYTES = 16 * 1024 * 1024;

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/InMemoryMailboxServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/InMemoryMailboxServiceTest.java
@@ -95,7 +95,7 @@ public class InMemoryMailboxServiceTest {
 
   private TransferableBlock getTestTransferableBlock(int index, boolean isEndOfStream) {
     if (isEndOfStream) {
-      return new TransferableBlock(DataBlockUtils.getEndOfStreamDataBlock(TEST_DATA_SCHEMA));
+      return new TransferableBlock(DataBlockUtils.getEndOfStreamDataBlock());
     }
     List<Object[]> rows = new ArrayList<>(index);
     rows.add(new Object[]{index, "test_data"});

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
@@ -85,7 +85,7 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
     }
     Preconditions.checkNotNull(mailboxReceiveOperator);
     return QueryDispatcher.toResultTable(QueryDispatcher.reduceMailboxReceive(mailboxReceiveOperator),
-        queryPlan.getQueryResultFields()).getRows();
+        queryPlan.getQueryResultFields(), queryPlan.getQueryStageMap().get(0).getDataSchema()).getRows();
   }
 
   private List<Object[]> queryH2(String sql)

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/TransferableBlockUtilsTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/TransferableBlockUtilsTest.java
@@ -88,7 +88,7 @@ public class TransferableBlockUtilsTest {
     validateNonSplittableBlock(columnarBlock);
 
     // METADATA
-    MetadataBlock metadataBlock = new MetadataBlock();
+    MetadataBlock metadataBlock = new MetadataBlock(MetadataBlock.MetadataBlockType.EOS);
     validateNonSplittableBlock(metadataBlock);
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
@@ -56,6 +56,9 @@ public class AggregateOperatorTest {
         new AggregateOperator(_upstreamOperator, OperatorTestUtil.TEST_DATA_SCHEMA, Arrays.asList(agg),
             Arrays.asList(new RexExpression.InputRef(1)));
     TransferableBlock result = sum0GroupBy1.getNextBlock();
+    while (result.isNoOpBlock()) {
+      result = sum0GroupBy1.getNextBlock();
+    }
     List<Object[]> resultRows = result.getContainer();
     List<Object[]> expectedRows = Arrays.asList(new Object[]{"Aa", 1}, new Object[]{"BB", 5.0});
     Assert.assertEquals(resultRows.size(), expectedRows.size());

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
@@ -71,7 +71,10 @@ public class HashJoinOperatorTest {
     HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, resultSchema,
         getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses, JoinRelType.INNER);
 
-    TransferableBlock result = join.getNextBlock();
+    TransferableBlock result = join.nextBlock();
+    while (result.isNoOpBlock()) {
+      result = join.nextBlock();
+    }
     List<Object[]> resultRows = result.getContainer();
     List<Object[]> expectedRows =
         Arrays.asList(new Object[]{1, "Aa", 1, "Aa"}, new Object[]{2, "BB", 2, "BB"}, new Object[]{2, "BB", 3, "BB"},
@@ -101,7 +104,10 @@ public class HashJoinOperatorTest {
     HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, resultSchema,
         getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses, JoinRelType.INNER);
 
-    TransferableBlock result = join.getNextBlock();
+    TransferableBlock result = join.nextBlock();
+    while (result.isNoOpBlock()) {
+      result = join.nextBlock();
+    }
     List<Object[]> resultRows = result.getContainer();
     Object[] expRow = new Object[]{1, "Aa", 2, "Aa"};
     List<Object[]> expectedRows = new ArrayList<>();
@@ -127,7 +133,10 @@ public class HashJoinOperatorTest {
     HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, resultSchema,
         getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses, JoinRelType.LEFT);
 
-    TransferableBlock result = join.getNextBlock();
+    TransferableBlock result = join.nextBlock();
+    while (result.isNoOpBlock()) {
+      result = join.nextBlock();
+    }
     List<Object[]> resultRows = result.getContainer();
     List<Object[]> expectedRows = Arrays.asList(new Object[]{1, "Aa", 2, "Aa"}, new Object[]{2, "BB", null, null},
         new Object[]{3, "BB", null, null});

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
@@ -33,11 +33,11 @@ public class OperatorTestUtil {
       new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING});
 
   public static TransferableBlock getEndOfStreamRowBlock() {
-    return getEndOfStreamRowBlockWithSchema(TEST_DATA_SCHEMA);
+    return getEndOfStreamRowBlockWithSchema();
   }
 
-  public static TransferableBlock getEndOfStreamRowBlockWithSchema(DataSchema schema) {
-    return new TransferableBlock(DataBlockUtils.getEndOfStreamDataBlock(schema));
+  public static TransferableBlock getEndOfStreamRowBlockWithSchema() {
+    return new TransferableBlock(DataBlockUtils.getEndOfStreamDataBlock());
   }
 
   public static TransferableBlock getRowDataBlock(List<Object[]> rows) {


### PR DESCRIPTION
See the [design doc](https://docs.google.com/document/d/1XAMHAlhFbINvX-kK1ANlzbRz4_RkS0map4qhqs1yDtE/edit#) for a big picture view.

This is the first PR in a series of PRs to improve our execution model. It implements "partial execution" of operator chains by allowing them to return a "noop" `MetadataBlock` in the scenario where there is either no data to process or no data to output.

This PR is a non-functional change because the `WorkerQueryExecutor` doesn't actually take advantage of the partial execution ability - it just calls `operator#nextBlock` whenever it processes a noop block.

### PR Review Guide

This PR is broken into 3 functional commits, which I recommend you review in order:

1. first commit supports different types of MetadataBlocks - in the past there were two: EOS block and ERROR block and they were differentiated by the presence of the exception map. The first commit uses the variable bytes data in `BaseDataBlock` to encode a JSON object with additional metadata. It's a little hacky, but in the grand scheme of things it's very localized and allows us to have a lot of flexibility in how we use the metadata blocks going forward and maintains backwards compatibility with the existing code. Specifically, this is used to introduce a `NOOP` metadata block type that will be used to signal to the future scheduler that the task has completed the processing that it can do at the moment.
2. This pipes the noop metadata blocks up an operator chain. There are two types of operators that produce noop metadata blocks: (a) the `MailboxReceiveOperator` when it has nothing available in its mailboxes and (b) stateful operators such as Sort/HashJoin that process a single block without producing anything (they need to process all blocks before producing).
3. This commit adds testing and fixes up some things for `MetadataBlock` - specifically making sure that it is backwards compatible with the existing code.

### Testing

We don't currently have any tests for the operators in the multistage engine, so it was tough to add that into this PR. I will follow this one up with one dedicated to testing operators. 