### PR TITLE
check mutable segment explicitly instead of checking existence of indexDir

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -200,6 +200,11 @@ public class MutableSegmentImpl implements MutableSegment {
       public long getLatestIngestionTimestamp() {
         return _latestIngestionTimeMs;
       }
+
+      @Override
+      public boolean isMutableSegment() {
+        return true;
+      }
     };
 
     _offHeap = config.isOffHeap();

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentMetadata.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentMetadata.java
@@ -119,4 +119,8 @@ public interface SegmentMetadata {
    * @return json representation of segment metadata.
    */
   JsonNode toJson(@Nullable Set<String> columnFilter);
+
+  default boolean isMutableSegment() {
+    return false;
+  }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -367,8 +367,7 @@ public class HelixInstanceDataManager implements InstanceDataManager {
       return;
     }
 
-    File indexDir = segmentMetadata.getIndexDir();
-    if (indexDir == null) {
+    if (segmentMetadata.isMutableSegment()) {
       // Use force commit to reload consuming segment
       SegmentDataManager segmentDataManager = tableDataManager.acquireSegment(segmentName);
       if (segmentDataManager == null) {


### PR DESCRIPTION
Check if a segment is mutable segment explicitly to be more robust, as there can be cases where immutable segments do not have `File indexDir` in their SegmentMetadata, e.g. when immutable segments are kept in remote storage system.