### PR TITLE
Deserialize Hyperloglog objects more optimally

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
@@ -51,7 +51,6 @@ import it.unimi.dsi.fastutil.objects.ObjectSet;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.IntBuffer;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -476,31 +475,22 @@ public class ObjectSerDeUtils {
 
     @Override
     public HyperLogLog deserialize(byte[] bytes) {
-      return deserialize(ByteBuffer.wrap(bytes)
-              .order(ByteOrder.BIG_ENDIAN)
-              .asIntBuffer());
+      return deserialize(ByteBuffer.wrap(bytes));
     }
 
     @Override
     public HyperLogLog deserialize(ByteBuffer byteBuffer) {
-      byte[] bytes = new byte[byteBuffer.remaining()];
-      byteBuffer.get(bytes);
-      return deserialize(bytes);
+      // NOTE: The passed in byte buffer is always BIG ENDIAN
+      return deserialize(byteBuffer.asIntBuffer());
     }
 
-    private HyperLogLog deserialize(IntBuffer intBuf) {
+    private HyperLogLog deserialize(IntBuffer intBuffer) {
       try {
-        // The first 2 integers are constant headers for the HLL. We only need the first byte, the log2m.
-        // We skip the second integer, array size, as we instead rely on comparing the buffer size to the
-        // remaining integers size.
-        int log2m = intBuf.get(0);
-        intBuf.position(2);
-
-        if (intBuf.remaining() != RegisterSet.getSizeForCount(1 << log2m)) {
-          throw new RuntimeException("Caught exception while deserializing HyperLogLog");
-        }
-        int[] bits = new int[intBuf.remaining()];
-        intBuf.get(bits);
+        // The first 2 integers are constant headers for the HLL: log2m and size in bytes
+        int log2m = intBuffer.get();
+        int numBits = intBuffer.get() >>> 2;
+        int[] bits = new int[numBits];
+        intBuffer.get(bits);
         return new HyperLogLog(log2m, new RegisterSet(1 << log2m, bits));
       } catch (RuntimeException e) {
         throw new RuntimeException("Caught exception while deserializing HyperLogLog", e);

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
@@ -483,7 +483,9 @@ public class ObjectSerDeUtils {
 
     @Override
     public HyperLogLog deserialize(ByteBuffer byteBuffer) {
-      return deserialize(byteBuffer.rewind().asIntBuffer());
+      byte[] bytes = new byte[byteBuffer.remaining()];
+      byteBuffer.get(bytes);
+      return deserialize(bytes);
     }
 
     private HyperLogLog deserialize(IntBuffer intBuf) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/ObjectSerDeUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/ObjectSerDeUtilsTest.java
@@ -43,10 +43,10 @@ import org.apache.pinot.segment.local.customobject.MinMaxRangePair;
 import org.apache.pinot.segment.local.customobject.QuantileDigest;
 import org.apache.pinot.segment.local.customobject.StringLongPair;
 import org.apache.pinot.segment.local.customobject.ValueLongPair;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 
 
 public class ObjectSerDeUtilsTest {
@@ -140,8 +140,7 @@ public class ObjectSerDeUtilsTest {
       ValueLongPair<Integer> expected = new IntLongPair(RANDOM.nextInt(), RANDOM.nextLong());
 
       byte[] bytes = ObjectSerDeUtils.serialize(expected);
-      ValueLongPair<Integer> actual = ObjectSerDeUtils.deserialize(bytes,
-          ObjectSerDeUtils.ObjectType.IntLongPair);
+      ValueLongPair<Integer> actual = ObjectSerDeUtils.deserialize(bytes, ObjectSerDeUtils.ObjectType.IntLongPair);
 
       assertEquals(actual.getValue(), expected.getValue(), ERROR_MESSAGE);
       assertEquals(actual.getTime(), expected.getTime(), ERROR_MESSAGE);
@@ -154,8 +153,7 @@ public class ObjectSerDeUtilsTest {
       ValueLongPair<Long> expected = new LongLongPair(RANDOM.nextLong(), RANDOM.nextLong());
 
       byte[] bytes = ObjectSerDeUtils.serialize(expected);
-      ValueLongPair<Long> actual = ObjectSerDeUtils.deserialize(bytes,
-          ObjectSerDeUtils.ObjectType.LongLongPair);
+      ValueLongPair<Long> actual = ObjectSerDeUtils.deserialize(bytes, ObjectSerDeUtils.ObjectType.LongLongPair);
 
       assertEquals(actual.getValue(), expected.getValue(), ERROR_MESSAGE);
       assertEquals(actual.getTime(), expected.getTime(), ERROR_MESSAGE);
@@ -181,8 +179,7 @@ public class ObjectSerDeUtilsTest {
       ValueLongPair<Double> expected = new DoubleLongPair(RANDOM.nextDouble(), RANDOM.nextLong());
 
       byte[] bytes = ObjectSerDeUtils.serialize(expected);
-      ValueLongPair<Double> actual = ObjectSerDeUtils.deserialize(bytes,
-          ObjectSerDeUtils.ObjectType.DoubleLongPair);
+      ValueLongPair<Double> actual = ObjectSerDeUtils.deserialize(bytes, ObjectSerDeUtils.ObjectType.DoubleLongPair);
 
       assertEquals(actual.getValue(), expected.getValue(), ERROR_MESSAGE);
       assertEquals(actual.getTime(), expected.getTime(), ERROR_MESSAGE);
@@ -196,8 +193,7 @@ public class ObjectSerDeUtilsTest {
 
       String temp = new String(expected.getValue().getBytes());
       byte[] bytes = ObjectSerDeUtils.serialize(expected);
-      ValueLongPair<String> actual = ObjectSerDeUtils.deserialize(bytes,
-          ObjectSerDeUtils.ObjectType.StringLongPair);
+      ValueLongPair<String> actual = ObjectSerDeUtils.deserialize(bytes, ObjectSerDeUtils.ObjectType.StringLongPair);
 
       assertEquals(actual.getValue(), expected.getValue(), ERROR_MESSAGE);
       assertEquals(actual.getTime(), expected.getTime(), ERROR_MESSAGE);
@@ -217,16 +213,14 @@ public class ObjectSerDeUtilsTest {
   }
 
   @Test
-  public void testHyperLogLogDeserializeThrowsForSizeMismatch() throws Exception {
-    // We serialize a HLL w/ log2m of 12 and then trim 1024 bytes from the end of it and try to
-    // deserialize it. An exception should occur for this log2m, 2732 bytes are expected after the headers,
-    // but instead it will only find 1078.
+  public void testHyperLogLogDeserializeThrowsForSizeMismatch()
+      throws Exception {
+    // We serialize a HLL w/ log2m of 12 and then trim 1024 bytes from the end of it and try to deserialize it. An
+    // exception should occur because 2732 bytes are expected after the headers, but instead it will only find 1708.
     byte[] bytes = (new HyperLogLog(12)).getBytes();
     byte[] trimmed = Arrays.copyOfRange(bytes, 0, bytes.length - 1024);
-    Assert.assertThrows(RuntimeException.class, () -> ObjectSerDeUtils.deserialize(
-            trimmed,
-            ObjectSerDeUtils.ObjectType.HyperLogLog
-    ));
+    assertThrows(RuntimeException.class,
+        () -> ObjectSerDeUtils.deserialize(trimmed, ObjectSerDeUtils.ObjectType.HyperLogLog));
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/ObjectSerDeUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/ObjectSerDeUtilsTest.java
@@ -223,7 +223,10 @@ public class ObjectSerDeUtilsTest {
     // but instead it will only find 1078.
     byte[] bytes = (new HyperLogLog(12)).getBytes();
     byte[] trimmed = Arrays.copyOfRange(bytes, 0, bytes.length - 1024);
-    Assert.assertThrows(RuntimeException.class, () -> ObjectSerDeUtils.deserialize(trimmed, ObjectSerDeUtils.ObjectType.HyperLogLog));
+    Assert.assertThrows(RuntimeException.class, () -> ObjectSerDeUtils.deserialize(
+            trimmed,
+            ObjectSerDeUtils.ObjectType.HyperLogLog
+    ));
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/ObjectSerDeUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/ObjectSerDeUtilsTest.java
@@ -27,6 +27,7 @@ import it.unimi.dsi.fastutil.ints.Int2LongOpenHashMap;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
@@ -42,6 +43,7 @@ import org.apache.pinot.segment.local.customobject.MinMaxRangePair;
 import org.apache.pinot.segment.local.customobject.QuantileDigest;
 import org.apache.pinot.segment.local.customobject.StringLongPair;
 import org.apache.pinot.segment.local.customobject.ValueLongPair;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -212,6 +214,16 @@ public class ObjectSerDeUtilsTest {
 
       assertEquals(actual.cardinality(), expected.cardinality(), ERROR_MESSAGE);
     }
+  }
+
+  @Test
+  public void testHyperLogLogDeserializeThrowsForSizeMismatch() throws Exception {
+    // We serialize a HLL w/ log2m of 12 and then trim 1024 bytes from the end of it and try to
+    // deserialize it. An exception should occur for this log2m, 2732 bytes are expected after the headers,
+    // but instead it will only find 1078.
+    byte[] bytes = (new HyperLogLog(12)).getBytes();
+    byte[] trimmed = Arrays.copyOfRange(bytes, 0, bytes.length - 1024);
+    Assert.assertThrows(RuntimeException.class, () -> ObjectSerDeUtils.deserialize(trimmed, ObjectSerDeUtils.ObjectType.HyperLogLog));
   }
 
   @Test


### PR DESCRIPTION
**Summary**
This PR more optimally de-serializes HyperLogLog objects. We see a 4x~ improvement in speed.
This has been useful for us at Stripe because we have queries that aggregate thousands up to hundreds of thousands of records. 

**Profile of host during aggregation queries before the change:**
![image](https://user-images.githubusercontent.com/10234864/200416947-10668bee-c119-401b-b421-3724af26fcd6.png)


**After the change:**
![image](https://user-images.githubusercontent.com/10234864/200416914-b9f74476-d3b0-4b66-98bb-cc6e97d598ba.png)


**Tests**
- a unit test to assert correctness of deserialization already exists.
- I added one to assert that we throw when the optimization logic that expects specific bytes size based on the log2m, there's a mismatch