### PR TITLE
mark spark-launcher as a provided dependency

### DIFF
--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -281,6 +281,7 @@
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-launcher_${scala.version}</artifactId>
       <version>${spark.version}</version>
+      <scope>provided</scope>
       <exclusions>
         <exclusion>
           <groupId>org.scala-lang</groupId>


### PR DESCRIPTION
I'm hoping someone that understands this code path well can review. But this marks the `spark_launcher` jar to be provided. We ran into this in a really weird case:
- we are in the midst of a spark2 -> spark3 migration 
- we fork spark, and we reverted a change to the launcher on our spark fork to work with the old launcher sh files
- we build pinot with shaded jars, i believe to pull in a correct, later hadoop dependency

Because this jar gets shaded, we were using the later code that didn't work with our launcher shell script. Spark core is already scoped as [provided](https://github.com/apache/pinot/blob/master/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3.2/pom.xml#L55), so this seems like the desired behavior here, too.