### PR TITLE
AdaptiveServerSelection: Update stats for servers that have not responded

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/AsyncQueryResponse.java
@@ -28,6 +28,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager;
 
 
 /**
@@ -43,12 +44,13 @@ public class AsyncQueryResponse implements QueryResponse {
   private final CountDownLatch _countDownLatch;
   private final long _maxEndTimeMs;
   private final long _timeoutMs;
+  private final ServerRoutingStatsManager _serverRoutingStatsManager;
 
   private volatile ServerRoutingInstance _failedServer;
   private volatile Exception _exception;
 
   public AsyncQueryResponse(QueryRouter queryRouter, long requestId, Set<ServerRoutingInstance> serversQueried,
-      long startTimeMs, long timeoutMs) {
+      long startTimeMs, long timeoutMs, ServerRoutingStatsManager serverRoutingStatsManager) {
     _queryRouter = queryRouter;
     _requestId = requestId;
     int numServersQueried = serversQueried.size();
@@ -59,6 +61,7 @@ public class AsyncQueryResponse implements QueryResponse {
     _countDownLatch = new CountDownLatch(numServersQueried);
     _timeoutMs = timeoutMs;
     _maxEndTimeMs = startTimeMs + timeoutMs;
+    _serverRoutingStatsManager = serverRoutingStatsManager;
   }
 
   @Override
@@ -84,6 +87,17 @@ public class AsyncQueryResponse implements QueryResponse {
       _status.compareAndSet(Status.IN_PROGRESS, finish ? Status.COMPLETED : Status.TIMED_OUT);
       return _responseMap;
     } finally {
+      // Update ServerRoutingStats.
+      for (Map.Entry<ServerRoutingInstance, ServerResponse> entry : _responseMap.entrySet()) {
+        ServerResponse response = entry.getValue();
+        if (response == null || response.getDataTable() == null) {
+          // These are servers from which a response was not received. So update query response stats for such
+          // servers with maximum latency i.e timeout value.
+          _serverRoutingStatsManager.recordStatsUponResponseArrival(_requestId, entry.getKey().getInstanceId(),
+              _timeoutMs);
+        }
+      }
+
       _queryRouter.markQueryDone(_requestId);
     }
   }
@@ -134,7 +148,15 @@ public class AsyncQueryResponse implements QueryResponse {
 
   void receiveDataTable(ServerRoutingInstance serverRoutingInstance, DataTable dataTable, int responseSize,
       int deserializationTimeMs) {
-    _responseMap.get(serverRoutingInstance).receiveDataTable(dataTable, responseSize, deserializationTimeMs);
+    ServerResponse response = _responseMap.get(serverRoutingInstance);
+    response.receiveDataTable(dataTable, responseSize, deserializationTimeMs);
+
+    // Record query completion stats immediately after receiving the response from the server instead of waiting
+    // for all servers to respond. This helps to keep the stats up-to-date.
+    long latencyMs = response.getResponseDelayMs();
+    _serverRoutingStatsManager.recordStatsUponResponseArrival(_requestId, serverRoutingInstance.getInstanceId(),
+        latencyMs);
+
     _numServersResponded.getAndIncrement();
     _countDownLatch.countDown();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
@@ -116,7 +116,8 @@ public class QueryRouter {
 
     // Create the asynchronous query response with the request map
     AsyncQueryResponse asyncQueryResponse =
-        new AsyncQueryResponse(this, requestId, requestMap.keySet(), System.currentTimeMillis(), timeoutMs);
+        new AsyncQueryResponse(this, requestId, requestMap.keySet(), System.currentTimeMillis(), timeoutMs,
+            _serverRoutingStatsManager);
     _asyncQueryResponseMap.put(requestId, asyncQueryResponse);
     for (Map.Entry<ServerRoutingInstance, InstanceRequest> entry : requestMap.entrySet()) {
       ServerRoutingInstance serverRoutingInstance = entry.getKey();
@@ -149,8 +150,6 @@ public class QueryRouter {
       AsyncQueryResponse asyncQueryResponse, Exception e) {
     LOGGER.error("Caught exception while sending request {} to server: {}, marking query failed", requestId,
         serverRoutingInstance, e);
-    _serverRoutingStatsManager.recordStatsUponResponseArrival(requestId, serverRoutingInstance.getInstanceId(),
-        (int) asyncQueryResponse.getTimeoutMs());
     asyncQueryResponse.markQueryFailed(serverRoutingInstance, e);
   }
 
@@ -183,20 +182,12 @@ public class QueryRouter {
     // Query future might be null if the query is already done (maybe due to failure)
     if (asyncQueryResponse != null) {
       asyncQueryResponse.receiveDataTable(serverRoutingInstance, dataTable, responseSize, deserializationTimeMs);
-
-      // Record query completion stats immediately after receiving the response from the server instead of waiting
-      // for the reduce phase.
-      long latencyMs = asyncQueryResponse.getServerResponseDelayMs(serverRoutingInstance);
-      _serverRoutingStatsManager.recordStatsUponResponseArrival(requestId, serverRoutingInstance.getInstanceId(),
-          latencyMs);
     }
   }
 
   void markServerDown(ServerRoutingInstance serverRoutingInstance, Exception exception) {
     for (AsyncQueryResponse asyncQueryResponse : _asyncQueryResponseMap.values()) {
       asyncQueryResponse.markServerDown(serverRoutingInstance, exception);
-      _serverRoutingStatsManager.recordStatsUponResponseArrival(asyncQueryResponse.getRequestId(),
-          serverRoutingInstance.getInstanceId(), (int) asyncQueryResponse.getTimeoutMs());
     }
   }
 


### PR DESCRIPTION
label = bugfix

When broker routes a query to a server, but the server doesn't respond back within the timeout, the `numInFlightRequests` in `ServerRoutingStats` is never decremented.  So, the algorithm now thinks that this server has outstanding requests and prefers this server lesser than the others. 

This PR fixes this bug. Added tests to confirm that `numInFlightRequests` is always zero - even if a server doesn't respond to a query.

@siddharthteotia  please review.