### PR TITLE
[multistage] Reproduce infinite loop in MailboxContentStreamObserver

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -47,12 +47,9 @@ import org.slf4j.LoggerFactory;
 public class MailboxReceiveOperator extends BaseOperator<TransferableBlock> {
   private static final Logger LOGGER = LoggerFactory.getLogger(MailboxReceiveOperator.class);
   private static final String EXPLAIN_NAME = "MAILBOX_RECEIVE";
-
   private final MailboxService<TransferableBlock> _mailboxService;
   private final RelDistribution.Type _exchangeType;
-  private final KeySelector<Object[], Object[]> _keySelector;
   private final List<ServerInstance> _sendingStageInstances;
-  private final DataSchema _dataSchema;
   private final String _hostName;
   private final int _port;
   private final long _jobId;
@@ -62,10 +59,9 @@ public class MailboxReceiveOperator extends BaseOperator<TransferableBlock> {
   private int _serverIdx;
   private TransferableBlock _upstreamErrorBlock;
 
-  public MailboxReceiveOperator(MailboxService<TransferableBlock> mailboxService, DataSchema dataSchema,
-      List<ServerInstance> sendingStageInstances, RelDistribution.Type exchangeType,
-      KeySelector<Object[], Object[]> keySelector, String hostName, int port, long jobId, int stageId) {
-    _dataSchema = dataSchema;
+  public MailboxReceiveOperator(MailboxService<TransferableBlock> mailboxService,
+      List<ServerInstance> sendingStageInstances, RelDistribution.Type exchangeType, String hostName,
+      int port, long jobId, int stageId) {
     _mailboxService = mailboxService;
     _exchangeType = exchangeType;
     if (_exchangeType == RelDistribution.Type.SINGLETON) {
@@ -77,7 +73,6 @@ public class MailboxReceiveOperator extends BaseOperator<TransferableBlock> {
           singletonInstance = serverInstance;
         }
       }
-
       if (singletonInstance == null) {
         // TODO: fix WorkerManager assignment, this should not happen if we properly assign workers.
         // see: https://github.com/apache/pinot/issues/9592
@@ -94,7 +89,6 @@ public class MailboxReceiveOperator extends BaseOperator<TransferableBlock> {
     _stageId = stageId;
     _timeout = System.nanoTime() + QueryConfig.DEFAULT_TIMEOUT_NANO;
     _upstreamErrorBlock = null;
-    _keySelector = keySelector;
     _serverIdx = 0;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
@@ -65,8 +65,8 @@ public class PhysicalPlanVisitor implements StageNodeVisitor<Operator<Transferab
   @Override
   public Operator<TransferableBlock> visitMailboxReceive(MailboxReceiveNode node, PlanRequestContext context) {
     List<ServerInstance> sendingInstances = context.getMetadataMap().get(node.getSenderStageId()).getServerInstances();
-    return new MailboxReceiveOperator(context.getMailboxService(), node.getDataSchema(), sendingInstances,
-        node.getExchangeType(), node.getPartitionKeySelector(), context.getHostName(), context.getPort(),
+    return new MailboxReceiveOperator(context.getMailboxService(), sendingInstances,
+        node.getExchangeType(), context.getHostName(), context.getPort(),
         context.getRequestId(), node.getSenderStageId());
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryConfig.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryConfig.java
@@ -22,7 +22,7 @@ package org.apache.pinot.query.service;
  * Configuration for setting up query runtime.
  */
 public class QueryConfig {
-  public static final long DEFAULT_TIMEOUT_NANO = 100_000_000_000L;
+  public static final long DEFAULT_TIMEOUT_NANO = 100_000_000_000L; // 100 seconds
 
   public static final String KEY_OF_MAX_INBOUND_QUERY_DATA_BLOCK_SIZE_BYTES = "pinot.query.runner.max.msg.size.bytes";
   public static final int DEFAULT_MAX_INBOUND_QUERY_DATA_BLOCK_SIZE_BYTES = 16 * 1024 * 1024;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryDispatcher.java
@@ -198,9 +198,8 @@ public class QueryDispatcher {
   public static MailboxReceiveOperator createReduceStageOperator(MailboxService<TransferableBlock> mailboxService,
       List<ServerInstance> sendingInstances, long jobId, int stageId, DataSchema dataSchema, String hostname,
       int port) {
-    MailboxReceiveOperator mailboxReceiveOperator =
-        new MailboxReceiveOperator(mailboxService, dataSchema, sendingInstances,
-            RelDistribution.Type.RANDOM_DISTRIBUTED, null, hostname, port, jobId, stageId);
+    MailboxReceiveOperator mailboxReceiveOperator = new MailboxReceiveOperator(mailboxService, sendingInstances,
+        RelDistribution.Type.RANDOM_DISTRIBUTED, hostname, port, jobId, stageId);
     return mailboxReceiveOperator;
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/channel/MailboxContentStreamObserverTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/channel/MailboxContentStreamObserverTest.java
@@ -1,0 +1,35 @@
+package org.apache.pinot.query.mailbox.channel;
+
+import io.grpc.stub.StreamObserver;
+import org.apache.pinot.common.proto.Mailbox;
+import org.apache.pinot.query.mailbox.GrpcMailboxService;
+import org.mockito.Mock;
+import org.testng.annotations.Test;
+
+
+public class MailboxContentStreamObserverTest {
+
+  private static final class Runner implements Runnable {
+    @Mock
+    GrpcMailboxService _mailboxService;
+    @Mock
+    StreamObserver<Mailbox.MailboxStatus> _streamObserver;
+
+    @Override
+    public void run() {
+      MailboxContentStreamObserver observer = new MailboxContentStreamObserver(_mailboxService, _streamObserver);
+      observer.poll();
+    }
+  }
+
+  @Test
+  public void TestPollInteruptException()
+      throws InterruptedException {
+    Runner t = new Runner();
+    Thread t1 = new Thread(t);
+    t1.start();
+    Thread.sleep(1000);
+    t1.interrupt();
+    t1.join();
+  }
+}


### PR DESCRIPTION
@walterddr 

Followup for issue https://github.com/apache/pinot/issues/9720

Is this expected to happen?
If I am right, park-wait doesn't solve this issue because 
line131 in MailboxReceiveOperator:  TransferableBlock block = mailbox.receive();  it never returns

@agavra 