### PR TITLE
render the tables list even as the table sizes are loading

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableSize.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableSize.java
@@ -98,6 +98,12 @@ public class TableSize {
     if (tableSizeDetails == null) {
       throw new ControllerApplicationException(LOGGER, "Table " + tableName + " not found", Response.Status.NOT_FOUND);
     }
+
+    try {
+      Thread.sleep(5000);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
     return tableSizeDetails;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableSize.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableSize.java
@@ -98,7 +98,6 @@ public class TableSize {
     if (tableSizeDetails == null) {
       throw new ControllerApplicationException(LOGGER, "Table " + tableName + " not found", Response.Status.NOT_FOUND);
     }
-
     return tableSizeDetails;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableSize.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableSize.java
@@ -99,11 +99,6 @@ public class TableSize {
       throw new ControllerApplicationException(LOGGER, "Table " + tableName + " not found", Response.Status.NOT_FOUND);
     }
 
-    try {
-      Thread.sleep(5000);
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
-    }
     return tableSizeDetails;
   }
 }

--- a/pinot-controller/src/main/resources/app/components/ComponentLoader.tsx
+++ b/pinot-controller/src/main/resources/app/components/ComponentLoader.tsx
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import * as React from 'react';
+
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { makeStyles, createStyles, Theme } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    root: {
+      display: 'flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      padding: '10px',
+      '& svg > circle': {
+        stroke: 'primary',
+      },
+    },
+  })
+);
+
+const ComponentLoader = () => {
+  const classes = useStyles();
+  return <CircularProgress className={classes.root} />;
+};
+
+export default ComponentLoader;

--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -26,6 +26,7 @@ import {
   makeStyles,
   useTheme,
 } from '@material-ui/core/styles';
+import ComponentLoader from './ComponentLoader';
 import Dialog from '@material-ui/core/Dialog';
 import Table from '@material-ui/core/Table';
 import TableBody from '@material-ui/core/TableBody';
