### PR TITLE
 [bugfix] Let StartControllerCommand also handle "pinot.zk.server", "pinot.cluster.name" in default conf/pinot-controller.conf

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
@@ -207,7 +207,7 @@ public class StartControllerCommand extends AbstractBaseAdminCommand implements 
       // Cluster.
       // Configs existence is already verified.
       _zkAddress = conf.getZkStr();
-      _clusterName = properties.get(ControllerConf.HELIX_CLUSTER_NAME).toString();
+      _clusterName = conf.getHelixClusterName();
     } else {
       if (_controllerHost == null) {
         _controllerHost = NetUtils.getHostAddress();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
@@ -201,10 +201,12 @@ public class StartControllerCommand extends AbstractBaseAdminCommand implements 
     Map<String, Object> properties = new HashMap<>();
     if (_configFileName != null) {
       properties.putAll(PinotConfigUtils.generateControllerConf(_configFileName));
+      ControllerConf conf = new ControllerConf(properties);
+
       // Override the zkAddress and clusterName to ensure ServiceManager is connecting to the right Zookeeper and
       // Cluster.
       // Configs existence is already verified.
-      _zkAddress = properties.get(ControllerConf.ZK_STR).toString();
+      _zkAddress = conf.getZkStr();
       _clusterName = properties.get(ControllerConf.HELIX_CLUSTER_NAME).toString();
     } else {
       if (_controllerHost == null) {


### PR DESCRIPTION
Let StartControllerCommand also handle "pinot.zk.server", "pinot.cluster.name" in default config file "conf/pinot-controller.conf"

This PR will resolve https://github.com/apache/pinot/issues/9553