### PR TITLE
[multistage] add big_decimal support and numeric type tests

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
@@ -70,6 +70,8 @@ public class TypeFactory extends JavaTypeFactoryImpl {
         return createSqlType(SqlTypeName.VARCHAR);
       case BYTES:
         return createSqlType(SqlTypeName.VARBINARY);
+      case BIG_DECIMAL:
+        return createSqlType(SqlTypeName.DECIMAL);
       case JSON:
         // TODO: support JSON, JSON should be supported using a special RelDataType as it is not a simple String,
         // nor can it be easily parsed as a STRUCT.

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
-import com.mchange.util.AssertException;
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -162,8 +161,9 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
     for (int i = 0; i < resultRows.size(); i++) {
       Object[] resultRow = resultRows.get(i);
       Object[] expectedRow = expectedRows.get(i);
-      Assert.assertTrue(resultRow.length == expectedRow.length, String.format("Unexpected row size mismatch. Expected: %s, Actual: %s",
-              Arrays.toString(expectedRow), Arrays.toString(resultRow)))
+      Assert.assertEquals(expectedRow.length, resultRow.length,
+          String.format("Unexpected row size mismatch. Expected: %s, Actual: %s", Arrays.toString(expectedRow),
+              Arrays.toString(resultRow)));
       for (int j = 0; j < resultRow.length; j++) {
         Assert.assertEquals(valueComp.compare(resultRow[j], expectedRow[j]), 0,
             "Not match at (" + i + "," + j + ")! Expected: " + Arrays.toString(expectedRow)

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
@@ -22,6 +22,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.mchange.util.AssertException;
+import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -36,6 +38,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.stream.Collectors;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.query.QueryEnvironment;
 import org.apache.pinot.query.QueryServerEnclosure;
@@ -109,7 +112,10 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
   }
 
   protected void compareRowEquals(List<Object[]> resultRows, List<Object[]> expectedRows) {
-    Assert.assertEquals(resultRows.size(), expectedRows.size());
+    Assert.assertEquals(resultRows.size(), expectedRows.size(),
+        String.format("Mismatched number of results. expected: %s, actual: %s",
+            expectedRows.stream().map(Arrays::toString).collect(Collectors.joining(",\n")),
+            resultRows.stream().map(Arrays::toString).collect(Collectors.joining(",\n"))));
 
     Comparator<Object> valueComp = (l, r) -> {
       if (l == null && r == null) {
@@ -131,6 +137,12 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
         return ((String) l).compareTo((String) r);
       } else if (l instanceof Boolean) {
         return ((Boolean) l).compareTo((Boolean) r);
+      } else if (l instanceof BigDecimal) {
+        if (r instanceof BigDecimal) {
+          return ((BigDecimal) l).compareTo((BigDecimal) r);
+        } else {
+          return ((BigDecimal) l).compareTo(new BigDecimal((String) r));
+        }
       } else {
         throw new RuntimeException("non supported type " + l.getClass());
       }
@@ -151,6 +163,10 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
       Object[] resultRow = resultRows.get(i);
       Object[] expectedRow = expectedRows.get(i);
       for (int j = 0; j < resultRow.length; j++) {
+        if (j >= expectedRow.length) {
+          throw new AssertException(String.format("Unexpected row size mismatch. Expected: %s, Actual: %s",
+              Arrays.toString(expectedRow), Arrays.toString(resultRow)));
+        }
         Assert.assertEquals(valueComp.compare(resultRow[j], expectedRow[j]), 0,
             "Not match at (" + i + "," + j + ")! Expected: " + Arrays.toString(expectedRow)
                 + " Actual: " + Arrays.toString(resultRow));
@@ -248,8 +264,14 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
         case STRING:
           fieldType = "varchar(128)";
           break;
+        case FLOAT:
+          fieldType = "real";
+          break;
         case DOUBLE:
           fieldType = "double";
+          break;
+        case BIG_DECIMAL:
+          fieldType = "NUMERIC";
           break;
         default:
           throw new UnsupportedOperationException("Unsupported type conversion to h2 type: " + dataType);
@@ -292,6 +314,8 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
       public String _description;
       @JsonProperty("outputs")
       public List<List<Object>> _outputs = Collections.emptyList();
+      @JsonProperty("expect")
+      public String _expect;
     }
 
     public static class ColumnAndType {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
@@ -314,8 +314,8 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
       public String _description;
       @JsonProperty("outputs")
       public List<List<Object>> _outputs = Collections.emptyList();
-      @JsonProperty("expect")
-      public String _expect;
+      @JsonProperty("expectedException")
+      public String _expectedException;
     }
 
     public static class ColumnAndType {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
@@ -162,11 +162,9 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
     for (int i = 0; i < resultRows.size(); i++) {
       Object[] resultRow = resultRows.get(i);
       Object[] expectedRow = expectedRows.get(i);
+      Assert.assertTrue(resultRow.length == expectedRow.length, String.format("Unexpected row size mismatch. Expected: %s, Actual: %s",
+              Arrays.toString(expectedRow), Arrays.toString(resultRow)))
       for (int j = 0; j < resultRow.length; j++) {
-        if (j >= expectedRow.length) {
-          throw new AssertException(String.format("Unexpected row size mismatch. Expected: %s, Actual: %s",
-              Arrays.toString(expectedRow), Arrays.toString(resultRow)));
-        }
         Assert.assertEquals(valueComp.compare(resultRow[j], expectedRow[j]), 0,
             "Not match at (" + i + "," + j + ")! Expected: " + Arrays.toString(expectedRow)
                 + " Actual: " + Arrays.toString(resultRow));

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.query.runtime.queries;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.ImmutableList;
-import com.mchange.util.AssertException;
 import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;

--- a/pinot-query-runtime/src/test/resources/queries/NumericTypes.json
+++ b/pinot-query-runtime/src/test/resources/queries/NumericTypes.json
@@ -1,0 +1,117 @@
+{
+  "smallint": {
+    "psql": "8.1.1",
+    "ignored": true,
+    "comment": "not supported"
+  },
+  "integers": {
+    "comment": "we don't support BIGINT notation",
+    "tables": {
+      "ints": {
+        "schema": [
+          {"name": "int32", "type": "INT"},
+          {"name": "int64", "type": "LONG"}
+        ],
+        "inputs": [
+          [0, 0],
+          [123, 321],
+          [-2147483648, -9223372036854775808],
+          [2147483647, 9223372036854775807]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "psql": "8.1.1",
+        "description": "test selecting integer values",
+        "sql": "SELECT * FROM {ints}"
+      },
+      {
+        "psql": "8.1.1",
+        "ignored": true,
+        "comment": "we don't properly support overflow behavior because we return doubles",
+        "description": "overflow behavior",
+        "sql": "SELECT int32 + 1, int32 - 1, int64 + 1, int64 -1 FROM {ints}",
+        "expect": "*out of range*"
+      }
+    ]
+  },
+  "numeric": {
+    "comment": "ANSI SQL calls this type NUMERIC(precision, scale) but we call it BIG_DECIMAL",
+    "tables": {
+      "numeric": {
+        "schema": [
+          {"name": "big", "type": "BIG_DECIMAL"}
+        ],
+        "inputs": [
+          ["92233720368547758071"],
+          ["92233720368547758071.0000000001"]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "psql": "8.1.2",
+        "TODO": "for some reason, when we select * with this test the timestamp column gets returned as well...",
+        "description": "test support for numeric types of arbitrary precision and scale with values larger than long can support",
+        "sql": "SELECT big FROM {numeric}"
+      }
+    ]
+  },
+  "nan_infinity": {
+    "ignored": true,
+    "comment": "we don't support NaN or Infinity",
+    "tables": {
+      "numeric": {
+        "schema": [
+          {"name": "big", "type": "BIG_DECIMAL"},
+          {"name": "float", "type": "FLOAT"},
+          {"name": "double", "type": "DOUBLE"}
+        ],
+        "inputs": [
+          ["NaN", "NaN", "NaN"],
+          ["Infinity", "Infinity", "Infinity"],
+          ["-Infinity", "-Infinity", "-Infinity"]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "psql": "8.1.2",
+        "TODO": "for some reason, when we select * with this test the timestamp column gets returned as well...",
+        "sql": "SELECT big, floatv, doublev FROM {numeric}",
+        "outputs": [
+          ["NaN"],
+          ["Infinity"],
+          ["-Infinity"]
+        ]
+      }
+    ]
+  },
+  "floating_point": {
+    "tables": {
+      "floats": {
+        "schema": [
+          {"name": "floatv", "type": "FLOAT"},
+          {"name": "doublev", "type": "DOUBLE"}
+        ],
+        "inputs": [
+          [0, 0],
+          [123.456, 123.456],
+          [1E-37, 1E-307],
+          [1E+37, 1E+307]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "description": "test floating point precision",
+        "sql": "SELECT * FROM {floats}"
+      },
+      {
+        "description": "test floating point overflow",
+        "sql": "SELECT floatv + 1, doublev + 1 FROM {floats}"
+      }
+    ]
+  }
+}

--- a/pinot-query-runtime/src/test/resources/queries/NumericTypes.json
+++ b/pinot-query-runtime/src/test/resources/queries/NumericTypes.json
@@ -32,7 +32,7 @@
         "comment": "we don't properly support overflow behavior because we return doubles",
         "description": "overflow behavior",
         "sql": "SELECT int32 + 1, int32 - 1, int64 + 1, int64 -1 FROM {ints}",
-        "expect": "*out of range*"
+        "expectedException": "*out of range*"
       }
     ]
   },

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -55,6 +55,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
   public static final String DEFAULT_DIMENSION_NULL_VALUE_OF_STRING = "null";
   public static final String DEFAULT_DIMENSION_NULL_VALUE_OF_JSON = "null";
   public static final byte[] DEFAULT_DIMENSION_NULL_VALUE_OF_BYTES = new byte[0];
+  public static final BigDecimal DEFAULT_DIMENSION_NULL_VALUE_OF_BIG_DECIMAL = BigDecimal.ZERO;
 
   public static final Integer DEFAULT_METRIC_NULL_VALUE_OF_INT = 0;
   public static final Long DEFAULT_METRIC_NULL_VALUE_OF_LONG = 0L;
@@ -238,6 +239,8 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
               return DEFAULT_DIMENSION_NULL_VALUE_OF_JSON;
             case BYTES:
               return DEFAULT_DIMENSION_NULL_VALUE_OF_BYTES;
+            case BIG_DECIMAL:
+              return DEFAULT_DIMENSION_NULL_VALUE_OF_BIG_DECIMAL;
             default:
               throw new IllegalStateException("Unsupported dimension/time data type: " + dataType);
           }


### PR DESCRIPTION
1. add support for `BIG_DECIMAL` in the multistage engine
2. add some tests for numeric types - most of the interesting tests for numeric types will be done per-operator (+, -, %, etc...) this just covers that we support the types at all.
3. make the test framework a bit more verbose with error messages