### PR TITLE
Add a new server directory to store metadata

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -134,7 +134,8 @@ public abstract class BaseTableDataManager implements TableDataManager {
     if (tableMetaDataDir != null) {
       _tableMetaDataDir = new File(tableMetaDataDir);
       if (!_tableMetaDataDir.exists()) {
-        Preconditions.checkState(_tableMetaDataDir.mkdirs(), "Unable to create metadata directory at %s. " + "Please check for available space and write-permissions for this directory.", _tableMetaDataDir);
+        Preconditions.checkState(_tableMetaDataDir.mkdirs(), "Unable to create metadata directory at %s. "
+            + "Please check for available space and write-permissions for this directory.", _tableMetaDataDir);
       }
     } else {
       _tableMetaDataDir = _indexDir;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -91,6 +91,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
   protected ServerMetrics _serverMetrics;
   protected String _tableNameWithType;
   protected String _tableDataDir;
+  protected File _tableMetaDataDir;
   protected File _indexDir;
   protected File _resourceTmpDir;
   protected Logger _logger;
@@ -128,6 +129,14 @@ public abstract class BaseTableDataManager implements TableDataManager {
       Preconditions.checkState(_indexDir.mkdirs(), "Unable to create index directory at %s. "
           + "Please check for available space and write-permissions for this directory.", _indexDir);
     }
+
+    String tableMetaDataDir = tableDataManagerConfig.getMetaDataDir();
+    _tableMetaDataDir = new File(tableMetaDataDir);
+    if (!_tableMetaDataDir.exists()) {
+      Preconditions.checkState(_tableMetaDataDir.mkdirs(), "Unable to create metadata directory at %s. "
+          + "Please check for available space and write-permissions for this directory.", _tableMetaDataDir);
+    }
+
     _resourceTmpDir = new File(_indexDir, "tmp");
     // This is meant to cleanup temp resources from TableDataManager. But other code using this same
     // directory will have those deleted as well.
@@ -320,6 +329,11 @@ public abstract class BaseTableDataManager implements TableDataManager {
   @Override
   public File getTableDataDir() {
     return _indexDir;
+  }
+
+  @Override
+  public File getTableMetaDataDir() {
+    return _tableMetaDataDir;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -131,10 +131,13 @@ public abstract class BaseTableDataManager implements TableDataManager {
     }
 
     String tableMetaDataDir = tableDataManagerConfig.getMetaDataDir();
-    _tableMetaDataDir = new File(tableMetaDataDir);
-    if (!_tableMetaDataDir.exists()) {
-      Preconditions.checkState(_tableMetaDataDir.mkdirs(), "Unable to create metadata directory at %s. "
-          + "Please check for available space and write-permissions for this directory.", _tableMetaDataDir);
+    if (tableMetaDataDir != null) {
+      _tableMetaDataDir = new File(tableMetaDataDir);
+      if (!_tableMetaDataDir.exists()) {
+        Preconditions.checkState(_tableMetaDataDir.mkdirs(), "Unable to create metadata directory at %s. " + "Please check for available space and write-permissions for this directory.", _tableMetaDataDir);
+      }
+    } else {
+      _tableMetaDataDir = _indexDir;
     }
 
     _resourceTmpDir = new File(_indexDir, "tmp");

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerAcquireSegmentTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerAcquireSegmentTest.java
@@ -123,6 +123,7 @@ public class BaseTableDataManagerAcquireSegmentTest {
       config = mock(TableDataManagerConfig.class);
       when(config.getTableName()).thenReturn(TABLE_NAME);
       when(config.getDataDir()).thenReturn(_tmpDir.getAbsolutePath());
+      when(config.getMetaDataDir()).thenReturn(_tmpDir.getAbsolutePath());
       when(config.getAuthConfig()).thenReturn(new MapConfiguration(new HashMap<>()));
       when(config.getTableDeletedSegmentsCacheSize()).thenReturn(DELETED_SEGMENTS_CACHE_SIZE);
       when(config.getTableDeletedSegmentsCacheTtlMinutes()).thenReturn(DELETED_SEGMENTS_TTL_MINUTES);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -664,6 +664,7 @@ public class BaseTableDataManagerTest {
     TableDataManagerConfig config = mock(TableDataManagerConfig.class);
     when(config.getTableName()).thenReturn(TABLE_NAME_WITH_TYPE);
     when(config.getDataDir()).thenReturn(TABLE_DATA_DIR.getAbsolutePath());
+//    when(config.getMetaDataDir()).thenReturn(TABLE_DATA_DIR.getAbsolutePath());
     when(config.getAuthConfig()).thenReturn(new MapConfiguration(Collections.emptyMap()));
 
     OfflineTableDataManager tableDataManager = new OfflineTableDataManager();

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
@@ -117,6 +117,7 @@ public class DimensionTableDataManagerTest {
       config = mock(TableDataManagerConfig.class);
       when(config.getTableName()).thenReturn(TABLE_NAME);
       when(config.getDataDir()).thenReturn(TEMP_DIR.getAbsolutePath());
+      when(config.getMetaDataDir()).thenReturn(TEMP_DIR.getAbsolutePath());
     }
     tableDataManager.init(config, "dummyInstance", helixManager.getHelixPropertyStore(),
         new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), helixManager, null,

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -838,6 +838,7 @@ public class LLRealtimeSegmentDataManagerTest {
     when(tableDataManagerConfig.getTableDataManagerType()).thenReturn("REALTIME");
     when(tableDataManagerConfig.getTableName()).thenReturn(tableConfig.getTableName());
     when(tableDataManagerConfig.getDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
+    when(tableDataManagerConfig.getMetaDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
     InstanceDataManagerConfig instanceDataManagerConfig = mock(InstanceDataManagerConfig.class);
     when(instanceDataManagerConfig.getMaxParallelSegmentBuilds()).thenReturn(4);
     when(instanceDataManagerConfig.getStreamSegmentDownloadUntarRateLimit()).thenReturn(-1L);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManagerTest.java
@@ -203,6 +203,7 @@ public class RealtimeTableDataManagerTest {
     TableDataManagerConfig tableDataManagerConfig = mock(TableDataManagerConfig.class);
     when(tableDataManagerConfig.getTableName()).thenReturn(TABLE_NAME_WITH_TYPE);
     when(tableDataManagerConfig.getDataDir()).thenReturn(TABLE_DATA_DIR.getAbsolutePath());
+    when(tableDataManagerConfig.getMetaDataDir()).thenReturn(TABLE_DATA_DIR.getAbsolutePath());
     return tableDataManagerConfig;
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorExceptionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorExceptionsTest.java
@@ -134,6 +134,7 @@ public class QueryExecutorExceptionsTest {
     when(tableDataManagerConfig.getTableDataManagerType()).thenReturn("OFFLINE");
     when(tableDataManagerConfig.getTableName()).thenReturn(TABLE_NAME);
     when(tableDataManagerConfig.getDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
+    when(tableDataManagerConfig.getMetaDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
     InstanceDataManagerConfig instanceDataManagerConfig = mock(InstanceDataManagerConfig.class);
     when(instanceDataManagerConfig.getMaxParallelSegmentBuilds()).thenReturn(4);
     when(instanceDataManagerConfig.getStreamSegmentDownloadUntarRateLimit()).thenReturn(-1L);

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorTest.java
@@ -131,6 +131,7 @@ public class QueryExecutorTest {
     when(tableDataManagerConfig.getTableDataManagerType()).thenReturn("OFFLINE");
     when(tableDataManagerConfig.getTableName()).thenReturn(TABLE_NAME);
     when(tableDataManagerConfig.getDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
+    when(tableDataManagerConfig.getMetaDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
     InstanceDataManagerConfig instanceDataManagerConfig = mock(InstanceDataManagerConfig.class);
     when(instanceDataManagerConfig.getMaxParallelSegmentBuilds()).thenReturn(4);
     when(instanceDataManagerConfig.getStreamSegmentDownloadUntarRateLimit()).thenReturn(-1L);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
@@ -269,6 +269,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     when(tableDataManagerConfig.getTableDataManagerType()).thenReturn("OFFLINE");
     when(tableDataManagerConfig.getTableName()).thenReturn(RAW_TABLE_NAME);
     when(tableDataManagerConfig.getDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
+    when(tableDataManagerConfig.getMetaDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
     InstanceDataManagerConfig instanceDataManagerConfig = mock(InstanceDataManagerConfig.class);
     when(instanceDataManagerConfig.getMaxParallelSegmentBuilds()).thenReturn(4);
     when(instanceDataManagerConfig.getStreamSegmentDownloadUntarRateLimit()).thenReturn(-1L);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -183,6 +183,11 @@ public interface TableDataManager {
   File getTableDataDir();
 
   /**
+   * Returns the dir which contains the table metadata e.g. upsert.
+   */
+  File getTableMetaDataDir();
+
+  /**
    * Add error related to segment, if any. The implementation
    * is expected to cache last 'N' errors for the table, related to
    * segment transitions.

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManagerConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManagerConfig.java
@@ -93,6 +93,8 @@ public class TableDataManagerConfig {
     defaultConfig.addProperty(TABLE_DATA_MANAGER_NAME, tableNameWithType);
     defaultConfig.addProperty(TABLE_DATA_MANAGER_DATA_DIRECTORY,
         instanceDataManagerConfig.getInstanceDataDir() + "/" + tableNameWithType);
+    defaultConfig.addProperty(TABLE_DATA_MANAGER_METADATA_DIRECTORY,
+        instanceDataManagerConfig.getInstanceMetadataDir() + "/" + tableNameWithType);
     defaultConfig.addProperty(TABLE_DATA_MANAGER_CONSUMER_DIRECTORY, instanceDataManagerConfig.getConsumerDir());
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
     Preconditions.checkNotNull(tableType);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManagerConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManagerConfig.java
@@ -33,6 +33,7 @@ import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 public class TableDataManagerConfig {
   private static final String TABLE_DATA_MANAGER_TYPE = "dataManagerType";
   private static final String TABLE_DATA_MANAGER_DATA_DIRECTORY = "directory";
+  private static final String TABLE_DATA_MANAGER_METADATA_DIRECTORY = "metadataDirectory";
   private static final String TABLE_DATA_MANAGER_CONSUMER_DIRECTORY = "consumerDirectory";
   private static final String TABLE_DATA_MANAGER_NAME = "name";
   private static final String TABLE_IS_DIMENSION = "isDimTable";
@@ -56,6 +57,10 @@ public class TableDataManagerConfig {
 
   public String getDataDir() {
     return _tableDataManagerConfig.getString(TABLE_DATA_MANAGER_DATA_DIRECTORY);
+  }
+
+  public String getMetaDataDir() {
+    return _tableDataManagerConfig.getString(TABLE_DATA_MANAGER_METADATA_DIRECTORY);
   }
 
   public String getConsumerDir() {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.local.upsert;
 
 import com.google.common.base.Preconditions;
+import java.io.File;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
@@ -39,6 +40,7 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
   protected HashFunction _hashFunction;
   protected PartialUpsertHandler _partialUpsertHandler;
   protected boolean _enableSnapshot;
+  protected File _metadataDir;
   protected ServerMetrics _serverMetrics;
 
   @Override
@@ -72,6 +74,7 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
 
     _enableSnapshot = upsertConfig.isEnableSnapshot();
 
+    _metadataDir = tableDataManager.getTableMetaDataDir();
     _serverMetrics = serverMetrics;
   }
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -47,6 +47,8 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   public static final String INSTANCE_ID = "id";
   // Key of instance data directory
   public static final String INSTANCE_DATA_DIR = "dataDir";
+  // Key of instance metadata directory
+  public static final String INSTANCE_METADATA_DIR = "metadataDir";
   // Key of consumer directory
   public static final String CONSUMER_DIR = "consumerDir";
   // Key of instance segment tar directory
@@ -163,6 +165,11 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   @Override
   public String getInstanceDataDir() {
     return _instanceDataManagerConfiguration.getProperty(INSTANCE_DATA_DIR);
+  }
+
+  @Override
+  public String getInstanceMetadataDir() {
+    return _instanceDataManagerConfiguration.getProperty(INSTANCE_METADATA_DIR, getInstanceDataDir());
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
@@ -29,6 +29,8 @@ public interface InstanceDataManagerConfig {
 
   String getInstanceDataDir();
 
+  String getInstanceMetadataDir();
+
   String getConsumerDir();
 
   String getInstanceSegmentTarDir();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -421,6 +421,7 @@ public class CommonConstants {
   public static class Server {
     public static final String CONFIG_OF_INSTANCE_ID = "pinot.server.instance.id";
     public static final String CONFIG_OF_INSTANCE_DATA_DIR = "pinot.server.instance.dataDir";
+    public static final String CONFIG_OF_INSTANCE_METADATA_DIR = "pinot.server.instance.metadataDir";
     public static final String CONFIG_OF_CONSUMER_DIR = "pinot.server.instance.consumerDir";
     public static final String CONFIG_OF_INSTANCE_SEGMENT_TAR_DIR = "pinot.server.instance.segmentTarDir";
     public static final String CONFIG_OF_INSTANCE_READ_MODE = "pinot.server.instance.readMode";


### PR DESCRIPTION
This new directory can be used to store metadata such as upsert metadata.
By default, it is set to data dir. 
However, having a separate directory allows user to mount it to a different file storage (e.g. local SSDs) for faster I/O.
Users can choose to have faster storage for metadata and slower one for segments so as to keep the costs of the server down.
