### PR TITLE
[multistage] decouple datablock from datatable

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlock.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlock.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.datablock;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.response.ProcessingException;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.roaringbitmap.RoaringBitmap;
+
+
+public interface DataBlock {
+  Map<String, String> getMetadata();
+
+  DataSchema getDataSchema();
+
+  int getNumberOfRows();
+
+  void addException(ProcessingException processingException);
+
+  void addException(int errCode, String errMsg);
+
+  Map<Integer, String> getExceptions();
+
+  byte[] toBytes()
+      throws IOException;
+
+  // --------------------------------------------------------------------------
+  // The following APIs are copied from {@link DataTable} and will be deprecated soon.
+  // --------------------------------------------------------------------------
+
+  int getVersion();
+
+  int getInt(int rowId, int colId);
+
+  long getLong(int rowId, int colId);
+
+  float getFloat(int rowId, int colId);
+
+  double getDouble(int rowId, int colId);
+
+  BigDecimal getBigDecimal(int rowId, int colId);
+
+  String getString(int rowId, int colId);
+
+  ByteArray getBytes(int rowId, int colId);
+
+  int[] getIntArray(int rowId, int colId);
+
+  long[] getLongArray(int rowId, int colId);
+
+  float[] getFloatArray(int rowId, int colId);
+
+  double[] getDoubleArray(int rowId, int colId);
+
+  String[] getStringArray(int rowId, int colId);
+
+  @Nullable
+  RoaringBitmap getNullRowIds(int colId);
+
+  DataBlock toMetadataOnlyDataTable();
+
+  DataBlock toDataOnlyDataTable();
+
+  enum Type {
+    ROW(0),
+    COLUMNAR(1),
+    METADATA(2);
+
+    private final int _ordinal;
+
+    Type(int ordinal) {
+      _ordinal = ordinal;
+    }
+
+    public static Type fromOrdinal(int ordinal) {
+      switch (ordinal) {
+        case 0:
+          return ROW;
+        case 1:
+          return COLUMNAR;
+        case 2:
+          return METADATA;
+        default:
+          throw new IllegalArgumentException("Invalid ordinal: " + ordinal);
+      }
+    }
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
@@ -63,11 +63,11 @@ public final class DataBlockUtils {
     return new MetadataBlock(MetadataBlock.MetadataBlockType.NOOP);
   }
 
-  public static BaseDataBlock getDataBlock(ByteBuffer byteBuffer)
+  public static DataBlock getDataBlock(ByteBuffer byteBuffer)
       throws IOException {
     int versionType = byteBuffer.getInt();
     int version = versionType & ((1 << VERSION_TYPE_SHIFT) - 1);
-    BaseDataBlock.Type type = BaseDataBlock.Type.fromOrdinal(versionType >> VERSION_TYPE_SHIFT);
+    DataBlock.Type type = DataBlock.Type.fromOrdinal(versionType >> VERSION_TYPE_SHIFT);
     switch (type) {
       case COLUMNAR:
         return new ColumnarDataBlock(byteBuffer);
@@ -80,84 +80,14 @@ public final class DataBlockUtils {
     }
   }
 
-  public static List<Object[]> extractRows(BaseDataBlock dataBlock) {
+  public static List<Object[]> extractRows(DataBlock dataBlock) {
     DataSchema dataSchema = dataBlock.getDataSchema();
     DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
+    RoaringBitmap[] nullBitmaps = extractNullBitmaps(dataBlock);
     int numRows = dataBlock.getNumberOfRows();
-    int numColumns = columnDataTypes.length;
-
     List<Object[]> rows = new ArrayList<>(numRows);
-    for (int i = 0; i < numRows; i++) {
-      Object[] row = new Object[numColumns];
-      for (int j = 0; j < numColumns; j++) {
-        switch (columnDataTypes[j]) {
-          // Single-value column
-          case INT:
-            row[j] = dataBlock.getInt(i, j);
-            break;
-          case LONG:
-            row[j] = dataBlock.getLong(i, j);
-            break;
-          case FLOAT:
-            row[j] = dataBlock.getFloat(i, j);
-            break;
-          case DOUBLE:
-            row[j] = dataBlock.getDouble(i, j);
-            break;
-          case BIG_DECIMAL:
-            row[j] = dataBlock.getBigDecimal(i, j);
-            break;
-          case BOOLEAN:
-            row[j] = DataSchema.ColumnDataType.BOOLEAN.convert(dataBlock.getInt(i, j));
-            break;
-          case TIMESTAMP:
-            row[j] = new Timestamp(dataBlock.getLong(i, j));
-            break;
-          case STRING:
-            row[j] = dataBlock.getString(i, j);
-            break;
-          case BYTES:
-            row[j] = dataBlock.getBytes(i, j);
-            break;
-
-          // Multi-value column
-          case INT_ARRAY:
-            row[j] = dataBlock.getIntArray(i, j);
-            break;
-          case LONG_ARRAY:
-            row[j] = dataBlock.getLongArray(i, j);
-            break;
-          case FLOAT_ARRAY:
-            row[j] = dataBlock.getFloatArray(i, j);
-            break;
-          case DOUBLE_ARRAY:
-            row[j] = dataBlock.getDoubleArray(i, j);
-            break;
-          case STRING_ARRAY:
-            row[j] = dataBlock.getStringArray(i, j);
-            break;
-          case BOOLEAN_ARRAY:
-            row[j] = DataSchema.ColumnDataType.BOOLEAN_ARRAY.convert(dataBlock.getIntArray(i, j));
-            break;
-          case TIMESTAMP_ARRAY:
-            row[j] = DataSchema.ColumnDataType.TIMESTAMP_ARRAY.convert(dataBlock.getLongArray(i, j));
-            break;
-          default:
-            throw new IllegalStateException(
-                String.format("Unsupported data type: %s for column: %s", columnDataTypes[j],
-                    dataSchema.getColumnName(j)));
-        }
-      }
-      rows.add(row);
-    }
-
-    for (int colId = 0; colId < numColumns; colId++) {
-      RoaringBitmap nullBitmap = dataBlock.getNullRowIds(colId);
-      if (nullBitmap != null) {
-        for (Integer rowId : nullBitmap) {
-          rows.get(rowId)[colId] = null;
-        }
-      }
+    for (int rowId = 0; rowId < numRows; rowId++) {
+      rows.add(extractRowFromDataBlock(dataBlock, rowId, columnDataTypes, nullBitmaps));
     }
     return rows;
   }
@@ -239,5 +169,86 @@ public final class DataBlockUtils {
           break;
       }
     }
+  }
+
+  public static RoaringBitmap[] extractNullBitmaps(DataBlock dataBlock) {
+    DataSchema dataSchema = dataBlock.getDataSchema();
+    DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
+    int numColumns = columnDataTypes.length;
+    RoaringBitmap[] nullBitmaps = new RoaringBitmap[numColumns];
+    for (int colId = 0; colId < numColumns; colId++) {
+      nullBitmaps[colId] = dataBlock.getNullRowIds(colId);
+    }
+    return nullBitmaps;
+  }
+
+  public static Object[] extractRowFromDataBlock(DataBlock dataBlock, int rowId, DataSchema.ColumnDataType[] dataTypes,
+      RoaringBitmap[] nullBitmaps) {
+    int numColumns = nullBitmaps.length;
+    Object[] row = new Object[numColumns];
+    for (int colId = 0; colId < numColumns; colId++) {
+      RoaringBitmap nullBitmap = nullBitmaps[colId];
+      if (nullBitmap != null && nullBitmap.contains(rowId)) {
+        row[colId] = null;
+      } else {
+        switch (dataTypes[colId]) {
+          // Single-value column
+          case INT:
+            row[colId] = dataBlock.getInt(rowId, colId);
+            break;
+          case LONG:
+            row[colId] = dataBlock.getLong(rowId, colId);
+            break;
+          case FLOAT:
+            row[colId] = dataBlock.getFloat(rowId, colId);
+            break;
+          case DOUBLE:
+            row[colId] = dataBlock.getDouble(rowId, colId);
+            break;
+          case BIG_DECIMAL:
+            row[colId] = dataBlock.getBigDecimal(rowId, colId);
+            break;
+          case BOOLEAN:
+            row[colId] = DataSchema.ColumnDataType.BOOLEAN.convert(dataBlock.getInt(rowId, colId));
+            break;
+          case TIMESTAMP:
+            row[colId] = new Timestamp(dataBlock.getLong(rowId, colId));
+            break;
+          case STRING:
+            row[colId] = dataBlock.getString(rowId, colId);
+            break;
+          case BYTES:
+            row[colId] = dataBlock.getBytes(rowId, colId);
+            break;
+
+          // Multi-value column
+          case INT_ARRAY:
+            row[colId] = dataBlock.getIntArray(rowId, colId);
+            break;
+          case LONG_ARRAY:
+            row[colId] = dataBlock.getLongArray(rowId, colId);
+            break;
+          case FLOAT_ARRAY:
+            row[colId] = dataBlock.getFloatArray(rowId, colId);
+            break;
+          case DOUBLE_ARRAY:
+            row[colId] = dataBlock.getDoubleArray(rowId, colId);
+            break;
+          case STRING_ARRAY:
+            row[colId] = dataBlock.getStringArray(rowId, colId);
+            break;
+          case BOOLEAN_ARRAY:
+            row[colId] = DataSchema.ColumnDataType.BOOLEAN_ARRAY.convert(dataBlock.getIntArray(rowId, colId));
+            break;
+          case TIMESTAMP_ARRAY:
+            row[colId] = DataSchema.ColumnDataType.TIMESTAMP_ARRAY.convert(dataBlock.getLongArray(rowId, colId));
+            break;
+          default:
+            throw new IllegalStateException(
+                String.format("Unsupported data type: %s for column: %s", dataTypes[colId], colId));
+        }
+      }
+    }
+    return row;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTableImplV4.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTableImplV4.java
@@ -19,35 +19,643 @@
 
 package org.apache.pinot.common.datatable;
 
+import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
-import org.apache.pinot.common.datablock.RowDataBlock;
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.datablock.DataBlockUtils;
+import org.apache.pinot.common.request.context.ThreadTimer;
+import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.spi.annotations.InterfaceStability;
+import org.apache.pinot.spi.utils.BigDecimalUtils;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.roaringbitmap.RoaringBitmap;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 
 /**
  * Datatable V4 Implementation is a wrapper around the Row-based data block.
  */
 @InterfaceStability.Evolving
-public class DataTableImplV4 extends RowDataBlock {
+public class DataTableImplV4 extends BaseDataTable {
+
+  protected static final int HEADER_SIZE = Integer.BYTES * 13;
+  // _errCodeToExceptionMap stores exceptions as a map of errorCode->errorMessage
+  protected Map<Integer, String> _errCodeToExceptionMap;
+
+  protected int _numRows;
+  protected int _numColumns;
+  protected int _fixDataSize;
+  protected DataSchema _dataSchema;
+  protected String[] _stringDictionary;
+  protected byte[] _fixedSizeDataBytes;
+  protected ByteBuffer _fixedSizeData;
+  protected byte[] _variableSizeDataBytes;
+  protected ByteBuffer _variableSizeData;
+  protected Map<String, String> _metadata;
+  private static final int VERSION = 1;
+  protected int[] _columnOffsets;
+  protected int _rowSizeInBytes;
 
   public DataTableImplV4() {
     super();
   }
 
-  public DataTableImplV4(ByteBuffer byteBuffer)
-      throws IOException {
-    super(byteBuffer);
+  public DataTableImplV4(int numRows, DataSchema dataSchema, String[] stringDictionary,
+      byte[] fixedSizeDataBytes, byte[] variableSizeDataBytes) {
+    _numRows = numRows;
+    _dataSchema = dataSchema;
+    _numColumns = dataSchema == null ? 0 : dataSchema.size();
+    _fixDataSize = 0;
+    _stringDictionary = stringDictionary;
+    _fixedSizeDataBytes = fixedSizeDataBytes;
+    _fixedSizeData = ByteBuffer.wrap(fixedSizeDataBytes);
+    _variableSizeDataBytes = variableSizeDataBytes;
+    _variableSizeData = ByteBuffer.wrap(variableSizeDataBytes);
+    _metadata = new HashMap<>();
+    _errCodeToExceptionMap = new HashMap<>();
+    computeBlockObjectConstants();
   }
 
-  public DataTableImplV4(int numRows, DataSchema dataSchema, String[] dictionary, byte[] fixedSizeDataBytes,
-      byte[] variableSizeDataBytes) {
-    super(numRows, dataSchema, dictionary, fixedSizeDataBytes, variableSizeDataBytes);
+  public DataTableImplV4(ByteBuffer byteBuffer)
+      throws IOException {
+    // Read header.
+    _numRows = byteBuffer.getInt();
+    _numColumns = byteBuffer.getInt();
+    int exceptionsStart = byteBuffer.getInt();
+    int exceptionsLength = byteBuffer.getInt();
+    int dictionaryMapStart = byteBuffer.getInt();
+    int dictionaryMapLength = byteBuffer.getInt();
+    int dataSchemaStart = byteBuffer.getInt();
+    int dataSchemaLength = byteBuffer.getInt();
+    int fixedSizeDataStart = byteBuffer.getInt();
+    int fixedSizeDataLength = byteBuffer.getInt();
+    int variableSizeDataStart = byteBuffer.getInt();
+    int variableSizeDataLength = byteBuffer.getInt();
+
+    // Read exceptions.
+    if (exceptionsLength != 0) {
+      byteBuffer.position(exceptionsStart);
+      _errCodeToExceptionMap = deserializeExceptions(byteBuffer);
+    } else {
+      _errCodeToExceptionMap = new HashMap<>();
+    }
+
+    // Read dictionary.
+    if (dictionaryMapLength != 0) {
+      byteBuffer.position(dictionaryMapStart);
+      _stringDictionary = deserializeStringDictionary(byteBuffer);
+    } else {
+      _stringDictionary = null;
+    }
+
+    // Read data schema.
+    if (dataSchemaLength != 0) {
+      byteBuffer.position(dataSchemaStart);
+      _dataSchema = DataSchema.fromBytes(byteBuffer);
+    } else {
+      _dataSchema = null;
+    }
+
+    // Read fixed size data.
+    if (fixedSizeDataLength != 0) {
+      _fixedSizeDataBytes = new byte[fixedSizeDataLength];
+      byteBuffer.position(fixedSizeDataStart);
+      byteBuffer.get(_fixedSizeDataBytes);
+      _fixedSizeData = ByteBuffer.wrap(_fixedSizeDataBytes);
+    } else {
+      _fixedSizeDataBytes = null;
+      _fixedSizeData = null;
+    }
+
+    // Read variable size data.
+    if (variableSizeDataLength != 0) {
+      _variableSizeDataBytes = new byte[variableSizeDataLength];
+      byteBuffer.position(variableSizeDataStart);
+      byteBuffer.get(_variableSizeDataBytes);
+      _variableSizeData = ByteBuffer.wrap(_variableSizeDataBytes);
+    } else {
+      _variableSizeDataBytes = null;
+      _variableSizeData = null;
+    }
+
+    // Read metadata.
+    int metadataLength = byteBuffer.getInt();
+    if (metadataLength != 0) {
+      _metadata = deserializeMetadata(byteBuffer);
+    }
+
+    // Compute extra constants.
+    computeBlockObjectConstants();
   }
 
   @Override
-  protected int getDataBlockVersionType() {
+  public int getVersion() {
     return DataTableFactory.VERSION_4;
+  }
+
+  @Override
+  public Map<String, String> getMetadata() {
+    return _metadata;
+  }
+
+  @Override
+  public DataSchema getDataSchema() {
+    return _dataSchema;
+  }
+
+  @Override
+  public int getNumberOfRows() {
+    return _numRows;
+  }
+
+  // --------------------------------------------------------------------------
+  // Fixed sized element access.
+  // --------------------------------------------------------------------------
+
+  @Override
+  public int getInt(int rowId, int colId) {
+    return _fixedSizeData.getInt(getOffsetInFixedBuffer(rowId, colId));
+  }
+
+  @Override
+  public long getLong(int rowId, int colId) {
+    return _fixedSizeData.getLong(getOffsetInFixedBuffer(rowId, colId));
+  }
+
+  @Override
+  public float getFloat(int rowId, int colId) {
+    return _fixedSizeData.getFloat(getOffsetInFixedBuffer(rowId, colId));
+  }
+
+  @Override
+  public double getDouble(int rowId, int colId) {
+    return _fixedSizeData.getDouble(getOffsetInFixedBuffer(rowId, colId));
+  }
+
+  @Override
+  public BigDecimal getBigDecimal(int rowId, int colId) {
+    int size = positionOffsetInVariableBufferAndGetLength(rowId, colId);
+    ByteBuffer byteBuffer = _variableSizeData.slice();
+    byteBuffer.limit(size);
+    return BigDecimalUtils.deserialize(byteBuffer);
+  }
+
+  @Override
+  public String getString(int rowId, int colId) {
+    return _stringDictionary[_fixedSizeData.getInt(getOffsetInFixedBuffer(rowId, colId))];
+  }
+
+  @Override
+  public ByteArray getBytes(int rowId, int colId) {
+    int size = positionOffsetInVariableBufferAndGetLength(rowId, colId);
+    byte[] buffer = new byte[size];
+    _variableSizeData.get(buffer);
+    return new ByteArray(buffer);
+  }
+
+  // --------------------------------------------------------------------------
+  // Variable sized element access.
+  // --------------------------------------------------------------------------
+
+  @Override
+  public int[] getIntArray(int rowId, int colId) {
+    int length = positionOffsetInVariableBufferAndGetLength(rowId, colId);
+    int[] ints = new int[length];
+    for (int i = 0; i < length; i++) {
+      ints[i] = _variableSizeData.getInt();
+    }
+    return ints;
+  }
+
+  @Override
+  public long[] getLongArray(int rowId, int colId) {
+    int length = positionOffsetInVariableBufferAndGetLength(rowId, colId);
+    long[] longs = new long[length];
+    for (int i = 0; i < length; i++) {
+      longs[i] = _variableSizeData.getLong();
+    }
+    return longs;
+  }
+
+  @Override
+  public float[] getFloatArray(int rowId, int colId) {
+    int length = positionOffsetInVariableBufferAndGetLength(rowId, colId);
+    float[] floats = new float[length];
+    for (int i = 0; i < length; i++) {
+      floats[i] = _variableSizeData.getFloat();
+    }
+    return floats;
+  }
+
+  @Override
+  public double[] getDoubleArray(int rowId, int colId) {
+    int length = positionOffsetInVariableBufferAndGetLength(rowId, colId);
+    double[] doubles = new double[length];
+    for (int i = 0; i < length; i++) {
+      doubles[i] = _variableSizeData.getDouble();
+    }
+    return doubles;
+  }
+
+  @Override
+  public String[] getStringArray(int rowId, int colId) {
+    int length = positionOffsetInVariableBufferAndGetLength(rowId, colId);
+    String[] strings = new String[length];
+    for (int i = 0; i < length; i++) {
+      strings[i] = _stringDictionary[_variableSizeData.getInt()];
+    }
+    return strings;
+  }
+
+  @Nullable
+  @Override
+  public CustomObject getCustomObject(int rowId, int colId) {
+    int size = positionOffsetInVariableBufferAndGetLength(rowId, colId);
+    int type = _variableSizeData.getInt();
+    if (size == 0) {
+      assert type == CustomObject.NULL_TYPE_VALUE;
+      return null;
+    }
+    ByteBuffer buffer = _variableSizeData.slice();
+    buffer.limit(size);
+    return new CustomObject(type, buffer);
+  }
+
+  @Nullable
+  @Override
+  public RoaringBitmap getNullRowIds(int colId) {
+    // _fixedSizeData stores two ints per col's null bitmap: offset, and length.
+    int position = _fixDataSize + colId * Integer.BYTES * 2;
+    if (_fixedSizeData == null || position >= _fixedSizeData.limit()) {
+      return null;
+    }
+    _fixedSizeData.position(position);
+    int offset = _fixedSizeData.getInt();
+    int bytesLength = _fixedSizeData.getInt();
+    if (bytesLength > 0) {
+      _variableSizeData.position(offset);
+      byte[] nullBitmapBytes = new byte[bytesLength];
+      _variableSizeData.get(nullBitmapBytes);
+      return RoaringBitmapUtils.deserialize(nullBitmapBytes);
+    } else {
+      return null;
+    }
+  }
+
+  // --------------------------------------------------------------------------
+  // Ser/De and exception handling
+  // --------------------------------------------------------------------------
+
+  /**
+   * Helper method to serialize dictionary map.
+   */
+  protected byte[] serializeStringDictionary()
+      throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
+
+    dataOutputStream.writeInt(_stringDictionary.length);
+    for (String entry : _stringDictionary) {
+      byte[] valueBytes = entry.getBytes(UTF_8);
+      dataOutputStream.writeInt(valueBytes.length);
+      dataOutputStream.write(valueBytes);
+    }
+
+    return byteArrayOutputStream.toByteArray();
+  }
+
+  /**
+   * Helper method to deserialize dictionary map.
+   */
+  protected String[] deserializeStringDictionary(ByteBuffer buffer)
+      throws IOException {
+    int dictionarySize = buffer.getInt();
+    String[] stringDictionary = new String[dictionarySize];
+    for (int i = 0; i < dictionarySize; i++) {
+      stringDictionary[i] = DataTableUtils.decodeString(buffer);
+    }
+    return stringDictionary;
+  }
+
+  @Override
+  public void addException(ProcessingException processingException) {
+    _errCodeToExceptionMap.put(processingException.getErrorCode(), processingException.getMessage());
+  }
+
+  @Override
+  public void addException(int errCode, String errMsg) {
+    _errCodeToExceptionMap.put(errCode, errMsg);
+  }
+
+  @Override
+  public Map<Integer, String> getExceptions() {
+    return _errCodeToExceptionMap;
+  }
+
+  @Override
+  public byte[] toBytes()
+      throws IOException {
+    ThreadTimer threadTimer = new ThreadTimer();
+
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
+    writeLeadingSections(dataOutputStream);
+
+    // Add table serialization time metadata if thread timer is enabled.
+    if (ThreadTimer.isThreadCpuTimeMeasurementEnabled()) {
+      long responseSerializationCpuTimeNs = threadTimer.getThreadTimeNs();
+      getMetadata().put(MetadataKey.RESPONSE_SER_CPU_TIME_NS.getName(), String.valueOf(responseSerializationCpuTimeNs));
+    }
+
+    // Write metadata: length followed by actual metadata bytes.
+    // NOTE: We ignore metadata serialization time in "responseSerializationCpuTimeNs" as it's negligible while
+    // considering it will bring a lot code complexity.
+    byte[] metadataBytes = serializeMetadata();
+    dataOutputStream.writeInt(metadataBytes.length);
+    dataOutputStream.write(metadataBytes);
+
+    return byteArrayOutputStream.toByteArray();
+  }
+
+  private void writeLeadingSections(DataOutputStream dataOutputStream)
+      throws IOException {
+    dataOutputStream.writeInt(getVersion());
+    dataOutputStream.writeInt(_numRows);
+    dataOutputStream.writeInt(_numColumns);
+    int dataOffset = HEADER_SIZE;
+
+    // Write exceptions section offset(START|SIZE).
+    dataOutputStream.writeInt(dataOffset);
+    byte[] exceptionsBytes;
+    exceptionsBytes = serializeExceptions();
+    dataOutputStream.writeInt(exceptionsBytes.length);
+    dataOffset += exceptionsBytes.length;
+
+    // Write dictionary map section offset(START|SIZE).
+    dataOutputStream.writeInt(dataOffset);
+    byte[] dictionaryBytes = null;
+    if (_stringDictionary != null) {
+      dictionaryBytes = serializeStringDictionary();
+      dataOutputStream.writeInt(dictionaryBytes.length);
+      dataOffset += dictionaryBytes.length;
+    } else {
+      dataOutputStream.writeInt(0);
+    }
+
+    // Write data schema section offset(START|SIZE).
+    dataOutputStream.writeInt(dataOffset);
+    byte[] dataSchemaBytes = null;
+    if (_dataSchema != null) {
+      dataSchemaBytes = _dataSchema.toBytes();
+      dataOutputStream.writeInt(dataSchemaBytes.length);
+      dataOffset += dataSchemaBytes.length;
+    } else {
+      dataOutputStream.writeInt(0);
+    }
+
+    // Write fixed size data section offset(START|SIZE).
+    dataOutputStream.writeInt(dataOffset);
+    if (_fixedSizeDataBytes != null) {
+      dataOutputStream.writeInt(_fixedSizeDataBytes.length);
+      dataOffset += _fixedSizeDataBytes.length;
+    } else {
+      dataOutputStream.writeInt(0);
+    }
+
+    // Write variable size data section offset(START|SIZE).
+    dataOutputStream.writeInt(dataOffset);
+    if (_variableSizeDataBytes != null) {
+      dataOutputStream.writeInt(_variableSizeDataBytes.length);
+    } else {
+      dataOutputStream.writeInt(0);
+    }
+
+    // Write actual data.
+    // Write exceptions bytes.
+    dataOutputStream.write(exceptionsBytes);
+    // Write dictionary map bytes.
+    if (dictionaryBytes != null) {
+      dataOutputStream.write(dictionaryBytes);
+    }
+    // Write data schema bytes.
+    if (dataSchemaBytes != null) {
+      dataOutputStream.write(dataSchemaBytes);
+    }
+    // Write fixed size data bytes.
+    if (_fixedSizeDataBytes != null) {
+      dataOutputStream.write(_fixedSizeDataBytes);
+    }
+    // Write variable size data bytes.
+    if (_variableSizeDataBytes != null) {
+      dataOutputStream.write(_variableSizeDataBytes);
+    }
+  }
+
+  /**
+   * Serialize metadata section to bytes.
+   * Format of the bytes looks like:
+   * [numEntries, bytesOfKV2, bytesOfKV2, bytesOfKV3]
+   * For each KV pair:
+   * - if the value type is String, encode it as: [enumKeyOrdinal, valueLength, Utf8EncodedValue].
+   * - if the value type is int, encode it as: [enumKeyOrdinal, bigEndianRepresentationOfIntValue]
+   * - if the value type is long, encode it as: [enumKeyOrdinal, bigEndianRepresentationOfLongValue]
+   *
+   * Unlike V2, where numeric metadata values (int and long) in V3 are encoded in UTF-8 in the wire format,
+   * in V3 big endian representation is used.
+   */
+  private byte[] serializeMetadata()
+      throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
+
+    dataOutputStream.writeInt(_metadata.size());
+
+    for (Map.Entry<String, String> entry : _metadata.entrySet()) {
+      MetadataKey key = MetadataKey.getByName(entry.getKey());
+      // Ignore unknown keys.
+      if (key == null) {
+        continue;
+      }
+      String value = entry.getValue();
+      dataOutputStream.writeInt(key.getId());
+      if (key.getValueType() == MetadataValueType.INT) {
+        dataOutputStream.write(Ints.toByteArray(Integer.parseInt(value)));
+      } else if (key.getValueType() == MetadataValueType.LONG) {
+        dataOutputStream.write(Longs.toByteArray(Long.parseLong(value)));
+      } else {
+        byte[] valueBytes = value.getBytes(UTF_8);
+        dataOutputStream.writeInt(valueBytes.length);
+        dataOutputStream.write(valueBytes);
+      }
+    }
+
+    return byteArrayOutputStream.toByteArray();
+  }
+
+  /**
+   * Even though the wire format of V3 uses UTF-8 for string/bytes and big-endian for numeric values,
+   * the in-memory representation is STRING based for processing the metadata before serialization
+   * (by the server as it adds the statistics in metadata) and after deserialization (by the broker as it receives
+   * DataTable from each server and aggregates the values).
+   * This is to make V3 implementation keep the consumers of Map<String, String> getMetadata() API in the code happy
+   * by internally converting it.
+   *
+   * This method use relative operations on the ByteBuffer and expects the buffer's position to be set correctly.
+   */
+  private Map<String, String> deserializeMetadata(ByteBuffer buffer)
+      throws IOException {
+    int numEntries = buffer.getInt();
+    Map<String, String> metadata = new HashMap<>();
+    for (int i = 0; i < numEntries; i++) {
+      int keyId = buffer.getInt();
+      MetadataKey key = MetadataKey.getById(keyId);
+      // Ignore unknown keys.
+      if (key == null) {
+        continue;
+      }
+      if (key.getValueType() == MetadataValueType.INT) {
+        String value = "" + buffer.getInt();
+        metadata.put(key.getName(), value);
+      } else if (key.getValueType() == MetadataValueType.LONG) {
+        String value = "" + buffer.getLong();
+        metadata.put(key.getName(), value);
+      } else {
+        String value = DataTableUtils.decodeString(buffer);
+        metadata.put(key.getName(), value);
+      }
+    }
+    return metadata;
+  }
+
+  private byte[] serializeExceptions()
+      throws IOException {
+    ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+    DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
+
+    dataOutputStream.writeInt(_errCodeToExceptionMap.size());
+
+    for (Map.Entry<Integer, String> entry : _errCodeToExceptionMap.entrySet()) {
+      int key = entry.getKey();
+      String value = entry.getValue();
+      byte[] valueBytes = value.getBytes(UTF_8);
+      dataOutputStream.writeInt(key);
+      dataOutputStream.writeInt(valueBytes.length);
+      dataOutputStream.write(valueBytes);
+    }
+
+    return byteArrayOutputStream.toByteArray();
+  }
+
+  private Map<Integer, String> deserializeExceptions(ByteBuffer buffer)
+      throws IOException {
+    int numExceptions = buffer.getInt();
+    Map<Integer, String> exceptions = new HashMap<>(numExceptions);
+    for (int i = 0; i < numExceptions; i++) {
+      int errCode = buffer.getInt();
+      String errMessage = DataTableUtils.decodeString(buffer);
+      exceptions.put(errCode, errMessage);
+    }
+    return exceptions;
+  }
+
+  protected void computeBlockObjectConstants() {
+    if (_dataSchema != null) {
+      _columnOffsets = new int[_numColumns];
+      _rowSizeInBytes = DataBlockUtils.computeColumnOffsets(_dataSchema, _columnOffsets);
+      _fixDataSize = _numRows * _rowSizeInBytes;
+    }
+  }
+
+  /**
+   * return the offset in {@code _fixedSizeDataBytes} of the row/column ID.
+   * @param rowId row ID
+   * @param colId column ID
+   * @return the offset in the fixed size buffer for the row/columnID.
+   */
+  protected int getOffsetInFixedBuffer(int rowId, int colId) {
+    return rowId * _rowSizeInBytes + _columnOffsets[colId];
+  }
+
+  /**
+   * position the {@code _variableSizeDataBytes} to the corresponding row/column ID. and return the
+   * length of bytes to extract from the variable size buffer.
+   *
+   * @param rowId row ID
+   * @param colId column ID
+   * @return the length to extract from variable size buffer.
+   */
+  protected int positionOffsetInVariableBufferAndGetLength(int rowId, int colId) {
+    int offset = getOffsetInFixedBuffer(rowId, colId);
+    _variableSizeData.position(_fixedSizeData.getInt(offset));
+    return _fixedSizeData.getInt(offset + 4);
+  }
+
+  @Override
+  public DataTable toMetadataOnlyDataTable() {
+    DataTableImplV4 metadataOnlyDataTable = new DataTableImplV4();
+    metadataOnlyDataTable._metadata.putAll(_metadata);
+    metadataOnlyDataTable._errCodeToExceptionMap.putAll(_errCodeToExceptionMap);
+    return metadataOnlyDataTable;
+  }
+
+  @Override
+  public DataTable toDataOnlyDataTable() {
+    return new DataTableImplV4(_numRows, _dataSchema, _stringDictionary, _fixedSizeDataBytes, _variableSizeDataBytes);
+  }
+
+  public int getRowSizeInBytes() {
+    return _rowSizeInBytes;
+  }
+
+  @Override
+  public String toString() {
+    if (_dataSchema == null) {
+      return _metadata.toString();
+    }
+
+    StringBuilder stringBuilder = new StringBuilder();
+    stringBuilder.append(_dataSchema).append('\n');
+    stringBuilder.append("numRows: ").append(_numRows).append('\n');
+
+    DataSchema.ColumnDataType[] storedColumnDataTypes = _dataSchema.getStoredColumnDataTypes();
+    _fixedSizeData.position(0);
+    for (int rowId = 0; rowId < _numRows; rowId++) {
+      for (int colId = 0; colId < _numColumns; colId++) {
+        switch (storedColumnDataTypes[colId]) {
+          case INT:
+            stringBuilder.append(_fixedSizeData.getInt());
+            break;
+          case LONG:
+            stringBuilder.append(_fixedSizeData.getLong());
+            break;
+          case FLOAT:
+            stringBuilder.append(_fixedSizeData.getFloat());
+            break;
+          case DOUBLE:
+            stringBuilder.append(_fixedSizeData.getDouble());
+            break;
+          case STRING:
+            stringBuilder.append(_fixedSizeData.getInt());
+            break;
+          // Object and array.
+          default:
+            stringBuilder.append(String.format("(%s:%s)", _fixedSizeData.getInt(), _fixedSizeData.getInt()));
+            break;
+        }
+        stringBuilder.append("\t");
+      }
+      stringBuilder.append("\n");
+    }
+    return stringBuilder.toString();
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/datablock/MetadataBlockTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/datablock/MetadataBlockTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.common.datablock;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import org.apache.pinot.common.datatable.DataTable;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -116,12 +115,12 @@ public class MetadataBlockTest {
     }
 
     @Override
-    public DataTable toMetadataOnlyDataTable() {
+    public DataBlock toMetadataOnlyDataTable() {
       return null;
     }
 
     @Override
-    public DataTable toDataOnlyDataTable() {
+    public DataBlock toDataOnlyDataTable() {
       return null;
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
@@ -30,6 +30,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.datablock.BaseDataBlock;
 import org.apache.pinot.common.datablock.ColumnarDataBlock;
+import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.datablock.RowDataBlock;
 import org.apache.pinot.common.datatable.DataTable;
@@ -67,7 +68,7 @@ public class DataBlockBuilder {
     _columnDataTypes = dataSchema.getColumnDataTypes();
     _blockType = blockType;
     _numColumns = dataSchema.size();
-    if (_blockType == BaseDataBlock.Type.COLUMNAR) {
+    if (_blockType == DataBlock.Type.COLUMNAR) {
       _cumulativeColumnOffsetSizeInBytes = new int[_numColumns];
       _columnSizeInBytes = new int[_numColumns];
       DataBlockUtils.computeColumnSizeInBytes(_dataSchema, _columnSizeInBytes);
@@ -76,7 +77,7 @@ public class DataBlockBuilder {
         _cumulativeColumnOffsetSizeInBytes[i] = cumulativeColumnOffset;
         cumulativeColumnOffset += _columnSizeInBytes[i] * _numRows;
       }
-    } else if (_blockType == BaseDataBlock.Type.ROW) {
+    } else if (_blockType == DataBlock.Type.ROW) {
       _columnOffsets = new int[_numColumns];
       _rowSizeInBytes = DataBlockUtils.computeColumnOffsets(dataSchema, _columnOffsets);
     }
@@ -96,7 +97,7 @@ public class DataBlockBuilder {
 
   public static RowDataBlock buildFromRows(List<Object[]> rows, DataSchema dataSchema)
       throws IOException {
-    DataBlockBuilder rowBuilder = new DataBlockBuilder(dataSchema, BaseDataBlock.Type.ROW);
+    DataBlockBuilder rowBuilder = new DataBlockBuilder(dataSchema, DataBlock.Type.ROW);
     // TODO: consolidate these null utils into data table utils.
     // Selection / Agg / Distinct all have similar code.
     int numColumns = rowBuilder._numColumns;
@@ -230,7 +231,7 @@ public class DataBlockBuilder {
 
   public static ColumnarDataBlock buildFromColumns(List<Object[]> columns, DataSchema dataSchema)
       throws IOException {
-    DataBlockBuilder columnarBuilder = new DataBlockBuilder(dataSchema, BaseDataBlock.Type.COLUMNAR);
+    DataBlockBuilder columnarBuilder = new DataBlockBuilder(dataSchema, DataBlock.Type.COLUMNAR);
 
     // TODO: consolidate these null utils into data table utils.
     // Selection / Agg / Distinct all have similar code.

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTest.java
@@ -24,8 +24,8 @@ import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.pinot.common.datablock.BaseDataBlock;
 import org.apache.pinot.common.datablock.ColumnarDataBlock;
+import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.datablock.RowDataBlock;
 import org.apache.pinot.common.datatable.DataTable;
@@ -56,7 +56,7 @@ public class DataBlockTest {
         QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, originalException);
     String expected = processingException.getMessage();
 
-    BaseDataBlock dataBlock = DataBlockUtils.getErrorDataBlock(originalException);
+    DataBlock dataBlock = DataBlockUtils.getErrorDataBlock(originalException);
     dataBlock.addException(processingException);
     Assert.assertEquals(dataBlock.getNumberOfRows(), 0);
 
@@ -93,7 +93,7 @@ public class DataBlockTest {
     DataTableBuilderFactory.setDataTableVersion(DataTableFactory.VERSION_4);
     convertToDataTableCompatibleRows(rows, dataSchema);
     DataTable dataTableImpl = SelectionOperatorUtils.getDataTableFromRows(rows, dataSchema, true);
-    BaseDataBlock dataBlockFromDataTable = DataBlockUtils.getDataBlock(ByteBuffer.wrap(dataTableImpl.toBytes()));
+    DataBlock dataBlockFromDataTable = DataBlockUtils.getDataBlock(ByteBuffer.wrap(dataTableImpl.toBytes()));
 
     RoaringBitmap[] nullBitmaps = new RoaringBitmap[numColumns];
     for (int coldId = 0; coldId < numColumns; coldId++) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTestUtils.java
@@ -71,10 +71,6 @@ public class DataBlockTestUtils {
         case BYTES:
           row[colId] = new ByteArray(RandomStringUtils.random(RANDOM.nextInt(20)).getBytes());
           break;
-        // Just test Double here, all object types will be covered in ObjectCustomSerDeTest.
-        case OBJECT:
-          row[colId] = RANDOM.nextDouble();
-          break;
         case INT_ARRAY:
           int length = RANDOM.nextInt(ARRAY_SIZE);
           int[] intArray = new int[length];
@@ -165,8 +161,6 @@ public class DataBlockTestUtils {
         return dataBlock.getString(rowId, colId);
       case BYTES:
         return dataBlock.getBytes(rowId, colId);
-      case OBJECT:
-        return dataBlock.getCustomObject(rowId, colId);
       case BOOLEAN_ARRAY:
       case INT_ARRAY:
         return dataBlock.getIntArray(rowId, colId);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcReceivingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcReceivingMailbox.java
@@ -24,7 +24,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.Nullable;
-import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.datablock.MetadataBlock;
 import org.apache.pinot.common.proto.Mailbox.MailboxContent;
@@ -115,7 +115,7 @@ public class GrpcReceivingMailbox implements ReceivingMailbox<TransferableBlock>
       throws IOException {
     ByteBuffer byteBuffer = mailboxContent.getPayload().asReadOnlyByteBuffer();
     if (byteBuffer.hasRemaining()) {
-      BaseDataBlock dataBlock = DataBlockUtils.getDataBlock(byteBuffer);
+      DataBlock dataBlock = DataBlockUtils.getDataBlock(byteBuffer);
       if (dataBlock instanceof MetadataBlock && !dataBlock.getExceptions().isEmpty()) {
         return TransferableBlockUtils.getErrorTransferableBlock(dataBlock.getExceptions());
       }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
@@ -23,7 +23,7 @@ import io.grpc.ManagedChannel;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.datablock.MetadataBlock;
 import org.apache.pinot.common.proto.Mailbox;
 import org.apache.pinot.common.proto.Mailbox.MailboxContent;
@@ -86,7 +86,7 @@ public class GrpcSendingMailbox implements SendingMailbox<TransferableBlock> {
     return _mailboxId;
   }
 
-  private MailboxContent toMailboxContent(BaseDataBlock dataBlock) {
+  private MailboxContent toMailboxContent(DataBlock dataBlock) {
     try {
       Mailbox.MailboxContent.Builder builder = Mailbox.MailboxContent.newBuilder().setMailboxId(_mailboxId)
           .setPayload(ByteString.copyFrom(dataBlock.toBytes()));

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
 import org.apache.helix.HelixManager;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
-import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.datablock.MetadataBlock;
 import org.apache.pinot.common.datatable.DataTable;
@@ -124,7 +124,7 @@ public class QueryRunner {
           requestMetadataMap, _helixPropertyStore, _mailboxService);
 
       // send the data table via mailbox in one-off fashion (e.g. no block-level split, one data table/partition key)
-      List<BaseDataBlock> serverQueryResults = new ArrayList<>(serverQueryRequests.size());
+      List<DataBlock> serverQueryResults = new ArrayList<>(serverQueryRequests.size());
       for (ServerPlanRequestContext requestContext : serverQueryRequests) {
         ServerQueryRequest request = new ServerQueryRequest(requestContext.getInstanceRequest(),
             new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), System.currentTimeMillis());
@@ -184,8 +184,8 @@ public class QueryRunner {
     return requests;
   }
 
-  private BaseDataBlock processServerQuery(ServerQueryRequest serverQueryRequest, ExecutorService executorService) {
-    BaseDataBlock dataBlock;
+  private DataBlock processServerQuery(ServerQueryRequest serverQueryRequest, ExecutorService executorService) {
+    DataBlock dataBlock;
     try {
       InstanceResponseBlock instanceResponse = _serverExecutor.execute(serverQueryRequest, executorService);
       if (!instanceResponse.getExceptions().isEmpty()) {
@@ -216,13 +216,13 @@ public class QueryRunner {
   private static class LeafStageTransferableBlockOperator extends BaseOperator<TransferableBlock> {
     private static final String EXPLAIN_NAME = "LEAF_STAGE_TRANSFER_OPERATOR";
 
-    private final BaseDataBlock _errorBlock;
-    private final List<BaseDataBlock> _baseDataBlocks;
+    private final DataBlock _errorBlock;
+    private final List<DataBlock> _baseDataBlocks;
     private final DataSchema _dataSchema;
     private boolean _hasTransferred;
     private int _currentIndex;
 
-    private LeafStageTransferableBlockOperator(List<BaseDataBlock> baseDataBlocks, DataSchema dataSchema) {
+    private LeafStageTransferableBlockOperator(List<DataBlock> baseDataBlocks, DataSchema dataSchema) {
       _baseDataBlocks = baseDataBlocks;
       _dataSchema = dataSchema;
       _errorBlock = baseDataBlocks.stream().filter(e -> !e.getExceptions().isEmpty()).findFirst().orElse(null);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlock.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlock.java
@@ -19,8 +19,8 @@
 package org.apache.pinot.query.runtime.blocks;
 
 import java.util.List;
-import org.apache.pinot.common.datablock.BaseDataBlock;
 import org.apache.pinot.common.datablock.ColumnarDataBlock;
+import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.datablock.MetadataBlock;
 import org.apache.pinot.common.datablock.RowDataBlock;
@@ -34,30 +34,30 @@ import org.apache.pinot.core.common.datablock.DataBlockBuilder;
 
 
 /**
- * A {@code TransferableBlock} is a wrapper around {@link BaseDataBlock} for transferring data using
+ * A {@code TransferableBlock} is a wrapper around {@link DataBlock} for transferring data using
  * {@link org.apache.pinot.common.proto.Mailbox}.
  */
 public class TransferableBlock implements Block {
 
-  private final BaseDataBlock.Type _type;
+  private final DataBlock.Type _type;
   private final DataSchema _dataSchema;
   private final int _numRows;
 
-  private BaseDataBlock _dataBlock;
+  private DataBlock _dataBlock;
   private List<Object[]> _container;
 
-  public TransferableBlock(List<Object[]> container, DataSchema dataSchema, BaseDataBlock.Type containerType) {
+  public TransferableBlock(List<Object[]> container, DataSchema dataSchema, DataBlock.Type containerType) {
     _container = container;
     _dataSchema = dataSchema;
     _type = containerType;
     _numRows = _container.size();
   }
 
-  public TransferableBlock(BaseDataBlock dataBlock) {
+  public TransferableBlock(DataBlock dataBlock) {
     _dataBlock = dataBlock;
     _dataSchema = dataBlock.getDataSchema();
-    _type = dataBlock instanceof ColumnarDataBlock ? BaseDataBlock.Type.COLUMNAR
-        : dataBlock instanceof RowDataBlock ? BaseDataBlock.Type.ROW : BaseDataBlock.Type.METADATA;
+    _type = dataBlock instanceof ColumnarDataBlock ? DataBlock.Type.COLUMNAR
+        : dataBlock instanceof RowDataBlock ? DataBlock.Type.ROW : DataBlock.Type.METADATA;
     _numRows = _dataBlock.getNumberOfRows();
   }
 
@@ -98,7 +98,7 @@ public class TransferableBlock implements Block {
    *
    * @return data block.
    */
-  public BaseDataBlock getDataBlock() {
+  public DataBlock getDataBlock() {
     if (_dataBlock == null) {
       try {
         switch (_type) {
@@ -125,7 +125,7 @@ public class TransferableBlock implements Block {
    *
    * @return return type of block
    */
-  public BaseDataBlock.Type getType() {
+  public DataBlock.Type getType() {
     return _type;
   }
 
@@ -160,7 +160,7 @@ public class TransferableBlock implements Block {
   }
 
   private boolean isType(MetadataBlock.MetadataBlockType type) {
-    if (_type != BaseDataBlock.Type.METADATA) {
+    if (_type != DataBlock.Type.METADATA) {
       return false;
     }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtils.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.datablock.RowDataBlock;
 
@@ -67,7 +68,7 @@ public final class TransferableBlockUtils {
    */
   public static List<TransferableBlock> splitBlock(TransferableBlock block, BaseDataBlock.Type type, int maxBlockSize) {
     List<TransferableBlock> blockChunks = new ArrayList<>();
-    if (type != BaseDataBlock.Type.ROW) {
+    if (type != DataBlock.Type.ROW) {
       return Collections.singletonList(block);
     } else {
       int rowSizeInBytes = ((RowDataBlock) block.getDataBlock()).getRowSizeInBytes();
@@ -87,7 +88,7 @@ public final class TransferableBlockUtils {
   }
 
   public static Object[] getRow(TransferableBlock transferableBlock, int rowId) {
-    Preconditions.checkState(transferableBlock.getType() == BaseDataBlock.Type.ROW,
+    Preconditions.checkState(transferableBlock.getType() == DataBlock.Type.ROW,
         "TransferableBlockUtils doesn't support get row from non-ROW-based data block type yet!");
     return transferableBlock.getContainer().get(rowId);
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
@@ -21,7 +21,7 @@ package org.apache.pinot.query.runtime.operator;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
-import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.BaseOperator;
@@ -84,6 +84,6 @@ public class FilterOperator extends BaseOperator<TransferableBlock> {
         resultRows.add(row);
       }
     }
-    return new TransferableBlock(resultRows, _dataSchema, BaseDataBlock.Type.ROW);
+    return new TransferableBlock(resultRows, _dataSchema, DataBlock.Type.ROW);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -24,7 +24,7 @@ import java.util.HashMap;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.core.JoinRelType;
-import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.data.table.Key;
@@ -169,7 +169,7 @@ public class HashJoinOperator extends BaseOperator<TransferableBlock> {
       }
     }
 
-    return new TransferableBlock(rows, _resultSchema, BaseDataBlock.Type.ROW);
+    return new TransferableBlock(rows, _resultSchema, DataBlock.Type.ROW);
   }
 
   private Object[] joinRow(Object[] leftRow, @Nullable Object[] rightRow) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
@@ -21,7 +21,7 @@ package org.apache.pinot.query.runtime.operator;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
-import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.BaseOperator;
@@ -74,6 +74,6 @@ public class LiteralValueOperator extends BaseOperator<TransferableBlock> {
       }
       blockContent.add(row);
     }
-    return new TransferableBlock(blockContent, _dataSchema, BaseDataBlock.Type.ROW);
+    return new TransferableBlock(blockContent, _dataSchema, DataBlock.Type.ROW);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
@@ -21,7 +21,7 @@ package org.apache.pinot.query.runtime.operator;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
-import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.BaseOperator;
@@ -96,6 +96,6 @@ public class TransformOperator extends BaseOperator<TransferableBlock> {
       }
       resultRows.add(resultRow);
     }
-    return new TransferableBlock(resultRows, _resultSchema, BaseDataBlock.Type.ROW);
+    return new TransferableBlock(resultRows, _resultSchema, DataBlock.Type.ROW);
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/GrpcMailboxServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/GrpcMailboxServiceTest.java
@@ -22,7 +22,7 @@ import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.datablock.MetadataBlock;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
@@ -92,7 +92,7 @@ public class GrpcMailboxServiceTest extends GrpcMailboxServiceTestBase {
 
     TransferableBlock receivedContent = receivingMailbox.receive();
     Assert.assertNotNull(receivedContent);
-    BaseDataBlock receivedDataBlock = receivedContent.getDataBlock();
+    DataBlock receivedDataBlock = receivedContent.getDataBlock();
     Assert.assertTrue(receivedDataBlock instanceof MetadataBlock);
     Assert.assertFalse(receivedDataBlock.getExceptions().isEmpty());
   }
@@ -100,7 +100,7 @@ public class GrpcMailboxServiceTest extends GrpcMailboxServiceTestBase {
   private TransferableBlock getTestTransferableBlock() {
     List<Object[]> rows = new ArrayList<>();
     rows.add(createRow(0, "test_string"));
-    return new TransferableBlock(rows, TEST_DATA_SCHEMA, BaseDataBlock.Type.ROW);
+    return new TransferableBlock(rows, TEST_DATA_SCHEMA, DataBlock.Type.ROW);
   }
 
   private TransferableBlock getTooLargeTransferableBlock() {
@@ -109,7 +109,7 @@ public class GrpcMailboxServiceTest extends GrpcMailboxServiceTestBase {
     for (int i = 0; i < size; i++) {
       rows.add(createRow(0, "test_string"));
     }
-    return new TransferableBlock(rows, TEST_DATA_SCHEMA, BaseDataBlock.Type.ROW);
+    return new TransferableBlock(rows, TEST_DATA_SCHEMA, DataBlock.Type.ROW);
   }
 
   private Object[] createRow(int intValue, String stringValue) {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/InMemoryMailboxServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/InMemoryMailboxServiceTest.java
@@ -20,7 +20,7 @@ package org.apache.pinot.query.mailbox;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.pinot.common.datablock.BaseDataBlock;
+import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
@@ -99,6 +99,6 @@ public class InMemoryMailboxServiceTest {
     }
     List<Object[]> rows = new ArrayList<>(index);
     rows.add(new Object[]{index, "test_data"});
-    return new TransferableBlock(rows, TEST_DATA_SCHEMA, BaseDataBlock.Type.ROW);
+    return new TransferableBlock(rows, TEST_DATA_SCHEMA, DataBlock.Type.ROW);
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/TransferableBlockUtilsTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/TransferableBlockUtilsTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.pinot.common.datablock.BaseDataBlock;
 import org.apache.pinot.common.datablock.ColumnarDataBlock;
+import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.datablock.MetadataBlock;
 import org.apache.pinot.common.datablock.RowDataBlock;
 import org.apache.pinot.common.utils.DataSchema;
@@ -71,10 +72,10 @@ public class TransferableBlockUtilsTest {
     RowDataBlock rowBlock = DataBlockBuilder.buildFromRows(rows, dataSchema);
     int rowSizeInBytes = rowBlock.getRowSizeInBytes();
     validateBlocks(TransferableBlockUtils.splitBlock(new TransferableBlock(rowBlock),
-        BaseDataBlock.Type.ROW, rowSizeInBytes * splitRowCount + 1), rows, dataSchema);
+        DataBlock.Type.ROW, rowSizeInBytes * splitRowCount + 1), rows, dataSchema);
     // compare non-serialized split
-    validateBlocks(TransferableBlockUtils.splitBlock(new TransferableBlock(rows, dataSchema, BaseDataBlock.Type.ROW),
-        BaseDataBlock.Type.ROW, rowSizeInBytes * splitRowCount + 1), rows, dataSchema);
+    validateBlocks(TransferableBlockUtils.splitBlock(new TransferableBlock(rows, dataSchema, DataBlock.Type.ROW),
+        DataBlock.Type.ROW, rowSizeInBytes * splitRowCount + 1), rows, dataSchema);
   }
 
   @Test
@@ -95,7 +96,7 @@ public class TransferableBlockUtilsTest {
   private void validateNonSplittableBlock(BaseDataBlock nonSplittableBlock)
       throws Exception {
     List<TransferableBlock> transferableBlocks =
-        TransferableBlockUtils.splitBlock(new TransferableBlock(nonSplittableBlock), BaseDataBlock.Type.METADATA,
+        TransferableBlockUtils.splitBlock(new TransferableBlock(nonSplittableBlock), DataBlock.Type.METADATA,
             4 * 1024 * 1024);
     Assert.assertEquals(transferableBlocks.size(), 1);
     Assert.assertEquals(transferableBlocks.get(0).getDataBlock(), nonSplittableBlock);


### PR DESCRIPTION
After #9561 . V2 engine no longer depend on anything datatable specific. It's time to decouple it

This PR is a single refactor that copied the DataTable API out into a DataBlock. So going forward any changes on datablock will not need to consider backward compatibility against data table. This opens up to use different serde encoding / remove not needed APIs later