### PR TITLE
[multistage] add tests for lexical structure and value exprs

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToStageConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToStageConverter.java
@@ -161,6 +161,7 @@ public final class RelToStageConverter {
       case TIME:
       case TIMESTAMP:
         return DataSchema.ColumnDataType.TIMESTAMP;
+      case CHAR:
       case VARCHAR:
         return DataSchema.ColumnDataType.STRING;
       case BINARY:

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.runtime;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -28,6 +29,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -150,7 +152,8 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
       Object[] expectedRow = expectedRows.get(i);
       for (int j = 0; j < resultRow.length; j++) {
         Assert.assertEquals(valueComp.compare(resultRow[j], expectedRow[j]), 0,
-            "Not match at (" + i + "," + j + ")! Expected: " + expectedRow[j] + " Actual: " + resultRow[j]);
+            "Not match at (" + i + "," + j + ")! Expected: " + Arrays.toString(expectedRow)
+                + " Actual: " + Arrays.toString(resultRow));
       }
     }
   }
@@ -256,11 +259,14 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
     return fieldNamesAndTypes;
   }
 
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public static class QueryTestCase {
-    public static final String REQUIRED_H2_KEY = "requireH2";
     public static final String BLOCK_SIZE_KEY = "blockSize";
     public static final String SERVER_ASSIGN_STRATEGY_KEY = "serverSelectionStrategy";
 
+    // ignores the entire query test case
+    @JsonProperty("ignored")
+    public boolean _ignored;
     @JsonProperty("tables")
     public Map<String, Table> _tables;
     @JsonProperty("queries")
@@ -275,7 +281,11 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
       public List<List<Object>> _inputs;
     }
 
+    @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Query {
+      // ignores just a single query test from the test case
+      @JsonProperty("ignored")
+      public boolean _ignored;
       @JsonProperty("sql")
       public String _sql;
       @JsonProperty("description")

--- a/pinot-query-runtime/src/test/resources/queries/BasicQuery.json
+++ b/pinot-query-runtime/src/test/resources/queries/BasicQuery.json
@@ -18,10 +18,7 @@
         "description": "basic test case example",
         "sql": "SELECT * FROM {tbl}"
       }
