### PR TITLE
[multistage] refactor MailboxSendOperator for testability and tests

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -138,7 +138,7 @@ public class QueryRunner {
       MailboxSendNode sendNode = (MailboxSendNode) distributedStagePlan.getStageRoot();
       StageMetadata receivingStageMetadata = distributedStagePlan.getMetadataMap().get(sendNode.getReceiverStageId());
       MailboxSendOperator mailboxSendOperator =
-          new MailboxSendOperator(_mailboxService, sendNode.getDataSchema(),
+          new MailboxSendOperator(_mailboxService,
               new LeafStageTransferableBlockOperator(serverQueryResults, sendNode.getDataSchema()),
               receivingStageMetadata.getServerInstances(), sendNode.getExchangeType(),
               sendNode.getPartitionKeySelector(), _hostname, _port, serverQueryRequests.get(0).getRequestId(),

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/BlockSplitter.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/BlockSplitter.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.blocks;
+
+import java.util.Iterator;
+import org.apache.pinot.common.datablock.BaseDataBlock;
+
+
+/**
+ * Interface for splitting transferable blocks. This is used for ensuring
+ * that the blocks that are sent along the wire play nicely with the
+ * underlying transport.
+ */
+public interface BlockSplitter {
+
+  /**
+   * @return a list of blocks that was split from the original {@code block}
+   */
+  Iterator<TransferableBlock> split(TransferableBlock block, BaseDataBlock.Type type, int maxBlockSize);
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtils.java
@@ -19,8 +19,9 @@
 package org.apache.pinot.query.runtime.blocks;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterators;
 import java.util.ArrayList;
-import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.datablock.DataBlock;
@@ -64,7 +65,7 @@ public final class TransferableBlockUtils {
    *
    * @see TransferableBlockUtils#splitBlock(TransferableBlock, DataBlock.Type, int, boolean)
    */
-  public static List<TransferableBlock> splitBlock(TransferableBlock block, DataBlock.Type type, int maxBlockSize) {
+  public static Iterator<TransferableBlock> splitBlock(TransferableBlock block, DataBlock.Type type, int maxBlockSize) {
     return splitBlock(block, type, maxBlockSize, false);
   }
 
@@ -84,7 +85,7 @@ public final class TransferableBlockUtils {
    *                          from leaf stage.
    * @return a list of data block chunks
    */
-  public static List<TransferableBlock> splitBlock(TransferableBlock block, DataBlock.Type type, int maxBlockSize,
+  public static Iterator<TransferableBlock> splitBlock(TransferableBlock block, DataBlock.Type type, int maxBlockSize,
       boolean needsCanonicalize) {
     List<TransferableBlock> blockChunks = new ArrayList<>();
     if (type == DataBlock.Type.ROW) {
@@ -105,9 +106,9 @@ public final class TransferableBlockUtils {
         currentRow += numRowsPerChunk;
         blockChunks.add(new TransferableBlock(chunk, block.getDataSchema(), block.getType()));
       }
-      return blockChunks;
+      return blockChunks.iterator();
     } else if (type == DataBlock.Type.METADATA) {
-      return Collections.singletonList(block);
+      return Iterators.singletonIterator(block);
     } else {
       throw new IllegalArgumentException("Unsupported data block type: " + type);
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -21,7 +21,6 @@ package org.apache.pinot.query.runtime.operator;
 import com.google.common.base.Preconditions;
 import java.util.Collections;
 import java.util.List;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.pinot.common.exception.QueryException;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -21,6 +21,7 @@ package org.apache.pinot.query.runtime.operator;
 import com.google.common.base.Preconditions;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.pinot.common.exception.QueryException;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -18,28 +18,26 @@
  */
 package org.apache.pinot.query.runtime.operator;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Random;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelDistribution;
-import org.apache.pinot.common.datablock.DataBlock;
-import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.query.mailbox.MailboxIdentifier;
 import org.apache.pinot.query.mailbox.MailboxService;
-import org.apache.pinot.query.mailbox.SendingMailbox;
 import org.apache.pinot.query.mailbox.StringMailboxIdentifier;
 import org.apache.pinot.query.planner.partitioning.KeySelector;
+import org.apache.pinot.query.runtime.blocks.BlockSplitter;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.apache.pinot.query.runtime.operator.exchange.BlockExchange;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,57 +47,67 @@ import org.slf4j.LoggerFactory;
  */
 public class MailboxSendOperator extends BaseOperator<TransferableBlock> {
   private static final Logger LOGGER = LoggerFactory.getLogger(MailboxSendOperator.class);
+
   private static final String EXPLAIN_NAME = "MAILBOX_SEND";
   private static final Set<RelDistribution.Type> SUPPORTED_EXCHANGE_TYPE =
       ImmutableSet.of(RelDistribution.Type.SINGLETON, RelDistribution.Type.RANDOM_DISTRIBUTED,
           RelDistribution.Type.BROADCAST_DISTRIBUTED, RelDistribution.Type.HASH_DISTRIBUTED);
-  private static final Random RANDOM = new Random();
-  // TODO: Deduct this value via grpc config maximum byte size; and make it configurable with override.
-  // TODO: Max block size is a soft limit. only counts fixedSize datatable byte buffer
-  private static final int MAX_MAILBOX_CONTENT_SIZE_BYTES = 4 * 1024 * 1024;
 
-  private final List<ServerInstance> _receivingStageInstances;
-  private final RelDistribution.Type _exchangeType;
-  private final KeySelector<Object[], Object[]> _keySelector;
-  private final String _serverHostName;
-  private final int _serverPort;
-  private final long _jobId;
-  private final int _stageId;
-  private final MailboxService<TransferableBlock> _mailboxService;
-  private final DataSchema _dataSchema;
-  private final boolean _isLeafStageSender;
-  private Operator<TransferableBlock> _dataTableBlockBaseOperator;
+  private final Operator<TransferableBlock> _dataTableBlockBaseOperator;
+  private final BlockExchange _exchange;
 
-  public MailboxSendOperator(MailboxService<TransferableBlock> mailboxService, DataSchema dataSchema,
+  @VisibleForTesting
+  interface BlockExchangeFactory {
+    BlockExchange build(MailboxService<TransferableBlock> mailboxService, List<MailboxIdentifier> destinations,
+        RelDistribution.Type exchange, KeySelector<Object[], Object[]> selector, BlockSplitter splitter);
+  }
+
+  @VisibleForTesting
+  interface MailboxIdGenerator {
+    MailboxIdentifier generate(ServerInstance server);
+  }
+
+  public MailboxSendOperator(MailboxService<TransferableBlock> mailboxService,
       Operator<TransferableBlock> dataTableBlockBaseOperator, List<ServerInstance> receivingStageInstances,
       RelDistribution.Type exchangeType, KeySelector<Object[], Object[]> keySelector, String hostName, int port,
       long jobId, int stageId, boolean isLeafStageSender) {
-    _dataSchema = dataSchema;
-    _mailboxService = mailboxService;
+    this(mailboxService, dataTableBlockBaseOperator, receivingStageInstances, exchangeType, keySelector,
+        isLeafStageSender, server -> toMailboxId(server, jobId, stageId, hostName, port), BlockExchange::getExchange);
+  }
+
+  @VisibleForTesting
+  MailboxSendOperator(MailboxService<TransferableBlock> mailboxService,
+      Operator<TransferableBlock> dataTableBlockBaseOperator, List<ServerInstance> receivingStageInstances,
+      RelDistribution.Type exchangeType, KeySelector<Object[], Object[]> keySelector,
+      boolean isLeafStageSender, MailboxIdGenerator mailboxIdGenerator, BlockExchangeFactory blockExchangeFactory) {
     _dataTableBlockBaseOperator = dataTableBlockBaseOperator;
-    _exchangeType = exchangeType;
-    if (_exchangeType == RelDistribution.Type.SINGLETON) {
+
+    List<MailboxIdentifier> receivingMailboxes;
+    if (exchangeType == RelDistribution.Type.SINGLETON) {
+      // TODO: this logic should be moved into SingletonExchange
       ServerInstance singletonInstance = null;
       for (ServerInstance serverInstance : receivingStageInstances) {
-        if (serverInstance.getHostname().equals(_mailboxService.getHostname())
-            && serverInstance.getQueryMailboxPort() == _mailboxService.getMailboxPort()) {
+        if (serverInstance.getHostname().equals(mailboxService.getHostname())
+            && serverInstance.getQueryMailboxPort() == mailboxService.getMailboxPort()) {
           Preconditions.checkState(singletonInstance == null, "multiple instance found for singleton exchange type!");
           singletonInstance = serverInstance;
         }
       }
       Preconditions.checkNotNull(singletonInstance, "Unable to find receiving instance for singleton exchange");
-      _receivingStageInstances = Collections.singletonList(singletonInstance);
+      receivingMailboxes = Collections.singletonList(mailboxIdGenerator.generate(singletonInstance));
     } else {
-      _receivingStageInstances = receivingStageInstances;
+      receivingMailboxes = receivingStageInstances
+          .stream()
+          .map(mailboxIdGenerator::generate)
+          .collect(Collectors.toList());
     }
-    _keySelector = keySelector;
-    _serverHostName = hostName;
-    _serverPort = port;
-    _jobId = jobId;
-    _stageId = stageId;
-    Preconditions.checkState(SUPPORTED_EXCHANGE_TYPE.contains(_exchangeType),
-        String.format("Exchange type '%s' is not supported yet", _exchangeType));
-    _isLeafStageSender = isLeafStageSender;
+
+    BlockSplitter splitter = (block, type, size)
+        -> TransferableBlockUtils.splitBlock(block, type, size, isLeafStageSender);
+    _exchange = blockExchangeFactory.build(mailboxService, receivingMailboxes, exchangeType, keySelector, splitter);
+
+    Preconditions.checkState(SUPPORTED_EXCHANGE_TYPE.contains(exchangeType),
+        String.format("Exchange type '%s' is not supported yet", exchangeType));
   }
 
   @Override
@@ -126,107 +134,20 @@ public class MailboxSendOperator extends BaseOperator<TransferableBlock> {
       transferableBlock = TransferableBlockUtils.getErrorTransferableBlock(e);
     }
 
-    if (TransferableBlockUtils.isNoOpBlock(transferableBlock)) {
-      return transferableBlock;
+    if (!TransferableBlockUtils.isNoOpBlock(transferableBlock)) {
+      try {
+        _exchange.send(transferableBlock);
+      } catch (Exception e) {
+        LOGGER.error("Exception while sending block to mailbox.", e);
+      }
     }
 
-    boolean isEndOfStream = TransferableBlockUtils.isEndOfStream(transferableBlock);
-    DataBlock.Type type = transferableBlock.getType();
-    try {
-      switch (_exchangeType) {
-        case SINGLETON:
-          sendDataTableBlockToServers(Arrays.asList(_receivingStageInstances.get(0)), transferableBlock, type,
-              isEndOfStream);
-          break;
-        case RANDOM_DISTRIBUTED:
-          if (isEndOfStream) {
-            sendDataTableBlockToServers(_receivingStageInstances, transferableBlock, type, true);
-          } else {
-            int randomInstanceIdx =
-                _exchangeType == RelDistribution.Type.SINGLETON ? 0 : RANDOM.nextInt(_receivingStageInstances.size());
-            ServerInstance randomInstance = _receivingStageInstances.get(randomInstanceIdx);
-            sendDataTableBlockToServers(Arrays.asList(randomInstance), transferableBlock, type, false);
-          }
-          break;
-        case BROADCAST_DISTRIBUTED:
-          sendDataTableBlockToServers(_receivingStageInstances, transferableBlock, type, isEndOfStream);
-          break;
-        case HASH_DISTRIBUTED:
-          // TODO: ensure that server instance list is sorted using same function in sender.
-          List<TransferableBlock> dataTableList = constructPartitionedDataBlock(transferableBlock, _keySelector,
-              _receivingStageInstances.size(), isEndOfStream);
-          for (int i = 0; i < _receivingStageInstances.size(); i++) {
-            sendDataTableBlockToServers(Arrays.asList(_receivingStageInstances.get(i)), dataTableList.get(i), type,
-                isEndOfStream);
-          }
-          break;
-        case RANGE_DISTRIBUTED:
-        case ROUND_ROBIN_DISTRIBUTED:
-        case ANY:
-        default:
-          throw new UnsupportedOperationException("Unsupported mailbox exchange type: " + _exchangeType);
-      }
-    } catch (Exception e) {
-      LOGGER.error("Exception occur while sending data via mailbox", e);
-    }
     return transferableBlock;
   }
 
-  private static List<TransferableBlock> constructPartitionedDataBlock(TransferableBlock transferableBlock,
-      KeySelector<Object[], Object[]> keySelector, int partitionSize, boolean isEndOfStream) {
-    List<TransferableBlock> transferableBlockList = new ArrayList<>(partitionSize);
-    if (isEndOfStream) {
-      for (int i = 0; i < partitionSize; i++) {
-        transferableBlockList.add(transferableBlock);
-      }
-    } else {
-      List<List<Object[]>> temporaryRows = new ArrayList<>(partitionSize);
-      for (int i = 0; i < partitionSize; i++) {
-        temporaryRows.add(new ArrayList<>());
-      }
-      for (Object[] row : transferableBlock.getContainer()) {
-        int partitionId = keySelector.computeHash(row) % partitionSize;
-        temporaryRows.get(partitionId).add(row);
-      }
-      for (int i = 0; i < partitionSize; i++) {
-        List<Object[]> container = temporaryRows.get(i);
-        transferableBlockList.add(new TransferableBlock(
-            container, transferableBlock.getDataSchema(), transferableBlock.getType()));
-      }
-    }
-    return transferableBlockList;
-  }
-
-  private void sendDataTableBlockToServers(List<ServerInstance> servers, TransferableBlock transferableBlock,
-      DataBlock.Type type, boolean isEndOfStream) {
-    if (isEndOfStream) {
-      for (ServerInstance server : servers) {
-        sendDataTableBlock(server, transferableBlock, true);
-      }
-    } else {
-      // Split the block only when it is not end of stream block.
-      List<TransferableBlock> chunks = TransferableBlockUtils.splitBlock(transferableBlock, type,
-          MAX_MAILBOX_CONTENT_SIZE_BYTES, _isLeafStageSender);
-      for (ServerInstance server : servers) {
-        for (TransferableBlock chunk : chunks) {
-          sendDataTableBlock(server, chunk, false);
-        }
-      }
-    }
-  }
-
-  private void sendDataTableBlock(ServerInstance serverInstance, TransferableBlock transferableBlock,
-      boolean isEndOfStream) {
-    MailboxIdentifier mailboxId = toMailboxId(serverInstance);
-    SendingMailbox<TransferableBlock> sendingMailbox = _mailboxService.getSendingMailbox(mailboxId);
-    sendingMailbox.send(transferableBlock);
-    if (isEndOfStream) {
-      sendingMailbox.complete();
-    }
-  }
-
-  private StringMailboxIdentifier toMailboxId(ServerInstance serverInstance) {
-    return new StringMailboxIdentifier(String.format("%s_%s", _jobId, _stageId), _serverHostName, _serverPort,
+  private static StringMailboxIdentifier toMailboxId(
+      ServerInstance serverInstance, long jobId, int stageId, String serverHostName, int serverPort) {
+    return new StringMailboxIdentifier(String.format("%s_%s", jobId, stageId), serverHostName, serverPort,
         serverInstance.getHostname(), serverInstance.getQueryMailboxPort());
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BlockExchange.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BlockExchange.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.exchange;
+
+import java.util.Iterator;
+import java.util.List;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.pinot.common.datablock.DataBlock;
+import org.apache.pinot.query.mailbox.MailboxIdentifier;
+import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.mailbox.SendingMailbox;
+import org.apache.pinot.query.planner.partitioning.KeySelector;
+import org.apache.pinot.query.runtime.blocks.BlockSplitter;
+import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+
+
+/**
+ * This class contains the shared logic across all different exchange types for
+ * exchanging data across different servers.
+ */
+public abstract class BlockExchange {
+  // TODO: Deduct this value via grpc config maximum byte size; and make it configurable with override.
+  // TODO: Max block size is a soft limit. only counts fixedSize datatable byte buffer
+  private static final int MAX_MAILBOX_CONTENT_SIZE_BYTES = 4 * 1024 * 1024;
+
+  private final MailboxService<TransferableBlock> _mailbox;
+  private final List<MailboxIdentifier> _destinations;
+  private final BlockSplitter _splitter;
+
+  public static BlockExchange getExchange(MailboxService<TransferableBlock> mailboxService,
+      List<MailboxIdentifier> destinations, RelDistribution.Type exchangeType,
+      KeySelector<Object[], Object[]> selector, BlockSplitter splitter) {
+    switch (exchangeType) {
+      case SINGLETON:
+        return new SingletonExchange(mailboxService, destinations, splitter);
+      case HASH_DISTRIBUTED:
+        return new HashExchange(mailboxService, destinations, selector, splitter);
+      case RANDOM_DISTRIBUTED:
+        return new RandomExchange(mailboxService, destinations, splitter);
+      case BROADCAST_DISTRIBUTED:
+        return new BroadcastExchange(mailboxService, destinations, splitter);
+      case ROUND_ROBIN_DISTRIBUTED:
+      case RANGE_DISTRIBUTED:
+      case ANY:
+      default:
+        throw new UnsupportedOperationException("Unsupported mailbox exchange type: " + exchangeType);
+    }
+  }
+
+  protected BlockExchange(MailboxService<TransferableBlock> mailbox, List<MailboxIdentifier> destinations,
+      BlockSplitter splitter) {
+    _mailbox = mailbox;
+    _destinations = destinations;
+    _splitter = splitter;
+  }
+
+  public void send(TransferableBlock block) {
+    if (block.isEndOfStreamBlock()) {
+      _destinations.forEach(destination -> sendBlock(destination, block));
+      return;
+    }
+
+    Iterator<RoutedBlock> routedBlocks = route(_destinations, block);
+    while (routedBlocks.hasNext()) {
+      RoutedBlock next = routedBlocks.next();
+      sendBlock(next._destination, next._block);
+    }
+  }
+
+  private void sendBlock(MailboxIdentifier mailboxId, TransferableBlock block) {
+    SendingMailbox<TransferableBlock> sendingMailbox = _mailbox.getSendingMailbox(mailboxId);
+
+    if (block.isEndOfStreamBlock()) {
+      sendingMailbox.send(block);
+      sendingMailbox.complete();
+      return;
+    }
+
+    DataBlock.Type type = block.getType();
+    Iterator<TransferableBlock> splits = _splitter.split(block, type, MAX_MAILBOX_CONTENT_SIZE_BYTES);
+
+    while (splits.hasNext()) {
+      sendingMailbox.send(splits.next());
+    }
+  }
+
+  protected abstract Iterator<RoutedBlock> route(List<MailboxIdentifier> destinations, TransferableBlock block);
+
+  protected static class RoutedBlock {
+    final MailboxIdentifier _destination;
+    final TransferableBlock _block;
+
+    protected RoutedBlock(MailboxIdentifier destination, TransferableBlock block) {
+      _destination = destination;
+      _block = block;
+    }
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BroadcastExchange.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BroadcastExchange.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.exchange;
+
+import java.util.Iterator;
+import java.util.List;
+import org.apache.pinot.query.mailbox.MailboxIdentifier;
+import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.runtime.blocks.BlockSplitter;
+import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+
+
+/**
+ * Broadcast blocks to all receiving servers.
+ */
+class BroadcastExchange extends BlockExchange {
+
+  protected BroadcastExchange(MailboxService<TransferableBlock> mailbox, List<MailboxIdentifier> destinations,
+      BlockSplitter splitter) {
+    super(mailbox, destinations, splitter);
+  }
+
+  @Override
+  protected Iterator<RoutedBlock> route(List<MailboxIdentifier> destinations, TransferableBlock block) {
+    return destinations.stream().map(dest -> new RoutedBlock(dest, block)).iterator();
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/HashExchange.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/HashExchange.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.exchange;
+
+import com.google.common.collect.Iterators;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.query.mailbox.MailboxIdentifier;
+import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.planner.partitioning.KeySelector;
+import org.apache.pinot.query.runtime.blocks.BlockSplitter;
+import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+
+
+/**
+ * Distributes blocks based on the hash of a key, selected by the specified
+ * {@code keySelector}. This will redistribute rows from input blocks (breaking
+ * them up if necessary).
+ */
+class HashExchange extends BlockExchange {
+
+  // TODO: ensure that server instance list is sorted using same function in sender.
+  private final KeySelector<Object[], Object[]> _keySelector;
+
+  HashExchange(MailboxService<TransferableBlock> mailbox, List<MailboxIdentifier> destinations,
+      KeySelector<Object[], Object[]> selector, BlockSplitter splitter) {
+    super(mailbox, destinations, splitter);
+    _keySelector = selector;
+  }
+
+  @Override
+  protected Iterator<RoutedBlock> route(List<MailboxIdentifier> destinations, TransferableBlock block) {
+    Map<Integer, List<Object[]>> destIdxToRows = new HashMap<>();
+
+    for (Object[] row : block.getContainer()) {
+      int partition = _keySelector.computeHash(row) % destinations.size();
+      destIdxToRows.computeIfAbsent(partition, k -> new ArrayList<>()).add(row);
+    }
+
+    return Iterators.transform(
+        destIdxToRows.entrySet().iterator(),
+        partitionAndBlock -> new RoutedBlock(
+            destinations.get(partitionAndBlock.getKey()),
+            new TransferableBlock(partitionAndBlock.getValue(), block.getDataSchema(), block.getType())));
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/RandomExchange.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/RandomExchange.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.exchange;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Iterators;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Random;
+import java.util.function.IntFunction;
+import org.apache.pinot.query.mailbox.MailboxIdentifier;
+import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.runtime.blocks.BlockSplitter;
+import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+
+
+/**
+ * Randomly distributes blocks across a set of input servers (NOTE: this
+ * is not round-robin, but rather truly random block distribution).
+ */
+class RandomExchange extends BlockExchange {
+  private static final Random RANDOM = new Random();
+
+  private final IntFunction<Integer> _rand;
+
+  RandomExchange(MailboxService<TransferableBlock> mailbox, List<MailboxIdentifier> destinations,
+      BlockSplitter splitter) {
+    this(mailbox, destinations, RANDOM::nextInt, splitter);
+  }
+
+  @VisibleForTesting
+  RandomExchange(MailboxService<TransferableBlock> mailbox, List<MailboxIdentifier> destinations,
+      IntFunction<Integer> rand, BlockSplitter splitter) {
+    super(mailbox, destinations, splitter);
+    _rand = rand;
+  }
+
+  @Override
+  protected Iterator<RoutedBlock> route(List<MailboxIdentifier> destinations, TransferableBlock block) {
+    int destinationIdx = _rand.apply(destinations.size());
+    return Iterators.singletonIterator(new RoutedBlock(destinations.get(destinationIdx), block));
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/SingletonExchange.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/SingletonExchange.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.exchange;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Iterators;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.pinot.query.mailbox.MailboxIdentifier;
+import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.runtime.blocks.BlockSplitter;
+import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+
+
+/**
+ * Sends blocks to a specific server, with the expectation that only one
+ * server is ever on the receiving end.
+ */
+class SingletonExchange extends BlockExchange {
+
+  SingletonExchange(MailboxService<TransferableBlock> mailbox, List<MailboxIdentifier> destinations,
+      BlockSplitter splitter) {
+    super(mailbox, destinations, splitter);
+  }
+
+  @Override
+  protected Iterator<RoutedBlock> route(List<MailboxIdentifier> destinations, TransferableBlock block) {
+    return Iterators.singletonIterator(new RoutedBlock(Iterables.getOnlyElement(destinations), block));
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
@@ -74,7 +74,7 @@ public class PhysicalPlanVisitor implements StageNodeVisitor<Operator<Transferab
   public Operator<TransferableBlock> visitMailboxSend(MailboxSendNode node, PlanRequestContext context) {
     Operator<TransferableBlock> nextOperator = node.getInputs().get(0).visit(this, context);
     StageMetadata receivingStageMetadata = context.getMetadataMap().get(node.getReceiverStageId());
-    return new MailboxSendOperator(context.getMailboxService(), node.getDataSchema(), nextOperator,
+    return new MailboxSendOperator(context.getMailboxService(), nextOperator,
         receivingStageMetadata.getServerInstances(), node.getExchangeType(), node.getPartitionKeySelector(),
         context.getHostName(), context.getPort(), context.getRequestId(), node.getStageId(), false);
   }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtilsTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.query.runtime.blocks;
 
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import org.apache.pinot.common.datablock.BaseDataBlock;
 import org.apache.pinot.common.datablock.ColumnarDataBlock;
@@ -94,17 +95,19 @@ public class TransferableBlockUtilsTest {
 
   private void validateNonSplittableBlock(BaseDataBlock nonSplittableBlock)
       throws Exception {
-    List<TransferableBlock> transferableBlocks =
+    Iterator<TransferableBlock> transferableBlocks =
         TransferableBlockUtils.splitBlock(new TransferableBlock(nonSplittableBlock), DataBlock.Type.METADATA,
             4 * 1024 * 1024);
-    Assert.assertEquals(transferableBlocks.size(), 1);
-    Assert.assertEquals(transferableBlocks.get(0).getDataBlock(), nonSplittableBlock);
+    Assert.assertTrue(transferableBlocks.hasNext());
+    Assert.assertEquals(transferableBlocks.next().getDataBlock(), nonSplittableBlock);
+    Assert.assertFalse(transferableBlocks.hasNext());
   }
 
-  private void validateBlocks(List<TransferableBlock> blocks, List<Object[]> rows, DataSchema dataSchema)
+  private void validateBlocks(Iterator<TransferableBlock> blocks, List<Object[]> rows, DataSchema dataSchema)
       throws Exception {
     int rowId = 0;
-    for (TransferableBlock block : blocks) {
+    while (blocks.hasNext()) {
+      TransferableBlock block = blocks.next();
       for (Object[] row : block.getContainer()) {
         for (int colId = 0; colId < dataSchema.getColumnNames().length; colId++) {
           if (row[colId] == null && rows.get(rowId)[colId] == null) {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
@@ -1,0 +1,166 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Arrays;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.pinot.common.datablock.DataBlock;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.transport.ServerInstance;
+import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.mailbox.StringMailboxIdentifier;
+import org.apache.pinot.query.planner.partitioning.KeySelector;
+import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.apache.pinot.query.runtime.operator.exchange.BlockExchange;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class MailboxSendOperatorTest {
+
+  private AutoCloseable _mocks;
+
+  @Mock
+  private Operator<TransferableBlock> _input;
+  @Mock
+  private MailboxService<TransferableBlock> _mailboxService;
+  @Mock
+  private ServerInstance _server;
+  @Mock
+  private KeySelector<Object[], Object[]> _selector;
+  @Mock
+  private MailboxSendOperator.BlockExchangeFactory _exchangeFactory;
+  @Mock
+  private BlockExchange _exchange;
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = MockitoAnnotations.openMocks(this);
+    Mockito.when(_exchangeFactory.build(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+        .thenReturn(_exchange);
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void shouldSwallowNoOpBlockFromUpstream() {
+    // Given:
+    MailboxSendOperator operator = new MailboxSendOperator(
+        _mailboxService, _input, ImmutableList.of(_server), RelDistribution.Type.HASH_DISTRIBUTED, _selector,
+        false, server -> new StringMailboxIdentifier("123:from:1:to:2"), _exchangeFactory);
+    Mockito.when(_input.nextBlock())
+        .thenReturn(TransferableBlockUtils.getNoOpTransferableBlock());
+
+    // When:
+    TransferableBlock block = operator.nextBlock();
+
+    // Then:
+    Assert.assertTrue(block.isNoOpBlock(), "expected noop block to propagate");
+    Mockito.verify(_exchange, Mockito.never()).send(Mockito.any());
+  }
+
+  @Test
+  public void shouldSendErrorBlock() {
+    // Given:
+    MailboxSendOperator operator = new MailboxSendOperator(
+        _mailboxService, _input, ImmutableList.of(_server), RelDistribution.Type.HASH_DISTRIBUTED, _selector,
+        false, server -> new StringMailboxIdentifier("123:from:1:to:2"), _exchangeFactory);
+    TransferableBlock errorBlock = TransferableBlockUtils.getErrorTransferableBlock(new Exception("foo!"));
+    Mockito.when(_input.nextBlock())
+        .thenReturn(errorBlock);
+
+    // When:
+    TransferableBlock block = operator.nextBlock();
+
+    // Then:
+    Assert.assertTrue(block.isErrorBlock(), "expected error block to propagate");
+    Mockito.verify(_exchange).send(errorBlock);
+  }
+
+  @Test
+  public void shouldSendErrorBlockWhenInputThrows() {
+    // Given:
+    MailboxSendOperator operator = new MailboxSendOperator(
+        _mailboxService, _input, ImmutableList.of(_server), RelDistribution.Type.HASH_DISTRIBUTED, _selector,
+        false, server -> new StringMailboxIdentifier("123:from:1:to:2"), _exchangeFactory);
+    Mockito.when(_input.nextBlock())
+        .thenThrow(new RuntimeException("foo!"));
+    ArgumentCaptor<TransferableBlock> captor = ArgumentCaptor.forClass(TransferableBlock.class);
+
+    // When:
+    TransferableBlock block = operator.nextBlock();
+
+    // Then:
+    Assert.assertTrue(block.isErrorBlock(), "expected error block when input throws error");
+    Mockito.verify(_exchange).send(captor.capture());
+    Assert.assertTrue(captor.getValue().isErrorBlock(), "expected to send error block to exchange");
+  }
+
+  @Test
+  public void shouldSendEosBlock() {
+    // Given:
+    MailboxSendOperator operator = new MailboxSendOperator(
+        _mailboxService, _input, ImmutableList.of(_server), RelDistribution.Type.HASH_DISTRIBUTED, _selector,
+        false, server -> new StringMailboxIdentifier("123:from:1:to:2"), _exchangeFactory);
+    TransferableBlock eosBlock = TransferableBlockUtils.getEndOfStreamTransferableBlock();
+    Mockito.when(_input.nextBlock())
+        .thenReturn(eosBlock);
+
+    // When:
+    TransferableBlock block = operator.nextBlock();
+
+    // Then:
+    Assert.assertTrue(block.isEndOfStreamBlock(), "expected EOS block to propagate");
+    Mockito.verify(_exchange).send(eosBlock);
+  }
+
+  @Test
+  public void shouldSendDataBlock() {
+    // Given:
+    MailboxSendOperator operator = new MailboxSendOperator(
+        _mailboxService, _input, ImmutableList.of(_server), RelDistribution.Type.HASH_DISTRIBUTED, _selector,
+        false, server -> new StringMailboxIdentifier("123:from:1:to:2"), _exchangeFactory);
+    TransferableBlock dataBlock = block(new DataSchema(new String[]{}, new DataSchema.ColumnDataType[]{}));
+    Mockito.when(_input.nextBlock())
+        .thenReturn(dataBlock);
+
+    // When:
+    TransferableBlock block = operator.nextBlock();
+
+    // Then:
+    Assert.assertSame(block.getType(), DataBlock.Type.ROW, "expected data block to propagate");
+    Mockito.verify(_exchange).send(dataBlock);
+  }
+
+  private static TransferableBlock block(DataSchema schema, Object[]... rows) {
+    return new TransferableBlock(Arrays.asList(rows), schema, DataBlock.Type.ROW);
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/BlockExchangeTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/BlockExchangeTest.java
@@ -1,0 +1,177 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.exchange;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
+import java.util.Iterator;
+import java.util.List;
+import java.util.function.BiFunction;
+import org.apache.pinot.common.datablock.DataBlock;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.query.mailbox.MailboxIdentifier;
+import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.mailbox.SendingMailbox;
+import org.apache.pinot.query.mailbox.StringMailboxIdentifier;
+import org.apache.pinot.query.runtime.blocks.BlockSplitter;
+import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class BlockExchangeTest {
+
+  private static final MailboxIdentifier MAILBOX_1 = new StringMailboxIdentifier("1:host:1:host:1");
+  private static final MailboxIdentifier MAILBOX_2 = new StringMailboxIdentifier("1:host:1:host:2");
+
+  private AutoCloseable _mocks;
+
+  @Mock
+  private MailboxService<TransferableBlock> _mailboxService;
+  @Mock
+  private SendingMailbox<TransferableBlock> _mailbox1;
+  @Mock
+  private SendingMailbox<TransferableBlock> _mailbox2;
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = MockitoAnnotations.openMocks(this);
+    Mockito.when(_mailboxService.getSendingMailbox(MAILBOX_1)).thenReturn(_mailbox1);
+    Mockito.when(_mailboxService.getSendingMailbox(MAILBOX_2)).thenReturn(_mailbox2);
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void shouldSendEosBlockToAllDestinations() {
+    // Given:
+    List<MailboxIdentifier> destinations = ImmutableList.of(MAILBOX_1, MAILBOX_2);
+    BlockExchange exchange = new TestBlockExchange(
+        _mailboxService,
+        destinations,
+        (dest, block) -> Iterators.singletonIterator(new BlockExchange.RoutedBlock(MAILBOX_1, block))
+    );
+
+    // When:
+    exchange.send(TransferableBlockUtils.getEndOfStreamTransferableBlock());
+
+    // Then:
+    ArgumentCaptor<TransferableBlock> captor = ArgumentCaptor.forClass(TransferableBlock.class);
+
+    Mockito.verify(_mailbox1).complete();
+    Mockito.verify(_mailbox1, Mockito.times(1)).send(captor.capture());
+    Assert.assertTrue(captor.getValue().isEndOfStreamBlock());
+
+    Mockito.verify(_mailbox2).complete();
+    Mockito.verify(_mailbox2, Mockito.times(1)).send(captor.capture());
+    Assert.assertTrue(captor.getValue().isEndOfStreamBlock());
+  }
+
+  @Test
+  public void shouldSendDataBlocksOnlyToTargetDestination() {
+    // Given:
+    List<MailboxIdentifier> destinations = ImmutableList.of(MAILBOX_1, MAILBOX_2);
+    BlockExchange exchange = new TestBlockExchange(
+        _mailboxService,
+        destinations,
+        (dest, block) -> Iterators.singletonIterator(new BlockExchange.RoutedBlock(MAILBOX_1, block))
+    );
+    TransferableBlock block = new TransferableBlock(ImmutableList.of(new Object[]{"val"}),
+        new DataSchema(new String[]{"foo"}, new ColumnDataType[]{ColumnDataType.STRING}), DataBlock.Type.ROW);
+
+    // When:
+    exchange.send(block);
+
+    // Then:
+    ArgumentCaptor<TransferableBlock> captor = ArgumentCaptor.forClass(TransferableBlock.class);
+    Mockito.verify(_mailbox1, Mockito.times(1)).send(captor.capture());
+    Assert.assertEquals(captor.getValue().getContainer(), block.getContainer());
+
+    Mockito.verify(_mailbox2, Mockito.never()).send(Mockito.any());
+  }
+
+  @Test
+  public void shouldSplitBlocks() {
+    // Given:
+    List<MailboxIdentifier> destinations = ImmutableList.of(MAILBOX_1, MAILBOX_2);
+
+    DataSchema schema = new DataSchema(new String[]{"foo"}, new ColumnDataType[]{ColumnDataType.STRING});
+
+    TransferableBlock inBlock = new TransferableBlock(
+        ImmutableList.of(new Object[]{"one"}, new Object[]{"two"}), schema, DataBlock.Type.ROW);
+
+    TransferableBlock outBlockOne = new TransferableBlock(
+        ImmutableList.of(new Object[]{"one"}), schema, DataBlock.Type.ROW);
+
+    TransferableBlock outBlockTwo = new TransferableBlock(
+        ImmutableList.of(new Object[]{"two"}), schema, DataBlock.Type.ROW);
+
+    BlockExchange exchange = new TestBlockExchange(
+        _mailboxService,
+        destinations,
+        (dest, block) -> Iterators.singletonIterator(new BlockExchange.RoutedBlock(MAILBOX_1, block)),
+        (block, type, maxSize) -> ImmutableList.of(outBlockOne, outBlockTwo).iterator()
+    );
+
+    // When:
+    exchange.send(inBlock);
+
+    // Then:
+    ArgumentCaptor<TransferableBlock> captor = ArgumentCaptor.forClass(TransferableBlock.class);
+    Mockito.verify(_mailbox1, Mockito.times(2)).send(captor.capture());
+
+    List<TransferableBlock> sentBlocks = captor.getAllValues();
+    Assert.assertEquals(sentBlocks.size(), 2, "expected to send two blocks");
+    Assert.assertEquals(sentBlocks.get(0).getContainer(), outBlockOne.getContainer());
+    Assert.assertEquals(sentBlocks.get(1).getContainer(), outBlockTwo.getContainer());
+  }
+
+  private static class TestBlockExchange extends BlockExchange {
+
+    private final BiFunction<List<MailboxIdentifier>, TransferableBlock, Iterator<RoutedBlock>> _router;
+
+    protected TestBlockExchange(MailboxService<TransferableBlock> mailbox, List<MailboxIdentifier> destinations,
+        BiFunction<List<MailboxIdentifier>, TransferableBlock, Iterator<RoutedBlock>> router) {
+      this(mailbox, destinations, router, (block, type, size) -> Iterators.singletonIterator(block));
+    }
+
+    protected TestBlockExchange(MailboxService<TransferableBlock> mailbox, List<MailboxIdentifier> destinations,
+        BiFunction<List<MailboxIdentifier>, TransferableBlock, Iterator<RoutedBlock>> router, BlockSplitter splitter) {
+      super(mailbox, destinations, splitter);
+      _router = router;
+    }
+
+    @Override
+    protected Iterator<RoutedBlock> route(List<MailboxIdentifier> destinations, TransferableBlock block) {
+      return _router.apply(destinations, block);
+    }
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/BroadcastExchangeTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/BroadcastExchangeTest.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.exchange;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Iterator;
+import org.apache.pinot.query.mailbox.MailboxIdentifier;
+import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.mailbox.StringMailboxIdentifier;
+import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class BroadcastExchangeTest {
+  private static final MailboxIdentifier MAILBOX_1 = new StringMailboxIdentifier("1:host:1:host:1");
+  private static final MailboxIdentifier MAILBOX_2 = new StringMailboxIdentifier("1:host:1:host:2");
+
+  private AutoCloseable _mocks;
+
+  @Mock
+  TransferableBlock _block;
+  @Mock
+  MailboxService<TransferableBlock> _mailboxService;
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void shouldBroadcast() {
+    // Given:
+    ImmutableList<MailboxIdentifier> destinations = ImmutableList.of(MAILBOX_1, MAILBOX_2);
+
+    // When:
+    Iterator<BlockExchange.RoutedBlock> route =
+        new BroadcastExchange(_mailboxService, destinations, TransferableBlockUtils::splitBlock)
+            .route(destinations, _block);
+
+    // Then:
+    BlockExchange.RoutedBlock routedBlock = route.next();
+    Assert.assertEquals(routedBlock._destination, MAILBOX_1);
+    Assert.assertEquals(routedBlock._block, _block);
+
+    routedBlock = route.next();
+    Assert.assertEquals(routedBlock._destination, MAILBOX_2);
+    Assert.assertEquals(routedBlock._block, _block);
+
+    Assert.assertFalse(route.hasNext(), "should be done with routing");
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/HashExchangeTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/HashExchangeTest.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.exchange;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterators;
+import java.util.Iterator;
+import org.apache.pinot.query.mailbox.MailboxIdentifier;
+import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.mailbox.StringMailboxIdentifier;
+import org.apache.pinot.query.planner.partitioning.KeySelector;
+import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class HashExchangeTest {
+
+  private static final MailboxIdentifier MAILBOX_1 = new StringMailboxIdentifier("1:host:1:host:1");
+  private static final MailboxIdentifier MAILBOX_2 = new StringMailboxIdentifier("1:host:1:host:2");
+
+  private AutoCloseable _mocks;
+
+  @Mock
+  TransferableBlock _block;
+  @Mock
+  MailboxService<TransferableBlock> _mailboxService;
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void shouldSplitAndRouteBlocksBasedOnPartitionKey() {
+    // Given:
+    TestSelector selector = new TestSelector(Iterators.forArray(2, 0, 1));
+    Mockito.when(_block.getContainer()).thenReturn(ImmutableList.of(
+        new Object[]{0},
+        new Object[]{1},
+        new Object[]{2}
+    ));
+    ImmutableList<MailboxIdentifier> destinations = ImmutableList.of(MAILBOX_1, MAILBOX_2);
+
+    // When:
+    Iterator<BlockExchange.RoutedBlock> route =
+        new HashExchange(_mailboxService, destinations, selector, TransferableBlockUtils::splitBlock)
+            .route(destinations, _block);
+
+    // Then:
+    BlockExchange.RoutedBlock block1 = route.next();
+    Assert.assertEquals(block1._destination, MAILBOX_1);
+    Assert.assertEquals(block1._block.getContainer().get(0), new Object[]{0});
+    Assert.assertEquals(block1._block.getContainer().get(1), new Object[]{1});
+
+    BlockExchange.RoutedBlock block2 = route.next();
+    Assert.assertEquals(block2._destination, MAILBOX_2);
+    Assert.assertEquals(block2._block.getContainer().get(0), new Object[]{2});
+
+    Assert.assertFalse(route.hasNext());
+  }
+
+  private static class TestSelector implements KeySelector<Object[], Object[]> {
+
+    private final Iterator<Integer> _hashes;
+
+    public TestSelector(Iterator<Integer> hashes) {
+      _hashes = hashes;
+    }
+
+    @Override
+    public Object[] getKey(Object[] input) {
+      throw new UnsupportedOperationException("Should not be called");
+    }
+
+    @Override
+    public int computeHash(Object[] input) {
+      return _hashes.next();
+    }
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/RandomExchangeTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/RandomExchangeTest.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.exchange;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Iterator;
+import org.apache.pinot.query.mailbox.MailboxIdentifier;
+import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.mailbox.StringMailboxIdentifier;
+import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class RandomExchangeTest {
+  private static final MailboxIdentifier MAILBOX_1 = new StringMailboxIdentifier("1:host:1:host:1");
+  private static final MailboxIdentifier MAILBOX_2 = new StringMailboxIdentifier("1:host:1:host:2");
+
+  private AutoCloseable _mocks;
+
+  @Mock
+  TransferableBlock _block;
+  @Mock
+  MailboxService<TransferableBlock> _mailboxService;
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void shouldRouteRandomly() {
+    // Given:
+    ImmutableList<MailboxIdentifier> destinations = ImmutableList.of(MAILBOX_1, MAILBOX_2);
+
+    // When:
+    Iterator<BlockExchange.RoutedBlock> route =
+        new RandomExchange(_mailboxService, destinations, size -> 1, TransferableBlockUtils::splitBlock)
+            .route(destinations, _block);
+
+    // Then:
+    BlockExchange.RoutedBlock routedBlock = route.next();
+    Assert.assertEquals(routedBlock._destination, MAILBOX_2);
+    Assert.assertEquals(routedBlock._block, _block);
+    Assert.assertFalse(route.hasNext(), "should be done with routing");
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/SingletonExchangeTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/SingletonExchangeTest.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.exchange;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Iterator;
+import org.apache.pinot.query.mailbox.MailboxIdentifier;
+import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.mailbox.StringMailboxIdentifier;
+import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class SingletonExchangeTest {
+  private static final MailboxIdentifier MAILBOX_1 = new StringMailboxIdentifier("1:host:1:host:1");
+
+  private AutoCloseable _mocks;
+
+  @Mock
+  TransferableBlock _block;
+  @Mock
+  MailboxService<TransferableBlock> _mailboxService;
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void shouldRouteSingleton() {
+    // Given:
+    ImmutableList<MailboxIdentifier> destinations = ImmutableList.of(MAILBOX_1);
+
+    // When:
+    Iterator<BlockExchange.RoutedBlock> route =
+        new SingletonExchange(_mailboxService, destinations, TransferableBlockUtils::splitBlock)
+            .route(destinations, _block);
+
+    // Then:
+    BlockExchange.RoutedBlock routedBlock = route.next();
+    Assert.assertEquals(routedBlock._destination, MAILBOX_1);
+    Assert.assertEquals(routedBlock._block, _block);
+    Assert.assertFalse(route.hasNext(), "should be done with routing");
+  }
+}


### PR DESCRIPTION
This PR does two things: refactors `MailboxSendOperator` into testable components, and then tests each of those components.

The refactor essentially factors out each of the exchange logic (hash, singleton, random, etc...) into their own classes as well as a top level class for all the common exchange logic. Now `MailboxSendOperator` can be really dumb and just pipes blocks to the underlying sender.