### PR TITLE
Optimize AdaptiveServerSelection for replicaGroup based routing

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/adaptiveserverselector/AdaptiveServerSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/adaptiveserverselector/AdaptiveServerSelector.java
@@ -45,4 +45,14 @@ public interface AdaptiveServerSelector {
    * @return List of servers along with their values ranked from best to worst.
    */
   List<Pair<String, Double>> fetchAllServerRankingsWithScores();
+
+  /**
+   * Same as above but fetches ranking only for the list of serverCandidates provided in the parameter. If a server
+   * doesn't have an entry, it's ranked better than other serverCandidates and a value of -1.0 is returned. With the
+   * above "fetchAllServerRankingsWithScores" API, ranking for all the servers are fetched. This can become
+   * problematic if a broker is routing to multiple  server tenants but a query needs to touch only a single server
+   * tenant. This API helps fetch ranking only for a subset of servers.
+   * @return List of servers along with their values ranked from best to worst.
+   */
+  List<Pair<String, Double>> fetchServerRankingsWithScores(List<String> serverCandidates);
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/adaptiveserverselector/HybridSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/adaptiveserverselector/HybridSelector.java
@@ -18,9 +18,11 @@
  */
 package org.apache.pinot.broker.routing.adaptiveserverselector;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Random;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager;
 
@@ -75,6 +77,32 @@ public class HybridSelector implements AdaptiveServerSelector {
   @Override
   public List<Pair<String, Double>> fetchAllServerRankingsWithScores() {
     List<Pair<String, Double>> pairList = _serverRoutingStatsManager.fetchHybridScoreForAllServers();
+
+    // Let's shuffle the list before sorting. This helps with randomly choosing different servers if there is a tie.
+    Collections.shuffle(pairList);
+    Collections.sort(pairList, (o1, o2) -> {
+      int val = Double.compare(o1.getRight(), o2.getRight());
+      return val;
+    });
+
+    return pairList;
+  }
+
+  @Override
+  public List<Pair<String, Double>> fetchServerRankingsWithScores(List<String> serverCandidates) {
+    List<Pair<String, Double>> pairList = new ArrayList<>();
+    if (serverCandidates.size() == 0) {
+      return pairList;
+    }
+
+    for (String server : serverCandidates) {
+      Double score = _serverRoutingStatsManager.fetchHybridScoreForServer(server);
+      if (score == null) {
+        score = -1.0;
+      }
+
+      pairList.add(new ImmutablePair<>(server, score));
+    }
 
     // Let's shuffle the list before sorting. This helps with randomly choosing different servers if there is a tie.
     Collections.shuffle(pairList);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/adaptiveserverselector/NumInFlightReqSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/adaptiveserverselector/NumInFlightReqSelector.java
@@ -85,4 +85,30 @@ public class NumInFlightReqSelector implements AdaptiveServerSelector {
 
     return pairList;
   }
+
+  @Override
+  public List<Pair<String, Double>> fetchServerRankingsWithScores(List<String> serverCandidates) {
+    List<Pair<String, Double>> pairList = new ArrayList<>();
+    if (serverCandidates.size() == 0) {
+      return pairList;
+    }
+
+    for (String server : serverCandidates) {
+      Integer score = _serverRoutingStatsManager.fetchNumInFlightRequestsForServer(server);
+      if (score == null) {
+        score = -1;
+      }
+
+      pairList.add(new ImmutablePair<>(server, (double) score));
+    }
+
+    // Let's shuffle the list before sorting. This helps with randomly choosing different servers if there is a tie.
+    Collections.shuffle(pairList);
+    Collections.sort(pairList, (o1, o2) -> {
+      int val = Double.compare(o1.getRight(), o2.getRight());
+      return val;
+    });
+
+    return pairList;
+  }
 }


### PR DESCRIPTION
When AdaptiveServerSelector is used with `replicaGroupInstanceSelector`, it fetches the ranking of all available servers. If a broker is routing to multiple server tenants, we will be unnecessarily fetching the ranking for a lot more servers than required. Note that fetching server rankings also involves waiting for a read lock to fetch the stats. 

In this PR, we first determine the candidate set of servers to which a query could be potentially routed. The ranking is performed only for servers in this candidate set. 