### PR TITLE
Fix serialization exceptions for DataTypeTransformer

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatPatternSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatPatternSpec.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.spi.data;
 
+import java.io.Serializable;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.TimeZone;
@@ -33,7 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-public class DateTimeFormatPatternSpec {
+public class DateTimeFormatPatternSpec implements Serializable {
   public static final Logger LOGGER = LoggerFactory.getLogger(DateTimeFormatPatternSpec.class);
 
   public static final DateTimeZone DEFAULT_DATE_TIME_ZONE = DateTimeZone.UTC;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatSpec.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.spi.data;
 
 import com.google.common.base.Preconditions;
+import java.io.Serializable;
 import java.sql.Timestamp;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -35,7 +36,7 @@ import org.joda.time.format.ISODateTimeFormat;
 /**
  * Class to represent format from {@link DateTimeFieldSpec}
  */
-public class DateTimeFormatSpec {
+public class DateTimeFormatSpec implements Serializable {
 
   // Colon format: 'size:timeUnit:timeFormat:pattern tz(timeZone)'
   // 'pattern' applies to the 'SIMPLE_DATE_FORMAT' time format

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatUnitSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatUnitSpec.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.spi.data;
 
 import com.google.common.base.Preconditions;
+import java.io.Serializable;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.EnumUtils;
@@ -26,7 +27,7 @@ import org.joda.time.DurationFieldType;
 import org.joda.time.chrono.ISOChronology;
 
 
-public class DateTimeFormatUnitSpec {
+public class DateTimeFormatUnitSpec implements Serializable {
 
   /**
    * Time unit enum with range from MILLISECONDS to YEARS


### PR DESCRIPTION
A `DateTimeFormatSpec` field was added to `DataTypeTransformer` which makes it non-serializable in #9320 . This pr fix the issue by making `DateTimeFormatSpec` and its inner fields serializable.