### PR TITLE
Add null value index for default column

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -554,13 +554,18 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
       }
     }
 
-    if (!_segmentWriter.hasIndexFor(column, ColumnIndexType.NULLVALUE_VECTOR)) {
-      try (NullValueVectorCreator nullValueVectorCreator = new NullValueVectorCreator(_indexDir, fieldSpec.getName())) {
-        for (int docId = 0; docId < totalDocs; docId++) {
-          nullValueVectorCreator.setNull(docId);
-        }
+    if (_indexLoadingConfig.getTableConfig() != null
+        && _indexLoadingConfig.getTableConfig().getIndexingConfig() != null
+        && _indexLoadingConfig.getTableConfig().getIndexingConfig().isNullHandlingEnabled()) {
+      if (!_segmentWriter.hasIndexFor(column, ColumnIndexType.NULLVALUE_VECTOR)) {
+        try (NullValueVectorCreator nullValueVectorCreator =
+            new NullValueVectorCreator(_indexDir, fieldSpec.getName())) {
+          for (int docId = 0; docId < totalDocs; docId++) {
+            nullValueVectorCreator.setNull(docId);
+          }
 
-        nullValueVectorCreator.seal();
+          nullValueVectorCreator.seal();
+        }
       }
     }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -43,6 +43,7 @@ import org.apache.pinot.segment.local.segment.creator.impl.fwd.MultiValueUnsorte
 import org.apache.pinot.segment.local.segment.creator.impl.fwd.SingleValueSortedForwardIndexCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.fwd.SingleValueUnsortedForwardIndexCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.inv.BitSlicedRangeIndexCreator;
+import org.apache.pinot.segment.local.segment.creator.impl.nullvalue.NullValueVectorCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.BytesColumnPredIndexStatsCollector;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.DoubleColumnPreIndexStatsCollector;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.FloatColumnPreIndexStatsCollector;
@@ -551,6 +552,14 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
           mvFwdIndexCreator.putDictIdMV(dictIds);
         }
       }
+    }
+
+    try (NullValueVectorCreator nullValueVectorCreator = new NullValueVectorCreator(_indexDir, fieldSpec.getName())) {
+      for (int docId = 0; docId < totalDocs; docId++) {
+        nullValueVectorCreator.setNull(docId);
+      }
+
+      nullValueVectorCreator.seal();
     }
 
     // Add the column metadata information to the metadata properties.

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -554,12 +554,14 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
       }
     }
 
-    try (NullValueVectorCreator nullValueVectorCreator = new NullValueVectorCreator(_indexDir, fieldSpec.getName())) {
-      for (int docId = 0; docId < totalDocs; docId++) {
-        nullValueVectorCreator.setNull(docId);
-      }
+    if (!_segmentWriter.hasIndexFor(column, ColumnIndexType.NULLVALUE_VECTOR)) {
+      try (NullValueVectorCreator nullValueVectorCreator = new NullValueVectorCreator(_indexDir, fieldSpec.getName())) {
+        for (int docId = 0; docId < totalDocs; docId++) {
+          nullValueVectorCreator.setNull(docId);
+        }
 
-      nullValueVectorCreator.seal();
+        nullValueVectorCreator.seal();
+      }
     }
 
     // Add the column metadata information to the metadata properties.

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/V3DefaultColumnHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/V3DefaultColumnHandler.java
@@ -74,6 +74,11 @@ public class V3DefaultColumnHandler extends BaseDefaultColumnHandler {
     LoaderUtils.writeIndexToV3Format(_segmentWriter, column, forwardIndexFile, ColumnIndexType.FORWARD_INDEX);
     File dictionaryFile = new File(_indexDir, column + V1Constants.Dict.FILE_EXTENSION);
     LoaderUtils.writeIndexToV3Format(_segmentWriter, column, dictionaryFile, ColumnIndexType.DICTIONARY);
+
+    File nullValueVectorFile = new File(_indexDir, column + V1Constants.Indexes.NULLVALUE_VECTOR_FILE_EXTENSION);
+    if (nullValueVectorFile.exists()) {
+      LoaderUtils.writeIndexToV3Format(_segmentWriter, column, nullValueVectorFile, ColumnIndexType.NULLVALUE_VECTOR);
+    }
     return true;
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
@@ -1092,6 +1092,13 @@ public class SegmentPreProcessorTest {
       assertTrue(reader.hasIndexFor(NEW_INT_SV_DIMENSION_COLUMN_NAME, ColumnIndexType.FORWARD_INDEX));
       assertTrue(reader.hasIndexFor(NEW_STRING_MV_DIMENSION_COLUMN_NAME, ColumnIndexType.DICTIONARY));
       assertTrue(reader.hasIndexFor(NEW_STRING_MV_DIMENSION_COLUMN_NAME, ColumnIndexType.FORWARD_INDEX));
+
+      assertTrue(reader.hasIndexFor(NEW_INT_METRIC_COLUMN_NAME, ColumnIndexType.NULLVALUE_VECTOR));
+      assertTrue(reader.hasIndexFor(NEW_LONG_METRIC_COLUMN_NAME, ColumnIndexType.NULLVALUE_VECTOR));
+      assertTrue(reader.hasIndexFor(NEW_FLOAT_METRIC_COLUMN_NAME, ColumnIndexType.NULLVALUE_VECTOR));
+      assertTrue(reader.hasIndexFor(NEW_DOUBLE_METRIC_COLUMN_NAME, ColumnIndexType.NULLVALUE_VECTOR));
+      assertTrue(reader.hasIndexFor(NEW_BOOLEAN_SV_DIMENSION_COLUMN_NAME, ColumnIndexType.NULLVALUE_VECTOR));
+      assertTrue(reader.hasIndexFor(NEW_STRING_MV_DIMENSION_COLUMN_NAME, ColumnIndexType.NULLVALUE_VECTOR));
     }
 
     // Use the second schema and update default value again.

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
@@ -163,7 +163,7 @@ public class SegmentPreProcessorTest {
     ingestionConfig.setSegmentTimeValueCheck(false);
     _tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").setTimeColumnName("daysSinceEpoch")
-            .setIngestionConfig(ingestionConfig).build();
+            .setIngestionConfig(ingestionConfig).setNullHandlingEnabled(true).build();
     _indexLoadingConfig = getDefaultIndexLoadingConfig();
 
     // We specify two columns without inverted index ('column1', 'column13'), one non-existing column ('noSuchColumn')
@@ -219,6 +219,8 @@ public class SegmentPreProcessorTest {
     indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_STRING_COL_RAW);
     indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_INT_COL_RAW_MV);
     indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_INT_COL_RAW);
+
+    indexLoadingConfig.setTableConfig(_tableConfig);
     return indexLoadingConfig;
   }
 


### PR DESCRIPTION
Currently, if a new column is added to schema, we backfill the old segments with default null values.
However, when a user runs the query `WHERE new_col IS NULL`, they don't receive the old rows in the response.
This PR aims to fix this issue.