@@ -279,6 +280,13 @@ export default function CustomizedTables({
   React.useEffect( () => {
     setInitialData(data);
   }, [data]);
+  // We do not use data.isLoading directly in the renderer because there's a gap between data
+  // changing and finalData being set. Without this, there's a flicker where we go from
+  // loading -> no records found -> not loading + data.
+  const [isLoading, setIsLoading] = React.useState(false);
+  React.useEffect( () => {
+    setIsLoading(data.isLoading || false);
+  }, [finalData]);
 
   const [order, setOrder] = React.useState(false);
   const [columnClicked, setColumnClicked] = React.useState('');
@@ -450,7 +458,7 @@ export default function CustomizedTables({
           <Table className={classes.table} size="small" stickyHeader={isSticky}>
             <TableHead>
               <TableRow>
-                {data.columns.map((column, index) => (
+                {data.columns && data.columns.map((column, index) => (
                   <StyledTableCell
                     className={classes.head}
                     key={index}
@@ -494,7 +502,8 @@ export default function CustomizedTables({
               </TableRow>
             </TableHead>
             <TableBody className={classes.body}>
-              {finalData.length === 0 ? (
+              {isLoading ? <ComponentLoader /> : (
+                finalData.length === 0 ? (
                 <TableRow>
                   <StyledTableCell
                     className={classes.nodata}
@@ -531,7 +540,7 @@ export default function CustomizedTables({
                       })}
                     </StyledTableRow>
                   ))
-              )}
+              ))}
             </TableBody>
           </Table>
         </TableContainer>

--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -270,7 +270,15 @@ export default function CustomizedTables({
   accordionToggleObject,
   tooltipData
 }: Props) {
+  // Separate the initial and final data into two separte state variables.
+  // This way we can filter and sort the data without affecting the original data.
+  // If the component receives new data, we can simply set the new data to the initial data,
+  // and the filters and sorts will be applied to the new data.
+  const [initialData, setInitialData] = React.useState(data);
   const [finalData, setFinalData] = React.useState(Utils.tableFormat(data));
+  React.useEffect( () => {
+    setInitialData(data);
+  }, [data]);
 
   const [order, setOrder] = React.useState(false);
   const [columnClicked, setColumnClicked] = React.useState('');
@@ -296,9 +304,9 @@ export default function CustomizedTables({
 
   const filterSearchResults = React.useCallback((str: string) => {
     if (str === '') {
-      setFinalData(finalData);
+      setFinalData(Utils.tableFormat(data));
     } else {
-      const filteredRescords = data.records.filter((record) => {
+      const filteredRescords = initialData.records.filter((record) => {
         const searchFound = record.find(
           (cell) => cell.toString().toLowerCase().indexOf(str) > -1
         );
@@ -309,7 +317,7 @@ export default function CustomizedTables({
       });
       setFinalData(filteredRescords);
     }
-  }, [data, setFinalData]);
+  }, [initialData, setFinalData]);
 
   React.useEffect(() => {
     clearTimeout(timeoutId.current);
@@ -322,9 +330,9 @@ export default function CustomizedTables({
     };
   }, [search, timeoutId, filterSearchResults]);
 
-  React.useCallback(()=>{
-    setFinalData(Utils.tableFormat(data));
-  }, [data]);
+  // React.useCallback(()=>{
+    // setFinalData(Utils.tableFormat(data));
+  // }, [data]);
 
   const styleCell = (str: string) => {
     if (str === 'Good' || str.toLowerCase() === 'online' || str.toLowerCase() === 'alive' || str.toLowerCase() === 'true') {
@@ -454,7 +462,7 @@ export default function CustomizedTables({
                           const result = order ? (aSegmentInt > bSegmentInt) : (aSegmentInt < bSegmentInt);
                           return result ? 1 : -1;
                         });
-                        setFinalData(data);
+                        setFinalData(finalData);
                       } else {
                         setFinalData(orderBy(finalData, column+app_state.columnNameSeparator+index, order ? 'asc' : 'desc'));
                       }

--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -338,10 +338,6 @@ export default function CustomizedTables({
     };
   }, [search, timeoutId, filterSearchResults]);
 
-  // React.useCallback(()=>{
-    // setFinalData(Utils.tableFormat(data));
-  // }, [data]);
-
   const styleCell = (str: string) => {
     if (str === 'Good' || str.toLowerCase() === 'online' || str.toLowerCase() === 'alive' || str.toLowerCase() === 'true') {
       return (

--- a/pinot-controller/src/main/resources/app/interfaces/types.d.ts
+++ b/pinot-controller/src/main/resources/app/interfaces/types.d.ts
@@ -22,6 +22,7 @@ declare module 'Models' {
     records: Array<Array<string | number | boolean>>;
     columns: Array<string>;
     error?: string;
+    isLoading? : boolean
   };
 
   type SchemaDetails = {

--- a/pinot-controller/src/main/resources/app/pages/TablesListingPage.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TablesListingPage.tsx
@@ -54,8 +54,6 @@ const TableTooltipData = [
 const TablesListingPage = () => {
   const classes = useStyles();
 
-  // const [fetchingTableData, setFetchingTableData] = useState(true);
-  // const [fetchingSchemaData, setFetchingSchemaData] = useState(true);
   const [schemaDetails, setSchemaDetails] = useState<TableData>({
     columns: PinotMethodUtils.allSchemaDetailsColumnHeader,
     records: [],

--- a/pinot-controller/src/main/resources/app/pages/TablesListingPage.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TablesListingPage.tsx
@@ -67,13 +67,39 @@ const TablesListingPage = () => {
   const [showAddOfflineTableModal, setShowAddOfflineTableModal] = useState(false);
   const [showAddRealtimeTableModal, setShowAddRealtimeTableModal] = useState(false);
 
+  const loading = 'Loading...';
+
   const fetchData = async () => {
     !fetching && setFetching(true);
     const tablesResponse = await PinotMethodUtils.getQueryTablesList({bothType: true});
     const tablesList = [];
+    const tableData = []
+    const columnHeaders = [
+      'Table Name',
+      'Reported Size',
+      'Estimated Size',
+      'Number of Segments',
+      'Status',
+    ];
     tablesResponse.records.map((record)=>{
       tablesList.push(...record);
     });
+    tablesList.map((table)=>{
+      tableData.push([
+        table,
+        loading,
+        loading,
+        loading,
+        loading,
+      ]);
+    });
+    // Set the table data to "Loading..." at first as tableSize can take minutes to fetch
+    // for larger tables.
+    setTableData({
+      columns: columnHeaders,
+      records: tableData
+    });
+
     const tableDetails = await PinotMethodUtils.getAllTableDetails(tablesList);
     const schemaDetailsData = await PinotMethodUtils.getAllSchemaDetails();
     setTableData(tableDetails);
@@ -85,9 +111,7 @@ const TablesListingPage = () => {
     fetchData();
   }, []);
 
-  return fetching ? (
-    <AppLoader />
-  ) : (
+  return (
     <Grid item xs className={classes.gridContainer}>
       <div className={classes.operationDiv}>
         <SimpleAccordion

--- a/pinot-controller/src/main/resources/app/pages/TablesListingPage.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TablesListingPage.tsx
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import React, {useState, useEffect} from 'react';
+import React, { useState, useEffect } from 'react';
 import { Grid, makeStyles } from '@material-ui/core';
 import { TableData } from 'Models';
 import AppLoader from '../components/AppLoader';
@@ -34,107 +34,122 @@ const useStyles = makeStyles(() => ({
     padding: 20,
     backgroundColor: 'white',
     maxHeight: 'calc(100vh - 70px)',
-    overflowY: 'auto'
+    overflowY: 'auto',
   },
   operationDiv: {
     border: '1px #BDCCD9 solid',
     borderRadius: 4,
-    marginBottom: 20
-  }
+    marginBottom: 20,
+  },
 }));
 
 const TableTooltipData = [
   null,
-  "Uncompressed size of all data segments",
-  "Estimated size of all data segments, in case any servers are not reachable for actual size",
+  'Uncompressed size of all data segments',
+  'Estimated size of all data segments, in case any servers are not reachable for actual size',
   null,
-  "GOOD if all replicas of all segments are up"
+  'GOOD if all replicas of all segments are up',
 ];
 
 const TablesListingPage = () => {
   const classes = useStyles();
 
-  const [fetching, setFetching] = useState(true);
-  const [schemaDetails,setSchemaDetails] = useState<TableData>({
-    columns: [],
-    records: []
+  // const [fetchingTableData, setFetchingTableData] = useState(true);
+  // const [fetchingSchemaData, setFetchingSchemaData] = useState(true);
+  const [schemaDetails, setSchemaDetails] = useState<TableData>({
+    columns: PinotMethodUtils.allSchemaDetailsColumnHeader,
+    records: [],
+    isLoading: true,
   });
   const [tableData, setTableData] = useState<TableData>({
-    columns: [],
-    records: []
+    columns: PinotMethodUtils.allTableDetailsColumnHeader,
+    records: [],
+    isLoading: true,
   });
   const [showSchemaModal, setShowSchemaModal] = useState(false);
-  const [showAddOfflineTableModal, setShowAddOfflineTableModal] = useState(false);
-  const [showAddRealtimeTableModal, setShowAddRealtimeTableModal] = useState(false);
+  const [showAddOfflineTableModal, setShowAddOfflineTableModal] = useState(
+    false
+  );
+  const [showAddRealtimeTableModal, setShowAddRealtimeTableModal] = useState(
+    false
+  );
 
   const loading = 'Loading...';
 
   const fetchData = async () => {
-    !fetching && setFetching(true);
-    const tablesResponse = await PinotMethodUtils.getQueryTablesList({bothType: true});
+    const tablesResponse = await PinotMethodUtils.getQueryTablesList({
+      bothType: true,
+    });
     const tablesList = [];
-    const tableData = []
-    const columnHeaders = [
+    const tableData = [];
+    const tableColumnHeaders = [
       'Table Name',
       'Reported Size',
       'Estimated Size',
       'Number of Segments',
       'Status',
     ];
-    tablesResponse.records.map((record)=>{
+    tablesResponse.records.map((record) => {
       tablesList.push(...record);
     });
-    tablesList.map((table)=>{
-      tableData.push([
-        table,
-        loading,
-        loading,
-        loading,
-        loading,
-      ]);
+    tablesList.map((table) => {
+      tableData.push([table, loading, loading, loading, loading]);
     });
     // Set the table data to "Loading..." at first as tableSize can take minutes to fetch
     // for larger tables.
     setTableData({
-      columns: columnHeaders,
-      records: tableData
+      columns: tableColumnHeaders,
+      records: tableData,
+      isLoading: false,
     });
 
+    // Set just the column headers so these do not have to load with the data
+    setSchemaDetails({
+      columns: PinotMethodUtils.allSchemaDetailsColumnHeader,
+      records: [],
+      isLoading: true,
+    });
+
+    // these implicitly set isLoading=false by leaving it undefined
     const tableDetails = await PinotMethodUtils.getAllTableDetails(tablesList);
-    const schemaDetailsData = await PinotMethodUtils.getAllSchemaDetails();
     setTableData(tableDetails);
-    setSchemaDetails(schemaDetailsData)
-    setFetching(false);
+    const schemaDetailsData = await PinotMethodUtils.getAllSchemaDetails();
+    setSchemaDetails(schemaDetailsData);
   };
 
   useEffect(() => {
     fetchData();
   }, []);
 
-  return (
+  return tableData.isLoading && schemaDetails.isLoading ? (
+    <AppLoader />
+  ) : (
     <Grid item xs className={classes.gridContainer}>
       <div className={classes.operationDiv}>
-        <SimpleAccordion
-          headerTitle="Operations"
-          showSearchBox={false}
-        >
+        <SimpleAccordion headerTitle="Operations" showSearchBox={false}>
           <div>
             <CustomButton
-              onClick={()=>{setShowSchemaModal(true)}}
+              onClick={() => {
+                setShowSchemaModal(true);
+              }}
               tooltipTitle="Define the dimensions, metrics and date time columns of your data"
               enableTooltip={true}
             >
               Add Schema
             </CustomButton>
             <CustomButton
-              onClick={()=>{setShowAddOfflineTableModal(true)}}
+              onClick={() => {
+                setShowAddOfflineTableModal(true);
+              }}
               tooltipTitle="Create a Pinot table to ingest from batch data sources, such as S3"
               enableTooltip={true}
             >
               Add Offline Table
             </CustomButton>
             <CustomButton
-              onClick={()=>{setShowAddRealtimeTableModal(true)}}
+              onClick={() => {
+                setShowAddRealtimeTableModal(true);
+              }}
               tooltipTitle="Create a Pinot table to ingest from stream data sources, such as Kafka"
               enableTooltip={true}
             >
@@ -153,36 +168,39 @@ const TablesListingPage = () => {
         tooltipData={TableTooltipData}
       />
       <CustomizedTables
-          title="Schemas"
-          data={schemaDetails}
-          showSearchBox={true}
-          inAccordionFormat={true}
-          addLinks
-          baseURL="/tenants/schema/"
+        title="Schemas"
+        data={schemaDetails}
+        showSearchBox={true}
+        inAccordionFormat={true}
+        addLinks
+        baseURL="/tenants/schema/"
       />
-      {
-        showSchemaModal &&
+      {showSchemaModal && (
         <AddSchemaOp
-          hideModal={()=>{setShowSchemaModal(false);}}
+          hideModal={() => {
+            setShowSchemaModal(false);
+          }}
           fetchData={fetchData}
         />
-      }
-      {
-        showAddOfflineTableModal &&
+      )}
+      {showAddOfflineTableModal && (
         <AddOfflineTableOp
-          hideModal={()=>{setShowAddOfflineTableModal(false);}}
+          hideModal={() => {
+            setShowAddOfflineTableModal(false);
+          }}
           fetchData={fetchData}
-          tableType={"OFFLINE"}
+          tableType={'OFFLINE'}
         />
-      }
-      {
-        showAddRealtimeTableModal &&
+      )}
+      {showAddRealtimeTableModal && (
         <AddRealtimeTableOp
-          hideModal={()=>{setShowAddRealtimeTableModal(false);}}
+          hideModal={() => {
+            setShowAddRealtimeTableModal(false);
+          }}
           fetchData={fetchData}
-          tableType={"REALTIME"}
+          tableType={'REALTIME'}
         />
-      }
+      )}
     </Grid>
   );
 };

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -352,8 +352,9 @@ const getSchemaObject = async (schemaName) =>{
       return schemaObj;
   }
 
+const allSchemaDetailsColumnHeader = ["Schema Name", "Dimension Columns", "Date-Time Columns", "Metrics Columns", "Total Columns"];
+
 const getAllSchemaDetails = async () => {
-  const columnHeaders = ["Schema Name", "Dimension Columns", "Date-Time Columns", "Metrics Columns", "Total Columns"]
   let schemaDetails:Array<any> = [];
   let promiseArr = [];
   const {data} = await getSchemaList()
@@ -371,19 +372,20 @@ const getAllSchemaDetails = async () => {
     return schemaObj;
   })
   return {
-    columns: columnHeaders,
+    columns: allSchemaDetailsColumnHeader,
     records: schemaDetails
   };
 }
 
+const allTableDetailsColumnHeader = [
+  'Table Name',
+  'Reported Size',
+  'Estimated Size',
+  'Number of Segments',
+  'Status',
+];
+
 const getAllTableDetails = (tablesList) => {
-  const columnHeaders = [
-    'Table Name',
-    'Reported Size',
-    'Estimated Size',
-    'Number of Segments',
-    'Status',
-  ];
   if (tablesList.length) {
     const promiseArr = [];
     tablesList.map((name) => {
@@ -433,13 +435,13 @@ const getAllTableDetails = (tablesList) => {
         }
       });
       return {
-        columns: columnHeaders,
+        columns: allTableDetailsColumnHeader,
         records: finalRecordsArr,
       };
     });
   }
   return {
-    columns: columnHeaders,
+    columns: allTableDetailsColumnHeader,
     records: []
   };
 };
@@ -1096,6 +1098,7 @@ export default {
   getTableSchemaData,
   getQueryResults,
   getTenantTableData,
+  allTableDetailsColumnHeader,
   getAllTableDetails,
   getTableSummaryData,
   getSegmentList,
@@ -1154,6 +1157,7 @@ export default {
   saveSchemaAction,
   saveTableAction,
   getSchemaData,
+  allSchemaDetailsColumnHeader,
   getAllSchemaDetails,
   getTableState,
   getAuthInfo,


### PR DESCRIPTION
Reopening from #9198 because I couldn't figure out the mess I made between rebase and merging.

This is a `ui` `feature`

This will fix something that's annoyed me greatly about the tables page. We fetch the table list, then the table data, then the schema data. But we don't render the tables until we have all that data. Since this can take minutes (specifically getting the size of big tables), it leaves the page on a spinner when usually we just want the table list immediately.

- modifies the `TableData` model to track if the data is still loading
- modifies `Tables.tsx` to render a loading indicator
- modifies `TablesListingPage.tsx` to separately load schema and table data
- modifies `Tables.tsx` to track initial data separately from the data that is finally rendered so we can update the table data while still maintaining sorts and filters.

https://user-images.githubusercontent.com/4760722/200185441-2c498393-8472-4f57-8b45-6225ce369f97.mov