### PR TITLE
show table metadata info in aggregate index size form

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/TableMetadataInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/TableMetadataInfo.java
@@ -42,13 +42,15 @@ public class TableMetadataInfo {
   private final Map<String, Double> _columnLengthMap;
   private final Map<String, Double> _columnCardinalityMap;
   private final Map<String, Double> _maxNumMultiValuesMap;
+  private final Map<String, Map<String, Double>> _columnIndexSizeMap;
 
   @JsonCreator
   public TableMetadataInfo(@JsonProperty("tableName") String tableName,
       @JsonProperty("diskSizeInBytes") long sizeInBytes, @JsonProperty("numSegments") long numSegments,
       @JsonProperty("numRows") long numRows, @JsonProperty("columnLengthMap") Map<String, Double> columnLengthMap,
       @JsonProperty("columnCardinalityMap") Map<String, Double> columnCardinalityMap,
-      @JsonProperty("maxNumMultiValuesMap") Map<String, Double> maxNumMultiValuesMap) {
+      @JsonProperty("maxNumMultiValuesMap") Map<String, Double> maxNumMultiValuesMap,
+      @JsonProperty("columnIndexSizeMap") Map<String, Map<String, Double>> columnIndexSizeMap) {
     _tableName = tableName;
     _diskSizeInBytes = sizeInBytes;
     _numSegments = numSegments;
@@ -56,6 +58,7 @@ public class TableMetadataInfo {
     _columnLengthMap = columnLengthMap;
     _columnCardinalityMap = columnCardinalityMap;
     _maxNumMultiValuesMap = maxNumMultiValuesMap;
+    _columnIndexSizeMap = columnIndexSizeMap;
   }
 
   public String getTableName() {
@@ -84,5 +87,9 @@ public class TableMetadataInfo {
 
   public Map<String, Double> getMaxNumMultiValuesMap() {
     return _maxNumMultiValuesMap;
+  }
+
+  public Map<String, Map<String, Double>> getColumnIndexSizeMap() {
+    return _columnIndexSizeMap;
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -259,10 +259,10 @@ public class TablesResource {
               maxNumMultiValuesMap.merge(column, (double) maxNumMultiValues, Double::sum);
             }
             for (Map.Entry<ColumnIndexType, Long> entry : columnMetadata.getIndexSizeMap().entrySet()) {
+              String indexName = entry.getKey().getIndexName();
               Map<String, Double> columnIndexSizes = columnIndexSizesMap.getOrDefault(column, new HashMap<>());
-              Double indexSize = columnIndexSizes.getOrDefault(entry.getKey().getIndexName(), 0d);
-              indexSize += entry.getValue();
-              columnIndexSizes.put(entry.getKey().getIndexName(), indexSize);
+              Double indexSize = columnIndexSizes.getOrDefault(indexName, 0d) + entry.getValue();
+              columnIndexSizes.put(indexName, indexSize);
               columnIndexSizesMap.put(column, columnIndexSizes);
             }
           }

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
@@ -122,8 +122,10 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertEquals(metadataInfo.getColumnLengthMap().size(), 2);
     Assert.assertEquals(metadataInfo.getColumnCardinalityMap().size(), 2);
     Assert.assertEquals(metadataInfo.getColumnIndexSizeMap().size(), 2);
-    Assert.assertTrue(metadataInfo.getColumnIndexSizeMap().containsKey(ColumnIndexType.DICTIONARY.getIndexName()));
-    Assert.assertTrue(metadataInfo.getColumnIndexSizeMap().containsKey(ColumnIndexType.FORWARD_INDEX.getIndexName()));
+    Assert.assertTrue(metadataInfo.getColumnIndexSizeMap().get("column1")
+        .containsKey(ColumnIndexType.DICTIONARY.getIndexName()));
+    Assert.assertTrue(metadataInfo.getColumnIndexSizeMap().get("column2")
+        .containsKey(ColumnIndexType.FORWARD_INDEX.getIndexName()));
 
     // No such table
     Response response = _webTarget.path("/tables/noSuchTable/metadata").request().get(Response.class);

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.List;
 import javax.ws.rs.core.Response;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.restlet.resources.TableMetadataInfo;
 import org.apache.pinot.common.restlet.resources.TableSegments;
 import org.apache.pinot.common.restlet.resources.TablesList;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
@@ -32,6 +33,7 @@ import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
+import org.apache.pinot.segment.spi.store.ColumnIndexType;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.testng.Assert;
@@ -100,6 +102,36 @@ public class TablesResourceTest extends BaseResourceTest {
   }
 
   @Test
+  public void getTableMetadata()
+      throws Exception {
+    String tableMetadataPath = "/tables/" + TableNameBuilder.REALTIME.tableNameWithType(TABLE_NAME) + "/metadata";
+
+    JsonNode jsonResponse =
+        JsonUtils.stringToJsonNode(_webTarget.path(tableMetadataPath).request().get(String.class));
+    TableMetadataInfo metadataInfo = JsonUtils.jsonNodeToObject(jsonResponse, TableMetadataInfo.class);
+    Assert.assertNotNull(metadataInfo);
+    Assert.assertEquals(metadataInfo.getNumSegments(), 2);
+    Assert.assertEquals(metadataInfo.getTableName(), TableNameBuilder.REALTIME.tableNameWithType(TABLE_NAME));
+    Assert.assertEquals(metadataInfo.getColumnLengthMap().size(), 0);
+    Assert.assertEquals(metadataInfo.getColumnCardinalityMap().size(), 0);
+    Assert.assertEquals(metadataInfo.getColumnIndexSizeMap().size(), 0);
+
+    jsonResponse = JsonUtils.stringToJsonNode(_webTarget.path(tableMetadataPath)
+        .queryParam("columns", "column1").queryParam("columns", "column2").request().get(String.class));
+    metadataInfo = JsonUtils.jsonNodeToObject(jsonResponse, TableMetadataInfo.class);
+    Assert.assertEquals(metadataInfo.getColumnLengthMap().size(), 2);
+    Assert.assertEquals(metadataInfo.getColumnCardinalityMap().size(), 2);
+    Assert.assertEquals(metadataInfo.getColumnIndexSizeMap().size(), 2);
+    Assert.assertTrue(metadataInfo.getColumnIndexSizeMap().containsKey(ColumnIndexType.DICTIONARY.getIndexName()));
+    Assert.assertTrue(metadataInfo.getColumnIndexSizeMap().containsKey(ColumnIndexType.FORWARD_INDEX.getIndexName()));
+
+    // No such table
+    Response response = _webTarget.path("/tables/noSuchTable/metadata").request().get(Response.class);
+    Assert.assertNotNull(response);
+    Assert.assertEquals(response.getStatus(), Response.Status.NOT_FOUND.getStatusCode());
+  }
+
+  @Test
   public void testSegmentMetadata()
       throws Exception {
     IndexSegment defaultSegment = _realtimeIndexSegments.get(0);
@@ -124,6 +156,8 @@ public class TablesResourceTest extends BaseResourceTest {
             .get(String.class));
     Assert.assertEquals(jsonResponse.get("columns").size(), 2);
     Assert.assertEquals(jsonResponse.get("indexes").size(), 2);
+    Assert.assertNotNull(jsonResponse.get("columns").get(0).get("indexSizeMap"));
+    Assert.assertNotNull(jsonResponse.get("columns").get(1).get("indexSizeMap"));
 
     jsonResponse = JsonUtils.stringToJsonNode(
         (_webTarget.path(segmentMetadataPath).queryParam("columns", "*").request().get(String.class)));


### PR DESCRIPTION
follow up on #9712 .

This PR show aggregated column index size (avg) on table metadata API Path: `/tables/{tableName}/metadata`
![TableLevel](https://user-images.githubusercontent.com/3581352/200365604-52ad2011-012c-421b-9390-9b258352701c.png)

