### PR TITLE
Throw Runtime Exception instead of NullPointer Exception when gapfill…

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillProcessor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillProcessor.java
@@ -85,6 +85,10 @@ public class GapfillProcessor extends BaseGapfillProcessor {
 
     // The first one argument of timeSeries is time column. The left ones are defining entity.
     for (ExpressionContext entityColum : _timeSeries) {
+      if (indexes.containsKey(entityColum.getIdentifier())) {
+        throw new RuntimeException(
+                String.format("column (%s) inside timeSeries is not inside the gapfill selector.", entityColum));
+      }
       int index = indexes.get(entityColum.getIdentifier());
       _isGroupBySelections[index] = true;
     }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/GapfillQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/GapfillQueriesTest.java
@@ -4028,6 +4028,25 @@ public class GapfillQueriesTest extends BaseQueriesTest {
     }
   }
 
+  @Test
+  public void missingColumnFromTimeSeriesInsideGapfillSelector() {
+    try {
+      String gapfillQuery = "SELECT GapFill(DATETIMECONVERT(eventTime, '1:MILLISECONDS:EPOCH', "
+          + "    '1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS', '1:HOURS'), "
+          + "    '1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS', "
+          + "    '2021-11-07 4:00:00.000',  '2021-11-07 12:00:00.000', '1:HOURS',"
+          + "     FILL(isOccupied, 'FILL_PREVIOUS_VALUE'), TIMESERIESON(levelId, lotId)) AS time_col,"
+          + "     levelId, isOccupied "
+          + "FROM parkingData "
+          + "WHERE eventTime >= 1636257600000 AND eventTime <= 1636286400000 "
+          + "LIMIT 200 ";
+
+      getBrokerResponse(gapfillQuery);
+      Assert.fail();
+    } catch (RuntimeException ex) {
+    }
+  }
+
   @AfterClass
   public void tearDown()
       throws IOException {


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Throw RuntimeException when gapfill selector lacks a timeSeries column\.

```mermaid
flowchart TD
  N0["Enter GapfillProcessor#46;process #40;F1#41;"]:::stModified
  N1["Iterate over each entity column in #95;timeSeries #40;F1#41;"]:::stModified
  N2["Check if column identifier exists in indexes map #40;F1#41;"]:::stModified
  N3["Column present#58; set #95;isGroupBySelections#91;index#93; #61; true #40;F1#41;"]:::stModified
  N4["Column absent#58; throw RuntimeException with message #40;F1#41;"]:::stModified
  N5["Exit process #40;exception thrown or normal completion#41; #40;F1#41;"]:::stModified
  N0 -->|"start loop"| N1
  N1 -->|"next column"| N2
  N2 -->|"column present"| N3
  N2 -->|"column missing"| N4
  N3 -->|"continue loop"| N1
  N4 -->|"exception exits"| N5
  N1 -->|"loop end #40;no more columns#41;"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillProcessor\.java — [before](https://github.com/apache/pinot/blob/2f640ff8683728b844be9e045d5ce0f026d09e71/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillProcessor.java) · [after](https://github.com/apache/pinot/blob/4edf2d523751993661c91eece9fa59c02d5f8f16/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillProcessor.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjJmNjQwZmY4NjgzNzI4Yjg0NGJlOWUwNDVkNWNlMGYwMjZkMDllNzEiLCJjb250ZXh0X2hhc2giOiI2ZjAzOGY4ODYzYTMxODEwMDQwMDZiYjcyNTUxYTI2Y2E0NGI4YzZiMzc3OGRhMGVjMjBkZmYyNzJhMTkwYjQxIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MTMwNDg0LCJoZWFkX3NoYSI6IjRlZGYyZDUyMzc1MTk5MzY2MWM5MWVlY2U5ZmE1OWMwMmQ1ZjhmMTYiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIyZjY0MGZmODY4MzcyOGI4NDRiZTllMDQ1ZDVjZTBmMDI2ZDA5ZTcxIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature d3699f8d30c1742c446822561f53b82cca7ebd06eb79d0f3c608814829d9e0b3 -->
<!-- pinot-pr-flow:end -->

… selector does not have the column from timeseries clause.

Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
