### PR TITLE
[multistage] refactor: use DataTable interface where possible (MINOR)

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/BaseDataBlock.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/BaseDataBlock.java
@@ -680,29 +680,4 @@ public abstract class BaseDataBlock implements DataTable {
     }
     return stringBuilder.toString();
   }
-
-  public enum Type {
-    ROW(0),
-    COLUMNAR(1),
-    METADATA(2);
-
-    private final int _ordinal;
-
-    Type(int ordinal) {
-      _ordinal = ordinal;
-    }
-
-    public static Type fromOrdinal(int ordinal) {
-      switch (ordinal) {
-        case 0:
-          return ROW;
-        case 1:
-          return COLUMNAR;
-        case 2:
-          return METADATA;
-        default:
-          throw new IllegalArgumentException("Invalid ordinal: " + ordinal);
-      }
-    }
-  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/BlockType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/BlockType.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.datablock;
+
+public enum BlockType {
+  ROW(0), COLUMNAR(1), METADATA(2);
+
+  private final int _ordinal;
+
+  BlockType(int ordinal) {
+    _ordinal = ordinal;
+  }
+
+  public static BlockType fromOrdinal(int ordinal) {
+    switch (ordinal) {
+      case 0:
+        return ROW;
+      case 1:
+        return COLUMNAR;
+      case 2:
+        return METADATA;
+      default:
+        throw new IllegalArgumentException("Invalid ordinal: " + ordinal);
+    }
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/ColumnarDataBlock.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/ColumnarDataBlock.java
@@ -64,7 +64,7 @@ public class ColumnarDataBlock extends BaseDataBlock {
 
   @Override
   protected int getDataBlockVersionType() {
-    return VERSION + (Type.COLUMNAR.ordinal() << DataBlockUtils.VERSION_TYPE_SHIFT);
+    return VERSION + (BlockType.COLUMNAR.ordinal() << DataBlockUtils.VERSION_TYPE_SHIFT);
   }
 
   @Override
@@ -90,6 +90,11 @@ public class ColumnarDataBlock extends BaseDataBlock {
   @Override
   public ColumnarDataBlock toDataOnlyDataTable() {
     return new ColumnarDataBlock(_numRows, _dataSchema, _stringDictionary, _fixedSizeDataBytes, _variableSizeDataBytes);
+  }
+
+  @Override
+  public BlockType getBlockType() {
+    return BlockType.COLUMNAR;
   }
 
   // TODO: add whole-column access methods.

--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.common.utils.DataSchema;
@@ -59,11 +60,11 @@ public final class DataBlockUtils {
     return new MetadataBlock(dataSchema);
   }
 
-  public static BaseDataBlock getDataBlock(ByteBuffer byteBuffer)
+  public static DataTable getDataBlock(ByteBuffer byteBuffer)
       throws IOException {
     int versionType = byteBuffer.getInt();
     int version = versionType & ((1 << VERSION_TYPE_SHIFT) - 1);
-    BaseDataBlock.Type type = BaseDataBlock.Type.fromOrdinal(versionType >> VERSION_TYPE_SHIFT);
+    BlockType type = BlockType.fromOrdinal(versionType >> VERSION_TYPE_SHIFT);
     switch (type) {
       case COLUMNAR:
         return new ColumnarDataBlock(byteBuffer);

--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/MetadataBlock.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/MetadataBlock.java
@@ -44,7 +44,7 @@ public class MetadataBlock extends BaseDataBlock {
 
   @Override
   public int getDataBlockVersionType() {
-    return VERSION + (Type.METADATA.ordinal() << DataBlockUtils.VERSION_TYPE_SHIFT);
+    return VERSION + (BlockType.METADATA.ordinal() << DataBlockUtils.VERSION_TYPE_SHIFT);
   }
 
   @Override
@@ -65,5 +65,10 @@ public class MetadataBlock extends BaseDataBlock {
   @Override
   public MetadataBlock toDataOnlyDataTable() {
     return new MetadataBlock(_dataSchema);
+  }
+
+  @Override
+  public BlockType getBlockType() {
+    return BlockType.METADATA;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/RowDataBlock.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/RowDataBlock.java
@@ -57,7 +57,7 @@ public class RowDataBlock extends BaseDataBlock {
 
   @Override
   protected int getDataBlockVersionType() {
-    return VERSION + (Type.ROW.ordinal() << DataBlockUtils.VERSION_TYPE_SHIFT);
+    return VERSION + (BlockType.ROW.ordinal() << DataBlockUtils.VERSION_TYPE_SHIFT);
   }
 
   @Override
@@ -83,6 +83,11 @@ public class RowDataBlock extends BaseDataBlock {
   @Override
   public RowDataBlock toDataOnlyDataTable() {
     return new RowDataBlock(_numRows, _dataSchema, _stringDictionary, _fixedSizeDataBytes, _variableSizeDataBytes);
+  }
+
+  @Override
+  public BlockType getBlockType() {
+    return BlockType.ROW;
   }
 
   public int getRowSizeInBytes() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/datatable/BaseDataTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datatable/BaseDataTable.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.datablock.BlockType;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
@@ -265,6 +266,11 @@ public abstract class BaseDataTable implements DataTable {
     int offset = rowId * _rowSizeInBytes + _columnOffsets[colId];
     _variableSizeData.position(_fixedSizeData.getInt(offset));
     return _fixedSizeData.getInt(offset + 4);
+  }
+
+  @Override
+  public BlockType getBlockType() {
+    return BlockType.ROW;
   }
 
   @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTable.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.datablock.BlockType;
 import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.spi.utils.ByteArray;
@@ -88,6 +89,8 @@ public interface DataTable {
   DataTable toMetadataOnlyDataTable();
 
   DataTable toDataOnlyDataTable();
+
+  BlockType getBlockType();
 
   class CustomObject {
     public static final int NULL_TYPE_VALUE = 100;

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
@@ -28,7 +28,7 @@ import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 import java.util.List;
 import javax.annotation.Nullable;
-import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.BlockType;
 import org.apache.pinot.common.datablock.ColumnarDataBlock;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.datablock.RowDataBlock;
@@ -44,7 +44,7 @@ import org.roaringbitmap.RoaringBitmap;
 
 public class DataBlockBuilder {
   private final DataSchema _dataSchema;
-  private final BaseDataBlock.Type _blockType;
+  private final BlockType _blockType;
   private final DataSchema.ColumnDataType[] _columnDataTypes;
 
   private int[] _columnOffsets;
@@ -62,12 +62,12 @@ public class DataBlockBuilder {
   private final DataOutputStream _variableSizeDataOutputStream =
       new DataOutputStream(_variableSizeDataByteArrayOutputStream);
 
-  private DataBlockBuilder(DataSchema dataSchema, BaseDataBlock.Type blockType) {
+  private DataBlockBuilder(DataSchema dataSchema, BlockType blockType) {
     _dataSchema = dataSchema;
     _columnDataTypes = dataSchema.getColumnDataTypes();
     _blockType = blockType;
     _numColumns = dataSchema.size();
-    if (_blockType == BaseDataBlock.Type.COLUMNAR) {
+    if (_blockType == BlockType.COLUMNAR) {
       _cumulativeColumnOffsetSizeInBytes = new int[_numColumns];
       _columnSizeInBytes = new int[_numColumns];
       DataBlockUtils.computeColumnSizeInBytes(_dataSchema, _columnSizeInBytes);
@@ -76,7 +76,7 @@ public class DataBlockBuilder {
         _cumulativeColumnOffsetSizeInBytes[i] = cumulativeColumnOffset;
         cumulativeColumnOffset += _columnSizeInBytes[i] * _numRows;
       }
-    } else if (_blockType == BaseDataBlock.Type.ROW) {
+    } else if (_blockType == BlockType.ROW) {
       _columnOffsets = new int[_numColumns];
       _rowSizeInBytes = DataBlockUtils.computeColumnOffsets(dataSchema, _columnOffsets);
     }
@@ -96,7 +96,7 @@ public class DataBlockBuilder {
 
   public static RowDataBlock buildFromRows(List<Object[]> rows, DataSchema dataSchema)
       throws IOException {
-    DataBlockBuilder rowBuilder = new DataBlockBuilder(dataSchema, BaseDataBlock.Type.ROW);
+    DataBlockBuilder rowBuilder = new DataBlockBuilder(dataSchema, BlockType.ROW);
     // TODO: consolidate these null utils into data table utils.
     // Selection / Agg / Distinct all have similar code.
     int numColumns = rowBuilder._numColumns;
@@ -230,7 +230,7 @@ public class DataBlockBuilder {
 
   public static ColumnarDataBlock buildFromColumns(List<Object[]> columns, DataSchema dataSchema)
       throws IOException {
-    DataBlockBuilder columnarBuilder = new DataBlockBuilder(dataSchema, BaseDataBlock.Type.COLUMNAR);
+    DataBlockBuilder columnarBuilder = new DataBlockBuilder(dataSchema, BlockType.COLUMNAR);
 
     // TODO: consolidate these null utils into data table utils.
     // Selection / Agg / Distinct all have similar code.

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTest.java
@@ -94,7 +94,8 @@ public class DataBlockTest {
     DataTableBuilderFactory.setDataTableVersion(DataTableFactory.VERSION_4);
     convertToDataTableCompatibleRows(rows, dataSchema);
     DataTable dataTableImpl = SelectionOperatorUtils.getDataTableFromRows(rows, dataSchema, true);
-    BaseDataBlock dataBlockFromDataTable = DataBlockUtils.getDataBlock(ByteBuffer.wrap(dataTableImpl.toBytes()));
+    BaseDataBlock dataBlockFromDataTable =
+        (BaseDataBlock) DataBlockUtils.getDataBlock(ByteBuffer.wrap(dataTableImpl.toBytes()));
 
     RoaringBitmap[] nullBitmaps = new RoaringBitmap[numColumns];
     for (int coldId = 0; coldId < numColumns; coldId++) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcReceivingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcReceivingMailbox.java
@@ -24,9 +24,9 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
-import org.apache.pinot.common.datablock.BaseDataBlock;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.datablock.MetadataBlock;
+import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.proto.Mailbox.MailboxContent;
 import org.apache.pinot.query.mailbox.channel.MailboxContentStreamObserver;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
@@ -115,7 +115,7 @@ public class GrpcReceivingMailbox implements ReceivingMailbox<TransferableBlock>
       throws IOException {
     ByteBuffer byteBuffer = mailboxContent.getPayload().asReadOnlyByteBuffer();
     if (byteBuffer.hasRemaining()) {
-      BaseDataBlock dataBlock = DataBlockUtils.getDataBlock(byteBuffer);
+      DataTable dataBlock = DataBlockUtils.getDataBlock(byteBuffer);
       if (dataBlock instanceof MetadataBlock && !dataBlock.getExceptions().isEmpty()) {
         return TransferableBlockUtils.getErrorTransferableBlock(dataBlock.getExceptions());
       }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
@@ -23,8 +23,8 @@ import io.grpc.ManagedChannel;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.pinot.common.datablock.BaseDataBlock;
 import org.apache.pinot.common.datablock.MetadataBlock;
+import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.proto.Mailbox;
 import org.apache.pinot.common.proto.Mailbox.MailboxContent;
 import org.apache.pinot.common.proto.PinotMailboxGrpc;
@@ -86,7 +86,7 @@ public class GrpcSendingMailbox implements SendingMailbox<TransferableBlock> {
     return _mailboxId;
   }
 
-  private MailboxContent toMailboxContent(BaseDataBlock dataBlock) {
+  private MailboxContent toMailboxContent(DataTable dataBlock) {
     try {
       Mailbox.MailboxContent.Builder builder = Mailbox.MailboxContent.newBuilder().setMailboxId(_mailboxId)
           .setPayload(ByteString.copyFrom(dataBlock.toBytes()));

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -28,7 +28,6 @@ import javax.annotation.Nullable;
 import org.apache.helix.HelixManager;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
-import org.apache.pinot.common.datablock.BaseDataBlock;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.datablock.MetadataBlock;
 import org.apache.pinot.common.datatable.DataTable;
@@ -124,7 +123,7 @@ public class QueryRunner {
           requestMetadataMap, _helixPropertyStore, _mailboxService);
 
       // send the data table via mailbox in one-off fashion (e.g. no block-level split, one data table/partition key)
-      List<BaseDataBlock> serverQueryResults = new ArrayList<>(serverQueryRequests.size());
+      List<DataTable> serverQueryResults = new ArrayList<>(serverQueryRequests.size());
       for (ServerPlanRequestContext requestContext : serverQueryRequests) {
         ServerQueryRequest request = new ServerQueryRequest(requestContext.getInstanceRequest(),
             new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), System.currentTimeMillis());
@@ -184,8 +183,8 @@ public class QueryRunner {
     return requests;
   }
 
-  private BaseDataBlock processServerQuery(ServerQueryRequest serverQueryRequest, ExecutorService executorService) {
-    BaseDataBlock dataBlock;
+  private DataTable processServerQuery(ServerQueryRequest serverQueryRequest, ExecutorService executorService) {
+    DataTable dataBlock;
     try {
       InstanceResponseBlock instanceResponse = _serverExecutor.execute(serverQueryRequest, executorService);
       if (!instanceResponse.getExceptions().isEmpty()) {
@@ -216,13 +215,13 @@ public class QueryRunner {
   private static class LeafStageTransferableBlockOperator extends BaseOperator<TransferableBlock> {
     private static final String EXPLAIN_NAME = "LEAF_STAGE_TRANSFER_OPERATOR";
 
-    private final BaseDataBlock _errorBlock;
-    private final List<BaseDataBlock> _baseDataBlocks;
+    private final DataTable _errorBlock;
+    private final List<DataTable> _baseDataBlocks;
     private final DataSchema _dataSchema;
     private boolean _hasTransferred;
     private int _currentIndex;
 
-    private LeafStageTransferableBlockOperator(List<BaseDataBlock> baseDataBlocks, DataSchema dataSchema) {
+    private LeafStageTransferableBlockOperator(List<DataTable> baseDataBlocks, DataSchema dataSchema) {
       _baseDataBlocks = baseDataBlocks;
       _dataSchema = dataSchema;
       _errorBlock = baseDataBlocks.stream().filter(e -> !e.getExceptions().isEmpty()).findFirst().orElse(null);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtils.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.BlockType;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.datablock.RowDataBlock;
 import org.apache.pinot.common.utils.DataSchema;
@@ -58,9 +58,9 @@ public final class TransferableBlockUtils {
    *
    *  When row size is greater than maxBlockSize, we pack each row as a separate block.
    */
-  public static List<TransferableBlock> splitBlock(TransferableBlock block, BaseDataBlock.Type type, int maxBlockSize) {
+  public static List<TransferableBlock> splitBlock(TransferableBlock block, BlockType type, int maxBlockSize) {
     List<TransferableBlock> blockChunks = new ArrayList<>();
-    if (type != BaseDataBlock.Type.ROW) {
+    if (type != BlockType.ROW) {
       return Collections.singletonList(block);
     } else {
       int rowSizeInBytes = ((RowDataBlock) block.getDataBlock()).getRowSizeInBytes();
@@ -80,7 +80,7 @@ public final class TransferableBlockUtils {
   }
 
   public static Object[] getRow(TransferableBlock transferableBlock, int rowId) {
-    Preconditions.checkState(transferableBlock.getType() == BaseDataBlock.Type.ROW,
+    Preconditions.checkState(transferableBlock.getType() == BlockType.ROW,
         "TransferableBlockUtils doesn't support get row from non-ROW-based data block type yet!");
     return transferableBlock.getContainer().get(rowId);
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -25,7 +25,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.BlockType;
+import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
@@ -144,7 +145,7 @@ public class AggregateOperator extends BaseOperator<TransferableBlock> {
       if (rows.size() == 0) {
         return TransferableBlockUtils.getEndOfStreamTransferableBlock(_resultSchema);
       } else {
-        return new TransferableBlock(rows, _resultSchema, BaseDataBlock.Type.ROW);
+        return new TransferableBlock(rows, _resultSchema, BlockType.ROW);
       }
     } else {
       return TransferableBlockUtils.getEndOfStreamTransferableBlock(_resultSchema);
@@ -155,7 +156,7 @@ public class AggregateOperator extends BaseOperator<TransferableBlock> {
     if (!_isCumulativeBlockConstructed) {
       TransferableBlock block = _inputOperator.nextBlock();
       while (!TransferableBlockUtils.isEndOfStream(block)) {
-        BaseDataBlock dataBlock = block.getDataBlock();
+        DataTable dataBlock = block.getDataBlock();
         int numRows = dataBlock.getNumberOfRows();
         for (int rowId = 0; rowId < numRows; rowId++) {
           Object[] row = SelectionOperatorUtils.extractRowFromDataTable(dataBlock, rowId);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
@@ -21,7 +21,7 @@ package org.apache.pinot.query.runtime.operator;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
-import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.BlockType;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
@@ -80,7 +80,7 @@ public class FilterOperator extends BaseOperator<TransferableBlock> {
           resultRows.add(row);
         }
       }
-      return new TransferableBlock(resultRows, _dataSchema, BaseDataBlock.Type.ROW);
+      return new TransferableBlock(resultRows, _dataSchema, BlockType.ROW);
     } else if (block.isErrorBlock()) {
       _upstreamErrorBlock = block;
       return _upstreamErrorBlock;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.core.JoinRelType;
-import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.BlockType;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
@@ -150,7 +150,7 @@ public class HashJoinOperator extends BaseOperator<TransferableBlock> {
           }
         }
       }
-      return new TransferableBlock(rows, _resultSchema, BaseDataBlock.Type.ROW);
+      return new TransferableBlock(rows, _resultSchema, BlockType.ROW);
     } else if (leftBlock.isErrorBlock()) {
       _upstreamErrorBlock = leftBlock;
       return _upstreamErrorBlock;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
@@ -21,7 +21,7 @@ package org.apache.pinot.query.runtime.operator;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
-import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.BlockType;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.BaseOperator;
@@ -74,6 +74,6 @@ public class LiteralValueOperator extends BaseOperator<TransferableBlock> {
       }
       blockContent.add(row);
     }
-    return new TransferableBlock(blockContent, _dataSchema, BaseDataBlock.Type.ROW);
+    return new TransferableBlock(blockContent, _dataSchema, BlockType.ROW);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -28,7 +28,7 @@ import java.util.Random;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelDistribution;
-import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.BlockType;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.BaseOperator;
@@ -116,7 +116,7 @@ public class MailboxSendOperator extends BaseOperator<TransferableBlock> {
   protected TransferableBlock getNextBlock() {
     TransferableBlock transferableBlock = _dataTableBlockBaseOperator.nextBlock();
     boolean isEndOfStream = TransferableBlockUtils.isEndOfStream(transferableBlock);
-    BaseDataBlock.Type type = transferableBlock.getType();
+    BlockType type = transferableBlock.getType();
     try {
       switch (_exchangeType) {
         case SINGLETON:
@@ -184,7 +184,7 @@ public class MailboxSendOperator extends BaseOperator<TransferableBlock> {
   }
 
   private void sendDataTableBlockToServers(List<ServerInstance> servers, TransferableBlock transferableBlock,
-      BaseDataBlock.Type type, boolean isEndOfStream) {
+      BlockType type, boolean isEndOfStream) {
     if (isEndOfStream) {
       for (ServerInstance server : servers) {
         sendDataTableBlock(server, transferableBlock, true);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -25,7 +25,8 @@ import java.util.List;
 import java.util.PriorityQueue;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelFieldCollation;
-import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.BlockType;
+import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.BaseOperator;
@@ -98,7 +99,7 @@ public class SortOperator extends BaseOperator<TransferableBlock> {
       if (rows.size() == 0) {
         return TransferableBlockUtils.getEndOfStreamTransferableBlock(_dataSchema);
       } else {
-        return new TransferableBlock(rows, _dataSchema, BaseDataBlock.Type.ROW);
+        return new TransferableBlock(rows, _dataSchema, BlockType.ROW);
       }
     } else {
       return TransferableBlockUtils.getEndOfStreamTransferableBlock(_dataSchema);
@@ -109,7 +110,7 @@ public class SortOperator extends BaseOperator<TransferableBlock> {
     if (!_isSortedBlockConstructed) {
       TransferableBlock block = _upstreamOperator.nextBlock();
       while (!TransferableBlockUtils.isEndOfStream(block)) {
-        BaseDataBlock dataBlock = block.getDataBlock();
+        DataTable dataBlock = block.getDataBlock();
         int numRows = dataBlock.getNumberOfRows();
         for (int rowId = 0; rowId < numRows; rowId++) {
           Object[] row = SelectionOperatorUtils.extractRowFromDataTable(dataBlock, rowId);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
@@ -21,7 +21,7 @@ package org.apache.pinot.query.runtime.operator;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
-import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.BlockType;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
@@ -90,7 +90,7 @@ public class TransformOperator extends BaseOperator<TransferableBlock> {
         }
         resultRows.add(resultRow);
       }
-      return new TransferableBlock(resultRows, _resultSchema, BaseDataBlock.Type.ROW);
+      return new TransferableBlock(resultRows, _resultSchema, BlockType.ROW);
     } else if (block.isErrorBlock()) {
       _upstreamErrorBlock = block;
       return _upstreamErrorBlock;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryDispatcher.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.calcite.util.Pair;
-import org.apache.pinot.common.datablock.BaseDataBlock;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.exception.QueryException;
@@ -138,7 +137,7 @@ public class QueryDispatcher {
               + transferableBlock.getDataBlock().getExceptions());
       }
       if (transferableBlock.getDataBlock() != null) {
-        BaseDataBlock dataTable = transferableBlock.getDataBlock();
+        DataTable dataTable = transferableBlock.getDataBlock();
         resultDataBlocks.add(dataTable);
       }
       if (transferableBlock.isEndOfStreamBlock()) {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/GrpcMailboxServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/GrpcMailboxServiceTest.java
@@ -22,8 +22,9 @@ import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.BlockType;
 import org.apache.pinot.common.datablock.MetadataBlock;
+import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.util.TestUtils;
@@ -92,7 +93,7 @@ public class GrpcMailboxServiceTest extends GrpcMailboxServiceTestBase {
 
     TransferableBlock receivedContent = receivingMailbox.receive();
     Assert.assertNotNull(receivedContent);
-    BaseDataBlock receivedDataBlock = receivedContent.getDataBlock();
+    DataTable receivedDataBlock = receivedContent.getDataBlock();
     Assert.assertTrue(receivedDataBlock instanceof MetadataBlock);
     Assert.assertFalse(receivedDataBlock.getExceptions().isEmpty());
   }
@@ -100,7 +101,7 @@ public class GrpcMailboxServiceTest extends GrpcMailboxServiceTestBase {
   private TransferableBlock getTestTransferableBlock() {
     List<Object[]> rows = new ArrayList<>();
     rows.add(createRow(0, "test_string"));
-    return new TransferableBlock(rows, TEST_DATA_SCHEMA, BaseDataBlock.Type.ROW);
+    return new TransferableBlock(rows, TEST_DATA_SCHEMA, BlockType.ROW);
   }
 
   private TransferableBlock getTooLargeTransferableBlock() {
@@ -109,7 +110,7 @@ public class GrpcMailboxServiceTest extends GrpcMailboxServiceTestBase {
     for (int i = 0; i < size; i++) {
       rows.add(createRow(0, "test_string"));
     }
-    return new TransferableBlock(rows, TEST_DATA_SCHEMA, BaseDataBlock.Type.ROW);
+    return new TransferableBlock(rows, TEST_DATA_SCHEMA, BlockType.ROW);
   }
 
   private Object[] createRow(int intValue, String stringValue) {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/InMemoryMailboxServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/InMemoryMailboxServiceTest.java
@@ -20,7 +20,7 @@ package org.apache.pinot.query.mailbox;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.BlockType;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
@@ -99,6 +99,6 @@ public class InMemoryMailboxServiceTest {
     }
     List<Object[]> rows = new ArrayList<>(index);
     rows.add(new Object[]{index, "test_data"});
-    return new TransferableBlock(rows, TEST_DATA_SCHEMA, BaseDataBlock.Type.ROW);
+    return new TransferableBlock(rows, TEST_DATA_SCHEMA, BlockType.ROW);
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/TransferableBlockUtilsTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/TransferableBlockUtilsTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.BlockType;
 import org.apache.pinot.common.datablock.ColumnarDataBlock;
 import org.apache.pinot.common.datablock.MetadataBlock;
 import org.apache.pinot.common.datablock.RowDataBlock;
@@ -71,10 +72,10 @@ public class TransferableBlockUtilsTest {
     RowDataBlock rowBlock = DataBlockBuilder.buildFromRows(rows, dataSchema);
     int rowSizeInBytes = rowBlock.getRowSizeInBytes();
     validateBlocks(TransferableBlockUtils.splitBlock(new TransferableBlock(rowBlock),
-        BaseDataBlock.Type.ROW, rowSizeInBytes * splitRowCount + 1), rows, dataSchema);
+        BlockType.ROW, rowSizeInBytes * splitRowCount + 1), rows, dataSchema);
     // compare non-serialized split
-    validateBlocks(TransferableBlockUtils.splitBlock(new TransferableBlock(rows, dataSchema, BaseDataBlock.Type.ROW),
-        BaseDataBlock.Type.ROW, rowSizeInBytes * splitRowCount + 1), rows, dataSchema);
+    validateBlocks(TransferableBlockUtils.splitBlock(new TransferableBlock(rows, dataSchema, BlockType.ROW),
+        BlockType.ROW, rowSizeInBytes * splitRowCount + 1), rows, dataSchema);
   }
 
   @Test
@@ -95,7 +96,7 @@ public class TransferableBlockUtilsTest {
   private void validateNonSplittableBlock(BaseDataBlock nonSplittableBlock)
       throws Exception {
     List<TransferableBlock> transferableBlocks =
-        TransferableBlockUtils.splitBlock(new TransferableBlock(nonSplittableBlock), BaseDataBlock.Type.METADATA,
+        TransferableBlockUtils.splitBlock(new TransferableBlock(nonSplittableBlock), BlockType.METADATA,
             4 * 1024 * 1024);
     Assert.assertEquals(transferableBlocks.size(), 1);
     Assert.assertEquals(transferableBlocks.get(0).getDataBlock(), nonSplittableBlock);


### PR DESCRIPTION
this is a MINOR PR, mostly the result of automatic refactoring tools from IntelliJ. this will help set up an additional refactor as part of #9711 where we will split `MetadataBlock` into two separate blocks that don't implement `BaseDataBlock`: `MetadataBlock` and `SignalBlock`, both of which will have their data encoded in JSON instead of the custom pinot format.