### PR TITLE
update log4j2.xml to write helix logs into dedicated files

### DIFF
--- a/docker/images/pinot/etc/conf/pinot-broker-log4j2.xml
+++ b/docker/images/pinot/etc/conf/pinot-broker-log4j2.xml
@@ -46,6 +46,21 @@
       <DefaultRolloverStrategy max="10"/>
     </RollingFile>
     <RollingFile
+        name="brokerHelixLog"
+        fileName="${env:LOG_DIR}/pinotBrokerHelix.log"
+        filePattern="${env:LOG_DIR}/pinotBrokerHelix.%d{yyyy-MM-dd}.%i.log.gz"
+        immediateFlush="false">
+      <PatternLayout>
+        <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Pattern>
+      </PatternLayout>
+      <Policies>
+        <OnStartupTriggeringPolicy/>
+        <SizeBasedTriggeringPolicy size="20 MB"/>
+        <TimeBasedTriggeringPolicy/>
+      </Policies>
+      <DefaultRolloverStrategy max="10"/>
+    </RollingFile>
+    <RollingFile
         name="querylog"
         fileName="${env:LOG_DIR}/querylog.log"
         filePattern="${env:LOG_DIR}/querylog.%d{yyyy-MM-dd}.%i.log.gz"
@@ -68,6 +83,10 @@
       <!-- Direct most logs to the log file -->
       <AppenderRef ref="brokerLog"/>
     </Root>
+    <!-- Output helix logs to dedicated files -->
+    <Logger name="org.apache.helix" level="info" additivity="false">
+      <AppenderRef ref="brokerHelixLog"/>
+    </Logger>
     <!-- Output querylogs to its own file -->
     <Logger name="org.apache.pinot.broker.querylog.QueryLogger" level="info" additivity="false">
       <AppenderRef ref="queryLog"/>

--- a/docker/images/pinot/etc/conf/pinot-controller-log4j2.xml
+++ b/docker/images/pinot/etc/conf/pinot-controller-log4j2.xml
@@ -44,6 +44,21 @@
       </Policies>
       <DefaultRolloverStrategy max="10"/>
     </RollingFile>
+    <RollingFile
+        name="controllerHelixLog"
+        fileName="${env:LOG_DIR}/pinotControllerHelix.log"
+        filePattern="${env:LOG_DIR}/pinotControllerHelix.%d{yyyy-MM-dd}.%i.log.gz"
+        immediateFlush="false">
+      <PatternLayout>
+        <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Pattern>
+      </PatternLayout>
+      <Policies>
+        <OnStartupTriggeringPolicy/>
+        <SizeBasedTriggeringPolicy size="20 MB"/>
+        <TimeBasedTriggeringPolicy/>
+      </Policies>
+      <DefaultRolloverStrategy max="10"/>
+    </RollingFile>
   </Appenders>
   <Loggers>
     <Root level="info" additivity="false">
@@ -52,6 +67,10 @@
       <!-- Direct most logs to the log file -->
       <AppenderRef ref="controllerLog"/>
     </Root>
+    <!-- Output helix logs to dedicated files -->
+    <Logger name="org.apache.helix" level="info" additivity="false">
+      <AppenderRef ref="controllerHelixLog"/>
+    </Logger>
     <!-- Output controller starter logs to the console -->
     <Logger name="org.apache.pinot.controller.ControllerStarter" level="info" additivity="false">
       <AppenderRef ref="console"/>

--- a/docker/images/pinot/etc/conf/pinot-server-log4j2.xml
+++ b/docker/images/pinot/etc/conf/pinot-server-log4j2.xml
@@ -44,6 +44,21 @@
       </Policies>
       <DefaultRolloverStrategy max="10"/>
     </RollingFile>
+    <RollingFile
+        name="serverHelixLog"
+        fileName="${env:LOG_DIR}/pinotServerHelix.log"
+        filePattern="${env:LOG_DIR}/pinotServerHelix.%d{yyyy-MM-dd}.%i.log.gz"
+        immediateFlush="false">
+      <PatternLayout>
+        <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Pattern>
+      </PatternLayout>
+      <Policies>
+        <OnStartupTriggeringPolicy/>
+        <SizeBasedTriggeringPolicy size="20 MB"/>
+        <TimeBasedTriggeringPolicy/>
+      </Policies>
+      <DefaultRolloverStrategy max="10"/>
+    </RollingFile>
   </Appenders>
   <Loggers>
     <Root level="info" additivity="false">
@@ -52,6 +67,10 @@
       <!-- Direct most logs to the log file -->
       <AppenderRef ref="serverLog"/>
     </Root>
+    <!-- Output helix logs to dedicated files -->
+    <Logger name="org.apache.helix" level="info" additivity="false">
+      <AppenderRef ref="serverHelixLog"/>
+    </Logger>
     <!-- Output server starter logs to the console -->
     <Logger name="org.apache.pinot.server.starter.helix.HelixServerStarter" level="info" additivity="false">
       <AppenderRef ref="console"/>

