### PR TITLE
Add memory optimized dimension table

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigUtils.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import org.apache.commons.collections.MapUtils;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.spi.config.table.DedupConfig;
+import org.apache.pinot.spi.config.table.DimensionTableConfig;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.QueryConfig;
@@ -139,6 +140,12 @@ public class TableConfigUtils {
       dedupConfig = JsonUtils.stringToObject(dedupConfigString, DedupConfig.class);
     }
 
+    DimensionTableConfig dimensionTableConfig = null;
+    String dimensionTableConfigString = simpleFields.get(TableConfig.DIMENSION_TABLE_CONFIG_KEY);
+    if (dimensionTableConfigString != null) {
+      dimensionTableConfig = JsonUtils.stringToObject(dimensionTableConfigString, DimensionTableConfig.class);
+    }
+
     IngestionConfig ingestionConfig = null;
     String ingestionConfigString = simpleFields.get(TableConfig.INGESTION_CONFIG_KEY);
     if (ingestionConfigString != null) {
@@ -175,7 +182,7 @@ public class TableConfigUtils {
 
     return new TableConfig(tableName, tableType, validationConfig, tenantConfig, indexingConfig, customConfig,
         quotaConfig, taskConfig, routingConfig, queryConfig, instanceAssignmentConfigMap,
-        fieldConfigList, upsertConfig, dedupConfig, ingestionConfig, tierConfigList, isDimTable,
+        fieldConfigList, upsertConfig, dedupConfig, dimensionTableConfig, ingestionConfig, tierConfigList, isDimTable,
         tunerConfigList, instancePartitionsMap, segmentAssignmentConfigMap);
   }
 
@@ -226,6 +233,10 @@ public class TableConfigUtils {
     DedupConfig dedupConfig = tableConfig.getDedupConfig();
     if (dedupConfig != null) {
       simpleFields.put(TableConfig.DEDUP_CONFIG_KEY, JsonUtils.objectToString(dedupConfig));
+    }
+    DimensionTableConfig dimensionTableConfig = tableConfig.getDimensionTableConfig();
+    if (dimensionTableConfig != null) {
+      simpleFields.put(TableConfig.DIMENSION_TABLE_CONFIG_KEY, JsonUtils.objectToString(dimensionTableConfig));
     }
     IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
     if (ingestionConfig != null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTable.java
@@ -18,13 +18,14 @@
  */
 package org.apache.pinot.core.data.manager.offline;
 
+import java.io.Closeable;
 import java.util.List;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
 
 
-public interface DimensionTable {
+public interface DimensionTable extends Closeable {
 
   List<String> getPrimaryKeyColumns();
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTable.java
@@ -24,13 +24,11 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
 
 
-public interface DimensionTable<T> {
+public interface DimensionTable {
 
   List<String> getPrimaryKeyColumns();
 
   GenericRow get(PrimaryKey pk);
-
-  boolean put(PrimaryKey pk, T value);
 
   boolean isEmpty();
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
@@ -96,7 +96,7 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
     if (tableConfig != null) {
       DimensionTableConfig dimensionTableConfig = tableConfig.getDimensionTableConfig();
       if (dimensionTableConfig != null) {
-        _disablePreload = dimensionTableConfig.isOptimizeMemory();
+        _disablePreload = dimensionTableConfig.isDisablePreload();
       }
     }
 
@@ -206,7 +206,7 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
             for (int i = 0; i < numTotalDocs; i++) {
               GenericRow row = new GenericRow();
               recordReader.getRecord(i, row);
-              lookupTable.put(row.getPrimaryKey(primaryKeyColumns), new LookupRecordLocation(indexSegment, i));
+              lookupTable.put(row.getPrimaryKey(primaryKeyColumns), new LookupRecordLocation(recordReader, i));
             }
           } catch (Exception e) {
             throw new RuntimeException(

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
@@ -20,7 +20,7 @@ package org.apache.pinot.core.data.manager.offline;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -102,8 +102,8 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
     }
 
     if (_disablePreload) {
-      _dimensionTable = new MemoryOptimizedDimensionTable(schema, primaryKeyColumns, new HashMap<>(),
-          new ArrayList<>(), this);
+      _dimensionTable = new MemoryOptimizedDimensionTable(schema, primaryKeyColumns, Collections.emptyMap(),
+          Collections.emptyList(), this);
     } else {
       _dimensionTable = new FastLookupDimensionTable(schema, primaryKeyColumns, new HashMap<>());
     }
@@ -142,11 +142,11 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
   }
 
   private void closeDimensionTable(DimensionTable dimensionTable) {
-      try {
-        dimensionTable.close();
-      } catch (Exception e) {
-        _logger.warn("Cannot close dimension table: {}", _tableNameWithType, e);
-      }
+    try {
+      dimensionTable.close();
+    } catch (Exception e) {
+      _logger.warn("Cannot close dimension table: {}", _tableNameWithType, e);
+    }
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
@@ -145,12 +145,12 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
       if (_disablePreload) {
         replacement = createMemOptimisedDimensionTable();
       } else {
-        replacement = createDimensionTable();
+        replacement = createFastLookupDimensionTable();
       }
     } while (!UPDATER.compareAndSet(this, snapshot, replacement));
   }
 
-  private DimensionTable createDimensionTable() {
+  private DimensionTable createFastLookupDimensionTable() {
     Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
     Preconditions.checkState(schema != null, "Failed to find schema for dimension table: %s", _tableNameWithType);
 
@@ -178,7 +178,7 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
           }
         }
       }
-        return new FastLookupDimensionTable(schema, primaryKeyColumns, lookupTable);
+      return new FastLookupDimensionTable(schema, primaryKeyColumns, lookupTable);
     } finally {
       for (SegmentDataManager segmentManager : segmentManagers) {
         releaseSegment(segmentManager);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
@@ -80,7 +80,7 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
       AtomicReferenceFieldUpdater.newUpdater(DimensionTableDataManager.class, DimensionTable.class, "_dimensionTable");
 
   private volatile DimensionTable _dimensionTable;
-  private boolean _isMemoryOptimized = true;
+  private boolean _disablePreload = false;
 
   @Override
   protected void doInit() {
@@ -96,11 +96,11 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
     if (tableConfig != null) {
       DimensionTableConfig dimensionTableConfig = tableConfig.getDimensionTableConfig();
       if (dimensionTableConfig != null) {
-        _isMemoryOptimized = dimensionTableConfig.isOptimizeMemory();
+        _disablePreload = dimensionTableConfig.isOptimizeMemory();
       }
     }
 
-    if (_isMemoryOptimized) {
+    if (_disablePreload) {
       _dimensionTable = new MemoryOptimizedDimensionTable(schema, primaryKeyColumns);
     } else {
       _dimensionTable = new FastLookupDimensionTable(schema, primaryKeyColumns);
@@ -142,7 +142,7 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
     DimensionTable replacement;
     do {
       snapshot = _dimensionTable;
-      if (_isMemoryOptimized) {
+      if (_disablePreload) {
         replacement = createMemOptimisedDimensionTable();
       } else {
         replacement = createDimensionTable();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/FastLookupDimensionTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/FastLookupDimensionTable.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager.offline;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.PrimaryKey;
+
+
+class FastLookupDimensionTable implements DimensionTable<GenericRow> {
+
+  private Map<PrimaryKey, GenericRow> _lookupTable;
+  private final Schema _tableSchema;
+  private final List<String> _primaryKeyColumns;
+
+  FastLookupDimensionTable(Schema tableSchema, List<String> primaryKeyColumns) {
+    this(tableSchema, primaryKeyColumns, new HashMap<>());
+  }
+
+  FastLookupDimensionTable(Schema tableSchema, List<String> primaryKeyColumns,
+      Map<PrimaryKey, GenericRow> lookupTable) {
+    _lookupTable = lookupTable;
+    _tableSchema = tableSchema;
+    _primaryKeyColumns = primaryKeyColumns;
+  }
+
+  @Override
+  public List<String> getPrimaryKeyColumns() {
+    return _primaryKeyColumns;
+  }
+
+  @Override
+  public GenericRow get(PrimaryKey pk) {
+    return _lookupTable.get(pk);
+  }
+
+  @Override
+  public boolean put(PrimaryKey pk, GenericRow value) {
+    _lookupTable.put(pk, value);
+    return true;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return _lookupTable.isEmpty();
+  }
+
+  @Override
+  public FieldSpec getFieldSpecFor(String columnName) {
+    return _tableSchema.getFieldSpecFor(columnName);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/FastLookupDimensionTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/FastLookupDimensionTable.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.data.manager.offline;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -62,5 +63,11 @@ class FastLookupDimensionTable implements DimensionTable {
   @Override
   public FieldSpec getFieldSpecFor(String columnName) {
     return _tableSchema.getFieldSpecFor(columnName);
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/FastLookupDimensionTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/FastLookupDimensionTable.java
@@ -27,7 +27,7 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
 
 
-class FastLookupDimensionTable implements DimensionTable<GenericRow> {
+class FastLookupDimensionTable implements DimensionTable {
 
   private Map<PrimaryKey, GenericRow> _lookupTable;
   private final Schema _tableSchema;
@@ -52,12 +52,6 @@ class FastLookupDimensionTable implements DimensionTable<GenericRow> {
   @Override
   public GenericRow get(PrimaryKey pk) {
     return _lookupTable.get(pk);
-  }
-
-  @Override
-  public boolean put(PrimaryKey pk, GenericRow value) {
-    _lookupTable.put(pk, value);
-    return true;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/FastLookupDimensionTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/FastLookupDimensionTable.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.data.manager.offline;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -33,10 +32,6 @@ class FastLookupDimensionTable implements DimensionTable {
   private Map<PrimaryKey, GenericRow> _lookupTable;
   private final Schema _tableSchema;
   private final List<String> _primaryKeyColumns;
-
-  FastLookupDimensionTable(Schema tableSchema, List<String> primaryKeyColumns) {
-    this(tableSchema, primaryKeyColumns, new HashMap<>());
-  }
 
   FastLookupDimensionTable(Schema tableSchema, List<String> primaryKeyColumns,
       Map<PrimaryKey, GenericRow> lookupTable) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/FastLookupDimensionTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/FastLookupDimensionTable.java
@@ -68,6 +68,5 @@ class FastLookupDimensionTable implements DimensionTable {
   @Override
   public void close()
       throws IOException {
-
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/LookupRecordLocation.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/LookupRecordLocation.java
@@ -18,21 +18,23 @@
  */
 package org.apache.pinot.core.data.manager.offline;
 
-import java.util.List;
-import org.apache.pinot.spi.data.FieldSpec;
-import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.data.readers.PrimaryKey;
+import org.apache.pinot.segment.spi.IndexSegment;
 
 
-public interface DimensionTable<T> {
+public class LookupRecordLocation {
+  private final IndexSegment _indexSegment;
+  private final int _docId;
 
-  List<String> getPrimaryKeyColumns();
+  public LookupRecordLocation(IndexSegment indexSegment, int docId) {
+    _indexSegment = indexSegment;
+    _docId = docId;
+  }
 
-  GenericRow get(PrimaryKey pk);
+  public IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
 
-  boolean put(PrimaryKey pk, T value);
-
-  boolean isEmpty();
-
-  FieldSpec getFieldSpecFor(String columnName);
+  public int getDocId() {
+    return _docId;
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/LookupRecordLocation.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/LookupRecordLocation.java
@@ -18,23 +18,29 @@
  */
 package org.apache.pinot.core.data.manager.offline;
 
-import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
+import org.apache.pinot.spi.data.readers.GenericRow;
 
 
 public class LookupRecordLocation {
-  private final IndexSegment _indexSegment;
+  private final PinotSegmentRecordReader _pinotSegmentRecordReader;
   private final int _docId;
 
-  public LookupRecordLocation(IndexSegment indexSegment, int docId) {
-    _indexSegment = indexSegment;
+  public LookupRecordLocation(PinotSegmentRecordReader pinotSegmentRecordReader, int docId) {
+    _pinotSegmentRecordReader = pinotSegmentRecordReader;
     _docId = docId;
   }
 
-  public IndexSegment getIndexSegment() {
-    return _indexSegment;
+  public PinotSegmentRecordReader getPinotSegmentRecordReader() {
+    return _pinotSegmentRecordReader;
   }
 
   public int getDocId() {
     return _docId;
+  }
+
+  public GenericRow getRecord(GenericRow reuse) {
+    _pinotSegmentRecordReader.getRecord(_docId, reuse);
+    return reuse;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/MemoryOptimizedDimensionTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/MemoryOptimizedDimensionTable.java
@@ -27,7 +27,7 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
 
 
-class MemoryOptimizedDimensionTable implements DimensionTable<LookupRecordLocation> {
+class MemoryOptimizedDimensionTable implements DimensionTable {
 
   private Map<PrimaryKey, LookupRecordLocation> _lookupTable;
   private final Schema _tableSchema;
@@ -56,12 +56,6 @@ class MemoryOptimizedDimensionTable implements DimensionTable<LookupRecordLocati
       return null;
     }
     return lookupRecordLocation.getIndexSegment().getRecord(lookupRecordLocation.getDocId(), new GenericRow());
-  }
-
-  @Override
-  public boolean put(PrimaryKey pk, LookupRecordLocation value) {
-    _lookupTable.put(pk, value);
-    return true;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/MemoryOptimizedDimensionTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/MemoryOptimizedDimensionTable.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.data.manager.offline;
 
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,5 +68,17 @@ class MemoryOptimizedDimensionTable implements DimensionTable {
   @Override
   public FieldSpec getFieldSpecFor(String columnName) {
     return _tableSchema.getFieldSpecFor(columnName);
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    for(LookupRecordLocation lookupRecordLocation: _lookupTable.values()) {
+      try {
+        lookupRecordLocation.getPinotSegmentRecordReader().close();
+      } catch (Exception e) {
+        //TODO: log warning
+      }
+    }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/MemoryOptimizedDimensionTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/MemoryOptimizedDimensionTable.java
@@ -78,7 +78,7 @@ class MemoryOptimizedDimensionTable implements DimensionTable {
   @Override
   public void close()
       throws IOException {
-    for (LookupRecordLocation lookupRecordLocation: _lookupTable.values()) {
+    for (LookupRecordLocation lookupRecordLocation : _lookupTable.values()) {
       try {
         lookupRecordLocation.getPinotSegmentRecordReader().close();
       } catch (Exception e) {
@@ -86,8 +86,8 @@ class MemoryOptimizedDimensionTable implements DimensionTable {
       }
     }
 
-    for (SegmentDataManager segmentDataManager: _segmentDataManagers) {
-        _tableDataManager.releaseSegment(segmentDataManager);
+    for (SegmentDataManager segmentDataManager : _segmentDataManagers) {
+      _tableDataManager.releaseSegment(segmentDataManager);
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/MemoryOptimizedDimensionTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/MemoryOptimizedDimensionTable.java
@@ -22,13 +22,17 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.core.data.manager.BaseTableDataManager;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 class MemoryOptimizedDimensionTable implements DimensionTable {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BaseTableDataManager.class);
 
   private final Map<PrimaryKey, LookupRecordLocation> _lookupTable;
   private final Schema _tableSchema;
@@ -73,11 +77,11 @@ class MemoryOptimizedDimensionTable implements DimensionTable {
   @Override
   public void close()
       throws IOException {
-    for(LookupRecordLocation lookupRecordLocation: _lookupTable.values()) {
+    for (LookupRecordLocation lookupRecordLocation: _lookupTable.values()) {
       try {
         lookupRecordLocation.getPinotSegmentRecordReader().close();
       } catch (Exception e) {
-        //TODO: log warning
+        LOGGER.warn("Cannot close segment record reader", e);
       }
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/MemoryOptimizedDimensionTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/MemoryOptimizedDimensionTable.java
@@ -29,9 +29,10 @@ import org.apache.pinot.spi.data.readers.PrimaryKey;
 
 class MemoryOptimizedDimensionTable implements DimensionTable {
 
-  private Map<PrimaryKey, LookupRecordLocation> _lookupTable;
+  private final Map<PrimaryKey, LookupRecordLocation> _lookupTable;
   private final Schema _tableSchema;
   private final List<String> _primaryKeyColumns;
+  private final GenericRow _reuse = new GenericRow();
 
   MemoryOptimizedDimensionTable(Schema tableSchema, List<String> primaryKeyColumns) {
     this(tableSchema, primaryKeyColumns, new HashMap<>());
@@ -55,7 +56,7 @@ class MemoryOptimizedDimensionTable implements DimensionTable {
     if (lookupRecordLocation == null) {
       return null;
     }
-    return lookupRecordLocation.getIndexSegment().getRecord(lookupRecordLocation.getDocId(), new GenericRow());
+    return lookupRecordLocation.getRecord(_reuse);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/MemoryOptimizedDimensionTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/MemoryOptimizedDimensionTable.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.data.manager.offline;
 
 import java.io.IOException;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.data.manager.BaseTableDataManager;
@@ -38,10 +37,6 @@ class MemoryOptimizedDimensionTable implements DimensionTable {
   private final Schema _tableSchema;
   private final List<String> _primaryKeyColumns;
   private final GenericRow _reuse = new GenericRow();
-
-  MemoryOptimizedDimensionTable(Schema tableSchema, List<String> primaryKeyColumns) {
-    this(tableSchema, primaryKeyColumns, new HashMap<>());
-  }
 
   MemoryOptimizedDimensionTable(Schema tableSchema, List<String> primaryKeyColumns,
       Map<PrimaryKey, LookupRecordLocation> lookupTable) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/MemoryOptimizedDimensionTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/MemoryOptimizedDimensionTable.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager.offline;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.PrimaryKey;
+
+
+class MemoryOptimizedDimensionTable implements DimensionTable<LookupRecordLocation> {
+
+  private Map<PrimaryKey, LookupRecordLocation> _lookupTable;
+  private final Schema _tableSchema;
+  private final List<String> _primaryKeyColumns;
+
+  MemoryOptimizedDimensionTable(Schema tableSchema, List<String> primaryKeyColumns) {
+    this(tableSchema, primaryKeyColumns, new HashMap<>());
+  }
+
+  MemoryOptimizedDimensionTable(Schema tableSchema, List<String> primaryKeyColumns,
+      Map<PrimaryKey, LookupRecordLocation> lookupTable) {
+    _lookupTable = lookupTable;
+    _tableSchema = tableSchema;
+    _primaryKeyColumns = primaryKeyColumns;
+  }
+
+  @Override
+  public List<String> getPrimaryKeyColumns() {
+    return _primaryKeyColumns;
+  }
+
+  @Override
+  public GenericRow get(PrimaryKey pk) {
+    LookupRecordLocation lookupRecordLocation = _lookupTable.get(pk);
+    if (lookupRecordLocation == null) {
+      return null;
+    }
+    return lookupRecordLocation.getIndexSegment().getRecord(lookupRecordLocation.getDocId(), new GenericRow());
+  }
+
+  @Override
+  public boolean put(PrimaryKey pk, LookupRecordLocation value) {
+    _lookupTable.put(pk, value);
+    return true;
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return _lookupTable.isEmpty();
+  }
+
+  @Override
+  public FieldSpec getFieldSpecFor(String columnName) {
+    return _tableSchema.getFieldSpecFor(columnName);
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/DimensionTableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/DimensionTableConfig.java
@@ -16,23 +16,22 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.core.data.manager.offline;
+package org.apache.pinot.spi.config.table;
 
-import java.util.List;
-import org.apache.pinot.spi.data.FieldSpec;
-import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.data.readers.PrimaryKey;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.pinot.spi.config.BaseJsonConfig;
 
 
-public interface DimensionTable<T> {
+public class DimensionTableConfig extends BaseJsonConfig {
+  private final boolean _optimizeMemory;
 
-  List<String> getPrimaryKeyColumns();
+  @JsonCreator
+  public DimensionTableConfig(@JsonProperty(value = "optimizeMemory", required = true) boolean optimizeMemory) {
+    _optimizeMemory = optimizeMemory;
+  }
 
-  GenericRow get(PrimaryKey pk);
-
-  boolean put(PrimaryKey pk, T value);
-
-  boolean isEmpty();
-
-  FieldSpec getFieldSpecFor(String columnName);
+  public boolean isOptimizeMemory() {
+    return _optimizeMemory;
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/DimensionTableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/DimensionTableConfig.java
@@ -24,14 +24,14 @@ import org.apache.pinot.spi.config.BaseJsonConfig;
 
 
 public class DimensionTableConfig extends BaseJsonConfig {
-  private final boolean _optimizeMemory;
+  private final boolean _disablePreload;
 
   @JsonCreator
-  public DimensionTableConfig(@JsonProperty(value = "optimizeMemory", required = true) boolean optimizeMemory) {
-    _optimizeMemory = optimizeMemory;
+  public DimensionTableConfig(@JsonProperty(value = "disablePreload", required = true) boolean disablePreload) {
+    _disablePreload = disablePreload;
   }
 
-  public boolean isOptimizeMemory() {
-    return _optimizeMemory;
+  public boolean isDisablePreload() {
+    return _disablePreload;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
@@ -53,6 +53,7 @@ public class TableConfig extends BaseJsonConfig {
   public static final String FIELD_CONFIG_LIST_KEY = "fieldConfigList";
   public static final String UPSERT_CONFIG_KEY = "upsertConfig";
   public static final String DEDUP_CONFIG_KEY = "dedupConfig";
+  public static final String DIMENSION_TABLE_CONFIG_KEY = "dimensionTableConfig";
   public static final String INGESTION_CONFIG_KEY = "ingestionConfig";
   public static final String TIER_CONFIGS_LIST_KEY = "tierConfigs";
   public static final String TUNER_CONFIG_LIST_KEY = "tunerConfigs";
@@ -129,6 +130,7 @@ public class TableConfig extends BaseJsonConfig {
       @JsonProperty(FIELD_CONFIG_LIST_KEY) @Nullable List<FieldConfig> fieldConfigList,
       @JsonProperty(UPSERT_CONFIG_KEY) @Nullable UpsertConfig upsertConfig,
       @JsonProperty(DEDUP_CONFIG_KEY) @Nullable DedupConfig dedupConfig,
+      @JsonProperty(DIMENSION_TABLE_CONFIG_KEY) @Nullable DimensionTableConfig dimensionTableConfig,
       @JsonProperty(INGESTION_CONFIG_KEY) @Nullable IngestionConfig ingestionConfig,
       @JsonProperty(TIER_CONFIGS_LIST_KEY) @Nullable List<TierConfig> tierConfigsList,
       @JsonProperty(IS_DIM_TABLE_KEY) boolean dimTable,
@@ -161,6 +163,7 @@ public class TableConfig extends BaseJsonConfig {
     _fieldConfigList = fieldConfigList;
     _upsertConfig = upsertConfig;
     _dedupConfig = dedupConfig;
+    _dimensionTableConfig = dimensionTableConfig;
     _ingestionConfig = ingestionConfig;
     _tierConfigsList = tierConfigsList;
     _dimTable = dimTable;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
@@ -100,6 +100,9 @@ public class TableConfig extends BaseJsonConfig {
   @JsonPropertyDescription(value = "Dedup related config")
   private DedupConfig _dedupConfig;
 
+  @JsonPropertyDescription(value = "Dimension Table related config")
+  private DimensionTableConfig _dimensionTableConfig;
+
   @JsonPropertyDescription(value = "Config related to ingesting data into the table")
   private IngestionConfig _ingestionConfig;
 
@@ -303,6 +306,15 @@ public class TableConfig extends BaseJsonConfig {
 
   public void setDedupConfig(DedupConfig dedupConfig) {
     _dedupConfig = dedupConfig;
+  }
+
+  @Nullable
+  public DimensionTableConfig getDimensionTableConfig() {
+    return _dimensionTableConfig;
+  }
+
+  public void setDimensionTableConfig(DimensionTableConfig dimensionTableConfig) {
+    _dimensionTableConfig = dimensionTableConfig;
   }
 
   @JsonProperty(INGESTION_CONFIG_KEY)

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.spi.config.table.CompletionConfig;
 import org.apache.pinot.spi.config.table.DedupConfig;
+import org.apache.pinot.spi.config.table.DimensionTableConfig;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.QueryConfig;
@@ -115,6 +116,7 @@ public class TableConfigBuilder {
 
   private UpsertConfig _upsertConfig;
   private DedupConfig _dedupConfig;
+  private DimensionTableConfig _dimensionTableConfig;
   private IngestionConfig _ingestionConfig;
   private List<TierConfig> _tierConfigList;
   private List<TunerConfig> _tunerConfigList;
@@ -357,6 +359,11 @@ public class TableConfigBuilder {
     return this;
   }
 
+  public TableConfigBuilder setDimensionTableConfig(DimensionTableConfig dimensionTableConfig) {
+    _dimensionTableConfig = dimensionTableConfig;
+    return this;
+  }
+
   public TableConfigBuilder setPeerSegmentDownloadScheme(String peerSegmentDownloadScheme) {
     _peerSegmentDownloadScheme = peerSegmentDownloadScheme;
     return this;
@@ -439,7 +446,7 @@ public class TableConfigBuilder {
 
     return new TableConfig(_tableName, _tableType.toString(), validationConfig, tenantConfig, indexingConfig,
         _customConfig, _quotaConfig, _taskConfig, _routingConfig, _queryConfig, _instanceAssignmentConfigMap,
-        _fieldConfigList, _upsertConfig, _dedupConfig, _ingestionConfig, _tierConfigList, _isDimTable, _tunerConfigList,
-        _instancePartitionsMap, _segmentAssignmentConfigMap);
+        _fieldConfigList, _upsertConfig, _dedupConfig, _dimensionTableConfig, _ingestionConfig, _tierConfigList,
+        _isDimTable, _tunerConfigList, _instancePartitionsMap, _segmentAssignmentConfigMap);
   }
 }


### PR DESCRIPTION
Currently, we store the whole row in the Dimension table hash map for fast lookups.
However, in some cases, we can trade off the speed for memory efficiency.
In this PR, I am adding a new implementation that only stores the segment reference and docID, and the actual value is read at the time of lookup.

I have also created another design where I am using different DataManager implementations instead of DataTable implementations. It touches a lot of code paths though hence I didn't raise PR for that approach. The code can be seen here 
https://github.com/KKcorps/incubator-pinot/pull/23/files