### PR TITLE
Remove leftover file before downloading segmentTar

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -468,6 +468,13 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
 
   private void downloadSegmentFromDeepStore(String segmentName, IndexLoadingConfig indexLoadingConfig, String uri) {
     File segmentTarFile = new File(_indexDir, segmentName + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
+    if (segmentTarFile.exists()) {
+      _logger.warn(
+          "Segment tar file: {} already exists (possibly due to server restart/crash resulting in skipped cleanup). "
+              + "Deleting it before fetching again from uri: {}",
+          segmentName, uri);
+      FileUtils.deleteQuietly(segmentTarFile);
+    }
     try {
       SegmentFetcherFactory.fetchSegmentToLocal(uri, segmentTarFile);
       _logger.info("Downloaded file from {} to {}; Length of downloaded file: {}", uri, segmentTarFile,


### PR DESCRIPTION
Before this code change, if for some reason `segmentTarFile` already existed on the server (at `indexDir/tableName_REALTIME/segmentName.tar.gz`), then we would simply fail with FileAlreadyExistsException during `SegmentFetcherFactory.fetchSegmentToLocal(uri, segmentTarFile);`
The file could already exist in the scenario where server gets restarted or killed, before we get to the finally of this method, which is supposed to clean up the file. 
```
private void downloadSegmentFromDeepStore(String segmentName, IndexLoadingConfig indexLoadingConfig, String uri) {
    File segmentTarFile = new File(_indexDir, segmentName + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
    try {
      SegmentFetcherFactory.fetchSegmentToLocal(uri, segmentTarFile);
      _logger.info("Downloaded file from {} to {}; Length of downloaded file: {}", uri, segmentTarFile,
          segmentTarFile.length());
      untarAndMoveSegment(segmentName, indexLoadingConfig, segmentTarFile);
    } catch (Exception e) {
      _logger.warn("Failed to download segment {} from deep store: ", segmentName, e);
      throw new RuntimeException(e);
    } finally {
      FileUtils.deleteQuietly(segmentTarFile);
    }
  }
```

Cleaning up the file explicitly before fetching to local.