-    ],
-    "extraProps": {
-      "requireH2": true
-    }
+    ]
   },
   "framework_test": {
     "tables": {
@@ -58,7 +55,6 @@
       }
     ],
     "extraProps": {
-      "requireH2": true,
       "comment": "TODO: these demonstrate how extra properties are used but the following keys are not supported yet",
       "blockSize": 2,
       "serverSelectionStrategy": "RANDOM"

--- a/pinot-query-runtime/src/test/resources/queries/LexicalStructure.json
+++ b/pinot-query-runtime/src/test/resources/queries/LexicalStructure.json
@@ -1,0 +1,184 @@
+{
+  "unquoted_identifiers": {
+    "tables": {
+      "tbl": {
+        "schema": [
+          {"name": "alphabet", "type": "STRING"},
+          {"name": "alpha123", "type": "STRING"},
+          {"name": "ignoreCASE", "type": "STRING"},
+          {"name": "has_underscore", "type": "STRING"},
+          {"name": "has$dollar$sign", "type": "STRING"}
+        ],
+        "inputs": [
+          ["1", "2", "3", "4", "5"]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "psql": "4.1.1",
+        "description": "unquoted identifier support",
+        "sql": "SELECT * FROM {tbl}"
+      }
+    ]
+  },
+  "quoted_identifiers": {
+    "tables": {
+      "tbl": {
+        "schema": [
+          {"name": "\"case_matters\"", "type": "STRING"},
+          {"name": "\"CASE_matters\"", "type": "STRING"},
+          {"name": "\"CASE_MATTERS\"", "type": "STRING"},
+          {"name": "\"%illegal.symbols%\"", "type": "STRING"}
+        ],
+        "inputs": [
+          ["1", "2", "3", "4"]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "ignored": true,
+        "comment": "we don't properly handle default case resolution",
+        "psql": "4.1.1",
+        "description": "unquoted identifier support",
+        "sql": "SELECT * FROM {tbl}"
+      },
+      {
+        "ignored": true,
+        "comment": "error is: Column 'case_matters' is not found in any table. not sure if test framework or real bug",
+        "psql": "4.1.1",
+        "description": "unquoted identifier support",
+        "sql": "SELECT \"case_matters\", \"CASE_matters\", \"CASE_MATTERS\", \"%illegal.symbols%\" FROM {tbl}"
+      }
+    ]
+  },
+  "unicode_escapes": {
+    "ignored": true,
+    "comment": "ignored because we don't support U& identifiers",
+    "tables": {
+      "tbl": {
+        "schema": [{"name": "U&\"d\\0061t\\+000061\"", "type": "STRING"}],
+        "inputs": [["1"]]
+      }
+    },
+    "queries": [
+      {
+        "psql": "4.1.1",
+        "description": "quoted identifier support",
+        "sql": "SELECT * FROM {tbl}"
+      }
+    ]
+  },
+  "c_string_constants": {
+    "tables": {
+      "tbl": {
+        "schema": [{"name": "data", "type": "STRING"}],
+        "inputs": [["1"]]
+      }
+    },
+    "queries": [{
+      "psql": ["4.1.2.1", "4.1.2.2"],
+      "description": "constants with c-style escapes",
+      "sql": "SELECT data, 'foo', 'foo\nbar', concat(data, 'foo\tbar', '') FROM {tbl}"
+    }]
+  },
+  "unicode_string_constants": {
+    "tables": {
+      "tbl": {
+        "schema": [{"name": "data", "type": "STRING"}],
+        "inputs": [["1"]]
+      }
+    },
+    "queries": [{
+      "psql": "4.1.2.3",
+      "description": "constants with unicode escapes",
+      "sql": "SELECT data, U&'d\\0061ta' FROM {tbl}",
+      "outputs": [["1", "data"]]
+    }]
+  },
+  "dollar_string_constants": {
+    "tables": {
+      "tbl": {
+        "schema": [{"name": "data", "type": "STRING"}],
+        "inputs": [["1"]]
+      }
+    },
+    "queries": [{
+      "psql": "4.1.2.4",
+      "ignored": true,
+      "comment": "unsupported",
+      "description": "constants with $ escapes",
+      "sql": "SELECT data, $$Dianne's horse$$, $tag$Dianne's\nhorse$tag$ FROM {tbl}"
+    }]
+  },
+  "bit_string_constants": {
+    "ignored": true,
+    "comment": "bit string constants not supported",
+    "tables": {
+      "tbl": {
+        "schema": [{"name": "data", "type": "STRING"}],
+        "inputs": [["1"]]
+      }
+    },
+    "queries": [{
+      "psql": "4.1.2.5",
+      "description": "bit string constant support",
+      "sql": "SELECT data, B'1001', X'1FF' FROM {tbl}",
+      "outputs": [["1", "bytes", "bytes"]]
+    }]
+  },
+  "numeric_constants": {
+    "tables": {
+      "tbl": {
+        "schema": [{"name": "data", "type": "STRING"}],
+        "inputs": [["1"]]
+      }
+    },
+    "queries": [{
+      "psql": "4.1.2.6",
+      "description": "numeric constant supports",
+      "sql": "SELECT data, 42, 3.5, 4., .001, 5e2, 1.925e-3 FROM {tbl}"
+    }]
+  },
+  "constant_casting": {
+    "tables": {
+      "tbl": {
+        "schema": [{"name": "data", "type": "STRING"}],
+        "inputs": [["1"]]
+      }
+    },
+    "queries": [{
+      "psql": "4.1.2.7",
+      "description": "constant casting",
+      "sql": "SELECT data, CAST ('42' AS INT) FROM {tbl}"
+    }]
+  },
+  "comments": {
+    "tables": {
+      "tbl": {
+        "schema": [{"name": "data", "type": "STRING"}],
+        "inputs": [["1"]]
+      }
+    },
+    "queries": [{
+      "psql": "4.1.5",
+      "description": "testing comment support",
+      "sql": "---this is a comment\nSELECT data FROM {tbl}"
+    }]
+  },
+  "operator_precedence" : {
+    "comments": "we don't support ^ or array[x] yet in v2, unary minus is broken",
+    "tables": {
+      "tbl": {
+        "schema": [{"name": "data", "type": "INT"}],
+        "inputs": [[3]]
+      }
+    },
+    "queries": [{
+      "psql": "4.1.6",
+      "description": "testing operator precedence",
+      "sql": "SELECT NOT +{tbl}.data * 2 - 2 = -8 and true or false, data * 2 between 4 and 7 FROM {tbl}"
+    }]
+  }
+}

--- a/pinot-query-runtime/src/test/resources/queries/ValueExpressions.json
+++ b/pinot-query-runtime/src/test/resources/queries/ValueExpressions.json
@@ -1,0 +1,102 @@
+{
+  "subscript": {
+    "psql": "4.2.3",
+    "ignored": true,
+    "comment": "query runner test doesn't yet support multivalue columns",
+    "tables": {
+      "tbl": {
+        "schema":[{"name": "data", "type": "INT[]"}],
+        "inputs": [[[1]]]
+      }
+    },
+    "queries": [{
+      "description": "test array subscripting",
+      "sql": "SELECT data[0] FROM {tbl}"
+    }]
+  },
+  "scalar_function_call": {
+    "psql": "4.2.6",
+    "tables": {
+      "tbl": {
+        "schema":[{"name": "data", "type": "STRING"}],
+        "inputs": [[" foo "]]
+      }
+    },
+    "queries": [{
+      "description": "test basic function call syntax works",
+      "sql": "SELECT trim(data) FROM {tbl}"
+    }]
+  },
+  "custom_collation": {
+    "psql": "4.2.10",
+    "ignored": true,
+    "comment": "COLLATE is not supported",
+    "tables": {
+      "tbl": {
+        "schema": [{"name": "data", "type": "STRING"}],
+        "inputs": [["1"]]
+      }
+    },
+    "queries": [{
+      "psql": "4.1.2.7",
+      "description": "test non-standard collation specification",
+      "sql": "SELECT data > 'bar' COLLATE \"C\" FROM {tbl}"
+    }]
+  },
+  "scalar_subqueries": {
+    "psql": "4.2.11",
+    "ignored": true,
+    "comment": "can't compile the logical plan",
+    "tables": {
+      "cities": {
+        "schema": [
+          {"name": "name", "type": "STRING"},
+          {"name": "population", "type": "INT"},
+          {"name": "state", "type": "STRING"}],
+        "inputs": [
+          ["san francisco", 800000, "CA"],
+          ["san jose", 1000000, "CA"],
+          ["new york", 8500000, "NY"]
+        ]
+      },
+      "states": {
+        "schema": [{"name": "name", "type": "STRING"}],
+        "inputs": [["CA"], ["NY"]]
+      }
+    },
+    "queries": [{
+        "description": "test support for scalar subqueries",
+        "sql": "SELECT name, (SELECT max(population) FROM {cities} WHERE {cities}.state = {states}.name) FROM {states}"
+      }]
+  },
+  "array_constructors": {
+    "psql": "4.2.12",
+    "ignored": true,
+    "comment": "cannot parse",
+    "tables": {
+      "tbl": {
+        "schema": [{"name": "data", "type": "STRING"}],
+        "inputs": [["1"]]
+      }
+    },
+    "queries": [{
+      "description": "test inline array constructing",
+      "sql": "SELECT data, ARRAY[1,2,3+4] FROM {tbl}"
+    }]
+  },
+  "calling_functions": {
+    "psql": "4.3",
+    "ignored": true,
+    "comment": "named calling notation not supported",
+    "tables": {
+      "tbl": {
+        "schema": [{"name": "data", "type": "STRING"}],
+        "inputs": [["1"]]
+      }
+    },
+    "queries": [{
+      "description": "test calling functions via named/mixed notation",
+      "sql": "SELECT data, trim(data), trim(input => data) FROM {tbl}"
+    }]
+  }
+}


### PR DESCRIPTION
adds tests for lexical structure, value expressions and calling functions (see postgres documentation: https://www.postgresql.org/docs/15/sql-syntax-lexical.html and https://www.postgresql.org/docs/15/sql-expressions.html and https://www.postgresql.org/docs/15/sql-syntax-calling-funcs.html)

also:
- fix issue with `CHAR(N)` (fixed length string) constants not being returnable as a column
- add ability to ignore tests in the JSON framework