--- a/pinot-tools/src/main/resources/conf/pinot-broker-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/pinot-broker-log4j2.xml
@@ -31,6 +31,11 @@
         <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Pattern>
       </PatternLayout>
     </RandomAccessFile>
+    <RandomAccessFile name="brokerHelixLog" fileName="pinotBrokerHelix.log" immediateFlush="false">
+      <PatternLayout>
+        <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Pattern>
+      </PatternLayout>
+    </RandomAccessFile>
     <RandomAccessFile name="querylog" fileName="querylog.log" immediateFlush="false">
       <PatternLayout>
         <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Pattern>
@@ -44,6 +49,10 @@
       <!-- Direct most logs to the log file -->
       <AppenderRef ref="brokerLog"/>
     </Root>
+    <!-- Output helix logs to a dedicated file-->
+    <Logger name="org.apache.helix" level="info" additivity="false">
+      <AppenderRef ref="brokerHelixLog"/>
+    </Logger>
     <!-- Output query logs to a dedicated file-->
     <Logger name="org.apache.pinot.broker.querylog.QueryLogger" level="debug" additivity="false">
       <AppenderRef ref="querylog"/>

--- a/pinot-tools/src/main/resources/conf/pinot-controller-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/pinot-controller-log4j2.xml
@@ -31,6 +31,11 @@
         <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Pattern>
       </PatternLayout>
     </RandomAccessFile>
+    <RandomAccessFile name="controllerHelixLog" fileName="pinotControllerHelix.log" immediateFlush="false">
+      <PatternLayout>
+        <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Pattern>
+      </PatternLayout>
+    </RandomAccessFile>
   </Appenders>
   <Loggers>
     <Root level="info" additivity="false">
@@ -39,6 +44,10 @@
       <!-- Direct most logs to the log file -->
       <AppenderRef ref="controllerLog"/>
     </Root>
+    <!-- Output helix logs to a dedicated file-->
+    <Logger name="org.apache.helix" level="info" additivity="false">
+      <AppenderRef ref="controllerHelixLog"/>
+    </Logger>
     <!-- Output controller starter logs to the console -->
     <Logger name="org.apache.pinot.controller.ControllerStarter" level="info" additivity="false">
       <AppenderRef ref="console"/>

--- a/pinot-tools/src/main/resources/conf/pinot-minion-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/pinot-minion-log4j2.xml
@@ -31,6 +31,11 @@
         <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Pattern>
       </PatternLayout>
     </RandomAccessFile>
+    <RandomAccessFile name="minionHelixLog" fileName="pinotMinionHelix.log" immediateFlush="false">
+      <PatternLayout>
+        <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Pattern>
+      </PatternLayout>
+    </RandomAccessFile>
   </Appenders>
   <Loggers>
     <Root level="info" additivity="false">
@@ -39,6 +44,10 @@
       <!-- Direct most logs to the log file -->
       <AppenderRef ref="minionLog"/>
     </Root>
+    <!-- Output helix logs to a dedicated file-->
+    <Logger name="org.apache.helix" level="info" additivity="false">
+      <AppenderRef ref="minionHelixLog"/>
+    </Logger>
     <!-- Output server starter logs to the console -->
     <Logger name="org.apache.pinot.minion.MinionStarter" level="info" additivity="false">
       <AppenderRef ref="console"/>

--- a/pinot-tools/src/main/resources/conf/pinot-server-log4j2.xml
+++ b/pinot-tools/src/main/resources/conf/pinot-server-log4j2.xml
@@ -31,6 +31,11 @@
         <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Pattern>
       </PatternLayout>
     </RandomAccessFile>
+    <RandomAccessFile name="serverHelixLog" fileName="pinotServerHelix.log" immediateFlush="false">
+      <PatternLayout>
+        <Pattern>%d{yyyy/MM/dd HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n</Pattern>
+      </PatternLayout>
+    </RandomAccessFile>
   </Appenders>
   <Loggers>
     <Root level="info" additivity="false">
@@ -39,6 +44,10 @@
       <!-- Direct most logs to the log file -->
       <AppenderRef ref="serverLog"/>
     </Root>
+    <!-- Output helix logs to a dedicated file-->
+    <Logger name="org.apache.helix" level="info" additivity="false">
+      <AppenderRef ref="serverHelixLog"/>
+    </Logger>
     <!-- Output server starter logs to the console -->
     <Logger name="org.apache.pinot.server.starter.helix.HelixServerStarter" level="info" additivity="false">
       <AppenderRef ref="console"/>


### PR DESCRIPTION
This PR changes log4j2.xml files to write helix logs into dedicated files so logs are more readable.