### PR TITLE
revert default timeout nano change in QueryConfig

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryConfig.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryConfig.java
@@ -22,7 +22,7 @@ package org.apache.pinot.query.service;
  * Configuration for setting up query runtime.
  */
 public class QueryConfig {
-  public static final long DEFAULT_TIMEOUT_NANO = 100_000_000_000L;
+  public static final long DEFAULT_TIMEOUT_NANO = 10_000_000_000L;
 
   public static final String KEY_OF_MAX_INBOUND_QUERY_DATA_BLOCK_SIZE_BYTES = "pinot.query.runner.max.msg.size.bytes";
   public static final int DEFAULT_MAX_INBOUND_QUERY_DATA_BLOCK_SIZE_BYTES = 16 * 1024 * 1024;


### PR DESCRIPTION
this was accidentally checked in as part of debugging and should be reverted (see https://github.com/apache/pinot/pull/9711/files#diff-432313d724e736eb977d1ba6dd06db03340ff9e75440004e343dda8c4121024b)